### PR TITLE
Pp retry create acls

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -306,6 +306,10 @@ client::create_topic(kafka::creatable_topic req) {
                   return ss::make_exception_future<create_topics_response>(
                     topic_error(
                       model::topic_view{res.data.topics[0].name}, ec));
+              case error_code::topic_authorization_failed:
+                  return ss::make_exception_future<create_topics_response>(
+                    topic_error(
+                      model::topic_view{res.data.topics[0].name}, ec));
               default:
                   return ss::make_ready_future<create_topics_response>(
                     std::move(res));

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -272,10 +272,12 @@ static ss::future<std::vector<metadata_response::topic>> get_topic_metadata(
                   security::acl_operation::describe,
                   tp_ns.tp,
                   authz_quiet{true})) {
-                continue;
+                res.push_back(make_error_topic_response(
+                  tp_ns.tp, error_code::topic_authorization_failed));
+            } else {
+                res.push_back(make_topic_response(
+                  ctx, request, md.metadata, is_node_isolated));
             }
-            res.push_back(
-              make_topic_response(ctx, request, md.metadata, is_node_isolated));
         }
 
         return ss::make_ready_future<std::vector<metadata_response::topic>>(

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -193,6 +193,36 @@ ss::future<> service::do_start() {
     });
 }
 
+ss::future<> create_acls(cluster::security_frontend& security_fe) {
+    // Initialize with any non-success errc
+    std::vector<cluster::errc> err_vec{cluster::errc::timeout};
+
+    std::vector<security::acl_binding> princpal_acl_binding{
+      security::acl_binding{
+        security::resource_pattern{
+          security::resource_type::topic,
+          model::schema_registry_internal_tp.topic,
+          security::pattern_type::literal},
+        security::acl_entry{
+          principal,
+          security::acl_host::wildcard_host(),
+          security::acl_operation::all,
+          security::acl_permission::allow}}};
+
+    err_vec = co_await security_fe.create_acls(princpal_acl_binding, 5s);
+
+    if (err_vec[0] != cluster::errc::success) {
+        vlog(
+          plog.warn,
+          "Failed to create ACLs for {}, err {} - {}",
+          principal,
+          err_vec[0],
+          cluster::make_error_code(err_vec[0]).message());
+    } else {
+        vlog(plog.debug, "Successfully created ACLs for {}", principal);
+    }
+}
+
 ss::future<> service::configure() {
     auto config = co_await pandaproxy::create_client_credentials(
       *_controller,
@@ -207,18 +237,6 @@ ss::future<> service::configure() {
       _ctx.smp_sg, [has_ephemeral_credentials](service& s) {
           s._has_ephemeral_credentials = has_ephemeral_credentials;
       });
-    co_await _controller->get_security_frontend().local().create_acls(
-      {security::acl_binding{
-        security::resource_pattern{
-          security::resource_type::topic,
-          model::schema_registry_internal_tp.topic,
-          security::pattern_type::literal},
-        security::acl_entry{
-          principal,
-          security::acl_host::wildcard_host(),
-          security::acl_operation::all,
-          security::acl_permission::allow}}},
-      5s);
 }
 
 ss::future<> service::mitigate_error(std::exception_ptr eptr) {
@@ -227,17 +245,29 @@ ss::future<> service::mitigate_error(std::exception_ptr eptr) {
         return ss::now();
     }
     vlog(plog.warn, "mitigate_error: {}", eptr);
-    return ss::make_exception_future<>(eptr).handle_exception_type(
-      [this, eptr](kafka::client::broker_error const& ex) {
+    return ss::make_exception_future<>(eptr)
+      .handle_exception_type(
+        [this, eptr](kafka::client::broker_error const& ex) {
+            if (
+              ex.error == kafka::error_code::sasl_authentication_failed
+              && _has_ephemeral_credentials) {
+                return inform(ex.node_id).then([this]() {
+                    // This fully mitigates, don't rethrow.
+                    return _client.local().connect();
+                });
+            }
+
+            // Rethrow unhandled exceptions
+            return ss::make_exception_future<>(eptr);
+        })
+      .handle_exception_type([this,
+                              eptr](kafka::client::topic_error const& ex) {
           if (
-            ex.error == kafka::error_code::sasl_authentication_failed
+            ex.error == kafka::error_code::topic_authorization_failed
             && _has_ephemeral_credentials) {
-              return inform(ex.node_id).then([this]() {
-                  // This fully mitigates, don't rethrow.
-                  return _client.local().connect();
-              });
+              return create_acls(_controller->get_security_frontend().local());
           }
-          // Rethrow unhandled exceptions
+
           return ss::make_exception_future<>(eptr);
       });
 }

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -20,7 +20,6 @@
 #include "seastarx.h"
 #include "utils/request_auth.h"
 
-#include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
@@ -72,7 +71,6 @@ private:
     sharded_store& _store;
     ss::sharded<seq_writer>& _writer;
     std::unique_ptr<cluster::controller>& _controller;
-    ss::abort_source _as;
 
     one_shot _ensure_started;
     request_authenticator _auth;

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -287,9 +287,10 @@ class PandaProxyEndpoints(RedpandaTest):
     def _produce_topic(self,
                        topic,
                        data,
+                       hostname=None,
                        headers=HTTP_PRODUCE_BINARY_V2_TOPIC_HEADERS,
                        **kwargs):
-        return requests.post(f"{self._base_uri()}/topics/{topic}",
+        return requests.post(f"{self._base_uri(hostname)}/topics/{topic}",
                              data,
                              headers=headers,
                              **kwargs)
@@ -300,10 +301,11 @@ class PandaProxyEndpoints(RedpandaTest):
                      offset=0,
                      max_bytes=1024,
                      timeout_ms=1000,
+                     hostname=None,
                      headers=HTTP_FETCH_TOPIC_HEADERS,
                      **kwargs):
         return requests.get(
-            f"{self._base_uri()}/topics/{topic}/partitions/{partition}/records?offset={offset}&max_bytes={max_bytes}&timeout={timeout_ms}",
+            f"{self._base_uri(hostname)}/topics/{topic}/partitions/{partition}/records?offset={offset}&max_bytes={max_bytes}&timeout={timeout_ms}",
             headers=headers,
             **kwargs)
 
@@ -1711,6 +1713,9 @@ class PandaProxyAutoAuthTest(PandaProxyTestMethods):
                                                     partition=0)
             self.logger.info(f"Restarting node: {restart_node_idx}")
             self.redpanda.restart_nodes(victim)
+            admin.await_stable_leader(topic="controller",
+                                      partition=0,
+                                      namespace="redpanda")
 
         for _ in range(5):
             for n in self.redpanda.nodes:


### PR DESCRIPTION
Currently, the PP will set authz for the principal at startup but that could fail. This PR is ongoing work to set authz during error handling.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
