### PR TITLE
rptest: Add proper zone mock to GCP client

### DIFF
--- a/tests/rptest/services/provider_clients/gcp_client.py
+++ b/tests/rptest/services/provider_clients/gcp_client.py
@@ -43,5 +43,8 @@ class GCPClient:
         """
         # TODO: Implement zones list
         # Hardcoded to us-west2
-        z = {"us-west2": ['us-west2-a', 'us-west2-b', 'us-west2-c']}
+        z = {
+            "us-west2": ['us-west2-a', 'us-west2-b', 'us-west2-c'],
+            "us-west1": ['us-west1-a', 'us-west1-b', 'us-west1-c']
+        }
         return z[region][:1]


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none