### PR TITLE
[v23.1.x] Retry listing groups in test flipping consumer offsets topic leadership 

### DIFF
--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -184,7 +184,5 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
 
         self.logger.info("stopping producer")
         producer.stop()
-        self.logger.info("waiting for producer")
-        producer.wait()
         self.logger.info("waiting for consumer")
         consumer.wait()

--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -70,7 +70,8 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
             do_list_groups,
             timeout_sec=30,
             backoff_sec=0.5,
-            err_msg="RPK failed to list consumer groups")
+            err_msg="RPK failed to list consumer groups",
+            retry_on_exc=True)
 
         return group_list_res[0]
 

--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -47,7 +47,8 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
         gd = self.rpk.group_describe(group_name)
 
         for p in gd.partitions:
-            offsets[f"{p.topic}/{p.partition}"] = p.current_offset
+            if p.current_offset is not None:
+                offsets[f"{p.topic}/{p.partition}"] = p.current_offset
         return offsets
 
     def get_group(self):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12996
Fixes: https://github.com/redpanda-data/redpanda/issues/13038,