### PR TITLE
Fixed configuration status and brokers list discrepancy 

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1025,7 +1025,8 @@ class RedpandaServiceBase(Service):
                               start_timeout=None,
                               stop_timeout=None,
                               use_maintenance_mode=True,
-                              omit_seeds_on_idx_one=True):
+                              omit_seeds_on_idx_one=True,
+                              auto_assign_node_id=False):
         nodes = [nodes] if isinstance(nodes, ClusterNode) else nodes
         restarter = RollingRestarter(self)
         restarter.restart_nodes(nodes,
@@ -1033,7 +1034,8 @@ class RedpandaServiceBase(Service):
                                 start_timeout=start_timeout,
                                 stop_timeout=stop_timeout,
                                 use_maintenance_mode=use_maintenance_mode,
-                                omit_seeds_on_idx_one=omit_seeds_on_idx_one)
+                                omit_seeds_on_idx_one=omit_seeds_on_idx_one,
+                                auto_assign_node_id=auto_assign_node_id)
 
     def set_cluster_config(self,
                            values: dict,

--- a/tests/rptest/services/rolling_restarter.py
+++ b/tests/rptest/services/rolling_restarter.py
@@ -25,7 +25,8 @@ class RollingRestarter:
                       start_timeout=None,
                       stop_timeout=None,
                       use_maintenance_mode=True,
-                      omit_seeds_on_idx_one=True):
+                      omit_seeds_on_idx_one=True,
+                      auto_assign_node_id=True):
         """
         Performs a rolling restart on the given nodes, optionally overriding
         the given configs.
@@ -38,7 +39,7 @@ class RollingRestarter:
 
         def has_drained_leaders(node):
             try:
-                node_id = self.redpanda.idx(node)
+                node_id = self.redpanda.node_id(node)
                 broker_resp = admin.get_broker(node_id, node=node)
                 maintenance_status = broker_resp["maintenance_status"]
                 return maintenance_status["draining"] and maintenance_status[
@@ -51,7 +52,7 @@ class RollingRestarter:
                        timeout_sec=stop_timeout,
                        backoff_sec=1)
             # Wait for the cluster to agree on a controller leader.
-            return self.redpanda.get_node(
+            return self.redpanda.get_node_by_id(
                 admin.await_stable_leader(
                     topic="controller",
                     partition=0,
@@ -100,7 +101,8 @@ class RollingRestarter:
                 node,
                 override_cfg_params,
                 timeout=start_timeout,
-                omit_seeds_on_idx_one=omit_seeds_on_idx_one)
+                omit_seeds_on_idx_one=omit_seeds_on_idx_one,
+                auto_assign_node_id=auto_assign_node_id)
 
             controller_leader = wait_until_cluster_healthy(start_timeout)
 

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -153,6 +153,7 @@ class RedpandaTest(Test):
         self,
         versions_in: list[RedpandaVersion],
         already_running: bool = False,
+        auto_assign_node_id: bool = False,
         mid_upgrade_check: Callable[[dict[Any, RedpandaVersion]],
                                     None] = lambda x: None):
         """
@@ -258,7 +259,8 @@ class RedpandaTest(Test):
                 canary_nodes,
                 start_timeout=90,
                 stop_timeout=90,
-                use_maintenance_mode=use_maintenance_mode)
+                use_maintenance_mode=use_maintenance_mode,
+                auto_assign_node_id=auto_assign_node_id)
             mid_upgrade_check({n: current_version
                                for n in canary_nodes}
                               | {n: old_version
@@ -267,7 +269,8 @@ class RedpandaTest(Test):
                 rest_nodes,
                 start_timeout=90,
                 stop_timeout=90,
-                use_maintenance_mode=use_maintenance_mode)
+                use_maintenance_mode=use_maintenance_mode,
+                auto_assign_node_id=auto_assign_node_id)
 
             if current_version[0:2] == (22, 1):
                 # Special case: the version in which we adopted the __consumer_offsets topic


### PR DESCRIPTION
There is a dependency between the `cluster::config_manager` and members
table. Cluster configuration status updates are not explicitly removed
from status but but `config_manager` rely on notifications from members
table. The relationship is correct since all the controller log commands
are applied in order i.e. if member was deleted after its configuration
status was updated the notification is guaranteed to be generated after
the status update hence `config_manager` can use notification to cleanup
not longer relevant statuses.

Issue leading to discrepancy between members table content and
`config_manager` status map was caused by the fact that manage
notification was register after the update was generated.

Moved the notification subscription earlier (to the constructor of
`config_manager`. The solution isn't perfect as there is a dependency in
order of starup and notification registration. In future we are going
to replace the notification between the two components by simply
listening to members related commands in the `config_manager` (currently
it is impossible due to limitation in `mux_state_machine`).

Signed-off-by: Michal Maslanka <michal@redpanda.com>
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixed discrepancy between node list reported in `/brokers` and `/cluster_config/status` endpoints
