### PR TITLE
rptest: Support gcpkeyfile parameter on rptest for GCP Nightly

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -121,7 +121,7 @@ class CloudClusterConfig:
     teleport_bot_token: str = ""
     id: str = ""  # empty string makes it easier to pass thru default value from duck.py
     delete_cluster: bool = True
-
+    gcp_keyfile: str = ""
     region: str = "us-west-2"
     provider: str = "AWS"
     type: str = "FMC"


### PR DESCRIPTION
This is `rptest` side of the freshly merged https://github.com/redpanda-data/vtools/pull/2058
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none