### PR TITLE
Introduce wasmtime as a wasm::runtime

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -104,6 +104,17 @@ fetch_dep(hdrhistogram
   REPO https://github.com/HdrHistogram/HdrHistogram_c
   TAG 0.11.5)
 
+# We need submodules for wasmtime to compile
+FetchContent_Declare(
+  wasmtime
+  GIT_REPOSITORY https://github.com/bytecodealliance/wasmtime
+  GIT_TAG 8efcb9851602287fd07a1a1e91501f51f2653d7e
+  GIT_PROGRESS TRUE
+  USES_TERMINAL_DOWNLOAD TRUE
+  OVERRIDE_FIND_PACKAGE
+  SYSTEM
+  SOURCE_SUBDIR crates/c-api)
+
 FetchContent_MakeAvailable(
     fmt
     rapidjson
@@ -115,6 +126,7 @@ FetchContent_MakeAvailable(
     avro
     tinygo
     wasmedge
+    wasmtime
     hdrhistogram)
 
 add_library(Crc32c::crc32c ALIAS crc32c)

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -26,96 +26,96 @@ fi
 
 deb_deps=(
   cargo
-  cmake
-  ninja-build
   clang
-  lld
+  cmake
   git
+  gnutls-dev
+  golang
+  libabsl-dev
   libboost-all-dev
   libc-ares-dev
   libcrypto++-dev
+  libgssapi-krb5-2
+  libkrb5-dev
   liblz4-dev
-  gnutls-dev
-  libsctp-dev
-  libyaml-cpp-dev
-  ragel
-  valgrind
-  libsnappy-dev
-  libabsl-dev
-  libxxhash-dev
-  libzstd-dev
   libprotobuf-dev
   libprotoc-dev
-  protobuf-compiler
-  python3-jsonschema
-  python3-jinja2
-  xfslibs-dev
   libre2-dev
-  systemtap-sdt-dev
-  libkrb5-dev
-  libgssapi-krb5-2
-  golang
+  libsctp-dev
+  libsnappy-dev
+  libxxhash-dev
+  libyaml-cpp-dev
+  libzstd-dev
+  lld
+  ninja-build
+  protobuf-compiler
   python3
+  python3-jinja2
+  python3-jsonschema
+  ragel
+  systemtap-sdt-dev
+  valgrind
+  xfslibs-dev
 )
 fedora_deps=(
-  cargo
-  rust
-  cmake
-  ninja-build
-  clang
-  compiler-rt
-  llvm
-  lld
-  git
+  abseil-cpp-devel
   boost-devel
   c-ares-devel
+  cargo
+  clang
+  cmake
+  compiler-rt
   cryptopp-devel
-  lz4-devel
+  git
   gnutls-devel
+  golang
   hwloc-devel
+  krb5-devel
+  libxml2-devel
+  libzstd-devel
   lksctp-tools-devel
+  lld
+  llvm
+  lz4-devel
+  ninja-build
   numactl-devel
-  yaml-cpp-devel
+  procps
+  protobuf-devel
+  python3
+  python3-jinja2
+  python3-jsonschema
   ragel-devel
+  re2-devel
+  rust
+  snappy-devel
+  systemtap-sdt-devel
   valgrind-devel
   xfsprogs-devel
-  systemtap-sdt-devel
-  snappy-devel
-  abseil-cpp-devel
-  zlib-devel
   xxhash-devel
-  libzstd-devel
-  protobuf-devel
-  libxml2-devel
-  re2-devel
-  krb5-devel
-  python3-jsonschema
-  python3-jinja2
-  golang
-  python3
-  procps
+  yaml-cpp-devel
+  zlib-devel
 )
 arch_deps=(
-  rust
   ccache
   clang
   curl
   git
   go
-  zstd
-  llvm
   lld
+  llvm
   pkg-config
   procps
   python-jinja
   python-virtualenv
   rapidjson
+  rust
   snappy
+  unzip
   which
   xxhash
   xz
   zip
-  unzip
+  zstd
 )
 
 case "$ID" in

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -25,6 +25,7 @@ else
 fi
 
 deb_deps=(
+  cargo
   cmake
   ninja-build
   clang
@@ -57,6 +58,8 @@ deb_deps=(
   python3
 )
 fedora_deps=(
+  cargo
+  rust
   cmake
   ninja-build
   clang
@@ -93,6 +96,7 @@ fedora_deps=(
   procps
 )
 arch_deps=(
+  rust
   ccache
   clang
   curl

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -44,6 +44,173 @@ please keep this up to date with every new library use.
 | yaml-cpp        | MIT                                |
 | zlib            | Zlib                               |
 | zstd            | BSD                                |
+
+<!-- 
+These are dependencies of wasmtime and can be generated via a script like:
+
+```bash
+# Make sure you run this in the vtools directory with the patched wasmtime to remove the features we don't need.
+rm -f /tmp/license.md
+for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
+do
+    cargo license --avoid-build-deps --avoid-dev-deps --filter-platform=$target --json \
+      | jq 'map({name, license})' | jq -r '(.[0] | keys_unsorted) as $keys | map([.[ $keys[] ]])[] | @text "| \(.[0]) | \(.[1]) |"' \
+      >> /tmp/license.md
+done
+cat /tmp/license.md | sort | uniq
+```
+-->
+
+| rust crate  | license       |
+| :---------- | :------------ |
+| addr2line | Apache-2.0 OR MIT |
+| ahash | Apache-2.0 OR MIT |
+| aho-corasick | MIT OR Unlicense |
+| anyhow | Apache-2.0 OR MIT |
+| arbitrary | Apache-2.0 OR MIT |
+| async-trait | Apache-2.0 OR MIT |
+| base64 | Apache-2.0 OR MIT |
+| bincode | MIT |
+| bitflags | Apache-2.0 OR MIT |
+| block-buffer | Apache-2.0 OR MIT |
+| bumpalo | Apache-2.0 OR MIT |
+| byteorder | MIT OR Unlicense |
+| capstone | MIT |
+| capstone-sys | MIT |
+| cfg-if | Apache-2.0 OR MIT |
+| cpp_demangle | Apache-2.0 OR MIT |
+| cpufeatures | Apache-2.0 OR MIT |
+| cranelift-bforest | Apache-2.0 WITH LLVM-exception |
+| cranelift-codegen | Apache-2.0 WITH LLVM-exception |
+| cranelift-codegen-shared | Apache-2.0 WITH LLVM-exception |
+| cranelift-control | Apache-2.0 WITH LLVM-exception |
+| cranelift-entity | Apache-2.0 WITH LLVM-exception |
+| cranelift-frontend | Apache-2.0 WITH LLVM-exception |
+| cranelift-native | Apache-2.0 WITH LLVM-exception |
+| cranelift-wasm | Apache-2.0 WITH LLVM-exception |
+| crc32fast | Apache-2.0 OR MIT |
+| crossbeam-channel | Apache-2.0 OR MIT |
+| crossbeam-deque | Apache-2.0 OR MIT |
+| crossbeam-epoch | Apache-2.0 OR MIT |
+| crossbeam-utils | Apache-2.0 OR MIT |
+| crypto-common | Apache-2.0 OR MIT |
+| debugid | Apache-2.0 |
+| derive_arbitrary | Apache-2.0 OR MIT |
+| digest | Apache-2.0 OR MIT |
+| directories-next | Apache-2.0 OR MIT |
+| dirs-sys-next | Apache-2.0 OR MIT |
+| either | Apache-2.0 OR MIT |
+| encoding_rs | (Apache-2.0 OR MIT) AND BSD-3-Clause |
+| env_logger | Apache-2.0 OR MIT |
+| equivalent | Apache-2.0 OR MIT |
+| fallible-iterator | Apache-2.0 OR MIT |
+| form_urlencoded | Apache-2.0 OR MIT |
+| fxhash | Apache-2.0 OR MIT |
+| fxprof-processed-profile | Apache-2.0 OR MIT |
+| generic-array | MIT |
+| getrandom | Apache-2.0 OR MIT |
+| gimli | Apache-2.0 OR MIT |
+| hashbrown | Apache-2.0 OR MIT |
+| heck | Apache-2.0 OR MIT |
+| humantime | Apache-2.0 OR MIT |
+| id-arena | Apache-2.0 OR MIT |
+| idna | Apache-2.0 OR MIT |
+| indexmap | Apache-2.0 OR MIT |
+| io-lifetimes | Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT |
+| is-terminal | MIT |
+| itertools | Apache-2.0 OR MIT |
+| itoa | Apache-2.0 OR MIT |
+| ittapi | BSD-3-Clause OR GPL-2.0-only |
+| ittapi-sys | BSD-3-Clause OR GPL-2.0-only |
+| leb128 | Apache-2.0 OR MIT |
+| libc | Apache-2.0 OR MIT |
+| linux-raw-sys | Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT |
+| log | Apache-2.0 OR MIT |
+| memchr | MIT OR Unlicense |
+| memfd | Apache-2.0 OR MIT |
+| memoffset | MIT |
+| num_cpus | Apache-2.0 OR MIT |
+| object | Apache-2.0 OR MIT |
+| once_cell | Apache-2.0 OR MIT |
+| paste | Apache-2.0 OR MIT |
+| percent-encoding | Apache-2.0 OR MIT |
+| ppv-lite86 | Apache-2.0 OR MIT |
+| proc-macro2 | Apache-2.0 OR MIT |
+| psm | Apache-2.0 OR MIT |
+| pulldown-cmark | MIT |
+| quote | Apache-2.0 OR MIT |
+| rand | Apache-2.0 OR MIT |
+| rand_chacha | Apache-2.0 OR MIT |
+| rand_core | Apache-2.0 OR MIT |
+| rayon | Apache-2.0 OR MIT |
+| rayon-core | Apache-2.0 OR MIT |
+| regalloc2 | Apache-2.0 WITH LLVM-exception |
+| regex | Apache-2.0 OR MIT |
+| regex-automata | Apache-2.0 OR MIT |
+| regex-syntax | Apache-2.0 OR MIT |
+| rustc-demangle | Apache-2.0 OR MIT |
+| rustc-hash | Apache-2.0 OR MIT |
+| rustix | Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT |
+| ryu | Apache-2.0 OR BSL-1.0 |
+| scopeguard | Apache-2.0 OR MIT |
+| semver | Apache-2.0 OR MIT |
+| serde | Apache-2.0 OR MIT |
+| serde_derive | Apache-2.0 OR MIT |
+| serde_json | Apache-2.0 OR MIT |
+| sha2 | Apache-2.0 OR MIT |
+| slice-group-by | MIT |
+| smallvec | Apache-2.0 OR MIT |
+| souper-ir | Apache-2.0 OR MIT |
+| sptr | Apache-2.0 OR MIT |
+| stable_deref_trait | Apache-2.0 OR MIT |
+| syn | Apache-2.0 OR MIT |
+| target-lexicon | Apache-2.0 WITH LLVM-exception |
+| termcolor | MIT OR Unlicense |
+| thiserror | Apache-2.0 OR MIT |
+| thiserror-impl | Apache-2.0 OR MIT |
+| tinyvec | Apache-2.0 OR MIT OR Zlib |
+| tinyvec_macros | Apache-2.0 OR MIT OR Zlib |
+| toml | Apache-2.0 OR MIT |
+| typenum | Apache-2.0 OR MIT |
+| unicase | Apache-2.0 OR MIT |
+| unicode-bidi | Apache-2.0 OR MIT |
+| unicode-ident | (MIT OR Apache-2.0) AND Unicode-DFS-2016 |
+| unicode-normalization | Apache-2.0 OR MIT |
+| unicode-segmentation | Apache-2.0 OR MIT |
+| unicode-width | Apache-2.0 OR MIT |
+| unicode-xid | Apache-2.0 OR MIT |
+| url | Apache-2.0 OR MIT |
+| uuid | Apache-2.0 OR MIT |
+| wasm-encoder | Apache-2.0 WITH LLVM-exception |
+| wasmparser | Apache-2.0 WITH LLVM-exception |
+| wasmprinter | Apache-2.0 WITH LLVM-exception |
+| wasmtime | Apache-2.0 WITH LLVM-exception |
+| wasmtime-asm-macros | Apache-2.0 WITH LLVM-exception |
+| wasmtime-cache | Apache-2.0 WITH LLVM-exception |
+| wasmtime-c-api | Apache-2.0 WITH LLVM-exception |
+| wasmtime-c-api-macros | Apache-2.0 WITH LLVM-exception |
+| wasmtime-component-macro | Apache-2.0 WITH LLVM-exception |
+| wasmtime-component-util | Apache-2.0 WITH LLVM-exception |
+| wasmtime-cranelift | Apache-2.0 WITH LLVM-exception |
+| wasmtime-cranelift-shared | Apache-2.0 WITH LLVM-exception |
+| wasmtime-environ | Apache-2.0 WITH LLVM-exception |
+| wasmtime-fiber | Apache-2.0 WITH LLVM-exception |
+| wasmtime-jit | Apache-2.0 WITH LLVM-exception |
+| wasmtime-jit-debug | Apache-2.0 WITH LLVM-exception |
+| wasmtime-jit-icache-coherence | Apache-2.0 WITH LLVM-exception |
+| wasmtime-runtime | Apache-2.0 WITH LLVM-exception |
+| wasmtime-types | Apache-2.0 WITH LLVM-exception |
+| wasmtime-versioned-export-macros | Apache-2.0 WITH LLVM-exception |
+| wasmtime-winch | Apache-2.0 WITH LLVM-exception |
+| wasmtime-wit-bindgen | Apache-2.0 WITH LLVM-exception |
+| wasmtime-wmemcheck | Apache-2.0 WITH LLVM-exception |
+| wast | Apache-2.0 WITH LLVM-exception |
+| wat | Apache-2.0 WITH LLVM-exception |
+| winch-codegen | Apache-2.0 WITH LLVM-exception |
+| wit-parser | Apache-2.0 WITH LLVM-exception |
+| zstd | MIT |
+| zstd-safe | Apache-2.0 OR MIT |
+| zstd-sys | Apache-2.0 OR MIT |
  
 # Go deps _used_ in production in RPK (exclude all test dependencies)
 

--- a/src/v/utils/log_hist.h
+++ b/src/v/utils/log_hist.h
@@ -57,6 +57,7 @@ public:
       first_bucket_upper_bound - 1);
     static constexpr int first_bucket_exp = 64 - first_bucket_clz;
 
+    using duration_type = duration_t;
     using clock_type = std::chrono::high_resolution_clock;
 
     /// \brief move-only type to tracking durations

--- a/src/v/wasm/CMakeLists.txt
+++ b/src/v/wasm/CMakeLists.txt
@@ -13,9 +13,11 @@ v_cc_library(
     transform_module.cc
     wasi.cc
     wasmedge.cc
+    wasmtime.cc
     work_queue.cc
   DEPS
     wasmedge
+    wasmtime
     v::storage
     v::model
     v::pandaproxy_schema_registry

--- a/src/v/wasm/api.cc
+++ b/src/v/wasm/api.cc
@@ -12,12 +12,12 @@
 #include "wasm/api.h"
 
 #include "wasm/schema_registry.h"
-#include "wasm/wasmedge.h"
+#include "wasm/wasmtime.h"
 
 namespace wasm {
 std::unique_ptr<runtime>
 runtime::create_default(pandaproxy::schema_registry::api* schema_reg) {
-    return wasmedge::create_runtime(
+    return wasmtime::create_runtime(
       wasm::schema_registry::make_default(schema_reg));
 }
 } // namespace wasm

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -82,6 +82,8 @@ public:
     runtime& operator=(const runtime&) = delete;
     runtime(runtime&&) = delete;
     runtime& operator=(runtime&&) = delete;
+    virtual ss::future<> start() = 0;
+    virtual ss::future<> stop() = 0;
     /**
      * Create a factory for this transform and the corresponding source wasm
      * module.

--- a/src/v/wasm/probe.h
+++ b/src/v/wasm/probe.h
@@ -39,6 +39,7 @@ public:
     std::unique_ptr<hist_t::measurement> latency_measurement() {
         return _transform_latency.auto_measure();
     }
+    void record_latency(uint64_t v) { _transform_latency.record(v); }
     void transform_error() { ++_transform_errors; }
 
     void setup_metrics(ss::sstring transform_name);

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -23,7 +23,7 @@
 #include "storage/record_batch_builder.h"
 #include "wasm/api.h"
 #include "wasm/probe.h"
-#include "wasm/wasmedge.h"
+#include "wasm/wasmtime.h"
 
 #include <seastar/util/file.hh>
 
@@ -112,7 +112,7 @@ void WasmTestFixture::SetUp() {
     _probe = std::make_unique<wasm::transform_probe>();
     auto sr = std::make_unique<fake_schema_registry>();
     _sr = sr.get();
-    _runtime = wasm::wasmedge::create_runtime(std::move(sr));
+    _runtime = wasm::wasmtime::create_runtime(std::move(sr));
     _runtime->start().get();
     _meta = {
       .name = model::transform_name(ss::sstring("test_wasm_transform")),

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -113,6 +113,7 @@ void WasmTestFixture::SetUp() {
     auto sr = std::make_unique<fake_schema_registry>();
     _sr = sr.get();
     _runtime = wasm::wasmedge::create_runtime(std::move(sr));
+    _runtime->start().get();
     _meta = {
       .name = model::transform_name(ss::sstring("test_wasm_transform")),
       .input_topic = model::random_topic_namespace(),
@@ -126,6 +127,7 @@ void WasmTestFixture::TearDown() {
         _engine->stop().get();
     }
     _factory = nullptr;
+    _runtime->stop().get();
     _runtime = nullptr;
     _probe = nullptr;
 }

--- a/src/v/wasm/wasmedge.cc
+++ b/src/v/wasm/wasmedge.cc
@@ -623,6 +623,9 @@ public:
       : _config_ctx(WasmEdge_ConfigureCreate())
       , _sr(std::move(sr)) {}
 
+    ss::future<> start() final { co_return; }
+    ss::future<> stop() final { co_return; }
+
     ss::future<std::unique_ptr<factory>> make_factory(
       model::transform_metadata meta, iobuf buf, ss::logger* logger) final {
         // TODO: Move compilation to here and reuse the compiled artifact

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -1,0 +1,764 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "wasm/wasmtime.h"
+
+#include "model/record.h"
+#include "ssx/thread_worker.h"
+#include "storage/parser_utils.h"
+#include "wasm/api.h"
+#include "wasm/errc.h"
+#include "wasm/ffi.h"
+#include "wasm/logger.h"
+#include "wasm/probe.h"
+#include "wasm/schema_registry_module.h"
+#include "wasm/transform_module.h"
+#include "wasm/wasi.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/posix.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/util/backtrace.hh>
+#include <seastar/util/defer.hh>
+
+#include <wasmtime/config.h>
+#include <wasmtime/error.h>
+#include <wasmtime/extern.h>
+#include <wasmtime/instance.h>
+#include <wasmtime/memory.h>
+#include <wasmtime/store.h>
+
+#include <csignal>
+#include <memory>
+#include <pthread.h>
+#include <span>
+#include <wasm.h>
+#include <wasmtime.h>
+
+namespace wasm::wasmtime {
+
+namespace {
+
+constexpr uint64_t wasmtime_fuel_amount = 1'000'000'000;
+
+template<typename T, auto fn>
+struct deleter {
+    void operator()(T* ptr) { fn(ptr); }
+};
+template<typename T, auto fn>
+using handle = std::unique_ptr<T, deleter<T, fn>>;
+
+void check_error(const wasmtime_error_t* error) {
+    if (!error) {
+        return;
+    }
+    wasm_name_t msg;
+    wasmtime_error_message(error, &msg);
+    std::string str(msg.data, msg.size);
+    wasm_byte_vec_delete(&msg);
+    throw wasm_exception(std::move(str), errc::load_failure);
+}
+void check_trap(const wasm_trap_t* trap) {
+    if (!trap) {
+        return;
+    }
+    wasm_name_t msg{.size = 0, .data = nullptr};
+    wasm_trap_message(trap, &msg);
+    std::stringstream sb;
+    sb << std::string_view(msg.data, msg.size);
+    wasm_byte_vec_delete(&msg);
+    wasm_frame_vec_t trace{.size = 0, .data = nullptr};
+    wasm_trap_trace(trap, &trace);
+    for (wasm_frame_t* frame : std::span(trace.data, trace.size)) {
+        auto* module_name = wasmtime_frame_module_name(frame);
+        auto* function_name = wasmtime_frame_func_name(frame);
+        if (module_name && function_name) {
+            sb << std::endl
+               << std::string_view(module_name->data, module_name->size) << "::"
+               << std::string_view(function_name->data, function_name->size);
+        } else if (module_name) {
+            sb << std::endl
+               << std::string_view(module_name->data, module_name->size)
+               << "::??";
+        } else if (function_name) {
+            sb << std::endl
+               << std::string_view(function_name->data, function_name->size);
+        }
+    }
+    wasm_frame_vec_delete(&trace);
+    throw wasm_exception(sb.str(), errc::user_code_failure);
+}
+
+std::vector<uint64_t> to_raw_values(std::span<const wasmtime_val_t> values) {
+    std::vector<uint64_t> raw;
+    raw.reserve(values.size());
+    for (const wasmtime_val_t val : values) {
+        switch (val.kind) {
+        case WASMTIME_I32:
+            raw.push_back(val.of.i32);
+            break;
+        case WASMTIME_I64:
+            raw.push_back(val.of.i64);
+            break;
+        default:
+            throw wasm_exception(
+              ss::format("Unsupported value type: {}", val.kind),
+              errc::user_code_failure);
+        }
+    }
+    return raw;
+}
+
+wasm_valtype_vec_t
+convert_to_wasmtime(const std::vector<ffi::val_type>& ffi_types) {
+    wasm_valtype_vec_t wasm_types;
+    wasm_valtype_vec_new_uninitialized(&wasm_types, ffi_types.size());
+    std::span<wasm_valtype_t*> wasm_types_span{
+      wasm_types.data, ffi_types.size()};
+    for (size_t i = 0; i < ffi_types.size(); ++i) {
+        switch (ffi_types[i]) {
+        case ffi::val_type::i32:
+            wasm_types_span[i] = wasm_valtype_new(WASM_I32);
+            break;
+        case ffi::val_type::i64:
+            wasm_types_span[i] = wasm_valtype_new(WASM_I64);
+            break;
+        }
+    }
+    return wasm_types;
+}
+template<typename T>
+wasmtime_val_t convert_to_wasmtime(T value) {
+    if constexpr (reflection::is_rp_named_type<T>) {
+        return convert_to_wasmtime(value());
+    } else if constexpr (
+      std::is_integral_v<T> && sizeof(T) == sizeof(int64_t)) {
+        return wasmtime_val_t{
+          .kind = WASMTIME_I64, .of = {.i64 = static_cast<int64_t>(value)}};
+    } else if constexpr (std::is_integral_v<T>) {
+        return wasmtime_val_t{
+          .kind = WASMTIME_I32, .of = {.i32 = static_cast<int32_t>(value)}};
+    } else {
+        static_assert(
+          ffi::detail::dependent_false<T>::value,
+          "Unsupported wasm result type");
+    }
+}
+
+class memory : public ffi::memory {
+public:
+    explicit memory(wasmtime_context_t* ctx, wasmtime_memory_t* mem)
+      : ffi::memory()
+      , _ctx(ctx)
+      , _underlying(mem) {}
+
+    void* translate_raw(size_t guest_ptr, size_t len) final {
+        auto memory_size = wasmtime_memory_data_size(_ctx, _underlying);
+        if ((guest_ptr + len) > memory_size) [[unlikely]] {
+            throw wasm_exception(
+              ss::format(
+                "Out of bounds memory access in FFI: {} + {} >= {}",
+                guest_ptr,
+                len,
+                memory_size),
+              errc::user_code_failure);
+        }
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        return wasmtime_memory_data(_ctx, _underlying) + guest_ptr;
+    }
+
+private:
+    wasmtime_context_t* _ctx;
+    wasmtime_memory_t* _underlying;
+};
+
+struct host_function_environment {
+    void* host_module;
+    ss::alien::instance* alien;
+    ss::shard_id shard_id;
+};
+
+template<auto value>
+struct host_function;
+template<
+  typename Module,
+  typename ReturnType,
+  typename... ArgTypes,
+  ReturnType (Module::*module_func)(ArgTypes...)>
+struct host_function<module_func> {
+    static void reg(
+      wasmtime_linker_t* linker,
+      host_function_environment* env,
+      std::string_view function_name) {
+        std::vector<ffi::val_type> ffi_inputs;
+        ffi::transform_types<ArgTypes...>(ffi_inputs);
+        std::vector<ffi::val_type> ffi_outputs;
+        ffi::transform_types<ReturnType>(ffi_outputs);
+        auto inputs = convert_to_wasmtime(ffi_inputs);
+        auto outputs = convert_to_wasmtime(ffi_outputs);
+        // Takes ownership of inputs and outputs
+        handle<wasm_functype_t, wasm_functype_delete> functype{
+          wasm_functype_new(&inputs, &outputs)};
+        auto* err = wasmtime_linker_define_func(
+          linker,
+          Module::name.data(),
+          Module::name.size(),
+          function_name.data(),
+          function_name.size(),
+          functype.get(),
+          [](
+            void* env,
+            wasmtime_caller_t* caller,
+            const wasmtime_val_t* args,
+            size_t nargs,
+            wasmtime_val_t* results,
+            size_t) -> wasm_trap_t* {
+              auto* fenv = static_cast<host_function_environment*>(env);
+              auto* host_module = static_cast<Module*>(fenv->host_module);
+              constexpr std::string_view memory_export_name = "memory";
+              wasmtime_extern_t extern_item;
+              bool ok = wasmtime_caller_export_get(
+                caller,
+                memory_export_name.data(),
+                memory_export_name.size(),
+                &extern_item);
+              if (!ok || extern_item.kind != WASMTIME_EXTERN_MEMORY)
+                [[unlikely]] {
+                  constexpr std::string_view error = "Missing memory export";
+                  vlog(wasm_log.warn, "{}", error);
+                  return wasmtime_trap_new(error.data(), error.size());
+              }
+              memory mem(
+                wasmtime_caller_context(caller), &extern_item.of.memory);
+
+              try {
+                  auto raw = to_raw_values({args, nargs});
+
+                  auto host_params = ffi::extract_parameters<ArgTypes...>(
+                    &mem, raw, 0);
+                  if constexpr (std::is_void_v<ReturnType>) {
+                      std::apply(
+                        module_func,
+                        std::tuple_cat(
+                          std::make_tuple(host_module),
+                          std::move(host_params)));
+                  } else if constexpr (ss::is_future<ReturnType>::value) {
+                      auto fut = ss::alien::submit_to(
+                        *fenv->alien,
+                        fenv->shard_id,
+                        [host_module,
+                         host_params = std::move(host_params)]() mutable {
+                            return std::apply(
+                              module_func,
+                              std::tuple_cat(
+                                std::make_tuple(host_module),
+                                std::move(host_params)));
+                        });
+                      *results
+                        = convert_to_wasmtime<typename ReturnType::value_type>(
+                          std::move(fut).get());
+                  } else {
+                      ReturnType host_result = std::apply(
+                        module_func,
+                        std::tuple_cat(
+                          std::make_tuple(host_module),
+                          std::move(host_params)));
+                      *results = convert_to_wasmtime<ReturnType>(
+                        std::move(host_result));
+                  }
+              } catch (const std::exception& e) {
+                  vlog(wasm_log.warn, "Failure executing host function: {}", e);
+                  std::string_view msg = e.what();
+                  return wasmtime_trap_new(msg.data(), msg.size());
+              }
+              return nullptr;
+          },
+          env,
+          nullptr);
+
+        if (err) [[unlikely]] {
+            throw wasm::wasm_exception(
+              ss::format("Unable to register {}", function_name),
+              errc::engine_creation_failure);
+        }
+    }
+};
+
+std::unique_ptr<host_function_environment> register_wasi_module(
+  wasi::preview1_module* mod,
+  wasmtime_linker_t* linker,
+  ss::alien::instance* alien,
+  ss::shard_id shard_id) {
+    auto env = std::make_unique<host_function_environment>(
+      mod, alien, shard_id);
+    // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define REG_HOST_FN(name)                                                      \
+    host_function<&wasi::preview1_module::name>::reg(linker, env.get(), #name)
+    REG_HOST_FN(args_get);
+    REG_HOST_FN(args_sizes_get);
+    REG_HOST_FN(environ_get);
+    REG_HOST_FN(environ_sizes_get);
+    REG_HOST_FN(clock_res_get);
+    REG_HOST_FN(clock_time_get);
+    REG_HOST_FN(fd_advise);
+    REG_HOST_FN(fd_allocate);
+    REG_HOST_FN(fd_close);
+    REG_HOST_FN(fd_datasync);
+    REG_HOST_FN(fd_fdstat_get);
+    REG_HOST_FN(fd_fdstat_set_flags);
+    REG_HOST_FN(fd_filestat_get);
+    REG_HOST_FN(fd_filestat_set_size);
+    REG_HOST_FN(fd_filestat_set_times);
+    REG_HOST_FN(fd_pread);
+    REG_HOST_FN(fd_prestat_get);
+    REG_HOST_FN(fd_prestat_dir_name);
+    REG_HOST_FN(fd_pwrite);
+    REG_HOST_FN(fd_read);
+    REG_HOST_FN(fd_readdir);
+    REG_HOST_FN(fd_renumber);
+    REG_HOST_FN(fd_seek);
+    REG_HOST_FN(fd_sync);
+    REG_HOST_FN(fd_tell);
+    REG_HOST_FN(fd_write);
+    REG_HOST_FN(path_create_directory);
+    REG_HOST_FN(path_filestat_get);
+    REG_HOST_FN(path_filestat_set_times);
+    REG_HOST_FN(path_link);
+    REG_HOST_FN(path_open);
+    REG_HOST_FN(path_readlink);
+    REG_HOST_FN(path_remove_directory);
+    REG_HOST_FN(path_rename);
+    REG_HOST_FN(path_symlink);
+    REG_HOST_FN(path_unlink_file);
+    REG_HOST_FN(poll_oneoff);
+    REG_HOST_FN(proc_exit);
+    REG_HOST_FN(sched_yield);
+    REG_HOST_FN(random_get);
+    REG_HOST_FN(sock_accept);
+    REG_HOST_FN(sock_recv);
+    REG_HOST_FN(sock_send);
+    REG_HOST_FN(sock_shutdown);
+#undef REG_HOST_FN
+    return env;
+}
+
+std::unique_ptr<host_function_environment> register_transform_module(
+  transform_module* mod,
+  wasmtime_linker_t* linker,
+  ss::alien::instance* alien,
+  ss::shard_id shard_id) {
+    auto env = std::make_unique<host_function_environment>(
+      mod, alien, shard_id);
+    // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define REG_HOST_FN(name)                                                      \
+    host_function<&transform_module::name>::reg(linker, env.get(), #name)
+    REG_HOST_FN(read_batch_header);
+    REG_HOST_FN(read_record);
+    REG_HOST_FN(write_record);
+#undef REG_HOST_FN
+    return env;
+}
+std::unique_ptr<host_function_environment> register_sr_module(
+  schema_registry_module* mod,
+  wasmtime_linker_t* linker,
+  ss::alien::instance* alien,
+  ss::shard_id shard_id) {
+    auto env = std::make_unique<host_function_environment>(
+      mod, alien, shard_id);
+    // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define REG_HOST_FN(name)                                                      \
+    host_function<&schema_registry_module::name>::reg(linker, env.get(), #name)
+    REG_HOST_FN(get_schema_definition);
+    REG_HOST_FN(get_schema_definition_len);
+    REG_HOST_FN(get_subject_schema);
+    REG_HOST_FN(get_subject_schema_len);
+    REG_HOST_FN(create_subject_schema);
+#undef REG_HOST_FN
+    return env;
+}
+
+class wasmtime_engine : public engine {
+public:
+    wasmtime_engine(
+      ss::sstring user_module_name,
+      handle<wasmtime_linker_t, wasmtime_linker_delete> l,
+      handle<wasmtime_store_t, wasmtime_store_delete> s,
+      std::shared_ptr<wasmtime_module_t> user_module,
+      std::unique_ptr<transform_module> transform_module,
+      std::unique_ptr<schema_registry_module> sr_module,
+      std::unique_ptr<wasi::preview1_module> wasi_module,
+      std::vector<std::unique_ptr<host_function_environment>>
+        host_function_environments,
+      wasmtime_instance_t instance,
+      ssx::sharded_thread_worker* workers)
+      : _user_module_name(std::move(user_module_name))
+      , _store(std::move(s))
+      , _user_module(std::move(user_module))
+      , _transform_module(std::move(transform_module))
+      , _sr_module(std::move(sr_module))
+      , _wasi_module(std::move(wasi_module))
+      , _linker(std::move(l))
+      , _instance(instance)
+      , _workers(workers)
+      , _host_function_environments(std::move(host_function_environments)) {}
+    wasmtime_engine(const wasmtime_engine&) = delete;
+    wasmtime_engine& operator=(const wasmtime_engine&) = delete;
+    wasmtime_engine(wasmtime_engine&&) = default;
+    wasmtime_engine& operator=(wasmtime_engine&&) = default;
+
+    ~wasmtime_engine() override = default;
+
+    std::string_view function_name() const final { return _user_module_name; }
+
+    uint64_t memory_usage_size_bytes() const final {
+        std::string_view memory_export_name = "memory";
+        auto* ctx = wasmtime_store_context(_store.get());
+        wasmtime_extern_t memory_extern;
+        bool ok = wasmtime_instance_export_get(
+          ctx,
+          &_instance,
+          memory_export_name.data(),
+          memory_export_name.size(),
+          &memory_extern);
+        if (!ok || memory_extern.kind != WASMTIME_EXTERN_MEMORY) {
+            return 0;
+        }
+        return wasmtime_memory_data_size(ctx, &memory_extern.of.memory);
+    };
+
+    ss::future<> start() final { co_return; }
+
+    ss::future<> initialize() final { return initialize_wasi(); }
+
+    ss::future<> stop() final { co_return; }
+
+    struct transform_result {
+        model::record_batch batch;
+        // it's not safe to access seastar state in an alien thread, so make
+        // sure we're passing back the stats we need to record.
+        std::vector<uint64_t> latencies;
+    };
+
+    ss::future<model::record_batch>
+    transform(model::record_batch batch, transform_probe* probe) override {
+        vlog(wasm_log.trace, "Transforming batch: {}", batch.header());
+        if (batch.record_count() == 0) {
+            co_return std::move(batch);
+        }
+        if (batch.compressed()) {
+            batch = co_await storage::internal::decompress_batch(
+              std::move(batch));
+        }
+        ss::future<transform_result> fut = co_await ss::coroutine::as_future(
+          invoke_transform(&batch));
+        if (fut.failed()) {
+            probe->transform_error();
+            std::rethrow_exception(fut.get_exception());
+        }
+        transform_result r = std::move(fut).get();
+        for (uint64_t latency : r.latencies) {
+            probe->record_latency(latency);
+        }
+        co_return std::move(r.batch);
+    }
+
+private:
+    void reset_fuel() {
+        auto* ctx = wasmtime_store_context(_store.get());
+        uint64_t fuel = 0;
+        wasmtime_context_fuel_remaining(ctx, &fuel);
+        handle<wasmtime_error_t, wasmtime_error_delete> error(
+          wasmtime_context_add_fuel(ctx, wasmtime_fuel_amount - fuel));
+    }
+
+    ss::future<> initialize_wasi() {
+        return _workers->submit([this] {
+            // TODO: Consider having a different amount of fuel for
+            // initialization.
+            reset_fuel();
+            auto* ctx = wasmtime_store_context(_store.get());
+            wasmtime_extern_t start;
+            bool ok = wasmtime_instance_export_get(
+              ctx,
+              &_instance,
+              wasi::preview_1_start_function_name.data(),
+              wasi::preview_1_start_function_name.size(),
+              &start);
+            if (!ok || start.kind != WASMTIME_EXTERN_FUNC) {
+                throw wasm_exception(
+                  "Missing wasi initialization function",
+                  errc::user_code_failure);
+            }
+            vlog(
+              wasm_log.info,
+              "Initializing wasm function {}",
+              _user_module_name);
+            wasm_trap_t* trap_ptr = nullptr;
+            handle<wasmtime_error_t, wasmtime_error_delete> error{
+              wasmtime_func_call(
+                ctx, &start.of.func, nullptr, 0, nullptr, 0, &trap_ptr)};
+            handle<wasm_trap_t, wasm_trap_delete> trap{trap_ptr};
+            check_error(error.get());
+            check_trap(trap.get());
+            vlog(
+              wasm_log.info, "Wasm function {} initialized", _user_module_name);
+        });
+    }
+
+    ss::future<transform_result>
+    invoke_transform(const model::record_batch* batch) {
+        return _workers->submit([this, batch] {
+            std::vector<uint64_t> latencies;
+            auto* ctx = wasmtime_store_context(_store.get());
+            wasmtime_extern_t cb;
+            bool ok = wasmtime_instance_export_get(
+              ctx,
+              &_instance,
+              redpanda_on_record_callback_function_name.data(),
+              redpanda_on_record_callback_function_name.size(),
+              &cb);
+            if (!ok || cb.kind != WASMTIME_EXTERN_FUNC) {
+                throw wasm_exception(
+                  "Missing wasi initialization function",
+                  errc::user_code_failure);
+            }
+            auto transformed = _transform_module->for_each_record(
+              batch, [this, &ctx, &cb, &latencies](wasm_call_params params) {
+                  reset_fuel();
+                  _wasi_module->set_timestamp(params.current_record_timestamp);
+                  auto recorder = ss::defer(
+                    [&latencies,
+                     start_time = transform_probe::hist_t::clock_type::now()] {
+                        latencies.push_back(
+                          std::chrono::duration_cast<
+                            transform_probe::hist_t::duration_type>(
+                            transform_probe::hist_t::clock_type::now()
+                            - start_time)
+                            .count());
+                    });
+                  wasmtime_val_t result = {
+                    .kind = WASMTIME_I32, .of = {.i32 = -1}};
+                  std::array<wasmtime_val_t, 4> args = {
+                    wasmtime_val_t{
+                      .kind = WASMTIME_I32, .of = {.i32 = params.batch_handle}},
+                    {.kind = WASMTIME_I32, .of = {.i32 = params.record_handle}},
+                    {.kind = WASMTIME_I32, .of = {.i32 = params.record_size}},
+                    {.kind = WASMTIME_I32,
+                     .of = {.i32 = params.current_record_offset}}};
+                  wasm_trap_t* trap_ptr = nullptr;
+                  handle<wasmtime_error_t, wasmtime_error_delete> error{
+                    wasmtime_func_call(
+                      ctx,
+                      &cb.of.func,
+                      args.data(),
+                      args.size(),
+                      &result,
+                      /*results_size=*/1,
+                      &trap_ptr)};
+                  handle<wasm_trap_t, wasm_trap_delete> trap{trap_ptr};
+                  check_error(error.get());
+                  check_trap(trap.get());
+                  if (result.kind != WASMTIME_I32 || result.of.i32 != 0) {
+                      throw wasm_exception(
+                        ss::format(
+                          "transform execution {} resulted in error {}",
+                          _user_module_name,
+                          result.of.i32),
+                        errc::user_code_failure);
+                  }
+              });
+            return transform_result{
+              .batch = std::move(transformed),
+              .latencies = std::move(latencies),
+            };
+        });
+    }
+
+    ss::sstring _user_module_name;
+    handle<wasmtime_store_t, wasmtime_store_delete> _store;
+    std::shared_ptr<wasmtime_module_t> _user_module;
+    std::unique_ptr<transform_module> _transform_module;
+    std::unique_ptr<schema_registry_module> _sr_module;
+    std::unique_ptr<wasi::preview1_module> _wasi_module;
+    handle<wasmtime_linker_t, wasmtime_linker_delete> _linker;
+    wasmtime_instance_t _instance;
+    ssx::sharded_thread_worker* _workers;
+    std::vector<std::unique_ptr<host_function_environment>>
+      _host_function_environments;
+};
+
+class wasmtime_engine_factory : public factory {
+public:
+    wasmtime_engine_factory(
+      wasm_engine_t* engine,
+      model::transform_metadata meta,
+      std::shared_ptr<wasmtime_module_t> mod,
+      schema_registry* sr,
+      ss::logger* l,
+      ssx::sharded_thread_worker* w)
+      : _engine(engine)
+      , _module(std::move(mod))
+      , _meta(std::move(meta))
+      , _sr(sr)
+      , _logger(l)
+      , _workers(w) {}
+
+    ss::future<std::unique_ptr<engine>> make_engine() final {
+        ss::alien::instance* alien = &ss::engine().alien();
+        ss::shard_id shard_id = ss::this_shard_id();
+        return _workers->submit(
+          [this, alien, shard_id]() -> std::unique_ptr<engine> {
+              handle<wasmtime_store_t, wasmtime_store_delete> store{
+                wasmtime_store_new(_engine, nullptr, nullptr)};
+              auto* context = wasmtime_store_context(store.get());
+              handle<wasmtime_error_t, wasmtime_error_delete> error(
+                wasmtime_context_add_fuel(context, 0));
+              check_error(error.get());
+              handle<wasmtime_linker_t, wasmtime_linker_delete> linker{
+                wasmtime_linker_new(_engine)};
+
+              std::vector<std::unique_ptr<host_function_environment>>
+                host_function_envs;
+
+              auto xform_module = std::make_unique<transform_module>();
+              host_function_envs.push_back(register_transform_module(
+                xform_module.get(), linker.get(), alien, shard_id));
+
+              auto sr_module = std::make_unique<schema_registry_module>(_sr);
+              host_function_envs.push_back(register_sr_module(
+                sr_module.get(), linker.get(), alien, shard_id));
+
+              std::vector<ss::sstring> args{_meta.name()};
+              absl::flat_hash_map<ss::sstring, ss::sstring> env
+                = _meta.environment;
+              env.emplace("REDPANDA_INPUT_TOPIC", _meta.input_topic.tp());
+              env.emplace(
+                "REDPANDA_OUTPUT_TOPIC", _meta.output_topics.begin()->tp());
+              auto wasi_module = std::make_unique<wasi::preview1_module>(
+                std::move(args), std::move(env), _logger);
+              host_function_envs.push_back(register_wasi_module(
+                wasi_module.get(), linker.get(), alien, shard_id));
+
+              wasmtime_instance_t instance;
+              wasm_trap_t* trap_ptr = nullptr;
+              error.reset(wasmtime_linker_instantiate(
+                linker.get(), context, _module.get(), &instance, &trap_ptr));
+              handle<wasm_trap_t, wasm_trap_delete> trap{trap_ptr};
+              check_error(error.get());
+              check_trap(trap.get());
+
+              return std::make_unique<wasmtime_engine>(
+                _meta.name(),
+                std::move(linker),
+                std::move(store),
+                _module,
+                std::move(xform_module),
+                std::move(sr_module),
+                std::move(wasi_module),
+                std::move(host_function_envs),
+                instance,
+                _workers);
+          });
+    }
+
+private:
+    wasm_engine_t* _engine;
+    std::shared_ptr<wasmtime_module_t> _module;
+    model::transform_metadata _meta;
+    schema_registry* _sr;
+    ss::logger* _logger;
+    ssx::sharded_thread_worker* _workers;
+};
+
+class wasmtime_runtime : public runtime {
+public:
+    wasmtime_runtime(
+      handle<wasm_engine_t, &wasm_engine_delete> h,
+      std::unique_ptr<schema_registry> sr)
+      : _engine(std::move(h))
+      , _sr(std::move(sr)) {}
+
+    ss::future<> start() override {
+        co_await _workers.start({.name = "wasm"});
+        co_await ss::smp::invoke_on_all([this] {
+            return _workers.submit([] {
+                // wasmtime needs some signals for it's handling, make sure we
+                // unblock them
+                auto mask = ss::make_empty_sigset_mask();
+                sigaddset(&mask, SIGSEGV);
+                sigaddset(&mask, SIGILL);
+                sigaddset(&mask, SIGFPE);
+                ss::throw_pthread_error(
+                  ::pthread_sigmask(SIG_UNBLOCK, &mask, nullptr));
+            });
+        });
+    }
+
+    ss::future<> stop() override { return _workers.stop(); }
+
+    ss::future<std::unique_ptr<factory>> make_factory(
+      model::transform_metadata meta, iobuf buf, ss::logger* logger) override {
+        auto user_module = co_await _workers.submit([this, &meta, &buf] {
+            vlog(wasm_log.debug, "compiling wasm module {}", meta.name);
+            bytes b = iobuf_to_bytes(buf);
+            wasmtime_module_t* user_module_ptr = nullptr;
+            handle<wasmtime_error_t, wasmtime_error_delete> error{
+              wasmtime_module_new(
+                _engine.get(), b.data(), b.size(), &user_module_ptr)};
+            check_error(error.get());
+            std::shared_ptr<wasmtime_module_t> user_module{
+              user_module_ptr, wasmtime_module_delete};
+            wasm_log.info("Finished compiling wasm module {}", meta.name);
+            return user_module;
+        });
+        co_return std::make_unique<wasmtime_engine_factory>(
+          _engine.get(),
+          std::move(meta),
+          user_module,
+          _sr.get(),
+          logger,
+          &_workers);
+    }
+
+private:
+    handle<wasm_engine_t, &wasm_engine_delete> _engine;
+    std::unique_ptr<schema_registry> _sr;
+    ssx::sharded_thread_worker _workers;
+};
+
+} // namespace
+
+std::unique_ptr<runtime> create_runtime(std::unique_ptr<schema_registry> sr) {
+    wasm_config_t* config = wasm_config_new();
+
+    wasmtime_config_cranelift_opt_level_set(config, WASMTIME_OPT_LEVEL_SPEED);
+    wasmtime_config_consume_fuel_set(config, true);
+    wasmtime_config_wasm_bulk_memory_set(config, true);
+    // Our internal build disables this feature, so we don't need to turn it
+    // off, otherwise we'd want to turn this off by default.
+    // wasmtime_config_parallel_compilation_set(config, false);
+
+    // Set max stack size to generally be as big as a contiguous memory region
+    // we're willing to allocate in Redpanda.
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    wasmtime_config_max_wasm_stack_set(config, 128_KiB);
+    // This disables static memory
+    wasmtime_config_static_memory_maximum_size_set(config, 0_KiB);
+    wasmtime_config_dynamic_memory_guard_size_set(config, 0_KiB);
+    wasmtime_config_dynamic_memory_reserved_for_growth_set(config, 0_KiB);
+    // don't modify the unwind info as registering these symbols causes C++
+    // exceptions to grab a lock in libgcc and deadlock the Redpanda process.
+    wasmtime_config_native_unwind_info_set(config, false);
+
+    handle<wasm_engine_t, &wasm_engine_delete> engine{
+      wasm_engine_new_with_config(config)};
+    return std::make_unique<wasmtime_runtime>(std::move(engine), std::move(sr));
+}
+} // namespace wasm::wasmtime

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -707,6 +707,8 @@ public:
       model::transform_metadata meta, iobuf buf, ss::logger* logger) override {
         auto user_module = co_await _workers.submit([this, &meta, &buf] {
             vlog(wasm_log.debug, "compiling wasm module {}", meta.name);
+            // This can be a large contiguous allocation, however it happens on
+            // an alien thread so it bypasses the seastar allocator.
             bytes b = iobuf_to_bytes(buf);
             wasmtime_module_t* user_module_ptr = nullptr;
             handle<wasmtime_error_t, wasmtime_error_delete> error{

--- a/src/v/wasm/wasmtime.h
+++ b/src/v/wasm/wasmtime.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "seastarx.h"
+#include "ssx/thread_worker.h"
+#include "wasm/fwd.h"
+
+#include <seastar/core/future.hh>
+
+namespace wasm::wasmtime {
+std::unique_ptr<runtime> create_runtime(std::unique_ptr<schema_registry>);
+}


### PR DESCRIPTION
This patchset introduces wasmtime as a wasm::runtime in Redpanda and switches our usages over to it.

Currently WasmEdge AOT doesn't work in Redpanda, and the interpreter mode doesn't give us acceptable performance.

Instead we JIT compile WebAssembly at runtime for better performance. We must run compilation of WebAssembly on an
alien thread, Rust + cranelift (Wasmtime's JIT compiler) puts too much data on the stack, so at least in tests when 
we're running on a ss::thread with 128KiB of stack, we get stack overflow assertions in ASAN. Also compilation is 
synchronous and can be quite slow with large modules, so that will always need to run on an alien thread.

This PR also runs Wasmtime's VM itself on an alien thread - as there is some signals that the VM relies on to operate, 
which seem cause issues when run on the reactor. Potenially we could [remove the need for Wasmtime to use signals][signals],
but an alien thread gives us stability for now, more analysis can be done to see if there is a way to ensure that we can
properly handle these signals within seastar.

[signals]: https://github.com/bytecodealliance/wasmtime/issues/6926

Related vtools changes: https://github.com/redpanda-data/vtools/pull/2014

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
