### PR TITLE
operator: add dependabot only for /src/go/k8s

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: go
-    directory: /src/go/k8s
+  - package-ecosystem: gomod
+    directory: /src/go/k8s/
     schedule:
       interval: daily
     groups:
@@ -11,3 +11,7 @@ updates:
           - "k8s.io/*"
         exclude-patterns:
           - "k8s.io/utils"
+    labels:
+      - dependencies
+      - area/k8s
+      - k8s/tests


### PR DESCRIPTION
Enable dependabot PRs for the `src/go/k8s` tree

## Backports Required


- [x] none - not a bug fix


## Release Notes

* none
