### PR TITLE
[storage]: make space management chill out

### DIFF
--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -110,7 +110,14 @@ ss::future<> disk_space_manager::run_loop() {
             continue;
         }
 
-        co_await manage_data_disk(_target_size);
+        try {
+            co_await manage_data_disk(_target_size);
+        } catch (...) {
+            vlog(
+              stlog.info,
+              "Recoverable error running space management loop: {}",
+              std::current_exception());
+        }
     }
 }
 

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -270,6 +270,7 @@ private:
     storage_resources& _resources;
     ss::sharded<features::feature_table>& _feature_table;
     simple_time_jitter<ss::lowres_clock> _jitter;
+    simple_time_jitter<ss::lowres_clock> _trigger_gc_jitter;
     logs_type _logs;
     compaction_list_type _logs_list;
     batch_cache _batch_cache;


### PR DESCRIPTION
Unbounded creation of num_partition * num_segment futures combined with default (1000) share scheduling group meant that a system with a large number of partitions/segments could really drown out other work.

Reduces concurrency and CPU shares to address concern.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

