### PR TITLE
cloud_storage: replace empty dir type with fragmented vector

### DIFF
--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -98,7 +98,7 @@ ss::future<walk_result> recursive_directory_walker::walk(
     // Object to accumulate data as we walk directories
     walk_accumulator state(start_dir, tracker, std::move(collect_filter));
 
-    std::vector<ss::sstring> empty_dirs;
+    fragmented_vector<ss::sstring> empty_dirs;
 
     while (!state.empty()) {
         auto target = state.pop();

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -32,7 +32,7 @@ struct walk_result {
     uint64_t cache_size{0};
     size_t filtered_out_files{0};
     fragmented_vector<file_list_item> regular_files;
-    std::vector<ss::sstring> empty_dirs;
+    fragmented_vector<ss::sstring> empty_dirs;
 };
 
 class recursive_directory_walker {


### PR DESCRIPTION
It's typically unexpected for this container to grow large, but we've seen it before during manual intervention on a node: when trying to quickly clear out recent data from a cache directory.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Bug Fixes

* Redpanda will now allocate less contiguous memory when scanning a tiered storage cache directory that contains many empty directories.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
