### PR TITLE
[v23.1.x] schema_registry: Support GET /schemas/ids/{id}/subjects

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -322,6 +322,55 @@
         }
       }
     },
+    "/schemas/ids/{id}/subjects": {
+      "get": {
+        "summary": "Retrieve a list of subjects associated with some schema ID.",
+        "operationId": "get_schemas_ids_id_subjects",
+        "consumes": [
+          "application/vnd.schemaregistry.v1+json",
+          "application/vnd.schemaregistry+json",
+          "application/json"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "type": "integer"
+          },
+          {
+            "name": "deleted",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
+          }
+        ],
+        "produces": ["application/vnd.schemaregistry.v1+json"],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "404": {
+            "description": "Schema not found",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          },
+          "500": {
+            "description": "Internal Server error",
+            "schema": {
+              "$ref": "#/definitions/error_body"
+            }
+          }
+        }
+      }
+    },
     "/subjects": {
       "get": {
         "summary": "Retrieve a list of subjects.",

--- a/src/v/pandaproxy/api/api-doc/schema_registry_header.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_header.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "Pandaproxy Schema Registry",
-    "version": "1.0.2"
+    "version": "1.0.3"
   },
   "host": "{{Host}}",
   "basePath": "/",

--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -234,6 +234,28 @@ get_schemas_ids_id_versions(server::request_t rq, server::reply_t rp) {
     co_return rp;
 }
 
+ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp) {
+    parse_accept_header(rq, rp);
+    auto id = parse::request_param<schema_id>(*rq.req, "id");
+    auto incl_del{
+      parse::query_param<std::optional<include_deleted>>(*rq.req, "deleted")
+        .value_or(include_deleted::no)};
+    rq.req.reset();
+
+    // List-type request: must ensure we see latest writes
+    co_await rq.service().writer().read_sync();
+
+    // Force early 40403 if the schema id isn't found
+    co_await rq.service().schema_store().get_schema_definition(id);
+
+    auto subjects = co_await rq.service().schema_store().get_schema_subjects(
+      id, incl_del);
+    auto json_rslt{json::rjson_serialize(subjects)};
+    rp.rep->write_body("json", json_rslt);
+    co_return rp;
+}
+
 ss::future<server::reply_t>
 get_subjects(server::request_t rq, server::reply_t rp) {
     parse_accept_header(rq, rp);

--- a/src/v/pandaproxy/schema_registry/handlers.h
+++ b/src/v/pandaproxy/schema_registry/handlers.h
@@ -43,6 +43,9 @@ ss::future<ctx_server<service>::reply_t> get_schemas_ids_id(
 ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_versions(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 
+ss::future<ctx_server<service>::reply_t> get_schemas_ids_id_subjects(
+  ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
+
 ss::future<ctx_server<service>::reply_t> get_subjects(
   ctx_server<service>::request_t rq, ctx_server<service>::reply_t rp);
 

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -120,6 +120,10 @@ server::routes_t get_schema_registry_routes(ss::gate& gate, one_shot& es) {
       wrap(gate, es, get_schemas_ids_id_versions)});
 
     routes.routes.emplace_back(server::route_t{
+      ss::httpd::schema_registry_json::get_schemas_ids_id_subjects,
+      wrap(gate, es, get_schemas_ids_id_subjects)});
+
+    routes.routes.emplace_back(server::route_t{
       ss::httpd::schema_registry_json::get_subjects,
       wrap(gate, es, get_subjects)});
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -33,6 +33,7 @@
 #include <fmt/core.h>
 
 #include <functional>
+#include <iterator>
 
 namespace pandaproxy::schema_registry {
 
@@ -304,6 +305,24 @@ sharded_store::get_schema_subject_versions(schema_id id) {
       };
     co_return co_await _store.map_reduce0(
       map, std::vector<subject_version>{}, reduce);
+}
+
+ss::future<std::vector<subject>>
+sharded_store::get_schema_subjects(schema_id id, include_deleted inc_del) {
+    auto map = [id, inc_del](store& s) {
+        return s.get_schema_subjects(id, inc_del);
+    };
+    auto reduce = [](std::vector<subject> acc, std::vector<subject> subs) {
+        acc.insert(
+          acc.end(),
+          std::make_move_iterator(subs.begin()),
+          std::make_move_iterator(subs.end()));
+        return acc;
+    };
+    auto subs = co_await _store.map_reduce0(
+      map, std::vector<subject>{}, reduce);
+    absl::c_sort(subs);
+    co_return subs;
 }
 
 ss::future<subject_schema> sharded_store::get_subject_schema(

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -67,6 +67,10 @@ public:
     ss::future<std::vector<subject_version>>
     get_schema_subject_versions(schema_id id);
 
+    ///\brief Return a list of subjects for the schema id.
+    ss::future<std::vector<subject>>
+    get_schema_subjects(schema_id id, include_deleted inc_del);
+
     ///\brief Return a schema by subject and version (or latest).
     ss::future<subject_schema> get_subject_schema(
       subject sub,

--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -112,6 +112,21 @@ public:
         return svs;
     }
 
+    ///\brief Return a list of subjects for the schema id.
+    std::vector<subject>
+    get_schema_subjects(schema_id id, include_deleted inc_del) {
+        std::vector<subject> subs;
+        for (const auto& s : _subjects) {
+            if (absl::c_any_of(
+                  s.second.versions, [id, inc_del](const auto& vs) {
+                      return vs.id == id && (inc_del || !vs.deleted);
+                  })) {
+                subs.emplace_back(s.first);
+            }
+        }
+        return subs;
+    }
+
     ///\brief Return subject_version_id for a subject and version
     result<subject_version_entry> get_subject_version_id(
       const subject& sub,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13020
Fixes: https://github.com/redpanda-data/redpanda/issues/13083,