### PR TITLE
[v22.3.x] cloud_storage: replace empty dir type with fragmented vector

### DIFF
--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -83,7 +83,7 @@ ss::future<walk_result> recursive_directory_walker::walk(
     // Object to accumulate data as we walk directories
     walk_accumulator state(start_dir, tracker);
 
-    std::vector<ss::sstring> empty_dirs;
+    fragmented_vector<ss::sstring> empty_dirs;
 
     while (!state.empty()) {
         auto target = state.pop();

--- a/src/v/cloud_storage/recursive_directory_walker.h
+++ b/src/v/cloud_storage/recursive_directory_walker.h
@@ -30,7 +30,7 @@ struct file_list_item {
 struct walk_result {
     uint64_t cache_size{0};
     fragmented_vector<file_list_item> regular_files;
-    std::vector<ss::sstring> empty_dirs;
+    fragmented_vector<ss::sstring> empty_dirs;
 };
 
 class recursive_directory_walker {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13079
