### PR TITLE
[v23.2.x] cloud_storage: become compatible with Azure Storage Accounts where HNS is enabled

### DIFF
--- a/cmake/oss.cmake.in
+++ b/cmake/oss.cmake.in
@@ -179,7 +179,7 @@ ExternalProject_Add(fmt
 
 ExternalProject_Add(seastar
   GIT_REPOSITORY https://github.com/redpanda-data/seastar.git
-  GIT_TAG 2dd7455b854d97dcba8c8030eb90026e50b073c2
+  GIT_TAG 2b3c2992ca2c913c26e8a52f00f0eb8adf4c896f
   INSTALL_DIR    @REDPANDA_DEPS_INSTALL_DIR@
   CMAKE_COMMAND ${CMAKE_COMMAND} -E env ${cmake_build_env} ${CMAKE_COMMAND}
   LIST_SEPARATOR |

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -170,12 +170,6 @@ ntp_archiver::ntp_archiver(
       config::shard_local_cfg().cloud_storage_housekeeping_interval_ms.bind())
   , _housekeeping_jitter(_housekeeping_interval(), housekeeping_jit)
   , _next_housekeeping(_housekeeping_jitter())
-  , _segment_tags(cloud_storage::remote::make_segment_tags(_ntp, _rev))
-  , _manifest_tags(
-      cloud_storage::remote::make_partition_manifest_tags(_ntp, _rev))
-  , _tx_tags(cloud_storage::remote::make_tx_manifest_tags(_ntp, _rev))
-  , _segment_index_tags(
-      cloud_storage::remote::make_segment_index_tags(_ntp, _rev))
   , _local_segment_merger(maybe_make_adjacent_segment_merger(
       *this, _rtclog, parent.log().config(), parent.is_leader()))
   , _manifest_upload_interval(
@@ -936,7 +930,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
       manifest().get_manifest_path());
 
     auto result = co_await _remote.upload_manifest(
-      get_bucket_name(), manifest(), fib, _manifest_tags);
+      get_bucket_name(), manifest(), fib);
 
     if (result == cloud_storage::upload_result::success) {
         _last_manifest_upload_time = ss::lowres_clock::now();
@@ -1069,8 +1063,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::do_upload_segment(
           candidate.content_length,
           std::move(reset_func),
           fib,
-          lazy_abort_source,
-          _segment_tags);
+          lazy_abort_source);
     } catch (const ss::gate_closed_exception&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const ss::abort_requested_exception&) {
@@ -1133,7 +1126,6 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
           cloud_storage_clients::object_key{index_path},
           idx_res->index.to_iobuf(),
           fib,
-          _segment_index_tags,
           "segment-index");
 
         co_return ntp_archiver_upload_result(idx_res->stats);
@@ -1238,7 +1230,7 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_tx(
     cloud_storage::tx_range_manifest manifest(path, std::move(tx_range));
 
     co_return co_await _remote.upload_manifest(
-      get_bucket_name(), manifest, fib, _tx_tags);
+      get_bucket_name(), manifest, fib);
 }
 
 ss::future<std::optional<ntp_archiver::make_segment_index_result>>

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -422,8 +422,9 @@ ss::future<> ntp_archiver::upload_topic_manifest() {
         } else {
             _topic_manifest_dirty = false;
         }
-    } catch (const ss::gate_closed_exception& err) {
-    } catch (const ss::abort_requested_exception& err) {
+    } catch (const ss::gate_closed_exception&) {
+    } catch (const ss::broken_named_semaphore&) {
+    } catch (const ss::abort_requested_exception&) {
     } catch (...) {
         vlog(
           _rtclog.warn,
@@ -1067,6 +1068,8 @@ ss::future<cloud_storage::upload_result> ntp_archiver::do_upload_segment(
     } catch (const ss::gate_closed_exception&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const ss::abort_requested_exception&) {
+        response = cloud_storage::upload_result::cancelled;
+    } catch (const ss::broken_named_semaphore&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const std::exception& e) {
         vlog(_rtclog.error, "failed to upload segment {}: {}", path, e);

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -636,11 +636,6 @@ private:
 
     std::optional<ntp_level_probe> _probe{std::nullopt};
 
-    const cloud_storage_clients::object_tag_formatter _segment_tags;
-    const cloud_storage_clients::object_tag_formatter _manifest_tags;
-    const cloud_storage_clients::object_tag_formatter _tx_tags;
-    const cloud_storage_clients::object_tag_formatter _segment_index_tags;
-
     // NTP level adjacent segment merging job
     std::unique_ptr<housekeeping_job> _local_segment_merger;
 

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -548,8 +548,6 @@ scrubber::write_remote_lifecycle_marker(
       marker_key,
       serde::to_iobuf(std::move(remote_marker)),
       marker_rtc,
-      _api.make_lifecycle_marker_tags(
-        nt_revision.nt.ns, nt_revision.nt.tp, nt_revision.initial_revision_id),
       "remote_lifecycle_marker");
 }
 

--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -428,7 +428,7 @@ static constexpr auto required_headers = {
   "If-Modified-Since",
   "If-Match",
   "If-None-Match",
-  "If-UnmodifiedSince",
+  "If-Unmodified-Since",
   "Range"};
 
 result<ss::sstring> signature_abs::get_canonicalized_resource(

--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -155,7 +155,7 @@ private:
     // version that we've tested with is used in field.
     //
     // Update this version to use a different storage API version.
-    static constexpr auto azure_storage_api_version = "2021-08-06";
+    static constexpr auto azure_storage_api_version = "2023-01-03";
 
     result<ss::sstring>
     get_string_to_sign(http::client::request_header& header) const;

--- a/src/v/cloud_roles/tests/signature_test.cc
+++ b/src/v/cloud_roles/tests/signature_test.cc
@@ -188,7 +188,7 @@ SEASTAR_THREAD_TEST_CASE(test_abs_signature_computation) {
 
     std::string expected
       = "SharedKey "
-        "vladstorageaccount123:rDsCDHPhdsr7SMkt81ofyrnNNxL3VKFW7ydsDQeVPIM=";
+        "vladstorageaccount123:W5Xz1fJNgftpQm0ppLUcOJRzXStXct7OEe8pgj7Og5A=";
 
     BOOST_REQUIRE_EQUAL(
       header.at(boost::beast::http::field::authorization), expected);
@@ -216,7 +216,7 @@ SEASTAR_THREAD_TEST_CASE(test_abs_signature_computation_many_query_params) {
 
     std::string expected
       = "SharedKey "
-        "vladstorageaccount123:hWp74AgakkrSYVzYBKSabfLP4NWVa410CNRm/dMxX2M=";
+        "vladstorageaccount123:2P67qqyi833QDaUq+ghFvwewOJkJFjA8PY3hnssTy0M=";
 
     BOOST_REQUIRE_EQUAL(
       header.at(boost::beast::http::field::authorization), expected);

--- a/src/v/cloud_storage/recovery_utils.cc
+++ b/src/v/cloud_storage/recovery_utils.cc
@@ -68,14 +68,11 @@ ss::future<> place_download_result(
   retry_chain_node& parent) {
     retry_chain_node fib{&parent};
     auto result_path = generate_result_path(ntp_cfg, result_completed);
-    cloud_storage_clients::object_tag_formatter tags{
-      {"rp-type", "download-result"}};
     auto result = co_await remote.upload_object(
       bucket,
       cloud_storage_clients::object_key{result_path},
       iobuf{},
       fib,
-      tags,
       "download result file");
     if (result != upload_result::success) {
         vlog(

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -117,17 +117,6 @@ enum class api_activity_notification {
 /// things like reconnects, backpressure and backoff.
 class remote : public ss::peering_sharded_service<remote> {
 public:
-    /// Default tags applied to objects
-    static const cloud_storage_clients::object_tag_formatter
-      default_segment_tags;
-    static const cloud_storage_clients::object_tag_formatter
-      default_partition_manifest_tags;
-    static const cloud_storage_clients::object_tag_formatter
-      default_topic_manifest_tags;
-    static const cloud_storage_clients::object_tag_formatter default_index_tags;
-    static const cloud_storage_clients::object_tag_formatter
-      default_lifecycle_marker_tags;
-
     /// Functor that returns fresh input_stream object that can be used
     /// to re-upload and will return all data that needs to be uploaded
     using reset_input_stream = ss::noncopyable_function<
@@ -248,9 +237,7 @@ public:
     ss::future<upload_result> upload_manifest(
       const cloud_storage_clients::bucket_name& bucket,
       const base_manifest& manifest,
-      retry_chain_node& parent,
-      const cloud_storage_clients::object_tag_formatter& tags
-      = default_partition_manifest_tags);
+      retry_chain_node& parent);
 
     /// \brief Upload segment to S3
     ///
@@ -266,9 +253,7 @@ public:
       uint64_t content_length,
       const reset_input_stream& reset_str,
       retry_chain_node& parent,
-      lazy_abort_source& lazy_abort_source,
-      const cloud_storage_clients::object_tag_formatter& tags
-      = default_segment_tags);
+      lazy_abort_source& lazy_abort_source);
 
     /// \brief Download segment from S3
     ///
@@ -362,7 +347,6 @@ public:
       const cloud_storage_clients::object_key& object_path,
       iobuf payload,
       retry_chain_node& parent,
-      const cloud_storage_clients::object_tag_formatter& tags,
       const char* log_object_type = "object");
 
     ss::future<download_result> do_download_manifest(
@@ -433,28 +417,6 @@ public:
     /// \return the future which will be available after the next cloud storage
     ///         API operation.
     ss::future<api_activity_notification> subscribe(event_filter& filter);
-
-    /// Add partition manifest tags (includes partition id)
-    static cloud_storage_clients::object_tag_formatter
-    make_partition_manifest_tags(
-      const model::ntp& ntp, model::initial_revision_id rev);
-    /// Add topic manifest tags (no partition id)
-    static cloud_storage_clients::object_tag_formatter make_topic_manifest_tags(
-      const model::topic_namespace& ntp, model::initial_revision_id rev);
-    /// Add segment level tags
-    static cloud_storage_clients::object_tag_formatter
-    make_segment_tags(const model::ntp& ntp, model::initial_revision_id rev);
-    /// Add tags for tx-manifest
-    static cloud_storage_clients::object_tag_formatter make_tx_manifest_tags(
-      const model::ntp& ntp, model::initial_revision_id rev);
-
-    static cloud_storage_clients::object_tag_formatter make_segment_index_tags(
-      const model::ntp& ntp, model::initial_revision_id rev);
-    static cloud_storage_clients::object_tag_formatter
-    make_lifecycle_marker_tags(
-      const model::ns& ns,
-      const model::topic& topic,
-      const model::initial_revision_id rev);
 
     // If you need to spawn a background task that relies on
     // this object staying alive, spawn it with this gate.

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1083,7 +1083,6 @@ struct finalize_data {
     model::initial_revision_id revision;
     cloud_storage_clients::bucket_name bucket;
     cloud_storage_clients::object_key key;
-    cloud_storage_clients::object_tag_formatter tags;
     iobuf serialized_manifest;
     model::offset insync_offset;
 };
@@ -1138,7 +1137,6 @@ ss::future<> finalize_background(remote& api, finalize_data data) {
           data.key,
           std::move(data.serialized_manifest),
           local_rtc,
-          data.tags,
           "manifest");
 
         if (manifest_put_result != upload_result::success) {
@@ -1182,8 +1180,6 @@ void remote_partition::finalize() {
       .bucket = _bucket,
       .key
       = cloud_storage_clients::object_key{stm_manifest.get_manifest_path()()},
-      .tags = cloud_storage::remote::make_partition_manifest_tags(
-        stm_manifest.get_ntp(), stm_manifest.get_revision_id()),
       .serialized_manifest = std::move(serialized_manifest),
       .insync_offset = stm_manifest.get_insync_offset()};
 

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -199,8 +199,7 @@ void upload_index(
                           cloud_storage_clients::object_key{
                             path().native() + ".index"},
                           std::move(ixbuf),
-                          fib,
-                          remote::default_index_tags)
+                          fib)
                         .get();
     BOOST_REQUIRE(upload_res == upload_result::success);
 }

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -99,8 +99,6 @@ static iobuf make_iobuf_from_string(std::string_view s) {
     return b;
 }
 
-static const cloud_storage_clients::object_tag_formatter upload_tags{{}};
-
 struct noop_mixin_t {};
 
 template<model::cloud_storage_backend backend>
@@ -605,8 +603,7 @@ FIXTURE_TEST(test_list_bucket, remote_fixture) {
                 cloud_storage_clients::object_key path{
                   fmt::format("{}/{}/{}", i, j, k)};
                 auto result = remote.local()
-                                .upload_object(
-                                  bucket, path, iobuf{}, fib, upload_tags)
+                                .upload_object(bucket, path, iobuf{}, fib)
                                 .get();
                 BOOST_REQUIRE_EQUAL(
                   cloud_storage::upload_result::success, result);
@@ -652,10 +649,8 @@ FIXTURE_TEST(test_list_bucket_with_prefix, remote_fixture) {
         for (const char second : {'a', 'b'}) {
             cloud_storage_clients::object_key path{
               fmt::format("{}/{}", first, second)};
-            auto result = remote.local()
-                            .upload_object(
-                              bucket, path, iobuf{}, fib, upload_tags)
-                            .get();
+            auto result
+              = remote.local().upload_object(bucket, path, iobuf{}, fib).get();
             BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
         }
     }
@@ -681,9 +676,8 @@ FIXTURE_TEST(test_list_bucket_with_filter, remote_fixture) {
     retry_chain_node fib(never_abort, 100ms, 20ms);
     cloud_storage_clients::bucket_name bucket{"test"};
     cloud_storage_clients::object_key path{"b"};
-    auto upl_result = remote.local()
-                        .upload_object(bucket, path, iobuf{}, fib, upload_tags)
-                        .get();
+    auto upl_result
+      = remote.local().upload_object(bucket, path, iobuf{}, fib).get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, upl_result);
 
     auto result = remote.local()
@@ -708,11 +702,10 @@ FIXTURE_TEST(test_put_string, remote_fixture) {
     retry_chain_node fib(never_abort, 100ms, 20ms);
 
     cloud_storage_clients::object_key path{"p"};
-    auto result
-      = remote.local()
-          .upload_object(
-            bucket, path, make_iobuf_from_string("p"), fib, upload_tags)
-          .get();
+    auto result = remote.local()
+                    .upload_object(
+                      bucket, path, make_iobuf_from_string("p"), fib)
+                    .get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
 
     auto request = get_requests()[0];
@@ -771,8 +764,7 @@ FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
           bucket,
           cloud_storage_clients::object_key{"p"},
           make_iobuf_from_string("p"),
-          fib,
-          upload_tags)
+          fib)
         .get());
     BOOST_REQUIRE_EQUAL(
       cloud_storage::upload_result::success,
@@ -781,8 +773,7 @@ FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
           bucket,
           cloud_storage_clients::object_key{"q"},
           make_iobuf_from_string("q"),
-          fib,
-          upload_tags)
+          fib)
         .get());
 
     std::vector<cloud_storage_clients::object_key> to_delete{
@@ -818,8 +809,7 @@ FIXTURE_TEST(
           bucket,
           cloud_storage_clients::object_key{"p"},
           make_iobuf_from_string("p"),
-          fib,
-          upload_tags)
+          fib)
         .get());
 
     std::vector<cloud_storage_clients::object_key> to_delete{

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -174,7 +174,7 @@ result<http::client::request_header> abs_request_creator::make_get_blob_request(
     // GET /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format("/{}/{}", name(), key().string());
     const boost::beast::string_view host{_ap().data(), _ap().length()};
@@ -204,7 +204,7 @@ result<http::client::request_header> abs_request_creator::make_put_blob_request(
     // PUT /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     // Content-Length:{payload-size}
     // Content-Type: text/plain
@@ -235,7 +235,7 @@ abs_request_creator::make_get_blob_metadata_request(
     // HEAD /{container-id}/{blob-id}?comp=metadata HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format(
       "/{}/{}?comp=metadata", name(), key().string());
@@ -260,7 +260,7 @@ abs_request_creator::make_delete_blob_request(
     // DELETE /{container-id}/{blob-id} HTTP/1.1
     // Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format("/{}/{}", name(), key().string());
 
@@ -292,7 +292,7 @@ abs_request_creator::make_list_blobs_request(
     // ...&max_results{max_keys}
     // HTTP/1.1 Host: {storage-account-id}.blob.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     auto target = fmt::format("/{}?restype=container&comp=list", name());
     if (prefix) {
@@ -353,7 +353,7 @@ abs_request_creator::make_delete_file_request(
     // DELETE /{container-id}/{path} HTTP/1.1
     // Host: {storage-account-id}.dfs.core.windows.net
     // x-ms-date:{req-datetime in RFC9110} # added by 'add_auth'
-    // x-ms-version:"2021-08-06"           # added by 'add_auth'
+    // x-ms-version:"2023-01-23"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format("/{}/{}", name(), path().string());
 

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -403,16 +403,11 @@ abs_client::abs_client(
     vlog(abs_log.trace, "Created client with config:{}", conf);
 }
 
-ss::future<client_self_configuration_result> abs_client::self_configure() {
-    auto result = co_await get_account_info(5s);
+ss::future<result<client_self_configuration_output, error_outcome>>
+abs_client::self_configure() {
+    auto result = co_await get_account_info(http::default_connect_timeout);
     if (!result) {
-        vlog(
-          abs_log.warn,
-          "Get Account Information request failed: {}. Proceeding without self "
-          "configuration ...",
-          result.error());
-
-        co_return abs_self_configuration_result{.is_hns_enabled = false};
+        co_return result.error();
     } else {
         co_return abs_self_configuration_result{
           .is_hns_enabled = result.value().is_hns_enabled};

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -15,6 +15,7 @@
 #include "cloud_storage_clients/logger.h"
 #include "cloud_storage_clients/util.h"
 #include "cloud_storage_clients/xml_sax_parser.h"
+#include "config/configuration.h"
 #include "vlog.h"
 
 #include <utility>
@@ -191,6 +192,7 @@ abs_request_creator::make_delete_blob_request(
     // x-ms-version:"2021-08-06"           # added by 'add_auth'
     // Authorization:{signature}           # added by 'add_auth'
     const auto target = fmt::format("/{}/{}", name(), key().string());
+
     const boost::beast::string_view host{_ap().data(), _ap().length()};
 
     http::client::request_header header{};
@@ -262,6 +264,11 @@ abs_client::abs_client(
   : _requestor(conf, std::move(apply_credentials))
   , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
+
+ss::future<client_self_configuration_result> abs_client::self_configure() {
+    // TODO: A future commit will plug in the implementation
+    co_return abs_self_configuration_result{.is_hns_enabled = false};
+}
 
 ss::future<> abs_client::stop() {
     vlog(abs_log.debug, "Stopping ABS client");

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -372,8 +372,19 @@ abs_client::abs_client(
 }
 
 ss::future<client_self_configuration_result> abs_client::self_configure() {
-    // TODO: A future commit will plug in the implementation
-    co_return abs_self_configuration_result{.is_hns_enabled = false};
+    auto result = co_await get_account_info(5s);
+    if (!result) {
+        vlog(
+          abs_log.warn,
+          "Get Account Information request failed: {}. Proceeding without self "
+          "configuration ...",
+          result.error());
+
+        co_return abs_self_configuration_result{.is_hns_enabled = false};
+    } else {
+        co_return abs_self_configuration_result{
+          .is_hns_enabled = result.value().is_hns_enabled};
+    }
 }
 
 ss::future<> abs_client::stop() {

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -245,8 +245,23 @@ private:
     ss::future<storage_account_info>
     do_get_account_info(ss::lowres_clock::duration timeout);
 
+    std::optional<abs_configuration> _data_lake_v2_client_config;
     abs_request_creator _requestor;
     http::client _client;
+
+    // Azure Storage accounts may have enabled Hierarchical Namespaces (HNS),
+    // in which case the container will emulate file system like semantics.
+    // For instance uploading blob "a/b/log.txt", creates two directory blobs
+    // ("a" and "a/b") and one file blob ("a/b/log.txt").
+    //
+    // This changes the semantics of certain Blob Storage REST API requests:
+    // * ListObjects will list both files and directories by default
+    // * DeleteBlob cannot delete directory files
+    //
+    // `_adls_client` connects to the Azure Data Lake Storage V2 REST API
+    // endpoint when HNS is enabled and is used for deletions.
+    std::optional<http::client> _adls_client;
+
     ss::shared_ptr<client_probe> _probe;
 };
 

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -120,7 +120,8 @@ public:
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
-    ss::future<client_self_configuration_result> self_configure() override;
+    ss::future<result<client_self_configuration_output, error_outcome>>
+    self_configure() override;
 
     /// Stop the client
     ss::future<> stop() override;

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -238,7 +238,6 @@ private:
     template<typename T>
     ss::future<result<T, error_outcome>> send_request(
       ss::future<T> request_future,
-      const bucket_name& bucket,
       const object_key& key,
       std::optional<op_type_tag> op_type = std::nullopt);
 

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -65,16 +65,19 @@ public:
     result<http::client::request_header>
     make_delete_blob_request(bucket_name const& name, object_key const& key);
 
+    // clang-format off
     /// \brief Initialize http header for 'List Blobs' request
     ///
     /// \param name of the container
+    /// \param files_only should always be set to true when HNS is enabled and false otherwise
     /// \param prefix prefix of returned blob's names
-    /// \param start_after is always ignored
-    /// \param max_keys is the max number of returned objects
+    /// \param start_after is always ignored \param max_keys is the max number of returned objects
     /// \param delimiter used to group common prefixes
     /// \return initialized and signed http header or error
+    // clang-format on
     result<http::client::request_header> make_list_blobs_request(
       const bucket_name& name,
+      bool files_only,
       std::optional<object_key> prefix,
       std::optional<object_key> start_after,
       std::optional<size_t> max_keys,

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -102,6 +102,8 @@ public:
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
+    ss::future<client_self_configuration_result> self_configure() override;
+
     /// Stop the client
     ss::future<> stop() override;
 

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -80,6 +80,9 @@ public:
       std::optional<size_t> max_keys,
       std::optional<char> delimiter = std::nullopt);
 
+    /// \brief Init http header for 'Get Account Information' request
+    result<http::client::request_header> make_get_account_info_request();
+
 private:
     access_point_uri _ap;
     /// Applies credentials to http requests by adding headers and signing
@@ -187,6 +190,16 @@ public:
       std::vector<object_key> keys,
       ss::lowres_clock::duration timeout) override;
 
+    struct storage_account_info {
+        bool is_hns_enabled{false};
+    };
+
+    /// Send Get Account Information request (used to detect
+    /// if the account has Hierarchical Namespace enabled).
+    /// \param timeout is a timeout of the operation
+    ss::future<result<storage_account_info, error_outcome>>
+    get_account_info(ss::lowres_clock::duration timeout);
+
 private:
     template<typename T>
     ss::future<result<T, error_outcome>> send_request(
@@ -228,6 +241,9 @@ private:
       ss::lowres_clock::duration timeout,
       std::optional<char> delimiter = std::nullopt,
       std::optional<item_filter> collect_item_if = std::nullopt);
+
+    ss::future<storage_account_info>
+    do_get_account_info(ss::lowres_clock::duration timeout);
 
     abs_request_creator _requestor;
     http::client _client;

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -33,13 +33,11 @@ public:
     /// \param key is the blob identifier
     /// \param payload_size_bytes is a size of the object in bytes
     /// \param payload_size_bytes is a size of the object in bytes
-    /// \param tags are formatted tags for 'x-ms-tags'
     /// \return initialized and signed http header or error
     result<http::client::request_header> make_put_blob_request(
       bucket_name const& name,
       object_key const& key,
-      size_t payload_size_bytes,
-      const object_tag_formatter& tags);
+      size_t payload_size_bytes);
 
     /// \brief Create a 'Get Blob' request header
     ///
@@ -147,7 +145,6 @@ public:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout) override;
 
     /// Send List Blobs request
@@ -208,7 +205,6 @@ private:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout);
 
     ss::future<head_object_result> do_head_object(

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -45,6 +45,8 @@ std::istream& operator>>(std::istream& i, abs_error_code& code) {
           .match(
             "ContainerBeingDeleted", abs_error_code::container_being_deleted)
           .match("ContainerNotFound", abs_error_code::container_not_found)
+          .match("DirectoryNotEmpty", abs_error_code::directory_not_empty)
+          .match("PathNotFound", abs_error_code::path_not_found)
           .default_match(abs_error_code::_unknown);
 
     return i;

--- a/src/v/cloud_storage_clients/abs_error.h
+++ b/src/v/cloud_storage_clients/abs_error.h
@@ -38,7 +38,9 @@ enum class abs_error_code {
     blob_being_rehydrated,
     container_being_disabled,
     container_being_deleted,
-    container_not_found
+    container_not_found,
+    directory_not_empty,
+    path_not_found
 };
 
 /// Operators to use with lexical_cast

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -31,6 +31,8 @@ public:
 
     virtual ~client() = default;
 
+    virtual ss::future<client_self_configuration_result> self_configure() = 0;
+
     /// Stop the client
     virtual ss::future<> stop() = 0;
 

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -31,7 +31,8 @@ public:
 
     virtual ~client() = default;
 
-    virtual ss::future<client_self_configuration_result> self_configure() = 0;
+    virtual ss::future<result<client_self_configuration_output, error_outcome>>
+    self_configure() = 0;
 
     /// Stop the client
     virtual ss::future<> stop() = 0;

--- a/src/v/cloud_storage_clients/client.h
+++ b/src/v/cloud_storage_clients/client.h
@@ -23,41 +23,6 @@
 
 namespace cloud_storage_clients {
 
-/// Object tag formatter that can be used
-/// to format tags for x_amz_tagging or x-ms-tag fields
-/// The value is supposed to be cached and
-/// not re-created on every request.
-class object_tag_formatter {
-public:
-    object_tag_formatter() = default;
-
-    object_tag_formatter(
-      std::initializer_list<std::pair<std::string_view, std::string_view>>&&
-        il) {
-        for (auto [key, value] : il) {
-            add(key, value);
-        }
-    }
-
-    template<class ValueT>
-    void add(std::string_view tag, const ValueT& value) {
-        if (empty()) {
-            _tags += ssx::sformat("{}={}", tag, value);
-        } else {
-            _tags += ssx::sformat("&{}={}", tag, value);
-        }
-    }
-
-    bool empty() const { return _tags.empty(); }
-
-    boost::beast::string_view str() const {
-        return {_tags.data(), _tags.size()};
-    }
-
-private:
-    ss::sstring _tags;
-};
-
 using http_byte_range = std::pair<uint64_t, uint64_t>;
 
 class client {
@@ -111,7 +76,6 @@ public:
     /// \param key is an id of the object
     /// \param payload_size is a size of the object in bytes
     /// \param body is an input_stream that can be used to read body
-    /// \param tags is a a tag formatter using query string format
     /// \param timeout is a timeout of the operation
     /// \return future that becomes ready when the upload is completed
     virtual ss::future<result<no_response, error_outcome>> put_object(
@@ -119,7 +83,6 @@ public:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout)
       = 0;
 

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -15,6 +15,7 @@
 #include "utils/gate_guard.h"
 #include "utils/hdr_hist.h"
 #include "utils/intrusive_list_helpers.h"
+#include "utils/stop_signal.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/sharded.hh>
@@ -31,6 +32,8 @@ enum class client_pool_overdraft_policy {
     /// Client pool should try to borrow connection from another shard
     borrow_if_empty
 };
+
+constexpr ss::shard_id self_config_shard = ss::shard_id{0};
 
 /// Connection pool implementation
 /// All connections share the same configuration
@@ -95,11 +98,15 @@ public:
     /// \param conf is a client configuration
     /// \param policy controls what happens when the pool is empty (wait or try
     ///               to borrow from another shard)
+    /// \param application_abort_source abort source which can be used to stop
+    /// Redpanda gracefully
     client_pool(
       size_t size,
       client_configuration conf,
       client_pool_overdraft_policy policy
-      = client_pool_overdraft_policy::wait_if_empty);
+      = client_pool_overdraft_policy::wait_if_empty,
+      std::optional<std::reference_wrapper<stop_signal>> application_stop_signal
+      = std::nullopt);
 
     ss::future<> stop();
 
@@ -127,9 +134,14 @@ public:
     size_t max_size() const noexcept;
 
 private:
-    ss::future<> client_self_configure();
+    ss::future<>
+    client_self_configure(std::optional<std::reference_wrapper<stop_signal>>
+                            application_stop_signal);
+    ss::future<
+      std::optional<cloud_storage_clients::client_self_configuration_output>>
+    do_client_self_configure(http_client_ptr client);
     ss::future<> accept_self_configure_result(
-      std::optional<client_self_configuration_result> result);
+      std::optional<client_self_configuration_output> result);
 
     void populate_client_pool();
     http_client_ptr make_client() const;

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -127,6 +127,10 @@ public:
     size_t max_size() const noexcept;
 
 private:
+    ss::future<> client_self_configure();
+    ss::future<> accept_self_configure_result(
+      std::optional<client_self_configuration_result> result);
+
     void populate_client_pool();
     http_client_ptr make_client() const;
     void release(http_client_ptr leased);
@@ -158,6 +162,8 @@ private:
     /// enable rotating credentials to all clients.
     ss::lw_shared_ptr<cloud_roles::apply_credentials> _apply_credentials;
     ss::condition_variable _credentials_var;
+
+    ssx::semaphore _self_config_barrier{0, "self_config_barrier"};
 };
 
 } // namespace cloud_storage_clients

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -162,6 +162,17 @@ ss::future<abs_configuration> abs_configuration::make_configuration(
     co_return client_cfg;
 }
 
+abs_configuration abs_configuration::make_adls_configuration() const {
+    abs_configuration adls_config{*this};
+
+    const auto endpoint_uri = ssx::sformat("{}.dfs.core.windows.net", storage_account_name());
+    adls_config.tls_sni_hostname = endpoint_uri; 
+    adls_config.uri = access_point_uri{endpoint_uri};
+    adls_config.server_addr = net::unresolved_address{endpoint_uri, default_port};
+
+    return adls_config;
+}
+
 void apply_self_configuration_result(
   client_configuration& cfg, const client_self_configuration_result& res) {
     std::visit(

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -136,6 +136,11 @@ ss::future<abs_configuration> abs_configuration::make_configuration(
         return ssx::sformat("{}.blob.core.windows.net", storage_account_name());
     }();
 
+    // The ABS TLS server misbehaves and does not send an EOF
+    // when prompted to close the connection. Thus, skip the wait
+    // in order to avoid Seastar's hardcoded 10s wait.
+    client_cfg.wait_for_tls_server_eof = false;
+
     client_cfg.tls_sni_hostname = endpoint_uri;
     client_cfg.storage_account_name = storage_account_name;
     client_cfg.shared_key = shared_key;

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -187,7 +187,7 @@ abs_configuration abs_configuration::make_adls_configuration() const {
 }
 
 void apply_self_configuration_result(
-  client_configuration& cfg, const client_self_configuration_result& res) {
+  client_configuration& cfg, const client_self_configuration_output& res) {
     std::visit(
       [&res](auto& cfg) -> void {
           using cfg_type = std::decay_t<decltype(cfg)>;
@@ -239,7 +239,7 @@ std::ostream& operator<<(std::ostream& o, const s3_self_configuration_result&) {
 }
 
 std::ostream&
-operator<<(std::ostream& o, const client_self_configuration_result& r) {
+operator<<(std::ostream& o, const client_self_configuration_output& r) {
     return std::visit(
       [&o](const auto& self_cfg) -> std::ostream& {
           using cfg_type = std::decay_t<decltype(self_cfg)>;

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -78,6 +78,8 @@ struct abs_configuration : common_configuration {
     std::optional<cloud_roles::private_key_str> shared_key;
     bool is_hns_enabled{false};
 
+    abs_configuration make_adls_configuration() const;
+
     static ss::future<abs_configuration> make_configuration(
       const std::optional<cloud_roles::private_key_str>& shared_key,
       const cloud_roles::storage_account& storage_account_name,

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -38,6 +38,8 @@ struct common_configuration : net::base_transport::configuration {
     ss::lowres_clock::duration max_idle_time;
     /// Metrics probe (should be created for every aws account on every shard)
     ss::shared_ptr<client_probe> _probe;
+
+    bool requires_self_configuration{false};
 };
 
 struct s3_configuration : common_configuration {
@@ -74,6 +76,7 @@ struct s3_configuration : common_configuration {
 struct abs_configuration : common_configuration {
     cloud_roles::storage_account storage_account_name;
     std::optional<cloud_roles::private_key_str> shared_key;
+    bool is_hns_enabled{false};
 
     static ss::future<abs_configuration> make_configuration(
       const std::optional<cloud_roles::private_key_str>& shared_key,
@@ -96,6 +99,25 @@ using client_configuration_variant = std::variant<Ts...>;
 
 using client_configuration
   = client_configuration_variant<abs_configuration, s3_configuration>;
+
+std::ostream& operator<<(std::ostream&, const client_configuration&);
+
+struct abs_self_configuration_result {
+    bool is_hns_enabled;
+};
+
+struct s3_self_configuration_result {};
+
+using client_self_configuration_result
+  = std::variant<abs_self_configuration_result, s3_self_configuration_result>;
+
+void apply_self_configuration_result(
+  client_configuration&, const client_self_configuration_result&);
+
+std::ostream& operator<<(std::ostream&, const abs_self_configuration_result&);
+std::ostream& operator<<(std::ostream&, const s3_self_configuration_result&);
+std::ostream&
+operator<<(std::ostream&, const client_self_configuration_result&);
 
 model::cloud_storage_backend infer_backend_from_configuration(
   const client_configuration& client_config,

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -110,16 +110,16 @@ struct abs_self_configuration_result {
 
 struct s3_self_configuration_result {};
 
-using client_self_configuration_result
+using client_self_configuration_output
   = std::variant<abs_self_configuration_result, s3_self_configuration_result>;
 
 void apply_self_configuration_result(
-  client_configuration&, const client_self_configuration_result&);
+  client_configuration&, const client_self_configuration_output&);
 
 std::ostream& operator<<(std::ostream&, const abs_self_configuration_result&);
 std::ostream& operator<<(std::ostream&, const s3_self_configuration_result&);
 std::ostream&
-operator<<(std::ostream&, const client_self_configuration_result&);
+operator<<(std::ostream&, const client_self_configuration_output&);
 
 model::cloud_storage_backend infer_backend_from_configuration(
   const client_configuration& client_config,

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -128,10 +128,7 @@ result<http::client::request_header> request_creator::make_head_object_request(
 
 result<http::client::request_header>
 request_creator::make_unsigned_put_object_request(
-  bucket_name const& name,
-  object_key const& key,
-  size_t payload_size_bytes,
-  const object_tag_formatter& tags) {
+  bucket_name const& name, object_key const& key, size_t payload_size_bytes) {
     // PUT /my-image.jpg HTTP/1.1
     // Host: myBucket.s3.<Region>.amazonaws.com
     // Date: Wed, 12 Oct 2009 17:50:00 GMT
@@ -154,10 +151,6 @@ request_creator::make_unsigned_put_object_request(
     header.insert(
       boost::beast::http::field::content_length,
       std::to_string(payload_size_bytes));
-
-    if (!tags.empty()) {
-        header.insert(aws_header_names::x_amz_tagging, tags.str());
-    }
 
     auto ec = _apply_credentials->add_auth(header);
     if (ec) {
@@ -624,10 +617,9 @@ ss::future<result<s3_client::no_response, error_outcome>> s3_client::put_object(
   object_key const& key,
   size_t payload_size,
   ss::input_stream<char> body,
-  const object_tag_formatter& tags,
   ss::lowres_clock::duration timeout) {
     return send_request(
-      do_put_object(name, key, payload_size, std::move(body), tags, timeout)
+      do_put_object(name, key, payload_size, std::move(body), timeout)
         .then(
           []() { return ss::make_ready_future<no_response>(no_response{}); }),
       name,
@@ -639,10 +631,9 @@ ss::future<> s3_client::do_put_object(
   object_key const& id,
   size_t payload_size,
   ss::input_stream<char> body,
-  const object_tag_formatter& tags,
   ss::lowres_clock::duration timeout) {
     auto header = _requestor.make_unsigned_put_object_request(
-      name, id, payload_size, tags);
+      name, id, payload_size);
     if (!header) {
         return body.close().then([header] {
             return ss::make_exception_future<>(

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -470,7 +470,8 @@ s3_client::s3_client(
   , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
 
-ss::future<client_self_configuration_result> s3_client::self_configure() {
+ss::future<result<client_self_configuration_output, error_outcome>>
+s3_client::self_configure() {
     vlog(
       s3_log.error,
       "Call to self_configure was made, but the S3 client doesn't require self "

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -470,6 +470,14 @@ s3_client::s3_client(
   , _client(conf, &as, conf._probe, conf.max_idle_time)
   , _probe(conf._probe) {}
 
+ss::future<client_self_configuration_result> s3_client::self_configure() {
+    vlog(
+      s3_log.error,
+      "Call to self_configure was made, but the S3 client doesn't require self "
+      "configuration");
+    co_return s3_self_configuration_result{};
+}
+
 ss::future<> s3_client::stop() { return _client.stop(); }
 
 void s3_client::shutdown() { _client.shutdown(); }

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -126,7 +126,8 @@ public:
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
-    ss::future<client_self_configuration_result> self_configure() override;
+    ss::future<result<client_self_configuration_output, error_outcome>>
+    self_configure() override;
 
     /// Stop the client
     ss::future<> stop() override;

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -126,6 +126,8 @@ public:
       ss::lw_shared_ptr<const cloud_roles::apply_credentials>
         apply_credentials);
 
+    ss::future<client_self_configuration_result> self_configure() override;
+
     /// Stop the client
     ss::future<> stop() override;
     /// Shutdown the underlying connection

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -50,8 +50,7 @@ public:
     result<http::client::request_header> make_unsigned_put_object_request(
       bucket_name const& name,
       object_key const& key,
-      size_t payload_size_bytes,
-      const object_tag_formatter& tags);
+      size_t payload_size_bytes);
 
     /// \brief Create a 'GetObject' request header
     ///
@@ -167,7 +166,6 @@ public:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout) override;
 
     ss::future<result<list_bucket_result, error_outcome>> list_objects(
@@ -208,7 +206,6 @@ private:
       object_key const& key,
       size_t payload_size,
       ss::input_stream<char> body,
-      const object_tag_formatter& tags,
       ss::lowres_clock::duration timeout);
 
     ss::future<list_bucket_result> do_list_objects_v2(

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -281,7 +281,6 @@ int main(int args, char** argv, char** env) {
                                                 lcfg.blobs.front(),
                                                 payload_size,
                                                 std::move(payload),
-                                                {},
                                                 http::default_connect_timeout)
                                               .get0();
                         if (!result) {

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -98,6 +98,7 @@ void cli_opts(boost::program_options::options_description_easy_init opt) {
     opt("port", po::value<uint16_t>(), "alternative port for the api endpoint");
 
     opt("disable-tls", "disable tls for this connection");
+    opt("hns-enabled", "HNS enabled for the storage account");
 }
 
 struct test_conf {
@@ -167,6 +168,9 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
             .disable_tls = m.contains("disable-tls") > 0,
           })
           .get0();
+    if (m.contains("hns-enabled")) {
+        client_cfg.is_hns_enabled = true;
+    }
     vlog(test_log.info, "connecting to {}", client_cfg.server_addr);
     return test_conf{
       .storage_account = storage_acc,

--- a/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
@@ -283,7 +283,6 @@ int main(int args, char** argv, char** env) {
                                                 lcfg.objects.front(),
                                                 payload_size,
                                                 std::move(payload),
-                                                {},
                                                 http::default_connect_timeout)
                                               .get0();
 

--- a/src/v/cloud_storage_clients/tests/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ rp_test(
     s3_client_test.cc
     xml_sax_parser_test.cc
     exception_test.cc
+    util_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main Boost::unit_test_framework v::http v::cloud_storage_clients v::cloud_roles
   ARGS "-- -c 1"

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -354,7 +354,6 @@ SEASTAR_TEST_CASE(test_put_object_success) {
             cloud_storage_clients::object_key("test"),
             expected_payload_size,
             std::move(payload_stream),
-            {},
             100ms)
           .get();
         // shouldn't throw
@@ -378,7 +377,6 @@ SEASTAR_TEST_CASE(test_put_object_failure) {
                                 cloud_storage_clients::object_key("test-error"),
                                 expected_payload_size,
                                 std::move(payload_stream),
-                                {},
                                 100ms)
                               .get();
         BOOST_REQUIRE(!result);

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -19,6 +19,7 @@
 #include "net/types.h"
 #include "net/unresolved_address.h"
 #include "seastarx.h"
+#include "test_utils/fixture.h"
 #include "utils/base64.h"
 
 #include <seastar/core/future.hh>
@@ -714,35 +715,42 @@ SEASTAR_TEST_CASE(test_delete_object_retry) {
         server->stop().get();
     });
 }
-/// Http server and client
-struct configured_server_and_client_pool {
+
+class client_pool_fixture {
+public:
+    client_pool_fixture()
+      : s3_conf(transport_configuration())
+      , server(ss::make_shared<ss::httpd::http_server_control>()) {
+        pool
+          .start(
+            2,
+            ss::sharded_parameter([] { return transport_configuration(); }),
+            cloud_storage_clients::client_pool_overdraft_policy::wait_if_empty)
+          .get();
+
+        auto credentials = cloud_roles::aws_credentials{
+          s3_conf.access_key.value(),
+          s3_conf.secret_key.value(),
+          std::nullopt,
+          s3_conf.region};
+
+        pool.local().load_credentials(std::move(credentials));
+
+        server->start().get();
+        server->set_routes(set_routes).get();
+        auto resolved = net::resolve_dns(s3_conf.server_addr).get0();
+        server->listen(resolved).get();
+    }
+
+    ~client_pool_fixture() {
+        pool.stop().get();
+        server->stop().get();
+    }
+
+    cloud_storage_clients::s3_configuration s3_conf;
     ss::shared_ptr<ss::httpd::http_server_control> server;
-    ss::shared_ptr<cloud_storage_clients::client_pool> pool;
+    ss::sharded<cloud_storage_clients::client_pool> pool;
 };
-/// Create server and client connection pool, server is initialized with default
-/// testing paths and listening.
-configured_server_and_client_pool started_pool_and_server(
-  size_t size,
-  cloud_storage_clients::client_pool_overdraft_policy policy,
-  const cloud_storage_clients::s3_configuration& conf) {
-    auto credentials = cloud_roles::aws_credentials{
-      conf.access_key.value(),
-      conf.secret_key.value(),
-      std::nullopt,
-      conf.region};
-    auto client = ss::make_shared<cloud_storage_clients::client_pool>(
-      size, conf, policy);
-    client->load_credentials(std::move(credentials));
-    auto server = ss::make_shared<ss::httpd::http_server_control>();
-    server->start().get();
-    server->set_routes(set_routes).get();
-    auto resolved = net::resolve_dns(conf.server_addr).get0();
-    server->listen(resolved).get();
-    return {
-      .server = server,
-      .pool = client,
-    };
-}
 
 static ss::future<> test_client_pool_payload(
   ss::shared_ptr<ss::httpd::http_server_control> server,
@@ -763,16 +771,13 @@ static ss::future<> test_client_pool_payload(
     BOOST_REQUIRE_EQUAL(actual_payload, expected_payload);
 }
 
-void test_client_pool(
-  cloud_storage_clients::client_pool_overdraft_policy policy) {
-    auto conf = transport_configuration();
-    auto [server, pool] = started_pool_and_server(2, policy, conf);
-
+FIXTURE_TEST(test_client_pool_wait_strategy, client_pool_fixture) {
     ss::abort_source never_abort;
     std::vector<ss::future<>> fut;
     for (size_t i = 0; i < 20; i++) {
         auto f
-          = pool->acquire(never_abort)
+          = pool.local()
+              .acquire(never_abort)
               .then([server = server](
                       cloud_storage_clients::client_pool::client_lease lease) {
                   return test_client_pool_payload(server, std::move(lease));
@@ -780,15 +785,7 @@ void test_client_pool(
         fut.emplace_back(std::move(f));
     }
     ss::when_all_succeed(fut.begin(), fut.end()).get0();
-    BOOST_REQUIRE(pool->size() == 2);
-    server->stop().get();
-}
-
-SEASTAR_TEST_CASE(test_client_pool_wait_strategy) {
-    return ss::async([] {
-        test_client_pool(
-          cloud_storage_clients::client_pool_overdraft_policy::wait_if_empty);
-    });
+    BOOST_REQUIRE(pool.local().size() == 2);
 }
 
 static ss::future<bool> test_client_pool_reconnect_helper(
@@ -817,31 +814,22 @@ static ss::future<bool> test_client_pool_reconnect_helper(
     co_return true;
 }
 
-SEASTAR_TEST_CASE(test_client_pool_reconnect) {
-    return ss::async([] {
-        using namespace std::chrono_literals;
-        auto conf = transport_configuration();
-        auto [server, pool] = started_pool_and_server(
-          2,
-          cloud_storage_clients::client_pool_overdraft_policy::wait_if_empty,
-          conf);
-
-        ss::abort_source never_abort;
-        std::vector<ss::future<bool>> fut;
-        for (size_t i = 0; i < 20; i++) {
-            auto f
-              = pool->acquire(never_abort)
-                  .then(
-                    [server = server](
-                      cloud_storage_clients::client_pool::client_lease lease) {
-                        return test_client_pool_reconnect_helper(
-                          server, std::move(lease));
-                    });
-            fut.emplace_back(std::move(f));
-        }
-        auto result = ss::when_all_succeed(fut.begin(), fut.end()).get0();
-        auto count = std::count(result.begin(), result.end(), true);
-        BOOST_REQUIRE(count == 20);
-        server->stop().get();
-    });
+FIXTURE_TEST(test_client_pool_reconnect, client_pool_fixture) {
+    using namespace std::chrono_literals;
+    ss::abort_source never_abort;
+    std::vector<ss::future<bool>> fut;
+    for (size_t i = 0; i < 20; i++) {
+        auto f = pool.local()
+                   .acquire(never_abort)
+                   .then(
+                     [server = server](
+                       cloud_storage_clients::client_pool::client_lease lease) {
+                         return test_client_pool_reconnect_helper(
+                           server, std::move(lease));
+                     });
+        fut.emplace_back(std::move(f));
+    }
+    auto result = ss::when_all_succeed(fut.begin(), fut.end()).get0();
+    auto count = std::count(result.begin(), result.end(), true);
+    BOOST_REQUIRE(count == 20);
 }

--- a/src/v/cloud_storage_clients/tests/util_test.cc
+++ b/src/v/cloud_storage_clients/tests/util_test.cc
@@ -1,0 +1,24 @@
+#include "cloud_storage_clients/util.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(test_all_paths_to_file) {
+    using namespace cloud_storage_clients;
+
+    auto result1 = util::all_paths_to_file(object_key{"a/b/c/log.txt"});
+    auto expected1 = std::vector<object_key>{
+      object_key{"a"},
+      object_key{"a/b"},
+      object_key{"a/b/c"},
+      object_key{"a/b/c/log.txt"}};
+    BOOST_REQUIRE_EQUAL(result1, expected1);
+
+    auto result2 = util::all_paths_to_file(object_key{"a/b/c/"});
+    BOOST_REQUIRE_EQUAL(result2, std::vector<object_key>{});
+
+    auto result3 = util::all_paths_to_file(object_key{""});
+    BOOST_REQUIRE_EQUAL(result3, std::vector<object_key>{});
+
+    auto result4 = util::all_paths_to_file(object_key{"foo"});
+    BOOST_REQUIRE_EQUAL(result4, std::vector<object_key>{object_key{"foo"}});
+}

--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -197,4 +197,25 @@ void log_buffer_with_rate_limiting(
     vlog(log_with_rate_limit, "{}: {}", msg, sview);
 }
 
+std::vector<object_key> all_paths_to_file(const object_key& path) {
+    if (!path().has_filename()) {
+        return {};
+    }
+
+    std::vector<object_key> paths;
+    std::filesystem::path current_path;
+    for (auto path_iter = path().begin(); path_iter != path().end();
+         ++path_iter) {
+        if (current_path == "") {
+            current_path += *path_iter;
+        } else {
+            current_path /= *path_iter;
+        }
+
+        paths.emplace_back(current_path);
+    }
+
+    return paths;
+}
+
 } // namespace cloud_storage_clients::util

--- a/src/v/cloud_storage_clients/util.h
+++ b/src/v/cloud_storage_clients/util.h
@@ -47,4 +47,9 @@ void log_buffer_with_rate_limiting(
 
 bool has_abort_or_gate_close_exception(const ss::nested_exception& ex);
 
+/// \brief: Given a file system like path, generate the full list
+/// of valid prefix paths. For instance, if the input is: a/b/log.txt,
+/// return a, a/b, a/b/log.txt
+std::vector<object_key> all_paths_to_file(const object_key& path);
+
 } // namespace cloud_storage_clients::util

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1574,6 +1574,22 @@ configuration::configuration()
        .secret = is_secret::yes},
       std::nullopt,
       &validate_non_empty_string_opt)
+  , cloud_storage_azure_adls_endpoint(
+      *this,
+      "cloud_storage_azure_adls_endpoint",
+      "Azure Data Lake Storage v2 endpoint override. Use when Hierarchical "
+      "Namespaces are enabled on your storage account and you have set up a "
+      "custom endpoint.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt,
+      &validate_non_empty_string_opt)
+  , cloud_storage_azure_adls_port(
+      *this,
+      "cloud_storage_azure_adls_port",
+      "Azure Data Lake Storage v2 port override. Also see "
+      "cloud_storage_azure_adls_endpoint.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      std::nullopt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -308,6 +308,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;
     property<std::optional<ss::sstring>> cloud_storage_azure_container;
     property<std::optional<ss::sstring>> cloud_storage_azure_shared_key;
+    property<std::optional<ss::sstring>> cloud_storage_azure_adls_endpoint;
+    property<std::optional<uint16_t>> cloud_storage_azure_adls_port;
 
     // Archival upload controller
     property<std::chrono::milliseconds>

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -49,6 +49,8 @@ public:
           = net::public_metrics_disabled::no;
         /// Optional server name indication (SNI) for TLS connection
         std::optional<ss::sstring> tls_sni_hostname;
+        /// Potentially skip wait for EOF after BYE message on TLS session end
+        bool wait_for_tls_server_eof = true;
     };
 
     explicit base_transport(configuration c);
@@ -93,6 +95,7 @@ private:
     unresolved_address _server_addr;
     ss::shared_ptr<ss::tls::certificate_credentials> _creds;
     std::optional<ss::sstring> _tls_sni_hostname;
+    bool _wait_for_tls_server_eof;
 
     // Track if shutdown was called on the current `_fd`
     bool _shutdown{false};

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -170,9 +170,10 @@ private:
     void start_bootstrap_services();
 
     // Constructs services across shards meant for Redpanda runtime.
-    void wire_up_runtime_services(model::node_id node_id);
+    void
+    wire_up_runtime_services(model::node_id node_id, ::stop_signal& app_signal);
     void configure_admin_server();
-    void wire_up_redpanda_services(model::node_id);
+    void wire_up_redpanda_services(model::node_id, ::stop_signal& app_signal);
 
     void load_feature_table_snapshot();
 

--- a/src/v/utils/stop_signal.h
+++ b/src/v/utils/stop_signal.h
@@ -40,7 +40,6 @@ public:
 
     ss::abort_source& abort_source() { return _as; };
 
-private:
     void signaled() {
         if (!_as.abort_requested()) {
             _as.request_abort();
@@ -48,6 +47,7 @@ private:
         _cond.broadcast();
     }
 
+private:
     ss::condition_variable _cond;
     ss::abort_source _as;
 };

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     restart: always
     ports:
     - 10000:10000
-    image: mcr.microsoft.com/azure-storage/azurite:3.21.0
+    image: mcr.microsoft.com/azure-storage/azurite:3.25.0
     networks:
     - redpanda-test
   rp:

--- a/tests/rptest/archival/abs_client.py
+++ b/tests/rptest/archival/abs_client.py
@@ -170,6 +170,9 @@ class ABSClient:
                 self.logger.debug(f"Skip {blob_props.name} for {topic}")
                 continue
 
+            if blob_props.content_settings.content_md5 is None:
+                continue
+
             yield ObjectMetadata(
                 bucket=blob_props.container,
                 key=blob_props.name,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -154,7 +154,9 @@ PREV_VERSION_LOG_ALLOW_LIST = [
     # e.g.  raft - [group_id:3, {kafka/topic/2}] consensus.cc:2317 - unable to replicate updated configuration: raft::errc::replicated_entry_truncated
     "raft - .*unable to replicate updated configuration: .*",
     # e.g. recovery_stm.cc:432 - recovery append entries error: rpc::errc::client_request_timeout"
-    "raft - .*recovery append entries error.*client_request_timeout"
+    "raft - .*recovery append entries error.*client_request_timeout",
+    # Pre v23.2 Redpanda's don't know how to interact with HNS Storage Accounts correctly
+    "abs - .*FeatureNotYetSupportedForHierarchicalNamespaceAccounts"
 ]
 
 # Path to the LSAN suppressions file

--- a/tests/rptest/tests/adjacent_segment_merging_test.py
+++ b/tests/rptest/tests/adjacent_segment_merging_test.py
@@ -63,10 +63,6 @@ class AdjacentSegmentMergingTest(RedpandaTest):
     def setUp(self):
         super().setUp()  # topic is created here
 
-    def tearDown(self):
-        self.cloud_storage_client.empty_bucket(self.bucket_name)
-        super().tearDown()
-
     @cluster(num_nodes=3)
     @matrix(acks=[-1, 1], cloud_storage_type=get_cloud_storage_type())
     def test_reupload_of_local_segments(self, acks, cloud_storage_type):

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -229,10 +229,6 @@ class ArchivalTest(RedpandaTest):
             self.rpk.alter_topic_config(topic.name, 'redpanda.remote.write',
                                         'true')
 
-    def tearDown(self):
-        self.cloud_storage_client.empty_bucket(self.s3_bucket_name)
-        super().tearDown()
-
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_write(self, cloud_storage_type):

--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -61,10 +61,6 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
         # Do not start redpanda here, let the tests start with custom config options
         pass
 
-    def teardown(self):
-        self.redpanda.cloud_storage_client.empty_bucket(
-            self.si_settings.cloud_storage_bucket)
-
     def _set_params_and_start_redpanda(self, **kwargs):
         if kwargs:
             self.extra_rp_conf.update(kwargs)

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -85,10 +85,6 @@ class EndToEndShadowIndexingBase(EndToEndTest):
         for topic in self.topics:
             self.kafka_tools.create_topic(topic)
 
-    def tearDown(self):
-        assert self.redpanda and self.redpanda.cloud_storage_client
-        self.redpanda.cloud_storage_client.empty_bucket(self.s3_bucket_name)
-
 
 def num_manifests_uploaded(test_self):
     s = test_self.redpanda.metric_sum(

--- a/tests/rptest/tests/follower_fetching_test.py
+++ b/tests/rptest/tests/follower_fetching_test.py
@@ -50,10 +50,6 @@ class FollowerFetchingTest(PreallocNodesTest):
             },
             si_settings=si_settings)
 
-    def tearDown(self):
-        self.cloud_storage_client.empty_bucket(self.s3_bucket_name)
-        super().tearDown()
-
     def setUp(self):
         # Delay startup, so that the test case can configure redpanda
         # based on test parameters before starting it.

--- a/tests/rptest/tests/license_upgrade_test.py
+++ b/tests/rptest/tests/license_upgrade_test.py
@@ -12,11 +12,12 @@ import re
 import time
 
 from ducktape.utils.util import wait_until
+from ducktape.mark import matrix
 from rptest.utils.rpenv import sample_license
 from rptest.services.admin import Admin
 from ducktape.utils.util import wait_until
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import SISettings, CloudStorageType, get_cloud_storage_type
 from rptest.services.cluster import cluster
 from requests.exceptions import HTTPError
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
@@ -49,7 +50,9 @@ class UpgradeToLicenseChecks(RedpandaTest):
         super(UpgradeToLicenseChecks, self).setUp()
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    def test_basic_upgrade(self):
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
+    def test_basic_upgrade(self, cloud_storage_type):
         # Modified environment variables apply to processes restarted from this point onwards
         self.redpanda.set_environment({
             '__REDPANDA_LICENSE_CHECK_INTERVAL_SEC':
@@ -129,7 +132,9 @@ class UpgradeMigratingLicenseVersion(RedpandaTest):
         super(UpgradeMigratingLicenseVersion, self).setUp()
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    def test_license_upgrade(self):
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
+    def test_license_upgrade(self, cloud_storage_type):
         license = sample_license()
         if license is None:
             self.logger.info(

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -266,7 +266,9 @@ class TestReadReplicaService(EndToEndTest):
             return None
 
     @cluster(num_nodes=7, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
-    @matrix(partition_count=[5], cloud_storage_type=[CloudStorageType.S3])
+    @matrix(
+        partition_count=[5],
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True))
     def test_identical_lwms_after_delete_records(
             self, partition_count: int,
             cloud_storage_type: CloudStorageType) -> None:
@@ -322,7 +324,9 @@ class TestReadReplicaService(EndToEndTest):
         check_lwm(7)
 
     @cluster(num_nodes=8, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
-    @matrix(partition_count=[5], cloud_storage_type=[CloudStorageType.S3])
+    @matrix(
+        partition_count=[5],
+        cloud_storage_type=get_cloud_storage_type(docker_use_arbitrary=True))
     def test_identical_hwms(self, partition_count: int,
                             cloud_storage_type: CloudStorageType) -> None:
         self._setup_read_replica(partition_count=partition_count,

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -464,7 +464,9 @@ class ReadReplicasUpgradeTest(EndToEndTest):
         self.second_cluster = None
 
     @cluster(num_nodes=8)
-    def test_upgrades(self):
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
+    def test_upgrades(self, cloud_storage_type):
         partition_count = 1
         install_opts = InstallOptions(install_previous_version=True)
         self.start_redpanda(3,

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -154,7 +154,8 @@ class BucketScrubSelfTest(RedpandaTest):
     @skip_debug_mode  # We wait for a decent amount of traffic
     @cluster(num_nodes=4)
     #@matrix(cloud_storage_type=get_cloud_storage_type())
-    @matrix(cloud_storage_type=[CloudStorageType.S3])
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
     def test_missing_segment(self, cloud_storage_type):
         topic = 'test'
 

--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -72,10 +72,6 @@ class SIAdminApiTest(RedpandaTest):
         # feature on after start.
         self.redpanda.set_cluster_config({'admin_api_require_auth': True})
 
-    def tearDown(self):
-        self.cloud_storage_client.empty_bucket(self.s3_bucket_name)
-        super().tearDown()
-
     @cluster(num_nodes=3, log_allow_list=CONNECTION_ERROR_LOGS)
     @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_bucket_validation(self, cloud_storage_type):

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -19,12 +19,11 @@ from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkException, RpkTool
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.services.producer_swarm import ProducerSwarm
-from rptest.services.redpanda import ResourceSettings, SISettings
+from rptest.services.redpanda import ResourceSettings, SISettings, CloudStorageType, get_cloud_storage_type
 from rptest.services.redpanda_installer import RedpandaInstaller
 from rptest.services.rpk_producer import RpkProducer
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.util import wait_for_local_storage_truncate, expect_exception
-from rptest.utils.mode_checks import skip_azure_blob_storage
 from rptest.clients.kcl import KCL
 
 from ducktape.utils.util import wait_until
@@ -560,8 +559,10 @@ class CreateTopicUpgradeTest(RedpandaTest):
                                         target_bytes=local_retention)
 
     @cluster(num_nodes=3)
-    @skip_azure_blob_storage
-    def test_cloud_storage_sticky_enablement_v22_2_to_v22_3(self):
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
+    def test_cloud_storage_sticky_enablement_v22_2_to_v22_3(
+            self, cloud_storage_type):
         """
         In Redpanda 22.3, the cluster defaults for cloud storage change
         from being applied at runtime to being sticky at creation time,
@@ -628,8 +629,10 @@ class CreateTopicUpgradeTest(RedpandaTest):
         assert described['redpanda.remote.read'] == ('false', 'DEFAULT_CONFIG')
 
     @cluster(num_nodes=3)
-    @skip_azure_blob_storage
-    def test_retention_config_on_upgrade_from_v22_2_to_v22_3(self):
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
+    def test_retention_config_on_upgrade_from_v22_2_to_v22_3(
+            self, cloud_storage_type):
         self.install_and_start()
 
         self.rpk.create_topic("test-topic-with-retention",
@@ -814,8 +817,10 @@ class CreateTopicUpgradeTest(RedpandaTest):
             assert len(deleted_objects) == 0
 
     @cluster(num_nodes=3)
-    @skip_azure_blob_storage
-    def test_retention_upgrade_with_cluster_remote_write(self):
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
+    def test_retention_upgrade_with_cluster_remote_write(
+            self, cloud_storage_type):
         """
         Validate how the cluster-wide cloud_storage_enable_remote_write
         is handled on upgrades from <=22.2

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -12,7 +12,7 @@ import time
 from collections import defaultdict
 from packaging.version import Version
 
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize, matrix
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool
@@ -28,9 +28,8 @@ from rptest.util import (
     wait_until_segments,
 )
 from rptest.utils.si_utils import BucketView
-from rptest.utils.mode_checks import skip_azure_blob_storage
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import SISettings, CloudStorageType, get_cloud_storage_type
 from rptest.services.kgo_verifier_services import (
     KgoVerifierProducer,
     KgoVerifierSeqConsumer,
@@ -380,8 +379,9 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
         super().setUp()
 
     @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
-    @skip_azure_blob_storage
-    def test_rolling_upgrade(self):
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
+    def test_rolling_upgrade(self, cloud_storage_type):
         """
         Verify that when tiered storage writes happen during a rolling upgrade,
         we continue to write remote content that old versions can read, until

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 from rptest.clients.offline_log_viewer import OfflineLogViewer
 from rptest.services.cluster import cluster
 from rptest.services.admin import Admin
-from rptest.services.redpanda import SISettings
+from rptest.services.redpanda import SISettings, CloudStorageType, get_cloud_storage_type
 from rptest.services.redpanda_installer import RedpandaInstaller, RedpandaVersion, RedpandaVersionTriple
 from rptest.services.workload_protocol import PWorkload
 from rptest.tests.prealloc_nodes import PreallocNodesTest
@@ -22,6 +22,7 @@ from rptest.tests.workload_dummy import DummyWorkload, MinimalWorkload
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.workload_license import LicenseWorkload
 from rptest.utils.mode_checks import skip_debug_mode
+from ducktape.mark import matrix
 
 
 def expand_version(
@@ -248,7 +249,11 @@ class RedpandaUpgradeTest(PreallocNodesTest):
 
     @skip_debug_mode
     @cluster(num_nodes=4)
-    def test_workloads_through_releases(self):
+    # TODO(vlad): Allow this test on ABS once we have at least two versions
+    # of Redpanda that support Azure Hierarchical Namespaces.
+    @matrix(cloud_storage_type=get_cloud_storage_type(
+        applies_only_on=[CloudStorageType.S3]))
+    def test_workloads_through_releases(self, cloud_storage_type):
         # this callback will be called between each upgrade, in a mixed version state
         def mid_upgrade_check(raw_versions: dict[Any, RedpandaVersion]):
             rp_versions = {

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -63,35 +63,3 @@ def skip_debug_mode(func):
         return func(*args, **kwargs)
 
     return f
-
-
-def skip_azure_blob_storage(func):
-    """
-    Decorator applied to a test class method. The property `azure_blob_storage` should be present
-    on the object.
-
-    If set to true, the wrapped function call is skipped, and a cleanup action
-    is performed instead.
-
-    If set to false, the wrapped function (usually a test case) is called.
-    """
-    @functools.wraps(func)
-    def f(*args, **kwargs):
-        assert args, 'skip_azure_blob_storage must be placed on a test method in a class'
-
-        caller = args[0]
-
-        assert hasattr(
-            caller, 'azure_blob_storage'
-        ), 'skip_azure_blob_storage called on object which does not have azure_blob_storage attribute'
-        assert hasattr(
-            caller, 'logger'
-        ), 'skip_azure_blob_storage called on object which has no logger'
-        if caller.azure_blob_storage:
-            caller.logger.info(
-                "Skipping Azure Blob Storage test in (requires S3)")
-            cleanup_on_early_exit(caller)
-            return None
-        return func(*args, **kwargs)
-
-    return f


### PR DESCRIPTION
This PR back ports all of the Azure HNS work to v23.2.x:
* https://github.com/redpanda-data/redpanda/pull/12449
* https://github.com/redpanda-data/redpanda/pull/12632
* https://github.com/redpanda-data/redpanda/pull/12936

Amazingly, everything cherry picked without conflict.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* Repanda Tiered Storage is now compatible with Azure Storage accounts which have Hierarchical Namespaces enabled
