### PR TITLE
c/members_manager: validate if node exists in the cluster before update

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -498,11 +498,11 @@ std::optional<ss::sstring> check_result_configuration(
   const members_table::cache_t& current_brokers,
   const model::broker& new_configuration) {
     auto it = current_brokers.find(new_configuration.id());
-    vassert(
-      it != current_brokers.end(),
-      "When broker configuration is being updated the broker must exists. "
-      "Updating broker {} configuration.",
-      new_configuration);
+    if (it == current_brokers.end()) {
+        return fmt::format(
+          "broker {} does not exists in list of cluster members",
+          new_configuration.id());
+    }
     auto& current_configuration = it->second.broker;
     /**
      * do no allow to decrease node core count


### PR DESCRIPTION
Previously `members_manager::handle_configuration_update_request` method did not validate if a node exists in the cluster. This lead to assertion being triggered when resulting cluster configuration was checked. Added validation of node existence in the `members_table`.

Fixes: #13108

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
