### PR TITLE
raft: suppress heartbeats with a guard

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -467,8 +467,7 @@ partition_raft_state get_partition_raft_state(consensus_ptr ptr) {
             state.last_received_seq = md.last_received_seq;
             state.last_successful_received_seq
               = md.last_successful_received_seq;
-            state.suppress_heartbeats = md.suppress_heartbeats
-                                        == raft::heartbeats_suppressed::yes;
+            state.suppress_heartbeats = md.are_heartbeats_suppressed();
             followers.push_back(std::move(state));
         }
         raft_state.followers = std::move(followers);

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -405,10 +405,35 @@ public:
      * heartbeats when other append entries request or heartbeat request is in
      * flight.
      */
-    heartbeats_suppressed are_heartbeats_suppressed(vnode) const;
 
-    void update_suppress_heartbeats(
-      vnode, follower_req_seq, heartbeats_suppressed);
+    class suppress_heartbeats_guard {
+    public:
+        suppress_heartbeats_guard() noexcept = default;
+        explicit suppress_heartbeats_guard(
+          consensus& parent, vnode target) noexcept;
+
+        void unsuppress();
+
+        suppress_heartbeats_guard(suppress_heartbeats_guard&& other) noexcept
+          : _parent(other._parent)
+          , _target(other._target) {
+            other._parent = nullptr;
+        }
+        suppress_heartbeats_guard(const suppress_heartbeats_guard& other)
+          = delete;
+        suppress_heartbeats_guard& operator=(suppress_heartbeats_guard&& other)
+          = delete;
+        suppress_heartbeats_guard&
+        operator=(const suppress_heartbeats_guard& other)
+          = delete;
+        ~suppress_heartbeats_guard() noexcept { unsuppress(); }
+
+    private:
+        consensus* _parent = nullptr;
+        vnode _target;
+    };
+
+    suppress_heartbeats_guard suppress_heartbeats(vnode);
 
     void update_heartbeat_status(vnode, bool);
 

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -92,18 +92,18 @@ public:
     struct follower_request_meta {
         follower_request_meta(
           consensus_ptr, follower_req_seq, model::offset, vnode);
-        ~follower_request_meta() noexcept;
 
         follower_request_meta(const follower_request_meta&) = delete;
         follower_request_meta(follower_request_meta&&) noexcept = default;
         follower_request_meta& operator=(const follower_request_meta&) = delete;
         follower_request_meta& operator=(follower_request_meta&&) noexcept
-          = default;
+          = delete;
 
         consensus_ptr c;
         follower_req_seq seq;
         model::offset dirty_offset;
         vnode follower_vnode;
+        consensus::suppress_heartbeats_guard hb_guard;
     };
     // Heartbeats from all groups for single node
     struct node_heartbeat {

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -16,6 +16,7 @@
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "outcome.h"
+#include "raft/consensus.h"
 #include "raft/fwd.h"
 #include "raft/group_configuration.h"
 #include "raft/logger.h"
@@ -134,6 +135,7 @@ private:
     flush_after_append _is_flush_required;
     std::optional<model::record_batch_reader> _batches;
     absl::flat_hash_map<vnode, follower_req_seq> _followers_seq;
+    absl::flat_hash_map<vnode, consensus::suppress_heartbeats_guard> _hb_guards;
     mutex _share_mutex;
     ssx::semaphore _dispatch_sem{0, "raft/repl-dispatch"};
     ss::gate _req_bg;

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -145,8 +145,6 @@ void follower_index_metadata::reset() {
     last_sent_seq = follower_req_seq{0};
     last_received_seq = follower_req_seq{0};
     last_successful_received_seq = follower_req_seq{0};
-    last_suppress_heartbeats_seq = follower_req_seq{0};
-    suppress_heartbeats = heartbeats_suppressed::no;
     last_sent_protocol_meta.reset();
 }
 


### PR DESCRIPTION
Previously, concurrency in heartbeat suppression requests was managed by checking the sequence number of the request on the unsuppress call. This protected against the following:
* suppress(seq=1)
* suppress(seq=2)
* unsuppress(seq=1)
* unsuppress(seq=2)

But didn't protect against
* suppress(seq=1)
* suppress(seq=2)
* unsuppress(seq=2) (should still be suppressed here)
* unsuppress(seq=1)

The latter scenario is possible when we skip the recovering follower in replicate_entries_stm. Fix this by introducing a RAII guard that takes care of updating the in-flight requests count.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none