### PR TITLE
update ducktape version

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,7 +13,7 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@fd01d72b8c82ae852986bb288c69818c7ffb4de8',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@62e0285f6b3a2f22fd4a43b5fdbc13be8d4290d9',
         'prometheus-client==0.9.0', 'pyyaml==6.0', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==2.0.2', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==4.21.8', 'fastavro==1.4.9',

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -19,7 +19,7 @@ setup(
         'xxhash==2.0.2', 'protobuf==4.21.8', 'fastavro==1.4.9',
         'psutil==5.9.0', 'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
         'jump-consistent-hash==3.2.0', 'azure-storage-blob==12.14.1',
-        'kafkatest@git+https://github.com/apache/kafka.git@058589b03db686803b33052d574ce887fb5cfbd1#egg=kafkatest&subdirectory=tests',
+        'kafkatest@git+https://github.com/apache/kafka.git@3.2.0#egg=kafkatest&subdirectory=tests',
         'grpcio==1.57.0', 'grpcio-tools==1.57', 'grpcio-status==1.57.0',
         'cachetools==5.3.1', 'google-api-core==2.11.1', 'google-auth==2.22.0',
         'googleapis-common-protos==1.60.0', 'google.cloud.compute==1.14.0',


### PR DESCRIPTION
Our fork of ducktape was rebased on top of 0.8.x. This PR updates the ducktape version.
It also updates the kafkatest version, since the older version of kafkatest, depends on
ducktape 0.8.8. the new one depends on
ducktape >0.8

ref https://github.com/redpanda-data/devprod/issues/332

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
