### PR TITLE
tests/docker: bump client-swarm

### DIFF
--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -6,7 +6,7 @@ pushd /tmp
 git clone https://github.com/redpanda-data/client-swarm.git
 
 pushd client-swarm
-git reset --hard 5610f614545ee34f593e1279b30ee9986959d9b0
+git reset --hard d20bbf6aa9451fd1d725146c05799b675ab20084
 cargo build --release
 cp target/release/client-swarm /usr/local/bin
 popd


### PR DESCRIPTION
bump to latest version to bring in SASL SSL support from https://github.com/redpanda-data/client-swarm/pull/12. comparison of diff: https://github.com/redpanda-data/client-swarm/compare/5610f614545ee34f593e1279b30ee9986959d9b0...d20bbf6aa9451fd1d725146c05799b675ab20084

related issue https://github.com/redpanda-data/cloudv2/issues/8190

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none