### PR TITLE
[v22.3.x] rptest: improve timequery below start offset test

### DIFF
--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -139,58 +139,6 @@ class RetentionPolicyTest(RedpandaTest):
                                   partition_idx=0,
                                   count=5)
 
-    @cluster(num_nodes=3)
-    def test_timequery_after_segments_eviction(self):
-        """
-        Test checking if the offset returned by time based index is
-        valid during applying log cleanup policy
-        """
-        segment_size = 1048576
-
-        # produce until segments have been compacted
-        produce_until_segments(
-            self.redpanda,
-            topic=self.topic,
-            partition_idx=0,
-            count=10,
-            acks=-1,
-        )
-
-        # restart all nodes to force replicating raft configuration
-        self.redpanda.restart_nodes(self.redpanda.nodes)
-
-        kafka_tools = KafkaCliTools(self.redpanda)
-        # Wait for controller, alter configs doesn't have a retry loop
-        kafka_tools.describe_topic(self.topic)
-
-        # change retention bytes to preserve 15 segments
-        self.client().alter_topic_configs(
-            self.topic, {
-                TopicSpec.PROPERTY_RETENTION_BYTES:
-                bytes_for_segments(2, segment_size),
-            })
-
-        def validate_time_query_until_deleted():
-            def done():
-                kcat = KafkaCat(self.redpanda)
-                ts = 1638748800  # 12.6.2021 - old timestamp, query first offset
-                offset = kcat.query_offset(self.topic, 0, ts)
-                # assert that offset is valid
-                assert offset >= 0
-
-                topic_partitions = segments_count(self.redpanda, self.topic, 0)
-                partitions = []
-                for p in topic_partitions:
-                    partitions.append(p <= 5)
-                return all([p <= 5 for p in topic_partitions])
-
-            wait_until(done,
-                       timeout_sec=30,
-                       backoff_sec=5,
-                       err_msg="Segments were not removed")
-
-        validate_time_query_until_deleted()
-
 
 class ShadowIndexingRetentionTest(RedpandaTest):
     segment_size = 1000000  # 1MB

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -287,6 +287,9 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
                 cloud_storage_enable_remote_write=True,
             )
             self.redpanda.set_si_settings(si_settings)
+        else:
+            self.redpanda.add_extra_rp_conf(
+                {'log_segment_size': self.log_segment_size})
 
         self.redpanda.start()
 


### PR DESCRIPTION
Partial backport of https://github.com/redpanda-data/redpanda/pull/8955

CONFLICT:
- This patch was already mostly merged as a part of c41022f, but missed out on this bit to update segment size for non-cloud-storage clusters, and a removal of a test. This meant the log would not roll a segment, and therefore never have anything viable for GC, hence the failure to advance the start offset.

Previously, `test_timequery_after_segments_eviction` expected that timequeries for offsets within a segment would be serviced up until the segment was removed from disk. This assumption is not correct, as we should not serve timequeries that fall below the start offset of the local log (unless cloud storage is enabled and the offset is in the cloud log).

This commit removes the mentioned test, and adds a new test that checks that local timequeries don't return data below the start offset of the local log.

(cherry picked from commit 06c1a2c6b8a5b18d8fa369a93e9d1501398f9555)

Fixes #10140

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
