### PR TITLE
ducky: add timeout to mark_transaction_expired's allow list

### DIFF
--- a/tests/rptest/tests/tx_admin_api_test.py
+++ b/tests/rptest/tests/tx_admin_api_test.py
@@ -23,6 +23,10 @@ NON_EXISTENT_TID_LOG_ALLOW_LIST = [
         r".*Unexpected tx_error error: {tx_errc::unknown_server_error}.*")
 ]
 
+TIMEOUT_ALLOW_LIST = [
+    re.compile(r".*Unexpected tx_error error: {tx_errc::timeout}.*")
+]
+
 
 class TxAdminTest(RedpandaTest):
     topics = (TopicSpec(partition_count=3, replication_factor=3),
@@ -87,7 +91,8 @@ class TxAdminTest(RedpandaTest):
                     assert (tx['status'] == 'ongoing')
                     assert (tx['timeout_ms'] == 60000)
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3,
+             log_allow_list=DEFAULT_LOG_ALLOW_LIST + TIMEOUT_ALLOW_LIST)
     def test_mark_transaction_expired(self):
         producer1 = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),


### PR DESCRIPTION
`mark_transaction_expired` is an idempotent operation and is retried on any error; timeout is one of the possible transient errors; adding it to the allow list to prevent false positive test failure

Fixes #12806

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none