### PR TITLE
rptest: create max connections test using ProducerSwarm

### DIFF
--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -207,11 +207,20 @@ class HighThroughputTest2(PreallocNodesTest):
             f"Producing {msg_count} messages of {msg_size} B, "
             f"{msg_count*msg_size} B total, target rate {ingress_rate} B/s")
 
+        # if this is a redpanda cloud cluster,
+        # use the default test superuser user/pass
+        security_config = self.redpanda.security_config()
+        username = security_config.get('sasl_plain_username', None)
+        password = security_config.get('sasl_plain_password', None)
+        enable_tls = security_config.get('enable_tls', False)
         producer0 = KgoVerifierProducer(self.test_context,
                                         self.redpanda,
                                         self.topic,
                                         msg_size=msg_size,
-                                        msg_count=msg_count)
+                                        msg_count=msg_count,
+                                        username=username,
+                                        password=password,
+                                        enable_tls=enable_tls)
         producer0.start()
         start = time.time()
 
@@ -254,7 +263,7 @@ class HighThroughputTest2(PreallocNodesTest):
             self.logger.info("Creating test topic")
         self.rpk.create_topic(name,
                               partitions=partitions,
-                              replicas=3,
+                              replicas=1,
                               config=topic_config)
         return
 
@@ -264,7 +273,8 @@ class HighThroughputTest2(PreallocNodesTest):
             for node in sw_node.nodes:
                 _current = int(
                     node.account.ssh_output(
-                        "sudo netstat -plan | grep ':9092' | wc -l").decode(
+                        "netstat -pan -t tcp | grep ESTABLISHED "
+                        "| grep ':9092' | grep 'client-swarm' | wc -l").decode(
                             "utf-8").strip())
                 _list.append(_current)
         return _list
@@ -276,15 +286,15 @@ class HighThroughputTest2(PreallocNodesTest):
         PRODUCER_TIMEOUT_MS = 5000
 
         tier_config = self.redpanda.advertised_tier_config
-        _partition_count = tier_config.num_brokers * tier_config.partitions_min
+        _partition_count = tier_config.num_brokers
 
         # Prepare cluster
         self._stage_setup_cluster(TOPIC_NAME, _partition_count)
 
         # setup ProducerSwarm parameters
         producer_kwargs = {}
-        producer_kwargs['min_record_size'] = 4096
-        producer_kwargs['max_record_size'] = 8192
+        producer_kwargs['min_record_size'] = 64
+        producer_kwargs['max_record_size'] = 64
 
         effective_msg_size = producer_kwargs['min_record_size'] + (
             producer_kwargs['max_record_size'] -
@@ -292,16 +302,16 @@ class HighThroughputTest2(PreallocNodesTest):
 
         # connections per node at max (tier-5) is ~3700
         # We sending 10% above the limit to reach target
-        _target_per_node = tier_config.connections_limit // len(
-            self.cluster.nodes)
+        _target_per_node = int(tier_config.connections_limit //
+                               len(self.cluster.nodes))
         _conn_per_node = int(_target_per_node * 1.1)
         # calculate message rate based on 10 MB/s per node
         # 10 MiB = 3 messages per producer per sec
-        msg_rate = (10 * MiB) // effective_msg_size
+        msg_rate = int((0.1 * MiB) // effective_msg_size)
         messages_per_sec_per_producer = msg_rate // _conn_per_node
         # single producer runtime
-        target_runtime_s = 90
-        # for 50 MiB total message count is 3060
+        target_runtime_s = 30
+        # for 50 MiB total messag30e count is 3060
         records_per_producer = messages_per_sec_per_producer * target_runtime_s
 
         producer_kwargs[
@@ -336,41 +346,32 @@ class HighThroughputTest2(PreallocNodesTest):
             # Start first node
             self.logger.warn(f"Starting swarm node {idx}")
             swarm[idx - 1].start()
-
-            # Track Connections
-            _now = time.time()
-            # One target_runtime is a grace period to wait
-            # for target connection count
-            _grace_period = target_runtime_s
-            while (_now - _start) < (target_runtime_s * idx + _grace_period):
-                _now = time.time()
-                _connections = self._get_swarm_connections_count(swarm)
-                _total = sum(_connections)
-                self.logger.warn(f"{_total} connections "
-                                 f"({'/'.join(map(str, _connections))}) "
-                                 f"at {_now - _start:.3f}s")
-                # Save maximum
-                connectMax = _total if connectMax < _total else connectMax
-                # Once reaches _conn_per_node * idx,
-                # proceed to another one
-                _target = (_target_per_node * idx)
-                # Check if target reached and break out if yes
-                if _total >= _target:
-                    self.logger.warn(f"Reached target of {_target} "
-                                     f"connections ({_total})")
-                    # Calculate how much time is left till
-                    # the end of the iteration
-                    _elapsed = _now - _start
-                    _sleep = int(target_runtime_s * idx - _elapsed)
-                    #self.logger.warn(f"Sleeping for {_sleep}s")
-                    #time.sleep(_sleep)
-                    break
-                else:
-                    # sleep before next measurement
-                    time.sleep(10)
-
             # Next swarm node
             idx += 1
+
+        # Track Connections
+        _now = time.time()
+        idx = len(swarm)
+        while (_now - _start) < target_runtime_s:
+            _now = time.time()
+            _connections = self._get_swarm_connections_count(swarm)
+            _total = sum(_connections)
+            self.logger.warn(f"{_total} connections "
+                             f"({'/'.join(map(str, _connections))}) "
+                             f"at {_now - _start:.3f}s")
+            # Save maximum
+            connectMax = _total if connectMax < _total else connectMax
+            # Once reaches _conn_per_node * idx,
+            # proceed to another one
+            _target = (_target_per_node * idx)
+            # Check if target reached and break out if yes
+            if _total >= _target:
+                self.logger.warn(f"Reached target of {_target} "
+                                 f"connections ({_total})")
+                break
+            else:
+                # sleep before next measurement
+                time.sleep(10)
 
         # wait for the end
         self.logger.warn("Waiting for swarm to finish")

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1529,6 +1529,9 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
     def sockets_clear(self, node):
         True
 
+    def all_up(self):
+        return self._cloud_cluster.isAlive
+
 
 class RedpandaService(RedpandaServiceBase):
     def __init__(self,

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -66,13 +66,14 @@ class RpCloudApiClient(object):
             self._token = j['access_token']
         return self._token
 
-    def _http_get(self, endpoint='', **kwargs):
+    def _http_get(self, endpoint='', base_url=None, **kwargs):
         token = self._get_token()
         headers = {
             'Authorization': f'Bearer {token}',
             'Accept': 'application/json'
         }
-        resp = requests.get(f'{self._config.api_url}{endpoint}',
+        _base = base_url if base_url else self._config.api_url
+        resp = requests.get(f'{_base}{endpoint}',
                             headers=headers,
                             **kwargs)
         _r = self._handle_error(resp)
@@ -139,6 +140,7 @@ class LiveClusterParams:
     connection_type: str = 'public'
     namespace_uuid: str = None
     name: str = None
+    consoleUrl: str = ""
     network_id: str = None
     network_cidr: str = None
     install_pack_ver: str = None
@@ -272,6 +274,44 @@ class CloudCluster():
             'health'] == 'healthy' else False
         return self.current._isAlive
 
+    def _get_cloud_users(self):
+        _users = []
+        _offset = 0
+        _total = 1
+        while _offset < _total:
+            _params = {'offset': _offset}
+            _r = self.cloudv2._http_get(endpoint="/api/v1/users",
+                                        params=_params)
+            if _r is None:
+                return {}
+            _users += _r['users']['results']
+            _offset += len(_r['users']['results'])
+            _total = _r['users']['total']
+        return _users
+
+    def _get_cluster_users(self):
+        _r = self.cloudv2._http_get(base_url=self.current.consoleUrl,
+                                    endpoint="/api/users",)
+        if _r is None:
+            return []
+        else:
+            return _r['users']
+
+    def cloudUserExists(self, username):
+        _users = self._get_cloud_users()
+        if not _users:
+            return False
+        else:
+            _usernames = [u['name'] for u in _users]
+            return False if username not in _usernames else True
+
+    def clusterUserExists(self, username):
+        _users = self._get_cluster_users()
+        if not _users:
+            return False
+        else:
+            return False if username not in _users else True
+
     def _create_namespace(self):
         # format namespace name as 'rp-ducktape-ns-3b36f516
         name = f'rp-ducktape-ns-{self._unique_id}'
@@ -297,6 +337,12 @@ class CloudCluster():
                     raise RuntimeError("Creation failed (state 'unknown') "
                                        f"for '{self.config.provider}'")
         return False
+
+    def _get_cluster_console_url(self):
+        cluster = self.cloudv2._http_get(
+            endpoint=f'/api/v1/clusters/{self.config.id}')
+        return cluster['status']['listeners']['redpandaConsole'][
+            'default']['urls'][0]
 
     def _get_cluster_id_and_network_id(self):
         """
@@ -447,6 +493,15 @@ class CloudCluster():
 
         return
 
+    def update_cluster_acls(self, superuser):
+        if superuser is not None and not self.clusterUserExists(superuser.username):
+            self._logger.debug(f'super username: {superuser.username}, '
+                               f'algorithm: {superuser.algorithm}')
+            self._create_user(superuser)
+            self._create_acls(superuser.username)
+
+        return
+
     def create(self,
                config_profile_name: str = 'default',
                superuser: Optional[SaslCredentials] = None) -> str:
@@ -471,72 +526,64 @@ class CloudCluster():
             self._update_live_cluster_info()
             # Fill in additional info based on collected from cluster
             self.current.product_id = self._get_product_id(config_profile_name)
-            # If network type is private, trigget VPC Peering
-            if not self.isPublicNetwork:
-                # Create VPC peering
-                self.create_vpc_peering()
-            return self.config.id
+        else:
+            # In order not to have long list of arguments in each internal
+            # functions, use self.current as a data store
+            # Each of the _*_payload functions and _get_* will use it as a source
+            # of data to create proper body for REST request
+            self.current.namespace_uuid = self._create_namespace()
+            # name rp-ducktape-cluster-3b36f516
+            self.current.name = f'rp-ducktape-cluster-{self._unique_id}'
+            # Install pack handling
+            if self.config.install_pack_ver == 'latest':
+                self.config.install_pack_ver = self._get_latest_install_pack_ver()
+            self.current.install_pack_ver = self.config.install_pack_ver
+            # Multi-zone not supported, so get a single one from the list
+            self.current.region = self.config.region
+            self.current.region_id = self._get_region_id()
+            self.current.zones = self.provider_cli.get_single_zone(
+                self.current.region)
+            # Call CloudV2 API to determine Product ID
+            self.current.product_id = self._get_product_id(config_profile_name)
+            if self.current.product_id is None:
+                raise RuntimeError("ProductID failed to be determined for "
+                                f"'{self.config.provider}', "
+                                f"'{self.config.type}', "
+                                f"'{self.config.install_pack_ver}', "
+                                f"'{self.config.region}'")
 
-        # In order not to have long list of arguments in each internal
-        # functions, use self.current as a data store
-        # Each of the _*_payload functions and _get_* will use it as a source
-        # of data to create proper body for REST request
-        self.current.namespace_uuid = self._create_namespace()
-        # name rp-ducktape-cluster-3b36f516
-        self.current.name = f'rp-ducktape-cluster-{self._unique_id}'
-        # Install pack handling
-        if self.config.install_pack_ver == 'latest':
-            self.config.install_pack_ver = self._get_latest_install_pack_ver()
-        self.current.install_pack_ver = self.config.install_pack_ver
-        # Multi-zone not supported, so get a single one from the list
-        self.current.region = self.config.region
-        self.current.region_id = self._get_region_id()
-        self.current.zones = self.provider_cli.get_single_zone(
-            self.current.region)
-        # Call CloudV2 API to determine Product ID
-        self.current.product_id = self._get_product_id(config_profile_name)
-        if self.current.product_id is None:
-            raise RuntimeError("ProductID failed to be determined for "
-                               f"'{self.config.provider}', "
-                               f"'{self.config.type}', "
-                               f"'{self.config.install_pack_ver}', "
-                               f"'{self.config.region}'")
+            # Call Api to create cluster
+            self._logger.info(f'creating cluster name {self.current.name}')
+            # Prepare cluster payload block
+            _body = self._create_cluster_payload()
+            self._logger.debug(f'body: {json.dumps(_body)}')
+            # Send API request
+            r = self.cloudv2._http_post(
+                endpoint='/api/v1/workflows/network-cluster', json=_body)
 
-        # Call Api to create cluster
-        self._logger.info(f'creating cluster name {self.current.name}')
-        # Prepare cluster payload block
-        _body = self._create_cluster_payload()
-        self._logger.debug(f'body: {json.dumps(_body)}')
-        # Send API request
-        r = self.cloudv2._http_post(
-            endpoint='/api/v1/workflows/network-cluster', json=_body)
+            # handle error on CloudV2 side
+            if r is None:
+                raise RuntimeError(self.cloudv2.lasterror)
 
-        # handle error on CloudV2 side
-        if r is None:
-            raise RuntimeError(self.cloudv2.lasterror)
+            self._logger.info(
+                f'waiting for creation of cluster {self.current.name} '
+                f'namespaceUuid {r["namespaceUuid"]}, checking every '
+                f'{self.CHECK_BACKOFF_SEC} seconds')
+            # Poll API and wait for the cluster creation
+            wait_until(lambda: self._cluster_ready(),
+                    timeout_sec=self.CHECK_TIMEOUT_SEC,
+                    backoff_sec=self.CHECK_BACKOFF_SEC,
+                    err_msg='Unable to deterimine readiness '
+                    f'of cloud cluster {self.current.name}')
+            self.config.id, self.current.network_id = \
+                self._get_cluster_id_and_network_id()
 
-        self._logger.info(
-            f'waiting for creation of cluster {self.current.name} '
-            f'namespaceUuid {r["namespaceUuid"]}, checking every '
-            f'{self.CHECK_BACKOFF_SEC} seconds')
-        # Poll API and wait for the cluster creation
-        wait_until(lambda: self._cluster_ready(),
-                   timeout_sec=self.CHECK_TIMEOUT_SEC,
-                   backoff_sec=self.CHECK_BACKOFF_SEC,
-                   err_msg='Unable to deterimine readiness '
-                   f'of cloud cluster {self.current.name}')
-        self.config.id, self.current.network_id = \
-            self._get_cluster_id_and_network_id()
+        # Update Cluster console Url
+        self.current.consoleUrl = self._get_cluster_console_url()
+        # update cluster ACLs
+        self.update_cluster_acls(superuser)
 
-        if not self.isPublicNetwork:
-            self.create_vpc_peering()
-
-        if superuser is not None:
-            self._logger.debug(f'super username: {superuser.username}, '
-                               f'algorithm: {superuser.algorithm}')
-            self._create_user(superuser)
-            self._create_acls(superuser.username)
-
+        # If network type is private, trigget VPC Peering
         if not self.isPublicNetwork:
             self.create_vpc_peering()
         self.current._isAlive = True
@@ -572,18 +619,13 @@ class CloudCluster():
     def _create_user(self, user: SaslCredentials):
         """Create SASL user
         """
-
-        cluster = self.cloudv2._http_get(
-            endpoint=f'/api/v1/clusters/{self.config.id}')
-        base_url = cluster['status']['listeners']['redpandaConsole'][
-            'default']['urls'][0]
         payload = {
             'mechanism': user.algorithm,
             'password': user.password,
             'username': user.username,
         }
         # use the console api url to create sasl users; uses the same auth token
-        return self.cloudv2._http_post(base_url=base_url,
+        return self.cloudv2._http_post(base_url=self.current.consoleUrl,
                                        endpoint='/api/users',
                                        json=payload)
 

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -73,9 +73,7 @@ class RpCloudApiClient(object):
             'Accept': 'application/json'
         }
         _base = base_url if base_url else self._config.api_url
-        resp = requests.get(f'{_base}{endpoint}',
-                            headers=headers,
-                            **kwargs)
+        resp = requests.get(f'{_base}{endpoint}', headers=headers, **kwargs)
         _r = self._handle_error(resp)
         return _r if _r is None else _r.json()
 
@@ -290,8 +288,10 @@ class CloudCluster():
         return _users
 
     def _get_cluster_users(self):
-        _r = self.cloudv2._http_get(base_url=self.current.consoleUrl,
-                                    endpoint="/api/users",)
+        _r = self.cloudv2._http_get(
+            base_url=self.current.consoleUrl,
+            endpoint="/api/users",
+        )
         if _r is None:
             return []
         else:
@@ -341,8 +341,8 @@ class CloudCluster():
     def _get_cluster_console_url(self):
         cluster = self.cloudv2._http_get(
             endpoint=f'/api/v1/clusters/{self.config.id}')
-        return cluster['status']['listeners']['redpandaConsole'][
-            'default']['urls'][0]
+        return cluster['status']['listeners']['redpandaConsole']['default'][
+            'urls'][0]
 
     def _get_cluster_id_and_network_id(self):
         """
@@ -494,7 +494,8 @@ class CloudCluster():
         return
 
     def update_cluster_acls(self, superuser):
-        if superuser is not None and not self.clusterUserExists(superuser.username):
+        if superuser is not None and not self.clusterUserExists(
+                superuser.username):
             self._logger.debug(f'super username: {superuser.username}, '
                                f'algorithm: {superuser.algorithm}')
             self._create_user(superuser)
@@ -536,7 +537,8 @@ class CloudCluster():
             self.current.name = f'rp-ducktape-cluster-{self._unique_id}'
             # Install pack handling
             if self.config.install_pack_ver == 'latest':
-                self.config.install_pack_ver = self._get_latest_install_pack_ver()
+                self.config.install_pack_ver = \
+                    self._get_latest_install_pack_ver()
             self.current.install_pack_ver = self.config.install_pack_ver
             # Multi-zone not supported, so get a single one from the list
             self.current.region = self.config.region
@@ -547,10 +549,10 @@ class CloudCluster():
             self.current.product_id = self._get_product_id(config_profile_name)
             if self.current.product_id is None:
                 raise RuntimeError("ProductID failed to be determined for "
-                                f"'{self.config.provider}', "
-                                f"'{self.config.type}', "
-                                f"'{self.config.install_pack_ver}', "
-                                f"'{self.config.region}'")
+                                   f"'{self.config.provider}', "
+                                   f"'{self.config.type}', "
+                                   f"'{self.config.install_pack_ver}', "
+                                   f"'{self.config.region}'")
 
             # Call Api to create cluster
             self._logger.info(f'creating cluster name {self.current.name}')
@@ -571,10 +573,10 @@ class CloudCluster():
                 f'{self.CHECK_BACKOFF_SEC} seconds')
             # Poll API and wait for the cluster creation
             wait_until(lambda: self._cluster_ready(),
-                    timeout_sec=self.CHECK_TIMEOUT_SEC,
-                    backoff_sec=self.CHECK_BACKOFF_SEC,
-                    err_msg='Unable to deterimine readiness '
-                    f'of cloud cluster {self.current.name}')
+                       timeout_sec=self.CHECK_TIMEOUT_SEC,
+                       backoff_sec=self.CHECK_BACKOFF_SEC,
+                       err_msg='Unable to deterimine readiness '
+                       f'of cloud cluster {self.current.name}')
             self.config.id, self.current.network_id = \
                 self._get_cluster_id_and_network_id()
 

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -14,3 +14,4 @@ cloud:
     - tests/services_self_test.py::SimpleSelfTest
     - tests/services_self_test.py::OpenBenchmarkSelfTest
     - scale_tests/high_throughput_test.py::HighThroughputTest2.test_throughput_simple
+    - scale_tests/high_throughput_test.py::HighThroughputTest2.test_max_connections

--- a/tests/rptest/test_suite_ec2.yml
+++ b/tests/rptest/test_suite_ec2.yml
@@ -9,3 +9,4 @@ ec2:
     - tests/e2e_iam_role_test.py # use static credentials
     - tests/consumer_group_recovery_tool_test.py # use script available in dockerfile
     - scale_tests/many_partitions_test.py::ManyPartitionsTest.test_many_partitions_tiered_storage # time consuming in main suite
+    - scale_tests/high_throughput_test.py::HighThroughputTest2.test_max_connections # not compatible with locally deployed Redpanda


### PR DESCRIPTION
  Check and implement functions that needed to run ProducerSwarm class
  with RedpandaServiceCloud.

  After that, create main test that will ramp-up connection load node-by-node

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none