### PR TITLE
ducky: relax assert in transactions_test

### DIFF
--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -924,6 +924,13 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
         self.do_upgrade_with_tx(get_topic_leader)
 
 
+def remote_path_exists(node, path):
+    wait_until(lambda: node.account.exists(path),
+               timeout_sec=20,
+               backoff_sec=2,
+               err_msg=f"Can't find \"{path}\" on {node.account.hostname}")
+
+
 class StaticPartitioning_MixedVersionsTest(RedpandaTest, TransactionsMixin):
     def __init__(self, test_context):
         extra_rp_conf = {
@@ -968,7 +975,7 @@ class StaticPartitioning_MixedVersionsTest(RedpandaTest, TransactionsMixin):
                         "tx_registry")
             assert not node.account.exists(path)
             path = join(RedpandaService.DATA_DIR, "kafka_internal", "tx")
-            assert node.account.exists(path)
+            remote_path_exists(node, path)
             assert node.account.isdir(path)
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -993,7 +1000,7 @@ class StaticPartitioning_MixedVersionsTest(RedpandaTest, TransactionsMixin):
                         "tx_registry")
             assert not node.account.exists(path)
             path = join(RedpandaService.DATA_DIR, "kafka_internal", "tx")
-            assert node.account.exists(path)
+            remote_path_exists(node, path)
             assert node.account.isdir(path)
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -1019,7 +1026,7 @@ class StaticPartitioning_MixedVersionsTest(RedpandaTest, TransactionsMixin):
             for tx_topic in ["tx", "tx_registry"]:
                 path = join(RedpandaService.DATA_DIR, "kafka_internal",
                             tx_topic)
-                assert node.account.exists(path)
+                remote_path_exists(node, path)
                 assert node.account.isdir(path)
 
 


### PR DESCRIPTION
Topic creation may be acked before it's created on all replicas but the test was expecting to find topic on all replicas immediately after the request is acked. Replacing an assert with wait_until to give RP time to propagate the change.

Fixes #11737

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none