### PR TITLE
[v23.2.x] [storage]: make space management chill out

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1713,6 +1713,24 @@ configuration::configuration()
       25.0,
       {.min = 0.0, .max = 100.0},
       legacy_default<double>(0.0, legacy_version{9}))
+  , space_management_max_log_concurrency(
+      *this,
+      "space_management_max_log_concurrency",
+      "Maximum parallel logs inspected during space management process.",
+      {.needs_restart = needs_restart::no,
+       .example = "20",
+       .visibility = visibility::tunable},
+      20,
+      {.min = 1})
+  , space_management_max_segment_concurrency(
+      *this,
+      "space_management_max_segment_concurrency",
+      "Maximum parallel segments inspected during space management process.",
+      {.needs_restart = needs_restart::no,
+       .example = "10",
+       .visibility = visibility::tunable},
+      10,
+      {.min = 1})
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -331,6 +331,8 @@ struct configuration final : public config_store {
     property<double> retention_local_trim_overage_coeff;
     property<bool> space_management_enable;
     bounded_property<double, numeric_bounds> disk_reservation_percent;
+    bounded_property<uint16_t> space_management_max_log_concurrency;
+    bounded_property<uint16_t> space_management_max_segment_concurrency;
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -110,7 +110,14 @@ ss::future<> disk_space_manager::run_loop() {
             continue;
         }
 
-        co_await manage_data_disk(_target_size);
+        try {
+            co_await manage_data_disk(_target_size);
+        } catch (...) {
+            vlog(
+              stlog.info,
+              "Recoverable error running space management loop: {}",
+              std::current_exception());
+        }
     }
 }
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2069,7 +2069,8 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
         }
     }
 
-    ss::semaphore limit(10);
+    ss::semaphore limit(std::max<size_t>(
+      1, config::shard_local_cfg().space_management_max_segment_concurrency()));
 
     auto [retention, available, remaining, lcl] = co_await ss::when_all_succeed(
       // reduce segment subject to retention policy
@@ -2292,7 +2293,8 @@ disk_log_impl::disk_usage_target_time_retention(gc_config cfg) {
         co_return std::nullopt;
     }
 
-    ss::semaphore limit(10);
+    ss::semaphore limit(std::max<size_t>(
+      1, config::shard_local_cfg().space_management_max_segment_concurrency()));
 
     // roll up the amount of disk space taken by these segments
     auto usage = co_await ss::map_reduce(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2069,32 +2069,46 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
         }
     }
 
+    ss::semaphore limit(10);
+
     auto [retention, available, remaining, lcl] = co_await ss::when_all_succeed(
       // reduce segment subject to retention policy
       ss::map_reduce(
         retention_segments,
-        [](const segment_set::type& seg) { return seg->persistent_size(); },
+        [&limit](const segment_set::type& seg) {
+            return ss::with_semaphore(
+              limit, 1, [&seg] { return seg->persistent_size(); });
+        },
         usage{},
         [](usage acc, usage u) { return acc + u; }),
 
       // reduce segments available for reclaim
       ss::map_reduce(
         available_segments,
-        [](const segment_set::type& seg) { return seg->persistent_size(); },
+        [&limit](const segment_set::type& seg) {
+            return ss::with_semaphore(
+              limit, 1, [&seg] { return seg->persistent_size(); });
+        },
         usage{},
         [](usage acc, usage u) { return acc + u; }),
 
       // reduce segments not available for reclaim
       ss::map_reduce(
         remaining_segments,
-        [](const segment_set::type& seg) { return seg->persistent_size(); },
+        [&limit](const segment_set::type& seg) {
+            return ss::with_semaphore(
+              limit, 1, [&seg] { return seg->persistent_size(); });
+        },
         usage{},
         [](usage acc, usage u) { return acc + u; }),
 
       // reduce segments not available for reclaim
       ss::map_reduce(
         local_retention_segments,
-        [](const segment_set::type& seg) { return seg->persistent_size(); },
+        [&limit](const segment_set::type& seg) {
+            return ss::with_semaphore(
+              limit, 1, [&seg] { return seg->persistent_size(); });
+        },
         usage{},
         [](usage acc, usage u) { return acc + u; }));
 
@@ -2278,10 +2292,15 @@ disk_log_impl::disk_usage_target_time_retention(gc_config cfg) {
         co_return std::nullopt;
     }
 
+    ss::semaphore limit(10);
+
     // roll up the amount of disk space taken by these segments
     auto usage = co_await ss::map_reduce(
       segments,
-      [](const segment_set::type& seg) { return seg->persistent_size(); },
+      [&limit](const segment_set::type& seg) {
+          return ss::with_semaphore(
+            limit, 1, [&seg] { return seg->persistent_size(); });
+      },
       storage::usage{},
       [](storage::usage acc, storage::usage u) { return acc + u; });
 

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -139,6 +139,7 @@ log_manager::log_manager(
   , _resources(resources)
   , _feature_table(feature_table)
   , _jitter(_config.compaction_interval())
+  , _trigger_gc_jitter(0s, 5s)
   , _batch_cache(config.reclaim_opts) {
     _config.compaction_interval.watch([this]() {
         _jitter = simple_time_jitter<ss::lowres_clock>{
@@ -796,8 +797,14 @@ void log_manager::handle_disk_notification(storage::disk_space_alert alert) {
 }
 
 void log_manager::trigger_gc() {
-    _gc_triggered = true;
-    _housekeeping_sem.signal();
+    ssx::spawn_with_gate(_open_gate, [this] {
+        return ss::sleep_abortable(
+                 _trigger_gc_jitter.next_duration(), _abort_source)
+          .then([this] {
+              _gc_triggered = true;
+              _housekeeping_sem.signal();
+          });
+    });
 }
 
 } // namespace storage

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -762,7 +762,8 @@ ss::future<usage_report> log_manager::disk_usage() {
         logs.push_back(it.second->handle);
     }
 
-    ss::semaphore limit(20);
+    ss::semaphore limit(std::max<size_t>(
+      1, config::shard_local_cfg().space_management_max_log_concurrency()));
 
     co_return co_await ss::map_reduce(
       logs.begin(),

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -269,6 +269,7 @@ private:
     storage_resources& _resources;
     ss::sharded<features::feature_table>& _feature_table;
     simple_time_jitter<ss::lowres_clock> _jitter;
+    simple_time_jitter<ss::lowres_clock> _trigger_gc_jitter;
     logs_type _logs;
     compaction_list_type _logs_list;
     batch_cache _batch_cache;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13072

I also added this one: https://github.com/redpanda-data/redpanda/pull/13094 which would have needed backporting too, and depends on 13072.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

