### PR TITLE
[v23.2.x] t/full_disk_test: longer timeout in debug_mode

### DIFF
--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -246,10 +246,11 @@ class FullDiskTest(EndToEndTest):
             self.full_disk.trigger_low_space()
 
             # confirm we were blocked from producing
-            not_producing = RateTarget(max_total_sec=40,
-                                       target_sec=5,
-                                       target_min_rate=0,
-                                       target_max_rate=1)
+            not_producing = RateTarget(
+                max_total_sec=40 if not self.debug_mode else 100,
+                target_sec=5,
+                target_min_rate=0,
+                target_max_rate=1)
             self.bytes_prod.expect_rate(not_producing)
 
             self.full_disk.clear_low_space()


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12023
Fixes: https://github.com/redpanda-data/redpanda/issues/13150,