### PR TITLE
Made `consumer_offsets_consistency_test.py` more robust

### DIFF
--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -199,7 +199,7 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
                     )
                     if self.failure_cnt >= 20:
                         break
-                    timeout = 60
+                    timeout = 120
                     if time.time() - self.last_success > timeout:
                         assert False, f"Unable to retrieve group description for {timeout} seconds"
         finally:

--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -80,6 +80,9 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
     def test_flipping_leadership(self):
         topic = TopicSpec(partition_count=64, replication_factor=3)
         self.client().create_topic([topic])
+        # set new members join timeout to 5 seconds to make the test execution faster
+        self.redpanda.set_cluster_config(
+            {"group_new_member_join_timeout": 5000})
         msg_size = 16
         msg_cnt = 5000000
 

--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -44,7 +44,17 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
 
     def get_offsets(self, group_name):
         offsets = {}
-        gd = self.rpk.group_describe(group_name)
+
+        def do_describe():
+            gd = self.rpk.group_describe(group_name)
+            return (True, gd)
+
+        gd = wait_until_result(
+            do_describe,
+            timeout_sec=30,
+            backoff_sec=0.5,
+            err_msg="RPK failed to get consumer group offsets",
+            retry_on_exc=True)
 
         for p in gd.partitions:
             if p.current_offset is not None:


### PR DESCRIPTION
Added retries to offset listing logic and reduced new members join timeout to make the test stable.

Fixes: #13061 
Fixes: #13159 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none