### PR TITLE
Reshedule tick immediately when topic table was modified

### DIFF
--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -23,6 +23,7 @@
 #include "config/property.h"
 #include "random/generators.h"
 #include "utils/gate_guard.h"
+#include "utils/stable_iterator_adaptor.h"
 
 #include <seastar/core/coroutine.hh>
 
@@ -255,6 +256,13 @@ void partition_balancer_backend::tick() {
                   e.what());
                 maybe_rearm_timer(true);
             })
+          .handle_exception_type([this](iterator_stability_violation& e) {
+              vlog(
+                clusterlog.debug,
+                "iterator_stability_violation: {}, rescheduling tick",
+                e.what());
+              maybe_rearm_timer(true);
+          })
           .handle_exception([](const std::exception_ptr& e) {
               vlog(clusterlog.warn, "tick error: {}", e);
           });


### PR DESCRIPTION
If topic table was modified during iterating over topics in partition balancer planner the `partition_balancer_backend` tick should be rescheduled immediately.

Fixes: #11999

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none