### PR TITLE
kvstore::start: Defer snapshot save until after version check

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1839,6 +1839,12 @@ void application::start_bootstrap_services() {
     // as they start.
     load_feature_table_snapshot();
 
+    // save snapshot and finally GC segments
+    storage
+      .invoke_on_all(
+        [](storage::api& s) mutable { return s.kvs().cleanup_start(); })
+      .get();
+
     // Before we start up our bootstrapping RPC service, load any relevant
     // on-disk state we may need: existing cluster UUID, node ID, etc.
     if (std::optional<iobuf> cluster_uuid_buf = storage.local().kvs().get(

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -109,6 +109,7 @@ public:
     ~kvstore() noexcept;
 
     ss::future<> start();
+    ss::future<> cleanup_start();
     ss::future<> stop();
 
     std::optional<iobuf> get(key_space ks, bytes_view key);
@@ -137,6 +138,7 @@ private:
     ss::abort_source _as;
     simple_snapshot_manager _snap;
     bool _started{false};
+    std::vector<std::pair<ss::sstring, ss::sstring>> _segs_to_remove;
 
     /**
      * Database operation. A std::nullopt value is a deletion.


### PR DESCRIPTION
This commit refactors the kvstore startup recovery sequence to account for situations where an upgrade is halted due to an incompatible logical version.

In order to assert logical version compatibility, we must first materialize the key value store in memory. After doing so, we can assert on the difference between the cluster's active version and the latest logical version baked into the loaded binary.

However, at the end of the kvstore startup sequence, after replaying any snapshots and/or segments into memory, we save a snapshot of the result back to disk and GC the corresponding segments as needed. This is done to avoid accumulating a bunch of tiny segments if there are frequent restarts without much useful activity.

The result of all this is that, even when a new binary version has been rejected on startup, that node's kvstore has been snapshotted back to disk based on the _new_ version's serialization format. This can lead to unexpected behaviors when the node must eventually be "downgraded" to a compatible logical version.

So this commit adds code to defer the kvstore's opportunistic GC operations until _after_ the version compatibility assertion has been made, ensuring that the data directory is not modified when a node upgrade is disrupted in this way.

Fixes redpanda-data/core-internal#739

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [x] v22.3.x

## Release Notes

### Bug Fixes

* Avoid modifying node-local data before checking upgrade version

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
