### PR TITLE
[v23.2.x] Made `consumer_offsets_consistency_test.py` more robust

### DIFF
--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -199,7 +199,7 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
                     )
                     if self.failure_cnt >= 20:
                         break
-                    timeout = 60
+                    timeout = 120
                     if time.time() - self.last_success > timeout:
                         assert False, f"Unable to retrieve group description for {timeout} seconds"
         finally:

--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -80,6 +80,9 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
     def test_flipping_leadership(self):
         topic = TopicSpec(partition_count=64, replication_factor=3)
         self.client().create_topic([topic])
+        # set new members join timeout to 5 seconds to make the test execution faster
+        self.redpanda.set_cluster_config(
+            {"group_new_member_join_timeout": 5000})
         msg_size = 16
         msg_cnt = 5000000
 

--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -44,7 +44,17 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
 
     def get_offsets(self, group_name):
         offsets = {}
-        gd = self.rpk.group_describe(group_name)
+
+        def do_describe():
+            gd = self.rpk.group_describe(group_name)
+            return (True, gd)
+
+        gd = wait_until_result(
+            do_describe,
+            timeout_sec=30,
+            backoff_sec=0.5,
+            err_msg="RPK failed to get consumer group offsets",
+            retry_on_exc=True)
 
         for p in gd.partitions:
             if p.current_offset is not None:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13160
Fixes: https://github.com/redpanda-data/redpanda/issues/13196,