### PR TITLE
cmake/dependencies.cmake: added re2 and krb5 via pkgconfig

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -117,9 +117,19 @@ FetchContent_MakeAvailable(
     wasmedge
     hdrhistogram)
 
+# for pkg_check_modules
+find_package(PkgConfig REQUIRED)
+
+# this creates the target PkgConfig::RE2, it can be aliased to another name
+pkg_check_modules(RE2 REQUIRED IMPORTED_TARGET re2)
+# this is for PkgConfig::KRB5 that links to libkrb5-dev
+pkg_check_modules(KRB5 REQUIRED IMPORTED_TARGET krb5)
+
 add_library(Crc32c::crc32c ALIAS crc32c)
 add_library(aklomp::base64 ALIAS base64)
 add_library(Hdrhistogram::hdr_histogram ALIAS hdr_histogram)
+add_library(re2 ALIAS PkgConfig::RE2)
+add_library(krb5 ALIAS PkgConfig::KRB5)
 
 list(APPEND CMAKE_PROGRAM_PATH ${tinygo_SOURCE_DIR}/bin)
 


### PR DESCRIPTION
re2 and krb5 are not supported by find_package, but can be found with pkgconfig.
The advantage of listing them in this way is to move the error at configuration time.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none