### PR TITLE
gha: run go test on PRs to release branches

### DIFF
--- a/.github/workflows/redpanda-migration-build.yml
+++ b/.github/workflows/redpanda-migration-build.yml
@@ -14,15 +14,15 @@ on:
       - '*'
   pull_request:
     branches:
-      - main
       - dev
+      - 'v*'
     paths:
       - .github/workflows/redpanda-migration-build.yml
       - src/go/cluster-to-redpanda-migration
 
 jobs:
   test:
-    name: Run tests
+    name: Test cluster-to-redpanda-migration
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -14,15 +14,15 @@ on:
       - '*'
   pull_request:
     branches:
-      - main
       - dev
+      - 'v*'
     paths:
       - .github/workflows/rpk-build.yml
       - src/go/rpk
 
 jobs:
   test:
-    name: Run tests
+    name: Test rpk
     strategy:
       matrix:
         os: [linux, darwin, windows]

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -20,7 +20,6 @@ on:
   pull_request:
     branches:
       - dev
-      # Run on any backports
       - 'v*'
     paths:
       - 'src/go/transform-sdk/**'
@@ -28,7 +27,7 @@ on:
 
 jobs:
   test:
-    name: Run tests
+    name: Test transform-sdk
     runs-on: ubuntu-latest
     steps:
 

--- a/src/go/cluster-to-redpanda-migration/go.mod
+++ b/src/go/cluster-to-redpanda-migration/go.mod
@@ -18,7 +18,7 @@ require (
 require (
 	emperror.dev/errors v0.8.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cert-manager/cert-manager v1.11.0 // indirect

--- a/src/go/cluster-to-redpanda-migration/go.sum
+++ b/src/go/cluster-to-redpanda-migration/go.sum
@@ -5,8 +5,9 @@ emperror.dev/errors v0.8.1/go.mod h1:YcRvLPh626Ubn2xqtoprejnA5nFha+TJ+2vew48kWuE
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7YgDP83g=
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
+github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
+github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=


### PR DESCRIPTION
The golang github actions were only run on PRs to `dev` branch and git tag events. This PR updates gha to run them on PRs to release branches as well.

This will help catch issues in PRs like https://github.com/redpanda-data/redpanda/pull/13129 before tagging for release.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
