### PR TITLE
cloud_storage: debug log on query below log start

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -483,6 +483,28 @@ private:
         // Find manifest that contains requested offset or timestamp
         auto cur = co_await _partition->_manifest_view->get_cursor(query);
         if (cur.has_failure()) {
+            if (
+              cur.error() == error_outcome::out_of_range
+              && std::holds_alternative<kafka::offset>(query)) {
+                // Special case queries below the start offset of the log.
+                // The start offset may have advanced while the request was
+                // in progress. This is expected, so log at debug level.
+                const auto log_start_offset = _partition->_manifest_view
+                                                ->stm_manifest()
+                                                .full_log_start_kafka_offset();
+
+                const auto query_offset = std::get<kafka::offset>(query);
+                if (log_start_offset && query_offset < *log_start_offset) {
+                    vlog(
+                      _ctxlog.debug,
+                      "Manifest query below the log's start Kafka offset: {} < "
+                      "{}",
+                      query_offset(),
+                      log_start_offset.value()());
+                    co_return;
+                }
+            }
+
             vlog(
               _ctxlog.error,
               "Failed to query spillover manifests: {}, query: {}",


### PR DESCRIPTION
Previously, when the start offset of the log advanced while processsing a fetch resulting in the fetch to land below the start of the log, we would log at ERROR level. However, this situation is normal when the consumer is fetching close to the boundary from which retention is operating.

This patch detects such situations and downgrades the log to the DEBUG level.

Fixes #12105

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
