### PR TITLE
[v22.3.x] ducktape: extend timeout in timequery_test

### DIFF
--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -233,7 +233,7 @@ class BaseTimeQuery:
             return next(rpk.describe_topic(topic.name)).start_offset
 
         wait_until(lambda: start_offset() > 0,
-                   timeout_sec=60,
+                   timeout_sec=120,
                    backoff_sec=5,
                    err_msg="Start offset did not advance")
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12127
Fixes: https://github.com/redpanda-data/redpanda/issues/13214,