### PR TITLE
[v23.2.x] rptest: Support gcpkeyfile parameter on rptest for GCP Nightly

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -121,7 +121,7 @@ class CloudClusterConfig:
     teleport_bot_token: str = ""
     id: str = ""  # empty string makes it easier to pass thru default value from duck.py
     delete_cluster: bool = True
-
+    gcp_keyfile: str = ""
     region: str = "us-west-2"
     provider: str = "AWS"
     type: str = "FMC"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13059
