### PR TITLE
Coordinated recovery: add message fields

### DIFF
--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -2057,6 +2057,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           .last_dirty_log_index = tests::random_named_int<model::offset>(),
           .last_term_base_offset = tests::random_named_int<model::offset>(),
           .result = raft::reply_result::group_unavailable,
+          .may_recover = tests::random_bool(),
         };
         roundtrip_test(data);
     }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1902,6 +1902,8 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
               .prev_log_term = tests::random_named_int<model::term_id>(),
               .last_visible_index = tests::random_named_int<model::offset>(),
             };
+            meta.dirty_offset
+              = meta.prev_log_index; // always true for heartbeats
             raft::heartbeat_metadata hm{
               .meta = meta,
               .node_id = raft::
@@ -1982,6 +1984,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           .prev_log_index = tests::random_named_int<model::offset>(),
           .prev_log_term = tests::random_named_int<model::term_id>(),
           .last_visible_index = tests::random_named_int<model::offset>(),
+          .dirty_offset = tests::random_named_int<model::offset>(),
         };
         roundtrip_test(data);
     }
@@ -2003,6 +2006,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           .prev_log_index = tests::random_named_int<model::offset>(),
           .prev_log_term = tests::random_named_int<model::term_id>(),
           .last_visible_index = tests::random_named_int<model::offset>(),
+          .dirty_offset = tests::random_named_int<model::offset>(),
         };
 
         raft::append_entries_request data{

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1828,6 +1828,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
           .chunk = bytes_to_iobuf(
             random_generators::get_bytes(random_generators::get_int(1024))),
           .done = tests::random_bool(),
+          .dirty_offset = tests::random_named_int<model::offset>(),
         };
         /*
          * manual adl/serde test to workaround iobuf being move-only
@@ -1842,6 +1843,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
               .file_offset = orig.file_offset,
               .chunk = orig.chunk.copy(),
               .done = orig.done,
+              .dirty_offset = orig.dirty_offset,
             };
             auto serde_out = serde::to_iobuf(std::move(serde_in));
             auto from_serde = serde::from_iobuf<raft::install_snapshot_request>(

--- a/src/v/compat/raft_compat.h
+++ b/src/v/compat/raft_compat.h
@@ -270,6 +270,7 @@ struct compat_check<raft::install_snapshot_request> {
         json_write(file_offset);
         json_write(chunk);
         json_write(done);
+        json_write(dirty_offset);
     }
 
     static raft::install_snapshot_request from_json(json::Value& rd) {
@@ -282,6 +283,7 @@ struct compat_check<raft::install_snapshot_request> {
         json_read(file_offset);
         json_read(chunk);
         json_read(done);
+        json_read(dirty_offset);
         return obj;
     }
 
@@ -308,6 +310,7 @@ compat_copy(raft::install_snapshot_request obj) {
           .file_offset = obj.file_offset,
           .chunk = obj.chunk.copy(),
           .done = obj.done,
+          .dirty_offset = obj.dirty_offset,
         };
     };
     return std::make_pair(f(), f());

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -251,6 +251,7 @@ struct instance_generator<raft::protocol_metadata> {
           .prev_log_index = tests::random_named_int<model::offset>(),
           .prev_log_term = tests::random_named_int<model::term_id>(),
           .last_visible_index = tests::random_named_int<model::offset>(),
+          .dirty_offset = tests::random_named_int<model::offset>(),
         };
     }
 
@@ -285,6 +286,12 @@ struct instance_generator<raft::heartbeat_request> {
               vnode{target_node_id, tests::random_named_int<model::revision_id>()},
           },
         }};
+
+        for (auto& hb : ret.heartbeats) {
+            // for heartbeats dirty_offset and prev_log_index are always the
+            // same.
+            hb.meta.dirty_offset = hb.meta.prev_log_index;
+        }
 
         /*
          * the serialization step for heartbeat_request will automatically sort

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -190,7 +190,7 @@ struct instance_generator<raft::install_snapshot_request> {
           .chunk = bytes_to_iobuf(
             random_generators::get_bytes(random_generators::get_int(1, 512))),
           .done = tests::random_bool(),
-        };
+          .dirty_offset = tests::random_named_int<model::offset>()};
     }
 
     static std::vector<raft::install_snapshot_request> limits() { return {}; }

--- a/src/v/compat/raft_generator.h
+++ b/src/v/compat/raft_generator.h
@@ -340,6 +340,7 @@ struct instance_generator<raft::append_entries_reply> {
              raft::reply_result::failure,
              raft::reply_result::group_unavailable,
              raft::reply_result::timeout}),
+          .may_recover = tests::random_bool(),
         };
     }
 
@@ -384,6 +385,12 @@ struct instance_generator<raft::heartbeat_reply> {
         };
 
         std::sort(ret.meta.begin(), ret.meta.end(), sorter_fn{});
+
+        // For old-style heartbeats may_recover is not serialized and defaults
+        // to true.
+        for (auto& r : ret.meta) {
+            r.may_recover = true;
+        }
 
         return ret;
     }

--- a/src/v/compat/raft_json.h
+++ b/src/v/compat/raft_json.h
@@ -48,6 +48,8 @@ inline void rjson_serialize(
     rjson_serialize(w, v.prev_log_term);
     w.Key("last_visible_index");
     rjson_serialize(w, v.last_visible_index);
+    w.Key("dirty_offset");
+    rjson_serialize(w, v.dirty_offset);
     w.EndObject();
 }
 
@@ -59,6 +61,7 @@ inline void read_value(json::Value const& rd, raft::protocol_metadata& obj) {
     read_member(rd, "prev_log_index", tmp.prev_log_index);
     read_member(rd, "prev_log_term", tmp.prev_log_term);
     read_member(rd, "last_visible_index", tmp.last_visible_index);
+    read_member(rd, "dirty_offset", tmp.dirty_offset);
     obj = tmp;
 }
 

--- a/src/v/compat/raft_json.h
+++ b/src/v/compat/raft_json.h
@@ -108,6 +108,7 @@ inline void read_value(json::Value const& rd, raft::append_entries_reply& out) {
     default:
         vassert(false, "invalid result {}", result);
     }
+    json_read(may_recover);
     out = obj;
 }
 
@@ -130,6 +131,7 @@ inline void rjson_serialize(
     json_write(last_dirty_log_index);
     json_write(last_term_base_offset);
     json_write(result);
+    json_write(may_recover);
 }
 
 inline void rjson_serialize(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2633,7 +2633,8 @@ protocol_metadata consensus::meta() const {
       .term = _term,
       .prev_log_index = lstats.dirty_offset,
       .prev_log_term = prev_log_term,
-      .last_visible_index = last_visible_index()};
+      .last_visible_index = last_visible_index(),
+      .dirty_offset = lstats.dirty_offset};
 }
 
 void consensus::update_node_append_timestamp(vnode id) {
@@ -3633,6 +3634,7 @@ ss::future<full_heartbeat_reply> consensus::full_heartbeat(
         .prev_log_index = hb_data.prev_log_index,
         .prev_log_term = hb_data.prev_log_term,
         .last_visible_index = hb_data.last_visible_index,
+        .dirty_offset = hb_data.prev_log_index,
       },
       model::make_memory_record_batch_reader(
         ss::circular_buffer<model::record_batch>{}),

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3646,6 +3646,7 @@ ss::future<full_heartbeat_reply> consensus::full_heartbeat(
       .last_flushed_log_index = r.last_flushed_log_index,
       .last_dirty_log_index = r.last_dirty_log_index,
       .last_term_base_offset = r.last_term_base_offset,
+      .may_recover = r.may_recover,
     };
     co_return reply;
 }

--- a/src/v/raft/heartbeat_manager.cc
+++ b/src/v/raft/heartbeat_manager.cc
@@ -571,6 +571,7 @@ void heartbeat_manager::process_reply(
             .last_dirty_log_index = m.data.last_dirty_log_index,
             .last_term_base_offset = m.data.last_term_base_offset,
             .result = m.result,
+            .may_recover = m.data.may_recover,
           }),
           meta_it->second.seq,
           meta_it->second.dirty_offset);

--- a/src/v/raft/heartbeats.h
+++ b/src/v/raft/heartbeats.h
@@ -237,6 +237,8 @@ struct heartbeat_reply_data
     model::offset last_dirty_log_index;
     model::offset last_term_base_offset;
 
+    bool may_recover = false;
+
     auto serde_fields() {
         return std::tie(
           source_revision,
@@ -244,7 +246,8 @@ struct heartbeat_reply_data
           term,
           last_flushed_log_index,
           last_dirty_log_index,
-          last_term_base_offset);
+          last_term_base_offset,
+          may_recover);
     }
 
     friend bool

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -79,6 +79,7 @@ ss::future<> recovery_stm::do_recover(ss::io_priority_class iopc) {
     }
 
     auto lstats = _ptr->_log->offsets();
+
     // follower last index was already evicted at the leader, use snapshot
     if (meta.value()->next_index <= _ptr->_last_snapshot_index) {
         co_return co_await install_snapshot();
@@ -419,6 +420,9 @@ ss::future<> recovery_stm::replicate(
     auto commit_idx = std::min(_last_batch_offset, _committed_offset);
     auto last_visible_idx = std::min(
       _last_batch_offset, _ptr->last_visible_index());
+
+    auto lstats = _ptr->_log->offsets();
+
     // build request
     append_entries_request r(
       _ptr->self(),
@@ -429,7 +433,8 @@ ss::future<> recovery_stm::replicate(
         .term = _term,
         .prev_log_index = prev_log_idx,
         .prev_log_term = prev_log_term,
-        .last_visible_index = last_visible_idx},
+        .last_visible_index = last_visible_idx,
+        .dirty_offset = lstats.dirty_offset},
       std::move(reader),
       flush);
     auto meta = get_follower_meta();
@@ -445,7 +450,6 @@ ss::future<> recovery_stm::replicate(
     auto seq = _ptr->next_follower_sequence(_node_id);
     auto hb_guard = _ptr->suppress_heartbeats(_node_id);
 
-    auto lstats = _ptr->_log->offsets();
     std::vector<ssx::semaphore_units> units;
     units.push_back(std::move(mem_units));
     return dispatch_append_entries(std::move(r), std::move(units))

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -315,7 +315,8 @@ ss::future<> recovery_stm::send_install_snapshot_request() {
             .last_included_index = _ptr->_last_snapshot_index,
             .file_offset = _sent_snapshot_bytes,
             .chunk = std::move(chunk),
-            .done = (_sent_snapshot_bytes + chunk_size) == _snapshot_size};
+            .done = (_sent_snapshot_bytes + chunk_size) == _snapshot_size,
+            .dirty_offset = _ptr->dirty_offset()};
 
           _sent_snapshot_bytes += chunk_size;
 

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -386,6 +386,9 @@ private:
             .prev_log_index = hb.data->prev_log_index,
             .prev_log_term = hb.data->prev_log_term,
             .last_visible_index = hb.data->last_visible_index,
+            // for heartbeats dirty_offset and prev_log_index are always the
+            // same
+            .dirty_offset = hb.data->prev_log_index,
           },
           model::make_memory_record_batch_reader(
             ss::circular_buffer<model::record_batch>{}),

--- a/src/v/raft/tests/heartbeat_bench.cc
+++ b/src/v/raft/tests/heartbeat_bench.cc
@@ -62,6 +62,7 @@ struct fixture {
               .prev_log_term = tests::random_named_int<model::term_id>(),
               .last_visible_index = tests::random_named_int<model::offset>(),
             };
+            meta.dirty_offset = meta.prev_log_index;
             req.heartbeats.push_back(raft::heartbeat_metadata{
               .meta = meta,
               .node_id = raft::vnode(

--- a/src/v/raft/tests/heartbeats_test.cc
+++ b/src/v/raft/tests/heartbeats_test.cc
@@ -88,6 +88,7 @@ raft::heartbeat_reply_v2 random_reply() {
                 = tests::random_named_int<model::offset>(),
                 .last_term_base_offset
                 = tests::random_named_int<model::offset>(),
+                .may_recover = tests::random_bool(),
               });
         } else {
             reply.add(g, random_reply_status());
@@ -146,6 +147,7 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_reply_for_each) {
                 = tests::random_named_int<model::offset>(),
                 .last_term_base_offset
                 = tests::random_named_int<model::offset>(),
+                .may_recover = tests::random_bool(),
               });
         } else {
             auto status = random_reply_status();

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -247,6 +247,8 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_response_roundtrip) {
           expected[gr].last_dirty_log_index,
           result.meta[i].last_dirty_log_index);
         BOOST_REQUIRE_EQUAL(expected[gr].result, result.meta[i].result);
+        // v1 heartbeats always have default may_recover
+        BOOST_REQUIRE_EQUAL(result.meta[i].may_recover, true);
     }
 }
 

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -79,6 +79,7 @@ SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
       .prev_log_index = model::offset(99),
       .prev_log_term = model::term_id(-1),
       .last_visible_index = model::offset(200),
+      .dirty_offset = model::offset(99),
     };
     raft::append_entries_request req(
       raft::vnode(model::node_id(1), model::revision_id(10)),
@@ -104,6 +105,7 @@ SEASTAR_THREAD_TEST_CASE(append_entries_requests) {
     BOOST_REQUIRE_EQUAL(d.metadata().prev_log_term, meta.prev_log_term);
     BOOST_REQUIRE_EQUAL(
       d.metadata().last_visible_index, meta.last_visible_index);
+    BOOST_REQUIRE_EQUAL(d.metadata().dirty_offset, meta.dirty_offset);
 
     auto batches_result = model::consume_reader_to_memory(
                             std::move(readers.back()), model::no_timeout)
@@ -141,6 +143,7 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip) {
         req.heartbeats[i].meta.prev_log_index = model::offset(i);
         req.heartbeats[i].meta.prev_log_term = model::term_id(i);
         req.heartbeats[i].meta.last_visible_index = model::offset(i);
+        req.heartbeats[i].meta.dirty_offset = model::offset(i);
         req.heartbeats[i].target_node_id = raft::vnode(
           model::node_id(0), model::revision_id(i));
     }
@@ -160,6 +163,8 @@ SEASTAR_THREAD_TEST_CASE(heartbeat_request_roundtrip) {
           res.heartbeats[i].meta.prev_log_term, model::term_id(i));
         BOOST_REQUIRE_EQUAL(
           res.heartbeats[i].meta.last_visible_index, model::offset(i));
+        BOOST_REQUIRE_EQUAL(
+          res.heartbeats[i].meta.dirty_offset, model::offset(i));
         BOOST_REQUIRE_EQUAL(
           res.heartbeats[i].target_node_id,
           raft::vnode(model::node_id(0), model::revision_id(i)));
@@ -557,6 +562,7 @@ SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
       .prev_log_index = model::offset(99),
       .prev_log_term = model::term_id(-1),
       .last_visible_index = model::offset(200),
+      .dirty_offset = model::offset(99),
     };
     raft::append_entries_request req(
       raft::vnode(model::node_id(1), model::revision_id(10)),
@@ -590,6 +596,7 @@ SEASTAR_THREAD_TEST_CASE(append_entries_request_serde_wrapper_serde) {
       decoded_req.metadata().prev_log_term, meta.prev_log_term);
     BOOST_REQUIRE_EQUAL(
       decoded_req.metadata().last_visible_index, meta.last_visible_index);
+    BOOST_REQUIRE_EQUAL(decoded_req.metadata().dirty_offset, meta.dirty_offset);
 
     auto batches_result = model::consume_reader_to_memory(
                             std::move(readers.back()), model::no_timeout)

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -249,7 +249,7 @@ std::ostream& operator<<(std::ostream& o, const install_snapshot_request& r) {
       o,
       "{{term: {}, group: {}, target_node_id: {}, node_id: {}, "
       "last_included_index: {}, "
-      "file_offset: {}, chunk_size: {}, done: {}}}",
+      "file_offset: {}, chunk_size: {}, done: {}, dirty_offset: {}}}",
       r.term,
       r.group,
       r.target_node_id,
@@ -257,7 +257,8 @@ std::ostream& operator<<(std::ostream& o, const install_snapshot_request& r) {
       r.last_included_index,
       r.file_offset,
       r.chunk.size_bytes(),
-      r.done);
+      r.done,
+      r.dirty_offset);
     return o;
 }
 

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -17,6 +17,7 @@
 #include "raft/consensus_utils.h"
 #include "raft/errc.h"
 #include "raft/group_configuration.h"
+#include "raft/logger.h"
 #include "reflection/adl.h"
 #include "reflection/async_adl.h"
 #include "serde/serde.h"
@@ -217,7 +218,8 @@ std::ostream& operator<<(std::ostream& o, const protocol_metadata& m) {
     return o << "{raft_group:" << m.group << ", commit_index:" << m.commit_index
              << ", term:" << m.term << ", prev_log_index:" << m.prev_log_index
              << ", prev_log_term:" << m.prev_log_term
-             << ", last_visible_index:" << m.last_visible_index << "}";
+             << ", last_visible_index:" << m.last_visible_index
+             << ", dirty_offset:" << m.dirty_offset << "}";
 }
 std::ostream& operator<<(std::ostream& o, const vote_reply& r) {
     return o << "{term:" << r.term << ", target_node_id" << r.target_node_id
@@ -419,6 +421,8 @@ void heartbeat_request::serde_read(
         hb.meta.commit_index = decode_signed(hb.meta.commit_index);
         hb.meta.prev_log_term = decode_signed(hb.meta.prev_log_term);
         hb.meta.last_visible_index = decode_signed(hb.meta.last_visible_index);
+        // for heartbeats dirty_offset and prev_log_index are always the same.
+        hb.meta.dirty_offset = hb.meta.prev_log_index;
         hb.node_id = raft::vnode(
           hb.node_id.id(), decode_signed(hb.node_id.revision()));
         hb.target_node_id = raft::vnode(

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -753,35 +753,6 @@ std::ostream& operator<<(std::ostream& o, const append_entries_request& r) {
 
 namespace reflection {
 
-void adl<raft::protocol_metadata>::to(
-  iobuf& out, raft::protocol_metadata request) {
-    std::array<bytes::value_type, 6 * vint::max_length> staging{};
-    auto idx = vint::serialize(request.group(), staging.data());
-    idx += vint::serialize(request.commit_index(), staging.data() + idx);
-    idx += vint::serialize(request.term(), staging.data() + idx);
-
-    // varint the delta-encoded value
-    idx += vint::serialize(request.prev_log_index(), staging.data() + idx);
-    idx += vint::serialize(request.prev_log_term(), staging.data() + idx);
-    idx += vint::serialize(request.last_visible_index(), staging.data() + idx);
-
-    out.append(
-      // NOLINTNEXTLINE
-      reinterpret_cast<const char*>(staging.data()),
-      idx);
-}
-
-raft::protocol_metadata adl<raft::protocol_metadata>::from(iobuf_parser& in) {
-    raft::protocol_metadata ret;
-    ret.group = varlong_reader<raft::group_id>(in);
-    ret.commit_index = varlong_reader<model::offset>(in);
-    ret.term = varlong_reader<model::term_id>(in);
-    ret.prev_log_index = varlong_reader<model::offset>(in);
-    ret.prev_log_term = varlong_reader<model::term_id>(in);
-    ret.last_visible_index = varlong_reader<model::offset>(in);
-    return ret;
-}
-
 raft::snapshot_metadata adl<raft::snapshot_metadata>::from(iobuf_parser& in) {
     auto last_included_index = adl<model::offset>{}.from(in);
     auto last_included_term = adl<model::term_id>{}.from(in);

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -159,7 +159,8 @@ std::ostream& operator<<(std::ostream& o, const append_entries_reply& r) {
              << ", last_dirty_log_index:" << r.last_dirty_log_index
              << ", last_flushed_log_index:" << r.last_flushed_log_index
              << ", last_term_base_offset:" << r.last_term_base_offset
-             << ", result: " << r.result << "}";
+             << ", result: " << r.result << ", may_recover:" << r.may_recover
+             << "}";
 }
 
 std::ostream& operator<<(std::ostream& o, const vote_request& r) {
@@ -505,6 +506,8 @@ void heartbeat_reply::serde_write(iobuf& dst) {
     for (auto& m : reply.meta) {
         write(out, m.result);
     }
+    // Don't bother serializing m.may_recover because nodes that will have
+    // meaningful may_recover are expected to use lightweight heartbeats anyway.
 
     write(dst, std::move(out));
 }

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -845,12 +845,6 @@ using keep_snapshotted_log = ss::bool_class<struct keep_snapshotted_log_tag>;
 namespace reflection {
 
 template<>
-struct adl<raft::protocol_metadata> {
-    void to(iobuf& out, raft::protocol_metadata request);
-    raft::protocol_metadata from(iobuf_parser& in);
-};
-
-template<>
 struct adl<raft::snapshot_metadata> {
     void to(iobuf& out, raft::snapshot_metadata&& request);
     raft::snapshot_metadata from(iobuf_parser& in);

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -48,13 +48,14 @@ using group_id = named_type<int64_t, struct raft_group_id_type>;
 
 struct protocol_metadata
   : serde::
-      envelope<protocol_metadata, serde::version<0>, serde::compat_version<0>> {
+      envelope<protocol_metadata, serde::version<1>, serde::compat_version<0>> {
     group_id group;
     model::offset commit_index;
     model::term_id term;
     model::offset prev_log_index;
     model::term_id prev_log_term;
     model::offset last_visible_index;
+    model::offset dirty_offset;
 
     friend std::ostream&
     operator<<(std::ostream& o, const protocol_metadata& m);
@@ -69,7 +70,8 @@ struct protocol_metadata
           term,
           prev_log_index,
           prev_log_term,
-          last_visible_index);
+          last_visible_index,
+          dirty_offset);
     }
 };
 

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -553,7 +553,7 @@ struct snapshot_metadata {
 struct install_snapshot_request
   : serde::envelope<
       install_snapshot_request,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
     // node id to validate on receiver
@@ -572,6 +572,8 @@ struct install_snapshot_request
     iobuf chunk;
     // true if this is the last chunk
     bool done;
+    // leader dirty offset
+    model::offset dirty_offset;
 
     raft::group_id target_group() const { return group; }
     vnode source_node() const { return node_id; }
@@ -592,7 +594,8 @@ struct install_snapshot_request
           last_included_index,
           file_offset,
           chunk,
-          done);
+          done,
+          dirty_offset);
     }
 };
 
@@ -615,7 +618,8 @@ public:
           .last_included_index = _ptr->last_included_index,
           .file_offset = _ptr->file_offset,
           .chunk = _ptr->chunk.copy(),
-          .done = _ptr->done};
+          .done = _ptr->done,
+          .dirty_offset = _ptr->dirty_offset};
     }
     raft::group_id target_group() const { return _ptr->target_group(); }
     vnode target_node() const { return _ptr->target_node_id; }

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -311,7 +311,7 @@ enum class reply_result : uint8_t {
 struct append_entries_reply
   : serde::envelope<
       append_entries_reply,
-      serde::version<0>,
+      serde::version<1>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
@@ -333,6 +333,13 @@ struct append_entries_reply
     /// \brief did the rpc succeed or not
     reply_result result = reply_result::failure;
 
+    // Hint from follower to leader, indicating they are ready for
+    // recovery traffic (false if they may not have enough resources to
+    // handle recovery).
+    // This is true by default to reflect the legacy case, where
+    // older nodes are always ready for recovery.
+    bool may_recover = true;
+
     friend std::ostream&
     operator<<(std::ostream& o, const append_entries_reply& r);
 
@@ -349,7 +356,8 @@ struct append_entries_reply
           last_flushed_log_index,
           last_dirty_log_index,
           last_term_base_offset,
-          result);
+          result,
+          may_recover);
     }
 };
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -954,13 +954,18 @@ class RedpandaServiceBase(Service):
                    metric_name,
                    metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS,
                    ns=None,
-                   topic=None):
+                   topic=None,
+                   nodes=None):
         """
         Pings the 'metrics_endpoint' of each node and returns the summed values
         of the given metric, optionally filtering by namespace and topic.
         """
+
+        if nodes is None:
+            nodes = self.nodes
+
         count = 0
-        for n in self.nodes:
+        for n in nodes:
             metrics = self.metrics(n, metrics_endpoint=metrics_endpoint)
             for family in metrics:
                 for sample in family.samples:

--- a/tests/rptest/tests/raft_recovery_test.py
+++ b/tests/rptest/tests/raft_recovery_test.py
@@ -1,0 +1,150 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.util import wait_until, wait_until_result
+from rptest.utils.mode_checks import skip_debug_mode
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from ducktape.cluster.cluster import ClusterNode
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda_installer import RedpandaInstaller
+
+
+def _high_watermarks(rpk: RpkTool, topic: str):
+    def func():
+        hwms = list(p.high_watermark
+                    for p in rpk.describe_topic(topic, tolerant=True))
+        if any(o is None for o in hwms):
+            return False
+
+        rpk._redpanda.logger.debug(f"topic '{topic}' high watermarks: {hwms}")
+        return True, hwms
+
+    return wait_until_result(func,
+                             backoff_sec=1,
+                             timeout_sec=60,
+                             err_msg="failed to wait for valid hwm offsets")
+
+
+def _await_progress_in_all_partitions(rpk: RpkTool, topic: str):
+    start = _high_watermarks(rpk, topic)
+
+    def condition():
+        current = _high_watermarks(rpk, topic)
+        assert len(current) == len(start)
+        return all(c > s for c, s in zip(current, start))
+
+    wait_until(condition,
+               backoff_sec=1,
+               timeout_sec=60,
+               err_msg="failed to wait for progress in all partitions")
+
+
+class RaftRecoveryUpgradeTest(RedpandaTest):
+    def setUp(self):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=3, **kwargs)
+
+    @skip_debug_mode
+    @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_upgrade(self):
+        """
+        Verify that recovery works both ways during upgrade
+        """
+
+        installer = self.redpanda._installer
+        prev_version = installer.highest_from_prior_feature_version(
+            RedpandaInstaller.HEAD)
+        self.logger.info(f"will test against prev version {prev_version}")
+
+        installer.install(self.redpanda.nodes, prev_version)
+        self.redpanda.start()
+
+        topic = "mytopic"
+        partition_count = 32
+        self.client().create_topic(
+            TopicSpec(name=topic,
+                      partition_count=partition_count,
+                      retention_bytes=8 * 1024 * 1024,
+                      segment_bytes=1024 * 1024))
+
+        rpk = RpkTool(self.redpanda)
+
+        def wait_for_recovery_finished():
+            _await_progress_in_all_partitions(rpk, topic)
+            self._wait_for_underreplicated(self.redpanda.nodes, 0)
+            self.logger.info(f"recovery finished")
+
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            topic,
+            msg_size=1024,
+            # some large number to get produce load till the end of test
+            msg_count=2**30,
+            rate_limit_bps=4 * 2**20)
+        producer.start()
+
+        _await_progress_in_all_partitions(rpk, topic)
+
+        # upgrade node 3 but don't start it yet, wait for replication lag to accumulate
+        node3 = self.redpanda.nodes[2]
+        self.redpanda.stop_node(node3)
+        installer.install([node3], RedpandaInstaller.HEAD)
+        self.logger.info(f"stopped node {node3.name}")
+        self._wait_for_underreplicated(self.redpanda.nodes[0:2],
+                                       partition_count)
+
+        # start node3 and check that it can recover from old nodes
+        self.redpanda.start_node(node3)
+        self.logger.info(f"started node {node3.name}")
+        wait_for_recovery_finished()
+
+        # upgrade and restart node 2 and wait for the cluster to stabilize
+        node2 = self.redpanda.nodes[1]
+        self.redpanda.stop_node(node2)
+        installer.install([node2], RedpandaInstaller.HEAD)
+        self.redpanda.start_node(node2)
+        self.logger.info(f"upgraded node {node2.name}")
+        wait_for_recovery_finished()
+
+        # stop node 1 and wait for the replication lag to accumulate
+        node1 = self.redpanda.nodes[0]
+        self.redpanda.stop_node(node1)
+        self.logger.info(f"stopped node {node1.name}")
+        _await_progress_in_all_partitions(rpk, topic)
+        self._wait_for_underreplicated(self.redpanda.nodes[1:3],
+                                       partition_count)
+
+        # start node 1 and check that it can recover from upgraded nodes
+        self.redpanda.start_node(node1)
+        self.logger.info(f"started node {node1.name}")
+        wait_for_recovery_finished()
+
+    def _wait_for_underreplicated(self, nodes: [ClusterNode], target: int):
+        def ready():
+            count = self.redpanda.metric_sum(
+                'vectorized_cluster_partition_under_replicated_replicas',
+                nodes=nodes)
+            self.logger.info(f"under-replicated partitions count: {count}")
+            if target == 0:
+                return count == 0
+            else:
+                return count >= target
+
+        wait_until(
+            ready,
+            timeout_sec=60,
+            backoff_sec=2,
+            err_msg=f"couldn't reach under-replicated count target: {target}")


### PR DESCRIPTION
Add message fields that will be used for coordinating recovery:
* `append_entries_reply::may_recover` - This flag will be used by followers limit concurrency of in-progress recovery streams - the follower responding with may_recover=false is an advice to the leader that it is better to delay recovery for now.
* `protocol_metadata::dirty_offset` - Leader dirty_offset will be used by followers to distinguish between ordinary and recovery append_entries and also to get a sense of how many offsets are left to recover. For coordinated recovery, receiving an append_entries request with prev_log_index == dirty_offset will signal to the follower that recovery is over and another raft group can be allowed to start recovery.
* `install_snapshot_request::dirty_offset` - similar to the previous one

Also added a test verifying that recovery works both ways during the upgrade process.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none