### PR TITLE
Add macros to defer evaluation of log args

### DIFF
--- a/src/v/vlog.h
+++ b/src/v/vlog.h
@@ -25,3 +25,23 @@
 // NOLINTNEXTLINE
 #define vlogl(logger, level, fmt, args...)                                     \
     fmt_with_ctx_level(logger, level, fmt, ##args)
+
+#define vlog_error(logger, fmt, args...)                                       \
+    check_level_then_log(logger, seastar::log_level::error, fmt, ##args)
+
+#define vlog_warn(logger, fmt, args...)                                        \
+    check_level_then_log(logger, seastar::log_level::warn, fmt, ##args)
+
+#define vlog_info(logger, fmt, args...)                                        \
+    check_level_then_log(logger, seastar::log_level::info, fmt, ##args)
+
+#define vlog_debug(logger, fmt, args...)                                       \
+    check_level_then_log(logger, seastar::log_level::debug, fmt, ##args)
+
+#define vlog_trace(logger, fmt, args...)                                       \
+    check_level_then_log(logger, seastar::log_level::trace, fmt, ##args)
+
+#define check_level_then_log(logger, level, fmt, args...)                      \
+    if (logger.is_enabled(level)) {                                            \
+        fmt_with_ctx_level(logger, level, fmt, ##args);                        \
+    }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Adds a new set of logging macros `vlog_{trace, info, warn...}(logger, fmt, args...)` that only evaluates `args` if the logger is enabled for the specified level. I.e, in;

```cpp
  int expensive_function() {                                                                                                                                                                  
      return 1;                                                                                                                                                                               
  }                                                                                                                                                                                           
                                                                                                                                                                                              
  BOOST_AUTO_TEST_CASE(new_logger) {                                                                                                                                                          
      ss::logger tstlog(name: "test_logger");                                                                                                                                                  
      tstlog.set_level(ss::log_level::error);                                                                                                                                                 
      vlog_trace(tstlog, "hello world! {}", expensive_function());                                                                                                                            
  }                                                                                                                                                                                           
```

`expensive_function` will never be called.
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
