### PR TITLE
[v23.2.x] treewide: Reset configs in tests

### DIFF
--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -624,6 +624,8 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
 
     config::shard_local_cfg().delete_retention_ms.set_value(
       std::chrono::milliseconds{5min});
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().delete_retention_ms.reset(); });
 
     // Apply retention within the archive.
     archiver.apply_archive_retention().get();
@@ -743,6 +745,9 @@ FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {
     listen();
     config::shard_local_cfg().delete_retention_ms.set_value(
       std::chrono::milliseconds{1min});
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().delete_retention_ms.reset(); });
+
     config::shard_local_cfg()
       .cloud_storage_max_segments_pending_deletion_per_partition(2);
 
@@ -1722,6 +1727,10 @@ static void test_manifest_spillover_impl(
       spillover_manifest_size);
     config::shard_local_cfg().cloud_storage_spillover_manifest_size.set_value(
       std::make_optional(static_cast<size_t>(spillover_manifest_size)));
+    auto reset_cfg = ss::defer([] {
+        config::shard_local_cfg().cloud_storage_spillover_manifest_size.reset();
+    });
+
     archiver.apply_spillover().get();
 
     const auto& stm_manifest = part->archival_meta_stm()->manifest();

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -237,6 +237,8 @@ FIXTURE_TEST(test_sts_credentials, fixture) {
 
     config::shard_local_cfg().cloud_storage_credentials_host.set_value(
       std::optional<ss::sstring>{"localhost"});
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().cloud_storage_credentials_host.reset(); });
 
     when()
       .request("/")

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -53,6 +53,11 @@ public:
         config::shard_local_cfg().cloud_storage_manifest_cache_ttl_ms.set_value(
           cache_ttl);
     }
+
+    ~set_config_mixin() {
+        config::shard_local_cfg().cloud_storage_manifest_cache_size.reset();
+        config::shard_local_cfg().cloud_storage_manifest_cache_ttl_ms.reset();
+    }
 };
 
 class async_manifest_view_fixture
@@ -168,8 +173,8 @@ public:
           _expectations.back().url);
     }
 
-    // The current content of the manifest will be spilled over to the archive
-    // and new elements will be generated.
+    // The current content of the manifest will be spilled over to the
+    // archive and new elements will be generated.
     void generate_manifest_section(int num_segments, bool hydrate = true) {
         if (stm_manifest.empty()) {
             add_random_segments(stm_manifest, num_segments);
@@ -488,7 +493,8 @@ FIXTURE_TEST(test_async_manifest_view_truncate, async_manifest_view_fixture) {
           ->with_manifest([&](const partition_manifest& m) {
               vlog(
                 test_log.info,
-                "Looking at the backlog manifest [{}/{}], archive start: {}",
+                "Looking at the backlog manifest [{}/{}], archive start: "
+                "{}",
                 m.get_start_offset(),
                 m.get_last_offset(),
                 stm_manifest.get_archive_start_offset());
@@ -517,7 +523,8 @@ FIXTURE_TEST(test_async_manifest_view_truncate, async_manifest_view_fixture) {
           ->with_manifest([&](const partition_manifest& m) {
               vlog(
                 test_log.info,
-                "Looking at the backlog manifest [{}/{}], archive start: {}",
+                "Looking at the backlog manifest [{}/{}], archive start: "
+                "{}",
                 m.get_start_offset(),
                 m.get_last_offset(),
                 stm_manifest.get_archive_start_offset());
@@ -590,10 +597,10 @@ FIXTURE_TEST(
                     meta.base_offset
                     < stm_manifest.get_archive_start_offset()) {
                       // The cursor only returns full manifests. If the new
-                      // archive start offset is in the middle of the manifest
-                      // it will return the whole manifest and the user has
-                      // to skip all segments below the archive start offset
-                      // manually.
+                      // archive start offset is in the middle of the
+                      // manifest it will return the whole manifest and the
+                      // user has to skip all segments below the archive
+                      // start offset manually.
                       continue;
                   }
                   actual.push_back(meta);
@@ -624,9 +631,10 @@ FIXTURE_TEST(
                     meta.base_offset
                     >= stm_manifest.get_archive_start_offset()) {
                       // The cursor only returns full manifests. If the new
-                      // archive start offset is in the middle of the manifest
-                      // the backlog will contain full manifest and the user has
-                      // to read up until the start offset of the manifest.
+                      // archive start offset is in the middle of the
+                      // manifest the backlog will contain full manifest and
+                      // the user has to read up until the start offset of
+                      // the manifest.
                       break;
                   }
                   actual.push_back(meta);
@@ -696,8 +704,8 @@ FIXTURE_TEST(test_async_manifest_view_retention, async_manifest_view_fixture) {
     }
 
     // Check the case when retention overshoots
-    // auto rr1 = view.compute_retention(total_size * 2, std::nullopt).get();
-    // BOOST_REQUIRE(rr1.has_value());
+    // auto rr1 = view.compute_retention(total_size * 2,
+    // std::nullopt).get(); BOOST_REQUIRE(rr1.has_value());
     // BOOST_REQUIRE_EQUAL(rr1.value().offset, model::offset{});
     // BOOST_REQUIRE_EQUAL(rr1.value().delta, model::offset_delta{});
 
@@ -734,7 +742,8 @@ FIXTURE_TEST(test_async_manifest_view_retention, async_manifest_view_fixture) {
 
     vlog(
       test_log.info,
-      "Triggering size-based retention, {} bytes will be evicted, total size "
+      "Triggering size-based retention, {} bytes will be evicted, total "
+      "size "
       "is {} bytes, expected new start offset: {}",
       prefix_size,
       total_size,
@@ -777,7 +786,8 @@ FIXTURE_TEST(test_async_manifest_view_retention, async_manifest_view_fixture) {
     stm_manifest.advance_start_kafka_offset(prefix_base_offset - prefix_delta);
     vlog(
       test_log.info,
-      "Triggering offset-based retention, current start kafka offset override: "
+      "Triggering offset-based retention, current start kafka offset "
+      "override: "
       "{}, expected offset: {}, expected delta: {}",
       stm_manifest.get_start_kafka_offset_override(),
       prefix_base_offset,
@@ -826,8 +836,8 @@ FIXTURE_TEST(test_async_manifest_view_after_gc, async_manifest_view_fixture) {
       second_seg_second_spill.delta_offset);
 
     // Advance the clean archive offset through each possible position given
-    // the current start offset and verify that the truncation point is correct
-    // (it should be the same every time).
+    // the current start offset and verify that the truncation point is
+    // correct (it should be the same every time).
     size_t prev_segment_size = 0;
     for (const auto& pre_start_seg : expected) {
         if (
@@ -1129,10 +1139,10 @@ FIXTURE_TEST(
     generate_random_segments(stm_manifest, 10);
     listen();
 
-    // Our generate_manifest_section() function generates segments with gaps in
-    // timestamps. Both base_timestamp and max_timestamp are generated randomly
-    // but they're always equal for the same segment. This means that there is a
-    // gap between any two segments.
+    // Our generate_manifest_section() function generates segments with gaps
+    // in timestamps. Both base_timestamp and max_timestamp are generated
+    // randomly but they're always equal for the same segment. This means
+    // that there is a gap between any two segments.
 
     for (const auto& meta : expected) {
         auto target = model::timestamp(meta.base_timestamp.value() - 1);

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -558,6 +558,8 @@ FIXTURE_TEST(test_remote_segment_chunk_read, cloud_storage_fixture) {
     // read
     config::shard_local_cfg().cloud_storage_cache_chunk_size.set_value(
       static_cast<uint64_t>(128_KiB));
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().cloud_storage_cache_chunk_size.reset(); });
 
     auto key = model::offset(1);
     retry_chain_node fib(never_abort, 300s, 200ms);
@@ -704,6 +706,8 @@ FIXTURE_TEST(test_remote_segment_chunk_read_fallback, cloud_storage_fixture) {
 FIXTURE_TEST(test_chunks_initialization, cloud_storage_fixture) {
     config::shard_local_cfg().cloud_storage_cache_chunk_size.set_value(
       static_cast<uint64_t>(128_KiB));
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().cloud_storage_cache_chunk_size.reset(); });
 
     auto key = model::offset(1);
     retry_chain_node fib(never_abort, 300s, 200ms);
@@ -766,6 +770,8 @@ FIXTURE_TEST(test_chunks_initialization, cloud_storage_fixture) {
 FIXTURE_TEST(test_chunk_hydration, cloud_storage_fixture) {
     config::shard_local_cfg().cloud_storage_cache_chunk_size.set_value(
       static_cast<uint64_t>(128_KiB));
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().cloud_storage_cache_chunk_size.reset(); });
 
     auto key = model::offset(1);
     retry_chain_node fib(never_abort, 300s, 200ms);
@@ -850,6 +856,8 @@ FIXTURE_TEST(test_chunk_hydration, cloud_storage_fixture) {
 FIXTURE_TEST(test_chunk_future_reader_stats, cloud_storage_fixture) {
     config::shard_local_cfg().cloud_storage_cache_chunk_size.set_value(
       static_cast<uint64_t>(128_KiB));
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().cloud_storage_cache_chunk_size.reset(); });
 
     auto key = model::offset(1);
     retry_chain_node fib(never_abort, 10s, 200ms);
@@ -903,6 +911,8 @@ FIXTURE_TEST(test_chunk_multiple_readers, cloud_storage_fixture) {
      */
     config::shard_local_cfg().cloud_storage_cache_chunk_size.set_value(
       static_cast<uint64_t>(128_KiB));
+    auto reset_cfg = ss::defer(
+      [] { config::shard_local_cfg().cloud_storage_cache_chunk_size.reset(); });
 
     auto key = model::offset(1);
     retry_chain_node fib(never_abort, 300s, 200ms);
@@ -981,6 +991,11 @@ FIXTURE_TEST(test_chunk_prefetch, cloud_storage_fixture) {
     const uint16_t prefetch = 1;
     config::shard_local_cfg().cloud_storage_chunk_prefetch.set_value(
       static_cast<uint16_t>(prefetch));
+
+    auto reset_cfg = ss::defer([] {
+        config::shard_local_cfg().cloud_storage_cache_chunk_size.reset();
+        config::shard_local_cfg().cloud_storage_chunk_prefetch.reset();
+    });
 
     const auto key = model::offset(1);
     retry_chain_node fib(never_abort, 300s, 200ms);

--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -53,6 +53,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
                 gr.disable_node(id);
             }
         }
+        config::shard_local_cfg().log_segment_size_min.reset();
     }
 
     void maybe_init_eviction_stm(model::node_id id) {

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3320,6 +3320,9 @@ FIXTURE_TEST(test_bytes_eviction_overrides, storage_test_fixture) {
         BOOST_REQUIRE_GT(
           disk_log->size_bytes(), tc.expected_bytes_left - segment_size);
     }
+    config::shard_local_cfg().cloud_storage_enabled.reset();
+    config::shard_local_cfg().retention_bytes.reset();
+    config::shard_local_cfg().retention_local_target_bytes_default.reset();
 }
 
 FIXTURE_TEST(issue_8091, storage_test_fixture) {

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -221,6 +221,10 @@ public:
     ~storage_test_fixture() {
         kvstore.stop().get();
         feature_table.stop().get();
+        ss::smp::invoke_on_all([] {
+            config::shard_local_cfg().get("disable_metrics").reset();
+            config::shard_local_cfg().get("log_segment_size_min").reset();
+        }).get();
     }
 
     /**


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13168
