### PR TITLE
[v23.2.x] serde: pass full header to serde_[async]_direct_read

### DIFF
--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -787,19 +787,20 @@ public:
     auto serde_fields() { return std::tie(_header, _records); }
 
     static model::record_batch
-    serde_direct_read(iobuf_parser& in, size_t const bytes_left_limit) {
+    serde_direct_read(iobuf_parser& in, const serde::header& h) {
         using serde::read_nested;
         auto header = read_nested<model::record_batch_header>(
-          in, bytes_left_limit);
-        auto data = read_nested<iobuf>(in, bytes_left_limit);
+          in, h._bytes_left_limit);
+        auto data = read_nested<iobuf>(in, h._bytes_left_limit);
 
         return {header, std::move(data), tag_ctor_ng()};
     }
 
     static ss::future<model::record_batch>
-    serde_async_direct_read(iobuf_parser& in, size_t const bytes_left_limit) {
+    serde_async_direct_read(iobuf_parser& in, serde::header h) {
         using serde::read_async_nested;
         // TODO: change to coroutine after we upgrade to clang-16
+        auto bytes_left_limit = h._bytes_left_limit;
         return read_async_nested<model::record_batch_header>(
                  in, bytes_left_limit)
           .then([&in, bytes_left_limit](model::record_batch_header header) {

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -631,11 +631,11 @@ ss::future<> append_entries_request::serde_async_write(iobuf& dst) {
 
 ss::future<append_entries_request>
 append_entries_request::serde_async_direct_read(
-  iobuf_parser& src, size_t bytes_left_limit) {
+  iobuf_parser& src, serde::header h) {
     using serde::read_async_nested;
     using serde::read_nested;
 
-    auto tmp = co_await read_async_nested<iobuf>(src, bytes_left_limit);
+    auto tmp = co_await read_async_nested<iobuf>(src, h._bytes_left_limit);
     iobuf_parser in(std::move(tmp));
 
     auto batch_count = read_nested<uint32_t>(in, 0U);
@@ -710,7 +710,7 @@ append_entries_request_serde_wrapper::serde_async_write(iobuf& dst) {
 
 ss::future<append_entries_request_serde_wrapper>
 append_entries_request_serde_wrapper::serde_async_direct_read(
-  iobuf_parser& src, size_t bytes_left_limit) {
+  iobuf_parser& src, serde::header h) {
     using serde::read_async_nested;
     using serde::read_nested;
 
@@ -724,7 +724,7 @@ append_entries_request_serde_wrapper::serde_async_direct_read(
 
     for (uint32_t i = 0; i < batch_count; ++i) {
         auto b = co_await serde::read_async_nested<model::record_batch>(
-          src, bytes_left_limit);
+          src, h._bytes_left_limit);
         batches.push_back(std::move(b));
         co_await ss::coroutine::maybe_yield();
     }

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -259,7 +259,7 @@ struct append_entries_request
     ss::future<> serde_async_write(iobuf& out);
 
     static ss::future<append_entries_request>
-    serde_async_direct_read(iobuf_parser&, size_t bytes_left_limit);
+    serde_async_direct_read(iobuf_parser&, serde::header);
 
 private:
     vnode _source_node;
@@ -284,7 +284,7 @@ public:
     ss::future<> serde_async_write(iobuf& out);
 
     static ss::future<append_entries_request_serde_wrapper>
-    serde_async_direct_read(iobuf_parser&, size_t bytes_left_limit);
+    serde_async_direct_read(iobuf_parser&, serde::header);
 
 private:
     append_entries_request _request;

--- a/src/v/serde/test/serde_test.cc
+++ b/src/v/serde/test/serde_test.cc
@@ -966,10 +966,10 @@ struct no_default_ctor
     bool operator==(const no_default_ctor&) const = default;
 
     static no_default_ctor
-    serde_direct_read(iobuf_parser& in, size_t const bytes_left_limit) {
+    serde_direct_read(iobuf_parser& in, const serde::header& h) {
         using serde::read_nested;
         int x;
-        read_nested(in, x, bytes_left_limit);
+        read_nested(in, x, h._bytes_left_limit);
         return no_default_ctor(x);
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13134
