### PR TITLE
rptest: tweak cloud storage reader stress test 

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2570,8 +2570,7 @@ class RedpandaService(RedpandaServiceBase):
                 if ".bin" in m:
                     try:
                         decoded = RpStorageTool(
-                            self.logger).decode_partition_manifest(
-                                body, self.logger)
+                            self.logger).decode_partition_manifest(body)
                     except Exception as e:
                         self.logger.warn(f"Failed to decode {m}: {e}")
                     else:


### PR DESCRIPTION
Previously, the assertions used to check for saturation with tiered
storage reads were too strong. Since the various limits on the read path
are now strongly enforced, the read path may become stalled at different
points.

Additionally, the test was very lax with the amount of time needed to
close all outstanding Kafka connections. Since we have a mechanism to
close Kafka connections on client abort, this limit is now set to the
default timequery timeout (5 seconds).

Fixes #12135 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
