### PR TITLE
rptest: allow ntr_no_topic_manifest in test_manifest_dump

### DIFF
--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -209,3 +209,6 @@ class SIAdminApiTest(RedpandaTest):
         with expect_http_error(400):
             not_enabled_response = self.admin.get_partition_manifest(
                 "test-topic", 0)
+
+        self.redpanda.si_settings.set_expected_damage(
+            {"ntr_no_topic_manifest"})


### PR DESCRIPTION
The test disables cloud storage at runtime. This may happen before the topic manifest upload goes through, so it's reasonable to allow the anomaly.

Fixes #10932

Based on @andrwng 's https://github.com/redpanda-data/redpanda/pull/12131

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

