### PR TITLE
rptest: use explicit cloud storage metric name

### DIFF
--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -184,22 +184,22 @@ class CloudStorageCompactionTest(EndToEndTest):
 
         upload_sucess = sum([
             sample.value for sample in self.redpanda.metrics_sample(
-                "successful_uploads",
+                "cloud_storage_successful_uploads",
                 metrics_endpoint=MetricsEndpoint.METRICS).samples
         ])
         upload_fails = sum([
             sample.value for sample in self.redpanda.metrics_sample(
-                "failed_uploads",
+                "cloud_storage_failed_uploads",
                 metrics_endpoint=MetricsEndpoint.METRICS).samples
         ])
         download_sucess = sum([
             sample.value for sample in self.rr_cluster.metrics_sample(
-                "successful_downloads",
+                "cloud_storage_successful_downloads",
                 metrics_endpoint=MetricsEndpoint.METRICS).samples
         ])
         download_fails = sum([
             sample.value for sample in self.rr_cluster.metrics_sample(
-                "failed_downloads",
+                "cloud_storage_failed_downloads",
                 metrics_endpoint=MetricsEndpoint.METRICS).samples
         ])
 


### PR DESCRIPTION
A new metric that matches the pattern has been introduced: `vectorized_cloud_storage_controller_snapshot_successful_uploads`. This breaks the metric collection in
`CloudStorageCompactionTest.test_read_from_replica`.

This commit fixes the issues by being more explicit with the metric's name.

Fixes #13181

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
