### PR TITLE
cloud_storage: Aggregate read path metrics by partition

### DIFF
--- a/src/v/cloud_storage/read_path_probes.cc
+++ b/src/v/cloud_storage/read_path_probes.cc
@@ -31,7 +31,10 @@ partition_probe::partition_probe(const model::ntp& ntp) {
       partition_label(ntp.tp.partition()),
     };
 
-    auto aggregate_labels = std::vector<sm::label>{sm::shard_label};
+    auto aggregate_labels = config::shard_local_cfg().aggregate_metrics()
+                              ? std::vector<sm::label>(
+                                {sm::shard_label, partition_label})
+                              : std::vector<sm::label>{sm::shard_label};
 
     _metrics.add_group(
       prometheus_sanitize::metrics_name("cloud_storage:partition"),


### PR DESCRIPTION
If the 'aggregate_metrics' configuration option is set aggregate metrics by id.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none