### PR TITLE
cloud_storage: add cloud storage scrubbing capabilities

### DIFF
--- a/src/v/archival/fwd.h
+++ b/src/v/archival/fwd.h
@@ -17,5 +17,6 @@ class ntp_archiver;
 struct configuration;
 class upload_housekeeping_service;
 class purger;
+class scrubber;
 
 } // namespace archival

--- a/src/v/archival/fwd.h
+++ b/src/v/archival/fwd.h
@@ -16,6 +16,6 @@ class upload_controller;
 class ntp_archiver;
 struct configuration;
 class upload_housekeeping_service;
-class scrubber;
+class purger;
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -464,6 +464,13 @@ ss::future<bool> ntp_archiver::sync_for_tests() {
     co_return false;
 }
 
+ss::future<std::error_code> ntp_archiver::process_anomalies(
+  model::timestamp, cloud_storage::scrub_status, cloud_storage::anomalies) {
+    // TODO: This is a stub for the anomaly "write path". A future commit will
+    // fill this in.
+    co_return cluster::errc::success;
+}
+
 ss::future<> ntp_archiver::upload_until_term_change() {
     ss::lowres_clock::duration backoff = _conf->upload_loop_initial_backoff;
 

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -137,6 +137,8 @@ public:
     /// Get revision id
     model::initial_revision_id get_revision_id() const;
 
+    const cloud_storage_clients::bucket_name& get_bucket_name() const;
+
     /// Get time when partition manifest was last uploaded
     const ss::lowres_clock::time_point get_last_manfiest_upload_time() const {
         return _last_manifest_upload_time;
@@ -338,6 +340,11 @@ public:
     /// the current term. Returns false if the sync was not successful.
     /// Must be called before updating archival metadata.
     ss::future<bool> sync_for_tests();
+
+    ss::future<std::error_code> process_anomalies(
+      model::timestamp scrub_timestamp,
+      cloud_storage::scrub_status status,
+      cloud_storage::anomalies detected);
 
 private:
     // Labels for contexts in which manifest uploads occur. Used for logging.
@@ -561,8 +568,6 @@ private:
 
     /// Method to use with lazy_abort_source
     std::optional<ss::sstring> upload_should_abort();
-
-    const cloud_storage_clients::bucket_name& get_bucket_name() const;
 
     // Adjacent segment merging
 

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -640,8 +640,13 @@ private:
 
     std::optional<ntp_level_probe> _probe{std::nullopt};
 
+    ss::sharded<features::feature_table>& _feature_table;
+
     // NTP level adjacent segment merging job
     std::unique_ptr<housekeeping_job> _local_segment_merger;
+
+    // NTP level scrubbing job
+    std::unique_ptr<housekeeping_job> _scrubber;
 
     // The archival metadata stm has its own clean/dirty mechanism, but it
     // is expensive to persistently mark it clean after each segment upload,
@@ -655,8 +660,6 @@ private:
     // then upload at the next opportunity.
     config::binding<std::optional<std::chrono::seconds>>
       _manifest_upload_interval;
-
-    ss::sharded<features::feature_table>& _feature_table;
 
     ss::shared_ptr<cloud_storage::async_manifest_view> _manifest_view;
 

--- a/src/v/archival/purger.h
+++ b/src/v/archival/purger.h
@@ -20,13 +20,16 @@
 namespace archival {
 
 /**
- * The scrubber is a global sharded service: it runs on all shards, and
- * decides internally which shard will scrub which ranges of objects
+ * The purger is a global sharded service: it runs on all shards, and
+ * decides internally which shard will purge which ranges of objects
  * in object storage.
+ *
+ * The purger's only goal is to remove the uploade objects belonging to deleted
+ * topics.
  */
-class scrubber : public housekeeping_job {
+class purger : public housekeeping_job {
 public:
-    explicit scrubber(
+    explicit purger(
       cloud_storage::remote&,
       cluster::topic_table&,
       ss::sharded<cluster::topics_frontend>&,

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/scrubber.h"
+
+#include "archival/logger.h"
+#include "archival/ntp_archiver_service.h"
+
+namespace archival {
+
+scrubber::scrubber(
+  ntp_archiver& archiver,
+  cloud_storage::remote& remote,
+  retry_chain_logger& logger,
+  features::feature_table& feature_table,
+  config::binding<bool> config_enabled,
+  config::binding<std::chrono::milliseconds> interval,
+  config::binding<std::chrono::milliseconds> jitter)
+  : _config_enabled(std::move(config_enabled))
+  , _archiver(archiver)
+  , _remote(remote)
+  , _logger(logger)
+  , _feature_table(feature_table)
+  , _scheduler(
+      [this] { return _archiver.manifest().last_partition_scrub(); },
+      std::move(interval),
+      std::move(jitter)) {
+    ssx::spawn_with_gate(_gate, [this] { return await_feature_enabled(); });
+}
+
+ss::future<> scrubber::await_feature_enabled() {
+    try {
+        co_await _feature_table.await_feature(
+          features::feature::cloud_storage_scrubbing, _as);
+    } catch (const ss::abort_requested_exception&) {
+        vlog(
+          _logger.warn,
+          "Scrubber abort request while awaiting feature activation");
+        co_return;
+    } catch (...) {
+        vlog(
+          _logger.error,
+          "Unexpected exception while awaiting feature activation: {}",
+          std::current_exception());
+        co_return;
+    }
+    _scheduler.pick_next_scrub_time();
+}
+
+ss::future<scrubber::run_result>
+scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
+    ss::gate::holder holder{_gate};
+
+    if (auto [skip, reason] = should_skip(); skip) {
+        vlog(_logger.debug, "Skipping cloud partition scrub: {}", *reason);
+        co_return run_result{
+          .status = run_status::skipped,
+          .consumed = run_quota_t{0},
+          .remaining = quota};
+    }
+
+    vlog(_logger.debug, "Starting scrub ...");
+
+    _scheduler.pick_next_scrub_time();
+
+    co_return run_result{
+      .status = run_status::ok, .consumed = run_quota_t{0}, .remaining = quota};
+}
+
+void scrubber::interrupt() { _as.request_abort(); }
+
+bool scrubber::interrupted() const { return _as.abort_requested(); }
+
+void scrubber::set_enabled(bool e) { _job_enabled = e; }
+
+void scrubber::acquire() {
+    vassert(
+      !_holder.has_value(), "scrubber::acquire called on an active instance");
+    _holder = ss::gate::holder(_gate);
+}
+
+void scrubber::release() {
+    vassert(
+      _holder.has_value(), "scrubber::release called before scrubber::acquire");
+    _holder->release();
+}
+
+ss::future<> scrubber::stop() {
+    vlog(archival_log.info, "Stopping scrubber ({})...", _gate.get_count());
+    _as.request_abort();
+    return _gate.close();
+}
+
+ss::sstring scrubber::name() const { return "scrubber"; }
+
+std::pair<bool, std::optional<ss::sstring>> scrubber::should_skip() const {
+    if (!_feature_table.is_active(features::feature::cloud_storage_scrubbing)) {
+        return {true, "cloud_storage_scrubbing feature not active"};
+    }
+
+    if (!_job_enabled) {
+        return {true, "scrubber housekeeping job disabled"};
+    }
+
+    if (!_config_enabled()) {
+        return {true, "scrubber disabled via cluster config"};
+    }
+
+    const bool not_yet = !_scheduler.should_scrub();
+    if (not_yet) {
+        const auto until_next = _scheduler.until_next_scrub();
+        if (!until_next.has_value()) {
+            return {true, "next scrub not scheduled"};
+        }
+
+        return {
+          true,
+          ssx::sformat(
+            "next scrub in {}",
+            std::chrono::duration_cast<std::chrono::minutes>(*until_next))};
+    }
+
+    return {false, std::nullopt};
+}
+
+} // namespace archival

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "archival/fwd.h"
+#include "archival/scrubber_scheduler.h"
+#include "archival/types.h"
+#include "cloud_storage/base_manifest.h"
+#include "cloud_storage/fwd.h"
+#include "cluster/fwd.h"
+#include "cluster/types.h"
+#include "features/feature_table.h"
+#include "random/simple_time_jitter.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/future.hh>
+
+namespace archival {
+
+class scrubber : public housekeeping_job {
+public:
+    scrubber(
+      ntp_archiver& archiver,
+      cloud_storage::remote& remote,
+      retry_chain_logger& logger,
+      features::feature_table& feature_table,
+      config::binding<bool> config_enabled,
+      config::binding<std::chrono::milliseconds> interval,
+      config::binding<std::chrono::milliseconds> jitter);
+
+    ss::future<> await_feature_enabled();
+
+    ss::future<run_result>
+    run(retry_chain_node& rtc, run_quota_t quota) override;
+
+    void interrupt() override;
+
+    bool interrupted() const override;
+
+    ss::future<> stop() override;
+
+    void set_enabled(bool) override;
+
+    void acquire() override;
+    void release() override;
+
+    ss::sstring name() const override;
+
+    std::pair<bool, std::optional<ss::sstring>> should_skip() const;
+
+    model::timestamp next_scrub_at() const;
+
+private:
+    ss::abort_source _as;
+    ss::gate _gate;
+
+    // A gate holder we keep on behalf of the housekeeping service, when
+    // it acquire()s us.
+    std::optional<ss::gate::holder> _holder;
+
+    // Whether the scrubbing housekeeping job is enabled (e.g. will be disabled
+    // on non-leader nodes)
+    bool _job_enabled{true};
+
+    // Binding to cloud_storage_scrubbing_enabled cluster config
+    config::binding<bool> _config_enabled;
+
+    [[maybe_unused]] ntp_archiver& _archiver;
+    [[maybe_unused]] cloud_storage::remote& _remote;
+    [[maybe_unused]] retry_chain_logger& _logger;
+
+    features::feature_table& _feature_table;
+
+    scrubber_scheduler<std::chrono::system_clock> _scheduler;
+};
+
+} // namespace archival

--- a/src/v/archival/scrubber_scheduler.h
+++ b/src/v/archival/scrubber_scheduler.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "config/property.h"
+#include "random/simple_time_jitter.h"
+
+#include <chrono>
+
+namespace archival {
+
+/*
+ * Utility class that schedules a scrubbing action given the interval and jitter
+ * cluster configs. Updates to the cluster configs are also handled.
+ *
+ * The utility can be used by a fiber that wakes up periodically in order to
+ * check whether it should perform an action. It should call the `should_scrub`
+ * method of the scheduler in order to determine that. If it does decide to go
+ * through with the action, it should call `schedule_next_scrub` once the action
+ * is completed.
+ *
+ * The first scheduled action will happen after the jitter duration. Subsequent
+ * actions will happen after the interval and jitter.
+ *
+ * This class was authored in terms of the cloud storage scrubber, but it's
+ * actually generic. If one wishes to reuse in the future, they should rename
+ * the class and its methods.
+ */
+template<typename Clock = std::chrono::system_clock>
+class scrubber_scheduler {
+public:
+    using last_scrub_type = std::function<model::timestamp()>;
+
+    scrubber_scheduler(
+      last_scrub_type get_last_scrub_time,
+      config::binding<std::chrono::milliseconds> interval,
+      config::binding<std::chrono::milliseconds> jitter)
+      : _get_last_scrub_time(std::move(get_last_scrub_time))
+      , _interval(std::move(interval))
+      , _jitter(std::move(jitter))
+      , _jittery_timer(_interval(), _jitter()) {
+        _interval.watch([this]() {
+            _jittery_timer = simple_time_jitter<model::timestamp_clock>(
+              _interval(), _jitter());
+            pick_next_scrub_time();
+        });
+
+        _jitter.watch([this]() {
+            _jittery_timer = simple_time_jitter<model::timestamp_clock>(
+              _interval(), _jitter());
+            pick_next_scrub_time();
+        });
+    }
+
+    bool should_scrub() const {
+        if (_next_scrub_at == model::timestamp::missing()) {
+            return false;
+        }
+
+        const auto now_ts = model::to_timestamp(Clock::now());
+        return now_ts >= _next_scrub_at;
+    }
+
+    void pick_next_scrub_time() {
+        const auto last_scrub_time = _get_last_scrub_time();
+        const auto first_scrub = last_scrub_time == model::timestamp::missing();
+
+        if (first_scrub) {
+            const auto now = Clock::now();
+            _next_scrub_at = model::to_timestamp(
+              now + _jittery_timer.next_jitter_duration());
+        } else {
+            _next_scrub_at = model::timestamp{
+              last_scrub_time()
+              + std::chrono::duration_cast<std::chrono::milliseconds>(
+                  _jittery_timer.next_duration())
+                  .count()};
+        }
+    }
+
+    std::optional<std::chrono::milliseconds> until_next_scrub() const {
+        if (_next_scrub_at == model::timestamp::missing()) {
+            return std::nullopt;
+        }
+
+        const auto now_ts = model::to_timestamp(Clock::now());
+        if (now_ts >= _next_scrub_at) {
+            return std::chrono::milliseconds(0);
+        }
+
+        return std::chrono::milliseconds{(_next_scrub_at - now_ts).value()};
+    }
+
+private:
+    last_scrub_type _get_last_scrub_time;
+    config::binding<std::chrono::milliseconds> _interval;
+    config::binding<std::chrono::milliseconds> _jitter;
+
+    simple_time_jitter<model::timestamp_clock> _jittery_timer;
+    model::timestamp _next_scrub_at;
+};
+
+} // namespace archival

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ else()
       BINARY_NAME test_archival_service
       SOURCES 
         upload_housekeeping_service_test.cc
+        scrubber_scheduler_test.cc
       DEFINITIONS BOOST_TEST_DYN_LINK
       LIBRARIES 
         v::seastar_testing_main 

--- a/src/v/archival/tests/scrubber_scheduler_test.cc
+++ b/src/v/archival/tests/scrubber_scheduler_test.cc
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "archival/scrubber_scheduler.h"
+#include "config/configuration.h"
+
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+using namespace std::chrono_literals;
+
+BOOST_AUTO_TEST_CASE(test_scrubber_scheduling) {
+    auto interval
+      = config::shard_local_cfg().cloud_storage_scrubbing_interval_ms.bind();
+    auto jitter = config::shard_local_cfg()
+                    .cloud_storage_scrubbing_interval_jitter_ms.bind();
+
+    model::timestamp last_scrub_time;
+    archival::scrubber_scheduler<ss::manual_clock> sched{
+      [&last_scrub_time] { return last_scrub_time; }, interval, jitter};
+
+    // Test that the first scrub happens after the jitter
+    {
+        sched.pick_next_scrub_time();
+        const auto until_next = sched.until_next_scrub();
+        BOOST_REQUIRE(until_next.has_value());
+
+        BOOST_REQUIRE_LE(until_next, jitter());
+        if (until_next > 0ms) {
+            BOOST_REQUIRE(!sched.should_scrub());
+        }
+
+        ss::manual_clock::advance(*until_next);
+        BOOST_REQUIRE(sched.should_scrub());
+
+        last_scrub_time = model::to_timestamp(ss::manual_clock::now());
+    }
+
+    // Test that the second scrub happens after interval + jitter
+    {
+        sched.pick_next_scrub_time();
+        const auto until_next = sched.until_next_scrub();
+        BOOST_REQUIRE(until_next.has_value());
+
+        BOOST_REQUIRE_GE(until_next, interval());
+        BOOST_REQUIRE_LE(until_next, interval() + jitter());
+        BOOST_REQUIRE(!sched.should_scrub());
+
+        ss::manual_clock::advance(*until_next);
+        BOOST_REQUIRE(sched.should_scrub());
+
+        last_scrub_time = model::to_timestamp(ss::manual_clock::now());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_no_scrub_scheduled) {
+    auto interval
+      = config::shard_local_cfg().cloud_storage_scrubbing_interval_ms.bind();
+    auto jitter = config::shard_local_cfg()
+                    .cloud_storage_scrubbing_interval_jitter_ms.bind();
+
+    model::timestamp last_scrub_time;
+    archival::scrubber_scheduler<ss::manual_clock> sched{
+      [&last_scrub_time] { return last_scrub_time; }, interval, jitter};
+
+    BOOST_REQUIRE(!sched.should_scrub());
+    BOOST_REQUIRE(!sched.until_next_scrub().has_value());
+}
+
+BOOST_AUTO_TEST_CASE(test_update_jitter) {
+    auto& interval
+      = config::shard_local_cfg().cloud_storage_scrubbing_interval_ms;
+    auto& jitter
+      = config::shard_local_cfg().cloud_storage_scrubbing_interval_jitter_ms;
+
+    interval.set_value(
+      std::chrono::duration_cast<std::chrono::milliseconds>(30min));
+    jitter.set_value(
+      std::chrono::duration_cast<std::chrono::milliseconds>(1min));
+
+    auto reset_configs = ss::defer([&interval, &jitter] {
+        interval.reset();
+        jitter.reset();
+    });
+
+    model::timestamp last_scrub_time;
+    archival::scrubber_scheduler<ss::manual_clock> sched{
+      [&last_scrub_time] { return last_scrub_time; },
+      interval.bind(),
+      jitter.bind()};
+
+    const auto updated_jitter = 10s;
+
+    // Test that updating the jitter reschedules the scrub correctly
+    {
+        sched.pick_next_scrub_time();
+        const auto until_next = sched.until_next_scrub();
+        BOOST_REQUIRE(until_next.has_value());
+
+        jitter.set_value(std::chrono::duration_cast<std::chrono::milliseconds>(
+          updated_jitter));
+        const auto until_next_after_jitter_change = sched.until_next_scrub();
+        BOOST_REQUIRE(until_next_after_jitter_change.has_value());
+
+        BOOST_REQUIRE_LE(until_next_after_jitter_change, updated_jitter);
+
+        ss::manual_clock::advance(*until_next_after_jitter_change);
+        BOOST_REQUIRE(sched.should_scrub());
+
+        last_scrub_time = model::to_timestamp(ss::manual_clock::now());
+    }
+
+    // Test that the next schedulling call uses the new jitter value and old
+    // duration
+    {
+        sched.pick_next_scrub_time();
+        const auto until_next = sched.until_next_scrub();
+        BOOST_REQUIRE(until_next.has_value());
+
+        BOOST_REQUIRE_GE(until_next, interval());
+        BOOST_REQUIRE_LE(until_next, interval() + updated_jitter);
+        BOOST_REQUIRE(!sched.should_scrub());
+
+        ss::manual_clock::advance(*until_next);
+        BOOST_REQUIRE(sched.should_scrub());
+
+        last_scrub_time = model::to_timestamp(ss::manual_clock::now());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_update_interval) {
+    auto& interval
+      = config::shard_local_cfg().cloud_storage_scrubbing_interval_ms;
+    auto& jitter
+      = config::shard_local_cfg().cloud_storage_scrubbing_interval_jitter_ms;
+
+    interval.set_value(
+      std::chrono::duration_cast<std::chrono::milliseconds>(30min));
+    jitter.set_value(
+      std::chrono::duration_cast<std::chrono::milliseconds>(1min));
+
+    auto reset_configs = ss::defer([&interval, &jitter] {
+        interval.reset();
+        jitter.reset();
+    });
+
+    model::timestamp last_scrub_time;
+    archival::scrubber_scheduler<ss::manual_clock> sched{
+      [&last_scrub_time] { return last_scrub_time; },
+      interval.bind(),
+      jitter.bind()};
+
+    // Test that updating the interval before the first scrub reschedules.
+    // We should reschedule before the jitter since this is the first scrub
+    // still.
+    {
+        sched.pick_next_scrub_time();
+
+        const auto updated_interval = 10min;
+        interval.set_value(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+            updated_interval));
+
+        const auto until_next_after_after_interval_change
+          = sched.until_next_scrub();
+        BOOST_REQUIRE(until_next_after_after_interval_change.has_value());
+
+        BOOST_REQUIRE_LE(until_next_after_after_interval_change, jitter());
+
+        ss::manual_clock::advance(*until_next_after_after_interval_change);
+        BOOST_REQUIRE(sched.should_scrub());
+
+        last_scrub_time = model::to_timestamp(ss::manual_clock::now());
+    }
+
+    // Test that updating the interval after the first job instance triggers
+    // a rescheduling.
+    {
+        sched.pick_next_scrub_time();
+
+        const auto updated_interval = 5min;
+        interval.set_value(
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+            updated_interval));
+
+        const auto until_next_after_after_interval_change
+          = sched.until_next_scrub();
+        BOOST_REQUIRE(until_next_after_after_interval_change.has_value());
+
+        BOOST_REQUIRE_GE(
+          until_next_after_after_interval_change, updated_interval);
+        BOOST_REQUIRE_LE(
+          until_next_after_after_interval_change, updated_interval + jitter());
+
+        ss::manual_clock::advance(*until_next_after_after_interval_change);
+        BOOST_REQUIRE(sched.should_scrub());
+
+        last_scrub_time = model::to_timestamp(ss::manual_clock::now());
+    }
+}

--- a/src/v/cloud_roles/tests/fetch_credentials_tests.cc
+++ b/src/v/cloud_roles/tests/fetch_credentials_tests.cc
@@ -354,7 +354,8 @@ FIXTURE_TEST(test_client_closed_on_error, fixture) {
     fail_request_if(
       [](const auto&) { return true; },
       http_test_utils::response{
-        "not found", ss::http::reply::status_type::not_found});
+        .body = "not found",
+        .status = ss::http::reply::status_type::not_found});
 
     listen();
 
@@ -419,7 +420,8 @@ FIXTURE_TEST(test_handle_bad_response, fixture) {
     fail_request_if(
       [](const auto&) { return true; },
       http_test_utils::response{
-        "{broken response", ss::http::reply::status_type::ok});
+        .body = "{broken response",
+        .status = ss::http::reply::status_type::ok});
 
     listen();
 
@@ -469,7 +471,8 @@ FIXTURE_TEST(test_intermittent_error, fixture) {
     fail_request_if(
       [&idx](const auto&) { return idx++ == 0; },
       http_test_utils::response{
-        "failed!", ss::http::reply::status_type::internal_server_error});
+        .body = "failed!",
+        .status = ss::http::reply::status_type::internal_server_error});
 
     listen();
 

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -41,6 +41,7 @@ v_cc_library(
     segment_chunk_data_source.cc
     async_manifest_view.cc
     materialized_manifest_cache.cc
+    anomalies_detector.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/anomalies_detector.cc
+++ b/src/v/cloud_storage/anomalies_detector.cc
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/anomalies_detector.h"
+
+#include "cloud_storage/base_manifest.h"
+#include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/spillover_manifest.h"
+
+namespace cloud_storage {
+
+anomalies_detector::anomalies_detector(
+  cloud_storage_clients::bucket_name bucket,
+  model::ntp ntp,
+  model::initial_revision_id initial_rev,
+  remote& remote,
+  retry_chain_logger& logger,
+  ss::abort_source& as)
+  : _bucket(std::move(bucket))
+  , _ntp(std::move(ntp))
+  , _initial_rev(initial_rev)
+  , _remote(remote)
+  , _logger(logger)
+  , _as(as) {}
+
+ss::future<anomalies_detector::result>
+anomalies_detector::run(retry_chain_node& rtc_node) {
+    anomalies detected{};
+    scrub_status status{scrub_status::full};
+    size_t ops = 0;
+
+    vlog(_logger.debug, "Downloading partition manifest ...");
+
+    partition_manifest manifest(_ntp, _initial_rev);
+    auto [dl_result, format] = co_await _remote.try_download_partition_manifest(
+      _bucket, manifest, rtc_node);
+    ++ops;
+
+    if (dl_result == download_result::notfound) {
+        detected.missing_partition_manifest = true;
+        co_return result{
+          .status = status, .detected = std::move(detected), .ops = ops};
+    } else if (dl_result != download_result::success) {
+        vlog(_logger.debug, "Failed downloading partition manifest ...");
+        co_return result{.status = scrub_status::failed, .ops = ops};
+    }
+
+    std::deque<ss::sstring> spill_manifest_paths;
+    const auto& spillovers = manifest.get_spillover_map();
+    for (auto iter = spillovers.begin(); iter != spillovers.end(); ++iter) {
+        spillover_manifest_path_components comp{
+          .base = iter->base_offset,
+          .last = iter->committed_offset,
+          .base_kafka = iter->base_kafka_offset(),
+          .next_kafka = iter->next_kafka_offset(),
+          .base_ts = iter->base_timestamp,
+          .last_ts = iter->max_timestamp,
+        };
+
+        auto spill_path = generate_spillover_manifest_path(
+          _ntp, _initial_rev, comp);
+        auto exists_result = co_await _remote.segment_exists(
+          _bucket, remote_segment_path{spill_path()}, rtc_node);
+        ++ops;
+        if (exists_result == download_result::notfound) {
+            detected.missing_spillover_manifests.emplace(comp);
+        } else if (dl_result != download_result::success) {
+            vlog(
+              _logger.debug,
+              "Failed to check existence of spillover manifest {}",
+              spill_path());
+            status = scrub_status::partial;
+        } else {
+            spill_manifest_paths.emplace_front(spill_path());
+        }
+    }
+
+    // Binary manifest encoding and spillover manifests were both added
+    // in the same release. Hence, it's an anomaly to have a JSON
+    // encoded manifest and spillover manifests.
+    if (format == manifest_format::json && spill_manifest_paths.size() > 0) {
+        detected.missing_partition_manifest = true;
+    }
+
+    result final_res{
+      .status = status, .detected = std::move(detected), .ops = ops};
+
+    auto stm_manifest_check_res = co_await check_manifest(manifest, rtc_node);
+    final_res += std::move(stm_manifest_check_res);
+
+    for (auto iter = spill_manifest_paths.begin();
+         iter != spill_manifest_paths.end();
+         ++iter) {
+        if (_as.abort_requested()) {
+            final_res.status = scrub_status::partial;
+            co_return final_res;
+        }
+
+        auto manifest_res = co_await download_and_check_spill_manifest(
+          *iter, rtc_node);
+        final_res += std::move(manifest_res);
+    }
+
+    co_return final_res;
+}
+
+ss::future<anomalies_detector::result>
+anomalies_detector::download_and_check_spill_manifest(
+  const ss::sstring& path, retry_chain_node& rtc_node) {
+    result res{};
+
+    vlog(_logger.debug, "Downloading spillover manifest {}", path);
+
+    spillover_manifest spill{_ntp, _initial_rev};
+    auto manifest_get_result = co_await _remote.download_manifest(
+      _bucket,
+      {manifest_format::serde, remote_manifest_path{path}},
+      spill,
+      rtc_node);
+    res.ops += 1;
+
+    if (manifest_get_result != download_result::success) {
+        vlog(_logger.debug, "Failed downloading spillover manifest {}", path);
+
+        res.status = scrub_status::partial;
+        co_return res;
+    }
+
+    res += co_await check_manifest(spill, rtc_node);
+
+    co_return res;
+}
+
+ss::future<anomalies_detector::result> anomalies_detector::check_manifest(
+  const partition_manifest& manifest, retry_chain_node& rtc_node) {
+    result res{};
+
+    vlog(_logger.debug, "Checking manifest {}", manifest.get_manifest_path());
+
+    for (auto seg_iter = manifest.begin(); seg_iter != manifest.end();
+         ++seg_iter) {
+        if (_as.abort_requested()) {
+            res.status = scrub_status::partial;
+            co_return res;
+        }
+
+        auto segment_path = manifest.generate_segment_path(*seg_iter);
+        auto exists_result = co_await _remote.segment_exists(
+          _bucket, segment_path, rtc_node);
+        res.ops += 1;
+
+        if (exists_result == download_result::notfound) {
+            res.detected.missing_segments.emplace(*seg_iter);
+        } else if (exists_result != download_result::success) {
+            vlog(
+              _logger.debug,
+              "Failed to check existence of segment at {}",
+              segment_path());
+
+            res.status = scrub_status::partial;
+        }
+    }
+
+    vlog(
+      _logger.debug,
+      "Finished checking manifest {}",
+      manifest.get_manifest_path());
+
+    co_return res;
+}
+
+anomalies_detector::result&
+anomalies_detector::result::operator+=(anomalies_detector::result&& other) {
+    if (
+      status == scrub_status::failed || other.status == scrub_status::failed) {
+        status = scrub_status::failed;
+    } else if (
+      status == scrub_status::partial
+      || other.status == scrub_status::partial) {
+        status = scrub_status::partial;
+    } else {
+        status = scrub_status::full;
+    }
+
+    ops += other.ops;
+    detected += std::move(other.detected);
+
+    return *this;
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/anomalies_detector.h
+++ b/src/v/cloud_storage/anomalies_detector.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/fwd.h"
+#include "cloud_storage/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "seastarx.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/sstring.hh>
+
+namespace cloud_storage {
+
+/*
+ * Utility class that detects anomalies in the data and metadata uploaded
+ * by a partition to cloud storage.
+ *
+ * It performs the following steps:
+ * 1. Download partition manifest
+ * 2. Check for existence of spillover manifests
+ * 3. Check for existence of segments referenced by partition manifest
+ * 4. For each spillover manifest, check for existence of the referenced
+ * segments
+ */
+class anomalies_detector {
+public:
+    anomalies_detector(
+      cloud_storage_clients::bucket_name bucket,
+      model::ntp ntp,
+      model::initial_revision_id initial_rev,
+      remote& remote,
+      retry_chain_logger& logger,
+      ss::abort_source& as);
+
+    struct result {
+        scrub_status status{scrub_status::full};
+        anomalies detected;
+        size_t ops{0};
+
+        result& operator+=(result&&);
+    };
+
+    ss::future<result> run(retry_chain_node&);
+
+    ss::future<anomalies_detector::result> download_and_check_spill_manifest(
+      const ss::sstring& path, retry_chain_node& rtc_node);
+
+    ss::future<anomalies_detector::result> check_manifest(
+      const partition_manifest& manifest, retry_chain_node& rtc_node);
+
+private:
+    cloud_storage_clients::bucket_name _bucket;
+    model::ntp _ntp;
+    model::initial_revision_id _initial_rev;
+
+    remote& _remote;
+    retry_chain_logger& _logger;
+    ss::abort_source& _as;
+};
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/lifecycle_marker.h
+++ b/src/v/cloud_storage/lifecycle_marker.h
@@ -34,7 +34,7 @@ namespace cloud_storage {
 // └────┬─────┘
 //      │
 //      │
-//      │ Topic purge complete (by scrubber)
+//      │ Topic purge complete (by purger)
 //      ▼
 // ┌──────────┐
 // │  Purged  │
@@ -64,7 +64,7 @@ enum class lifecycle_status : uint8_t {
  * as a tombstone that enables
  *  - readers to unambiguously understand that the
  *    topic is deleted and not just missing
- *  - scrubbers to know that it is safe to erase stray objects within the
+ *  - purgers to know that it is safe to erase stray objects within the
  *    NT that the lifecycle describes.
  *
  * For normal not-deleted topics, this marker doesn't tell you anything more

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -837,6 +837,10 @@ size_t partition_manifest::replaced_segments_count() const {
     return _replaced.size();
 }
 
+model::timestamp partition_manifest::last_partition_scrub() const {
+    return _last_partition_scrub;
+}
+
 std::optional<size_t> partition_manifest::move_aligned_offset_range(
   const segment_meta& replacing_segment) {
     size_t total_replaced_size = 0;
@@ -1020,7 +1024,8 @@ partition_manifest partition_manifest::clone() const {
       _archive_start_offset_delta,
       _archive_clean_offset,
       _archive_size_bytes,
-      spillover);
+      spillover,
+      _last_partition_scrub);
     return tmp;
 }
 
@@ -1392,6 +1397,8 @@ struct partition_manifest_handler
                 _start_kafka_offset = kafka::offset(u);
             } else if (_manifest_key == "archive_size_bytes") {
                 _archive_size_bytes = u;
+            } else if (_manifest_key == "last_partition_scrub") {
+                _last_partition_scrub = model::timestamp(u);
             } else {
                 return false;
             }
@@ -1721,6 +1728,7 @@ struct partition_manifest_handler
     std::optional<model::offset> _archive_clean_offset;
     std::optional<kafka::offset> _start_kafka_offset;
     std::optional<size_t> _archive_size_bytes;
+    std::optional<model::timestamp> _last_partition_scrub;
 
     // required segment meta fields
     std::optional<bool> _is_compacted;
@@ -1873,7 +1881,8 @@ constexpr auto to_underlying(Enum e) {
 void partition_manifest::do_update(partition_manifest_handler&& handler) {
     if (
       handler._version != to_underlying(manifest_version::v1)
-      && handler._version != to_underlying(manifest_version::v2)) {
+      && handler._version != to_underlying(manifest_version::v2)
+      && handler._version != to_underlying(manifest_version::v3)) {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "partition manifest version {} is not supported",
@@ -1940,6 +1949,9 @@ void partition_manifest::do_update(partition_manifest_handler&& handler) {
 
     _start_kafka_offset_override = handler._start_kafka_offset.value_or(
       kafka::offset{});
+
+    _last_partition_scrub = handler._last_partition_scrub.value_or(
+      model::timestamp::missing());
 }
 
 // This object is supposed to track state of the asynchronous
@@ -2075,6 +2087,10 @@ void partition_manifest::serialize_begin(
     if (_archive_size_bytes != 0) {
         w.Key("archive_size_bytes");
         w.Int64(static_cast<int64_t>(_archive_size_bytes));
+    }
+    if (_last_partition_scrub != model::timestamp::missing()) {
+        w.Key("last_partition_scrub");
+        w.Int64(static_cast<int64_t>(_last_partition_scrub()));
     }
     cursor->prologue_done = true;
 }
@@ -2429,7 +2445,7 @@ partition_manifest::timequery(model::timestamp t) const {
 struct partition_manifest_serde
   : public serde::envelope<
       partition_manifest_serde,
-      serde::version<to_underlying(manifest_version::v2)>,
+      serde::version<to_underlying(manifest_version::v3)>,
       serde::compat_version<0>> {
     model::ntp _ntp;
     model::initial_revision_id _rev;
@@ -2450,6 +2466,7 @@ struct partition_manifest_serde
     kafka::offset _start_kafka_offset;
     size_t archive_size_bytes;
     iobuf _spillover_manifests_serialized;
+    model::timestamp _last_partition_scrub;
 };
 
 static_assert(

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -153,7 +153,8 @@ public:
       model::offset archive_clean_offset,
       uint64_t archive_size_bytes,
       const fragmented_vector<segment_t>& spillover,
-      model::timestamp last_partition_scrub)
+      model::timestamp last_partition_scrub,
+      anomalies detected_anomalies)
       : _ntp(std::move(ntp))
       , _rev(rev)
       , _mem_tracker(std::move(manifest_mem_tracker))
@@ -167,7 +168,8 @@ public:
       , _archive_clean_offset(archive_clean_offset)
       , _start_kafka_offset_override(start_kafka_offset)
       , _archive_size_bytes(archive_size_bytes)
-      , _last_partition_scrub(last_partition_scrub) {
+      , _last_partition_scrub(last_partition_scrub)
+      , _detected_anomalies(std::move(detected_anomalies)) {
         for (auto nm : replaced) {
             auto key = parse_segment_name(nm.name);
             vassert(
@@ -449,6 +451,8 @@ public:
 
     model::timestamp last_partition_scrub() const;
 
+    const anomalies& detected_anomalies() const;
+
     /// Removes all replaced segments from the manifest.
     /// Method 'replaced_segments' will return empty value
     /// after the call.
@@ -532,6 +536,11 @@ public:
     void from_iobuf(iobuf in);
 
     iobuf to_iobuf() const;
+
+    void process_anomalies(
+      model::timestamp scrub_timestamp,
+      scrub_status status,
+      anomalies detected);
 
 private:
     std::optional<kafka::offset> compute_start_kafka_offset_local() const;
@@ -621,6 +630,8 @@ private:
     // with `_start_offset`. This value is computed from
     // `compute_start_kafka_offset_local` and is not in the serialized manifest.
     mutable std::optional<kafka::offset> _cached_start_kafka_offset_local;
+
+    anomalies _detected_anomalies;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/spillover_manifest.h
+++ b/src/v/cloud_storage/spillover_manifest.h
@@ -17,30 +17,6 @@
 
 namespace cloud_storage {
 
-struct spillover_manifest_path_components {
-    model::offset base;
-    model::offset last;
-    kafka::offset base_kafka;
-    kafka::offset next_kafka;
-    model::timestamp base_ts;
-    model::timestamp last_ts;
-};
-
-inline std::ostream&
-operator<<(std::ostream& o, const spillover_manifest_path_components& c) {
-    fmt::print(
-      o,
-      "{{base: {}, last: {}, base_kafka: {}, next_kafka: {}, base_ts: {}, "
-      "last_ts: {}}}",
-      c.base,
-      c.last,
-      c.base_kafka,
-      c.next_kafka,
-      c.base_ts,
-      c.last_ts);
-    return o;
-}
-
 namespace {
 
 remote_manifest_path generate_spillover_manifest_path(

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ rp_test(
     delete_records_e2e_test.cc
     async_manifest_view_test.cc
     read_replica_test.cc
+    anomalies_detector_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     Boost::unit_test_framework
@@ -58,6 +59,7 @@ rp_test(
     v::cloud_roles
     v::application
     v::kafka_test_utils
+    v::http_test_utils
   ARGS "-- -c 1"
   LABELS cloud_storage
 )

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -1,0 +1,502 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "bytes/iostream.h"
+#include "cloud_storage/anomalies_detector.h"
+#include "cloud_storage/base_manifest.h"
+#include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/spillover_manifest.h"
+#include "cloud_storage/types.h"
+#include "http/tests/http_imposter.h"
+#include "test_utils/fixture.h"
+
+#include <seastar/util/short_streams.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+namespace {
+
+ss::logger test_logger{"anomaly_detection_test"};
+
+constexpr std::string_view stm_manifest = R"json(
+{
+  "version": 3,
+  "namespace": "kafka",
+  "topic": "panda-topic",
+  "partition": 0,
+  "revision": 1,
+  "start_offset": 0,
+  "last_offset": 59,
+  "insync_offset": 100,
+  "segments": {
+      "40-1-v1.log": {
+          "size_bytes": 1024,
+          "base_offset": 40,
+          "committed_offset": 49,
+          "base_timestamp": 1000,
+          "max_timestamp":  1000,
+          "delta_offset": 8,
+          "delta_offset_end": 10,
+          "ntp_revision": 1,
+          "archiver_term": 1,
+          "segment_term": 1,
+          "sname_format": 2
+      },
+      "50-1-v1.log": {
+          "size_bytes": 1024,
+          "base_offset": 50,
+          "committed_offset": 59,
+          "base_timestamp": 1000,
+          "max_timestamp":  1000,
+          "delta_offset": 10,
+          "delta_offset_end": 12,
+          "ntp_revision": 1,
+          "archiver_term": 1,
+          "segment_term": 1,
+          "sname_format": 2
+      }
+  },
+  "spillover": [
+      {
+          "size_bytes": 2048,
+          "base_offset": 0,
+          "committed_offset": 19,
+          "base_timestamp": 1000,
+          "max_timestamp":  1000,
+          "delta_offset": 0,
+          "delta_offset_end": 4,
+          "ntp_revision": 1,
+          "archiver_term": 1,
+          "segment_term": 1,
+          "sname_format": 3,
+          "metadata_size_hint": 0
+      },
+      {
+          "size_bytes": 2048,
+          "base_offset": 20,
+          "committed_offset": 39,
+          "base_timestamp": 1000,
+          "max_timestamp":  1000,
+          "delta_offset": 4,
+          "delta_offset_end": 8,
+          "ntp_revision": 1,
+          "archiver_term": 1,
+          "segment_term": 1,
+          "sname_format": 3,
+          "metadata_size_hint": 0
+      }
+  ]
+}
+)json";
+
+constexpr std::string_view spillover_manifest_at_0 = R"json(
+{
+  "version": 3,
+  "namespace": "kafka",
+  "topic": "panda-topic",
+  "partition": 0,
+  "revision": 1,
+  "start_offset": 0,
+  "last_offset": 19,
+  "insync_offset": 10,
+  "segments": {
+      "0-1-v1.log": {
+          "size_bytes": 1024,
+          "base_offset": 0,
+          "committed_offset": 9,
+          "base_timestamp": 1000,
+          "max_timestamp":  1000,
+          "delta_offset": 0,
+          "delta_offset_end": 2,
+          "ntp_revision": 1,
+          "archiver_term": 1,
+          "segment_term": 1,
+          "sname_format": 2
+      },
+      "10-1-v1.log": {
+          "size_bytes": 1024,
+          "base_offset": 10,
+          "committed_offset": 19,
+          "base_timestamp": 1000,
+          "max_timestamp":  1000,
+          "delta_offset": 2,
+          "delta_offset_end": 4,
+          "ntp_revision": 1,
+          "archiver_term": 1,
+          "segment_term": 1,
+          "sname_format": 2
+      }
+  }
+}
+)json";
+
+constexpr std::string_view spillover_manifest_at_20 = R"json(
+{
+  "version": 3,
+  "namespace": "kafka",
+  "topic": "panda-topic",
+  "partition": 0,
+  "revision": 1,
+  "start_offset": 20,
+  "last_offset": 39,
+  "insync_offset": 20,
+  "segments": {
+      "20-1-v1.log": {
+          "size_bytes": 1024,
+          "base_offset": 20,
+          "committed_offset": 29,
+          "base_timestamp": 1000,
+          "max_timestamp":  1000,
+          "delta_offset": 4,
+          "delta_offset_end": 6,
+          "ntp_revision": 1,
+          "archiver_term": 1,
+          "segment_term": 1,
+          "sname_format": 2
+      },
+      "30-1-v1.log": {
+          "size_bytes": 1024,
+          "base_offset": 30,
+          "committed_offset": 39,
+          "base_timestamp": 1000,
+          "max_timestamp":  1000,
+          "delta_offset": 6,
+          "delta_offset_end": 8,
+          "ntp_revision": 1,
+          "archiver_term": 1,
+          "segment_term": 1,
+          "sname_format": 2
+      }
+  }
+}
+)json";
+
+constexpr auto not_found_response = R"xml(
+<Error>
+  <Code>NoSuchKey</Code>
+  <Message>Faked error message</Message>
+  <RequestId>Faked request id</RequestId>
+</Error>
+)xml";
+
+ss::input_stream<char> make_manifest_stream(std::string_view json) {
+    iobuf i;
+    i.append(json.data(), json.size());
+    return make_iobuf_input_stream(std::move(i));
+}
+
+ss::sstring iobuf_to_string(iobuf buf) {
+    auto input_stream = make_iobuf_input_stream(std::move(buf));
+    return ss::util::read_entire_stream_contiguous(input_stream).get();
+}
+
+} // namespace
+
+class bucket_view_fixture : http_imposter_fixture {
+public:
+    static constexpr auto host_name = "127.0.0.1";
+    static constexpr auto port = 4447;
+
+    bucket_view_fixture()
+      : http_imposter_fixture{port}
+      , _root_rtc{_as}
+      , _rtc_logger{test_logger, _root_rtc} {
+        _pool
+          .start(10, ss::sharded_parameter([this] {
+                     return get_client_configuration();
+                 }))
+          .get();
+
+        _remote
+          .start(
+            std::ref(_pool),
+            ss::sharded_parameter(
+              [this] { return get_client_configuration(); }),
+            ss::sharded_parameter(
+              [] { return model::cloud_credentials_source::config_file; }))
+          .get();
+
+        _remote
+          .invoke_on_all([](cloud_storage::remote& api) { return api.start(); })
+          .get();
+    }
+
+    ~bucket_view_fixture() override {
+        if (!_pool.local().shutdown_initiated()) {
+            _pool.local().shutdown_connections();
+        }
+        _remote.stop().get();
+        _pool.stop().get();
+    }
+
+    void init_view(
+      std::string_view stm_manifest,
+      std::vector<std::string_view> spillover_manifests) {
+        parse_manifests(stm_manifest, std::move(spillover_manifests));
+
+        check_spills_are_matching();
+
+        set_expectations_for_manifest(_stm_manifest);
+        remove_json_stm_manifest(_stm_manifest);
+
+        for (const auto& spill : _spillover_manifests) {
+            set_expectations_for_manifest(spill);
+        }
+
+        listen();
+
+        _detector.emplace(
+          cloud_storage_clients::bucket_name{"test_bucket"},
+          _stm_manifest.get_ntp(),
+          _stm_manifest.get_revision_id(),
+          _remote.local(),
+          _rtc_logger,
+          _as);
+    }
+
+    cloud_storage::anomalies_detector::result run_detector() {
+        BOOST_REQUIRE(_detector.has_value());
+
+        retry_chain_node anomaly_detection_rtc(1min, 100ms, &_root_rtc);
+        auto res = _detector->run(anomaly_detection_rtc).get();
+        vlog(
+          test_logger.info,
+          "Anomalies detector run result: status={}, detected={}",
+          res.status,
+          res.detected);
+
+        return res;
+    }
+
+    const cloud_storage::partition_manifest& get_stm_manifest() {
+        return _stm_manifest;
+    }
+
+    const std::vector<cloud_storage::spillover_manifest>&
+    get_spillover_manifests() {
+        return _spillover_manifests;
+    }
+
+    void remove_segment(
+      const cloud_storage::partition_manifest& manifest,
+      const cloud_storage::segment_meta& meta) {
+        auto path = manifest.generate_segment_path(meta);
+        remove_object(ssx::sformat("/{}", path().string()));
+    }
+
+    void remove_manifest(const cloud_storage::partition_manifest& manifest) {
+        auto path = manifest.get_manifest_path();
+        remove_object(ssx::sformat("/{}", path().string()));
+    }
+
+private:
+    void remove_json_stm_manifest(
+      const cloud_storage::partition_manifest& manifest) {
+        auto path = manifest.get_manifest_path(
+          cloud_storage::manifest_format::json);
+        remove_object(ssx::sformat("/{}", path().string()));
+    }
+
+    void remove_object(ss::sstring full_path) {
+        when()
+          .request(full_path)
+          .with_method(ss::httpd::operation_type::HEAD)
+          .then_reply_with(
+            std::vector<std::pair<ss::sstring, ss::sstring>>{
+              {"x-amz-request-id", "fake-id"}},
+            ss::http::reply::status_type::not_found);
+
+        when()
+          .request(full_path)
+          .with_method(ss::httpd::operation_type::GET)
+          .then_reply_with(
+            not_found_response, ss::http::reply::status_type::not_found);
+    }
+
+    void parse_manifests(
+      std::string_view stm_manifest,
+      std::vector<std::string_view> spillover_manifests) {
+        _stm_manifest
+          .update(
+            cloud_storage::manifest_format::json,
+            make_manifest_stream(stm_manifest))
+          .get();
+
+        std::vector<cloud_storage::spillover_manifest> spills;
+        for (const auto& spill_json : spillover_manifests) {
+            cloud_storage::spillover_manifest spill_manifest{
+              _stm_manifest.get_ntp(), _stm_manifest.get_revision_id()};
+            spill_manifest
+              .update(
+                cloud_storage::manifest_format::json,
+                make_manifest_stream(spill_json))
+              .get();
+
+            _spillover_manifests.emplace_back(std::move(spill_manifest));
+        }
+    }
+
+    void check_spills_are_matching() {
+        const auto& spill_map = _stm_manifest.get_spillover_map();
+        for (const auto& spill : _spillover_manifests) {
+            BOOST_REQUIRE(spill.get_start_offset().has_value());
+
+            auto iter = spill_map.find(spill.get_start_offset().value());
+            BOOST_REQUIRE(iter != spill_map.end());
+
+            cloud_storage::spillover_manifest_path_components comp{
+              .base = iter->base_offset,
+              .last = iter->committed_offset,
+              .base_kafka = iter->base_kafka_offset(),
+              .next_kafka = iter->next_kafka_offset(),
+              .base_ts = iter->base_timestamp,
+              .last_ts = iter->max_timestamp,
+            };
+
+            auto spill_path = cloud_storage::generate_spillover_manifest_path(
+              _stm_manifest.get_ntp(), _stm_manifest.get_revision_id(), comp);
+            BOOST_REQUIRE_EQUAL(spill_path, spill.get_manifest_path());
+        }
+    }
+
+    void set_expectations_for_manifest(
+      const cloud_storage::partition_manifest& manifest) {
+        const auto path = manifest.get_manifest_path()().string();
+        const auto reply_body = iobuf_to_string(manifest.to_iobuf());
+
+        when()
+          .request(fmt::format("/{}", path))
+          .with_method(ss::httpd::operation_type::GET)
+          .then_reply_with(reply_body);
+
+        when()
+          .request(fmt::format("/{}", path))
+          .with_method(ss::httpd::operation_type::HEAD)
+          .then_reply_with(
+            {{"ETag", "blah-blah"},
+             {"Content-Length", ssx::sformat("{}", reply_body.size())}},
+            ss::http::reply::status_type::ok);
+
+        set_expectations_for_segments(manifest);
+    }
+
+    void set_expectations_for_segments(
+      const cloud_storage::partition_manifest& manifest) {
+        for (const auto& seg : manifest) {
+            auto path = manifest.generate_segment_path(seg)().string();
+            when()
+              .request(fmt::format("/{}", path))
+              .with_method(ss::httpd::operation_type::HEAD)
+              .then_reply_with(
+                {{"ETag", "blah-blah"},
+                 {"Content-Length", ssx::sformat("{}", seg.size_bytes)}},
+                ss::http::reply::status_type::ok);
+        }
+    }
+
+    cloud_storage_clients::s3_configuration get_client_configuration() {
+        net::unresolved_address server_addr(host_name, port);
+
+        cloud_storage_clients::s3_configuration conf;
+        conf.uri = cloud_storage_clients::access_point_uri(host_name);
+        conf.access_key = cloud_roles::public_key_str("acess-key");
+        conf.secret_key = cloud_roles::private_key_str("secret-key");
+        conf.region = cloud_roles::aws_region_name("us-east-1");
+        conf.server_addr = server_addr;
+        conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
+          net::metrics_disabled::yes,
+          net::public_metrics_disabled::yes,
+          cloud_roles::aws_region_name{"us-east-1"},
+          cloud_storage_clients::endpoint_url{httpd_host_name});
+
+        return conf;
+    }
+
+    ss::abort_source _as;
+    retry_chain_node _root_rtc;
+    retry_chain_logger _rtc_logger;
+
+    ss::sharded<cloud_storage_clients::client_pool> _pool;
+    ss::sharded<cloud_storage::remote> _remote;
+
+    cloud_storage::partition_manifest _stm_manifest;
+    std::vector<cloud_storage::spillover_manifest> _spillover_manifests;
+
+    std::optional<cloud_storage::anomalies_detector> _detector;
+};
+
+FIXTURE_TEST(test_no_anomalies, bucket_view_fixture) {
+    init_view(
+      stm_manifest, {spillover_manifest_at_0, spillover_manifest_at_20});
+
+    auto result = run_detector();
+    BOOST_REQUIRE_EQUAL(result.status, cloud_storage::scrub_status::full);
+
+    BOOST_REQUIRE(!result.detected.has_value());
+}
+
+FIXTURE_TEST(test_missing_segments, bucket_view_fixture) {
+    init_view(
+      stm_manifest, {spillover_manifest_at_0, spillover_manifest_at_20});
+
+    const auto& stm_segment = get_stm_manifest().begin();
+    remove_segment(get_stm_manifest(), *stm_segment);
+
+    const auto& first_spill = get_spillover_manifests().at(0);
+    const auto& spill_segment = first_spill.begin();
+    remove_segment(first_spill, *spill_segment);
+
+    const auto result = run_detector();
+    BOOST_REQUIRE_EQUAL(result.status, cloud_storage::scrub_status::full);
+
+    BOOST_REQUIRE(result.detected.has_value());
+
+    const auto& missing_segs = result.detected.missing_segments;
+    BOOST_REQUIRE_EQUAL(missing_segs.size(), 2);
+    BOOST_REQUIRE(missing_segs.contains(*stm_segment));
+    BOOST_REQUIRE(missing_segs.contains(*spill_segment));
+}
+
+FIXTURE_TEST(test_missing_spillover_manifest, bucket_view_fixture) {
+    init_view(
+      stm_manifest, {spillover_manifest_at_0, spillover_manifest_at_20});
+
+    const auto& first_spill = get_spillover_manifests().at(0);
+    const auto& spill_segment = first_spill.begin();
+    remove_manifest(first_spill);
+
+    const auto result = run_detector();
+    BOOST_REQUIRE_EQUAL(result.status, cloud_storage::scrub_status::full);
+
+    BOOST_REQUIRE(result.detected.has_value());
+
+    const auto& missing_spills = result.detected.missing_spillover_manifests;
+    BOOST_REQUIRE_EQUAL(missing_spills.size(), 1);
+    const auto expected_path = cloud_storage::generate_spillover_manifest_path(
+      first_spill.get_ntp(),
+      first_spill.get_revision_id(),
+      *missing_spills.begin());
+    BOOST_REQUIRE_EQUAL(first_spill.get_manifest_path(), expected_path);
+}
+
+FIXTURE_TEST(test_missing_stm_manifest, bucket_view_fixture) {
+    init_view(
+      stm_manifest, {spillover_manifest_at_0, spillover_manifest_at_20});
+
+    remove_manifest(get_stm_manifest());
+
+    const auto result = run_detector();
+    BOOST_REQUIRE_EQUAL(result.status, cloud_storage::scrub_status::full);
+
+    BOOST_REQUIRE(result.detected.has_value());
+    BOOST_REQUIRE_EQUAL(result.detected.missing_partition_manifest, true);
+}

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -113,6 +113,21 @@ std::ostream& operator<<(std::ostream& o, const upload_result& r) {
     return o;
 }
 
+std::ostream&
+operator<<(std::ostream& o, const spillover_manifest_path_components& c) {
+    fmt::print(
+      o,
+      "{{base: {}, last: {}, base_kafka: {}, next_kafka: {}, base_ts: {}, "
+      "last_ts: {}}}",
+      c.base,
+      c.last,
+      c.base_kafka,
+      c.next_kafka,
+      c.base_ts,
+      c.last_ts);
+    return o;
+}
+
 std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
     fmt::print(
       o,

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -23,6 +23,8 @@
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
 
+#include <absl/container/node_hash_set.h>
+
 #include <chrono>
 #include <filesystem>
 
@@ -202,6 +204,16 @@ struct segment_meta {
     }
 
     auto operator<=>(const segment_meta&) const = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const segment_meta& meta) {
+        return H::combine(
+          std::move(h),
+          meta.base_offset(),
+          meta.committed_offset(),
+          meta.delta_offset(),
+          meta.delta_offset_end());
+    }
 };
 std::ostream& operator<<(std::ostream& o, const segment_meta& r);
 
@@ -290,17 +302,67 @@ struct cache_usage_target {
     }
 };
 
-struct spillover_manifest_path_components {
+struct spillover_manifest_path_components
+  : serde::envelope<
+      spillover_manifest_path_components,
+      serde::version<0>,
+      serde::compat_version<0>> {
     model::offset base;
     model::offset last;
     kafka::offset base_kafka;
     kafka::offset next_kafka;
     model::timestamp base_ts;
     model::timestamp last_ts;
+
+    auto serde_fields() {
+        return std::tie(base, last, base_kafka, next_kafka, base_ts, last_ts);
+    }
+
+    template<typename H>
+    friend H AbslHashValue(H h, const spillover_manifest_path_components& c) {
+        return H::combine(
+          std::move(h),
+          c.base(),
+          c.last(),
+          c.base_kafka(),
+          c.next_kafka(),
+          c.base_ts(),
+          c.last_ts());
+    }
 };
 
 std::ostream&
 operator<<(std::ostream& o, const spillover_manifest_path_components& c);
+
+enum class scrub_status : uint8_t { full, partial, failed };
+
+std::ostream& operator<<(std::ostream& o, const scrub_status&);
+
+// TODO: Add more anomaly types: malformed objects, gaps, overlaps, bad deltas
+struct anomalies
+  : serde::envelope<anomalies, serde::version<0>, serde::compat_version<0>> {
+    // Missing partition manifests
+    bool missing_partition_manifest{false};
+    // Spillover manifests referenced by the manifest which were not
+    // found
+    absl::node_hash_set<spillover_manifest_path_components>
+      missing_spillover_manifests;
+    // Segments referenced by the manifests which were not found
+    absl::node_hash_set<segment_meta> missing_segments;
+
+    auto serde_fields() {
+        return std::tie(
+          missing_partition_manifest,
+          missing_spillover_manifests,
+          missing_segments);
+    }
+
+    bool has_value() const;
+
+    anomalies& operator+=(anomalies&&);
+};
+
+std::ostream& operator<<(std::ostream& o, const anomalies& a);
 
 } // namespace cloud_storage
 

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -290,6 +290,18 @@ struct cache_usage_target {
     }
 };
 
+struct spillover_manifest_path_components {
+    model::offset base;
+    model::offset last;
+    kafka::offset base_kafka;
+    kafka::offset next_kafka;
+    model::timestamp base_ts;
+    model::timestamp last_ts;
+};
+
+std::ostream&
+operator<<(std::ostream& o, const spillover_manifest_path_components& c);
+
 } // namespace cloud_storage
 
 namespace std {

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -83,6 +83,7 @@ enum class upload_result : int32_t {
 enum class manifest_version : int32_t {
     v1 = 1,
     v2 = 2,
+    v3 = 3, // v23.3.x
 };
 
 enum class tx_range_manifest_version : int32_t {

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -176,6 +176,7 @@ v_cc_library(
     ../archival/upload_housekeeping_service.cc
     ../archival/adjacent_segment_merger.cc
     ../archival/purger.cc
+    ../archival/scrubber.cc
     cloud_metadata/cluster_manifest.cc
     cloud_metadata/key_utils.cc
     cloud_metadata/manifest_downloads.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -175,7 +175,7 @@ v_cc_library(
     ../archival/retention_calculator.cc
     ../archival/upload_housekeeping_service.cc
     ../archival/adjacent_segment_merger.cc
-    ../archival/scrubber.cc
+    ../archival/purger.cc
     cloud_metadata/cluster_manifest.cc
     cloud_metadata/key_utils.cc
     cloud_metadata/manifest_downloads.cc

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -147,6 +147,17 @@ struct archival_metadata_stm::replace_manifest_cmd {
     using value = iobuf;
 };
 
+struct archival_metadata_stm::process_anomalies_cmd {
+    static constexpr cmd_key key{11};
+
+    struct value
+      : serde::envelope<value, serde::version<0>, serde::compat_version<0>> {
+        model::timestamp scrub_timestamp;
+        cloud_storage::scrub_status status;
+        cloud_storage::anomalies detected;
+    };
+};
+
 struct archival_metadata_stm::snapshot
   : public serde::
       envelope<snapshot, serde::version<4>, serde::compat_version<0>> {
@@ -250,6 +261,21 @@ command_batch_builder::replace_manifest(iobuf replacement) {
     iobuf key_buf = serde::to_iobuf(
       archival_metadata_stm::replace_manifest_cmd::key);
     _builder.add_raw_kv(std::move(key_buf), std::move(replacement));
+    return *this;
+}
+
+command_batch_builder& command_batch_builder::process_anomalies(
+  model::timestamp scrub_timestamp,
+  cloud_storage::scrub_status status,
+  cloud_storage::anomalies detected) {
+    iobuf key_buf = serde::to_iobuf(
+      archival_metadata_stm::process_anomalies_cmd::key);
+    auto record_val = archival_metadata_stm::process_anomalies_cmd::value{
+      .scrub_timestamp = scrub_timestamp,
+      .status = status,
+      .detected = std::move(detected)};
+    _builder.add_raw_kv(
+      std::move(key_buf), serde::to_iobuf(std::move(record_val)));
     return *this;
 }
 
@@ -583,6 +609,17 @@ ss::future<std::error_code> archival_metadata_stm::cleanup_metadata(
     co_return co_await builder.replicate();
 }
 
+ss::future<std::error_code> archival_metadata_stm::process_anomalies(
+  model::timestamp scrub_timestamp,
+  cloud_storage::scrub_status status,
+  cloud_storage::anomalies detected,
+  ss::lowres_clock::time_point deadline,
+  ss::abort_source& as) {
+    auto builder = batch_start(deadline, as);
+    builder.process_anomalies(scrub_timestamp, status, std::move(detected));
+    co_return co_await builder.replicate();
+}
+
 ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
   model::record_batch batch, ss::abort_source& as) {
     auto current_term = _insync_term;
@@ -792,6 +829,9 @@ ss::future<> archival_metadata_stm::apply(const model::record_batch& b) {
             break;
         case replace_manifest_cmd::key:
             apply_replace_manifest(r.release_value());
+            break;
+        case process_anomalies_cmd::key:
+            apply_process_anomalies(r.release_value());
             break;
         default:
             throw std::runtime_error(fmt_with_ctx(
@@ -1144,6 +1184,21 @@ void archival_metadata_stm::apply_replace_manifest(iobuf val) {
       "Replace command applied, new start offset: {}, new last offset: {}",
       get_start_offset(),
       get_last_offset());
+}
+
+void archival_metadata_stm::apply_process_anomalies(iobuf buf) {
+    try {
+        auto cmd = serde::from_iobuf<process_anomalies_cmd::value>(
+          std::move(buf));
+        vlog(_logger.debug, "Processing anomalies: {}", cmd.detected);
+        _manifest->process_anomalies(
+          cmd.scrub_timestamp, cmd.status, std::move(cmd.detected));
+    } catch (...) {
+        vlog(
+          _logger.error,
+          "Failed to apply process anomalies command: {}",
+          std::current_exception());
+    }
 }
 
 std::vector<cloud_storage::partition_manifest::lw_segment_meta>

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -186,6 +186,8 @@ struct archival_metadata_stm::snapshot
     fragmented_vector<segment> spillover_manifests;
     // Timestamp of last completed scrub
     model::timestamp last_partition_scrub;
+    // Anomalies detected by the scrubber
+    cloud_storage::anomalies detected_anomalies;
 };
 
 inline archival_metadata_stm::segment
@@ -900,7 +902,8 @@ ss::future<> archival_metadata_stm::apply_local_snapshot(
       snap.archive_clean_offset,
       snap.archive_size_bytes,
       snap.spillover_manifests,
-      snap.last_partition_scrub);
+      snap.last_partition_scrub,
+      snap.detected_anomalies);
 
     vlog(
       _logger.info,
@@ -938,7 +941,8 @@ ss::future<stm_snapshot> archival_metadata_stm::take_local_snapshot() {
       .archive_size_bytes = _manifest->archive_size_bytes(),
       .start_kafka_offset = _manifest->get_start_kafka_offset_override(),
       .spillover_manifests = std::move(spillover),
-      .last_partition_scrub = _manifest->last_partition_scrub()});
+      .last_partition_scrub = _manifest->last_partition_scrub(),
+      .detected_anomalies = _manifest->detected_anomalies()});
 
     vlog(
       _logger.debug,

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -75,6 +75,10 @@ public:
     /// Totally replace the manifest
     cleanup_archive(model::offset start_rp_offset, uint64_t removed_size_bytes);
     command_batch_builder& replace_manifest(iobuf);
+    command_batch_builder& process_anomalies(
+      model::timestamp scrub_timestamp,
+      cloud_storage::scrub_status status,
+      cloud_storage::anomalies detected);
     /// Replicate the configuration batch
     ss::future<std::error_code> replicate();
 
@@ -154,6 +158,13 @@ public:
     ss::future<std::error_code> cleanup_archive(
       model::offset start_rp_offset,
       uint64_t removed_size_bytes,
+      ss::lowres_clock::time_point deadline,
+      ss::abort_source&);
+
+    ss::future<std::error_code> process_anomalies(
+      model::timestamp scrub_timestamp,
+      cloud_storage::scrub_status status,
+      cloud_storage::anomalies detected,
       ss::lowres_clock::time_point deadline,
       ss::abort_source&);
 
@@ -258,6 +269,7 @@ private:
     struct reset_metadata_cmd;
     struct spillover_cmd;
     struct replace_manifest_cmd;
+    struct process_anomalies_cmd;
     struct snapshot;
 
     friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
@@ -283,6 +295,7 @@ private:
     void apply_reset_metadata();
     void apply_spillover(const spillover_cmd& so);
     void apply_replace_manifest(iobuf);
+    void apply_process_anomalies(iobuf);
 
 private:
     prefix_logger _logger;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -267,6 +267,15 @@ partition_cloud_storage_status partition::get_cloud_storage_status() const {
     return status;
 }
 
+std::optional<cloud_storage::anomalies>
+partition::get_cloud_storage_anomalies() const {
+    if (!_archival_meta_stm || !is_leader()) {
+        return std::nullopt;
+    }
+
+    return _archival_meta_stm->manifest().detected_anomalies();
+}
+
 bool partition::is_remote_fetch_enabled() const {
     const auto& cfg = _raft->log_config();
     if (_feature_table.local().is_active(features::feature::cloud_retention)) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -319,6 +319,8 @@ public:
 
     partition_cloud_storage_status get_cloud_storage_status() const;
 
+    std::optional<cloud_storage::anomalies> get_cloud_storage_anomalies() const;
+
     /// Return true if shadow indexing is enabled for the partition
     bool is_remote_fetch_enabled() const;
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1470,6 +1470,25 @@ configuration::configuration()
       "performance",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , cloud_storage_enable_scrubbing(
+      *this,
+      "cloud_storage_enable_scrubbing",
+      "Enable scrubbing of cloud storage partitions. The scrubber validates "
+      "the integrity of data and metadata uploaded to cloud storage",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
+  , cloud_storage_scrubbing_interval_ms(
+      *this,
+      "cloud_storage_scrubbing_interval_ms",
+      "Time interval between scrubs of the same partition",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1h)
+  , cloud_storage_scrubbing_interval_jitter_ms(
+      *this,
+      "cloud_storage_scrubbing_interval_jitter_ms",
+      "Jitter applied to the cloud storage scrubbing interval.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10min)
   , cloud_storage_disable_upload_loop_for_tests(
       *this,
       "cloud_storage_disable_upload_loop_for_tests",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1601,7 +1601,7 @@ configuration::configuration()
   , cloud_storage_topic_purge_grace_period_ms(
       *this,
       "cloud_storage_topic_purge_grace_period_ms",
-      "Grace period during which the scrubber will refuse to purge the topic.",
+      "Grace period during which the purger will refuse to purge the topic.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       30s)
   , cloud_storage_disable_upload_consistency_checks(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -292,6 +292,10 @@ struct configuration final : public config_store {
       cloud_storage_cluster_metadata_upload_interval_ms;
     property<double> cloud_storage_idle_threshold_rps;
     property<bool> cloud_storage_enable_segment_merging;
+    property<bool> cloud_storage_enable_scrubbing;
+    property<std::chrono::milliseconds> cloud_storage_scrubbing_interval_ms;
+    property<std::chrono::milliseconds>
+      cloud_storage_scrubbing_interval_jitter_ms;
     property<bool> cloud_storage_disable_upload_loop_for_tests;
     property<bool> cloud_storage_disable_read_replica_loop_for_tests;
     property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -77,6 +77,8 @@ std::string_view to_string_view(feature f) {
         return "lightweight_heartbeats";
     case feature::raft_coordinated_recovery:
         return "raft_coordinated_recovery";
+    case feature::cloud_storage_scrubbing:
+        return "cloud_storage_scrubbing";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -63,6 +63,7 @@ enum class feature : std::uint64_t {
     delete_records = 1ULL << 29U,
     lightweight_heartbeats = 1ULL << 30U,
     raft_coordinated_recovery = 1ULL << 31U,
+    cloud_storage_scrubbing = 1ULL << 32U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -293,7 +294,12 @@ constexpr static std::array feature_schema{
     feature::raft_coordinated_recovery,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
-};
+  feature_spec{
+    cluster::cluster_version{11},
+    "cloud_storage_scrubbing",
+    feature::cloud_storage_scrubbing,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always}};
 
 std::string_view to_string_view(feature);
 std::string_view to_string_view(feature_state::state);

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -139,6 +139,10 @@ void http_imposter_fixture::set_routes(ss::httpd::routes& r) {
 
               auto response = lookup(lookup_r);
               repl.set_status(response.status);
+              for (const auto& [k, v] : response.headers) {
+                  repl.add_header(k, v);
+              }
+
               return response.body;
           }
       },

--- a/src/v/http/tests/registered_urls.cc
+++ b/src/v/http/tests/registered_urls.cc
@@ -45,6 +45,21 @@ void registered_urls::add_mapping::add_mapping_when::then_reply_with(
       .body = std::move(content), .status = status};
 }
 
+void registered_urls::add_mapping::add_mapping_when::then_reply_with(
+  std::vector<std::pair<ss::sstring, ss::sstring>> headers,
+  ss::http::reply::status_type status) {
+    if (!r.contains(url)) {
+        r[url] = method_reply_map{};
+    }
+
+    if (!r[url].contains(method)) {
+        r[url][method] = content_reply_map{};
+    }
+
+    r[url][method][request_content] = response{
+      .headers = std::move(headers), .status = status};
+}
+
 registered_urls::add_mapping::add_mapping_when&
 registered_urls::add_mapping::add_mapping_when::with_method(
   ss::httpd::operation_type m) {

--- a/src/v/http/tests/registered_urls.h
+++ b/src/v/http/tests/registered_urls.h
@@ -24,6 +24,7 @@ namespace http_test_utils {
 struct response {
     using status_type = ss::http::reply::status_type;
     ss::sstring body;
+    std::vector<std::pair<ss::sstring, ss::sstring>> headers;
     status_type status;
 };
 
@@ -95,6 +96,10 @@ struct registered_urls {
 
             void then_reply_with(
               ss::sstring content, ss::http::reply::status_type status);
+
+            void then_reply_with(
+              std::vector<std::pair<ss::sstring, ss::sstring>> headers,
+              ss::http::reply::status_type status);
 
             add_mapping_when& with_method(ss::httpd::operation_type m);
 

--- a/src/v/model/timestamp.h
+++ b/src/v/model/timestamp.h
@@ -14,6 +14,7 @@
 #include "seastarx.h"
 
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
 
 #include <chrono>
 #include <compare>
@@ -96,6 +97,12 @@ inline timestamp_clock::duration duration_since_epoch(timestamp ts) {
 }
 
 inline timestamp to_timestamp(timestamp_clock::time_point ts) {
+    return timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
+                       ts.time_since_epoch())
+                       .count());
+}
+
+inline timestamp to_timestamp(ss::manual_clock::time_point ts) {
     return timestamp(std::chrono::duration_cast<std::chrono::milliseconds>(
                        ts.time_since_epoch())
                        .count());

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -177,6 +177,47 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/v1/cloud_storage/anomalies/{namespace}/{topic}/{partition}",
+      "operations": [
+        {
+          "method": "GET",
+          "summary": "Retrieve cloud storage anomalies for a given partition",
+          "operationId": "get_cloud_storage_anomalies",
+          "nickname": "get_cloud_storage_anomalies",
+          "type": "cloud_storage_partition_anomalies",
+          "parameters": [
+            {
+              "name": "namespace",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "topic",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "partition",
+              "in": "path",
+              "required": true,
+              "type": "integer"
+            }
+          ],
+          "produces": [
+            "application/json"
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "message": "Success"
+            }
+          ]
+        }
+      ]
     }
   ],
   "models": {
@@ -345,6 +386,38 @@
         "markers": {
           "type": "array",
           "items": {"type":  "lifecycle_marker"}
+        }
+      }
+    },
+    "cloud_storage_partition_anomalies": {
+      "id": "cloud_storage_partition_anomalies",
+      "description": "Anomalies detected by the cloud storage scrubber",
+      "properties": {
+        "ns": {
+          "type": "string"
+        },
+        "topic": {
+          "type": "string"
+        },
+        "partition": {
+          "type": "long"
+        },
+        "revision_id": {
+          "type": "long"
+        },
+        "missing_partition_manifest": {
+          "type": "boolean",
+          "nullable": true
+        },
+        "missing_spillover_manifests": {
+          "type": "array",
+          "items": {"type": "string"},
+          "nullable": true
+        },
+        "missing_segments": {
+          "type": "array",
+          "items": {"type": "string"},
+          "nullable": true
         }
       }
     }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -458,6 +458,8 @@ private:
     ss::future<std::unique_ptr<ss::http::reply>> get_manifest(
       std::unique_ptr<ss::http::request> req,
       std::unique_ptr<ss::http::reply> rep);
+    ss::future<ss::json::json_return_type>
+      get_cloud_storage_anomalies(std::unique_ptr<ss::http::request>);
 
     /// Self test routes
     ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -268,7 +268,7 @@ private:
     ss::sharded<archival::upload_housekeeping_service>
       _archival_upload_housekeeping;
     std::unique_ptr<monitor_unsafe_log_flag> _monitor_unsafe_log_flag;
-    ss::sharded<archival::scrubber> _archival_scrubber;
+    ss::sharded<archival::purger> _archival_purger;
 
     ssx::metrics::metric_groups _metrics
       = ssx::metrics::metric_groups::make_internal();

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1088,3 +1088,9 @@ class Admin:
         it would not make sense to send it to just any node.
         """
         return self._request("GET", "raft/recovery/status", node=node).json()
+
+    def get_cloud_storage_anomalies(self, namespace: str, topic: str,
+                                    partition: int):
+        return self._request(
+            "GET",
+            f"cloud_storage/anomalies/{namespace}/{topic}/{partition}").json()

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -1,0 +1,275 @@
+#Copyright 2023 Redpanda Data, Inc.
+#
+#Licensed as a Redpanda Enterprise file under the Redpanda Community
+#License(the "License"); you may not use this file except in compliance with
+#the License.You may obtain a copy of the License at
+#
+#https: // github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SISettings, get_cloud_storage_type
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.utils.si_utils import parse_s3_segment_path, quiesce_uploads, BucketView, NTP, NTPR
+
+from ducktape.mark import matrix
+from ducktape.utils.util import wait_until
+
+import random
+
+# Attempts to compute the retention point for the cloud log will fail
+# after a spillover manifest is manually removed.
+SCRUBBER_LOG_ALLOW_LIST = [
+    r"cloud_storage - .* failed to download manifest {key_not_found}",
+    r"cloud_storage - .* failed to download manifest.*cloud_storage::error_outcome:2",
+    r"cloud_storage - .* Failed to materialize.*cloud_storage::error_outcome:2",
+    r"cloud_storage - .* failed to seek.*cloud_storage::error_outcome:2",
+    r"cloud_storage - .* Failed to compute time-based retention",
+    r"cloud_storage - .* Failed to compute size-based retention",
+    r"cloud_storage - .* Failed to compute retention",
+]
+
+
+class CloudStorageScrubberTest(RedpandaTest):
+    scrub_timeout = 30
+    partition_count = 3
+    message_size = 16 * 1024  # 16KiB
+    segment_size = 1024 * 1024  # 1MiB
+    to_produce = 30 * 1024 * 1024  # 100MiB per partition
+    topics = [TopicSpec(partition_count=partition_count)]
+
+    def __init__(self, test_context):
+        self.si_settings = SISettings(
+            test_context,
+            log_segment_size=self.segment_size,
+            cloud_storage_spillover_manifest_max_segments=5,
+            cloud_storage_housekeeping_interval_ms=1000 * 30,
+            fast_uploads=True)
+
+        self.bucket_name = self.si_settings.cloud_storage_bucket
+
+        super().__init__(test_context=test_context,
+                         extra_rp_conf={
+                             "cloud_storage_enable_scrubbing":
+                             True,
+                             "cloud_storage_scrubbing_interval_ms":
+                             10 * 1000,
+                             "cloud_storage_scrubbing_interval_jitter_ms":
+                             5 * 1000,
+                         },
+                         si_settings=self.si_settings)
+
+    def _produce(self):
+        msg_count = self.to_produce * self.partition_count // self.message_size
+        KgoVerifierProducer.oneshot(self.test_context,
+                                    self.redpanda,
+                                    self.topic,
+                                    self.message_size,
+                                    msg_count,
+                                    batch_max_bytes=self.message_size * 8,
+                                    timeout_sec=60)
+
+        quiesce_uploads(self.redpanda, [self.topic], timeout_sec=60)
+
+        def all_partitions_spilled():
+            bucket = BucketView(self.redpanda)
+            for pid in range(self.partition_count):
+                spillover_metas = bucket.get_spillover_metadata(
+                    NTP(ns="kafka", topic=self.topic, partition=pid))
+
+                if len(spillover_metas) == 0:
+                    self.logger.debug(f"{self.topic}/{pid} did not spill yet")
+                    return False
+
+            return True
+
+        wait_until(all_partitions_spilled,
+                   timeout_sec=60,
+                   backoff_sec=10,
+                   err_msg="Some or all partitions did not spill")
+
+    def _collect_anomalies(self):
+        anomalies_per_ntpr = {}
+
+        admin = Admin(self.redpanda)
+        for pid in range(self.partition_count):
+            anomalies = admin.get_cloud_storage_anomalies(namespace="kafka",
+                                                          topic=self.topic,
+                                                          partition=pid)
+
+            ntpr = NTPR(ns=anomalies["ns"],
+                        topic=anomalies["topic"],
+                        partition=anomalies["partition"],
+                        revision=anomalies["revision_id"])
+
+            if ("missing_partition_manifest" not in anomalies
+                    and "missing_spillover_manifests" not in anomalies
+                    and "missing_segments" not in anomalies):
+                anomalies = None
+
+            anomalies_per_ntpr[ntpr] = anomalies
+
+        return anomalies_per_ntpr
+
+    def _assert_no_anomalies(self):
+        anomalies_per_ntpr = self._collect_anomalies()
+        for ntpr, anomalies in anomalies_per_ntpr.items():
+            assert anomalies is None, f"{ntpr} reported unexpected anomalies: {anomalies}"
+
+    def _delete_segment_and_await_anomaly(self):
+        segment_metas = [
+            meta for meta in self.cloud_storage_client.list_objects(
+                self.bucket_name) if "log" in meta.key
+        ]
+
+        view = BucketView(self.redpanda)
+        to_delete = random.choice(segment_metas)
+        attempts = 1
+        while view.is_segment_part_of_a_manifest(to_delete) == False:
+            to_delete = random.choice(segment_metas)
+            attempts += 1
+
+            assert attempts < 100, "Too many attempts to find a segment to delete"
+
+        self.logger.info(f"Deleting segment at {to_delete.key}")
+        self.cloud_storage_client.delete_object(self.bucket_name,
+                                                to_delete.key,
+                                                verify=True)
+
+        ntpr = parse_s3_segment_path(to_delete.key).ntpr
+
+        self.logger.info(
+            f"Waiting for missing segment anomaly {to_delete.key} to be reported"
+        )
+
+        def ntpr_missing_segment():
+            anomalies_per_ntpr = self._collect_anomalies()
+            self.logger.debug(f"Reported anomalies {anomalies_per_ntpr}")
+
+            if ntpr not in anomalies_per_ntpr:
+                return False
+
+            if anomalies_per_ntpr[ntpr] is None:
+                return False
+
+            if "missing_segments" not in anomalies_per_ntpr[ntpr]:
+                return False
+
+            return to_delete.key in anomalies_per_ntpr[ntpr][
+                "missing_segments"]
+
+        wait_until(ntpr_missing_segment,
+                   timeout_sec=self.scrub_timeout,
+                   backoff_sec=2,
+                   err_msg="Missing spillover manifest anomaly not reported")
+
+    def _delete_spillover_manifest_and_await_anomaly(self):
+        pid = random.randint(0, 2)
+        view = BucketView(self.redpanda)
+        spillover_metas = view.get_spillover_metadata(
+            NTP(ns="kafka", topic=self.topic, partition=pid))
+        to_delete = random.choice(spillover_metas)
+        ntpr = to_delete.ntpr
+
+        self.logger.info(f"Deleting spillover manifest at {to_delete.path}")
+        self.cloud_storage_client.delete_object(self.bucket_name,
+                                                to_delete.path,
+                                                verify=True)
+
+        self.logger.info(
+            f"Waiting for missing spillover anomaly {to_delete.path} to be reported"
+        )
+
+        def ntpr_missing_spill_manifest():
+            anomalies_per_ntpr = self._collect_anomalies()
+            self.logger.debug(f"Reported anomalies {anomalies_per_ntpr}")
+
+            if ntpr not in anomalies_per_ntpr:
+                return False
+
+            if anomalies_per_ntpr[ntpr] is None:
+                return False
+
+            if "missing_spillover_manifests" not in anomalies_per_ntpr[ntpr]:
+                return False
+
+            return to_delete.path in anomalies_per_ntpr[ntpr][
+                "missing_spillover_manifests"]
+
+        wait_until(ntpr_missing_spill_manifest,
+                   timeout_sec=self.scrub_timeout,
+                   backoff_sec=2,
+                   err_msg="Missing spillover manifest anomaly not reported")
+
+    def _assert_anomalies_stable_after_leader_shuffle(self):
+        self.logger.info("Checking anomalies stay stable after leader shuffle")
+
+        old_anomalies = self._collect_anomalies()
+        assert any([
+            a is not None for a in old_anomalies.values()
+        ]), f"Expected anomalies on at least one ntpr, but got {old_anomalies}"
+
+        admin = Admin(self.redpanda)
+        for pid in range(self.partition_count):
+            admin.transfer_leadership_to(namespace="kafka",
+                                         topic=self.topic,
+                                         partition=pid)
+            admin.await_stable_leader(namespace='kafka',
+                                      topic=self.topic,
+                                      partition=pid)
+
+        def anomalies_stable():
+            anomalies = self._collect_anomalies()
+            self.logger.debug(f"Reported anomalies {anomalies}")
+
+            return anomalies == old_anomalies
+
+        wait_until(
+            anomalies_stable,
+            timeout_sec=self.scrub_timeout,
+            backoff_sec=2,
+            err_msg="Reported anomalies changed after leadership shuffle")
+
+    def _assert_anomalies_stable_after_restart(self):
+        self.logger.info(
+            "Checking anomalies stay stable after full cluster restart")
+
+        old_anomalies = self._collect_anomalies()
+        assert any([
+            a is not None for a in old_anomalies.values()
+        ]), f"Expected anomalies on at least one ntpr, but got {old_anomalies}"
+
+        for node in self.redpanda.nodes:
+            self.redpanda.stop_node(node)
+
+        for node in self.redpanda.nodes:
+            self.redpanda.start_node(node)
+
+        def anomalies_stable():
+            anomalies = self._collect_anomalies()
+            self.logger.debug(f"Reported anomalies {anomalies}")
+
+            return anomalies == old_anomalies
+
+        wait_until(anomalies_stable,
+                   timeout_sec=self.scrub_timeout,
+                   backoff_sec=2,
+                   err_msg="Reported anomalies changed after full restart")
+
+    @cluster(num_nodes=4, log_allow_list=SCRUBBER_LOG_ALLOW_LIST)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_scrubber(self, cloud_storage_type):
+        self._produce()
+        self._assert_no_anomalies()
+        self._delete_spillover_manifest_and_await_anomaly()
+        self._delete_segment_and_await_anomaly()
+
+        self._assert_anomalies_stable_after_leader_shuffle()
+        self._assert_anomalies_stable_after_restart()
+
+        # The test deletes segments, so rp-storage-tool will also
+        # pick up on it.
+        self.redpanda.si_settings.set_expected_damage({"missing_segments"})

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -381,7 +381,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                 # segments are deleted in the background by adjacent segment
                 # merging
                 'cloud_storage_enable_segment_merging': False,
-                # We rely on the scrubber to delete topic manifests, and to eventually
+                # We rely on the purger to delete topic manifests, and to eventually
                 # delete data if cloud storage was unavailable during initial delete.  To
                 # control test runtimes, set a short interval.
                 'cloud_storage_idle_timeout_ms': 3000,
@@ -578,7 +578,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
             # At this point, although we have deleted the controller
             # lifecycle marker, it is possible that Redpanda is still
             # in the middle of trying to delete the topic because it is
-            # inside a scrubber run.
+            # inside a purger run.
             #
             # To avoid leaving storage in a non-deterministic state,
             # restart redpanda before unblocking the firewall, so that we
@@ -650,7 +650,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         self._validate_topic_deletion(next_topic, cloud_storage_type)
 
         # Eventually, the original topic should be deleted: this is the tiered
-        # storage scrubber doing its thing.
+        # storage purger doing its thing.
         self._validate_topic_deletion(self.topic, cloud_storage_type)
 
     def _validate_topic_deletion(self, topic_name: str,
@@ -727,7 +727,7 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
 
         if status == LifecycleMarkerStatus.PURGED:
             # Shortly after the remote status goes to PURGED, we should see the local
-            # topic table status update (when the scrubber RPCs to the controller to
+            # topic table status update (when the purger RPCs to the controller to
             # ask it to drop the life cycle marker.
             def get_topics_with_markers():
                 admin = Admin(self.redpanda)


### PR DESCRIPTION
This is the first PR for cloud storage scrubbing. The idea is that we want Redpanda to detect
inconsistencies in the data and metadata uploaded to the cloud storage bucket on its own.

There's three parts to the approach in this PR.

1. Detection: a new housekeeping job is introduced. If it decides that scrubbing should be done,
then it downloads the metadata from the bucket and looks for anomalies. Currently only missing partition manifests,
missing spillover manifests and missing segments are supported. More will follow.
2. Persistence & Processing: Anomalies are persisted on the partition's log or in the snapshot. After the scrubber runs, it replicates a new archival STM command. When that command is applied, the in memory manifest checks
the anomalies to ensure they are not false positives. The valid anomalies are kept in memory.
3. Reporting: Anomalies can be retrieved from the admin api. Currently, this can only be done on a per partition basis, but it will be extended to be cluster wide.

In the interest of keeping this reviewable, let's defer the items below for the next PRs:
* Bulletproofing for scale: 
  * support low tput requests in the client pool
  * ensure the scrubber doesn't impact the cloud storage read/write paths
* Detect more types of anomalies
* Make the scrubber smarter: 
  * if the last scrub was partial, pick up from where that finished instead of restarting
  * Add a new error code for malformed manifests at the remote level
* Cluster wide anomaly reporting
* Add metric to alert on
* Endpoint for on-demand scrub
  
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* TODO

