### PR TITLE
[v23.2.x] rptest: allow ntr_no_topic_manifest in test_manifest_dump

### DIFF
--- a/tests/rptest/tests/shadow_indexing_admin_api_test.py
+++ b/tests/rptest/tests/shadow_indexing_admin_api_test.py
@@ -209,3 +209,6 @@ class SIAdminApiTest(RedpandaTest):
         with expect_http_error(400):
             not_enabled_response = self.admin.get_partition_manifest(
                 "test-topic", 0)
+
+        self.redpanda.si_settings.set_expected_damage(
+            {"ntr_no_topic_manifest"})


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13249
Fixes: https://github.com/redpanda-data/redpanda/issues/13255,