### PR TITLE
Do not always report all fields in maintenance status

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_broker.go
+++ b/src/go/rpk/pkg/adminapi/api_broker.go
@@ -22,13 +22,13 @@ const (
 )
 
 type MaintenanceStatus struct {
-	Draining     bool `json:"draining"`
-	Finished     bool `json:"finished"`
-	Errors       bool `json:"errors"`
-	Partitions   int  `json:"partitions"`
-	Eligible     int  `json:"eligible"`
-	Transferring int  `json:"transferring"`
-	Failed       int  `json:"failed"`
+	Draining     bool  `json:"draining"`
+	Finished     *bool `json:"finished"`
+	Errors       *bool `json:"errors"`
+	Partitions   *int  `json:"partitions"`
+	Eligible     *int  `json:"eligible"`
+	Transferring *int  `json:"transferring"`
+	Failed       *int  `json:"failed"`
 }
 
 // MembershipStatus enumerates possible membership states for brokers.

--- a/src/go/rpk/pkg/cli/cluster/maintenance/enable.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/enable.go
@@ -112,7 +112,7 @@ node exists that is already in maintenance mode then an error will be returned.
 				}
 				addBrokerMaintenanceReport(table, b)
 				table.Flush()
-				if b.Maintenance.Draining && b.Maintenance.Finished {
+				if b.Maintenance.Draining && b.Maintenance.Finished != nil && *b.Maintenance.Finished {
 					fmt.Printf("\nAll partitions on node %d have drained.\n", nodeID)
 					return
 				}

--- a/src/go/rpk/pkg/cli/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/status.go
@@ -10,6 +10,8 @@
 package maintenance
 
 import (
+	"fmt"
+
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
@@ -25,16 +27,24 @@ func newMaintenanceReportTable() *out.TabWriter {
 	return out.NewTable(headers...)
 }
 
+func nullableToStr[V any](v *V) string {
+	if v == nil {
+		return "-"
+	}
+
+	return fmt.Sprint(*v)
+}
+
 func addBrokerMaintenanceReport(table *out.TabWriter, b adminapi.Broker) {
 	table.Print(
 		b.NodeID,
 		b.Maintenance.Draining,
-		b.Maintenance.Finished,
-		b.Maintenance.Errors,
-		b.Maintenance.Partitions,
-		b.Maintenance.Eligible,
-		b.Maintenance.Transferring,
-		b.Maintenance.Failed)
+		nullableToStr(b.Maintenance.Finished),
+		nullableToStr(b.Maintenance.Errors),
+		nullableToStr(b.Maintenance.Partitions),
+		nullableToStr(b.Maintenance.Eligible),
+		nullableToStr(b.Maintenance.Transferring),
+		nullableToStr(b.Maintenance.Failed))
 }
 
 func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {

--- a/src/go/rpk/pkg/cli/cluster/maintenance/status.go
+++ b/src/go/rpk/pkg/cli/cluster/maintenance/status.go
@@ -19,7 +19,7 @@ import (
 
 func newMaintenanceReportTable() *out.TabWriter {
 	headers := []string{
-		"Node-ID", "Draining", "Finished", "Errors",
+		"Node-ID", "Enabled", "Finished", "Errors",
 		"Partitions", "Eligible", "Transferring", "Failed",
 	}
 	return out.NewTable(headers...)
@@ -47,13 +47,13 @@ This command reports maintenance status for each node in the cluster. The output
 is presented as a table with each row representing a node in the cluster.  The
 output can be used to monitor the progress of node draining.
 
-   NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
+   NODE-ID  ENABLED  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
    1        false     false     false   0           0         0             0
 
 Field descriptions:
 
         NODE-ID: the node ID
-       DRAINING: true if the node is actively draining leadership
+        ENABLED: true if the node is currently in maintenance mode
        FINISHED: leadership draining has completed
          ERRORS: errors have been encountered while draining
      PARTITIONS: number of partitions whose leadership has moved

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -304,15 +304,15 @@
         },
         "maintenance_status": {
             "id": "maintenance_status",
-            "description": "Drain status",
+            "description": "Status of maintenance mode",
             "properties": {
                 "draining": {
                     "type": "boolean",
-                    "description": "in maintenance state"
+                    "description": "Flag indicating if maintenance mode is enabled."
                 },
                 "finished": {
                     "type": "boolean",
-                    "description": "drain finished"
+                    "description": "Indicates that draining is finished. Note that the draining flag will always be true if maintenance mode is enable and draining has finished."
                 },
                 "errors": {
                     "type": "boolean",
@@ -349,7 +349,7 @@
                     "description": "number of replicas left on a node"
                 },
                 "allocation_failures": {
-                    "type" : "array",
+                    "type": "array",
                     "items": {
                         "type": "string",
                         "description": "ntp"

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -850,13 +850,6 @@ fill_maintenance_status(const cluster::broker_state& b_state) {
 
     ret.draining = b_state.get_maintenance_state()
                    == model::maintenance_state::active;
-    // ensure that the output json has all fields
-    ret.finished = false;
-    ret.errors = false;
-    ret.partitions = 0;
-    ret.transferring = 0;
-    ret.eligible = 0;
-    ret.failed = 0;
 
     return ret;
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -118,7 +118,7 @@ class RpkClusterInfoNode:
 
 class RpkMaintenanceStatus(typing.NamedTuple):
     node_id: int
-    draining: bool
+    enabled: bool
     finished: bool
     errors: bool
     partitions: int
@@ -980,7 +980,7 @@ class RpkTool:
                 return None
 
             # jerry@garcia:~/src/redpanda$ rpk cluster maintenance status
-            # NODE-ID  DRAINING  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
+            # NODE-ID  ENABLED  FINISHED  ERRORS  PARTITIONS  ELIGIBLE  TRANSFERRING  FAILED
             # 1        false     false     false   0           0         0             0
             line = line.split()
 
@@ -991,7 +991,7 @@ class RpkTool:
             if line[0] == "NODE-ID":
                 return None
             return RpkMaintenanceStatus(node_id=int(line[0]),
-                                        draining=line[1] == "true",
+                                        enabled=line[1] == "true",
                                         finished=line[2] == "true",
                                         errors=line[3] == "true",
                                         partitions=int(line[4]),

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -990,14 +990,21 @@ class RpkTool:
             line = [x.strip() for x in line]
             if line[0] == "NODE-ID":
                 return None
+
+            def bool_or_none(value: str):
+                return None if value == "-" else value == "true"
+
+            def int_or_none(value: str):
+                return None if value == "-" else int(value)
+
             return RpkMaintenanceStatus(node_id=int(line[0]),
                                         enabled=line[1] == "true",
-                                        finished=line[2] == "true",
-                                        errors=line[3] == "true",
-                                        partitions=int(line[4]),
-                                        eligible=int(line[5]),
-                                        transferring=int(line[6]),
-                                        failed=int(line[7]))
+                                        finished=bool_or_none(line[2]),
+                                        errors=bool_or_none(line[3]),
+                                        partitions=int_or_none(line[4]),
+                                        eligible=int_or_none(line[5]),
+                                        transferring=int_or_none(line[6]),
+                                        failed=int_or_none(line[7]))
 
         cmd = [
             self._rpk_binary(),

--- a/tests/rptest/tests/maintenance_test.py
+++ b/tests/rptest/tests/maintenance_test.py
@@ -108,7 +108,7 @@ class MaintenanceTest(RedpandaTest):
                           "{node.name}: {admin_status}")
 
         # ensure that both agree on expected outcome
-        return admin_status["draining"] == rpk_status.draining == draining
+        return admin_status["draining"] == rpk_status.enabled == draining
 
     def _enable_maintenance(self, node):
         """


### PR DESCRIPTION
Some of the fields in broker maintenance status are reported based on the node health report. If a node is unavailable then its health is not reported. This PR changes the output of `/v1/brokers` & `/v1/maintenance_status`  admin apis to account for not present health report. Now if values based on maintenance report are unavailable they are simply not included into `maintenance_staus` JSON reply. 

Fixes: #13239 
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes incorrect reporting of maintenance statues if a node is stopped 

