### PR TITLE
Introduce transform::manager

### DIFF
--- a/src/v/ssx/CMakeLists.txt
+++ b/src/v/ssx/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     work_queue.cc
   DEPS
     Seastar::seastar
+    absl::flat_hash_map
   )
 
 add_subdirectory(tests)

--- a/src/v/ssx/CMakeLists.txt
+++ b/src/v/ssx/CMakeLists.txt
@@ -4,6 +4,8 @@ v_cc_library(
   HDRS
     "future-util.h"
     "metrics.h"
+  SRCS
+    work_queue.cc
   DEPS
     Seastar::seastar
   )

--- a/src/v/ssx/CMakeLists.txt
+++ b/src/v/ssx/CMakeLists.txt
@@ -8,7 +8,6 @@ v_cc_library(
     work_queue.cc
   DEPS
     Seastar::seastar
-    absl::flat_hash_map
   )
 
 add_subdirectory(tests)

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -15,6 +15,16 @@ rp_test(
 
 rp_test(
   UNIT_TEST
+  GTEST
+  BINARY_NAME ssx_gunit
+  SOURCES
+    work_queue_test.cc
+  LIBRARIES v::gtest_main v::ssx
+  LABELS ssx
+)
+
+rp_test(
+  UNIT_TEST
   BINARY_NAME ssx_multi_thread
   SOURCES
     abort_source_test.cc

--- a/src/v/ssx/tests/work_queue_test.cc
+++ b/src/v/ssx/tests/work_queue_test.cc
@@ -11,6 +11,7 @@
 #include "ssx/work_queue.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/core/manual_clock.hh>
 #include <seastar/core/sleep.hh>
 
 #include <gmock/gmock.h>
@@ -22,14 +23,38 @@
 
 namespace ssx {
 
+using namespace std::chrono_literals;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
+
+namespace {
+ss::future<> submit_delayed(
+  work_queue* q,
+  ss::manual_clock::duration d,
+  ss::noncopyable_function<void()> fn) {
+    ss::promise<> p;
+    q->submit_delayed<ss::manual_clock>(d, [&] {
+        fn();
+        p.set_value();
+        return ss::now();
+    });
+    co_await p.get_future();
+}
+ss::future<> submit(work_queue* q, ss::noncopyable_function<void()> fn) {
+    ss::promise<> p;
+    q->submit([&] {
+        fn();
+        p.set_value();
+        return ss::now();
+    });
+    co_await p.get_future();
+}
+} // namespace
 
 TEST(WorkQueue, Order) {
     work_queue queue([](auto ex) { std::rethrow_exception(ex); });
 
     std::vector<int> values;
-    ss::promise<> p;
 
     queue.submit([&] {
         values.push_back(1);
@@ -39,14 +64,10 @@ TEST(WorkQueue, Order) {
         values.push_back(2);
         return ss::now();
     });
-    queue.submit([&] {
-        values.push_back(3);
-        p.set_value();
-        return ss::now();
-    });
+    auto done = submit(&queue, [&] { values.push_back(3); });
 
     EXPECT_THAT(values, IsEmpty());
-    p.get_future().get();
+    done.get();
     EXPECT_THAT(values, ElementsAre(1, 2, 3));
     queue.shutdown().get();
 }
@@ -56,7 +77,6 @@ TEST(WorkQueue, FailuresDoNotStopTheQueue) {
     work_queue queue([&error_count](auto) { ++error_count; });
 
     std::vector<int> values;
-    ss::promise<> p;
 
     queue.submit([&] {
         values.push_back(1);
@@ -64,15 +84,11 @@ TEST(WorkQueue, FailuresDoNotStopTheQueue) {
     });
     queue.submit(
       [&]() -> ss::future<> { throw std::runtime_error("oh noes!"); });
-    queue.submit([&] {
-        values.push_back(3);
-        p.set_value();
-        return ss::now();
-    });
+    auto done = submit(&queue, [&] { values.push_back(3); });
 
     EXPECT_THAT(values, IsEmpty());
     EXPECT_EQ(error_count, 0);
-    p.get_future().get();
+    done.get();
     EXPECT_EQ(error_count, 1);
     EXPECT_THAT(values, ElementsAre(1, 3));
     queue.shutdown().get();
@@ -87,6 +103,40 @@ TEST(WorkQueue, ShutdownStopsTheQueueImmediately) {
     });
     queue.shutdown().get();
     EXPECT_EQ(a, 1);
+}
+
+TEST(WorkQueue, CanSubmitDelayedTasks) {
+    work_queue queue([](auto ex) { std::rethrow_exception(ex); });
+    int a = 1;
+    ss::promise<> p1;
+    auto f1 = submit_delayed(&queue, 1s, [&] { a = 2; });
+    auto f2 = submit(&queue, [&] { a = 3; });
+    f2.get();
+    EXPECT_FALSE(f1.available());
+    EXPECT_EQ(a, 3);
+    ss::manual_clock::advance(1s);
+    f1.get();
+    EXPECT_EQ(a, 2);
+    queue.shutdown().get();
+}
+
+TEST(WorkQueue, CanShutdownWithDelayedTasks) {
+    work_queue queue([](auto ex) { std::rethrow_exception(ex); });
+    auto f1 = submit_delayed(&queue, 1s, [&] {});
+    bool a2 = false;
+    queue.submit_delayed<ss::manual_clock>(2s, [&] {
+        a2 = true;
+        return ss::now();
+    });
+    EXPECT_FALSE(f1.available());
+    EXPECT_FALSE(a2);
+    ss::manual_clock::advance(1s);
+    f1.get();
+    EXPECT_FALSE(a2);
+    queue.shutdown().get();
+    ss::manual_clock::advance(3s);
+    ss::now().get();
+    EXPECT_FALSE(a2);
 }
 
 } // namespace ssx

--- a/src/v/ssx/tests/work_queue_test.cc
+++ b/src/v/ssx/tests/work_queue_test.cc
@@ -1,0 +1,92 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "gmock/gmock.h"
+#include "seastarx.h"
+#include "ssx/work_queue.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <exception>
+#include <stdexcept>
+#include <vector>
+
+namespace ssx {
+
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+
+TEST(WorkQueue, Order) {
+    work_queue queue([](auto ex) { std::rethrow_exception(ex); });
+
+    std::vector<int> values;
+    ss::promise<> p;
+
+    queue.submit([&] {
+        values.push_back(1);
+        return ss::now();
+    });
+    queue.submit([&] {
+        values.push_back(2);
+        return ss::now();
+    });
+    queue.submit([&] {
+        values.push_back(3);
+        p.set_value();
+        return ss::now();
+    });
+
+    EXPECT_THAT(values, IsEmpty());
+    p.get_future().get();
+    EXPECT_THAT(values, ElementsAre(1, 2, 3));
+    queue.shutdown().get();
+}
+
+TEST(WorkQueue, FailuresDoNotStopTheQueue) {
+    int error_count = 0;
+    work_queue queue([&error_count](auto) { ++error_count; });
+
+    std::vector<int> values;
+    ss::promise<> p;
+
+    queue.submit([&] {
+        values.push_back(1);
+        return ss::now();
+    });
+    queue.submit(
+      [&]() -> ss::future<> { throw std::runtime_error("oh noes!"); });
+    queue.submit([&] {
+        values.push_back(3);
+        p.set_value();
+        return ss::now();
+    });
+
+    EXPECT_THAT(values, IsEmpty());
+    EXPECT_EQ(error_count, 0);
+    p.get_future().get();
+    EXPECT_EQ(error_count, 1);
+    EXPECT_THAT(values, ElementsAre(1, 3));
+    queue.shutdown().get();
+}
+
+TEST(WorkQueue, ShutdownStopsTheQueueImmediately) {
+    work_queue queue([](auto ex) { std::rethrow_exception(ex); });
+    int a = 1;
+    queue.submit([&] {
+        a = 2;
+        return ss::now();
+    });
+    queue.shutdown().get();
+    EXPECT_EQ(a, 1);
+}
+
+} // namespace ssx

--- a/src/v/ssx/tests/work_queue_test.cc
+++ b/src/v/ssx/tests/work_queue_test.cc
@@ -13,6 +13,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/manual_clock.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/util/later.hh>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -53,6 +54,10 @@ ss::future<> submit(work_queue* q, ss::noncopyable_function<void()> fn) {
 
 TEST(WorkQueue, Order) {
     work_queue queue([](auto ex) { std::rethrow_exception(ex); });
+    // Add a task that isn't ready to the queue, so that in release mode,
+    // seastar doesn't run it inline without adding it to the scheduler. These
+    // tests rely on the callbacks not executing immedately.
+    queue.submit([] { return ss::yield(); });
 
     std::vector<int> values;
 
@@ -75,6 +80,7 @@ TEST(WorkQueue, Order) {
 TEST(WorkQueue, FailuresDoNotStopTheQueue) {
     int error_count = 0;
     work_queue queue([&error_count](auto) { ++error_count; });
+    queue.submit([] { return ss::yield(); });
 
     std::vector<int> values;
 
@@ -96,6 +102,7 @@ TEST(WorkQueue, FailuresDoNotStopTheQueue) {
 
 TEST(WorkQueue, ShutdownStopsTheQueueImmediately) {
     work_queue queue([](auto ex) { std::rethrow_exception(ex); });
+    queue.submit([] { return ss::yield(); });
     int a = 1;
     queue.submit([&] {
         a = 2;

--- a/src/v/ssx/work_queue.cc
+++ b/src/v/ssx/work_queue.cc
@@ -1,0 +1,37 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/work_queue.h"
+
+#include <exception>
+
+namespace ssx {
+work_queue::work_queue(error_reporter_fn fn)
+  : _error_reporter(std::move(fn)) {}
+
+void work_queue::submit(ss::noncopyable_function<ss::future<>()> fn) {
+    if (_as.abort_requested()) {
+        return;
+    }
+    _tail = _tail
+              .then([this, fn = std::move(fn)]() {
+                  if (_as.abort_requested()) {
+                      return ss::now();
+                  }
+                  return fn();
+              })
+              .handle_exception(
+                [this](const std::exception_ptr& ex) { _error_reporter(ex); });
+}
+
+ss::future<> work_queue::shutdown() {
+    _as.request_abort();
+    return std::exchange(_tail, ss::now());
+}
+} // namespace ssx

--- a/src/v/ssx/work_queue.cc
+++ b/src/v/ssx/work_queue.cc
@@ -9,6 +9,9 @@
 
 #include "ssx/work_queue.h"
 
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sleep.hh>
+
 #include <exception>
 
 namespace ssx {
@@ -32,6 +35,29 @@ void work_queue::submit(ss::noncopyable_function<ss::future<>()> fn) {
 
 ss::future<> work_queue::shutdown() {
     _as.request_abort();
-    return std::exchange(_tail, ss::now());
+    for (auto& [_, fut] : _delayed_tasks) {
+        co_await std::move(fut);
+    }
+    _delayed_tasks.clear();
+    co_await std::exchange(_tail, ss::now());
+}
+
+void work_queue::submit_after(
+  ss::future<> fut, ss::noncopyable_function<ss::future<>()> fn) {
+    uint64_t my_id = _delayed_id++;
+    _delayed_tasks.emplace(
+      my_id,
+      std::move(fut).then_wrapped(
+        [this, my_id, fn = std::move(fn)](auto fut) mutable {
+            fut.ignore_ready_future();
+            if (_as.abort_requested()) {
+                // when an abort is requested, stop is
+                // responsible for deleting the future,
+                // as it needs to wait for them.
+                return;
+            }
+            _delayed_tasks.erase(my_id);
+            submit(std::move(fn));
+        }));
 }
 } // namespace ssx

--- a/src/v/ssx/work_queue.cc
+++ b/src/v/ssx/work_queue.cc
@@ -9,6 +9,8 @@
 
 #include "ssx/work_queue.h"
 
+#include "ssx/future-util.h"
+
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sleep.hh>
 
@@ -35,29 +37,17 @@ void work_queue::submit(ss::noncopyable_function<ss::future<>()> fn) {
 
 ss::future<> work_queue::shutdown() {
     _as.request_abort();
-    for (auto& [_, fut] : _delayed_tasks) {
-        co_await std::move(fut);
-    }
-    _delayed_tasks.clear();
+    co_await _gate.close();
     co_await std::exchange(_tail, ss::now());
 }
 
 void work_queue::submit_after(
   ss::future<> fut, ss::noncopyable_function<ss::future<>()> fn) {
-    uint64_t my_id = _delayed_id++;
-    _delayed_tasks.emplace(
-      my_id,
-      std::move(fut).then_wrapped(
-        [this, my_id, fn = std::move(fn)](auto fut) mutable {
-            fut.ignore_ready_future();
-            if (_as.abort_requested()) {
-                // when an abort is requested, stop is
-                // responsible for deleting the future,
-                // as it needs to wait for them.
-                return;
-            }
-            _delayed_tasks.erase(my_id);
-            submit(std::move(fn));
-        }));
+    auto holder = _gate.hold();
+    ssx::background = fut.then_wrapped(
+      [this, fn = std::move(fn), h = std::move(holder)](auto fut) mutable {
+          fut.ignore_ready_future();
+          submit(std::move(fn));
+      });
 }
 } // namespace ssx

--- a/src/v/ssx/work_queue.h
+++ b/src/v/ssx/work_queue.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future-util.hh>
+#include <seastar/core/future.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+namespace ssx {
+
+/**
+ * A small utility for running async tasks sequentially on a single fiber.
+ */
+class work_queue {
+public:
+    using error_reporter_fn
+      = ss::noncopyable_function<void(const std::exception_ptr&)>;
+
+    explicit work_queue(error_reporter_fn);
+    // Add a task to the queue to be processed.
+    void submit(ss::noncopyable_function<ss::future<>()>);
+    // Shutdown the queue, waiting for the currently executing task to finish.
+    ss::future<> shutdown();
+
+private:
+    error_reporter_fn _error_reporter;
+    ss::future<> _tail = ss::now();
+    ss::abort_source _as;
+};
+
+} // namespace ssx

--- a/src/v/ssx/work_queue.h
+++ b/src/v/ssx/work_queue.h
@@ -17,7 +17,10 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/util/noncopyable_function.hh>
+
+#include <absl/container/flat_hash_map.h>
 
 namespace ssx {
 
@@ -32,13 +35,26 @@ public:
     explicit work_queue(error_reporter_fn);
     // Add a task to the queue to be processed.
     void submit(ss::noncopyable_function<ss::future<>()>);
+    // Add a task to the queue to be processed after some timeout.
+    template<typename Clock = ss::lowres_clock>
+    void
+      submit_delayed(Clock::duration, ss::noncopyable_function<ss::future<>()>);
     // Shutdown the queue, waiting for the currently executing task to finish.
     ss::future<> shutdown();
 
 private:
+    void submit_after(ss::future<>, ss::noncopyable_function<ss::future<>()>);
+
     error_reporter_fn _error_reporter;
     ss::future<> _tail = ss::now();
     ss::abort_source _as;
+    uint64_t _delayed_id = 0;
+    absl::flat_hash_map<uint64_t, ss::future<>> _delayed_tasks;
 };
 
+template<typename Clock>
+void work_queue::submit_delayed(
+  Clock::duration delay, ss::noncopyable_function<ss::future<>()> fn) {
+    submit_after(ss::sleep_abortable<Clock>(delay, _as), std::move(fn));
+}
 } // namespace ssx

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -4,11 +4,13 @@ v_cc_library(
     probe.h
     logger.h
     transform_processor.h
+    transform_manager.h
     io.h
   SRCS
     probe.cc
     logger.cc
     transform_processor.cc
+    transform_manager.cc
   DEPS
     v::wasm
     v::model

--- a/src/v/transform/tests/CMakeLists.txt
+++ b/src/v/transform/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ v_cc_library(
     Seastar::seastar
     v::model_test_utils
     v::gtest_main
-  )
+)
 
 rp_test(
   UNIT_TEST
@@ -19,6 +19,20 @@ rp_test(
     transform_processor
   SOURCES
     transform_processor_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::transform_test_fixture
+  ARGS "-- -c 1"
+  LABELS transform
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME
+    transform_manager
+  SOURCES
+    transform_manager_test.cc
   LIBRARIES 
     v::gtest_main
     v::transform_test_fixture

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -1,0 +1,417 @@
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/transform.h"
+#include "transform/logger.h"
+#include "transform/tests/test_fixture.h"
+#include "transform/transform_manager.h"
+#include "transform/transform_processor.h"
+#include "utils/human.h"
+#include "utils/uuid.h"
+
+#include <seastar/core/idle_cpu_handler.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/print.hh>
+#include <seastar/core/reactor.hh>
+#include <seastar/util/later.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <absl/container/btree_map.h>
+#include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
+#include <absl/strings/charconv.h>
+#include <absl/strings/match.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace transform {
+
+namespace {
+
+struct transform_entry {
+    model::transform_id id;
+    model::transform_metadata meta;
+    bool name_was_reused;
+};
+
+class fake_registry : public registry {
+public:
+    absl::flat_hash_set<model::partition_id>
+    get_leader_partitions(model::topic_namespace_view tp_ns) const override {
+        const auto& leader_ntps = _states.back().leader_ntps;
+        absl::flat_hash_set<model::partition_id> leaders;
+        for (const auto& ntp : leader_ntps) {
+            if (ntp.ns == tp_ns.ns && ntp.tp.topic == tp_ns.tp) {
+                leaders.emplace(ntp.tp.partition);
+            }
+        }
+        return leaders;
+    }
+
+    absl::flat_hash_map<model::transform_id, model::transform_metadata>
+    lookup_by_input_topic(model::topic_namespace_view tp_ns) const override {
+        const auto& transforms = _states.back().transforms;
+        absl::flat_hash_map<model::transform_id, model::transform_metadata>
+          result;
+        for (const auto& entry : transforms) {
+            const auto& input = entry.second.input_topic;
+            if (input.ns == tp_ns.ns && input.tp == tp_ns.tp) {
+                result.emplace(entry.first, entry.second);
+            }
+        }
+        return result;
+    }
+
+    std::optional<model::transform_metadata>
+    lookup_by_id(model::transform_id id) const override {
+        const auto& transforms = _states.back().transforms;
+        auto it = transforms.find(id);
+        if (it == transforms.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    std::optional<std::pair<model::transform_id, model::transform_metadata>>
+    lookup_by_name(const model::transform_name& name) const {
+        for (const auto& entry : _states.back().transforms) {
+            if (entry.second.name == name) {
+                return entry;
+            }
+        }
+        return std::nullopt;
+    }
+
+    model::transform_id put_transform(const model::transform_metadata& meta) {
+        auto existing = lookup_by_name(meta.name);
+        state& new_state = _states.emplace_back(_states.back());
+        if (existing) {
+            new_state.transforms[existing->first] = meta;
+            return existing->first;
+        } else {
+            _names.emplace(meta.name);
+            new_state.transforms.emplace(++_next_id, meta);
+            return _next_id;
+        }
+    }
+    model::transform_id delete_transform(const model::transform_name& name) {
+        auto existing = lookup_by_name(name);
+        if (!existing) {
+            throw std::runtime_error(
+              ss::format("trying to delete non-existant transform {}", name));
+        }
+        state& new_state = _states.emplace_back(_states.back());
+        new_state.transforms.erase(existing->first);
+        return existing->first;
+    }
+    void add_leader(model::ntp ntp) {
+        state& new_state = _states.emplace_back(_states.back());
+        new_state.leader_ntps.emplace(ntp);
+    }
+    void delete_leader(const model::ntp& ntp) {
+        state& new_state = _states.emplace_back(_states.back());
+        new_state.leader_ntps.erase(ntp);
+    }
+
+    /** All transforms that ever existed. */
+    std::vector<transform_entry> all_transforms() {
+        absl::flat_hash_map<model::transform_id, transform_entry> deduped;
+        for (const auto& state : _states) {
+            for (const auto& [id, meta] : state.transforms) {
+                bool name_was_reused = _names.count(meta.name) > 1;
+                deduped.insert_or_assign(id, {id, meta, name_was_reused});
+            }
+        }
+        std::vector<transform_entry> result;
+        for (const auto& [_, entry] : deduped) {
+            result.push_back(entry);
+        }
+        return result;
+    }
+
+private:
+    model::transform_id _next_id = model::transform_id(1);
+    absl::btree_multiset<model::transform_name> _names;
+
+    // We use MVCC state here so we can do nice things like refer to specific
+    // versions of a given transform.
+    struct state {
+        absl::flat_hash_map<model::transform_id, model::transform_metadata>
+          transforms;
+        absl::flat_hash_set<model::ntp> leader_ntps;
+    };
+
+    std::vector<state> _states = {state{}};
+};
+
+enum class lifecycle_status { created, active, inactive, destroyed };
+std::ostream& operator<<(std::ostream& os, lifecycle_status s) {
+    switch (s) {
+    case lifecycle_status::created:
+        return os << "lifecycle::created";
+    case lifecycle_status::active:
+        return os << "lifecycle::active";
+    case lifecycle_status::inactive:
+        return os << "lifecycle::inactive";
+    case lifecycle_status::destroyed:
+        return os << "lifecycle::destroyed";
+    }
+    return os << "lifecycle::unknown";
+}
+
+class processor_tracker : public processor_factory {
+    class tracked_processor : public processor {
+        static std::vector<std::unique_ptr<sink>> make_sink() {
+            std::vector<std::unique_ptr<sink>> sinks;
+            sinks.push_back(std::make_unique<testing::fake_sink>());
+            return sinks;
+        }
+
+    public:
+        tracked_processor(
+          std::function<void(lifecycle_status)> cb,
+          model::transform_id id,
+          model::ntp ntp,
+          model::transform_metadata meta,
+          probe* p)
+          : processor(
+            id,
+            std::move(ntp),
+            std::move(meta),
+            std::make_unique<testing::fake_wasm_engine>(),
+            [](auto, auto, auto) {},
+            std::make_unique<testing::fake_source>(model::offset(1)),
+            make_sink(),
+            p)
+          , _track_fn(std::move(cb)) {
+            _track_fn(lifecycle_status::created);
+        }
+        tracked_processor(const tracked_processor&) = delete;
+        tracked_processor(tracked_processor&&) = delete;
+        tracked_processor& operator=(const tracked_processor&) = delete;
+        tracked_processor& operator=(tracked_processor&&) = delete;
+
+        ss::future<> start() override {
+            _track_fn(lifecycle_status::active);
+            co_return;
+        }
+        ss::future<> stop() override {
+            _track_fn(lifecycle_status::inactive);
+            co_return;
+        }
+        ~tracked_processor() override {
+            _track_fn(lifecycle_status::destroyed);
+        }
+
+    private:
+        std::function<void(lifecycle_status)> _track_fn;
+    };
+
+public:
+    // Create a processor with the given metadata and input partition.
+    ss::future<std::unique_ptr<processor>> create_processor(
+      model::transform_id id,
+      model::ntp ntp,
+      model::transform_metadata meta,
+      probe* probe) override {
+        EXPECT_NE(probe, nullptr);
+        co_return std::make_unique<tracked_processor>(
+          [this, id, ntp](lifecycle_status change) {
+              handle_lifecycle_change(id, ntp, change);
+          },
+          id,
+          ntp,
+          meta,
+          probe);
+    }
+
+    absl::flat_hash_map<
+      std::pair<model::transform_id, model::ntp>,
+      lifecycle_status>
+    statuses() {
+        return _status;
+    }
+
+private:
+    void handle_lifecycle_change(
+      model::transform_id id, model::ntp ntp, lifecycle_status change) {
+        _status.insert_or_assign(std::make_pair(id, std::move(ntp)), change);
+    }
+
+    absl::flat_hash_map<
+      std::pair<model::transform_id, model::ntp>,
+      lifecycle_status>
+      _status;
+};
+
+using status_map = absl::flat_hash_map<std::string, lifecycle_status>;
+
+template<typename... Args>
+concept EmptyPack = sizeof...(Args) == 0;
+
+template<typename... Rest>
+void make_status_map(status_map& output)
+requires EmptyPack<Rest...>
+{}
+
+template<typename... Rest>
+void make_status_map(
+  status_map& output, ss::sstring name, lifecycle_status status, Rest... rest) {
+    output.emplace(name, status);
+    make_status_map(output, rest...);
+}
+
+template<typename... Args>
+auto status_is(Args... args) {
+    status_map m;
+    make_status_map(m, args...);
+    return ::testing::Eq(m);
+}
+
+} // namespace
+
+class TransformManagerTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        auto r = std::make_unique<fake_registry>();
+        _registry = r.get();
+        auto t = std::make_unique<processor_tracker>();
+        _tracker = t.get();
+        _manager = std::make_unique<manager>(std::move(r), std::move(t));
+    }
+    void TearDown() override {
+        _registry = nullptr;
+        _tracker = nullptr;
+        _manager.reset();
+    }
+    void become_leader(std::string_view np_str) {
+        auto ntp = parse_ntp(np_str);
+        _registry->add_leader(ntp);
+        _manager->on_leadership_change(ntp, ntp_leader::yes);
+    }
+    void lose_leadership(std::string_view np_str) {
+        auto ntp = parse_ntp(np_str);
+        _registry->delete_leader(ntp);
+        _manager->on_leadership_change(ntp, ntp_leader::no);
+    }
+    void deploy_transform(std::string_view name) {
+        auto meta = parse_transform(name);
+        auto id = _registry->put_transform(meta);
+        _manager->on_plugin_change(id);
+    }
+    void delete_transform(std::string_view name) {
+        auto meta = parse_transform(name);
+        auto id = _registry->delete_transform(meta.name);
+        _manager->on_plugin_change(id);
+    }
+    void drain_queue() { _manager->drain_queue_for_test().get(); }
+    status_map status() {
+        status_map result;
+        auto statuses = _tracker->statuses();
+        for (const auto& entry : _registry->all_transforms()) {
+            auto name = entry.meta.name();
+            if (entry.name_was_reused) {
+                name += "#";
+                name += std::to_string(entry.meta.source_ptr());
+            }
+            for (const auto& [key, status] : statuses) {
+                auto [id, ntp] = key;
+                if (id == entry.id) {
+                    result.emplace(
+                      ss::format("{}/{}", name, ntp.tp.partition()), status);
+                }
+            }
+        }
+        return result;
+    }
+
+private:
+    model::ntp parse_ntp(std::string_view str) {
+        std::vector<std::string_view> parts = absl::StrSplit(str, '/');
+        if (parts.size() != 2) {
+            throw std::runtime_error(ss::format("invalid ntp: {}", str));
+        }
+        int32_t partition_id = 0;
+        if (!absl::SimpleAtoi(parts[1], &partition_id)) {
+            throw std::runtime_error(
+              ss::format("invalid partition: {}", parts[1]));
+        }
+        return {
+          model::kafka_namespace,
+          model::topic(parts[0]),
+          model::partition_id(partition_id)};
+    }
+    /**
+     * Parse a transform from a given string.
+     *
+     * Format is: (input_topic)->(output_topic)(#(version_number))?
+     *
+     * The version number is useful for multiple transforms that have been
+     * deleted or created with the same name, we can refer to a specific one.
+     */
+    model::transform_metadata parse_transform(std::string_view str) {
+        int version = 1;
+        std::vector<std::string_view> version_parts = absl::StrSplit(str, "#");
+        if (version_parts.size() == 2) {
+            str = version_parts[0];
+            if (!absl::SimpleAtoi(version_parts[1], &version)) {
+                throw std::runtime_error(
+                  ss::format("invalid version: {}", version_parts[1]));
+            }
+        } else if (version_parts.size() != 1) {
+            throw std::runtime_error(
+              ss::format("invalid transform name: {}", str));
+        }
+        std::vector<std::string_view> topic_parts = absl::StrSplit(str, "->");
+        if (topic_parts.size() != 2) {
+            throw std::runtime_error(ss::format("invalid transform: {}", str));
+        }
+        return {
+          .name = model::transform_name(str),
+          .input_topic = {model::kafka_namespace, model::topic(topic_parts[0])},
+          .output_topics
+          = {{model::kafka_namespace, model::topic(topic_parts[1])}},
+          .environment = {},
+          .uuid = uuid_t::create(),
+          // As a hack to track the version, we use the source ptr
+          .source_ptr = model::offset(version),
+        };
+    }
+
+    fake_registry* _registry;
+    processor_tracker* _tracker;
+    std::unique_ptr<manager> _manager;
+};
+
+TEST_F(TransformManagerTest, FullLifecycle) {
+    become_leader("foo/1");
+    deploy_transform("foo->bar");
+    drain_queue();
+    EXPECT_THAT(status(), status_is("foo->bar/1", lifecycle_status::active));
+    lose_leadership("foo/1");
+    drain_queue();
+    EXPECT_THAT(status(), status_is("foo->bar/1", lifecycle_status::destroyed));
+}
+
+TEST_F(TransformManagerTest, DeleteTransform) {
+    become_leader("foo/1");
+    deploy_transform("foo->bar");
+    drain_queue();
+    EXPECT_THAT(status(), status_is("foo->bar/1", lifecycle_status::active));
+    delete_transform("foo->bar");
+    drain_queue();
+    EXPECT_THAT(status(), status_is("foo->bar/1", lifecycle_status::destroyed));
+}
+
+} // namespace transform

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -59,15 +59,14 @@ public:
         return leaders;
     }
 
-    absl::flat_hash_map<model::transform_id, model::transform_metadata>
+    absl::flat_hash_set<model::transform_id>
     lookup_by_input_topic(model::topic_namespace_view tp_ns) const override {
         const auto& transforms = _states.back().transforms;
-        absl::flat_hash_map<model::transform_id, model::transform_metadata>
-          result;
+        absl::flat_hash_set<model::transform_id> result;
         for (const auto& entry : transforms) {
             const auto& input = entry.second.input_topic;
             if (input.ns == tp_ns.ns && input.tp == tp_ns.tp) {
-                result.emplace(entry.first, entry.second);
+                result.emplace(entry.first);
             }
         }
         return result;

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -288,7 +288,8 @@ public:
         _registry = r.get();
         auto t = std::make_unique<processor_tracker>();
         _tracker = t.get();
-        _manager = std::make_unique<manager>(std::move(r), std::move(t));
+        _manager = std::make_unique<manager<ss::manual_clock>>(
+          std::move(r), std::move(t));
     }
     void TearDown() override {
         _registry = nullptr;
@@ -352,6 +353,7 @@ private:
           model::topic(parts[0]),
           model::partition_id(partition_id)};
     }
+
     /**
      * Parse a transform from a given string.
      *
@@ -391,7 +393,7 @@ private:
 
     fake_registry* _registry;
     processor_tracker* _tracker;
-    std::unique_ptr<manager> _manager;
+    std::unique_ptr<manager<ss::manual_clock>> _manager;
 };
 
 TEST_F(TransformManagerTest, FullLifecycle) {

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -17,6 +17,7 @@
 #include "ssx/future-util.h"
 #include "transform/logger.h"
 #include "transform/transform_processor.h"
+#include "utils/human.h"
 #include "vassert.h"
 #include "vlog.h"
 #include "wasm/api.h"
@@ -318,7 +319,7 @@ ss::future<> manager::handle_transform_error(
       "transform {} errored on partition {}, delaying for {} then restarting",
       meta.name,
       ntp.tp.partition,
-      delay);
+      human::latency(delay));
     _queue.submit_delayed(delay, [this, id, ntp]() mutable {
         return start_processor(std::move(ntp), id);
     });

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "transform/transform_manager.h"
+
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/transform.h"
+#include "rpc/backoff_policy.h"
+#include "ssx/future-util.h"
+#include "transform/logger.h"
+#include "transform/transform_processor.h"
+#include "vassert.h"
+#include "vlog.h"
+#include "wasm/api.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/util/log.hh>
+
+#include <boost/multi_index/composite_key.hpp>
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/mem_fun.hpp>
+#include <boost/multi_index_container.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <functional>
+#include <future>
+#include <iterator>
+#include <memory>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace transform {
+
+using namespace std::chrono_literals;
+
+namespace {
+class processor_backoff {
+public:
+    static constexpr std::chrono::seconds base_duration = 1s;
+    static constexpr std::chrono::seconds max_duration = 30s;
+    // If a processor has been running for this long we mark it as good.
+    static constexpr std::chrono::seconds reset_duration = 10s;
+
+    // Mark that we attempted to start a processor, this is used to ensure that
+    // we properly reset backoff if the processor has been running for long
+    // enough.
+    void mark_start_attempt() { _start_time = ss::lowres_clock::now(); }
+
+    ss::lowres_clock::duration next_backoff_duration() {
+        auto now = ss::lowres_clock::now();
+        if (now > (_start_time + reset_duration)) {
+            _backoff.reset();
+        } else {
+            _backoff.next_backoff();
+        }
+        return _backoff.current_backoff_duration();
+    }
+
+private:
+    // the last time we started this processor
+    ss::lowres_clock::time_point _start_time = ss::lowres_clock::now();
+    // the backoff policy for this processor for when we attempt to restart
+    // the processor. If it's been enough time since our last restart of the
+    // processor we will reset this.
+    rpc::backoff_policy _backoff
+      = rpc::make_exponential_backoff_policy<ss::lowres_clock>(
+        base_duration, max_duration);
+};
+
+} // namespace
+
+// The underlying container for holding processors and indexing them correctly.
+//
+// It's possible for there to be the same ntp with multiple transforms and it's
+// also possible for a transform to be attached to multiple ntps, so the true
+// "key" for a processor is the tuple of (id, ntp), hence the need for the
+// complicated table of indexes.
+class processor_table {
+    struct key_index_t {};
+    struct ntp_index_t {};
+    struct id_index_t {};
+
+    class entry_t {
+    public:
+        entry_t(
+          std::unique_ptr<transform::processor> processor,
+          ss::lw_shared_ptr<transform::probe> probe)
+          : _processor(std::move(processor))
+          , _probe(std::move(probe))
+          , _backoff(std::make_unique<processor_backoff>()) {}
+
+        processor* processor() const { return _processor.get(); }
+        ss::lw_shared_ptr<probe> probe() const { return _probe; }
+        processor_backoff* backoff() const { return _backoff.get(); }
+
+        const model::ntp& ntp() const { return _processor->ntp(); }
+        model::transform_id id() const { return _processor->id(); }
+
+    private:
+        std::unique_ptr<transform::processor> _processor;
+        ss::lw_shared_ptr<transform::probe> _probe;
+        std::unique_ptr<processor_backoff> _backoff;
+    };
+
+    using underlying_t = boost::multi_index::multi_index_container<
+      entry_t,
+      boost::multi_index::indexed_by<
+        // uniquely indexed by id and ntp together
+        boost::multi_index::hashed_unique<
+          boost::multi_index::tag<key_index_t>,
+          boost::multi_index::composite_key<
+            entry_t,
+            boost::multi_index::
+              const_mem_fun<entry_t, model::transform_id, &entry_t::id>,
+            boost::multi_index::
+              const_mem_fun<entry_t, const model::ntp&, &entry_t::ntp>>,
+          boost::multi_index::composite_key_hash<
+            std::hash<model::transform_id>,
+            std::hash<model::ntp>>>,
+        // indexed by ntp
+        boost::multi_index::hashed_non_unique<
+          boost::multi_index::tag<ntp_index_t>,
+          boost::multi_index::
+            const_mem_fun<entry_t, const model::ntp&, &entry_t::ntp>,
+          std::hash<model::ntp>,
+          std::equal_to<>>,
+        // indexed by id
+        boost::multi_index::hashed_non_unique<
+          boost::multi_index::tag<id_index_t>,
+          boost::multi_index::
+            const_mem_fun<entry_t, model::transform_id, &entry_t::id>,
+          std::hash<model::transform_id>,
+          std::equal_to<>>>>;
+
+public:
+    const entry_t& insert(
+      std::unique_ptr<processor> processor,
+      ss::lw_shared_ptr<transform::probe> probe) {
+        auto [it, inserted] = _underlying.emplace(
+          std::move(processor), std::move(probe));
+        vassert(inserted, "invalid transform processor management");
+        return *it;
+    }
+
+    ss::lw_shared_ptr<probe> get_or_create_probe(
+      model::transform_id id, const model::transform_metadata& meta) {
+        auto& id_index = _underlying.get<id_index_t>();
+        auto id_it = id_index.find(id);
+        if (id_it == id_index.end()) {
+            auto probe = ss::make_lw_shared<transform::probe>();
+            probe->setup_metrics(meta.name);
+            return probe;
+        }
+        return id_it->probe();
+    }
+
+    bool contains(model::transform_id id, const model::ntp& ntp) {
+        auto& by_key = _underlying.get<key_index_t>();
+        return by_key.contains(std::make_tuple(id, ntp));
+    }
+
+    const entry_t* get_or_null(model::transform_id id, const model::ntp& ntp) {
+        auto& by_key = _underlying.get<key_index_t>();
+        auto it = by_key.find(std::make_tuple(id, ntp));
+        if (it == by_key.end()) {
+            return nullptr;
+        }
+        return std::addressof(*it);
+    }
+
+    ss::future<> clear() {
+        co_await ss::parallel_for_each(
+          _underlying.begin(),
+          _underlying.end(),
+          // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+          [](auto& e) { return e.processor()->stop(); });
+        _underlying.clear();
+    }
+
+    ss::future<> erase_by_id(model::transform_id id) {
+        auto& by_id = _underlying.get<id_index_t>();
+        auto range = by_id.equal_range(id);
+        co_await ss::parallel_for_each(
+          range.first,
+          range.second,
+          // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+          [](auto& e) { return e.processor()->stop(); });
+        by_id.erase(range.first, range.second);
+    }
+
+    // Clear our all the transforms with a given ntp and return all the IDs that
+    // no longer exist.
+    ss::future<> erase_by_ntp(model::ntp ntp) {
+        auto& by_ntp = _underlying.get<ntp_index_t>();
+        auto range = by_ntp.equal_range(ntp);
+        co_await ss::parallel_for_each(
+          range.first,
+          range.second,
+          // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
+          [](auto& e) { return e.processor()->stop(); });
+        by_ntp.erase(range.first, range.second);
+    }
+
+private:
+    underlying_t _underlying;
+};
+
+manager::manager(
+  std::unique_ptr<registry> r, std::unique_ptr<processor_factory> f)
+  : _queue([](const std::exception_ptr& ex) {
+      vlog(tlog.error, "unexpected transform manager error: {}", ex);
+  })
+  , _registry(std::move(r))
+  , _processors(std::make_unique<processor_table>())
+  , _processor_factory(std::move(f)) {}
+
+manager::~manager() = default;
+
+ss::future<> manager::start() { return ss::now(); }
+ss::future<> manager::stop() {
+    vlog(tlog.info, "Stopping transform manager...");
+    co_await _queue.shutdown();
+    co_await _processors->clear();
+    vlog(tlog.info, "Stopped transform manager.");
+}
+
+void manager::on_leadership_change(model::ntp ntp, ntp_leader leader_status) {
+    _queue.submit([this, ntp = std::move(ntp), leader_status]() mutable {
+        return handle_leadership_change(std::move(ntp), leader_status);
+    });
+}
+void manager::on_plugin_change(model::transform_id id) {
+    _queue.submit([this, id] { return handle_plugin_change(id); });
+}
+void manager::on_transform_error(
+  model::transform_id id, model::ntp ntp, model::transform_metadata meta) {
+    _queue.submit(
+      [this, id, ntp = std::move(ntp), meta = std::move(meta)]() mutable {
+          return handle_transform_error(id, std::move(ntp), std::move(meta));
+      });
+}
+
+ss::future<>
+manager::handle_leadership_change(model::ntp ntp, ntp_leader leader_status) {
+    vlog(
+      tlog.debug,
+      "handling leadership status change to leader={} for: {}",
+      leader_status,
+      ntp);
+
+    if (leader_status == ntp_leader::no) {
+        // We're not the leader anymore, time to shutdown all the processors
+        co_await _processors->erase_by_ntp(ntp);
+        co_return;
+    }
+    // We're the leader - start all the processor that aren't already running
+    auto transforms = _registry->lookup_by_input_topic(
+      model::topic_namespace_view(ntp));
+    co_await ss::parallel_for_each(
+      std::move(transforms),
+      [this, &ntp](auto entry) { return start_processor(ntp, entry.first); });
+}
+
+ss::future<> manager::handle_plugin_change(model::transform_id id) {
+    vlog(tlog.debug, "handling update to plugin: {}", id);
+    // If we have an existing processor we need to restart it with the updates
+    // applied.
+    co_await _processors->erase_by_id(id);
+
+    auto transform = _registry->lookup_by_id(id);
+    // If there is no transform we're good to go, everything is shutdown if
+    // needed.
+    if (!transform) {
+        co_return;
+    }
+    // Otherwise, start a processor for every partition we're a leader of.
+    auto partitions = _registry->get_leader_partitions(transform->input_topic);
+    co_await ss::parallel_for_each(
+      partitions.begin(),
+      partitions.end(),
+      [this, id, transform = *std::move(transform)](
+        model::partition_id partition) {
+          auto ntp = model::ntp(
+            transform.input_topic.ns, transform.input_topic.tp, partition);
+          // It's safe to directly create processors, because we deleted them
+          // for a full restart from this deploy
+          return create_processor(std::move(ntp), id, transform);
+      });
+}
+
+ss::future<> manager::handle_transform_error(
+  model::transform_id id, model::ntp ntp, model::transform_metadata meta) {
+    auto* entry = _processors->get_or_null(id, ntp);
+    if (!entry) {
+        co_return;
+    }
+    co_await entry->processor()->stop();
+    auto delay = entry->backoff()->next_backoff_duration();
+    vlog(
+      tlog.info,
+      "transform {} errored on partition {}, delaying for {} then restarting",
+      meta.name,
+      ntp.tp.partition,
+      delay);
+    _queue.submit_delayed(delay, [this, id, ntp]() mutable {
+        return start_processor(std::move(ntp), id);
+    });
+}
+
+ss::future<> manager::start_processor(model::ntp ntp, model::transform_id id) {
+    auto* entry = _processors->get_or_null(id, ntp);
+    // It's possible something else came along and kicked this processor and
+    // that worked.
+    if (entry && entry->processor()->is_running()) {
+        co_return;
+    }
+    auto transform = _registry->lookup_by_id(id);
+    // This transform was deleted, if there is an entry, it *should* have a
+    // pending delete notification enqueued (if there is an existing entry).
+    if (!transform) {
+        co_return;
+    }
+    auto leaders = _registry->get_leader_partitions(
+      model::topic_namespace_view(ntp));
+    // no longer a leader for this partition, if there was an entry, it
+    // *should* have a pending no_leader notification enqueued (that will
+    // cleanup the existing entry).
+    if (!leaders.contains(ntp.tp.partition)) {
+        co_return;
+    }
+    if (entry) {
+        entry->backoff()->mark_start_attempt();
+        co_await entry->processor()->start();
+    } else {
+        co_await create_processor(ntp, id, *std::move(transform));
+    }
+}
+
+ss::future<> manager::create_processor(
+  model::ntp ntp, model::transform_id id, model::transform_metadata meta) {
+    ss::lw_shared_ptr<transform::probe> probe
+      = _processors->get_or_create_probe(id, meta);
+    auto fut = co_await ss::coroutine::as_future(
+      _processor_factory->create_processor(id, ntp, meta, probe.get()));
+    if (fut.failed()) {
+        vlog(
+          tlog.warn,
+          "failed to create transform processor {}: {}, retrying...",
+          meta.name,
+          fut.get_exception());
+        // Delay some time before attempting to recreate a processor
+        // TODO: Should we have more sophisticated backoff mechanisms?
+        constexpr auto recreate_attempt_delay = 10s;
+        _queue.submit_delayed(
+          recreate_attempt_delay, [this, ntp = std::move(ntp), id]() mutable {
+              return start_processor(std::move(ntp), id);
+          });
+    } else {
+        // Ensure that we insert this transform into our mapping before we
+        // start it.
+        auto& entry = _processors->insert(
+          std::move(fut).get(), std::move(probe));
+        vlog(tlog.info, "starting transform {} on {}", meta.name, ntp);
+        entry.backoff()->mark_start_attempt();
+        co_await entry.processor()->start();
+    }
+}
+
+} // namespace transform

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -290,8 +290,8 @@ ss::future<> manager<ClockType>::handle_leadership_change(
     auto transforms = _registry->lookup_by_input_topic(
       model::topic_namespace_view(ntp));
     co_await ss::parallel_for_each(
-      transforms, [this, ntp = std::move(ntp)](const auto& entry) {
-          return start_processor(ntp, entry.first);
+      transforms, [this, ntp = std::move(ntp)](model::transform_id id) {
+          return start_processor(ntp, id);
       });
 }
 

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -383,4 +383,15 @@ ss::future<> manager::create_processor(
     }
 }
 
+ss::future<> manager::drain_queue_for_test() {
+    ss::promise<> p;
+    auto f = p.get_future();
+    // Move the promise into the queue so we get
+    // broken promise exceptions if the queue is shutdown.
+    _queue.submit([p = std::move(p)]() mutable {
+        p.set_value();
+        return ss::now();
+    });
+    co_await std::move(f);
+}
 } // namespace transform

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -363,7 +363,7 @@ ss::future<> manager<ClockType>::create_processor(
           fut.get_exception());
         // Delay some time before attempting to recreate a processor
         // TODO: Should we have more sophisticated backoff mechanisms?
-        constexpr auto recreate_attempt_delay = 10s;
+        constexpr auto recreate_attempt_delay = 30s;
         _queue.submit_delayed<ClockType>(
           recreate_attempt_delay, [this, ntp = std::move(ntp), id]() mutable {
               return start_processor(std::move(ntp), id);

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/types.h"
+#include "model/fundamental.h"
+#include "model/ktp.h"
+#include "model/metadata.h"
+#include "model/transform.h"
+#include "ssx/work_queue.h"
+#include "transform/fwd.h"
+#include "transform/io.h"
+#include "wasm/fwd.h"
+
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/bool_class.hh>
+
+namespace transform {
+
+using ntp_leader = ss::bool_class<struct is_ntp_leader>;
+
+// This allows reading the existing transforms by input topic or by ID.
+//
+// This allows us to swap out the data source for plugins in tests easily.
+class registry {
+public:
+    registry() = default;
+    registry(const registry&) = delete;
+    registry& operator=(const registry&) = delete;
+    registry(registry&&) = default;
+    registry& operator=(registry&&) = default;
+    virtual ~registry() = default;
+
+    // Get all the partitions that are leaders and this shard is responsible
+    // for
+    virtual absl::flat_hash_set<model::partition_id>
+      get_leader_partitions(model::topic_namespace_view) const = 0;
+
+    // Get all the transforms with this ns_tp as the input source.
+    virtual absl::flat_hash_map<model::transform_id, model::transform_metadata>
+      lookup_by_input_topic(model::topic_namespace_view) const = 0;
+
+    // Lookup a transform by ID
+    virtual std::optional<model::transform_metadata>
+      lookup_by_id(model::transform_id) const = 0;
+};
+
+// An interface for creating processors.
+//
+// Mostly used by tests to inject custom processors that report their lifetime
+// to test infrastructure.
+class processor_factory {
+public:
+    processor_factory() = default;
+    processor_factory(const processor_factory&) = default;
+    processor_factory(processor_factory&&) = delete;
+    processor_factory& operator=(const processor_factory&) = default;
+    processor_factory& operator=(processor_factory&&) = delete;
+    virtual ~processor_factory() = default;
+
+    // Create a processor with the given metadata and input partition.
+    virtual ss::future<std::unique_ptr<processor>> create_processor(
+      model::transform_id, model::ntp, model::transform_metadata, probe*) const
+      = 0;
+};
+
+class processor_table;
+
+// transform manager is responsible for managing the lifetime of a processor and
+// starting/stopping processors when various lifecycle events happen in the
+// system, such as leadership changes, or deployments of new transforms.
+//
+// There is a manager per core and it only handles the transforms where the
+// transform's source ntp is leader on the same shard.
+//
+// Internally, the manager operates on a single queue and lifecycle changes
+// cannot proceed concurrently, this way we don't have to try and juggle the
+// futures if a wasm::engine is starting up and a request comes in to tear it
+// down, we'll just handle them in the order they where submitted to the
+// manager. Note that it maybe possible to allow for **each** processor to have
+// it's own queue in the manager, but until it's proven to be required, a per
+// shard queue is used.
+class manager {
+public:
+    manager(std::unique_ptr<registry>, std::unique_ptr<processor_factory>);
+    manager(const manager&) = delete;
+    manager& operator=(const manager&) = delete;
+    manager(manager&&) = delete;
+    manager& operator=(manager&&) = delete;
+    ~manager();
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    // Called when this shard's ownership of an ntp leader changes
+    void on_leadership_change(model::ntp, ntp_leader);
+    // Called everytime a transform changes
+    void on_plugin_change(model::transform_id);
+    // Called when processors have errors
+    void on_transform_error(
+      model::transform_id, model::ntp, model::transform_metadata);
+
+private:
+    // All these private methods must be call "on" the queue.
+
+    // Implmentation of `on_leadership_change`
+    ss::future<> handle_leadership_change(model::ntp, ntp_leader);
+    // Implementation of `on_plugin_change`
+    ss::future<> handle_plugin_change(model::transform_id);
+    // Implementation of `on_transform_error`
+    ss::future<> handle_transform_error(
+      model::transform_id, model::ntp, model::transform_metadata);
+    // Attempt to start a processor if the existing one is idle or there is no
+    // currently running processor.
+    ss::future<> start_processor(model::ntp, model::transform_id);
+    // Create a processor - this should only be called if it there is no
+    // existing processor for this ntp + id.
+    ss::future<> create_processor(
+      model::ntp, model::transform_id, model::transform_metadata);
+
+    ssx::work_queue _queue;
+    std::unique_ptr<registry> _registry;
+    std::unique_ptr<processor_table> _processors;
+    std::unique_ptr<processor_factory> _processor_factory;
+};
+} // namespace transform

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -47,7 +47,7 @@ public:
       get_leader_partitions(model::topic_namespace_view) const = 0;
 
     // Get all the transforms with this ns_tp as the input source.
-    virtual absl::flat_hash_map<model::transform_id, model::transform_metadata>
+    virtual absl::flat_hash_set<model::transform_id>
       lookup_by_input_topic(model::topic_namespace_view) const = 0;
 
     // Lookup a transform by ID

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -68,7 +68,7 @@ public:
 
     // Create a processor with the given metadata and input partition.
     virtual ss::future<std::unique_ptr<processor>> create_processor(
-      model::transform_id, model::ntp, model::transform_metadata, probe*) const
+      model::transform_id, model::ntp, model::transform_metadata, probe*)
       = 0;
 };
 
@@ -107,6 +107,11 @@ public:
     // Called when processors have errors
     void on_transform_error(
       model::transform_id, model::ntp, model::transform_metadata);
+
+    // Exposed for testing, but drains all the pending operations.
+    //
+    // Any future here should resolve before calling `stop`.
+    ss::future<> drain_queue_for_test();
 
 private:
     // All these private methods must be call "on" the queue.

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -138,7 +138,10 @@ private:
     // Create a processor - this should only be called if it there is no
     // existing processor for this ntp + id.
     ss::future<> create_processor(
-      model::ntp, model::transform_id, model::transform_metadata);
+      model::ntp,
+      model::transform_id,
+      model::transform_metadata,
+      ss::lw_shared_ptr<probe>);
 
     ssx::work_queue _queue;
     std::unique_ptr<registry> _registry;

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -138,10 +138,7 @@ private:
     // Create a processor - this should only be called if it there is no
     // existing processor for this ntp + id.
     ss::future<> create_processor(
-      model::ntp,
-      model::transform_id,
-      model::transform_metadata,
-      ss::lw_shared_ptr<probe>);
+      model::ntp, model::transform_id, model::transform_metadata);
 
     ssx::work_queue _queue;
     std::unique_ptr<registry> _registry;

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -121,4 +121,6 @@ ss::future<> processor::do_run_transform_loop() {
 
 model::transform_id processor::id() const { return _id; }
 const model::ntp& processor::ntp() const { return _ntp; }
+const model::transform_metadata& processor::meta() const { return _meta; }
+bool processor::is_running() const { return !_task.available(); }
 } // namespace transform

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -47,8 +47,9 @@ public:
       std::vector<std::unique_ptr<sink>>,
       probe*);
 
-    ss::future<> start();
-    ss::future<> stop();
+    virtual ~processor() = default;
+    virtual ss::future<> start();
+    virtual ss::future<> stop();
 
     bool is_running() const;
     model::transform_id id() const;

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -50,8 +50,10 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    bool is_running() const;
     model::transform_id id() const;
     const model::ntp& ntp() const;
+    const model::transform_metadata& meta() const;
 
 private:
     ss::future<> run_transform_loop();

--- a/src/v/utils/human.cc
+++ b/src/v/utils/human.cc
@@ -18,30 +18,32 @@
 namespace human {
 
 std::ostream& operator<<(std::ostream& o, const ::human::latency& l) {
-    static const char* units[] = {"μs", "ms", "secs"};
+    constexpr static std::array units{"μs", "ms", "secs"};
     static constexpr double step = 1000;
-    auto x = l.value;
-    for (size_t i = 0; i < 3; ++i) {
+    double x = l.value;
+    for (const char* unit : units) {
         if (x <= step) {
-            fmt::print(o, "{:03.3f}{}", x, units[i]);
+            fmt::print(o, "{:03.3f}{}", x, unit);
             return o;
         }
         x /= step;
     }
-    return o << x << "uknown_units";
+    return o << x << "unknown_units";
 }
+
 std::ostream& operator<<(std::ostream& o, const ::human::bytes& l) {
-    static const char* units[] = {"bytes", "KiB", "MiB", "GiB", "TiB", "PiB"};
+    constexpr static std::array units = {
+      "bytes", "KiB", "MiB", "GiB", "TiB", "PiB"};
     static constexpr double step = 1024;
-    auto x = l.value;
-    for (size_t i = 0; i < 6; ++i) {
+    double x = l.value;
+    for (auto& unit : units) {
         if (x <= step) {
-            fmt::print(o, "{:03.3f}{}", x, units[i]);
+            fmt::print(o, "{:03.3f}{}", x, unit);
             return o;
         }
         x /= step;
     }
-    return o << x << "uknown_units";
+    return o << x << "unknown_units";
 }
 
 } // namespace human

--- a/src/v/utils/human.h
+++ b/src/v/utils/human.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <iosfwd>
 
 /// \brief usage: fmt::format("{}", human::bytes(3234.234));
@@ -23,8 +24,13 @@ struct bytes {
     friend std::ostream& operator<<(std::ostream& o, const bytes&);
 };
 struct latency {
+    // the input should be in microseconds
     explicit latency(double x)
       : value(x) {}
+    template<typename Duration>
+    explicit latency(Duration d)
+      : value(
+        std::chrono::duration_cast<std::chrono::microseconds>(d).count()) {}
     double value;
     friend std::ostream& operator<<(std::ostream& o, const latency&);
 };


### PR DESCRIPTION
Transform manager is the component for ensuring that the correct `transform::processor` is running for a given core.

It is a component that recieves notifications from the rest of the system and processes those notifications on a single fiber queue.

The queue makes handling shutdown a little simpler, as we can remove most of the logic for handling shutdown correctly into another class,
additionally using a single fiber means we don't need to worry about concurrent modifications of data structures or duplicate notifications
being scheduled.

We also template the manager based on the clock type. This is a similar pattern used in other places that allows us to use the seastar manual 
clock for fully deterministic testing, but use the lowres clock for production usage.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
