### PR TITLE
Introduce Internal Data Transform RPCs

### DIFF
--- a/src/v/kafka/protocol/errors.cc
+++ b/src/v/kafka/protocol/errors.cc
@@ -205,18 +205,19 @@ std::ostream& operator<<(std::ostream& o, error_code code) {
              << (int16_t)code << "] }";
 }
 
-struct error_category final : std::error_category {
-    const char* name() const noexcept override { return "kafka"; }
-    std::string message(int ec) const override {
-        return std::string(
-          kafka::error_code_to_str(static_cast<kafka::error_code>(ec)));
-    }
-};
-
-const error_category kafka_error_category{};
-
 std::error_code make_error_code(kafka::error_code ec) {
-    return {static_cast<int>(ec), kafka_error_category};
+    return {static_cast<int>(ec), error_category()};
 }
 
+const std::error_category& error_category() noexcept {
+    struct error_category final : std::error_category {
+        const char* name() const noexcept override { return "kafka"; }
+        std::string message(int ec) const override {
+            return std::string(
+              kafka::error_code_to_str(static_cast<kafka::error_code>(ec)));
+        }
+    };
+    static error_category e;
+    return e;
+}
 } // namespace kafka

--- a/src/v/kafka/protocol/errors.h
+++ b/src/v/kafka/protocol/errors.h
@@ -236,6 +236,7 @@ enum class error_code : int16_t {
 std::ostream& operator<<(std::ostream&, error_code);
 std::string_view error_code_to_str(error_code error);
 std::error_code make_error_code(error_code);
+const std::error_category& error_category() noexcept;
 
 } // namespace kafka
 

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -173,6 +173,10 @@ static error_code map_produce_error_code(std::error_code ec) {
         }
     }
 
+    if (ec.category() == kafka::error_category()) {
+        return static_cast<error_code>(ec.value());
+    }
+
     return error_code::request_timed_out;
 }
 

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -416,13 +416,6 @@ static partition_produce_stages produce_topic_partition(
                       ntp,
                       source_shard);
                 }
-                if (partition->is_read_replica_mode_enabled()) {
-                    return finalize_request_with_error_code(
-                      error_code::invalid_topic_exception,
-                      std::move(dispatch),
-                      ntp,
-                      source_shard);
-                }
 
                 auto probe = std::addressof(partition->probe());
                 return pandaproxy::schema_registry::maybe_validate_schema_id(

--- a/src/v/kafka/server/partition_proxy.cc
+++ b/src/v/kafka/server/partition_proxy.cc
@@ -29,5 +29,13 @@ std::optional<partition_proxy> make_partition_proxy(
     }
     return std::nullopt;
 }
+std::optional<partition_proxy> make_partition_proxy(
+  const model::ntp& ntp, cluster::partition_manager& cluster_pm) {
+    auto partition = cluster_pm.get(ntp);
+    if (partition) {
+        return make_with_impl<replicated_partition>(partition);
+    }
+    return std::nullopt;
+}
 
 } // namespace kafka

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -164,5 +164,7 @@ private:
 
 std::optional<partition_proxy>
 make_partition_proxy(const model::ktp&, cluster::partition_manager&);
+std::optional<partition_proxy>
+make_partition_proxy(const model::ntp&, cluster::partition_manager&);
 
 } // namespace kafka

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -157,12 +157,12 @@ public:
     timequery(storage::timequery_config cfg) final;
 
     ss::future<result<model::offset>>
-      replicate(model::record_batch_reader, raft::replicate_options);
+      replicate(model::record_batch_reader, raft::replicate_options) final;
 
     raft::replicate_stages replicate(
       model::batch_identity,
       model::record_batch_reader&&,
-      raft::replicate_options);
+      raft::replicate_options) final;
 
     ss::future<storage::translating_reader> make_reader(
       storage::log_reader_config cfg,

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -224,6 +224,8 @@ make_fragmented_memory_storage_batches(Container batches) {
             } else {
                 data.emplace_back(std::exchange(data_chunk, {}));
             }
+            data_chunk.reserve(
+              std::min(elements_per_fragment, batches.size() - i));
         }
         auto& b = *it;
         data_chunk.push_back(std::move(b));

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -17,6 +17,7 @@
 #include "seastarx.h"
 #include "utils/fragmented_vector.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/do_with.hh>
 #include <seastar/core/future.hh>
@@ -316,6 +317,9 @@ record_batch_reader
 
 record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   fragmented_vector<model::record_batch>);
+
+record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+  ss::chunked_fifo<model::record_batch>);
 
 record_batch_reader make_generating_record_batch_reader(
   ss::noncopyable_function<ss::future<record_batch_reader::data_t>()>);

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -15,6 +15,7 @@
 
 #include <seastar/core/loop.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/core/smp.hh>
 
 #include <fmt/format.h>
 
@@ -166,6 +167,7 @@ ss::future<> connection_cache::emplace(
       n,
       ss::make_lw_shared<rpc::reconnect_transport>(
         std::move(c), std::move(backoff_policy), _label, n));
+    _connection_map[n] = ss::this_shard_id();
 }
 
 /// \brief closes all client connections

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -98,6 +98,8 @@ public:
     transport_ptr get(model::node_id n) const { return _cache.get(n); }
 
     /// \brief for unit testing
+    ///
+    /// Force the connection cache to have an entry for the node on this shard.
     ss::future<>
     emplace(model::node_id n, rpc::transport_configuration c, backoff_policy);
 

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -56,12 +56,12 @@ RPC_TEMPLATE = """
 namespace {{namespace}} {
 
 template<typename Codec>
-class {{service_name}}_service_base : public rpc::service {
+class {{service_name}}_service_base : public ::rpc::service {
 public:
     class failure_probes;
 
     {% for method in methods %}
-    static constexpr rpc::method_info {{method.name}}_method = {"{{service_name}}::{{method.name}}", {{method.id}}};
+    static constexpr ::rpc::method_info {{method.name}}_method = {"{{service_name}}::{{method.name}}", {{method.id}}};
     {%- endfor %}
 
     {{service_name}}_service_base(ss::scheduling_group sc, ss::smp_service_group ssg)
@@ -113,7 +113,7 @@ public:
        return _ssg;
     }
 
-    rpc::method* method_from_id(uint32_t id) final {
+    ::rpc::method* method_from_id(uint32_t id) final {
        switch(id) {
        {%- for method in methods %}
          case {{method.id}}: return &_methods[{{loop.index - 1}}];
@@ -123,27 +123,27 @@ public:
     }
     {%- for method in methods %}
     /// \\brief {{method.input_type}} -> {{method.output_type}}
-    virtual ss::future<rpc::netbuf>
-    raw_{{method.name}}(ss::input_stream<char>& in, rpc::streaming_context& ctx) {
+    virtual ss::future<::rpc::netbuf>
+    raw_{{method.name}}(ss::input_stream<char>& in, ::rpc::streaming_context& ctx) {
       return execution_helper<{{method.input_type}},
                               {{method.output_type}},
                               Codec>::exec(in, ctx, {{method.name}}_method,
       [this](
-          {{method.input_type}}&& t, rpc::streaming_context& ctx) -> ss::future<{{method.output_type}}> {
+          {{method.input_type}}&& t, ::rpc::streaming_context& ctx) -> ss::future<{{method.output_type}}> {
           return {{method.name}}(std::move(t), ctx);
       });
     }
     virtual ss::future<{{method.output_type}}>
-    {{method.name}}({{method.input_type}}&&, rpc::streaming_context&) {
+    {{method.name}}({{method.input_type}}&&, ::rpc::streaming_context&) {
        throw std::runtime_error("unimplemented method");
     }
     {%- endfor %}
 private:
     ss::scheduling_group _sc;
     ss::smp_service_group _ssg;
-    std::array<rpc::method, {{methods|length}}> _methods{%raw %}{{{% endraw %}
+    std::array<::rpc::method, {{methods|length}}> _methods{%raw %}{{{% endraw %}
       {%- for method in methods %}
-      rpc::method([this] (ss::input_stream<char>& in, rpc::streaming_context& ctx) {
+      ::rpc::method([this] (ss::input_stream<char>& in, ::rpc::streaming_context& ctx) {
          return raw_{{method.name}}(in, ctx);
       }){{ "," if not loop.last }}
       {%- endfor %}
@@ -151,26 +151,26 @@ private:
     ssx::metrics::metric_groups _metrics;
 };
 
-using {{service_name}}_service = {{service_name}}_service_base<rpc::default_message_codec>;
+using {{service_name}}_service = {{service_name}}_service_base<::rpc::default_message_codec>;
 
 class {{service_name}}_client_protocol {
 public:
-    explicit {{service_name}}_client_protocol(ss::lw_shared_ptr<rpc::transport> t)
+    explicit {{service_name}}_client_protocol(ss::lw_shared_ptr<::rpc::transport> t)
       : _transport(t) {
     }
 
     virtual ~{{service_name}}_client_protocol() = default;
 
     {%- for method in methods %}
-    virtual inline ss::future<result<rpc::client_context<{{method.output_type}}>>>
-    {{method.name}}({{method.input_type}}&& r, rpc::client_opts opts) {
+    virtual inline ss::future<result<::rpc::client_context<{{method.output_type}}>>>
+    {{method.name}}({{method.input_type}}&& r, ::rpc::client_opts opts) {
        return _transport->send_typed<{{method.input_type}}, {{method.output_type}}>(std::move(r),
               {{service_name}}_service::{{method.name}}_method, std::move(opts));
     }
     {%- endfor %}
 
 private:
-    ss::lw_shared_ptr<rpc::transport> _transport;
+    ss::lw_shared_ptr<::rpc::transport> _transport;
 };
 
 template<typename Codec>

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -17,3 +17,4 @@ v_cc_library(
 )
 
 add_subdirectory(tests)
+add_subdirectory(rpc)

--- a/src/v/transform/rpc/CMakeLists.txt
+++ b/src/v/transform/rpc/CMakeLists.txt
@@ -29,3 +29,5 @@ v_cc_library(
     v::kafka
     Seastar::seastar
 )
+
+add_subdirectory(tests)

--- a/src/v/transform/rpc/CMakeLists.txt
+++ b/src/v/transform/rpc/CMakeLists.txt
@@ -1,14 +1,27 @@
+include(rpcgen)
+
+rpcgen(
+  TARGET generated_transform_rpc
+  IN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/rpc.json
+  OUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/rpc_service.h
+  INCLUDES ${CMAKE_BINARY_DIR}/src/v
+)
+
 v_cc_library(
   NAME transform_rpc
   HDRS
     logger.h
     serde.h
+    service.h
   SRCS
     serde.cc
     logger.cc
+    service.cc
   DEPS
+    generated_transform_rpc 
     v::cluster
     v::model
+    v::rpc
     Seastar::seastar
 )
 

--- a/src/v/transform/rpc/CMakeLists.txt
+++ b/src/v/transform/rpc/CMakeLists.txt
@@ -1,0 +1,12 @@
+v_cc_library(
+  NAME transform_rpc
+  HDRS
+    serde.h
+  SRCS
+    serde.cc
+  DEPS
+    v::cluster
+    v::model
+    Seastar::seastar
+)
+

--- a/src/v/transform/rpc/CMakeLists.txt
+++ b/src/v/transform/rpc/CMakeLists.txt
@@ -14,16 +14,18 @@ v_cc_library(
     logger.h
     serde.h
     service.h
+    deps.h
   SRCS
     client.cc
     logger.cc
     serde.cc
     service.cc
+    deps.cc
   DEPS
     generated_transform_rpc 
     v::cluster
     v::model
     v::rpc
+    v::kafka
     Seastar::seastar
 )
-

--- a/src/v/transform/rpc/CMakeLists.txt
+++ b/src/v/transform/rpc/CMakeLists.txt
@@ -10,12 +10,14 @@ rpcgen(
 v_cc_library(
   NAME transform_rpc
   HDRS
+    client.h
     logger.h
     serde.h
     service.h
   SRCS
-    serde.cc
+    client.cc
     logger.cc
+    serde.cc
     service.cc
   DEPS
     generated_transform_rpc 

--- a/src/v/transform/rpc/CMakeLists.txt
+++ b/src/v/transform/rpc/CMakeLists.txt
@@ -1,9 +1,11 @@
 v_cc_library(
   NAME transform_rpc
   HDRS
+    logger.h
     serde.h
   SRCS
     serde.cc
+    logger.cc
   DEPS
     v::cluster
     v::model

--- a/src/v/transform/rpc/client.cc
+++ b/src/v/transform/rpc/client.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/rpc/client.h"
+
+#include "cluster/errc.h"
+#include "cluster/partition_leaders_table.h"
+#include "cluster/scheduling/constraints.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/timeout_clock.h"
+#include "raft/errc.h"
+#include "rpc/errc.h"
+#include "rpc/types.h"
+#include "ssx/semaphore.h"
+#include "transform/rpc/logger.h"
+#include "transform/rpc/rpc_service.h"
+#include "transform/rpc/serde.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/semaphore.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <absl/container/btree_map.h>
+#include <absl/container/flat_hash_map.h>
+#include <boost/fusion/sequence/intrinsic/back.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <exception>
+#include <iterator>
+#include <stdexcept>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+namespace transform::rpc {
+
+namespace {
+constexpr auto timeout = std::chrono::seconds(1);
+
+cluster::errc map_errc(std::error_code ec) {
+    if (ec.category() == cluster::error_category()) {
+        return static_cast<cluster::errc>(ec.value());
+    } else if (ec.category() == raft::error_category()) {
+        auto raft_ec = static_cast<raft::errc>(ec.value());
+        switch (raft_ec) {
+        case raft::errc::not_leader:
+        case raft::errc::leadership_transfer_in_progress:
+            return cluster::errc::not_leader;
+        default:
+            vlog(log.error, "unexpected transform produce error: {}", raft_ec);
+            break;
+        }
+    } else if (ec.category() == ::rpc::error_category()) {
+        auto rpc_ec = static_cast<::rpc::errc>(ec.value());
+        switch (rpc_ec) {
+        case ::rpc::errc::client_request_timeout:
+        case ::rpc::errc::connection_timeout:
+        case ::rpc::errc::disconnected_endpoint:
+            return cluster::errc::timeout;
+        default:
+            vlog(log.error, "unexpected transform produce error: {}", rpc_ec);
+            break;
+        }
+    } else {
+        vlog(log.error, "unexpected transform produce error: {}", ec);
+    }
+    return cluster::errc::timeout;
+}
+} // namespace
+
+client::client(
+  model::node_id self,
+  ss::sharded<cluster::partition_leaders_table>* l,
+  ss::sharded<::rpc::connection_cache>* c,
+  ss::sharded<local_service>* s)
+  : _self(self)
+  , _leaders(l)
+  , _connections(c)
+  , _local_service(s) {}
+
+ss::future<cluster::errc> client::produce(
+  model::topic_partition tp, ss::chunked_fifo<model::record_batch> batches) {
+    vlog(log.trace, "producing {} batches to {}", batches.size(), tp);
+    auto leader = _leaders->local().get_leader(
+      model::topic_namespace_view(model::kafka_namespace, tp.topic),
+      tp.partition);
+    if (!leader) {
+        co_return cluster::errc::not_leader;
+    }
+    produce_request req;
+    req.topic_data.emplace_back(std::move(tp), std::move(batches));
+    req.timeout = timeout;
+    auto reply = co_await (
+      *leader == _self ? do_local_produce(std::move(req))
+                       : do_remote_produce(*leader, std::move(req)));
+    vassert(
+      reply.results.size() == 1,
+      "expected a single result: {}",
+      reply.results.size());
+
+    co_return reply.results.front().err;
+}
+
+ss::future<> client::stop() { return ss::now(); }
+
+ss::future<produce_reply> client::do_local_produce(produce_request req) {
+    auto r = co_await _local_service->local().produce(
+      std::move(req.topic_data), req.timeout);
+    co_return produce_reply(std::move(r));
+}
+
+ss::future<produce_reply>
+client::do_remote_produce(model::node_id node, produce_request req) {
+    auto resp = co_await _connections->local()
+                  .with_node_client<impl::transform_rpc_client_protocol>(
+                    _self,
+                    ss::this_shard_id(),
+                    node,
+                    timeout,
+                    [&req](impl::transform_rpc_client_protocol proto) mutable {
+                        return proto.produce(
+                          req.share(),
+                          ::rpc::client_opts(
+                            model::timeout_clock::now() + timeout));
+                    })
+                  .then(&::rpc::get_ctx_data<produce_reply>);
+    if (resp.has_error()) {
+        cluster::errc ec = map_errc(resp.assume_error());
+        produce_reply reply;
+        for (const auto& data : req.topic_data) {
+            reply.results.emplace_back(data.tp, ec);
+        }
+        co_return reply;
+    }
+    co_return std::move(resp).value();
+}
+} // namespace transform::rpc

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/errc.h"
+#include "cluster/fwd.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/record.h"
+#include "model/timeout_clock.h"
+#include "rpc/connection_cache.h"
+#include "transform/rpc/service.h"
+
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/sharded.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace transform::rpc {
+
+/**
+ * A client for the transform rpc service.
+ *
+ * This is a sharded service that exists on every core, requests that can be
+ * serviced locally will not go through the rpc boundary but will directly go to
+ * the local service.
+ */
+class client {
+public:
+    client(
+      model::node_id self,
+      ss::sharded<cluster::partition_leaders_table>*,
+      ss::sharded<::rpc::connection_cache>*,
+      ss::sharded<local_service>*);
+    client(client&&) = delete;
+    client& operator=(client&&) = delete;
+    client(const client&) = delete;
+    client& operator=(const client&) = delete;
+    ~client() = default;
+
+    ss::future<cluster::errc>
+      produce(model::topic_partition, ss::chunked_fifo<model::record_batch>);
+
+    ss::future<> stop();
+
+private:
+    ss::future<produce_reply> do_local_produce(produce_request);
+    ss::future<produce_reply>
+      do_remote_produce(model::node_id, produce_request);
+
+    model::node_id _self;
+    // need partition_leaders_table to know which node owns the partitions
+    ss::sharded<cluster::partition_leaders_table>* _leaders;
+    ss::sharded<::rpc::connection_cache>* _connections;
+    ss::sharded<local_service>* _local_service;
+};
+
+} // namespace transform::rpc

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -18,12 +18,15 @@
 #include "model/record.h"
 #include "model/timeout_clock.h"
 #include "rpc/connection_cache.h"
+#include "transform/rpc/deps.h"
 #include "transform/rpc/service.h"
 
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 
 #include <absl/container/flat_hash_map.h>
+
+#include <memory>
 
 namespace transform::rpc {
 
@@ -38,7 +41,7 @@ class client {
 public:
     client(
       model::node_id self,
-      ss::sharded<cluster::partition_leaders_table>*,
+      std::unique_ptr<partition_leader_cache>,
       ss::sharded<::rpc::connection_cache>*,
       ss::sharded<local_service>*);
     client(client&&) = delete;
@@ -59,7 +62,7 @@ private:
 
     model::node_id _self;
     // need partition_leaders_table to know which node owns the partitions
-    ss::sharded<cluster::partition_leaders_table>* _leaders;
+    std::unique_ptr<partition_leader_cache> _leaders;
     ss::sharded<::rpc::connection_cache>* _connections;
     ss::sharded<local_service>* _local_service;
 };

--- a/src/v/transform/rpc/deps.cc
+++ b/src/v/transform/rpc/deps.cc
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/rpc/deps.h"
+
+#include "cluster/fwd.h"
+#include "cluster/metadata_cache.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
+#include "kafka/server/partition_proxy.h"
+#include "model/ktp.h"
+
+#include <seastar/core/do_with.hh>
+#include <seastar/core/future.hh>
+
+namespace transform::rpc {
+
+namespace {
+class partition_leader_cache_impl final : public partition_leader_cache {
+public:
+    explicit partition_leader_cache_impl(
+      ss::sharded<cluster::partition_leaders_table>* table)
+      : _table(table) {}
+
+    std::optional<model::node_id> get_leader_node(
+      model::topic_namespace_view tp_ns, model::partition_id p) const final {
+        return _table->local().get_leader(tp_ns, p);
+    }
+
+private:
+    ss::sharded<cluster::partition_leaders_table>* _table;
+};
+class topic_metadata_cache_impl final : public topic_metadata_cache {
+public:
+    explicit topic_metadata_cache_impl(
+      ss::sharded<cluster::metadata_cache>* cache)
+      : _cache(cache) {}
+
+    std::optional<cluster::topic_configuration>
+    find_topic_cfg(model::topic_namespace_view tp_ns) const final {
+        return _cache->local().get_topic_cfg(tp_ns);
+    }
+
+    uint32_t get_default_batch_max_bytes() const final {
+        return _cache->local().get_default_batch_max_bytes();
+    };
+
+private:
+    ss::sharded<cluster::metadata_cache>* _cache;
+};
+class partition_manager_impl final : public partition_manager {
+public:
+    partition_manager_impl(
+      ss::sharded<cluster::shard_table>* table,
+      ss::sharded<cluster::partition_manager>* manager)
+      : _table(table)
+      , _manager(manager) {}
+
+    std::optional<ss::shard_id> shard_owner(const model::ktp& ntp) final {
+        return _table->local().shard_for(ntp);
+    };
+    std::optional<ss::shard_id> shard_owner(const model::ntp& ntp) final {
+        return _table->local().shard_for(ntp);
+    };
+
+    ss::future<cluster::errc> invoke_on_shard(
+      ss::shard_id shard,
+      const model::ktp& ntp,
+      ss::noncopyable_function<
+        ss::future<cluster::errc>(kafka::partition_proxy*)> fn) final {
+        return invoke_on_shard_impl(shard, ntp, std::move(fn));
+    }
+    ss::future<cluster::errc> invoke_on_shard(
+      ss::shard_id shard,
+      const model::ntp& ntp,
+      ss::noncopyable_function<
+        ss::future<cluster::errc>(kafka::partition_proxy*)> fn) final {
+        return invoke_on_shard_impl(shard, ntp, std::move(fn));
+    }
+
+private:
+    ss::future<cluster::errc> invoke_on_shard_impl(
+      ss::shard_id shard,
+      const model::any_ntp auto& ntp,
+      ss::noncopyable_function<
+        ss::future<cluster::errc>(kafka::partition_proxy*)> fn) {
+        return _manager->invoke_on(
+          shard,
+          [ntp, fn = std::move(fn)](cluster::partition_manager& mgr) mutable {
+              auto pp = kafka::make_partition_proxy(ntp, mgr);
+              if (!pp || !pp->is_leader()) {
+                  return ss::make_ready_future<cluster::errc>(
+                    cluster::errc::not_leader);
+              }
+              return ss::do_with(
+                *std::move(pp),
+                [fn = std::move(fn)](kafka::partition_proxy& pp) {
+                    return fn(&pp);
+                });
+          });
+    }
+
+    ss::sharded<cluster::shard_table>* _table;
+    ss::sharded<cluster::partition_manager>* _manager;
+};
+} // namespace
+
+std::unique_ptr<partition_leader_cache>
+transform::rpc::partition_leader_cache::make_default(
+  ss::sharded<cluster::partition_leaders_table>* table) {
+    return std::make_unique<partition_leader_cache_impl>(table);
+}
+
+std::optional<model::node_id>
+partition_leader_cache::get_leader_node(const model::ntp& ntp) const {
+    return get_leader_node(model::topic_namespace_view(ntp), ntp.tp.partition);
+}
+
+std::unique_ptr<topic_metadata_cache>
+transform::rpc::topic_metadata_cache::make_default(
+  ss::sharded<cluster::metadata_cache>* cache) {
+    return std::make_unique<topic_metadata_cache_impl>(cache);
+}
+
+std::unique_ptr<partition_manager>
+transform::rpc::partition_manager::make_default(
+  ss::sharded<cluster::shard_table>* table,
+  ss::sharded<cluster::partition_manager>* manager) {
+    return std::make_unique<partition_manager_impl>(table, manager);
+}
+
+std::optional<ss::shard_id>
+partition_manager::shard_owner(const model::ktp& ktp) {
+    return shard_owner(ktp.to_ntp());
+}
+ss::future<cluster::errc> partition_manager::invoke_on_shard(
+  ss::shard_id shard_id,
+  const model::ktp& ktp,
+  ss::noncopyable_function<ss::future<cluster::errc>(kafka::partition_proxy*)>
+    fn) {
+    auto ntp = ktp.to_ntp();
+    co_return co_await invoke_on_shard(shard_id, ntp, std::move(fn));
+}
+} // namespace transform::rpc

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/fwd.h"
+#include "cluster/types.h"
+#include "kafka/server/partition_proxy.h"
+#include "model/fundamental.h"
+#include "model/ktp.h"
+#include "model/metadata.h"
+
+#include <seastar/util/noncopyable_function.hh>
+
+/**
+ * These are wrapper types for types defined outside this module, useful for
+ * testing without spinning up a full Redpanda cluster.
+ */
+
+namespace transform::rpc {
+
+/**
+ * A cache for which node owns a given partition leader.
+ */
+class partition_leader_cache {
+public:
+    partition_leader_cache() = default;
+    partition_leader_cache(const partition_leader_cache&) = delete;
+    partition_leader_cache(partition_leader_cache&&) = delete;
+    partition_leader_cache& operator=(const partition_leader_cache&) = delete;
+    partition_leader_cache& operator=(partition_leader_cache&&) = delete;
+    virtual ~partition_leader_cache() = default;
+
+    static std::unique_ptr<partition_leader_cache>
+    make_default(ss::sharded<cluster::partition_leaders_table>*);
+
+    /**
+     * Lookup which node owns a given ntp's leader.
+     */
+    std::optional<model::node_id> get_leader_node(const model::ntp& ntp) const;
+
+    virtual std::optional<model::node_id>
+      get_leader_node(model::topic_namespace_view, model::partition_id) const
+      = 0;
+};
+
+/**
+ * A cache for topic/partition metadata.
+ */
+class topic_metadata_cache {
+public:
+    topic_metadata_cache() = default;
+    topic_metadata_cache(const topic_metadata_cache&) = delete;
+    topic_metadata_cache(topic_metadata_cache&&) = delete;
+    topic_metadata_cache& operator=(const topic_metadata_cache&) = delete;
+    topic_metadata_cache& operator=(topic_metadata_cache&&) = delete;
+    virtual ~topic_metadata_cache() = default;
+
+    static std::unique_ptr<topic_metadata_cache>
+    make_default(ss::sharded<cluster::metadata_cache>*);
+
+    /**
+     * Lookup the topic configuration.
+     */
+    virtual std::optional<cluster::topic_configuration>
+      find_topic_cfg(model::topic_namespace_view) const = 0;
+
+    /**
+     * The default max batch bytes size.
+     */
+    virtual uint32_t get_default_batch_max_bytes() const = 0;
+};
+
+/**
+ * Handles routing for shard local partitions.
+ */
+class partition_manager {
+public:
+    partition_manager() = default;
+    partition_manager(const partition_manager&) = delete;
+    partition_manager(partition_manager&&) = delete;
+    partition_manager& operator=(const partition_manager&) = delete;
+    partition_manager& operator=(partition_manager&&) = delete;
+    virtual ~partition_manager() = default;
+
+    static std::unique_ptr<partition_manager> make_default(
+      ss::sharded<cluster::shard_table>*,
+      ss::sharded<cluster::partition_manager>*);
+
+    /**
+     * Lookup which shard owns a particular ntp.
+     */
+    virtual std::optional<ss::shard_id> shard_owner(const model::ktp& ktp);
+    virtual std::optional<ss::shard_id> shard_owner(const model::ntp&) = 0;
+
+    /**
+     * Invoke a function on the ntp's leader shard.
+     *
+     * Will return cluster::errc::not_leader if the shard_id is incorrect for
+     * that ntp.
+     */
+    virtual ss::future<cluster::errc> invoke_on_shard(
+      ss::shard_id shard_id,
+      const model::ktp& ktp,
+      ss::noncopyable_function<
+        ss::future<cluster::errc>(kafka::partition_proxy*)> fn);
+
+    virtual ss::future<cluster::errc> invoke_on_shard(
+      ss::shard_id,
+      const model::ntp&,
+      ss::noncopyable_function<
+        ss::future<cluster::errc>(kafka::partition_proxy*)>)
+      = 0;
+};
+
+}; // namespace transform::rpc

--- a/src/v/transform/rpc/logger.cc
+++ b/src/v/transform/rpc/logger.cc
@@ -1,0 +1,14 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "transform/rpc/logger.h"
+
+namespace transform::rpc {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)
+ss::logger log("transform/rpc");
+} // namespace transform::rpc

--- a/src/v/transform/rpc/logger.h
+++ b/src/v/transform/rpc/logger.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/util/log.hh>
+
+namespace transform::rpc {
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+extern ss::logger log;
+} // namespace transform::rpc

--- a/src/v/transform/rpc/rpc.json
+++ b/src/v/transform/rpc/rpc.json
@@ -1,0 +1,14 @@
+{
+    "namespace": "transform::rpc::impl",
+    "service_name": "transform_rpc",
+    "includes": [
+        "transform/rpc/serde.h"
+    ],
+    "methods": [
+        {
+            "name": "produce",
+            "input_type": "produce_request",
+            "output_type": "produce_reply"
+        }
+    ]
+}

--- a/src/v/transform/rpc/serde.cc
+++ b/src/v/transform/rpc/serde.cc
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/rpc/serde.h"
+
+#include "model/record.h"
+
+#include <seastar/core/chunked_fifo.hh>
+
+namespace transform::rpc {
+transformed_topic_data::transformed_topic_data(
+  model::topic_partition tp, model::record_batch b)
+  : tp(std::move(tp)) {
+    batches.reserve(1);
+    batches.push_back(std::move(b));
+}
+
+transformed_topic_data::transformed_topic_data(
+  model::topic_partition tp, ss::chunked_fifo<model::record_batch> b)
+  : tp(std::move(tp))
+  , batches(std::move(b)) {}
+
+transformed_topic_data transformed_topic_data::share() {
+    ss::chunked_fifo<model::record_batch> shared;
+    shared.reserve(batches.size());
+    for (auto& batch : batches) {
+        shared.push_back(batch.share());
+    }
+    return {tp, std::move(shared)};
+}
+
+produce_request produce_request::share() {
+    ss::chunked_fifo<transformed_topic_data> shared;
+    shared.reserve(topic_data.size());
+    for (auto& data : topic_data) {
+        shared.push_back(data.share());
+    }
+    return {std::move(shared), timeout};
+}
+} // namespace transform::rpc

--- a/src/v/transform/rpc/serde.h
+++ b/src/v/transform/rpc/serde.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/errc.h"
+#include "model/record.h"
+#include "model/timeout_clock.h"
+#include "model/transform.h"
+#include "serde/envelope.h"
+
+#include <seastar/core/chunked_fifo.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace transform::rpc {
+
+struct transformed_topic_data
+  : serde::envelope<
+      transformed_topic_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    transformed_topic_data() = default;
+    transformed_topic_data(model::topic_partition, model::record_batch);
+    transformed_topic_data(
+      model::topic_partition, ss::chunked_fifo<model::record_batch>);
+
+    model::topic_partition tp;
+    ss::chunked_fifo<model::record_batch> batches;
+
+    transformed_topic_data share();
+
+    auto serde_fields() { return std::tie(tp, batches); }
+};
+
+struct produce_request
+  : serde::
+      envelope<produce_request, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    produce_request() = default;
+    produce_request(
+      ss::chunked_fifo<transformed_topic_data> topic_data,
+      model::timeout_clock::duration timeout)
+      : topic_data{std::move(topic_data)}
+      , timeout{timeout} {}
+
+    auto serde_fields() { return std::tie(topic_data, timeout); }
+
+    produce_request share();
+
+    ss::chunked_fifo<transformed_topic_data> topic_data;
+    model::timeout_clock::duration timeout{};
+};
+
+struct transformed_topic_data_result
+  : serde::envelope<
+      transformed_topic_data_result,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    transformed_topic_data_result() = default;
+    transformed_topic_data_result(model::topic_partition tp, cluster::errc ec)
+      : tp(std::move(tp))
+      , err(ec) {}
+
+    model::topic_partition tp;
+    cluster::errc err{cluster::errc::success};
+
+    auto serde_fields() { return std::tie(tp, err); }
+};
+
+struct produce_reply
+  : serde::
+      envelope<produce_reply, serde::version<0>, serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    produce_reply() = default;
+    explicit produce_reply(ss::chunked_fifo<transformed_topic_data_result> r)
+      : results(std::move(r)) {}
+
+    auto serde_fields() { return std::tie(results); }
+
+    ss::chunked_fifo<transformed_topic_data_result> results;
+};
+
+} // namespace transform::rpc

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/rpc/service.h"
+
+#include "cluster/metadata_cache.h"
+#include "cluster/partition_manager.h"
+#include "cluster/shard_table.h"
+#include "cluster/types.h"
+#include "model/ktp.h"
+#include "model/metadata.h"
+#include "model/record_batch_reader.h"
+#include "model/timeout_clock.h"
+#include "raft/errc.h"
+#include "raft/types.h"
+#include "transform/rpc/serde.h"
+
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/semaphore.hh>
+
+#include <algorithm>
+#include <iterator>
+#include <system_error>
+#include <vector>
+
+namespace transform::rpc {
+namespace {
+raft::replicate_options
+make_replicate_options(model::timeout_clock::duration timeout) {
+    return {
+      raft::consistency_level::quorum_ack,
+      std::chrono::duration_cast<std::chrono::milliseconds>(timeout)};
+}
+cluster::errc map_errc(std::error_code ec) {
+    if (ec.category() == cluster::error_category()) {
+        return static_cast<cluster::errc>(ec.value());
+    }
+    if (ec.category() == raft::error_category()) {
+        switch (static_cast<raft::errc>(ec.value())) {
+        case raft::errc::not_leader:
+        case raft::errc::replicated_entry_truncated:
+            return cluster::errc::not_leader;
+        case raft::errc::shutting_down:
+        default:
+            return cluster::errc::timeout;
+        }
+    }
+    return cluster::errc::replication_error;
+}
+} // namespace
+
+local_service::local_service(
+  ss::sharded<cluster::shard_table>* shard_table,
+  ss::sharded<cluster::metadata_cache>* metadata_cache,
+  ss::sharded<cluster::partition_manager>* partition_manager)
+  : _shard_table(shard_table)
+  , _metadata_cache(metadata_cache)
+  , _partition_manager(partition_manager) {}
+
+ss::future<ss::chunked_fifo<transformed_topic_data_result>>
+local_service::produce(
+  ss::chunked_fifo<transformed_topic_data> topic_data,
+  model::timeout_clock::duration timeout) {
+    ss::chunked_fifo<transformed_topic_data_result> results;
+    constexpr size_t max_concurrent_produces = 10;
+    ss::semaphore sem(max_concurrent_produces);
+    co_await ss::parallel_for_each(
+      std::make_move_iterator(topic_data.begin()),
+      std::make_move_iterator(topic_data.end()),
+      [this, timeout, &results, &sem](transformed_topic_data data) {
+          return ss::with_semaphore(
+            sem,
+            1,
+            [this, timeout, &results, data = std::move(data)]() mutable {
+                return produce(std::move(data), timeout)
+                  .then([&results](transformed_topic_data_result r) {
+                      results.push_back(std::move(r));
+                  });
+            });
+      });
+    co_return results;
+}
+
+ss::future<transformed_topic_data_result> local_service::produce(
+  transformed_topic_data data, model::timeout_clock::duration timeout) {
+    auto ktp = model::ktp(data.tp.topic, data.tp.partition);
+    auto shard = _shard_table->local().shard_for(ktp);
+    if (!shard) {
+        co_return transformed_topic_data_result(
+          data.tp, cluster::errc::not_leader);
+    }
+
+    auto topic_cfg = _metadata_cache->local().get_topic_cfg(ktp.as_tn_view());
+    if (!topic_cfg) {
+        co_return transformed_topic_data_result(
+          data.tp, cluster::errc::topic_not_exists);
+    }
+    // TODO: More validation of the batches, such as null record rejection and
+    // crc checks.
+    uint32_t max_batch_size = topic_cfg->properties.batch_max_bytes.value_or(
+      _metadata_cache->local().get_default_batch_max_bytes());
+    for (const auto& batch : data.batches) {
+        if (uint32_t(batch.size_bytes()) > max_batch_size) [[unlikely]] {
+            co_return transformed_topic_data_result(
+              data.tp, cluster::errc::invalid_request);
+        }
+    }
+    auto rdr = model::make_foreign_fragmented_memory_record_batch_reader(
+      std::move(data.batches));
+    // TODO: schema validation
+    auto ec = co_await _partition_manager->invoke_on(
+      *shard,
+      [&ktp, timeout](
+        cluster::partition_manager& mgr,
+        model::record_batch_reader rdr) mutable {
+          auto partition = mgr.get(ktp);
+          if (!partition || !partition->is_leader()) {
+              return ss::make_ready_future<cluster::errc>(
+                cluster::errc::not_leader);
+          }
+          if (partition->is_read_replica_mode_enabled()) {
+              return ss::make_ready_future<cluster::errc>(
+                cluster::errc::invalid_request);
+          }
+          return partition
+            ->replicate(std::move(rdr), make_replicate_options(timeout))
+            .then([](result<cluster::kafka_result> result) {
+                if (result.has_error()) {
+                    return map_errc(result.assume_error());
+                }
+                return cluster::errc::success;
+            });
+      },
+      std::move(rdr));
+
+    co_return transformed_topic_data_result(data.tp, ec);
+}
+
+ss::future<produce_reply>
+network_service::produce(produce_request&& req, ::rpc::streaming_context&) {
+    auto results = co_await _service->local().produce(
+      std::move(req.topic_data), req.timeout);
+    co_return produce_reply(std::move(results));
+}
+
+} // namespace transform::rpc

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -1,0 +1,64 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "model/fundamental.h"
+#include "transform/rpc/rpc_service.h"
+#include "transform/rpc/serde.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace transform::rpc {
+
+/**
+ * A per core sharded service that handles custom data path requests for data
+ * transforms.
+ */
+class local_service {
+public:
+    local_service(
+      ss::sharded<cluster::shard_table>* shard_table,
+      ss::sharded<cluster::metadata_cache>* metadata_cache,
+      ss::sharded<cluster::partition_manager>* partition_manager);
+
+    ss::future<ss::chunked_fifo<transformed_topic_data_result>> produce(
+      ss::chunked_fifo<transformed_topic_data> topic_data,
+      model::timeout_clock::duration timeout);
+
+private:
+    ss::future<transformed_topic_data_result>
+      produce(transformed_topic_data, model::timeout_clock::duration);
+
+    ss::sharded<cluster::shard_table>* _shard_table;
+    ss::sharded<cluster::metadata_cache>* _metadata_cache;
+    ss::sharded<cluster::partition_manager>* _partition_manager;
+};
+
+/**
+ * A networked wrapper for the local service.
+ */
+class network_service final : public impl::transform_rpc_service {
+public:
+    network_service(
+      ss::scheduling_group sc,
+      ss::smp_service_group ssg,
+      ss::sharded<local_service>* service)
+      : impl::transform_rpc_service{sc, ssg}
+      , _service(service) {}
+
+    ss::future<produce_reply>
+    produce(produce_request&&, ::rpc::streaming_context&) override;
+
+private:
+    ss::sharded<local_service>* _service;
+};
+
+} // namespace transform::rpc

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -11,10 +11,13 @@
 
 #include "cluster/fwd.h"
 #include "model/fundamental.h"
+#include "transform/rpc/deps.h"
 #include "transform/rpc/rpc_service.h"
 #include "transform/rpc/serde.h"
 
 #include <seastar/core/sharded.hh>
+
+#include <memory>
 
 namespace transform::rpc {
 
@@ -25,9 +28,8 @@ namespace transform::rpc {
 class local_service {
 public:
     local_service(
-      ss::sharded<cluster::shard_table>* shard_table,
-      ss::sharded<cluster::metadata_cache>* metadata_cache,
-      ss::sharded<cluster::partition_manager>* partition_manager);
+      std::unique_ptr<topic_metadata_cache> metadata_cache,
+      std::unique_ptr<partition_manager> partition_manager);
 
     ss::future<ss::chunked_fifo<transformed_topic_data_result>> produce(
       ss::chunked_fifo<transformed_topic_data> topic_data,
@@ -37,9 +39,8 @@ private:
     ss::future<transformed_topic_data_result>
       produce(transformed_topic_data, model::timeout_clock::duration);
 
-    ss::sharded<cluster::shard_table>* _shard_table;
-    ss::sharded<cluster::metadata_cache>* _metadata_cache;
-    ss::sharded<cluster::partition_manager>* _partition_manager;
+    std::unique_ptr<topic_metadata_cache> _metadata_cache;
+    std::unique_ptr<partition_manager> _partition_manager;
 };
 
 /**

--- a/src/v/transform/rpc/tests/CMakeLists.txt
+++ b/src/v/transform/rpc/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+rp_test(
+  FIXTURE_TEST
+  GTEST
+  BINARY_NAME
+    transform_rpc
+  SOURCES
+    transform_rpc_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::transform_rpc
+    v::model_test_utils
+  ARGS "-- -c 1"
+  LABELS transform_rpc
+)

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -1,0 +1,478 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/errc.h"
+#include "cluster/types.h"
+#include "gmock/gmock.h"
+#include "kafka/server/partition_proxy.h"
+#include "model/fundamental.h"
+#include "model/ktp.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/tests/random_batch.h"
+#include "model/tests/randoms.h"
+#include "model/timeout_clock.h"
+#include "net/server.h"
+#include "net/types.h"
+#include "net/unresolved_address.h"
+#include "rpc/backoff_policy.h"
+#include "rpc/connection_cache.h"
+#include "rpc/rpc_server.h"
+#include "transform/rpc/client.h"
+#include "transform/rpc/deps.h"
+#include "transform/rpc/logger.h"
+#include "transform/rpc/service.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/scheduling.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/smp.hh>
+#include <seastar/net/socket_defs.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+namespace transform::rpc {
+
+namespace {
+
+// A small helper struct to allow copies for easier to read tests and
+// integration with gmock matchers.
+struct record_batches {
+    static record_batches make() {
+        record_batches batches;
+        batches.underlying.emplace_back(
+          model::test::make_random_batch({.count = 1}));
+        return batches;
+    }
+
+    record_batches() = default;
+    explicit record_batches(ss::chunked_fifo<model::record_batch> underlying)
+      : underlying(std::move(underlying)) {}
+    record_batches(record_batches&&) = default;
+    record_batches& operator=(record_batches&&) = default;
+    record_batches(const record_batches& b)
+      : underlying(copy(b.underlying)) {}
+    record_batches& operator=(const record_batches& b) {
+        if (this != &b) {
+            underlying = copy(b.underlying);
+        }
+        return *this;
+    }
+    ~record_batches() = default;
+
+    bool operator==(const record_batches& other) const {
+        return std::equal(
+          underlying.begin(),
+          underlying.end(),
+          other.underlying.begin(),
+          other.underlying.end());
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const record_batches& b) {
+        return os << ss::format("{}", b.underlying);
+    }
+
+    bool empty() const { return underlying.empty(); }
+    size_t size() const { return underlying.size(); }
+    auto begin() const { return underlying.begin(); }
+    auto end() const { return underlying.end(); }
+
+    ss::chunked_fifo<model::record_batch> underlying;
+
+private:
+    ss::chunked_fifo<model::record_batch>
+    copy(const ss::chunked_fifo<model::record_batch>& batches) {
+        ss::chunked_fifo<model::record_batch> copied;
+        for (const auto& b : batches) {
+            copied.push_back(b.copy());
+        }
+        return copied;
+    }
+};
+
+class fake_partition_leader_cache : public partition_leader_cache {
+public:
+    std::optional<model::node_id> get_leader_node(
+      model::topic_namespace_view tp_ns, model::partition_id p) const final {
+        auto ntp = model::ntp(tp_ns.ns, tp_ns.tp, p);
+        auto it = _leader_map.find(ntp);
+        if (it == _leader_map.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    void set_leader_node(const model::ntp& ntp, model::node_id nid) {
+        _leader_map.insert_or_assign(ntp, nid);
+        vassert(_leader_map.find(ntp) != _leader_map.end(), "what??");
+    }
+
+private:
+    absl::flat_hash_map<model::ntp, model::node_id> _leader_map;
+};
+
+class fake_topic_metadata_cache : public topic_metadata_cache {
+public:
+    std::optional<cluster::topic_configuration>
+    find_topic_cfg(model::topic_namespace_view tp_ns) const final {
+        auto it = _topic_cfgs.find(model::topic_namespace(tp_ns));
+        if (it == _topic_cfgs.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    }
+
+    void set_topic_cfg(
+      const model::topic_namespace& tp_ns, cluster::topic_configuration cfg) {
+        _topic_cfgs.insert_or_assign(tp_ns, std::move(cfg));
+    }
+
+    uint32_t get_default_batch_max_bytes() const final { return 1_MiB; };
+
+private:
+    absl::flat_hash_map<model::topic_namespace, cluster::topic_configuration>
+      _topic_cfgs;
+};
+
+struct produced_batch {
+    model::ntp ntp;
+    model::record_batch batch;
+};
+
+class fake_partition_manager : public partition_manager {
+public:
+    std::optional<ss::shard_id> shard_owner(const model::ntp& ntp) final {
+        auto it = _shard_locations.find(ntp);
+        if (it == _shard_locations.end()) {
+            return std::nullopt;
+        }
+        return it->second;
+    };
+
+    void set_shard_owner(const model::ntp& ntp, ss::shard_id shard_id) {
+        _shard_locations.insert_or_assign(ntp, shard_id);
+    }
+    void remove_shard_owner(const model::ntp& ntp) {
+        _shard_locations.erase(ntp);
+    }
+
+    record_batches partition_records(const model::ntp& ntp) {
+        record_batches batches;
+        for (const auto& produced : _produced_batches) {
+            if (produced.ntp == ntp) {
+                batches.underlying.emplace_back(produced.batch.copy());
+            }
+        }
+        return batches;
+    }
+
+    ss::future<cluster::errc> invoke_on_shard(
+      ss::shard_id shard_id,
+      const model::ntp& ntp,
+      ss::noncopyable_function<
+        ss::future<cluster::errc>(kafka::partition_proxy*)> fn) final {
+        auto owner = shard_owner(ntp);
+        if (!owner || shard_id != *owner) {
+            co_return cluster::errc::not_leader;
+        }
+        auto pp = kafka::partition_proxy(
+          std::make_unique<write_only_proxy>(ntp, &_produced_batches));
+        co_return co_await fn(&pp);
+    }
+
+private:
+    class write_only_proxy : public kafka::partition_proxy::impl {
+    public:
+        write_only_proxy(
+          model::ntp ntp, ss::chunked_fifo<produced_batch>* produced_batches)
+          : _ntp(std::move(ntp))
+          , _produced_batches(produced_batches) {}
+
+        const model::ntp& ntp() const final { return _ntp; }
+        ss::future<result<model::offset, kafka::error_code>>
+        sync_effective_start(model::timeout_clock::duration) final {
+            throw std::runtime_error("unimplemented");
+        }
+        model::offset start_offset() const final {
+            throw std::runtime_error("unimplemented");
+        }
+        model::offset high_watermark() const final {
+            throw std::runtime_error("unimplemented");
+        }
+        checked<model::offset, kafka::error_code>
+        last_stable_offset() const final {
+            throw std::runtime_error("unimplemented");
+        }
+        kafka::leader_epoch leader_epoch() const final {
+            throw std::runtime_error("unimplemented");
+        }
+        ss::future<std::optional<model::offset>>
+        get_leader_epoch_last_offset(kafka::leader_epoch) const final {
+            throw std::runtime_error("unimplemented");
+        }
+        bool is_elected_leader() const final { return true; }
+        bool is_leader() const final { return true; }
+        ss::future<std::error_code> linearizable_barrier() final {
+            throw std::runtime_error("unimplemented");
+        }
+        ss::future<kafka::error_code>
+        prefix_truncate(model::offset, ss::lowres_clock::time_point) final {
+            throw std::runtime_error("unimplemented");
+        }
+        ss::future<storage::translating_reader> make_reader(
+          storage::log_reader_config,
+          std::optional<model::timeout_clock::time_point>) final {
+            throw std::runtime_error("unimplemented");
+        }
+        ss::future<std::optional<storage::timequery_result>>
+        timequery(storage::timequery_config) final {
+            throw std::runtime_error("unimplemented");
+        }
+        ss::future<std::vector<cluster::rm_stm::tx_range>> aborted_transactions(
+          model::offset,
+          model::offset,
+          ss::lw_shared_ptr<const storage::offset_translator_state>) final {
+            throw std::runtime_error("unimplemented");
+        }
+        ss::future<kafka::error_code> validate_fetch_offset(
+          model::offset, bool, model::timeout_clock::time_point) final {
+            throw std::runtime_error("unimplemented");
+        }
+
+        ss::future<result<model::offset>> replicate(
+          model::record_batch_reader rdr, raft::replicate_options) final {
+            auto batches = co_await model::consume_reader_to_memory(
+              std::move(rdr), model::no_timeout);
+            for (const auto& batch : batches) {
+                _produced_batches->emplace_back(_ntp, batch.copy());
+            }
+            co_return _produced_batches->back().batch.last_offset();
+        }
+
+        raft::replicate_stages replicate(
+          model::batch_identity,
+          model::record_batch_reader&&,
+          raft::replicate_options) final {
+            throw std::runtime_error("unimplemented");
+        }
+
+        result<kafka::partition_info> get_partition_info() const override {
+            throw std::runtime_error("unimplemented");
+        }
+        cluster::partition_probe& probe() override {
+            throw std::runtime_error("unimplemented");
+        }
+
+    private:
+        model::ntp _ntp;
+        ss::chunked_fifo<produced_batch>* _produced_batches;
+    };
+
+    ss::chunked_fifo<produced_batch> _produced_batches;
+    model::ntp_flat_map_type<ss::shard_id> _shard_locations;
+};
+
+constexpr uint16_t test_server_port = 8080;
+constexpr model::node_id self_node = model::node_id(1);
+constexpr model::node_id other_node = model::node_id(2);
+
+class TransformRpcTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _as.start().get();
+
+        // remote node start
+        _remote_services
+          .start_single(
+            ss::sharded_parameter([this]() {
+                auto ftmc = std::make_unique<fake_topic_metadata_cache>();
+                _remote_ftmc = ftmc.get();
+                return ftmc;
+            }),
+            ss::sharded_parameter([this]() {
+                auto fpm = std::make_unique<fake_partition_manager>();
+                _remote_fpm = fpm.get();
+                return fpm;
+            }))
+          .get();
+
+        net::server_configuration scfg("transform_test_rpc_server");
+        scfg.addrs.emplace_back(ss::socket_address(test_server_port));
+        scfg.max_service_memory_per_core = 1_GiB;
+        scfg.disable_metrics = net::metrics_disabled::yes;
+        scfg.disable_public_metrics = net::public_metrics_disabled::yes;
+        _server = std::make_unique<::rpc::rpc_server>(scfg);
+        std::vector<std::unique_ptr<::rpc::service>> rpc_services;
+        rpc_services.push_back(std::make_unique<network_service>(
+          ss::default_scheduling_group(),
+          ss::default_smp_service_group(),
+          &_remote_services));
+        _server->add_services(std::move(rpc_services));
+        _server->start();
+
+        // start local node
+        _local_services
+          .start_single(
+            ss::sharded_parameter([this]() {
+                auto ftmc = std::make_unique<fake_topic_metadata_cache>();
+                _local_ftmc = ftmc.get();
+                return ftmc;
+            }),
+            ss::sharded_parameter([this]() {
+                auto fpm = std::make_unique<fake_partition_manager>();
+                _local_fpm = fpm.get();
+                return fpm;
+            }))
+          .get();
+        _conn_cache.start(std::ref(_as), std::nullopt).get();
+        ::rpc::transport_configuration tcfg(
+          net::unresolved_address("localhost", test_server_port));
+        tcfg.disable_metrics = net::metrics_disabled::yes;
+        _conn_cache.local()
+          .emplace(
+            other_node,
+            tcfg,
+            ::rpc::make_exponential_backoff_policy<ss::lowres_clock>(1s, 3s))
+          .get();
+
+        auto fplc = std::make_unique<fake_partition_leader_cache>();
+        _fplc = fplc.get();
+        _client = std::make_unique<rpc::client>(
+          self_node, std::move(fplc), &_conn_cache, &_local_services);
+    }
+    void TearDown() override {
+        _client->stop().get();
+        _client.reset();
+        _conn_cache.stop().get();
+        _server->stop().get();
+        _server.reset();
+        _local_services.stop().get();
+        _remote_services.stop().get();
+        _as.stop().get();
+        _local_ftmc = nullptr;
+        _local_fpm = nullptr;
+        _remote_ftmc = nullptr;
+        _remote_fpm = nullptr;
+        _fplc = nullptr;
+    }
+
+    void create_topic(const model::topic_namespace& tp_ns) {
+        cluster::topic_configuration tcfg{
+          tp_ns.ns,
+          tp_ns.tp,
+          /*partition_count=*/1,
+          /*replication_factor=*/1,
+        };
+        remote_metadata_cache()->set_topic_cfg(tp_ns, tcfg);
+        local_metadata_cache()->set_topic_cfg(tp_ns, tcfg);
+    }
+
+    void elect_leader(const model::ntp& ntp, model::node_id node_id) {
+        partition_leader_cache()->set_leader_node(ntp, node_id);
+        if (node_id == self_node) {
+            local_partition_manager()->set_shard_owner(
+              ntp, ss::this_shard_id());
+            remote_partition_manager()->remove_shard_owner(ntp);
+        } else if (node_id == other_node) {
+            remote_partition_manager()->set_shard_owner(
+              ntp, ss::this_shard_id());
+            local_partition_manager()->remove_shard_owner(ntp);
+        } else {
+            throw std::runtime_error(ss::format("unknown node_id {}", node_id));
+        }
+    }
+
+    cluster::errc produce(const model::ntp& ntp, record_batches batches) {
+        return client()->produce(ntp.tp, std::move(batches.underlying)).get();
+    }
+
+    record_batches remote_batches(const model::ntp& ntp) {
+        return remote_partition_manager()->partition_records(ntp);
+    }
+    record_batches local_batches(const model::ntp& ntp) {
+        return local_partition_manager()->partition_records(ntp);
+    }
+
+    // local node state
+    fake_topic_metadata_cache* local_metadata_cache() { return _local_ftmc; }
+    fake_partition_manager* local_partition_manager() { return _local_fpm; }
+    fake_partition_leader_cache* partition_leader_cache() { return _fplc; }
+    rpc::local_service* local_service() { return &_local_services.local(); }
+    client* client() { return _client.get(); }
+
+    // remote node state
+    fake_topic_metadata_cache* remote_metadata_cache() { return _remote_ftmc; }
+    fake_partition_manager* remote_partition_manager() { return _remote_fpm; }
+    rpc::local_service* remote_service() { return &_remote_services.local(); }
+
+private:
+    std::unique_ptr<::rpc::rpc_server> _server;
+    fake_topic_metadata_cache* _local_ftmc = nullptr;
+    fake_partition_manager* _local_fpm = nullptr;
+    fake_topic_metadata_cache* _remote_ftmc = nullptr;
+    fake_partition_manager* _remote_fpm = nullptr;
+    fake_partition_leader_cache* _fplc = nullptr;
+    ss::sharded<rpc::local_service> _local_services;
+    ss::sharded<rpc::local_service> _remote_services;
+    ss::sharded<::rpc::connection_cache> _conn_cache;
+    std::unique_ptr<rpc::client> _client;
+    ss::sharded<ss::abort_source> _as;
+};
+
+} // namespace
+
+model::ntp make_ntp(std::string_view topic) {
+    return {
+      model::kafka_namespace, model::topic(topic), model::partition_id(1)};
+}
+
+using ::testing::IsEmpty;
+
+TEST_F(TransformRpcTest, ClientCanProduceLocally) {
+    auto ntp = make_ntp("foo");
+    create_topic(model::topic_namespace(ntp.ns, ntp.tp.topic));
+    elect_leader(ntp, self_node);
+    auto batches = record_batches::make();
+    cluster::errc ec = produce(ntp, batches);
+    EXPECT_EQ(ec, cluster::errc::success);
+    EXPECT_THAT(remote_batches(ntp), IsEmpty());
+    EXPECT_EQ(local_batches(ntp), batches);
+}
+
+TEST_F(TransformRpcTest, ClientCanProduceOverRpc) {
+    auto ntp = make_ntp("foo");
+    create_topic(model::topic_namespace(ntp.ns, ntp.tp.topic));
+    elect_leader(ntp, other_node);
+    auto batches = record_batches::make();
+    cluster::errc ec = produce(ntp, batches);
+    EXPECT_EQ(ec, cluster::errc::success)
+      << cluster::error_category().message(int(ec));
+    EXPECT_THAT(local_batches(ntp), IsEmpty());
+    EXPECT_EQ(remote_batches(ntp), batches);
+}
+
+} // namespace transform::rpc


### PR DESCRIPTION
This introduces the internal RPCs needed for producing the output of Wasm powered data transforms.

The justifications for using internal RPCs instead of the Kafka API:
- Our internal RPC client is not designed to be low latency or high throughput
- Using internal RPCs allows us to use a seperate set of accounting, limits, quotas and metrics specific to transforms
- Internal RPCs allows us to re-use internal authentication mechanism (mTLS, etc) instead of needing to mess with ephemeral credentials

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
