### PR TITLE
Add comments about which stm_snapshot backend to use

### DIFF
--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -58,6 +58,10 @@ struct stm_snapshot {
     }
 };
 
+// stm_snapshots powered by a seperate file on disk.
+//
+// This is the default backend for stm_snapshots and works well when
+// there are very few partitions (ie for internal topics).
 class file_backed_stm_snapshot {
 public:
     file_backed_stm_snapshot(
@@ -79,6 +83,11 @@ private:
     size_t _snapshot_size{0};
 };
 
+// stm_snapshots powered by the kvstore.
+//
+// This backend is recommended when it's possible there will be many partitions
+// for a given stm, as the alternative (files) does not scale well with many
+// partitions.
 class kvstore_backed_stm_snapshot {
 public:
     kvstore_backed_stm_snapshot(


### PR DESCRIPTION
I was reading the source and had to go lookup in the cover letters of
the PR that introduced the kvstore snapshots to understand when I should
use files over kvstore snapshots. This might help future readers of the
code.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
