### PR TITLE
infinite_retention_test: bump scrub timeout

### DIFF
--- a/tests/rptest/infinite_retention/infinite_retention_test.py
+++ b/tests/rptest/infinite_retention/infinite_retention_test.py
@@ -735,8 +735,7 @@ class InfiniteRetentionTest(PreallocNodesTest):
             scrub_start = time.time()
             # Run 'rp_storage_tool' to check for anomalies
             try:
-                self.redpanda.stop_and_scrub_object_storage(
-                    run_timeout=self.params.target_runtime * 2)
+                self.redpanda.stop_and_scrub_object_storage(run_timeout=1800)
             except Exception as exc:
                 self.logger.warn("Exception detected while running scrub")
                 scrub_exceptions += [exc]


### PR DESCRIPTION
The test fails after a scrub takes 10 minutes since we're using target_runtime (300 * 2). This bumps the timeout to 1800, as is used elsewhere in this test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
