### PR TITLE
[v23.2.x] rptest: tweak cloud storage reader stress test 

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2402,8 +2402,7 @@ class RedpandaService(RedpandaServiceBase):
                 if ".bin" in m:
                     try:
                         decoded = RpStorageTool(
-                            self.logger).decode_partition_manifest(
-                                body, self.logger)
+                            self.logger).decode_partition_manifest(body)
                     except Exception as e:
                         self.logger.warn(f"Failed to decode {m}")
                     else:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13246
Fixes: https://github.com/redpanda-data/redpanda/issues/13287,