### PR TITLE
Add initial boilerplate for `rpk transform`

### DIFF
--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -30,6 +30,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/profile"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/registry"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/topic"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/transform"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cobraext"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -107,6 +108,7 @@ func Execute() {
 		plugincmd.NewCommand(fs),
 		registry.NewCommand(fs, p),
 		topic.NewCommand(fs, p),
+		transform.NewCommand(fs, p),
 		version.NewCommand(fs, p),
 
 		newStatusCommand(), // deprecated

--- a/src/go/rpk/pkg/cli/transform/transform.go
+++ b/src/go/rpk/pkg/cli/transform/transform.go
@@ -1,0 +1,27 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package transform
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(_ afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "transform",
+		Aliases: []string{"wasm", "transfrom"}, //nolint:misspell // auto correct a common misspelling
+		Short:   "Develop, deploy and manage Redpanda data transforms",
+	}
+	p.InstallKafkaFlags(cmd)
+	// TODO(rockwood): Add commands
+	return cmd
+}


### PR DESCRIPTION
Just add the subcommand and alias `wasm` for this command (less to
type). I also regularly misspell `transform` as `transfrom` so I added an alias for that common typo.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
