### PR TITLE
cloud_storage: set default upload interval

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1394,7 +1394,7 @@ configuration::configuration()
       "Time that segment can be kept locally without uploading it to the "
       "remote storage (sec)",
       {.visibility = visibility::tunable},
-      std::nullopt)
+      1h)
   , cloud_storage_manifest_max_upload_interval_sec(
       *this,
       "cloud_storage_manifest_max_upload_interval_sec",


### PR DESCRIPTION
Now that the archival metadata in-memory format has a smaller footprint and we have spillover, it's much safer to always upload. This sets the default value for the upload interval to 1hr, matching Redpanda's cloud offering.

Fixes #7652

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Tiered-storage partitions will now upload at least once an hour. See the `cloud_storage_segment_max_upload_interval_sec` cluster configuration for more details.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
