### PR TITLE
kvstore::start: Defer kvstore GC until after version check

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1839,6 +1839,12 @@ void application::start_bootstrap_services() {
     // as they start.
     load_feature_table_snapshot();
 
+    // save snapshot and finally GC segments
+    storage
+      .invoke_on_all(
+        [](storage::api& s) mutable { return s.kvs().do_startup_compaction(); })
+      .get();
+
     // Before we start up our bootstrapping RPC service, load any relevant
     // on-disk state we may need: existing cluster UUID, node ID, etc.
     if (std::optional<iobuf> cluster_uuid_buf = storage.local().kvs().get(

--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -540,6 +540,53 @@ class FeaturesUpgradeAssertionTest(FeaturesTestBase):
             upgrade_node,
             override_cfg_params={'upgrade_override_checks': True})
 
+    @cluster(num_nodes=3,
+             log_allow_list="Attempted to upgrade from incompatible version")
+    def test_data_dir_unmodified(self):
+        upgrade_node = self.redpanda.nodes[-1]
+        self.redpanda.restart_nodes([upgrade_node])
+        self.redpanda.stop_node(upgrade_node)
+
+        data_checksum_pre = self.redpanda.data_checksum(upgrade_node)
+        du_pre = self.redpanda.data_dir_usage('', node=upgrade_node)
+
+        self.redpanda.set_environment({
+            "__REDPANDA_LATEST_LOGICAL_VERSION":
+            self.head_latest_logical_version + 2,
+            "__REDPANDA_EARLIEST_LOGICAL_VERSION":
+            self.head_latest_logical_version + 1,
+        })
+
+        # Startup should fail with an incompatible version
+        with expect_exception(DucktapeTimeoutError, lambda _: True):
+            self.redpanda.start_node(upgrade_node)
+
+        # Don't assume that the asserted node will have exited promptly: explicitly kill it.
+        self.redpanda.stop_node(upgrade_node, forced=True)
+
+        data_checksum_post = self.redpanda.data_checksum(upgrade_node)
+        du_post = self.redpanda.data_dir_usage('', upgrade_node)
+
+        self.logger.debug(f"pre: {json.dumps(data_checksum_pre, indent=2)}")
+        self.logger.debug(f"post: {json.dumps(data_checksum_post, indent=2)}")
+        self.logger.debug(f"disk usage: pre({du_pre}) ; post({du_post}))")
+
+        errors = []
+        for k in data_checksum_pre.keys():
+            if any([k.find(f) >= 0 for f in ['kvstore', 'controller']
+                    ]) and k.find('base_index') == -1:
+                if k not in data_checksum_post.keys():
+                    errors.append(f"Missing file: {k}")
+                elif data_checksum_pre[k] != data_checksum_post[k]:
+                    errors.append(f"Checksum mismatch: {k}")
+
+        for k in data_checksum_post.keys():
+            if any([k.find(f) >= 0 for f in ['kvstore', 'controller']
+                    ]) and k.find('base_index') == -1:
+                if k not in data_checksum_pre.keys():
+                    errors.append(f"Extra file: {k}")
+        assert len(errors) == 0, f"errors: {errors}"
+
 
 class FeaturesUpgradeActivationTest(FeaturesTestBase):
     def setUp(self):


### PR DESCRIPTION
This commit refactors the kvstore startup recovery sequence to account for situations where an upgrade is halted due to an incompatible logical version, deferring opportunistic garbage segment collection until _after_ the logical version check.

This was done to account for the fact that a failed upgrade of this type requires a downgrade to a version compatible with the rest of an active cluster but possibly _not_ forward compatible with the newer version's kvstore.

Fixes [redpanda-data/core-internal/739](https://github.com/redpanda-data/core-internal/issues/739)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [x] v22.3.x

## Release Notes

### Improvements

* kvstore garbage collection occurs after logical version compatibility checks.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
