### PR TITLE
rptest: Add model based test based on Z3

### DIFF
--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -57,6 +57,7 @@ adjacent_segment_merger::adjacent_segment_merger(
 ss::future<> adjacent_segment_merger::stop() { return _gate.close(); }
 
 void adjacent_segment_merger::set_enabled(bool enabled) {
+    vlog(_ctxlog.trace, "Setting adjacent segment merger enabled: {}", enabled);
     _job_enabled = enabled;
 }
 
@@ -150,6 +151,11 @@ adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
     };
 
     if (!enabled()) {
+        vlog(
+          _ctxlog.trace,
+          "Adjacent segment merging is disabled, config: {}, job: {}",
+          _config_enabled(),
+          _job_enabled);
         co_return result;
     }
 

--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -79,7 +79,9 @@ std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
     model::offset so = _last;
     if (so == model::offset{} && _is_local) {
         // Local lookup, start from local start offset
-        so = local_start_offset;
+        so = std::max(
+          manifest.get_start_offset().value_or(local_start_offset),
+          local_start_offset);
     } else {
         // Remote lookup, start from start offset in the manifest (or 0)
         so = _archiver.manifest().get_start_offset().value_or(model::offset{0});
@@ -95,6 +97,7 @@ std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
       max_segment_size);
 
     adjacent_segment_run run(_archiver.get_ntp());
+
     for (auto it = manifest.segment_containing(so); it != manifest.end();
          ++it) {
         if (!_is_local && it->committed_offset >= local_start_offset) {

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -248,13 +248,17 @@ ss::future<> ntp_archiver::start() {
 
 void ntp_archiver::notify_leadership(std::optional<model::node_id> leader_id) {
     bool is_leader = leader_id && *leader_id == _parent.raft()->self().id();
+    vlog(
+      _rtclog.debug,
+      "notify_leadership: is_leader={}, leader_id={}, raft group id={}",
+      is_leader,
+      leader_id ? *leader_id : model::node_id{},
+      _parent.raft()->self().id());
     if (is_leader) {
         _leader_cond.signal();
     }
     if (_local_segment_merger) {
-        _local_segment_merger->set_enabled(
-          is_leader
-          && config::shard_local_cfg().cloud_storage_enable_segment_merging());
+        _local_segment_merger->set_enabled(is_leader);
     }
 
     if (_scrubber) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1296,8 +1296,13 @@ ss::future<> disk_log_impl::apply_segment_ms() {
                                        // bouncer condition checked this
     co_await last->release_appender(_readers_cache.get());
     auto offsets = last->offsets();
-    co_await new_segment(
-      offsets.committed_offset + model::offset{1}, offsets.term, pc);
+    auto new_so = model::next_offset(offsets.committed_offset);
+    co_await new_segment(new_so, offsets.term, pc);
+    vlog(
+      stlog.trace,
+      "{} segment.ms applied, new segment start offset: {}",
+      config().ntp(),
+      seg_ms.value());
 }
 
 ss::future<model::record_batch_reader>

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1613,20 +1613,20 @@ def get_tiered_storage_test_cases(fast_run=False):
         solutions.append(
             model.solve_for(ts_read() == True,
                             spillover_manifest_uploaded() == True))
-        solutions.append(
-            model.solve_for(ts_read() == True,
-                            spillover_manifest_uploaded() == True,
-                            segment_rolled_by_timeout() == True))
+        # solutions.append(
+        #     model.solve_for(ts_read() == True,
+        #                     spillover_manifest_uploaded() == True,
+        #                     segment_rolled_by_timeout() == True))
         solutions.append(
             model.solve_for(ts_read() == True,
                             ts_txrange_materialized() == True))
         solutions.append(
             model.solve_for(ts_read() == True,
                             adjacent_segment_merger_reupload() == True))
-        solutions.append(
-            model.solve_for(ts_read() == True,
-                            adjacent_segment_merger_reupload() == True,
-                            segment_rolled_by_timeout() == True))
+        # solutions.append(
+        #     model.solve_for(ts_read() == True,
+        #                     adjacent_segment_merger_reupload() == True,
+        #                     segment_rolled_by_timeout() == True))
         solutions.append(
             model.solve_for(ts_read() == True,
                             ts_timequery() == True,

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1,0 +1,1675 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from collections.abc import Callable
+from typing import Any, List, Optional, Dict
+from functools import reduce
+from collections import defaultdict
+import z3
+from threading import Lock
+from abc import ABC, abstractclassmethod
+import os
+import sys
+import random
+
+from enum import Enum
+from logging import Logger
+import logging
+
+TestRunStage = Enum(
+    "TestRunStage",
+    ["Startup", "Produce", "Intermediate", "Consume", "Shutdown"])
+
+CONFIDENCE_THRESHOLD = 0.8
+FAKE_BASE_TIMESTAMP_MS = 1690000000000
+FAKE_TIMESTAMP_STEP_MS = 1
+LOG_SEGMENT_SIZE = 1024 * 1024
+LARGE_SEGMENT_SIZE = 2 * LOG_SEGMENT_SIZE
+LOCAL_TARGET_SIZE = LARGE_SEGMENT_SIZE
+SPILLOVER_MANIFEST_SIZE = 5
+LOW_THRESHOLD = 1
+
+
+class TieredStorageEndToEndTest(ABC):
+    """Tiered storage interface which is consumed by
+    validators and inputs."""
+    @abstractclassmethod
+    def set_redpanda_cluster_config(self,
+                                    config_name: str,
+                                    config_value: Any | None,
+                                    needs_restart: bool = False):
+        """Set redpanda cluster configuration.
+        param config_name: name of the configuration parameter
+        param config_value: value of the configuration parameter or None if the parameter should be removed
+        param needs_restart: True if the configuration change requires restart"""
+        pass
+
+    @abstractclassmethod
+    def get_redpanda_service(self):
+        pass
+
+    @abstractclassmethod
+    def get_bucket_view(self):
+        pass
+
+    @abstractclassmethod
+    def get_ntp(self):
+        pass
+
+    @abstractclassmethod
+    def get_logger(self) -> Logger:
+        pass
+
+    @abstractclassmethod
+    def get_public_metric(self, metric_name: str):
+        """Get metric value or None if the metric is not available"""
+        pass
+
+    @abstractclassmethod
+    def get_private_metric(self, metric_name: str):
+        """Get metric value or None if the metric is not available"""
+        pass
+
+    @abstractclassmethod
+    def alter_topic_config(self, config_name: str, config_value: str):
+        """Change topic configuration using rpk"""
+        pass
+
+    @abstractclassmethod
+    def subscribe_to_logs(self, validator, pattern):
+        """Subscribe to all log changes on all nodes. The validator will be invoked
+        when the log line is matched."""
+        pass
+
+    @abstractclassmethod
+    def set_consumer_parameters(self, **kwargs):
+        pass
+
+
+class Model:
+    """Tiered-storage model expressed in Z3 terms.
+    Model manages all conditions and relationships between them.
+    Once the test run is solved its job is to translate from the
+    representation used by Z3 to the actual objects."""
+
+    __default = None  # default model instance used by all tests
+
+    def __init__(self):
+        self.__solver = z3.Solver()
+        self.__table = {}
+        self.__curr_expr = []
+
+    @classmethod
+    def default(cls):
+        if cls.__default is None:
+            cls.__default = cls()
+        return cls.__default
+
+    def _register(self, cond):
+        self.__table[cond.name] = cond
+
+    def add(self, s_expr):
+        self.__curr_expr.append(s_expr)
+
+    def solve_for(self, *s_expr_list):
+        print(f"solving for {s_expr_list}")
+        results = []
+        args = [s for s in s_expr_list] + self.__curr_expr
+        self.__solver.push()
+        self.__solver.add(z3.And(*args))
+        try:
+            if self.__solver.check() == z3.sat:
+                m = self.__solver.model()
+                for d in m.decls():
+                    if str(d) in self.__table:
+                        print(f"Model parameter {d} = {m[d]}")
+                        # Only add the expression if it's a boolean set to True
+                        # The validators can only check that something is present. The
+                        # input modifiers can only enable something which is disabled by
+                        # default. This simplifies the model a lot.
+                        if m[d] == True:
+                            results.append(self.__table[str(d)])
+            else:
+                raise ValueError("Unsatisfiable")
+        finally:
+            # Backtrack
+            self.__solver.pop()
+        return str(s_expr_list), results
+
+    def find_all_solutions(self, parameters):
+        def get_combination(ix):
+            result = []
+            for p in parameters:
+                val = p[ix % len(p)]
+                result.append(val)
+                ix = ix // len(p)
+            return result
+
+        total_combinations = reduce(lambda a, b: a * b,
+                                    [len(p) for p in parameters])
+        print(f"total {total_combinations} combinations")
+        results = []
+        for ix in range(0, total_combinations):
+            comb = get_combination(ix)
+            print(f"solving {ix}")
+            results.append(self.solve_for(*comb))
+        return results
+
+
+class TestInput(ABC):
+    """Base class for all test state modifiers. Test inputs include
+    produced data, configuration parameters, topic configuration
+    parameters, etc. It can also be used to represent things which
+    are applied during test runtime. Things like failure injection and
+    random process restarts.
+    """
+    @abstractclassmethod
+    def name(self) -> str:
+        """Get name of the input mutator"""
+        pass
+
+    @abstractclassmethod
+    def start(self, test: TieredStorageEndToEndTest):
+        """Initialize input before the first use"""
+        pass
+
+    @abstractclassmethod
+    def run(self, test: TieredStorageEndToEndTest):
+        """Apply input (should only be called if need_to_run returns True)"""
+        pass
+
+    @abstractclassmethod
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        """Return True if the input need to be applied during this test execution stage"""
+        pass
+
+
+class EffectValidator(ABC):
+    """Base class for all test effect validators. Example of an effect is
+    a segment or manifest upload. Each effect can be validated by sampling
+    the state of the test periodically. For instance, the validator may
+    check the metric or look for the log messages.
+
+    The validator is stateful. Each observation changes its state. The end result
+    is produced when the validator has observed the even enough times. The
+    validator exposes two parameters: the result which can be True or False and the
+    confidence level which is a probability in 0.0 to 1.0 range.
+
+    Some validators can only run in certain stages of the test (produce or consume).
+    These validators have to check the status of the test internally. The test is
+    expected to be passed in the c-tor.
+
+    The validator can interfere with the test by prolonging certain test stages (this
+    is why it's called "validator" and not "observer"). For instance, the validator
+    may require test to run until the confidence reaches certain level.
+    """
+    @abstractclassmethod
+    def name(self) -> str:
+        """Get name of the validator"""
+        pass
+
+    @abstractclassmethod
+    def start(self, test: TieredStorageEndToEndTest):
+        pass
+
+    @abstractclassmethod
+    def run(self, test: TieredStorageEndToEndTest):
+        """Run checks incrementally"""
+        pass
+
+    @abstractclassmethod
+    def get_result(self) -> Optional[bool]:
+        """Return True if the effect is validated to be present or False if it's
+        validated to be not present. Return None if not enough information was
+        gathered."""
+        pass
+
+    @abstractclassmethod
+    def get_confidence(self) -> float:
+        """Get confidence level as value in [0-1] range"""
+        pass
+
+    @abstractclassmethod
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        """Return True if the validator need to run during this test execution stage"""
+        pass
+
+
+class Expression:
+    """Base class for both inputs and effects"""
+    def __init__(self,
+                 model: Model,
+                 name: str,
+                 _type: bool,
+                 maybe_comment: Optional[str] = None):
+        self.__name = name
+        self.__type = _type
+        if self.__type not in ["Bool", "Int", "Offset"]:
+            raise ValueError(f"can't initialize {name}, unknown type {_type}")
+        if self.__type == "Bool":
+            self.__expr = z3.Bool(name)
+        elif self.__type == "Int":
+            self.__expr = z3.Int(name)
+        elif self.__type == "Offset":
+            self.__expr = z3.Int(name)
+        self.__comment = maybe_comment
+        model._register(self)
+
+    @property
+    def name(self):
+        return self.__name
+
+    @property
+    def expr(self):
+        return self.__expr
+
+    def __call__(self):
+        return self.__expr
+
+    @property
+    def type_str(self):
+        return self.__type
+
+    @property
+    def comment(self):
+        return self.__comment
+
+    def requires(self, *s_expr_list):
+        """Request some preconditions to be met
+        Example:
+          ts_read.requires(cache_read == True)
+        Method returns s-expression that should be added
+        to the model explicitly.
+        Example:
+          se = ts_read.requires(cache_read == True)
+          model.add(se)
+        """
+        # Invariant: the s_expression should be boolean
+        s_expr = z3.And(
+            [z3.Implies(self.__expr == True, se) for se in s_expr_list])
+        return s_expr
+
+    def inv_requires(self, *s_expr_list):
+        """Similar to 'requires' but current condition is flipped"""
+        s_expr = z3.And(
+            [z3.Implies(self.__expr == False, se) for se in s_expr_list])
+        return s_expr
+
+    def __str__(self):
+        short_str = None
+        short_len = 48
+        if self.__comment is None:
+            short_str = f"{self.__name}:{self.__type}"
+        else:
+            short_str = f"{self.__name}:{self.__type}:{self.__comment}"
+        if len(short_str) < short_len:
+            short_str = short_str.ljust(short_len, '.')
+            return f"Expr[{short_str}]"
+        short_str = short_str[0:(short_len - 1)]
+        short_str = short_str.ljust(short_len, '>')
+        return f"Expr[{short_str}]"
+
+    def __eq__(self, val):
+        if isinstance(val, Expression):
+            return self.__expr == val()
+        return self.__expr == val
+
+    def __lt__(self, val):
+        if isinstance(val, Expression):
+            return self.__expr < val()
+        return self.__expr < val
+
+    def __gt__(self, val):
+        if isinstance(val, Expression):
+            return self.__expr > val()
+        return self.__expr > val
+
+    def __le__(self, val):
+        if isinstance(val, Expression):
+            return self.__expr <= val()
+        return self.__expr <= val
+
+    def __ge__(self, val):
+        if isinstance(val, Expression):
+            return self.__expr >= val()
+        return self.__expr >= val
+
+    def __ne__(self, val):
+        if isinstance(val, Expression):
+            return self.__expr != val()
+        return self.__expr != val
+
+    def __truediv__(self, val):
+        if isinstance(val, Expression):
+            return self.__expr / val()
+        return self.__expr / val
+
+    def make_inputs(self) -> List[TestInput]:
+        """Create set of input for the test"""
+        return []
+
+    def make_validators(self) -> List[EffectValidator]:
+        """Create set of effect observers to run while the data is produced or consumed"""
+        return []
+
+
+class LogBasedValidator(EffectValidator):
+    """Checks that the object is uploaded to S3"""
+    def __init__(self,
+                 name,
+                 pattern,
+                 confidence_threshold=10,
+                 execution_stage=TestRunStage.Produce):
+        self.__confidence_threshold = confidence_threshold
+        self.__name = name
+        self.__num_matches = 0
+        self.__confidence = 0.0
+        self.__pattern = pattern
+        self.__exec_stage = execution_stage
+        self.__logger = None
+
+    def start(self, test: TieredStorageEndToEndTest):
+        """Set initial state using the test instance"""
+        self.__logger = test.get_logger()
+        test.get_logger().info(
+            f"starting validator {self.__name}, pattern {self.__pattern}, threshold {self.__confidence_threshold}"
+        )
+        test.subscribe_to_logs(self, self.__pattern)
+
+    def on_match(self, node_name, line):
+        self.__logger.debug(
+            f"Validator {self.__name} got matching log line {line} on node {node_name}"
+        )
+        self.__num_matches += 1
+        self.__confidence = max(
+            min(self.__num_matches / self.__confidence_threshold, 0.0), 1.0)
+
+    def name(self) -> str:
+        """Get name of the validator"""
+        return self.__name
+
+    def run(self, test: TieredStorageEndToEndTest):
+        # This validator gets updated by the test runner through
+        # the callback
+        pass
+
+    def get_result(self) -> Optional[bool]:
+        """Return True if the effect is validated to be present or False if it's
+        validated to be not present. Return None if not enough information was
+        gathered."""
+        return self.__num_matches > 0
+
+    def get_confidence(self) -> float:
+        """Get confidence level as value in [0-1] range"""
+        return self.__confidence
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        """Return True if the validator need to run during this test execution stage"""
+        return stage == self.__exec_stage
+
+
+class LogUniquenessValidator(EffectValidator):
+    lock = Lock()
+    """Checks that the object is uploaded to S3"""
+    def __init__(self,
+                 name,
+                 pattern,
+                 confidence_threshold=10,
+                 execution_stage=TestRunStage.Produce):
+        self.__confidence_threshold = confidence_threshold
+        self.__name = name
+        self.__matches = defaultdict(set)
+        self.__duplicates = 0
+        self.__confidence = 0.0
+        self.__pattern = pattern
+        self.__exec_stage = execution_stage
+        self.__logger = None
+        self.__subscribed = False
+
+    def start(self, test: TieredStorageEndToEndTest):
+        """Set initial state using the test instance"""
+        with LogUniquenessValidator.lock:
+            assert self.__subscribed == False, f"start() called twice for {self.__name}"
+            self.__logger = test.get_logger()
+            test.get_logger().info(
+                f"starting validator {self.__name}, pattern {self.__pattern}, threshold {self.__confidence_threshold}"
+            )
+            test.subscribe_to_logs(self, self.__pattern)
+            self.__subscribed = True
+
+    def on_match(self, node_name, line):
+        with LogUniquenessValidator.lock:
+            orig = line
+            line = line[30:]  # Remove timestamp and log-level
+
+            if line not in self.__matches[node_name]:
+                self.__logger.debug(
+                    f"Validator {self.__name} got matching log line \"{orig}\" from {node_name}"
+                )
+                if self.__duplicates > 0:
+                    # The validator has seen duplicates already. No need to continue collecting.
+                    return
+                self.__matches[node_name].add(line)
+                total_matches = sum([len(v) for v in self.__matches.values()])
+                self.__confidence = max(
+                    min(total_matches / self.__confidence_threshold, 0.0), 1.0)
+                return
+
+            self.__logger.error(
+                f"Validator {self.__name} got duplicate log line \"{orig}\" from {node_name}"
+            )
+            lines = self.__matches.get(node_name) or []
+            for l in lines:
+                self.__logger.error(f"    previous entry: {l}")
+            self.__confidence = 1.0
+            self.__duplicates += 1
+
+    def name(self) -> str:
+        """Get name of the validator"""
+        return self.__name
+
+    def run(self, test: TieredStorageEndToEndTest):
+        # This validator gets updated by the test runner through
+        # the callback
+        pass
+
+    def get_result(self) -> Optional[bool]:
+        """Return True if the effect is validated to be present or False if it's
+        validated to be not present. Return None if not enough information was
+        gathered."""
+        with LogUniquenessValidator.lock:
+            return len(self.__matches) > 0 and self.__duplicates == 0
+
+    def get_confidence(self) -> float:
+        """Get confidence level as value in [0-1] range"""
+        with LogUniquenessValidator.lock:
+            return self.__confidence
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        """Return True if the validator need to run during this test execution stage"""
+        return stage == self.__exec_stage
+
+
+class MetricBasedValidator(EffectValidator):
+    """Checks that the object is uploaded to S3"""
+    def __init__(self,
+                 name,
+                 metric_name,
+                 confidence_threshold=10,
+                 execution_stage=TestRunStage.Produce):
+        self.__confidence_threshold = confidence_threshold
+        self.__name = name
+        self.__num_checks = 0
+        self.__baseline = None
+        self.__confidence = 0.0
+        self.__result = False
+        self.__metric_name = metric_name
+        self.__exec_stage = execution_stage
+
+    def start(self, test: TieredStorageEndToEndTest):
+        """Set initial state using the test instance"""
+        test.get_logger().info(
+            f"starting validator {self.__name}, metric {self.__metric_name}, threshold {self.__confidence_threshold}"
+        )
+
+    def __get_metric(self, test: TieredStorageEndToEndTest):
+        """Fetch the metric from the table of metrics using test instance"""
+        metric = test.get_public_metric(self.__metric_name)
+        if metric is None:
+            metric = test.get_private_metric(self.__metric_name)
+        test.get_logger().debug(
+            f"metric {self.__metric_name} is equal to {metric}")
+        return metric
+
+    def name(self) -> str:
+        """Get name of the validator"""
+        return self.__name
+
+    def run(self, test: TieredStorageEndToEndTest):
+        metric_value = self.__get_metric(test)
+        if metric_value is None:
+            # Metric is not produced yet, the baseline hast
+            # to be set to None in this case.
+            return
+
+        if self.__baseline is None:
+            # This is the first time we see the metric value. Use it as a baseline.
+            self.__baseline = metric_value
+
+        delta = metric_value - self.__baseline
+        self.__num_checks += 1
+        # Require at least one upload for the positive result
+        self.__result = delta > 0
+        # Recompute confidence level based on new observation
+        self.__confidence = max(min(delta / self.__confidence_threshold, 0.0),
+                                1.0)
+
+    def get_result(self) -> Optional[bool]:
+        """Return True if the effect is validated to be present or False if it's
+        validated to be not present. Return None if not enough information was
+        gathered."""
+        return self.__result
+
+    def get_confidence(self) -> float:
+        """Get confidence level as value in [0-1] range"""
+        return self.__confidence
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        """Return True if the validator need to run during this test execution stage"""
+        return stage == self.__exec_stage
+
+
+class BucketBasedValidator(EffectValidator):
+    """Validator that uses bucket state to validate the effect"""
+    def __init__(self, name, execution_stage=TestRunStage.Produce):
+        self.__name = name
+        self.__num_checks = 0
+        self.__result = False
+        self.__exec_stage = execution_stage
+
+    def start(self, test: TieredStorageEndToEndTest):
+        """Set initial state using the test instance"""
+        test.get_logger().info(
+            f"starting bucket based validator {self.__name}")
+
+    def name(self) -> str:
+        """Get name of the validator"""
+        return self.__name
+
+    def _do_check(self, bucket_view, ntp, logger=None) -> bool:
+        return False
+
+    def run(self, test: TieredStorageEndToEndTest):
+        if self.__result == True:
+            return
+        bucket_view = test.get_bucket_view()
+        if bucket_view is None:
+            return
+        ntp = test.get_ntp()
+        res = self._do_check(bucket_view, ntp, test.get_logger())
+        self.__num_checks += 1
+        # Require at least one upload for the positive result
+        self.__result = res
+
+    def get_result(self) -> Optional[bool]:
+        """Return True if the effect is validated to be present or False if it's
+        validated to be not present. Return None if not enough information was
+        gathered."""
+        return self.__result
+
+    def get_confidence(self) -> float:
+        """Bucket validator always gives certain result because it's checking the
+        end state and not counting events."""
+        return 1.0 if self.__num_checks > 0 else 0.0
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        """Return True if the validator need to run during this test execution stage"""
+        return stage == self.__exec_stage
+
+
+class TopicConfigInput(TestInput):
+    def __init__(self, name, config, value, stage=TestRunStage.Startup):
+        self.__name = name
+        self.__config = config
+        self.__value = value
+        self.__stage = stage
+
+    def name(self) -> str:
+        return self.__name
+
+    def start(self, test: TieredStorageEndToEndTest):
+        pass
+
+    def run(self, test: TieredStorageEndToEndTest):
+        test.alter_topic_config(self.__config, self.__value)
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        return stage == self.__stage
+
+
+class ClusterConfigInput(TestInput):
+    def __init__(self,
+                 name,
+                 configs: Dict[str, str],
+                 stage=TestRunStage.Startup,
+                 restart_required=False):
+        self.__name = name
+        self.__configs = configs
+        self.__stage = stage
+        self.__restart_required = restart_required
+
+    def name(self) -> str:
+        return self.__name
+
+    def run(self, test: TieredStorageEndToEndTest):
+        for config, value in self.__configs.items():
+            test.set_redpanda_cluster_config(
+                config, value, needs_restart=self.__restart_required)
+
+    def start(self, test: TieredStorageEndToEndTest):
+        pass
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        return stage == self.__stage
+
+
+class RandomizedClusterConfigInput(TestInput):
+    def __init__(self, name, stages, configs: List[Dict[str, str]]):
+        self.__name = name
+        self.__configs = configs
+        self.__stages = stages
+
+    def name(self) -> str:
+        return self.__name
+
+    def start(self, test: TieredStorageEndToEndTest):
+        choice = random.choice(self.__configs)
+        for config, value in choice.items():
+            test.set_redpanda_cluster_config(config, value)
+
+    def run(self, test: TieredStorageEndToEndTest):
+        choice = random.choice(self.__configs)
+        for config, value in choice.items():
+            test.set_redpanda_cluster_config(config, value)
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        return stage in self.__stages
+
+
+class ConsumerInput(TestInput):
+    def __init__(self, name, params):
+        self.__name = name
+        self.__params = params
+
+    def name(self) -> str:
+        return self.__name
+
+    def start(self, test: TieredStorageEndToEndTest):
+        test.set_consumer_parameters(**self.__params)
+
+    def run(self, test: TieredStorageEndToEndTest):
+        pass
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        return stage == TestRunStage.Consume
+
+
+class ProducerInput(TestInput):
+    def __init__(self, name, params):
+        self.__name = name
+        self.__params = params
+
+    def name(self) -> str:
+        return self.__name
+
+    def start(self, test: TieredStorageEndToEndTest):
+        test.get_logger().info(
+            f"{self.name} setting producer parameters {self.__params}")
+        test.set_producer_parameters(**self.__params)
+
+    def run(self, test: TieredStorageEndToEndTest):
+        pass
+
+    def need_to_run(self, stage: TestRunStage) -> bool:
+        return stage == TestRunStage.Produce
+
+
+class TS_Write(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_Write", "Bool",
+                         "Segment is uploaded to S3")
+
+    class Bucket_validator(BucketBasedValidator):
+        def __init__(self):
+            super().__init__("TS_Bucket_Write")
+
+        def _do_check(self, bucket_view, ntp, logger) -> bool:
+            return bucket_view.segment_objects > 0
+
+    def make_validators(self) -> List[EffectValidator]:
+        """Create set of effect observers to run while the data is produced or consumed"""
+        return [
+            MetricBasedValidator(
+                "TS_Write",
+                "vectorized_cloud_storage_successful_uploads_total",
+                execution_stage=TestRunStage.Produce),
+            LogBasedValidator(
+                "TS_STM_Write",
+                "Add segment command applied.*is_compacted: false",
+                execution_stage=TestRunStage.Produce),
+            TS_Write.Bucket_validator(),
+            # account.ssh_capture('tail -f') gives us false positives
+            # LogUniquenessValidator("TS_NoDuplicates",
+            #                        "Add segment command applied with",
+            #                        execution_stage=TestRunStage.Produce),
+        ]
+
+
+class TS_Read(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_Read", "Bool",
+                         "Segment is downloaded from S3")
+
+    def make_validators(self) -> List[EffectValidator]:
+        return [
+            MetricBasedValidator(
+                "TS_Read",
+                "vectorized_cloud_storage_successful_downloads_total",
+                execution_stage=TestRunStage.Consume)
+        ]
+
+
+class SegmentRoll(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "SegmentRoll", "Bool", "Segment is rolled")
+
+    def make_validators(self) -> List[EffectValidator]:
+        """Create set of effect observers to run while the data is produced or consumed"""
+        # TODO: implement log based validator
+        return [
+            MetricBasedValidator(
+                "SegmentRoll",
+                "vectorized_storage_log_log_segments_created_total",
+                execution_stage=TestRunStage.Produce)
+        ]
+
+
+class SegmentsRemoved(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "SegmentsRemoved", "Bool",
+                         "Segments are removed from local storage")
+
+    def make_validators(self) -> List[EffectValidator]:
+        """Create set of effect observers to run while the data is produced or consumed"""
+        return [
+            MetricBasedValidator(
+                "SegmentsRemoved",
+                "vectorized_storage_log_log_segments_removed_total",
+                execution_stage=TestRunStage.Intermediate)
+        ]
+
+
+class ApplySpilloverTriggered(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(
+            model, "SpilloverHousekeepingTriggered", "Bool",
+            "Housekeeping triggered spillover in the ntp_archiver")
+
+    def make_validators(self) -> List[EffectValidator]:
+        """Create set of effect observers to run while the data is produced or consumed"""
+        return [
+            LogBasedValidator("TS_HousekeepingSpillover",
+                              "Spillover command applied",
+                              confidence_threshold=LOW_THRESHOLD)
+        ]
+
+
+class TS_ManifestUploaded(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_ManifestUploaded", "Bool",
+                         "Manifest is uploaded to S3")
+
+    def make_validators(self) -> List[EffectValidator]:
+        return [
+            MetricBasedValidator(
+                "TS_ManifestUploaded_metric",
+                "vectorized_cloud_storage_partition_manifest_uploads_total")
+        ]
+
+
+class SpilloverManifestUploaded(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "SpilloverManifestUploaded", "Bool",
+                         "Spillover manifest is uploaded")
+
+    class Bucket_validator(BucketBasedValidator):
+        def __init__(self):
+            super().__init__("SpilloverManifestUploaded_bucket")
+
+        def _do_check(self, bucket_view, ntp, logger):
+            spm = bucket_view.get_spillover_manifests(ntp)
+            return spm is not None
+
+    def make_validators(self) -> List[EffectValidator]:
+        """Create set of effect observers to run while the data is produced or consumed"""
+        return [
+            MetricBasedValidator(
+                "SpilloverManifestUpload",
+                "redpanda_cloud_storage_spillover_manifest_uploads_total",
+                confidence_threshold=LOW_THRESHOLD,
+                execution_stage=TestRunStage.Produce),
+            LogBasedValidator("TS_SpilloverManifestUploaded",
+                              "Uploaded spillover manifest",
+                              confidence_threshold=LOW_THRESHOLD),
+            # Check that the spillover manifests are uploaded to the bucket for
+            # the ntp
+            SpilloverManifestUploaded.Bucket_validator(),
+        ]
+
+
+class AdjacentSegmentMergerReupload(Expression):
+    """Checks that adjacent segment reupload is triggered"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "AdjacentSegmentMergerReupload", "Bool",
+                         "Adjacent segment reupload is triggered")
+
+    def make_validators(self) -> List[EffectValidator]:
+        """Create set of validators"""
+        return [
+            LogBasedValidator(
+                "AdjacentSegmentMergerReupload",
+                "adjacent_segment_merger.*Successfuly uploaded segment",
+                confidence_threshold=LOW_THRESHOLD)
+        ]
+
+
+class CompactedReupload(Expression):
+    """Checks that compacted segment reupload is triggered"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "CompactedSegmentReupload", "Bool",
+                         "Compacted segment reupload is triggered")
+
+    class Bucket_validator(BucketBasedValidator):
+        def __init__(self):
+            super().__init__("CompactedSegmentReupload_bucket")
+
+        def _do_check(self, bucket_view, ntp, logger) -> bool:
+            num_compacted = 0
+            manifest = bucket_view.partition_manifests[ntp]
+            for _, sm in manifest['segments'].items():
+                if sm['is_compacted'] == True:
+                    num_compacted += 1
+            return num_compacted > 0
+
+    def make_validators(self) -> List[EffectValidator]:
+        """Create set of validators"""
+        return [
+            LogBasedValidator("CompactedSegmentReupload_CandidateFound",
+                              "segment_reupload.*Found segment for ntp",
+                              confidence_threshold=LOW_THRESHOLD),
+            LogBasedValidator(
+                "CompactedSegmentReupload_STM_Updated",
+                "Add segment command applied.*is_compacted: true",
+                confidence_threshold=LOW_THRESHOLD),
+            CompactedReupload.Bucket_validator(),
+        ]
+
+
+class TopicCompactionEnabled(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TopicCompactionEnabled", "Bool",
+                         "Topic compaction is enabled")
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            TopicConfigInput("TopicCompactionEnabled_topic_config",
+                             "cleanup.policy", "compact,delete"),
+            ProducerInput("TopicCompactionEnable_producer_config", {
+                "key_set_cardinality": 500,
+                "msg_count": 100000
+            }),
+            ClusterConfigInput(
+                "TopicCompactionEnabled_rp_config",
+                dict(max_compacted_log_segment_size=LOG_SEGMENT_SIZE))
+        ]
+
+
+class RemoteWriteTopicConfig(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "RemoteWriteTopicConfig", "Bool",
+                         "redpanda.remote.write topic property is set")
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            TopicConfigInput("RemoteWriteTopicConfig", "redpanda.remote.write",
+                             "true")
+        ]
+
+
+class RemoteReadTopicConfig(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "RemoteReadTopicConfig", "Bool",
+                         "redpanda.remote.read topic property is set")
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            TopicConfigInput("RemoteReadTopicConfig", "redpanda.remote.read",
+                             "true")
+        ]
+
+
+class RemoteWriteClusterConfig(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "RemoteWriteClusterConfig", "Bool",
+                         "cloud_storage_enable_remote_write config is set")
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            ClusterConfigInput("RemoteWriteClusterConfig",
+                               {"cloud_storage_enable_remote_write": "true"})
+        ]
+
+
+class RemoteReadClusterConfig(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "RemoteReadClusterConfig", "Bool",
+                         "cloud_storage_enable_remote_read config is set")
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            ClusterConfigInput("RemoteReadClusterConfig",
+                               {"cloud_storage_enable_remote_read": "true"})
+        ]
+
+
+class ShortLocalRetentionTopicConfig(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(
+            model, "ShortLocalRetentionTopicConfig", "Bool",
+            "retention.local.target.bytes config is set to small value (1 segment size)"
+        )
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            TopicConfigInput(
+                "ShortLocalRetentionTopicConfig",
+                # Local retention should be long enough to allow segment merging
+                # but low enough to allow remote reads to happen
+                "retention.local.target.bytes",
+                str(LOCAL_TARGET_SIZE),
+                stage=TestRunStage.Intermediate)
+        ]
+
+
+class EnableSpillover(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(
+            model, "EnableSpillover", "Bool",
+            "Spillover is enabled by setting cloud_storage_spillover_manifest_max_segments to small value"
+        )
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            ClusterConfigInput(
+                "EnableSpillover",
+                dict(cloud_storage_spillover_manifest_max_segments=
+                     SPILLOVER_MANIFEST_SIZE))
+        ]
+
+
+class TS_Housekeeping(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(
+            model, "TS_Housekeeping", "Bool",
+            "Housekeeping is enabled by setting cloud_storage_housekeeping_interval_ms to small value"
+        )
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            ClusterConfigInput(
+                "TS_Housekeeping",
+                {"cloud_storage_housekeeping_interval_ms": "2000"})
+        ]
+
+
+class LocalStorageHousekeeping(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "LocalStorageHousekeeping", "Bool",
+                         "Housekeeping in the local storage is triggered")
+
+    def make_validators(self) -> List[EffectValidator]:
+        return [
+            LogBasedValidator("LocalStorageHousekeeping",
+                              "house keeping with configuration from manager",
+                              confidence_threshold=LOW_THRESHOLD)
+        ]
+
+
+class EnableAdjacentSegmentMerging(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "EnableAdjacentSegmentMerging", "Bool",
+                         "Adjacent segment merging is enabled")
+
+    def make_inputs(self):
+        return [
+            ClusterConfigInput(
+                "EnableAdjacentSegmentMerging",
+                dict(cloud_storage_enable_segment_merging=True,
+                     cloud_storage_segment_size_target=LARGE_SEGMENT_SIZE))
+        ]
+
+
+class EnableCompactedSegmentReupload(Expression):
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "EnableCompactedSegmentReupload", "Bool",
+                         "Compacted segment reupload is enabled")
+
+    def make_inputs(self):
+        return [
+            ClusterConfigInput(
+                "EnableCompactedSegmentReupload",
+                dict(cloud_storage_enable_compacted_topic_reupload=True))
+        ]
+
+
+class SegmentSelfCompaction(Expression):
+    """Segment was self compacted in the local storage"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "SegmentSelfCompaction", "Bool",
+                         "Segment was self compacted")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator("SegmentSelfCompaction",
+                              "segment .* compaction result: .*",
+                              confidence_threshold=LOW_THRESHOLD)
+        ]
+
+
+class AdjacentSegmentCompaction(Expression):
+    """Adjacent segments compacted in the local storage"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "AdjacentSegmentCompaction", "Bool",
+                         "Adjacent segments were compacted")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator("AdjacentSegmentCompaction",
+                              "Adjacent segments of .*, compaction result",
+                              confidence_threshold=LOW_THRESHOLD)
+        ]
+
+
+class TS_Timequery(Expression):
+    """Timequery is used with tiered-storage"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_Timequery", "Bool", "Timequery is used")
+
+    def make_inputs(self) -> List[TestInput]:
+        return [
+            ProducerInput(
+                "TS_Timequery",
+                dict(fake_timestamp_ms=FAKE_BASE_TIMESTAMP_MS,
+                     fake_timestamp_step_ms=FAKE_TIMESTAMP_STEP_MS))
+        ]
+
+
+class TS_ChunkedRead(Expression):
+    """Chunked read from the tiered-storage"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_ChunkedRead", "Bool",
+                         "Chunked read is used")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator("TS_ChunkedRead_log",
+                              pattern="chunk received, chunk length",
+                              execution_stage=TestRunStage.Consume),
+            # Disabled because metric is always 0.0 (TODO: investigate)
+            # MetricBasedValidator(
+            #     "TS_ChunkedRead_metric",
+            #     "vectorized_cloud_storage_read_path_chunks_hydrated_total",
+            #     execution_stage=TestRunStage.Consume)
+        ]
+
+
+class EnableChunkedRead(Expression):
+    """Chunked reads are enabled"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "EnableChunkedRead", "Bool",
+                         "Chunked reads are enabled")
+
+    def make_inputs(self):
+        return [
+            ClusterConfigInput("EnableChunkedRead",
+                               {"cloud_storage_disable_chunk_reads": "true"})
+        ]
+
+
+class TS_TxRangeMaterialized(Expression):
+    """tx-manifest is downloaded and used when reading from the topic"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_TxRangeMaterialized", "Bool",
+                         "tx-manifest is used when reading from the topic")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator(
+                "TS_TxRangeMaterialized",
+                # This pattern is used by two messages, one is added to the log
+                # when the tx-range is available in the local cache and the
+                # other one is added when the tx-range is already materialized.
+                pattern="materialize tx_range",
+                confidence_threshold=LOW_THRESHOLD,
+                execution_stage=TestRunStage.Consume)
+        ]
+
+
+class TransactionsAborted(Expression):
+    """Produces uses transactions and aborts some of them"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TransactionsAborted", "Bool",
+                         "Transactions are aborted")
+
+    def make_inputs(self):
+        return [
+            ProducerInput(
+                "TransactionsAborted_producer_input",
+                dict(
+                    use_transactions=True,
+                    transaction_abort_rate=0.1,
+                    msgs_per_transaction=10,
+                ))
+        ]
+
+
+class TS_UploadIntervalTriggerWrite(Expression):
+    """Segment upload triggered by time limit"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_UploadIntervalTriggerWrite", "Bool",
+                         "Segment upload triggered by time limit")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator("TS_TimeboxedWrite",
+                              pattern="Using adjusted segment name",
+                              confidence_threshold=LOW_THRESHOLD,
+                              execution_stage=TestRunStage.Produce)
+        ]
+
+
+class EnableUploadInterval(Expression):
+    """Timeboxed uploads are enabled"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "EnableUploadInterval", "Bool",
+                         "Timeboxed uploads are enabled")
+
+    def make_inputs(self):
+        return [
+            # Set upload interval to very low value
+            ClusterConfigInput(
+                "EnableUploadInterval_config",
+                {"cloud_storage_segment_max_upload_interval_sec": 1},
+                restart_required=True)
+        ]
+
+
+class TS_Delete(Expression):
+    """The segment is deleted from the cloud storage"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_Delete", "Bool",
+                         "Segment is deleted from the cloud storage")
+
+    def make_validators(self):
+        return [
+            # We currently don't have metric for S3 delete
+            LogBasedValidator("TS_Delete_log",
+                              "remote.*Delete object",
+                              execution_stage=TestRunStage.Intermediate),
+        ]
+
+
+class TS_STM_DeleteByGC(Expression):
+    """Segment deletion triggered by garbage collection"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_STM_DeleteByGC", "Bool",
+                         "Segment deletion triggered by garbage collection")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator(
+                "TS_STM_DeleteByGC_log",
+                "ntp_archiver_service.*Deleted segment from cloud storage",
+                execution_stage=TestRunStage.Intermediate),
+        ]
+
+
+class TS_STM_GarbageCollect(Expression):
+    """GC is applied to the data in the STM"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_STM_GarbageCollect", "Bool",
+                         "GC is applied to the data in the STM")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator(
+                "TS_STM_GarbageCollect_log",
+                # The spillover GC uses similar line that has 'spillover' after
+                # the number of segments. We need to make sure that we don't
+                # match it by using more precise pattern.
+                "ntp_archiver_service.*Deleted \d* segments from the cloud",
+                confidence_threshold=LOW_THRESHOLD,
+                execution_stage=TestRunStage.Intermediate),
+        ]
+
+
+class TS_STM_SizeBasedRetentionApplied(Expression):
+    """Size based retention is triggered in tiered-storage in the STM region of the log"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(
+            model, "TS_STM_SizeBasedRetentionApplied", "Bool",
+            "Size based retention is triggered in tiered-storage")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator(
+                "TS_STM_SizeBasedRetention_log",
+                "ntp_archiver_service.*size_based_retention.*Advancing start offset to .* satisfy retention policy",
+                confidence_threshold=LOW_THRESHOLD,
+                execution_stage=TestRunStage.Intermediate),
+        ]
+
+
+class TS_Spillover_DeleteByGC(Expression):
+    """Segment deletion from the archive triggered by garbage collection"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_Spillover_DeleteByGC", "Bool",
+                         "Segment deletion triggered by garbage collection")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator(
+                "TS_Spillover_DeleteByGC_log",
+                # NOTE: this pattern is used by two messages, but there are two
+                # different places in the code that use it. One is used for
+                # deleting spillover segments and the other one is used for
+                # STM segments.
+                # TODO: update one of the log messages
+                "ntp_archiver_service.*Deleting segment from cloud storage",
+                execution_stage=TestRunStage.Intermediate),
+        ]
+
+
+class TS_Spillover_GarbageCollect(Expression):
+    """GC is applied to the data in the spillover region of the log"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(
+            model, "TS_Spillover_GarbageCollect", "Bool",
+            "GC is applied to the data in the spillover region of the log")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator(
+                "TS_Spillover_GarbageCollect_log",
+                "ntp_archiver_service.*Deleted .* spillover segments from the cloud",
+                confidence_threshold=LOW_THRESHOLD,
+                execution_stage=TestRunStage.Intermediate),
+        ]
+
+
+class TS_Spillover_SizeBasedRetentionApplied(Expression):
+    """Size based retention is applied to the data in the spillover region of the log"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(
+            model, "TS_Spillover_SizeBasedRetentionApplied", "Bool",
+            "Size based retention is applied to the data in the spillover region of the log"
+        )
+
+    def make_validators(self):
+        return [
+            LogBasedValidator(
+                "TS_Spillover_SizeBasedRetention_log",
+                "ntp_archiver_service.*Archive truncated to offset",
+                confidence_threshold=LOW_THRESHOLD,
+                execution_stage=TestRunStage.Intermediate),
+        ]
+
+
+class TS_Spillover_ManifestDeleted(Expression):
+    """Spillover manifest deleted from the cloud storage"""
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(model, "TS_Spillover_ManifestDeleted", "Bool",
+                         "Spillover manifest deleted from the cloud storage")
+
+    def make_validators(self):
+        return [
+            LogBasedValidator(
+                "TS_Spillover_ManifestDeleted_log",
+                "ntp_archiver_service.*Deleting spillover manifest from cloud storage",
+                confidence_threshold=LOW_THRESHOLD,
+                execution_stage=TestRunStage.Intermediate),
+        ]
+
+
+class TS_SmallSizeBasedRetentionTopicConfig(Expression):
+    """Size based retention is set for the topic using
+    retention.bytes config. The retention is set to very small
+    value.
+    """
+    def __init__(self, model: Model = Model.default()):
+        super().__init__(
+            model, "TS_SmallSizeBasedRetentionTopicConfig", "Bool",
+            "Size based retention is set for the topic using retention.bytes config"
+        )
+
+    def make_inputs(self):
+        return [
+            # Set retention to very small value to trigger size based retention
+            # in the STM region and in the archive. In this case the retention is
+            # equal to local.target size.
+            TopicConfigInput(
+                "TS_SmallSizeBasedRetentionTopicConfig",
+                "retention.bytes",
+                # This has to be larger than local target size to allow
+                # reads from the cloud storage. Otherwise the reads will
+                # be served by the local storage only.
+                str(2 * LOCAL_TARGET_SIZE),
+                stage=TestRunStage.Intermediate)
+        ]
+
+
+class TestCase(dict):
+    """Base class for test cases"""
+    def __init__(self, validators, inputs, name="None"):
+        self.__validators = validators
+        self.__inputs = inputs
+        self.__name = name
+        dict.__init__(self, name=name)
+
+    def __str__(self):
+        return self.__name
+
+    def validators(self) -> List[EffectValidator]:
+        """All validators which are needed to be checked by the test case"""
+        return self.__validators
+
+    def inputs(self) -> List[TestInput]:
+        """All inputs which are needed to set up the test case"""
+        return self.__inputs
+
+    def assert_validators(self, test: TieredStorageEndToEndTest):
+        """Check that all validators are done and raise error if
+        some of them failed."""
+        num_failed = 0
+        for v in self.validators():
+            r = v.get_result()
+            c = v.get_confidence()
+            if r is not None:
+                test.get_logger().info(
+                    f"Result of {v.name()} is {r} with confidence {c}")
+                if r == False or c < 0.5:
+                    num_failed += 1
+            else:
+                test.get_logger().info(f"Result of {v.name()} is None")
+        assert num_failed == 0, f"{num_failed} validators failed"
+
+
+def get_tiered_storage_test_cases(fast_run=False):
+    model = Model.default()
+    ts_read = TS_Read()
+    ts_write = TS_Write()
+    ts_delete = TS_Delete()
+    ts_manifest_uploaded = TS_ManifestUploaded()
+    ts_housekeeping = TS_Housekeeping()
+    segment_roll = SegmentRoll()
+    segments_removed = SegmentsRemoved()
+    local_housekeeping = LocalStorageHousekeeping()
+    short_local_retention = ShortLocalRetentionTopicConfig()
+    topic_remote_read = RemoteReadTopicConfig()
+    topic_remote_write = RemoteWriteTopicConfig()
+    global_remote_read = RemoteReadClusterConfig()
+    global_remote_write = RemoteWriteClusterConfig()
+    # Spillover
+    spillover_enabled = EnableSpillover()
+    spillover_manifest_uploaded = SpilloverManifestUploaded()
+    ts_apply_spillover = ApplySpilloverTriggered()
+    # Retention in the STM region
+    ts_stm_size_based_retention_applied = TS_STM_SizeBasedRetentionApplied()
+    ts_stm_garbage_collect = TS_STM_GarbageCollect()
+    ts_stm_delete_by_gc = TS_STM_DeleteByGC()
+    # Retention in the spillover region
+    ts_spillover_size_based_retention_applied = TS_Spillover_SizeBasedRetentionApplied(
+    )
+    ts_spillover_garbage_collect = TS_Spillover_GarbageCollect()
+    ts_spillover_delete_by_gc = TS_Spillover_DeleteByGC()
+    ts_spillover_manifest_deleted = TS_Spillover_ManifestDeleted()
+    # Retention topic config
+    ts_small_size_based_retention_topic_config = TS_SmallSizeBasedRetentionTopicConfig(
+    )
+    # Timequery
+    ts_timequery = TS_Timequery()
+    # ASM
+    adjacent_segment_merger_reupload = AdjacentSegmentMergerReupload()
+    adjacent_segment_merging_enabled = EnableAdjacentSegmentMerging()
+    # Compaction
+    compacted_segment_reupload = CompactedReupload()
+    enable_compacted_reupload = EnableCompactedSegmentReupload()
+    segment_self_compaction = SegmentSelfCompaction()
+    topic_is_compacted = TopicCompactionEnabled()
+    adjacent_segment_compaction = AdjacentSegmentCompaction()
+    # Chunked reads
+    enable_chunked_reads = EnableChunkedRead()
+    ts_chunked_read = TS_ChunkedRead()
+    # Upload interval
+    enable_upload_interval = EnableUploadInterval()
+    upload_interval_triggered = TS_UploadIntervalTriggerWrite()
+    # Transactions
+    ts_txrange_materialized = TS_TxRangeMaterialized()
+    transactions_aborted = TransactionsAborted()
+
+    model.add(ts_write.requires(segment_roll() == True))
+    model.add(
+        ts_write.requires(
+            z3.Or(topic_remote_write() == True,
+                  global_remote_write() == True)))
+    model.add(
+        ts_read.requires(
+            z3.Or(topic_remote_read() == True,
+                  global_remote_read() == True)))
+    model.add(ts_manifest_uploaded() == ts_write())
+    model.add(ts_read.requires(ts_write() == True))
+    model.add(ts_read.requires(segments_removed() == True))
+    model.add(
+        segments_removed.requires(
+            z3.And(short_local_retention() == True,
+                   local_housekeeping() == True)))
+    model.add(ts_chunked_read.requires(ts_read() == True))
+    model.add(ts_chunked_read.requires(enable_chunked_reads() == True))
+    model.add(
+        spillover_manifest_uploaded.requires(spillover_enabled() == True))
+    model.add(spillover_manifest_uploaded.requires(ts_write() == True))
+    model.add(ts_apply_spillover.requires(ts_housekeeping() == True))
+    model.add(
+        spillover_manifest_uploaded.requires(ts_apply_spillover() == True))
+    model.add(
+        adjacent_segment_merger_reupload.requires(
+            adjacent_segment_merging_enabled() == True))
+    model.add(segment_self_compaction.requires(local_housekeeping() == True))
+    model.add(
+        compacted_segment_reupload.requires(
+            z3.And(segment_self_compaction() == True,
+                   topic_is_compacted() == True,
+                   enable_compacted_reupload() == True)))
+    # Multiple segments can be compacted and merged only if the topic
+    # config is set and segments are self compacted
+    model.add(
+        adjacent_segment_compaction.requires(
+            z3.And(topic_is_compacted() == True,
+                   segment_self_compaction() == True)))
+
+    # We need enable upload interval to see uploads triggered by timeout
+    # We also need uploads to happen (this is not precise definition but its
+    # good enough for this test, the upload can be started even if the segment
+    # is not rolled)
+    model.add(
+        upload_interval_triggered.requires(enable_upload_interval() == True))
+    model.add(upload_interval_triggered.requires(ts_write() == True))
+
+    # Aborted transactions
+    model.add(ts_txrange_materialized.requires(transactions_aborted() == True))
+    model.add(ts_txrange_materialized.requires(ts_read() == True))
+
+    # Retention in the STM region
+    model.add(ts_stm_delete_by_gc.requires(ts_stm_garbage_collect() == True))
+    model.add(
+        ts_stm_garbage_collect.requires(
+            ts_stm_size_based_retention_applied() == True))
+    model.add(
+        ts_stm_size_based_retention_applied.requires(
+            ts_housekeeping() == True))
+    model.add(ts_stm_size_based_retention_applied.requires(ts_write() == True))
+    # Retention in the spillover region
+    model.add(
+        ts_spillover_delete_by_gc.requires(
+            ts_spillover_garbage_collect() == True))
+    model.add(
+        ts_spillover_garbage_collect.requires(
+            ts_spillover_size_based_retention_applied() == True))
+    model.add(
+        ts_spillover_size_based_retention_applied.requires(
+            ts_housekeeping() == True))
+    model.add(
+        ts_delete.requires(
+            z3.Or(ts_stm_delete_by_gc() == True,
+                  ts_spillover_delete_by_gc() == True)))
+    model.add(
+        ts_spillover_manifest_deleted.requires(
+            ts_spillover_delete_by_gc() == True))
+    model.add(
+        ts_spillover_size_based_retention_applied.requires(
+            spillover_manifest_uploaded() == True))
+    # Set retention
+    model.add(
+        ts_stm_size_based_retention_applied.requires(
+            ts_small_size_based_retention_topic_config() == True))
+    model.add(
+        ts_spillover_size_based_retention_applied.requires(
+            ts_small_size_based_retention_topic_config() == True))
+
+    tc_list = []
+
+    solutions = []
+    if fast_run:
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            ts_chunked_read() == True))
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            ts_timequery() == True))
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            spillover_manifest_uploaded() == True))
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            ts_txrange_materialized() == True))
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            adjacent_segment_merger_reupload() == True))
+        # solutions.append(model.solve_for(ts_read() == True, ts_timequery() == True, spillover_manifest_uploaded() == True))
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            compacted_segment_reupload() == True,
+                            adjacent_segment_compaction() == True))
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            ts_txrange_materialized() == True,
+                            spillover_manifest_uploaded() == True))
+        # solutions.append(model.solve_for(ts_read() == True, adjacent_segment_merger_reupload() == True, spillover_manifest_uploaded() == True))
+        solutions.append(
+            model.solve_for(ts_delete() == True,
+                            spillover_manifest_uploaded() == True,
+                            ts_spillover_manifest_deleted() == True))
+        solutions.append(
+            model.solve_for(ts_delete() == True,
+                            adjacent_segment_compaction() == True))
+    else:
+        # Check that we can enable uploads using both topic level config
+        # and cluster level config.
+        solutions += model.find_all_solutions([
+            [
+                ts_read() == True,
+            ],
+            [
+                topic_remote_read() == True,
+                global_remote_read() == True,
+            ],
+            [
+                topic_remote_write() == True,
+                global_remote_write() == True,
+            ],
+        ])
+
+        # Check all combinations without timequery. Also, use only one method
+        # to enable tiered-storage to limit number of test cases.
+        solutions += model.find_all_solutions([
+            [
+                ts_read() == True,
+                ts_delete() == True,
+            ],
+            [
+                compacted_segment_reupload() == True,
+                compacted_segment_reupload() == False,
+            ],
+            [
+                ts_txrange_materialized() == True,
+                ts_txrange_materialized() == False,
+            ],
+            [
+                ts_chunked_read() == True,
+                ts_chunked_read() == False,
+            ],
+            [
+                upload_interval_triggered() == True,
+                upload_interval_triggered() == False,
+            ],
+            [
+                spillover_manifest_uploaded() == True,
+                spillover_manifest_uploaded() == False,
+            ],
+        ])
+
+        # Check timequery. Note that the compaction and transactions are not used
+        # because timequery check does not support them yet.
+        solutions += model.find_all_solutions([
+            [
+                ts_read() == True,
+            ],
+            [
+                ts_timequery() == True,
+            ],
+            [
+                adjacent_segment_merger_reupload() == True,
+                adjacent_segment_merger_reupload() == False,
+            ],
+            [
+                ts_chunked_read() == True,
+                ts_chunked_read() == False,
+            ],
+            [
+                upload_interval_triggered() == True,
+                upload_interval_triggered() == False,
+            ],
+            [
+                spillover_manifest_uploaded() == True,
+                spillover_manifest_uploaded() == False,
+            ],
+        ])
+
+    for desc, solution in solutions:
+        val_list = []
+        inp_list = []
+        for c in solution:
+            for v in c.make_validators():
+                val_list.append(v)
+            for i in c.make_inputs():
+                inp_list.append(i)
+        tc = TestCase(val_list, inp_list, name=desc)
+        tc_list.append(tc)
+    return tc_list
+
+
+if __name__ == '__main__':
+    cases = get_tiered_storage_test_cases(True)
+    for c in cases:
+        print(f"test case {c}")
+        for v in c.validators():
+            print(f"  validator {v.name()}")
+        for i in c.inputs():
+            print(f"  input {i.name()}")
+    print(f"found {len(cases)} test cases")

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -241,22 +241,23 @@ class EffectValidator(ABC):
         pass
 
 
+ExpressionType = Enum("ExpressionType", ["Bool", "Int", "Offset"])
+
+
 class Expression:
     """Base class for both inputs and effects"""
     def __init__(self,
                  model: Model,
                  name: str,
-                 _type: bool,
+                 _type: ExpressionType,
                  maybe_comment: Optional[str] = None):
         self.__name = name
         self.__type = _type
-        if self.__type not in ["Bool", "Int", "Offset"]:
-            raise ValueError(f"can't initialize {name}, unknown type {_type}")
-        if self.__type == "Bool":
+        if self.__type == ExpressionType.Bool:
             self.__expr = z3.Bool(name)
-        elif self.__type == "Int":
+        elif self.__type == ExpressionType.Int:
             self.__expr = z3.Int(name)
-        elif self.__type == "Offset":
+        elif self.__type == ExpressionType.Offset:
             self.__expr = z3.Int(name)
         self.__comment = maybe_comment
         model._register(self)
@@ -722,7 +723,7 @@ class ProducerInput(TestInput):
 
 class TS_Write(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_Write", "Bool",
+        super().__init__(model, "TS_Write", ExpressionType.Bool,
                          "Segment is uploaded to S3")
 
     class Bucket_validator(BucketBasedValidator):
@@ -753,7 +754,7 @@ class TS_Write(Expression):
 
 class TS_Read(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_Read", "Bool",
+        super().__init__(model, "TS_Read", ExpressionType.Bool,
                          "Segment is downloaded from S3")
 
     def make_validators(self) -> List[EffectValidator]:
@@ -767,7 +768,8 @@ class TS_Read(Expression):
 
 class SegmentRoll(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "SegmentRoll", "Bool", "Segment is rolled")
+        super().__init__(model, "SegmentRoll", ExpressionType.Bool,
+                         "Segment is rolled")
 
     def make_validators(self) -> List[EffectValidator]:
         """Create set of effect observers to run while the data is produced or consumed"""
@@ -782,7 +784,7 @@ class SegmentRoll(Expression):
 
 class SegmentsRemoved(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "SegmentsRemoved", "Bool",
+        super().__init__(model, "SegmentsRemoved", ExpressionType.Bool,
                          "Segments are removed from local storage")
 
     def make_validators(self) -> List[EffectValidator]:
@@ -798,7 +800,7 @@ class SegmentsRemoved(Expression):
 class ApplySpilloverTriggered(Expression):
     def __init__(self, model: Model = Model.default()):
         super().__init__(
-            model, "SpilloverHousekeepingTriggered", "Bool",
+            model, "SpilloverHousekeepingTriggered", ExpressionType.Bool,
             "Housekeeping triggered spillover in the ntp_archiver")
 
     def make_validators(self) -> List[EffectValidator]:
@@ -812,7 +814,7 @@ class ApplySpilloverTriggered(Expression):
 
 class TS_ManifestUploaded(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_ManifestUploaded", "Bool",
+        super().__init__(model, "TS_ManifestUploaded", ExpressionType.Bool,
                          "Manifest is uploaded to S3")
 
     def make_validators(self) -> List[EffectValidator]:
@@ -825,8 +827,8 @@ class TS_ManifestUploaded(Expression):
 
 class SpilloverManifestUploaded(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "SpilloverManifestUploaded", "Bool",
-                         "Spillover manifest is uploaded")
+        super().__init__(model, "SpilloverManifestUploaded",
+                         ExpressionType.Bool, "Spillover manifest is uploaded")
 
     class Bucket_validator(BucketBasedValidator):
         def __init__(self):
@@ -856,7 +858,8 @@ class SpilloverManifestUploaded(Expression):
 class AdjacentSegmentMergerReupload(Expression):
     """Checks that adjacent segment reupload is triggered"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "AdjacentSegmentMergerReupload", "Bool",
+        super().__init__(model, "AdjacentSegmentMergerReupload",
+                         ExpressionType.Bool,
                          "Adjacent segment reupload is triggered")
 
     def make_validators(self) -> List[EffectValidator]:
@@ -872,7 +875,8 @@ class AdjacentSegmentMergerReupload(Expression):
 class CompactedReupload(Expression):
     """Checks that compacted segment reupload is triggered"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "CompactedSegmentReupload", "Bool",
+        super().__init__(model, "CompactedSegmentReupload",
+                         ExpressionType.Bool,
                          "Compacted segment reupload is triggered")
 
     class Bucket_validator(BucketBasedValidator):
@@ -903,7 +907,7 @@ class CompactedReupload(Expression):
 
 class TopicCompactionEnabled(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TopicCompactionEnabled", "Bool",
+        super().__init__(model, "TopicCompactionEnabled", ExpressionType.Bool,
                          "Topic compaction is enabled")
 
     def make_inputs(self) -> List[TestInput]:
@@ -922,7 +926,7 @@ class TopicCompactionEnabled(Expression):
 
 class RemoteWriteTopicConfig(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "RemoteWriteTopicConfig", "Bool",
+        super().__init__(model, "RemoteWriteTopicConfig", ExpressionType.Bool,
                          "redpanda.remote.write topic property is set")
 
     def make_inputs(self) -> List[TestInput]:
@@ -934,7 +938,7 @@ class RemoteWriteTopicConfig(Expression):
 
 class RemoteReadTopicConfig(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "RemoteReadTopicConfig", "Bool",
+        super().__init__(model, "RemoteReadTopicConfig", ExpressionType.Bool,
                          "redpanda.remote.read topic property is set")
 
     def make_inputs(self) -> List[TestInput]:
@@ -946,7 +950,8 @@ class RemoteReadTopicConfig(Expression):
 
 class RemoteWriteClusterConfig(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "RemoteWriteClusterConfig", "Bool",
+        super().__init__(model, "RemoteWriteClusterConfig",
+                         ExpressionType.Bool,
                          "cloud_storage_enable_remote_write config is set")
 
     def make_inputs(self) -> List[TestInput]:
@@ -958,7 +963,7 @@ class RemoteWriteClusterConfig(Expression):
 
 class RemoteReadClusterConfig(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "RemoteReadClusterConfig", "Bool",
+        super().__init__(model, "RemoteReadClusterConfig", ExpressionType.Bool,
                          "cloud_storage_enable_remote_read config is set")
 
     def make_inputs(self) -> List[TestInput]:
@@ -971,7 +976,7 @@ class RemoteReadClusterConfig(Expression):
 class ShortLocalRetentionTopicConfig(Expression):
     def __init__(self, model: Model = Model.default()):
         super().__init__(
-            model, "ShortLocalRetentionTopicConfig", "Bool",
+            model, "ShortLocalRetentionTopicConfig", ExpressionType.Bool,
             "retention.local.target.bytes config is set to small value (1 segment size)"
         )
 
@@ -990,7 +995,7 @@ class ShortLocalRetentionTopicConfig(Expression):
 class EnableSpillover(Expression):
     def __init__(self, model: Model = Model.default()):
         super().__init__(
-            model, "EnableSpillover", "Bool",
+            model, "EnableSpillover", ExpressionType.Bool,
             "Spillover is enabled by setting cloud_storage_spillover_manifest_max_segments to small value"
         )
 
@@ -1006,7 +1011,7 @@ class EnableSpillover(Expression):
 class TS_Housekeeping(Expression):
     def __init__(self, model: Model = Model.default()):
         super().__init__(
-            model, "TS_Housekeeping", "Bool",
+            model, "TS_Housekeeping", ExpressionType.Bool,
             "Housekeeping is enabled by setting cloud_storage_housekeeping_interval_ms to small value"
         )
 
@@ -1020,7 +1025,8 @@ class TS_Housekeeping(Expression):
 
 class LocalStorageHousekeeping(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "LocalStorageHousekeeping", "Bool",
+        super().__init__(model, "LocalStorageHousekeeping",
+                         ExpressionType.Bool,
                          "Housekeeping in the local storage is triggered")
 
     def make_validators(self) -> List[EffectValidator]:
@@ -1033,7 +1039,8 @@ class LocalStorageHousekeeping(Expression):
 
 class EnableAdjacentSegmentMerging(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "EnableAdjacentSegmentMerging", "Bool",
+        super().__init__(model, "EnableAdjacentSegmentMerging",
+                         ExpressionType.Bool,
                          "Adjacent segment merging is enabled")
 
     def make_inputs(self):
@@ -1047,7 +1054,8 @@ class EnableAdjacentSegmentMerging(Expression):
 
 class EnableCompactedSegmentReupload(Expression):
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "EnableCompactedSegmentReupload", "Bool",
+        super().__init__(model, "EnableCompactedSegmentReupload",
+                         ExpressionType.Bool,
                          "Compacted segment reupload is enabled")
 
     def make_inputs(self):
@@ -1061,7 +1069,7 @@ class EnableCompactedSegmentReupload(Expression):
 class SegmentSelfCompaction(Expression):
     """Segment was self compacted in the local storage"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "SegmentSelfCompaction", "Bool",
+        super().__init__(model, "SegmentSelfCompaction", ExpressionType.Bool,
                          "Segment was self compacted")
 
     def make_validators(self):
@@ -1075,7 +1083,8 @@ class SegmentSelfCompaction(Expression):
 class AdjacentSegmentCompaction(Expression):
     """Adjacent segments compacted in the local storage"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "AdjacentSegmentCompaction", "Bool",
+        super().__init__(model, "AdjacentSegmentCompaction",
+                         ExpressionType.Bool,
                          "Adjacent segments were compacted")
 
     def make_validators(self):
@@ -1089,7 +1098,8 @@ class AdjacentSegmentCompaction(Expression):
 class TS_Timequery(Expression):
     """Timequery is used with tiered-storage"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_Timequery", "Bool", "Timequery is used")
+        super().__init__(model, "TS_Timequery", ExpressionType.Bool,
+                         "Timequery is used")
 
     def make_inputs(self) -> List[TestInput]:
         return [
@@ -1103,7 +1113,7 @@ class TS_Timequery(Expression):
 class TS_ChunkedRead(Expression):
     """Chunked read from the tiered-storage"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_ChunkedRead", "Bool",
+        super().__init__(model, "TS_ChunkedRead", ExpressionType.Bool,
                          "Chunked read is used")
 
     def make_validators(self):
@@ -1122,7 +1132,7 @@ class TS_ChunkedRead(Expression):
 class EnableChunkedRead(Expression):
     """Chunked reads are enabled"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "EnableChunkedRead", "Bool",
+        super().__init__(model, "EnableChunkedRead", ExpressionType.Bool,
                          "Chunked reads are enabled")
 
     def make_inputs(self):
@@ -1135,7 +1145,7 @@ class EnableChunkedRead(Expression):
 class TS_TxRangeMaterialized(Expression):
     """tx-manifest is downloaded and used when reading from the topic"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_TxRangeMaterialized", "Bool",
+        super().__init__(model, "TS_TxRangeMaterialized", ExpressionType.Bool,
                          "tx-manifest is used when reading from the topic")
 
     def make_validators(self):
@@ -1154,7 +1164,7 @@ class TS_TxRangeMaterialized(Expression):
 class TransactionsAborted(Expression):
     """Produces uses transactions and aborts some of them"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TransactionsAborted", "Bool",
+        super().__init__(model, "TransactionsAborted", ExpressionType.Bool,
                          "Transactions are aborted")
 
     def make_inputs(self):
@@ -1172,7 +1182,8 @@ class TransactionsAborted(Expression):
 class TS_UploadIntervalTriggerWrite(Expression):
     """Segment upload triggered by time limit"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_UploadIntervalTriggerWrite", "Bool",
+        super().__init__(model, "TS_UploadIntervalTriggerWrite",
+                         ExpressionType.Bool,
                          "Segment upload triggered by time limit")
 
     def make_validators(self):
@@ -1187,7 +1198,7 @@ class TS_UploadIntervalTriggerWrite(Expression):
 class EnableUploadInterval(Expression):
     """Timeboxed uploads are enabled"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "EnableUploadInterval", "Bool",
+        super().__init__(model, "EnableUploadInterval", ExpressionType.Bool,
                          "Timeboxed uploads are enabled")
 
     def make_inputs(self):
@@ -1203,7 +1214,7 @@ class EnableUploadInterval(Expression):
 class TS_Delete(Expression):
     """The segment is deleted from the cloud storage"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_Delete", "Bool",
+        super().__init__(model, "TS_Delete", ExpressionType.Bool,
                          "Segment is deleted from the cloud storage")
 
     def make_validators(self):
@@ -1218,7 +1229,7 @@ class TS_Delete(Expression):
 class TS_STM_DeleteByGC(Expression):
     """Segment deletion triggered by garbage collection"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_STM_DeleteByGC", "Bool",
+        super().__init__(model, "TS_STM_DeleteByGC", ExpressionType.Bool,
                          "Segment deletion triggered by garbage collection")
 
     def make_validators(self):
@@ -1233,7 +1244,7 @@ class TS_STM_DeleteByGC(Expression):
 class TS_STM_GarbageCollect(Expression):
     """GC is applied to the data in the STM"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_STM_GarbageCollect", "Bool",
+        super().__init__(model, "TS_STM_GarbageCollect", ExpressionType.Bool,
                          "GC is applied to the data in the STM")
 
     def make_validators(self):
@@ -1253,7 +1264,7 @@ class TS_STM_SizeBasedRetentionApplied(Expression):
     """Size based retention is triggered in tiered-storage in the STM region of the log"""
     def __init__(self, model: Model = Model.default()):
         super().__init__(
-            model, "TS_STM_SizeBasedRetentionApplied", "Bool",
+            model, "TS_STM_SizeBasedRetentionApplied", ExpressionType.Bool,
             "Size based retention is triggered in tiered-storage")
 
     def make_validators(self):
@@ -1269,7 +1280,7 @@ class TS_STM_SizeBasedRetentionApplied(Expression):
 class TS_Spillover_DeleteByGC(Expression):
     """Segment deletion from the archive triggered by garbage collection"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_Spillover_DeleteByGC", "Bool",
+        super().__init__(model, "TS_Spillover_DeleteByGC", ExpressionType.Bool,
                          "Segment deletion triggered by garbage collection")
 
     def make_validators(self):
@@ -1290,7 +1301,7 @@ class TS_Spillover_GarbageCollect(Expression):
     """GC is applied to the data in the spillover region of the log"""
     def __init__(self, model: Model = Model.default()):
         super().__init__(
-            model, "TS_Spillover_GarbageCollect", "Bool",
+            model, "TS_Spillover_GarbageCollect", ExpressionType.Bool,
             "GC is applied to the data in the spillover region of the log")
 
     def make_validators(self):
@@ -1307,7 +1318,8 @@ class TS_Spillover_SizeBasedRetentionApplied(Expression):
     """Size based retention is applied to the data in the spillover region of the log"""
     def __init__(self, model: Model = Model.default()):
         super().__init__(
-            model, "TS_Spillover_SizeBasedRetentionApplied", "Bool",
+            model, "TS_Spillover_SizeBasedRetentionApplied",
+            ExpressionType.Bool,
             "Size based retention is applied to the data in the spillover region of the log"
         )
 
@@ -1324,7 +1336,8 @@ class TS_Spillover_SizeBasedRetentionApplied(Expression):
 class TS_Spillover_ManifestDeleted(Expression):
     """Spillover manifest deleted from the cloud storage"""
     def __init__(self, model: Model = Model.default()):
-        super().__init__(model, "TS_Spillover_ManifestDeleted", "Bool",
+        super().__init__(model, "TS_Spillover_ManifestDeleted",
+                         ExpressionType.Bool,
                          "Spillover manifest deleted from the cloud storage")
 
     def make_validators(self):
@@ -1344,7 +1357,8 @@ class TS_SmallSizeBasedRetentionTopicConfig(Expression):
     """
     def __init__(self, model: Model = Model.default()):
         super().__init__(
-            model, "TS_SmallSizeBasedRetentionTopicConfig", "Bool",
+            model, "TS_SmallSizeBasedRetentionTopicConfig",
+            ExpressionType.Bool,
             "Size based retention is set for the topic using retention.bytes config"
         )
 

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -30,7 +30,7 @@ CONFIDENCE_THRESHOLD = 0.8
 FAKE_BASE_TIMESTAMP_MS = 1690000000000
 FAKE_TIMESTAMP_STEP_MS = 1
 LOG_SEGMENT_SIZE = 1024 * 1024
-LARGE_SEGMENT_SIZE = 2 * LOG_SEGMENT_SIZE
+LARGE_SEGMENT_SIZE = 3 * LOG_SEGMENT_SIZE
 LOCAL_TARGET_SIZE = LARGE_SEGMENT_SIZE
 SPILLOVER_MANIFEST_SIZE = 5
 LOW_THRESHOLD = 1
@@ -864,7 +864,7 @@ class AdjacentSegmentMergerReupload(Expression):
         return [
             LogBasedValidator(
                 "AdjacentSegmentMergerReupload",
-                "adjacent_segment_merger.*Successfuly uploaded segment",
+                "adjacent_segment_merger.*Found adjacent segment run",
                 confidence_threshold=LOW_THRESHOLD)
         ]
 
@@ -1561,7 +1561,10 @@ def get_tiered_storage_test_cases(fast_run=False):
         solutions.append(
             model.solve_for(ts_read() == True,
                             adjacent_segment_merger_reupload() == True))
-        # solutions.append(model.solve_for(ts_read() == True, ts_timequery() == True, spillover_manifest_uploaded() == True))
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            ts_timequery() == True,
+                            spillover_manifest_uploaded() == True))
         solutions.append(
             model.solve_for(ts_read() == True,
                             compacted_segment_reupload() == True,
@@ -1570,7 +1573,10 @@ def get_tiered_storage_test_cases(fast_run=False):
             model.solve_for(ts_read() == True,
                             ts_txrange_materialized() == True,
                             spillover_manifest_uploaded() == True))
-        # solutions.append(model.solve_for(ts_read() == True, adjacent_segment_merger_reupload() == True, spillover_manifest_uploaded() == True))
+        solutions.append(
+            model.solve_for(ts_read() == True,
+                            adjacent_segment_merger_reupload() == True,
+                            spillover_manifest_uploaded() == True))
         solutions.append(
             model.solve_for(ts_delete() == True,
                             spillover_manifest_uploaded() == True,

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1635,10 +1635,10 @@ def get_tiered_storage_test_cases(fast_run=False):
             model.solve_for(ts_read() == True,
                             ts_timequery() == True,
                             spillover_manifest_uploaded() == True))
-        solutions.append(
-            model.solve_for(ts_read() == True,
-                            compacted_segment_reupload() == True,
-                            adjacent_segment_compaction() == True))
+        # solutions.append(
+        #     model.solve_for(ts_read() == True,
+        #                     compacted_segment_reupload() == True,
+        #                     adjacent_segment_compaction() == True))
         solutions.append(
             model.solve_for(ts_read() == True,
                             ts_txrange_materialized() == True,
@@ -1651,9 +1651,9 @@ def get_tiered_storage_test_cases(fast_run=False):
             model.solve_for(ts_delete() == True,
                             spillover_manifest_uploaded() == True,
                             ts_spillover_manifest_deleted() == True))
-        solutions.append(
-            model.solve_for(ts_delete() == True,
-                            adjacent_segment_compaction() == True))
+        # solutions.append(
+        #     model.solve_for(ts_delete() == True,
+        #                     adjacent_segment_compaction() == True))
     else:
         # Check that we can enable uploads using both topic level config
         # and cluster level config.

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1377,7 +1377,7 @@ class TS_SmallSizeBasedRetentionTopicConfig(Expression):
                 # This has to be larger than local target size to allow
                 # reads from the cloud storage. Otherwise the reads will
                 # be served by the local storage only.
-                str(2 * LOCAL_TARGET_SIZE),
+                str(LOCAL_TARGET_SIZE),
                 stage=TestRunStage.Intermediate)
         ]
 

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -1,0 +1,551 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import dataclasses
+import json
+import random
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor, Future
+from threading import Condition
+from collections import defaultdict
+
+from ducktape.mark import matrix
+from ducktape.tests.test import TestContext
+from ducktape.utils.util import wait_until
+
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.kafka_cat import KafkaCat
+from rptest.clients.rpk import RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.action_injector import random_process_kills
+from rptest.services.redpanda import RedpandaService
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer, KgoVerifierRandomConsumer, KgoVerifierSeqConsumer
+from rptest.services.redpanda import SISettings, get_cloud_storage_type, make_redpanda_service, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
+from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP
+from rptest.tests.tiered_storage_model import TestCase, TieredStorageEndToEndTest, get_tiered_storage_test_cases, TestRunStage, CONFIDENCE_THRESHOLD
+
+MAX_RETRIES = 5
+
+
+class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
+
+    # Topic doesn't have tiered storage enabled by default
+    topics = (
+        TopicSpec(
+            partition_count=1,  # TODO: maybe use more partitions
+            replication_factor=3,
+            retention_bytes=-1,
+            retention_ms=-1,
+        ), )
+
+    def __init__(self, test_context, extra_rp_conf=None, environment=None):
+
+        self.test_context = test_context
+
+        # The settings will be changed in the 'setUp' method
+        self.extra_rp_conf = extra_rp_conf or {}
+
+        self.extra_rp_conf['cloud_storage_enable_segment_merging'] = False
+        self.extra_rp_conf['compaction_ctrl_min_shares'] = 300
+        self.extra_rp_conf['cloud_storage_disable_chunk_reads'] = True
+
+        self.si_settings = SISettings(
+            test_context,
+            cloud_storage_max_connections=10,
+            log_segment_size=1024 * 1024,  # 1MB
+            fast_uploads=True,
+        )
+
+        super(TieredStorageTest,
+              self).__init__(test_context=test_context,
+                             si_settings=self.si_settings,
+                             extra_rp_conf=self.extra_rp_conf,
+                             environment=environment,
+                             log_level="trace")
+
+        self.s3_bucket_name = self.si_settings.cloud_storage_bucket
+
+        # The producer has some defaults which could be changed later
+        self.producer_config = dict(context=self.test_context,
+                                    redpanda=self.redpanda,
+                                    topic=self.topic,
+                                    msg_size=1024,
+                                    msg_count=10000,
+                                    use_transactions=False,
+                                    msgs_per_transaction=1,
+                                    debug_logs=True,
+                                    trace_logs=True)
+
+        # Configurable defaults for the consumer
+        self.consumer_config = dict(context=self.test_context,
+                                    redpanda=self.redpanda,
+                                    topic=self.topic,
+                                    msg_size=None,
+                                    debug_logs=True,
+                                    trace_logs=True)
+        self.timequery_map = {}
+
+        self.kafka_tools = KafkaCliTools(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+        self.kafka_cat = KafkaCat(self.redpanda)
+        self.thread_pool = ThreadPoolExecutor(max_workers=1024)
+        self.public_metrics = defaultdict(int)
+        self.private_metrics = defaultdict(int)
+        self.cond_stop = Condition()
+        self.stop_flag = False
+        self._log_patterns = defaultdict(list)
+        self.config_overrides = {}
+        self.current_stage = TestRunStage.Startup
+        self.bucket_view = None
+
+    def setUp(self):
+        super(TieredStorageTest, self).setUp()
+
+    def _build_timequery_map(self, num_runs, fake_ts):
+        """Build a map used by timequery check"""
+        # TODO: add compaction/retention support
+        # this code assumes that all offsets will be available
+        # but this is not the case if retention or compaction (or both) is enabled
+        if not fake_ts:
+            self.logger.info(f"Timequery check is disabled")
+            return
+        fake_ts_step = self.producer_config.get('fake_timestamp_step_ms', 1000)
+        num_messages = self.producer_config.get('msg_count', 10000)
+        # use reservoir sampling to sample timestamps
+        map_size = 100
+        reservoir = [(fake_ts + i * fake_ts_step, i)
+                     for i in range(0, map_size)]
+        for i in range(map_size, num_runs * num_messages):
+            x = random.randint(0, i)
+            if x < map_size:
+                reservoir[x] = (fake_ts + i * fake_ts_step, i)
+        for ts, i in reservoir:
+            self.timequery_map[ts] = i
+        self.logger.info(
+            f"Timequery map generated, size {len(self.timequery_map)}, number of produce runs: {num_runs}, fake_ts: {fake_ts}"
+        )
+        for ts, i in self.timequery_map.items():
+            self.logger.debug(f"Timequery map: {ts} -> {i}")
+
+    def _bg_loop(self, func, name, sleep_time=lambda: 1.0):
+        """Run function in a loop in the background"""
+        if self.stop_flag:
+            self.logger.info(f"BG loop for {name} is stopped")
+            return
+
+        func()
+
+        def recur(res: Future):
+            if res.exception():
+                # Keep retrying even in case of error
+                self.logger.error(
+                    f"Exception in the {name} background loop {res.exception()}"
+                )
+
+            self._bg_loop(func, name, sleep_time)
+
+        def pause(res: Future):
+            if res.exception():
+                self.logger.error(
+                    f"Exception in the {name} background loop {res.exception()}"
+                )
+
+            time.sleep(sleep_time())
+
+        fut = self.thread_pool.submit(func)
+        fut.add_done_callback(pause)
+        fut.add_done_callback(recur)
+
+    def _bg_validator_run(self, validator):
+        """Run validator in background."""
+        def invoke():
+            try:
+                self.logger.info(f"Running validator {validator.name()}")
+                validator.run(self)
+            except:
+                self.logger.error("Failed to run validator", exc_info=True)
+
+        self._bg_loop(invoke, validator.name(),
+                      lambda: random.uniform(0.5, 1.5))
+
+    def run_bg_validators(self, test_case):
+        """Run all validators in background."""
+        # Start all bg-loops which are needed to run validators
+        self._bg_grep_logs()
+        self._bg_metrics_pull(MetricsEndpoint.PUBLIC_METRICS)
+        self._bg_metrics_pull(MetricsEndpoint.METRICS)
+        self._bg_bucket_view_update()
+        # Start validators running in the background
+        for v in test_case.validators():
+            self._bg_validator_run(v)
+
+    def _bg_metrics_pull(self, endpoint):
+        """Pull metrics from the redpanda node. This is needed to avoid pulling metrics
+        from every validator individually. The validators are invoking functions of the
+        test suite to find individual metrics."""
+        try:
+            if self.stop_flag:
+                return
+            res = defaultdict(int)
+            for n in self.redpanda.nodes:
+                if n in self.redpanda._started:
+                    resp = self.redpanda.metrics(n, endpoint)
+                    for family in resp:
+                        for sample in family.samples:
+                            res[sample.name] += sample.value
+            # should be safe due to GIL
+            if endpoint == MetricsEndpoint.PUBLIC_METRICS:
+                self.public_metrics = res
+                self.logger.info(f"Public metrics {res}")
+            else:
+                self.private_metrics = res
+                self.logger.info(f"Private metrics {res}")
+            time.sleep(2)
+        except:
+            self.logger.error("Failed to pull metrics", exc_info=True)
+            time.sleep(2)
+        finally:
+            # Run 'loop' recursively
+            if not self.stop_flag:
+                self.thread_pool.submit(self._bg_metrics_pull, endpoint)
+
+    def _bg_bucket_view_update(self):
+        """Re-scan the bucket view in the background."""
+        try:
+            if self.stop_flag:
+                return
+            self.bucket_view = BucketView(self.redpanda,
+                                          topics=self.topics,
+                                          scan_segments=True)
+            self.bucket_view._ensure_listing()
+            self.logger.info(
+                f"Bucket view updated, {self.bucket_view.segment_objects} segments scanned"
+            )
+            time.sleep(10)
+        except:
+            self.logger.error("Failed to scan bucket", exc_info=True)
+            time.sleep(20)
+        finally:
+            if not self.stop_flag:
+                self.thread_pool.submit(self._bg_bucket_view_update)
+
+    def _bg_grep_logs(self):
+        if self.stop_flag:
+            return
+
+        def tail_minus_f(node):
+            self.logger.info(f"Running tail -f on {node.name}")
+            try:
+                # Redpanda produces fairly minor amount of logs, so it's OK to just
+                # grep all of them.
+
+                for line in node.account.ssh_capture(
+                        f"tail -f {RedpandaService.STDOUT_STDERR_CAPTURE}"):
+                    for pattern, validators in self._log_patterns.items():
+                        if re.search(pattern, line):
+                            for v in validators:
+                                v.on_match(node.name, line)
+                    if self.stop_flag:
+                        return
+            except:
+                self.logger.error("Failed to grep logs", exc_info=True)
+
+        for n in self.redpanda.nodes:
+            node = n
+            self.logger.info(f"Starting log fetch on a node {node.name}")
+            self.thread_pool.submit(lambda: tail_minus_f(node))
+
+    def tearDown(self):
+        self.stop_flag = True
+        self.thread_pool.shutdown()
+
+    def apply_config_overrides(self):
+        """Apply configuration overrides to the redpanda cluster."""
+        self.logger.info(f"Applying config overrides {self.config_overrides}")
+        needs_restart = False
+        values = {}
+        for k, v in self.config_overrides.items():
+            values[k] = v['value']
+            if v['needs_restart']:
+                needs_restart = True
+        if len(values) > 0:
+            self.redpanda.set_cluster_config(values=values,
+                                             expect_restart=needs_restart)
+        self.config_overrides = {}
+
+    # TieredStorageEndToEnd interface implementation
+
+    def get_bucket_view(self):
+        return self.bucket_view
+
+    def get_ntp(self):
+        return NTP("kafka", self.topic, 0)
+
+    def set_producer_parameters(self, **kwargs):
+        self.logger.info(f"Update producer parameters {kwargs}")
+        self.producer_config.update(**kwargs)
+
+    def set_consumer_parameters(self, **kwargs):
+        self.logger.info(f"Update consumer parameters {kwargs}")
+        self.consumer_config.update(**kwargs)
+
+    def subscribe_to_logs(self, validator, pattern):
+        """Subscribe to all log changes on all nodes. The validator will be invoked
+        when the log line is matched."""
+        self._log_patterns[pattern].append(validator)
+
+    def alter_topic_config(self, config_name: str, config_value: str):
+        self.logger.info(
+            f"Alter topic config for {self.topic}, setting {config_name} to {config_value}"
+        )
+        self.rpk.alter_topic_config(self.topic, config_name, config_value)
+
+    def get_redpanda_service(self):
+        return self.redpanda
+
+    def get_logger(self):
+        return self.logger
+
+    def set_redpanda_cluster_config(self,
+                                    config_name,
+                                    config_value,
+                                    needs_restart: bool = False):
+        """Override configuration of the redpanda service. The configuration will be changed
+        later using the self.redpanda.set_cluster_config method. This method shouldn't be
+        called for the same config name twice."""
+        self.config_overrides[config_name] = dict(value=config_value,
+                                                  needs_restart=needs_restart)
+
+    def stop_redpanda_cluster(self):
+        self.redpanda.stop()
+
+    def get_public_metric(self, metric_name: str):
+        value = self.public_metrics.get(metric_name)
+        self.logger.info(f"{metric_name} = {value}")
+        return value
+
+    def get_private_metric(self, metric_name: str):
+        value = self.private_metrics.get(metric_name)
+        self.logger.info(f"{metric_name} = {value}")
+        return value
+
+    def _oneshot_produce(self, **kwargs):
+        KgoVerifierProducer.oneshot(**self.producer_config)
+
+    def _oneshot_consume(self, **kwargs):
+        KgoVerifierSeqConsumer.oneshot(**self.consumer_config)
+
+    def produce_until_validated(self, test_case):
+        # If fake timestamps are enabled, we need to adjust the timestamp on every
+        # iteration to make them continuous.
+        fake_ts_enabled = self.producer_config.get(
+            'fake_timestamp_ms') is not None
+        fake_ts = self.producer_config.get('fake_timestamp_ms', 0)
+        original_fake_ts = fake_ts
+        fake_ts_step = self.producer_config.get('fake_timestamp_step_ms', 1000)
+        num_messages = self.producer_config.get('msg_count', 10000)
+        num_produce_runs = 0
+        done = 0
+        total = 0
+        for _ in range(0, MAX_RETRIES):
+            lagging_validators = []
+            self.logger.debug(f"Producer config: {self.producer_config}")
+            self._oneshot_produce()
+            num_produce_runs += 1
+            done = 0
+            total = 0
+            for v in test_case.validators():
+                if v.need_to_run(TestRunStage.Produce):
+                    self.logger.debug(
+                        f"Produce stage validator {v.name()} has result {v.get_result()} with {v.get_confidence()} confidence"
+                    )
+                    total += 1
+                    success = v.get_result(
+                    ) and v.get_confidence() > CONFIDENCE_THRESHOLD
+                    if success:
+                        done += 1
+                    else:
+                        lagging_validators.append(v.name())
+            # Stop if all validators are confident enough
+            if done == total:
+                break
+            else:
+                self.logger.info(
+                    f"Produce delayed by lagging validators: {lagging_validators}"
+                )
+                time.sleep(5)
+
+            if fake_ts_enabled:
+                fake_ts += fake_ts_step * num_messages
+                self.producer_config['fake_timestamp_ms'] = fake_ts
+
+            # Apply other inputs
+            self.run_stage_inputs(TestRunStage.Produce, test_case)
+
+        assert done == total, f"Failed to produce data after {num_produce_runs} runs"
+        self._build_timequery_map(num_produce_runs, original_fake_ts)
+
+    def consume_until_validated(self, test_case):
+        num_consume_runs = 0
+        for _ in range(0, MAX_RETRIES):
+            self._oneshot_consume()
+            self._timequery_consume()
+            num_consume_runs += 1
+            done = 0
+            total = 0
+            lagging_validators = []
+            for v in test_case.validators():
+                if v.need_to_run(TestRunStage.Consume):
+                    self.logger.debug(
+                        f"Consume stage validator {v.name()} has confidence {v.get_confidence()}"
+                    )
+                    total += 1
+                    r = v.get_result()
+                    c = v.get_confidence() > CONFIDENCE_THRESHOLD
+                    if r and c:
+                        done += 1
+                    else:
+                        lagging_validators.append(v.name())
+            if done == total:
+                break
+            else:
+                self.logger.info(
+                    f"Consume delayed by lagging validators: {lagging_validators}"
+                )
+                time.sleep(5)
+
+            # Apply inputs if needed
+            self.run_stage_inputs(TestRunStage.Consume, test_case)
+
+        return num_consume_runs
+
+    def _timequery_consume(self):
+        self.logger.info(
+            f"Running timequery check, map size {len(self.timequery_map)}")
+        if len(self.timequery_map) == 0:
+            return
+        for ts, expected_offset in self.timequery_map.items():
+            self.logger.debug(
+                f"Timequery check for timestamp: {ts}, expected offset: {expected_offset}"
+            )
+            actual_offset = self.kafka_cat.consume_one(
+                self.topic, 0, first_timestamp=ts)['offset']
+            matches = expected_offset == actual_offset
+            if not matches:
+                self.logger.error(
+                    f"Timequery mismatch: expected {expected_offset} but got {actual_offset} for timestamp {ts}"
+                )
+            assert matches, "Timequery mismatch"
+
+    def start_validators(self, test_case):
+        for v in test_case.validators():
+            self.logger.info(f"Starting validator {v.name()}")
+            v.start(self)
+
+    def run_stage_validators(self, stage, test_case):
+        """Run all validators for the given stage."""
+        for _ in range(0, MAX_RETRIES):
+            done = 0
+            total = 0
+            lagging_validators = []
+            for v in test_case.validators():
+                if v.need_to_run(stage):
+                    self.logger.debug(
+                        f"{stage} stage validator {v.name()} has result {v.get_result()} with {v.get_confidence()} confidence"
+                    )
+                    total += 1
+                    r = v.get_result()
+                    c = v.get_confidence() > CONFIDENCE_THRESHOLD
+                    if r and c:
+                        done += 1
+                    else:
+                        lagging_validators.append(v.name())
+            # Stop if all validators are confident enough
+            if done == total:
+                break
+            else:
+                self.logger.info(
+                    f"{stage} delayed by lagging validators: {lagging_validators}"
+                )
+                time.sleep(5)
+        assert done == total, f"Failed to validate data after {MAX_RETRIES} runs"
+
+    def start_inputs(self, test_case):
+        """Start all inputs."""
+        for inp in test_case.inputs():
+            self.logger.info(f"Starting input {inp.name()}")
+            inp.start(self)
+        self.apply_config_overrides()
+
+    def run_stage_inputs(self, stage, test_case):
+        """Run all inputs for the given stage."""
+        self.logger.info(f"Running input overrides for stage {stage}")
+        for inp in test_case.inputs():
+            if inp.need_to_run(stage):
+                self.logger.info(f"Running input overrides {inp.name()}")
+                inp.run(self)
+        self.apply_config_overrides()
+
+    def prepare_stage(self, stage, test_case):
+        """Set the current stage and run all inputs for the given stage."""
+        self.logger.info(f"Setting stage to {stage} and running inputs")
+        self.current_stage = stage
+        self.run_stage_inputs(stage, test_case)
+
+    def shutdown_bg_tasks(self):
+        self.logger.info(f"Shutting down background tasks")
+        self.stop_flag = True
+        self.thread_pool.shutdown()
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=get_cloud_storage_type(),
+            test_case=get_tiered_storage_test_cases(fast_run=True))
+    def test_tiered_storage(self, cloud_storage_type, test_case: TestCase):
+        """This is a main entry point of the test.
+           The test runs if 5 phases:
+            - Configuration phase
+            - Producing the data
+            - Intermediate step (change topic properties, wait for retention, etc)
+            - Consuming the data (use timequery)
+            - Shutting down
+        """
+        # Configuration phase
+        self.start_inputs(test_case)
+        self.start_validators(test_case)
+        self.run_bg_validators(test_case)
+
+        try:
+            # Setup stage
+            self.prepare_stage(TestRunStage.Startup, test_case)
+            self.run_stage_validators(TestRunStage.Startup, test_case)
+
+            # Producing the data
+            self.prepare_stage(TestRunStage.Produce, test_case)
+            self.produce_until_validated(test_case)
+
+            # Intermediate step
+            self.prepare_stage(TestRunStage.Intermediate, test_case)
+            self.run_stage_validators(TestRunStage.Intermediate, test_case)
+
+            # Consuming the data
+            self.prepare_stage(TestRunStage.Consume, test_case)
+            self.consume_until_validated(test_case)
+
+            # Shutting down
+            self.prepare_stage(TestRunStage.Shutdown, test_case)
+            self.run_stage_validators(TestRunStage.Shutdown, test_case)
+
+            self.shutdown_bg_tasks()
+        finally:
+            # Check that all validators are done and raise error if
+            # some of them failed.
+            test_case.assert_validators(self)

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -33,7 +33,7 @@ from rptest.services.redpanda import SISettings, get_cloud_storage_type, make_re
 from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP
 from rptest.tests.tiered_storage_model import TestCase, TieredStorageEndToEndTest, get_tiered_storage_test_cases, TestRunStage, CONFIDENCE_THRESHOLD
 
-MAX_RETRIES = 5
+MAX_RETRIES = 7
 
 
 class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
@@ -453,7 +453,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
 
     def run_stage_validators(self, stage, test_case):
         """Run all validators for the given stage."""
-        for _ in range(0, MAX_RETRIES):
+        for ix in range(0, MAX_RETRIES):
             done = 0
             total = 0
             lagging_validators = []
@@ -476,7 +476,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
                 self.logger.info(
                     f"{stage} delayed by lagging validators: {lagging_validators}"
                 )
-                time.sleep(5)
+                time.sleep(2 * ix)
         assert done == total, f"Failed to validate data after {MAX_RETRIES} runs"
 
     def start_inputs(self, test_case):

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -33,7 +33,7 @@ from rptest.services.redpanda import SISettings, get_cloud_storage_type, make_re
 from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP
 from rptest.tests.tiered_storage_model import TestCase, TieredStorageEndToEndTest, get_tiered_storage_test_cases, TestRunStage, CONFIDENCE_THRESHOLD
 
-MAX_RETRIES = 7
+MAX_RETRIES = 20
 
 
 class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
@@ -369,8 +369,8 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
                         f"Produce stage validator {v.name()} has result {v.get_result()} with {v.get_confidence()} confidence"
                     )
                     total += 1
-                    success = v.get_result(
-                    ) and v.get_confidence() > CONFIDENCE_THRESHOLD
+                    success = v.get_result() and v.get_confidence(
+                    ) > CONFIDENCE_THRESHOLD
                     if success:
                         done += 1
                     else:

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -24,7 +24,8 @@ setup(
         'cachetools==5.3.1', 'google-api-core==2.11.1', 'google-auth==2.22.0',
         'googleapis-common-protos==1.60.0', 'google.cloud.compute==1.14.0',
         'proto-plus==1.22.3', 'rsa==4.9',
-        'python-keycloak@git+https://github.com/redpanda-data/python-keycloak.git@10b822cb0320c54dbf5bf4fd00435afb1487415d'
+        'python-keycloak@git+https://github.com/redpanda-data/python-keycloak.git@10b822cb0320c54dbf5bf4fd00435afb1487415d',
+        'z3-solver==4.12.2', 'hypothesis==6.82'
     ],
     scripts=[],
 )


### PR DESCRIPTION
This PR adds new test that can be parametrised using solutions of the boolean model that represents dependencies between different actions that can be performed by tiered-storage.

The model captures dependencies like dependency between segment upload, download, segment rolling and produce.
The model is then solved to find what inputs are needed to see certain effect (e.g. segment download or segment deletion). The result contains not only inputs but all intermediate actions. The test runner uses set of validators to check if all these actions are actually performed so we could be certain that the actual test run matches with the model.

Currently, the model is solved only for few test cases (for instance, time query and spillover) to fill some gaps we have in our ducktape test suite. It can be easily extended on case by case basis. You only need to specify what outcomes you want to observe and solve the model for it. If it's solvable the test runner will be able to run the test and validate the results.

Example:
```Python
        solutions.append(
            model.solve_for(ts_read() == True,
                            ts_txrange_materialized() == True,
                            spillover_manifest_uploaded() == True))
```
This code generates a test case that checks transactions with spillover.

Things included into the model:
- Normal operations (uploads, downloads, deletions)
- Adjacent segment merging
- Timequeries
- Transactions
- Compacted segment reupload
- Upload interval timeout
- Chunked reads
- Size based retention in the local storage
- Size based retention in the  cloud storage
- Size based retention in the spillover region of the cloud storage
- Rolling segment using segment.ms

Things which are not working:
- Timequery checks are incompatible with compaction
- Timequery checks are incompatible with transactions
- And with retention

This PR also includes some fixes that should be backported to v23.2/v23.1

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none