### PR TITLE
Introduce model::batch_record_iterator

### DIFF
--- a/src/v/model/CMakeLists.txt
+++ b/src/v/model/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     adl_serde.cc
     validation.cc
     transform.cc
+    record.cc
   DEPS
     v::bytes
     v::utils

--- a/src/v/model/record.cc
+++ b/src/v/model/record.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "model/record.h"
+
+namespace model {
+
+bool record_batch_iterator::has_next() const noexcept {
+    return _index < _record_count;
+}
+
+model::record record_batch_iterator::next() {
+    auto r = model::parse_one_record_copy_from_buffer(_parser);
+    ++_index;
+    // if we're done, then check that we read all the buffer
+    if (!has_next() && _parser.bytes_left()) [[unlikely]] {
+        throw std::out_of_range(fmt::format(
+          "Record iteration stopped with {} bytes remaining",
+          _parser.bytes_left()));
+    }
+    return r;
+}
+
+record_batch_iterator
+record_batch_iterator::create(const model::record_batch& b) {
+    b.verify_iterable();
+    return {b.record_count(), iobuf_const_parser(b._records)};
+}
+
+record_batch_iterator::record_batch_iterator(int32_t rc, iobuf_const_parser p)
+  : _record_count(rc)
+  , _parser(std::move(p)) {}
+} // namespace model

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -78,3 +78,15 @@ SEASTAR_THREAD_TEST_CASE(set_max_timestamp) {
     BOOST_TEST(crc == batch.header().crc);
     BOOST_TEST(hdr_crc == batch.header().header_crc);
 }
+
+SEASTAR_THREAD_TEST_CASE(iterator) {
+    auto b = model::test::make_random_batch(model::offset(0), 10, false);
+
+    auto it = model::record_batch_iterator::create(b);
+    for (int i = 0; i < b.record_count(); ++i) {
+        BOOST_TEST(it.has_next());
+        model::record r = it.next();
+        BOOST_TEST(r.offset_delta() == i);
+    }
+    BOOST_TEST(!it.has_next());
+}

--- a/src/v/model/tests/record_batch_test.cc
+++ b/src/v/model/tests/record_batch_test.cc
@@ -90,3 +90,19 @@ SEASTAR_THREAD_TEST_CASE(iterator) {
     }
     BOOST_TEST(!it.has_next());
 }
+
+SEASTAR_THREAD_TEST_CASE(extra_bytes_iterator) {
+    auto b = model::test::make_random_batch(model::offset(0), 1, false);
+    auto buf = b.data().copy();
+    // If there are extra bytes at the end of the batch we should throw.
+    constexpr std::string_view extra_data = "foobar";
+    buf.append(extra_data.data(), extra_data.size());
+    auto header = b.header();
+    header.size_bytes = static_cast<int32_t>(
+      model::packed_record_batch_header_size + buf.size_bytes());
+    b = model::record_batch(
+      header, std::move(buf), model::record_batch::tag_ctor_ng{});
+    auto it = model::record_batch_iterator::create(b);
+    BOOST_TEST(it.has_next());
+    BOOST_REQUIRE_THROW(it.next(), std::out_of_range);
+}


### PR DESCRIPTION
Introduce a simple iterator over a batch instead of using the `for_each` callbacks.

The `for_each` callbacks aren't coroutine friendly and this utility will simplify a bunch of 
callsites that mix coroutines and callbacks because of the `for_each_record` style of iteration.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
