### PR TITLE
rptest: Trigger test failiure on uncaught exception

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1190,8 +1190,12 @@ class RedpandaServiceBase(Service):
 
             # List of regexes that will fail the test on if they appear in the log
             match_terms = [
-                "Segmentation fault", "[Aa]ssert",
-                "Exceptional future ignored", "UndefinedBehaviorSanitizer"
+                "Segmentation fault",
+                "[Aa]ssert",
+                "Exceptional future ignored",
+                "UndefinedBehaviorSanitizer",
+                "Aborting on shard",
+                "libc++abi: terminating due to uncaught exception",
             ]
             if self._raise_on_errors:
                 match_terms.append("^ERROR")


### PR DESCRIPTION
Previously, we triggered test failure in case if redpanda crashed due to assertion, segfault, ignored exceptional future or undefined behaviour sanitizer failure. Crashes caused by uncaught exceptions were unnoticed. If redpanda terminated due to exception the test would be marked green. This commit fixes this by adding regexes that shold catch this.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none