### PR TITLE
[v22.3.x] Handle gate closing exceptions in replicate_entries_stm

### DIFF
--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -295,7 +295,7 @@ ss::future<result<replicate_result>> replicate_entries_stm::apply(units_t u) {
 
     // wait for the requests to be dispatched in background and then release
     // units
-    (void)ss::with_gate(_req_bg, [this]() {
+    ssx::spawn_with_gate(_req_bg, [this]() {
         // Wait until all RPCs will be dispatched
         return _dispatch_sem.wait(_requests_count).then([this] {
             // release memory reservations, and destroy data


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13300
Fixes: https://github.com/redpanda-data/redpanda/issues/13314,