### PR TITLE
[v23.2.x] k8s: Bump Go version to v1.21.0

### DIFF
--- a/src/go/k8s/.golangci.yml
+++ b/src/go/k8s/.golangci.yml
@@ -2,6 +2,12 @@ run:
   skip-files:
     - internal/util/pod/pod.go
 linters-settings:
+  # If gofumpt is run outside a module, it assumes Go 1.0 rather than the
+  # latest Go. We always want the latest formatting.
+  #
+  # https://github.com/mvdan/gofumpt/issues/137
+  gofumpt:
+    lang-version: "1.21"
   dupl:
     threshold: 100
   funlen:

--- a/src/go/k8s/Dockerfile
+++ b/src/go/k8s/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.20.4 as builder
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.21.0 as builder
 
 ARG TARGETARCH
 ARG TARGETOS


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13283
