### PR TITLE
Coordinated recovery: scheduler

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -242,6 +242,15 @@ configuration::configuration()
       "enables raft optimization of heartbeats",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , raft_recovery_concurrency_per_shard(
+      *this,
+      "raft_recovery_concurrency_per_shard",
+      "How many partitions may simultaneously recover data to a particular "
+      "shard. This is limited to avoid overwhelming nodes when they come back "
+      "online after an outage.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      64,
+      {.min = 1, .max = 16384})
   , enable_usage(
       *this,
       "enable_usage",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -85,6 +85,7 @@ struct configuration final : public config_store {
     bounded_property<std::optional<size_t>> raft_max_recovery_memory;
     bounded_property<size_t> raft_recovery_default_read_size;
     property<bool> raft_enable_lw_heartbeat;
+    bounded_property<size_t> raft_recovery_concurrency_per_shard;
     // Kafka
     property<bool> enable_usage;
     bounded_property<size_t> usage_num_windows;

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -75,6 +75,8 @@ std::string_view to_string_view(feature f) {
         return "delete_records";
     case feature::lightweight_heartbeats:
         return "lightweight_heartbeats";
+    case feature::raft_coordinated_recovery:
+        return "raft_coordinated_recovery";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -62,6 +62,7 @@ enum class feature : std::uint64_t {
     raft_append_entries_serde = 1ULL << 28U,
     delete_records = 1ULL << 29U,
     lightweight_heartbeats = 1ULL << 30U,
+    raft_coordinated_recovery = 1ULL << 31U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -284,6 +285,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{11},
     "lightweight_heartbeats",
     feature::lightweight_heartbeats,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{11},
+    "raft_coordinated_recovery",
+    feature::raft_coordinated_recovery,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };

--- a/src/v/raft/CMakeLists.txt
+++ b/src/v/raft/CMakeLists.txt
@@ -37,6 +37,7 @@ v_cc_library(
     heartbeats.cc
     state_machine_manager.cc
     state_machine_base.cc
+    recovery_scheduler.cc
   DEPS
     v::storage
     raft_rpc

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -101,6 +101,7 @@ consensus::consensus(
   std::optional<std::reference_wrapper<coordinated_recovery_throttle>>
     recovery_throttle,
   recovery_memory_quota& recovery_mem_quota,
+  recovery_scheduler& recovery_scheduler,
   features::feature_table& ft,
   std::optional<voter_priority> voter_priority_override,
   keep_snapshotted_log should_keep_snapshotted_log)
@@ -134,6 +135,7 @@ consensus::consensus(
   , _storage(storage)
   , _recovery_throttle(recovery_throttle)
   , _recovery_mem_quota(recovery_mem_quota)
+  , _recovery_scheduler(recovery_scheduler)
   , _features(ft)
   , _snapshot_mgr(
       std::filesystem::path(_log->config().work_directory()),

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -31,6 +31,7 @@
 #include "raft/prevote_stm.h"
 #include "raft/probe.h"
 #include "raft/recovery_memory_quota.h"
+#include "raft/recovery_scheduler.h"
 #include "raft/replicate_batcher.h"
 #include "raft/state_machine_manager.h"
 #include "raft/timeout_jitter.h"
@@ -105,6 +106,7 @@ public:
       storage::api&,
       std::optional<std::reference_wrapper<coordinated_recovery_throttle>>,
       recovery_memory_quota&,
+      recovery_scheduler&,
       features::feature_table&,
       std::optional<voter_priority> = std::nullopt,
       keep_snapshotted_log = keep_snapshotted_log::no);
@@ -806,6 +808,7 @@ private:
     std::optional<std::reference_wrapper<coordinated_recovery_throttle>>
       _recovery_throttle;
     recovery_memory_quota& _recovery_mem_quota;
+    recovery_scheduler& _recovery_scheduler;
     features::feature_table& _features;
     storage::simple_snapshot_manager _snapshot_mgr;
     uint64_t _snapshot_size{0};

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -87,6 +87,10 @@ public:
         _notifications.unregister_cb(id);
     }
 
+    recovery_status get_recovery_status() {
+        return _recovery_scheduler.get_status();
+    }
+
 private:
     void trigger_leadership_notification(raft::leadership_status);
     void setup_metrics();

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -15,6 +15,7 @@
 #include "raft/consensus_client_protocol.h"
 #include "raft/heartbeat_manager.h"
 #include "raft/recovery_memory_quota.h"
+#include "raft/recovery_scheduler.h"
 #include "raft/types.h"
 #include "rpc/fwd.h"
 #include "ssx/metrics.h"
@@ -43,6 +44,7 @@ public:
         config::binding<std::chrono::milliseconds> heartbeat_timeout;
         config::binding<std::chrono::milliseconds> raft_io_timeout_ms;
         config::binding<bool> enable_lw_heartbeat;
+        config::binding<size_t> recovery_concurrency_per_shard;
     };
     using config_provider_fn = ss::noncopyable_function<configuration()>;
 
@@ -106,6 +108,7 @@ private:
     storage::api& _storage;
     coordinated_recovery_throttle& _recovery_throttle;
     recovery_memory_quota _recovery_mem_quota;
+    recovery_scheduler _recovery_scheduler;
     features::feature_table& _feature_table;
     bool _is_ready;
 };

--- a/src/v/raft/recovery_scheduler.cc
+++ b/src/v/raft/recovery_scheduler.cc
@@ -210,12 +210,7 @@ void recovery_scheduler_base::activate_some() {
 void recovery_scheduler_base::tick() {
     auto gate_guard = _gate.hold();
 
-    vlog(
-      raftlog.debug,
-      "tick: active {}/{}, pending {}",
-      _active.size(),
-      _max_active(),
-      _pending.size());
+    size_t prev_active = _active.size();
 
     activate_some();
 
@@ -230,7 +225,9 @@ void recovery_scheduler_base::tick() {
 
     vlog(
       raftlog.debug,
-      "updated recovery stats (active: {}, pending: {}, offsets pending: {})",
+      "after tick: "
+      "active count: {} -> {}, pending count: {}, offsets pending: {}",
+      prev_active,
       _active.size(),
       _pending.size(),
       _offsets_pending);

--- a/src/v/raft/recovery_scheduler.cc
+++ b/src/v/raft/recovery_scheduler.cc
@@ -1,0 +1,247 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "raft/recovery_scheduler.h"
+
+#include "raft/consensus.h"
+#include "seastar/core/coroutine.hh"
+#include "vassert.h"
+
+namespace raft {
+
+follower_recovery_state::follower_recovery_state(
+  recovery_scheduler_base& scheduler,
+  consensus& parent,
+  model::offset our_last,
+  model::offset leader_last,
+  bool already_recovering)
+  : _parent(&parent)
+  , _is_active(already_recovering)
+  , _our_last_offset(our_last)
+  , _leader_last_offset(leader_last)
+  , _scheduler(&scheduler) {
+    _scheduler->add(*this);
+}
+
+void follower_recovery_state::force_active() {
+    if (_scheduler && !_is_active) {
+        _scheduler->activate(*this);
+    }
+}
+
+void follower_recovery_state::update_progress(
+  model::offset our_last, model::offset leader_last) {
+    auto prev_pending = pending_offset_count();
+
+    vlog(
+      raftlog.trace,
+      "follower_recovery_state {} new offsets: our: {}, leader {}",
+      *this,
+      our_last,
+      leader_last);
+
+    _our_last_offset = our_last;
+
+    // Leader last offset can go backwards in the following cases:
+    // 1. leadership change
+    // 2. reordered request
+    // 3. request from pre 23.3 redpanda (where we can't always determine the
+    // last offset and it will be model::offset{}).
+    //
+    // Of these only 1 is valid but for the purposes of progress tracking it
+    // should be okay to just take the max.
+    _leader_last_offset = std::max(_leader_last_offset, leader_last);
+
+    if (_scheduler) {
+        _scheduler->_offsets_pending += pending_offset_count() - prev_pending;
+
+        if (!_is_active) {
+            // This partition might have just received an update from a new
+            // leader after being leaderless for a while, therefore we must
+            // ensure that there will be a tick in the near future.
+            _scheduler->request_tick();
+        }
+    }
+}
+
+void follower_recovery_state::yield() {
+    if (_scheduler && _is_active) {
+        _scheduler->yield(*this);
+    }
+}
+
+const model::ntp& follower_recovery_state::ntp() const {
+    return _parent->ntp();
+}
+
+int64_t follower_recovery_state::pending_offset_count() const {
+    // Follower last offset can be greater if it hasn't yet truncated its
+    // log in response to leader requests.
+
+    if (_leader_last_offset > _our_last_offset) {
+        if (_our_last_offset() >= 0) {
+            return _leader_last_offset - _our_last_offset;
+        } else {
+            return _leader_last_offset + model::offset{1};
+        }
+    } else {
+        return model::offset{0};
+    }
+}
+
+follower_recovery_state::~follower_recovery_state() noexcept {
+    if (_scheduler) {
+        _scheduler->remove(*this);
+        _scheduler = nullptr;
+    }
+}
+
+std::ostream& operator<<(std::ostream& o, const follower_recovery_state& frs) {
+    fmt::print(
+      o,
+      "{{ntp: {} is_active: {}, our_last_offset: {} leader_last_offset: {}}}",
+      frs.ntp(),
+      frs._is_active,
+      frs._our_last_offset,
+      frs._leader_last_offset);
+    return o;
+}
+
+recovery_scheduler_base::recovery_scheduler_base(
+  config::binding<size_t> max_active)
+  : _max_active(std::move(max_active)) {
+    _max_active.watch([this] {
+        if (_active.size() < _max_active()) {
+            request_tick();
+        }
+    });
+}
+
+recovery_scheduler_base::~recovery_scheduler_base() {
+    auto disposer = [](follower_recovery_state* frs) {
+        frs->_scheduler = nullptr;
+    };
+    _active.clear_and_dispose(disposer);
+    _pending.clear_and_dispose(disposer);
+}
+
+static bool is_internal(const model::ntp& ntp) {
+    return ntp.ns == model::redpanda_ns
+           || ntp.ns == model::kafka_internal_namespace
+           || (ntp.ns == model::kafka_namespace && ntp.tp.topic == model::kafka_consumer_offsets_topic);
+}
+
+void recovery_scheduler_base::add(follower_recovery_state& frs) {
+    if (frs.ntp() == model::controller_ntp) {
+        frs._is_active = true;
+    } else if (is_internal(frs.ntp()) && _active.size() < _max_active()) {
+        frs._is_active = true;
+    }
+
+    if (frs._is_active) {
+        _active.push_back(frs);
+    } else {
+        _pending.push_back(frs);
+        request_tick();
+    }
+
+    _offsets_pending += frs.pending_offset_count();
+    vlog(raftlog.trace, "frs {}: add", frs);
+}
+
+void recovery_scheduler_base::activate(follower_recovery_state& st) {
+    vassert(!st._is_active, "ntp {}: recovery already active!", st.ntp());
+    _pending.erase(state_list::s_iterator_to(st));
+    st._is_active = true;
+    _active.push_back(st);
+    vlog(raftlog.trace, "frs {}: activate", st);
+}
+
+void recovery_scheduler_base::yield(follower_recovery_state& st) {
+    vassert(st._is_active, "ntp {}: recovery not active!", st.ntp());
+    _active.erase(state_list::s_iterator_to(st));
+    st._is_active = false;
+    _pending.push_back(st);
+    request_tick();
+    vlog(raftlog.trace, "frs {}: yield", st);
+}
+
+void recovery_scheduler_base::remove(follower_recovery_state& frs) {
+    auto it = recovery_scheduler_base::state_list::s_iterator_to(frs);
+    if (frs._is_active) {
+        _active.erase(it);
+        request_tick();
+    } else {
+        _pending.erase(it);
+    }
+    _offsets_pending -= frs.pending_offset_count();
+    vlog(raftlog.trace, "frs {}: remove", frs);
+}
+
+void recovery_scheduler_base::activate_some() {
+    if (_active.size() >= _max_active() || _pending.empty()) {
+        return;
+    }
+
+    std::vector<std::pair<int, follower_recovery_state*>> to_sort;
+    to_sort.reserve(_pending.size());
+    for (auto& frs : _pending) {
+        int priority = (is_internal(frs.ntp()) ? 0 : 1);
+        to_sort.emplace_back(priority, &frs);
+    }
+
+    size_t to_activate = std::min(
+      _pending.size(), _max_active() - _active.size());
+    std::nth_element(
+      to_sort.begin(), to_sort.begin() + to_activate, to_sort.end());
+    to_sort.resize(to_activate);
+
+    for (auto [prio, frs] : to_sort) {
+        activate(*frs);
+    }
+}
+
+void recovery_scheduler_base::tick() {
+    auto gate_guard = _gate.hold();
+
+    vlog(
+      raftlog.debug,
+      "tick: active {}/{}, pending {}",
+      _active.size(),
+      _max_active(),
+      _pending.size());
+
+    activate_some();
+
+    // recalculate _offsets_pending just in case
+    _offsets_pending = 0;
+    for (const auto& frs : _active) {
+        _offsets_pending += frs.pending_offset_count();
+    }
+    for (const auto& frs : _pending) {
+        _offsets_pending += frs.pending_offset_count();
+    }
+
+    vlog(
+      raftlog.debug,
+      "updated recovery stats (active: {}, pending: {}, offsets pending: {})",
+      _active.size(),
+      _pending.size(),
+      _offsets_pending);
+}
+
+recovery_status recovery_scheduler_base::get_status() {
+    return {
+      .partitions_to_recover = _active.size() + _pending.size(),
+      .partitions_active = _active.size(),
+      .offsets_pending = uint64_t(std::max(_offsets_pending, int64_t(0))),
+    };
+}
+
+} // namespace raft

--- a/src/v/raft/recovery_scheduler.h
+++ b/src/v/raft/recovery_scheduler.h
@@ -17,7 +17,7 @@
 #include "seastar/core/lowres_clock.hh"
 #include "seastar/core/timer.hh"
 #include "seastarx.h"
-#include "ssx/semaphore.h"
+#include "ssx/metrics.h"
 #include "utils/intrusive_list_helpers.h"
 
 #include <fmt/core.h>
@@ -135,6 +135,8 @@ private:
      */
     virtual void request_tick() = 0;
 
+    void setup_metrics();
+
 private:
     config::binding<size_t> _max_active;
 
@@ -146,6 +148,11 @@ private:
     state_list _pending;
 
     int64_t _offsets_pending = 0;
+
+    ssx::metrics::metric_groups _metrics
+      = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 /**

--- a/src/v/raft/recovery_scheduler.h
+++ b/src/v/raft/recovery_scheduler.h
@@ -1,0 +1,194 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "config/property.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "raft/logger.h"
+#include "seastar/core/gate.hh"
+#include "seastar/core/lowres_clock.hh"
+#include "seastar/core/timer.hh"
+#include "seastarx.h"
+#include "ssx/semaphore.h"
+#include "utils/intrusive_list_helpers.h"
+
+#include <fmt/core.h>
+
+#include <vector>
+
+namespace raft {
+
+class recovery_scheduler_base;
+
+/**
+ * Summarized state of a recovery_scheduler.  Use merge()
+ * across statuses from all shards to get a total node state.
+ *
+ * Suitable for use in admin API, statistics, etc.
+ */
+struct recovery_status {
+    uint64_t partitions_to_recover{0};
+    uint64_t partitions_active{0};
+    uint64_t offsets_pending{0};
+
+    void merge(recovery_status const& rhs) {
+        partitions_to_recover += rhs.partitions_to_recover;
+        partitions_active += rhs.partitions_active;
+        offsets_pending += rhs.offsets_pending;
+    }
+};
+
+/**
+ * If a `consensus` object is a follower that needs recovery or is currently
+ * recovering, it instantiates one of these.
+ *
+ * It will register with recovery_scheduler so that it will start considering
+ * this partition as a candidate for allowing recovery.  However, this can also
+ * be constructed in an already-recovering state for situations where recovery
+ * has been initiated by the leader & not via the scheduler.
+ */
+class follower_recovery_state {
+public:
+    follower_recovery_state(
+      recovery_scheduler_base& scheduler,
+      consensus& parent,
+      model::offset our_last,
+      model::offset leader_last,
+      bool force_active);
+
+    follower_recovery_state(follower_recovery_state&& rhs) = delete;
+    follower_recovery_state(const follower_recovery_state& rhs) = delete;
+    follower_recovery_state& operator=(const follower_recovery_state&) = delete;
+    follower_recovery_state& operator=(follower_recovery_state&&) = delete;
+    ~follower_recovery_state() noexcept;
+
+    void force_active();
+    void update_progress(model::offset our_last, model::offset leader_last);
+    void yield();
+
+    const model::ntp& ntp() const;
+    bool is_active() const { return _is_active; }
+    int64_t pending_offset_count() const;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const follower_recovery_state&);
+
+private:
+    friend class recovery_scheduler_base;
+
+    consensus* _parent = nullptr;
+
+    bool _is_active = false;
+    model::offset _our_last_offset;
+    model::offset _leader_last_offset;
+
+    recovery_scheduler_base* _scheduler = nullptr;
+    safe_intrusive_list_hook _list_hook;
+};
+
+/**
+ * Although each raft group's recovery can proceed independently, it is
+ * not desirable to run all of them in parallel, because it leads to
+ * an excess of concurrent I/Os to a node coming back online after an outage.
+ *
+ * This class is responsible for limiting the number of recoveries
+ * done to a single shard (and therefore to a single node) at once, and
+ * prioritizing them to recover important metadata before bulk data.
+ *
+ * It is split into a "base" class that contains most of the logic, and
+ * then specialized into a subclass that contains timing code, so that the
+ * latter part can easily be switched out for unit testing with manual_clock.
+ */
+class recovery_scheduler_base {
+public:
+    explicit recovery_scheduler_base(config::binding<size_t> max_active);
+    virtual ~recovery_scheduler_base();
+
+    recovery_status get_status();
+
+protected:
+    void tick();
+    ss::gate _gate;
+
+private:
+    void activate_some();
+
+    friend class follower_recovery_state;
+
+    // state transitions
+    void add(follower_recovery_state&);
+    void activate(follower_recovery_state&);
+    void yield(follower_recovery_state&);
+    void remove(follower_recovery_state&);
+
+    /**
+     * Signal to the scheduler that something has changed, and it
+     * should wake up, make scheduling decisions and update status.
+     */
+    virtual void request_tick() = 0;
+
+private:
+    config::binding<size_t> _max_active;
+
+    using state_list = counted_intrusive_list<
+      follower_recovery_state,
+      &follower_recovery_state::_list_hook>;
+
+    state_list _active;
+    state_list _pending;
+
+    int64_t _offsets_pending = 0;
+};
+
+/**
+ * The 'ticker' is the concrete implementation of recovery_scheduler,
+ * templated on a particular clock type to use.
+ */
+template<typename Clock>
+class recovery_scheduler_ticker : public recovery_scheduler_base {
+public:
+    recovery_scheduler_ticker(
+      config::binding<size_t> max_active,
+      config::binding<std::chrono::milliseconds> period)
+      : recovery_scheduler_base(std::move(max_active))
+      , _timer([this] { return tick(); })
+      , _period(std::move(period)) {}
+
+    ss::future<> start() { co_return; }
+
+    ss::future<> stop() {
+        _timer.cancel();
+        return _gate.close();
+    }
+
+    void request_tick() override {
+        if (!_timer.armed()) {
+            // This time period is meant to be long enough to accumulate a round
+            // of heartbeats from all peers and then prioritize them in a batch.
+            _timer.arm(_period());
+        }
+    }
+
+private:
+    // This timer is armed after a follower registers or unregisters, to
+    // prompt a call to tick().  The timer's delay
+    seastar::timer<Clock> _timer;
+
+    // How long to accumulate registrations for before making the next
+    // decision about which partitions to start recovering. This time period is
+    // meant to be long enough to accumulate a round of heartbeats from all
+    // peers.
+    config::binding<std::chrono::milliseconds> _period;
+};
+
+using recovery_scheduler = recovery_scheduler_ticker<ss::lowres_clock>;
+
+} // namespace raft

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -347,6 +347,8 @@ raft_node_instance::raft_node_instance(
         .default_read_buffer_size = config::mock_binding<size_t>(128_KiB),
       };
   })
+  , _recovery_scheduler(
+      config::mock_binding<size_t>(64), config::mock_binding(10ms))
   , _leader_clb(std::move(leader_update_clb))
   , _logger(test_log, fmt::format("[node: {}]", _id)) {
     config::shard_local_cfg().disable_metrics.set_value(true);
@@ -401,6 +403,7 @@ ss::future<> raft_node_instance::start(
       _storage.local(),
       _recovery_throttle.local(),
       _recovery_mem_quota,
+      _recovery_scheduler,
       _features.local());
     co_await _hb_manager->register_group(_raft);
     co_await _raft->start(std::move(builder));

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -183,6 +183,7 @@ private:
     ss::sharded<features::feature_table> _features;
     ss::sharded<coordinated_recovery_throttle> _recovery_throttle;
     recovery_memory_quota _recovery_mem_quota;
+    recovery_scheduler _recovery_scheduler;
     std::unique_ptr<heartbeat_manager> _hb_manager;
     leader_update_clb_t _leader_clb;
     prefix_logger _logger;

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -159,6 +159,12 @@ struct raft_node {
             }))
           .get();
 
+        recovery_scheduler
+          .start(
+            config::mock_binding<size_t>(64),
+            config::mock_binding<std::chrono::milliseconds>(10ms))
+          .get();
+
         // setup consensus
         auto self_id = this->broker.id();
         consensus = ss::make_lw_shared<raft::consensus>(
@@ -176,6 +182,7 @@ struct raft_node {
           storage.local(),
           recovery_throttle.local(),
           recovery_mem_quota,
+          recovery_scheduler.local(),
           feature_table.local(),
           std::nullopt);
     }
@@ -273,8 +280,18 @@ struct raft_node {
                 "consensus destroyed at node {} {}",
                 broker.id(),
                 consensus.use_count());
+
+              // Forbid anyone keeping a consensus object alive after
+              // node shutdown: it may hold references to storage
+              // layer we are about to destroy.
+              assert(consensus.owned());
               consensus = nullptr;
               return ss::now();
+          })
+          .then([this] {
+              tstlog.info(
+                "Stopping recovery_scheduler at node {}", broker.id());
+              return recovery_scheduler.stop();
           })
           .then([this] {
               tstlog.info("Stopping cache at node {}", broker.id());
@@ -346,6 +363,7 @@ struct raft_node {
     model::broker broker;
     ss::sharded<storage::api> storage;
     ss::sharded<raft::coordinated_recovery_throttle> recovery_throttle;
+    ss::sharded<raft::recovery_scheduler> recovery_scheduler;
     ss::shared_ptr<storage::log> log;
     ss::sharded<ss::abort_source> as_service;
     ss::sharded<rpc::connection_cache> cache;

--- a/src/v/raft/tests/simple_raft_fixture.h
+++ b/src/v/raft/tests/simple_raft_fixture.h
@@ -87,6 +87,8 @@ struct simple_raft_fixture {
                   .raft_io_timeout_ms
                   = config::mock_binding<std::chrono::milliseconds>(30s),
                   .enable_lw_heartbeat = config::mock_binding<bool>(true),
+                  .recovery_concurrency_per_shard
+                  = config::mock_binding<size_t>(64),
                 };
             },
             [] {

--- a/src/v/raft/types.h
+++ b/src/v/raft/types.h
@@ -94,6 +94,8 @@ struct follower_index_metadata {
 
     follower_req_seq next_follower_sequence() { return ++last_sent_seq; }
 
+    static bool is_first_request(follower_req_seq seq) { return seq() == 1; }
+
     vnode node_id;
     // index of last known log for this follower
     model::offset last_flushed_log_index;

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -256,6 +256,7 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
     vlog(_ctxlog.trace, "vote acks in term {} from: {}", term, acks);
     // section vote:5.2.2
     _ptr->_vstate = consensus::vote_state::leader;
+    _ptr->_follower_recovery_state.reset();
     _ptr->_leader_id = _ptr->self();
     // reset target priority
     _ptr->_target_priority = voter_priority::max();

--- a/src/v/redpanda/admin/api-doc/raft.json
+++ b/src/v/redpanda/admin/api-doc/raft.json
@@ -1,24 +1,72 @@
-"/v1/raft/{group_id}/transfer_leadership": {
-  "post": {
-    "summary": "transfer raft group leadership",
-    "operationId": "raft_transfer_leadership",
-    "parameters": [
+{
+  "apiVersion": "0.0.1",
+  "swaggerVersion": "1.2",
+  "basePath": "/v1",
+  "resourcePath": "/raft",
+  "produces": [
+    "application/json"
+  ],
+  "apis": [
+    {
+      "path": "/v1/raft/{group_id}/transfer_leadership",
+      "operations": [
         {
-            "name": "group_id",
-            "in": "path",
-            "required": true,
-            "type": "integer"
-        },
-        {
-            "name":"target",
-            "in":"query",
-            "required":false,
-            "type":"integer"
+          "method": "POST",
+          "summary": "transfer raft group leadership",
+          "nickname": "raft_transfer_leadership",
+          "produces": [
+            "application/json"
+          ],
+          "parameters": [
+            {
+              "name": "group_id",
+              "in": "path",
+              "required": true,
+              "type": "integer"
+            },
+            {
+              "name": "target",
+              "in": "query",
+              "required": false,
+              "type": "integer"
+            }
+          ]
         }
-    ],
-    "responses": {
-      "200": {
-        "description": "Raft leadership transfer"
+      ]
+    },
+    {
+      "path": "/v1/raft/recovery/status",
+      "operations": [
+        {
+          "method": "GET",
+          "summary": "Get this node's recovery status",
+          "type": "recovery_status",
+          "nickname": "get_raft_recovery_status",
+          "produces": [
+            "application/json"
+          ],
+          "parameters": []
+        }
+      ]
+    }
+  ],
+  "models": {
+    "recovery_status": {
+      "id": "recovery_status",
+      "description": "Node raft recovery status",
+      "properties": {
+        "partitions_to_recover": {
+          "type": "long",
+          "description": "Total partitions needing recovery"
+        },
+        "partitions_active": {
+          "type": "long",
+          "description": "Partitions currently in recovery"
+        },
+        "offsets_pending": {
+          "type": "long",
+          "description": "Offsets currently awaiting recovery"
+        }
       }
     }
   }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -220,6 +220,7 @@ admin_server::admin_server(
   admin_server_cfg cfg,
   ss::sharded<stress_fiber_manager>& looper,
   ss::sharded<cluster::partition_manager>& pm,
+  ss::sharded<raft::group_manager>& rgm,
   cluster::controller* controller,
   ss::sharded<cluster::shard_table>& st,
   ss::sharded<cluster::metadata_cache>& metadata_cache,
@@ -242,6 +243,7 @@ admin_server::admin_server(
   , _cfg(std::move(cfg))
   , _stress_fiber_manager(looper)
   , _partition_manager(pm)
+  , _raft_group_manager(rgm)
   , _controller(controller)
   , _shard_table(st)
   , _metadata_cache(metadata_cache)
@@ -1762,15 +1764,44 @@ admin_server::raft_transfer_leadership_handler(
       });
 }
 
+ss::future<ss::json::json_return_type>
+admin_server::get_raft_recovery_status_handler(
+  std::unique_ptr<ss::http::request>) {
+    ss::httpd::raft_json::recovery_status result;
+
+    // Aggregate recovery status from all shards
+    auto s = co_await _raft_group_manager.map_reduce0(
+      [](auto& rgm) -> raft::recovery_status {
+          return rgm.get_recovery_status();
+      },
+      raft::recovery_status{},
+      [](raft::recovery_status acc, raft::recovery_status update) {
+          acc.merge(update);
+          return acc;
+      });
+
+    result.partitions_to_recover = s.partitions_to_recover;
+    result.partitions_active = s.partitions_active;
+    result.offsets_pending = s.offsets_pending;
+    co_return result;
+}
+
 void admin_server::register_raft_routes() {
     register_route<superuser>(
       ss::httpd::raft_json::raft_transfer_leadership,
       [this](std::unique_ptr<ss::http::request> req) {
           return raft_transfer_leadership_handler(std::move(req));
       });
+
+    register_route<auth_level::user>(
+      ss::httpd::raft_json::get_raft_recovery_status,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return get_raft_recovery_status_handler(std::move(req));
+      });
 }
 
 namespace {
+
 // TODO: factor out generic serialization from seastar http exceptions
 security::scram_credential parse_scram_credential(const json::Document& doc) {
     if (!doc.IsObject()) {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -68,6 +68,7 @@ public:
       admin_server_cfg,
       ss::sharded<stress_fiber_manager>&,
       ss::sharded<cluster::partition_manager>&,
+      ss::sharded<raft::group_manager>&,
       cluster::controller*,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::metadata_cache>&,
@@ -355,6 +356,8 @@ private:
     /// Raft routes
     ss::future<ss::json::json_return_type>
       raft_transfer_leadership_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      get_raft_recovery_status_handler(std::unique_ptr<ss::http::request>);
 
     /// Security routes
     ss::future<ss::json::json_return_type>
@@ -518,6 +521,7 @@ private:
     admin_server_cfg _cfg;
     ss::sharded<stress_fiber_manager>& _stress_fiber_manager;
     ss::sharded<cluster::partition_manager>& _partition_manager;
+    ss::sharded<raft::group_manager>& _raft_group_manager;
     cluster::controller* _controller;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1097,6 +1097,9 @@ void application::wire_up_redpanda_services(
               = config::shard_local_cfg().raft_io_timeout_ms.bind(),
               .enable_lw_heartbeat
               = config::shard_local_cfg().raft_enable_lw_heartbeat.bind(),
+              .recovery_concurrency_per_shard
+              = config::shard_local_cfg()
+                  .raft_recovery_concurrency_per_shard.bind(),
             };
         },
         [] {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -862,6 +862,7 @@ void application::configure_admin_server() {
       admin_server_cfg_from_global_cfg(sched_groups),
       std::ref(stress_fiber_manager),
       std::ref(partition_manager),
+      std::ref(raft_group_manager),
       controller.get(),
       std::ref(shard_table),
       std::ref(metadata_cache),

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1081,3 +1081,10 @@ class Admin:
             "PUT",
             f"debug/set_storage_failure_injection_enabled?value={str_value}",
             node=node)
+
+    def get_raft_recovery_status(self, *, node: ClusterNode):
+        """
+        Node must be specified because this API reports on node-local state:
+        it would not make sense to send it to just any node.
+        """
+        return self._request("GET", "raft/recovery/status", node=node).json()

--- a/tests/rptest/tests/raft_recovery_test.py
+++ b/tests/rptest/tests/raft_recovery_test.py
@@ -7,13 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
+
 from rptest.util import wait_until, wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from ducktape.cluster.cluster import ClusterNode
+from ducktape.mark import matrix
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.services.redpanda_installer import RedpandaInstaller
@@ -148,3 +152,138 @@ class RaftRecoveryUpgradeTest(RedpandaTest):
             timeout_sec=60,
             backoff_sec=2,
             err_msg=f"couldn't reach under-replicated count target: {target}")
+
+
+class RaftRecoveryTest(RedpandaTest):
+    topics = [TopicSpec(
+        partition_count=128,
+        replication_factor=3,
+    )]
+
+    msg_size = 4096
+
+    def setUp(self):
+        pass
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=3, **kwargs)
+
+    @skip_debug_mode
+    @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @matrix(stop_producer=[False, True])
+    def test_recovery_concurrency_limit(self, stop_producer):
+        """
+        Verify that `raft_concurrent_recoveries` is respected when
+        the number of partitions to recover exceeds it.
+        """
+
+        # Artificially low limits to slow down recovery enough that we
+        # can watch the partitions trickle through
+        shard_concurrency = 4
+        self.redpanda.set_extra_rp_conf({
+            'raft_recovery_concurrency_per_shard':
+            shard_concurrency,
+            'raft_max_recovery_memory':
+            32 * 1024 * 1024,
+            # FIXME: leadership transfers force recoveries that can then
+            # violate the concurrency limit
+            'enable_leader_balancer':
+            False,
+        })
+
+        cpu_count = self.redpanda.get_node_cpu_count()
+        node_concurrency = cpu_count * shard_concurrency
+
+        self.redpanda.start()
+
+        topic = "mytopic"
+        partition_count = 64 * cpu_count
+
+        # TODO: different values for CDT
+        segment_bytes = 2**20
+        produce_bandwidth = 5 * 2**20
+        recovery_data_target = 60 * produce_bandwidth
+
+        self.client().create_topic(
+            TopicSpec(name=topic,
+                      partition_count=partition_count,
+                      segment_bytes=segment_bytes,
+                      retention_bytes=16 * segment_bytes))
+
+        producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            topic,
+            msg_size=self.msg_size,
+            # some large number to get produce load till the end of test
+            msg_count=2**30,
+            rate_limit_bps=produce_bandwidth)
+        producer.start()
+
+        # Arbitrary choice of node to be restarted
+        victim_node = self.redpanda.nodes[1]
+
+        rpk = RpkTool(self.redpanda)
+
+        _await_progress_in_all_partitions(rpk, topic)
+        self.redpanda.stop_node(victim_node)
+
+        # Wait for recovery lag to accumulate.
+        recovery_msgs_target = recovery_data_target // self.msg_size
+        expect_progress_time = recovery_data_target / produce_bandwidth
+
+        start_count = producer.produce_status.acked
+        target_count = start_count + recovery_msgs_target
+
+        self.logger.info(
+            f"wait for producer to reach {target_count} acked msgs in {expect_progress_time} s."
+        )
+
+        time.sleep(expect_progress_time)
+        # give producer 2x expected time to produce the required amount of data
+        wait_until(lambda: producer.produce_status.acked >= target_count,
+                   backoff_sec=1,
+                   timeout_sec=expect_progress_time)
+
+        if stop_producer:
+            # Stop producer before starting the victim node so that
+            # its raft instances will have to rely on heartbeats to
+            # detect when to exit recovery.
+            producer.stop_node(producer.nodes[0])
+
+        self.redpanda.start_node(victim_node)
+
+        admin = Admin(self.redpanda)
+
+        # We will wait for various conditions, but continously want to validate
+        # general invariants such as that the concurrent recovery count
+        # is not violated.
+        def wait_with_invariants(check_fn, *, timeout_sec, backoff_sec):
+            def wrapped():
+                state = admin.get_raft_recovery_status(node=victim_node)
+                assert state['partitions_active'] <= node_concurrency
+                return check_fn(state)
+
+            return wait_until(wrapped,
+                              timeout_sec=timeout_sec,
+                              backoff_sec=backoff_sec)
+
+        # wait for recovery to start
+        wait_with_invariants(lambda s: s['partitions_active'] > 0,
+                             timeout_sec=15,
+                             backoff_sec=1)
+
+        def recovery_finished(state):
+            if state['partitions_to_recover'] > 0 or state[
+                    'offsets_pending'] > 0:
+                return False
+
+            # if recovery status says that we are done, additionally check metrics
+
+            count = self.redpanda.metric_sum(
+                'vectorized_cluster_partition_under_replicated_replicas')
+            self.logger.info(f"under-replicated partitions count: {count}")
+
+            return count == 0
+
+        wait_with_invariants(recovery_finished, timeout_sec=120, backoff_sec=1)


### PR DESCRIPTION
Although each raft group's recovery can proceed independently, it is not desirable to run all of them in parallel, because it leads to an excess of concurrent I/Os to a node coming back online after an outage. Introduce `recovery_scheduler` - the class responsible for limiting the number of recoveries done to a single node at once, and for prioritizing them to recover important metadata before bulk data.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
* Introduce *coordinated recovery* - avoid overwhelming a starting node that has been offline for a long time with Raft recovery traffic by limiting concurrency and prioritizing the order of partition recovery. This is enabled by default, to configure the per-shard concurrency limit, change the `raft_recovery_concurrency_per_shard` cluster config property.
