### PR TITLE
[storage]: remove recursion from segment_appender::do_append

### DIFF
--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -145,48 +145,48 @@ ss::future<> segment_appender::append(const char* buf, const size_t n) {
 }
 
 ss::future<> segment_appender::do_append(const char* buf, size_t n) {
-    while(true) {
-    vassert(!_closed, "append() on closed segment: {}", *this);
+    while (true) {
+        vassert(!_closed, "append() on closed segment: {}", *this);
 
-    /*
-     * if there is no current active chunk then we need to rehydrate. this can
-     * happen because of truncation or because the appender had been idle and
-     * its chunk was reclaimed into the chunk cache.
-     */
-    if (unlikely(!_head && _committed_offset > 0)) {
-        _head = co_await internal::chunks().get();
-        co_await hydrate_last_half_page();
-        continue;
-    }
-
-    if (next_committed_offset() + n > _fallocation_offset) {
-        co_await do_next_adaptive_fallocation();
-        continue;
-    }
-
-    size_t written = 0;
-    if (likely(_head)) {
-        const size_t sz = _head->append(buf + written, n - written);
-        written += sz;
-        _bytes_flush_pending += sz;
-        if (_head->is_full()) {
-            dispatch_background_head_write();
+        /*
+         * if there is no current active chunk then we need to rehydrate. this
+         * can happen because of truncation or because the appender had been
+         * idle and its chunk was reclaimed into the chunk cache.
+         */
+        if (unlikely(!_head && _committed_offset > 0)) {
+            _head = co_await internal::chunks().get();
+            co_await hydrate_last_half_page();
+            continue;
         }
-    }
-    if (written == n) {
-        co_return;
-    }
 
-    // barrier. do not hold the units!
-    auto units = co_await ss::get_units(_concurrent_flushes, 1);
-    units.return_all();
+        if (next_committed_offset() + n > _fallocation_offset) {
+            co_await do_next_adaptive_fallocation();
+            continue;
+        }
 
-    auto chunk = co_await internal::chunks().get();
-    vassert(!_head, "cannot overwrite existing chunk");
-    _head = std::move(chunk);
+        size_t written = 0;
+        if (likely(_head)) {
+            const size_t sz = _head->append(buf + written, n - written);
+            written += sz;
+            _bytes_flush_pending += sz;
+            if (_head->is_full()) {
+                dispatch_background_head_write();
+            }
+        }
+        if (written == n) {
+            co_return;
+        }
 
-    buf += written;
-    n -= written;
+        // barrier. do not hold the units!
+        auto units = co_await ss::get_units(_concurrent_flushes, 1);
+        units.return_all();
+
+        auto chunk = co_await internal::chunks().get();
+        vassert(!_head, "cannot overwrite existing chunk");
+        _head = std::move(chunk);
+
+        buf += written;
+        n -= written;
     }
 }
 

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -156,7 +156,7 @@ private:
     ss::future<> do_next_adaptive_fallocation();
     ss::future<> hydrate_last_half_page();
     ss::future<> do_truncation(size_t);
-    ss::future<> do_append(const char* buf, const size_t n);
+    ss::future<> do_append(const char* buf, size_t n);
 
     /*
      * committed offset isn't updated until the background write is dispatched.


### PR DESCRIPTION
When provided with a sufficiently large chunk of memory, `segment_appender::do_append` may produce deep enough recursion to cause a stack overflow. Fix by switching to a looping construct.

Fixes: https://github.com/redpanda-data/core-internal/issues/749

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

