### PR TITLE
[v23.2.x] cloud_storage: set default upload interval

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1359,7 +1359,7 @@ configuration::configuration()
       "Time that segment can be kept locally without uploading it to the "
       "remote storage (sec)",
       {.visibility = visibility::tunable},
-      std::nullopt)
+      1h)
   , cloud_storage_manifest_max_upload_interval_sec(
       *this,
       "cloud_storage_manifest_max_upload_interval_sec",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13292
Fixes: https://github.com/redpanda-data/redpanda/issues/13326,