### PR TITLE
Add advertised traffic generator for the high throughput tiers test suite

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -281,7 +281,7 @@ class HighThroughputTest(RedpandaTest):
         idx = random.randrange(len(self.cluster.nodes))
         return self.cluster.nodes[idx]
 
-    @cluster(num_nodes=5)
+    @cluster(num_nodes=2)
     def test_throughput_simple(self):
         with traffic_generator(self.test_context, self.redpanda,
                                self.tier_config, self.topic,
@@ -426,7 +426,7 @@ class HighThroughputTest(RedpandaTest):
         re.compile('storage - .* - Stopping parser, short read. .*')
     ] + RESTART_LOG_ALLOW_LIST
 
-    @cluster(num_nodes=5, log_allow_list=COMBO_PRELOADED_LOG_ALLOW_LIST)
+    @cluster(num_nodes=2, log_allow_list=COMBO_PRELOADED_LOG_ALLOW_LIST)
     def test_ht003_kgofailure(self):
         """
         Generates the maximum possible load to the cluster onto a topic that
@@ -510,7 +510,7 @@ class HighThroughputTest(RedpandaTest):
 
     # Temporary ignore until TS metrics can be queried via public_metrics
     @ignore  # https://github.com/redpanda-data/cloudv2/issues/8845
-    @cluster(num_nodes=5, log_allow_list=NOS3_LOG_ALLOW_LIST)
+    @cluster(num_nodes=2, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_disrupt_cloud_storage(self):
         """
         Make segments replicate to the cloud, then disrupt S3 connectivity
@@ -660,7 +660,7 @@ class HighThroughputTest(RedpandaTest):
 
     # Temporary ignore until TS metrics can be queried via public_metrics
     @ignore  # https://github.com/redpanda-data/cloudv2/issues/8845
-    @cluster(num_nodes=6, log_allow_list=NOS3_LOG_ALLOW_LIST)
+    @cluster(num_nodes=3, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_cloud_cache_thrash(self):
         """
         Try to exhaust cloud cache by reading at random offsets with many

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -503,12 +503,8 @@ class HighThroughputTest(PreallocNodesTest):
     # STORAGE_TARGET_REPLAY_BYTES.  The resulting walltime for startup
     # depends on the speed of the disk.  60 seconds is long enough
     # for an i3en.xlarge (and more than enough for faster instance types)
-    EXPECT_START_TIME = 60
-
-    LEADER_BALANCER_PERIOD_MS = 30000
     topic_name = "tiered_storage_topic"
     small_segment_size = 4 * KiB
-    num_segments_per_partition = 1000
     unavailable_timeout = 60
     msg_size = 128 * KiB
 
@@ -590,7 +586,8 @@ class HighThroughputTest(PreallocNodesTest):
                               config=topic_config)
 
     def load_many_segments(self):
-        target_cloud_segments = self.num_segments_per_partition * self.config.partitions_max_scaled
+        num_segments_per_partition = 1000
+        target_cloud_segments = num_segments_per_partition * self.config.partitions_max_scaled
         try:
             producer = KgoVerifierProducer(
                 self.test_context,

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -167,7 +167,7 @@ NoncloudTierConfigs = {
     #             egress|       cloud cache size|connections # limit|
     #           # of brokers|           partitions min|           memory per broker|
     "docker-local":
-    AdvertisedTierConfig(3 * MiB, 9 * MiB, 3, 128 * MiB, 20 * GiB, 1, 100, 100,
+    AdvertisedTierConfig(3 * MiB, 9 * MiB, 3, 128 * MiB, 20 * GiB, 1, 25, 100,
                          2 * GiB),
 }
 

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -34,7 +34,7 @@ from rptest.services.redpanda_cloud import AdvertisedTierConfigs, CloudTierName
 from rptest.services.redpanda import (RESTART_LOG_ALLOW_LIST, MetricsEndpoint,
                                       SISettings, RedpandaServiceCloud)
 from rptest.services.rpk_consumer import RpkConsumer
-from rptest.tests.prealloc_nodes import PreallocNodesTest
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import firewall_blocked
 from rptest.utils.node_operations import NodeDecommissionWaiter
 from rptest.utils.si_utils import nodes_report_cloud_segments
@@ -163,7 +163,7 @@ def traffic_generator(context, redpanda, tier_cfg, *args, **kwargs):
         ) >= tier_cfg.egress_rate, f"Observed consumer throughput {consumer_throughput} too low, expected: {tier_cfg.egress_rate}"
 
 
-class HighThroughputTest(PreallocNodesTest):
+class HighThroughputTest(RedpandaTest):
     small_segment_size = 4 * KiB
     unavailable_timeout = 60
     msg_size = 128 * KiB
@@ -191,7 +191,6 @@ class HighThroughputTest(PreallocNodesTest):
 
         super(HighThroughputTest,
               self).__init__(test_ctx,
-                             1,
                              *args,
                              num_brokers=num_brokers,
                              extra_rp_conf=extra_rp_conf,

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -722,6 +722,8 @@ class HighThroughputTest(PreallocNodesTest):
         )
         self.logger.info(f"{topic_partitions_on_node()} partitions moved")
 
+    # Temporary ignore until TS metrics can be queried via public_metrics
+    @ignore  # https://github.com/redpanda-data/cloudv2/issues/8845
     @cluster(num_nodes=6, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_cloud_cache_thrash(self):
         """

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -488,8 +488,12 @@ class HighThroughputTest(PreallocNodesTest):
 
         return
 
+    COMBO_PRELOADED_LOG_ALLOW_LIST = [
+        re.compile('storage - .* - Stopping parser, short read. .*')
+    ] + RESTART_LOG_ALLOW_LIST
+
     @ok_to_fail
-    @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    @cluster(num_nodes=5, log_allow_list=COMBO_PRELOADED_LOG_ALLOW_LIST)
     def test_combo_preloaded(self):
         """
         Preloads cluster with large number of messages/segments that are also

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -573,7 +573,8 @@ class HighThroughputTest(PreallocNodesTest):
                    timeout_sec=restart_timeout,
                    backoff_sec=1)
 
-    @ok_to_fail
+    # Temporary ignore until TS metrics can be queried via public_metrics
+    @ignore  # https://github.com/redpanda-data/cloudv2/issues/8845
     @cluster(num_nodes=5, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_disrupt_cloud_storage(self):
         """

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -181,7 +181,9 @@ class HighThroughputTest(PreallocNodesTest):
     def __init__(self, test_ctx: TestContext, *args, **kwargs):
         self._ctx = test_ctx
 
-        cloud_tier_str = test_ctx.globals.get("cloud_tier", "docker-local")
+        # Default set to tier-1-aws is a temporary work around for
+        # https://github.com/redpanda-data/cloudv2/issues/7903
+        cloud_tier_str = test_ctx.globals.get("cloud_tier", "tier-1-aws")
         if cloud_tier_str in NoncloudTierConfigs.keys():
             cloud_tier = None
             self.tier_config = NoncloudTierConfigs[cloud_tier_str]

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -27,9 +27,9 @@ from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import \
     OMBSampleConfigurations
 from rptest.services.producer_swarm import ProducerSwarm
-from rptest.services.redpanda import (RESTART_LOG_ALLOW_LIST,
-                                      AdvertisedTierConfig, CloudTierName,
-                                      MetricsEndpoint, SISettings)
+from rptest.services.redpanda_cloud import AdvertisedTierConfig, CloudTierName
+from rptest.services.redpanda import (RESTART_LOG_ALLOW_LIST, MetricsEndpoint,
+                                      SISettings)
 from rptest.services.rpk_consumer import RpkConsumer
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.util import firewall_blocked

--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -492,19 +492,17 @@ class HighThroughputTest(PreallocNodesTest):
         re.compile('storage - .* - Stopping parser, short read. .*')
     ] + RESTART_LOG_ALLOW_LIST
 
-    @ok_to_fail
     @cluster(num_nodes=5, log_allow_list=COMBO_PRELOADED_LOG_ALLOW_LIST)
-    def test_combo_preloaded(self):
+    def test_ht003_kgofailure(self):
         """
-        Preloads cluster with large number of messages/segments that are also
-        replicated to the cloud, and then run various different test stages
-        on the cluster:
+        Generates the maximum possible load to the cluster onto a topic that
+        is replicated to the cloud, and then run various different test
+        stages on the cluster:
         - rolling restart
         - stop and start single node, various scenarios
         - isolate and restore a node
         """
         # Generate a realistic number of segments per partition.
-        self.load_many_segments()
         with traffic_generator(self.test_context, self.redpanda,
                                self.tier_config, self.topic,
                                self.msg_size) as tgen:

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2990,7 +2990,7 @@ class RedpandaService(RedpandaServiceBase):
                            memory_allocation_warning_threshold=
                            memory_allocation_warning_threshold_bytes)
 
-        if override_cfg_params or self._extra_node_conf[node]:
+        if override_cfg_params or node in self._extra_node_conf:
             doc = yaml.full_load(conf)
             doc["redpanda"].update(self._extra_node_conf[node])
             self.logger.debug(

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -36,6 +36,7 @@ TIER_DEFAULTS = {PROVIDER_AWS: "tier-1-aws", PROVIDER_GCP: "tier-1-gcp"}
 
 
 class CloudTierName(Enum):
+    DOCKER = 'docker-local'
     AWS_1 = 'tier-1-aws'
     AWS_2 = 'tier-2-aws'
     AWS_3 = 'tier-3-aws'
@@ -114,6 +115,9 @@ AdvertisedTierConfigs = {
     ),
     CloudTierName.GCP_5: AdvertisedTierConfig(
         400*MiB, 600*MiB, 12,    1*GiB,  750*GiB,  100, 7500, 22500, 32*GiB
+    ),
+    CloudTierName.DOCKER: AdvertisedTierConfig(
+        3*MiB,   9*MiB,   3,   128*MiB,  20*GiB,   1,   25,   100,   2*GiB
     ),
 }
 # yapf: enable

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -10,9 +10,9 @@
 # Tests to run on a Redpanda Cloud cluster.
 cloud:
   included:
+    - redpanda_cloud_tests
     - tests/rpk_topic_test.py::RpkToolTest.test_consume_from_partition
     - tests/services_self_test.py::SimpleSelfTest
     - tests/services_self_test.py::OpenBenchmarkSelfTest
     - scale_tests/high_throughput_test.py::HighThroughputTest2.test_throughput_simple
     - scale_tests/high_throughput_test.py::HighThroughputTest2.test_max_connections
-    - redpanda_cloud_tests/config_profile_verify_test.py::ConfigProfileVerifyTest.test_config_profile_verify

--- a/tests/rptest/test_suite_ec2.yml
+++ b/tests/rptest/test_suite_ec2.yml
@@ -5,8 +5,8 @@ ec2:
     - scale_tests
 
   excluded:
+    - redpanda_cloud_tests
     - tests/librdkafka_test.py # normally disabled
     - tests/e2e_iam_role_test.py # use static credentials
     - tests/consumer_group_recovery_tool_test.py # use script available in dockerfile
     - scale_tests/many_partitions_test.py::ManyPartitionsTest.test_many_partitions_tiered_storage # time consuming in main suite
-    - scale_tests/high_throughput_test.py::HighThroughputTest2.test_max_connections # not compatible with locally deployed Redpanda


### PR DESCRIPTION
This PR introduces a number of changes to the high throughput tier suite. Most notably:
1. An actual traffic generator that allows all of the tests in the suite to operate under the advertised conditions, throwing if the throughput dips below the advertised
2. Refactor of the suite, unified the `HighThroughputTests` with the `HighThroughput2Tests` class
3. Removed the locally defined tier configurations in place of using the ones defined in `redpanda_cloud.py`
4. Other miscellaneous fixes and cleanup work

## Backports Required

- [x] none - not a bug fix
- [x] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none