### PR TITLE
rpk: fail when an unknown topic is passed in consume

### DIFF
--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
 )
 
@@ -77,6 +78,15 @@ func newConsumeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			adm, err := kafka.NewAdmin(fs, p)
 			out.MaybeDie(err, "unable to initialize admin kafka client: %v", err)
+
+			// We fail if the topic does not exist.
+			listed, err := adm.ListTopics(cmd.Context(), topics...)
+			out.MaybeDie(err, "unable to check topic existence: %v", err)
+			listed.EachError(func(d kadm.TopicDetail) {
+				if errors.Is(d.Err, kerr.UnknownTopicOrPartition) {
+					out.Die("unable to consume topic %q: %v", d.Topic, d.Err.Error())
+				}
+			})
 
 			err = c.parseOffset(offset, topics, adm)
 			out.MaybeDie(err, "invalid --offset %q: %v", offset, err)


### PR DESCRIPTION
Before, if you tried to consume from a topic that doesn't exist, rpk was blocked until the topic was created. 

That was confusing so we are failing now in those cases.

Fixes #11136

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements

* rpk: Now rpk will fail if you try to consume from a non-existent topic in `rpk topic consume` instead of blocking the flow.