### PR TITLE
kafka: Add poll count metric

### DIFF
--- a/src/v/kafka/latency_probe.h
+++ b/src/v/kafka/latency_probe.h
@@ -55,6 +55,20 @@ public:
              labels,
              [this] { return _produce_latency.internal_histogram_logform(); })
              .aggregate(aggregate_labels)});
+
+        _metrics.add_group(
+          prometheus_sanitize::metrics_name("fetch_stats"),
+          {// Amount of times we polled partitions for fetch data, i.e.: created
+           // and executed the fetch plan. Use in combination with per handler
+           // fetch metrics to get the ratio for how often we poll for a fetch
+           // request
+           sm::make_counter(
+             "poll_count",
+             sm::description("Amount of times we polled partitions for "
+                             "fetch data"),
+             labels,
+             [this] { return _poll_count; })
+             .aggregate(aggregate_labels)});
     }
 
     void setup_public_metrics() {
@@ -89,7 +103,10 @@ public:
         _fetch_latency.record(micros.count());
     }
 
+    void increment_poll_count() { ++_poll_count; }
+
 private:
+    size_t _poll_count = 0;
     hist_t _produce_latency;
     hist_t _fetch_latency;
     ssx::metrics::metric_groups _metrics

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -836,6 +836,8 @@ class simple_fetch_planner final : public fetch_planner::impl {
  */
 
 static ss::future<> fetch_topic_partitions(op_context& octx) {
+    octx.rctx.probe().increment_poll_count();
+
     auto planner = make_fetch_planner<simple_fetch_planner>();
 
     auto fetch_plan = planner.create_plan(octx);


### PR DESCRIPTION
Adds a metric to count the amount of times we did poll partitions in a
fetch request (create and execute the fetch plan).

Can be used to calculate the ratio of fetch requests to polls like so:

```
sum(irate(vectorized_kafka_handler_requests_completed_total{...,
handler="fetch"}[$__rate_interval])) by ($aggr_criteria) /
sum(irate(vectorized_fetch_stats_poll_count{...}[$__rate_interval])) by
($aggr_criteria)
```

Looking at some scenarios we get the following values:

 - 500MB/s, 4P/4C, 288P, ~110k batch, 1ms debounce: ~0.37
 - 500MB/s, 4P/4C, 288P, ~110k batch, 10ms debounce: ~0.66
 - 125MB/s, 8kP/8kC, 40k partitions, 1ms debounce: ~0.012
 - 125MB/s, 8kP/8kC, 40k partitions, 10ms debounce: ~0.035
 - 125MB/s, 8kP/8kC, 40k partitions, 100ms debounce: ~0.24

Note I went with `fetch_stats` + `poll_count` for the metrics name but I
am open for other suggestions. One possibility is that we go for
something like `fetch_stats_plan_executions` or similar.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none


