### PR TITLE
wasm: prevent goversion from changing tests

### DIFF
--- a/src/v/wasm/tests/wasi_test.cc
+++ b/src/v/wasm/tests/wasi_test.cc
@@ -55,5 +55,8 @@ TEST_F(WasmTestFixture, Wasi) {
     nanoseconds now_ns = duration_cast<nanoseconds>(now_ms);
     ASSERT_EQ(doc["NowNanos"].GetInt64(), now_ns.count());
 
-    ASSERT_EQ(doc["RandomNumber"].GetInt(), 240963032);
+    // The random number computed in wasm is dependent on how go computes
+    // it's initial seed for it's random number generator.
+    //
+    // ASSERT_EQ(doc["RandomNumber"].GetInt(), 240963032);
 }


### PR DESCRIPTION
Fixes #13348

We upgraded the golang version in our CI and that changes the way the initial seed for random numbers is generated, which broke this test. We should not let the test be dependent on the go version, so just disable that assertion.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
