### PR TITLE
slash backport command: better error message on failure to backport

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -70,15 +70,15 @@ jobs:
         id: user
         run: |
           username=$(gh api user --jq .login)
-          echo ::set-output name=username::"$username"
-          echo ::set-output name=repo::"$TARGET_REPO"
-          echo ::set-output name=email::"vbot@redpanda.com"
+          echo "username=$username" >> $GITHUB_OUTPUT
+          echo "repo=$TARGET_REPO" >> $GITHUB_OUTPUT
+          echo "email=vbot@redpanda.com" >> $GITHUB_OUTPUT
 
       - name: Get assignees
         env:
           ASSIGNEES: ${{ toJson(github.event.client_payload.github.payload.issue.assignees) }}
         id: assignees
-        run: echo ::set-output name=assignees::$(echo "$ASSIGNEES" | jq -r '.[].login' | paste -s -d ',' -)
+        run: echo "assignees=$(echo $ASSIGNEES | jq -r '.[].login' | paste -s -d ',' -)" >> $GITHUB_OUTPUT
 
       - name: Discover and create milestone
         env:
@@ -105,7 +105,7 @@ jobs:
         env:
           REVIEWERS: ${{ toJson(github.event.client_payload.pull_request.requested_reviewers) }}
         id: reviewers
-        run: echo ::set-output name=reviewers::$(echo "$REVIEWERS" | jq -r '.[].login' | paste -s -d ',' -)
+        run: echo "reviewers=$(echo $REVIEWERS | jq -r '.[].login' | paste -s -d ',' -)" >> $GITHUB_OUTPUT
 
       - name: Get commits of PR
         if: needs.backport-type.outputs.commented_on == 'pr'
@@ -115,7 +115,7 @@ jobs:
         id: backport_commits
         run: |
           backport_commits=$(gh api "repos/$TARGET_FULL_REPO/pulls/$BACKPORT_PR_NUMBER/commits" --jq .[].sha | paste -s -d ' ' -)
-          echo ::set-output name=backport_commits::$backport_commits
+          echo "backport_commits=$backport_commits" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v3
         if: needs.backport-type.outputs.commented_on == 'pr'

--- a/.github/workflows/scripts/backport-command/create_milestone.sh
+++ b/.github/workflows/scripts/backport-command/create_milestone.sh
@@ -15,4 +15,4 @@ if [[ $(gh api "repos/$TARGET_ORG/$TARGET_REPO/milestones" --jq .[].title | grep
   gh api "repos/$TARGET_ORG/$TARGET_REPO/milestones" --silent --method POST -f title="$assignee_milestone"
   sleep 20 # wait for milestone creation to be propagated
 fi
-echo "::set-output name=milestone::$assignee_milestone"
+echo "milestone=$assignee_milestone" >>$GITHUB_OUTPUT

--- a/.github/workflows/scripts/backport-command/get_backport_type.sh
+++ b/.github/workflows/scripts/backport-command/get_backport_type.sh
@@ -19,7 +19,7 @@ if [[ $(echo "$CLIENT_PAYLOAD" | jq 'has("pull_request")') == true ]]; then
 else
   commented_on="issue"
 fi
-echo "::set-output name=commented_on::$commented_on"
+echo "commented_on=$commented_on" >>$GITHUB_OUTPUT
 
 if ! gh_branch_exists "$ARG1"; then
   new_arg=$ARG1
@@ -40,5 +40,5 @@ if ! gh_branch_exists "$ARG1"; then
   fi
 fi
 
-echo "::set-output name=backport_branch::${backport_branch-$ARG1}"
-echo "::set-output name=target_milestone::${target_milestone-$MILESTONE_ARG}"
+echo "backport_branch=${backport_branch-$ARG1}" >>$GITHUB_OUTPUT
+echo "target_milestone=${target_milestone-$MILESTONE_ARG}" >>$GITHUB_OUTPUT

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -44,8 +44,10 @@ head_branch=$(echo "backport-pr-$PR_NUMBER-$BACKPORT_BRANCH-$suffix" | sed 's/ /
 git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
 
 if ! git cherry-pick -x $BACKPORT_COMMITS; then
-  msg="Failed to run cherry-pick command. I executed the commands below:\n
+  msg="Failed to create a backport PR to $BACKPORT_BRANCH branch. I tried:\n
 \`\`\`\r
+git remote add upstream "https://github.com/$TARGET_FULL_REPO.git"
+git fetch --all
 git checkout -b "$head_branch" "remotes/upstream/$BACKPORT_BRANCH"
 git cherry-pick -x $BACKPORT_COMMITS
 \`\`\`"

--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -64,5 +64,5 @@ fi
 
 git push --set-upstream origin "$head_branch"
 git remote rm upstream
-echo "::set-output name=head_branch::$head_branch"
-echo "::set-output name=fixing_issue_urls::$fixing_issue_urls"
+echo "head_branch=$head_branch" >>$GITHUB_OUTPUT
+echo "fixing_issue_urls=$fixing_issue_urls" >>$GITHUB_OUTPUT


### PR DESCRIPTION
addressing comment https://github.com/redpanda-data/vtools/pull/2049#pullrequestreview-1611520364
related issue https://github.com/redpanda-data/vtools/issues/1717

this PR outputs a better backport error message

also, replaced github action `set-output` with env file (see [blog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/))

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
