### PR TITLE
[v23.2.x] allow user-specified ServiceAccount name for Console deployment

### DIFF
--- a/src/go/k8s/apis/vectorized/v1alpha1/console_types.go
+++ b/src/go/k8s/apis/vectorized/v1alpha1/console_types.go
@@ -79,6 +79,9 @@ type ConsoleSpec struct {
 
 	// SecretStore contains the configuration for the cloud provider secret manager
 	SecretStore *SecretStore `json:"secretStore,omitempty"`
+
+	// The name of the ServiceAccount to be used by the Redpanda pods
+	ServiceAccount *string `json:"serviceAccount,omitempty"`
 }
 
 // Server is the Console app HTTP server config

--- a/src/go/k8s/pkg/console/deployment.go
+++ b/src/go/k8s/pkg/console/deployment.go
@@ -138,13 +138,24 @@ func (d *Deployment) Key() types.NamespacedName {
 	return types.NamespacedName{Name: d.consoleobj.GetName(), Namespace: d.consoleobj.GetNamespace()}
 }
 
+func (d *Deployment) getServiceAccountKey() types.NamespacedName {
+	var key types.NamespacedName
+	key.Name = d.consoleobj.GetName()
+	key.Namespace = d.consoleobj.GetNamespace()
+	if d.consoleobj.Spec.ServiceAccount != nil && *d.consoleobj.Spec.ServiceAccount != "" {
+		key.Name = *d.consoleobj.Spec.ServiceAccount
+	}
+	return key
+}
+
 // ensureServiceAccount gets or creates Service Account
 // It's best practice to use a separate Service Account per app instead of using the default
 func (d *Deployment) ensureServiceAccount(ctx context.Context) (string, error) {
+	saKey := d.getServiceAccountKey()
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        d.consoleobj.GetName(),
-			Namespace:   d.consoleobj.GetNamespace(),
+			Name:        saKey.Name,
+			Namespace:   saKey.Namespace,
 			Labels:      labels.ForConsole(d.consoleobj),
 			Annotations: map[string]string{},
 		},

--- a/src/go/k8s/pkg/console/deployment_internal_test.go
+++ b/src/go/k8s/pkg/console/deployment_internal_test.go
@@ -2,6 +2,7 @@ package console
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -10,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	vectorizedv1alpha1 "github.com/redpanda-data/redpanda/src/go/k8s/apis/vectorized/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 func TestGenEnvVars(t *testing.T) { //nolint:funlen // test table is long
@@ -117,5 +119,86 @@ func TestGenEnvVars(t *testing.T) { //nolint:funlen // test table is long
 			require.True(t, found, "expected envar %s, but not found", e)
 		}
 		require.Equal(t, len(tt.expectedEnvars), len(genEnvVars), "expected envars generated is %d, found %d", len(tt.expectedEnvars), len(genEnvVars))
+	}
+}
+
+func TestDeployment_getServiceAccountKey(t *testing.T) {
+	const (
+		testNamespace   = "betelgeuse"
+		testConsoleName = "deepthought"
+	)
+	testSAName := "slartibartfast"
+	testSAEmpty := ""
+	type fields struct {
+		consoleobj *vectorizedv1alpha1.Console
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   types.NamespacedName
+	}{
+		{
+			name: "Spec.ServiceAccount is set",
+			fields: fields{
+				consoleobj: &vectorizedv1alpha1.Console{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConsoleName,
+						Namespace: testNamespace,
+					},
+					Spec: vectorizedv1alpha1.ConsoleSpec{
+						ServiceAccount: &testSAName,
+					},
+				},
+			},
+			want: types.NamespacedName{
+				Name:      testSAName,
+				Namespace: testNamespace,
+			},
+		},
+		{
+			name: "Spec.ServiceAccount is set but empty",
+			fields: fields{
+				consoleobj: &vectorizedv1alpha1.Console{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConsoleName,
+						Namespace: testNamespace,
+					},
+					Spec: vectorizedv1alpha1.ConsoleSpec{
+						ServiceAccount: &testSAEmpty,
+					},
+				},
+			},
+			want: types.NamespacedName{
+				Name:      testConsoleName,
+				Namespace: testNamespace,
+			},
+		},
+		{
+			name: "Spec.ServiceAccount is nil",
+			fields: fields{
+				consoleobj: &vectorizedv1alpha1.Console{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testConsoleName,
+						Namespace: testNamespace,
+					},
+				},
+			},
+			want: types.NamespacedName{
+				Name:      testConsoleName,
+				Namespace: testNamespace,
+			},
+		},
+
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Deployment{
+				consoleobj: tt.fields.consoleobj,
+			}
+			if got := d.getServiceAccountKey(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Deployment.getServiceAccountKey() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13120
