### PR TITLE
rpk profile create: use StringArray rather than StringSlice

### DIFF
--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -109,7 +109,7 @@ rpk always switches to the newly created profile.
 		},
 	}
 
-	cmd.Flags().StringSliceVarP(&set, "set", "s", nil, "Create and switch to a new profile, setting profile fields with key=value pairs")
+	cmd.Flags().StringArrayVarP(&set, "set", "s", nil, "Create and switch to a new profile, setting profile fields with key=value pairs")
 	cmd.Flags().StringVar(&fromRedpanda, "from-redpanda", "", "Create and switch to a new profile from a redpanda.yaml file")
 	cmd.Flags().StringVar(&fromProfile, "from-profile", "", "Create and switch to a new profile from an existing profile or from a profile in a yaml file")
 	cmd.Flags().StringVar(&fromCloud, "from-cloud", "", "Create and switch to a new profile generated from a Redpanda Cloud cluster ID")


### PR DESCRIPTION
StringSlice splits all inputs at comma, meaning config.Set cannot work. Currently, people can only input one key=value. If people use a second value (key=value1,value2), the input is split at comma and then config.Set runs against value2 alone (no key) and fails.

For #12802.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release notes

### Bug Fixes

* `rpk profile set` now supports multiple comma separate values per key (`key=value1,value2`)