### PR TITLE
Add rpk transform delete command

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_transform.go
+++ b/src/go/rpk/pkg/adminapi/api_transform.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package adminapi
+
+import (
+	"context"
+	"net/http"
+)
+
+const (
+	baseTransformEndpoint = "/v1/transform/"
+	deleteSuffix          = "delete"
+)
+
+type transformDeleteRequest struct {
+	Name string `json:"name"`
+}
+
+// Delete a wasm transform in a cluster.
+func (a *AdminAPI) DeleteWasmTransform(ctx context.Context, name string) error {
+	return a.sendToLeader(ctx, http.MethodPost, baseTransformEndpoint+deleteSuffix, transformDeleteRequest{name}, nil)
+}

--- a/src/go/rpk/pkg/cli/transform/delete.go
+++ b/src/go/rpk/pkg/cli/transform/delete.go
@@ -1,0 +1,41 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package transform
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete [NAME]",
+		Short: "Delete a data transform",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			api, err := adminapi.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
+			functionName := args[0]
+
+			err = api.DeleteWasmTransform(cmd.Context(), functionName)
+			out.MaybeDie(err, "unable to delete transform %q: %v", functionName, err)
+			fmt.Println("Delete successful!")
+		},
+	}
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/transform/transform.go
+++ b/src/go/rpk/pkg/cli/transform/transform.go
@@ -15,13 +15,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCommand(_ afero.Fs, p *config.Params) *cobra.Command {
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "transform",
 		Aliases: []string{"wasm", "transfrom"}, //nolint:misspell // auto correct a common misspelling
 		Short:   "Develop, deploy and manage Redpanda data transforms",
 	}
 	p.InstallKafkaFlags(cmd)
-	// TODO(rockwood): Add commands
+	cmd.AddCommand(
+		newDeleteCommand(fs, p),
+	)
 	return cmd
 }


### PR DESCRIPTION
Add the ability to delete transforms.

See the corresponding RFCs for rpk and the admin API for context.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
