### PR TITLE
[v23.2.x] rpk: add move-status to show ongoing partition movements

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_partition.go
+++ b/src/go/rpk/pkg/adminapi/api_partition.go
@@ -32,10 +32,31 @@ type Partition struct {
 	Replicas    []Replica `json:"replicas"`
 }
 
-// Reconfiguration is the detail of a partition reconfiguration. There are
-// many keys returned, so the raw response is just unmarshalled into an
-// interface.
-type Reconfiguration map[string]interface{}
+type Operation struct {
+	Core        int    `json:"core"`
+	RetryNumber int    `json:"retry_number"`
+	Revision    int    `json:"revision"`
+	Status      string `json:"status"`
+	Type        string `json:"type"`
+}
+
+type Status struct {
+	NodeID     int         `json:"node_id"`
+	Operations []Operation `json:"operations"`
+}
+
+// Reconfiguration is the detail of a partition reconfiguration.
+type ReconfigurationsResponse struct {
+	Ns                     string    `json:"ns"`
+	Topic                  string    `json:"topic"`
+	PartitionID            int       `json:"partition"`
+	PartitionSize          int       `json:"partition_size"`
+	BytesMoved             int       `json:"bytes_moved"`
+	BytesLeft              int       `json:"bytes_left_to_move"`
+	PreviousReplicas       []Replica `json:"previous_replicas"`
+	NewReplicas            []Replica `json:"current_replicas"`
+	ReconciliationStatuses []Status  `json:"reconciliation_statuses"`
+}
 
 // GetPartition returns detailed partition information.
 func (a *AdminAPI) GetPartition(
@@ -51,7 +72,7 @@ func (a *AdminAPI) GetPartition(
 }
 
 // Reconfigurations returns the list of ongoing partition reconfigurations.
-func (a *AdminAPI) Reconfigurations(ctx context.Context) ([]Reconfiguration, error) {
-	var response []Reconfiguration
-	return response, a.sendAny(ctx, http.MethodGet, "/v1/partitions/reconfigurations", nil, &response)
+func (a *AdminAPI) Reconfigurations(ctx context.Context) ([]ReconfigurationsResponse, error) {
+	var rr []ReconfigurationsResponse
+	return rr, a.sendAny(ctx, http.MethodGet, "/v1/partitions/reconfigurations", nil, &rr)
 }

--- a/src/go/rpk/pkg/cli/cluster/partitions/cancel.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/cancel.go
@@ -10,14 +10,22 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type movementCancelHandler struct {
+	fs        afero.Fs
+	p         *config.Params
+	node      int
+	noConfirm bool
+}
+
 func newMovementCancelCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	var (
-		node      int
-		noConfirm bool
-	)
+	m := &movementCancelHandler{
+		fs: fs,
+		p:  p,
+	}
 	cmd := &cobra.Command{
-		Use:   "movement-cancel",
-		Short: "Cancel ongoing partition movements",
+		Use:     "move-cancel",
+		Aliases: []string{"alter-cancel"},
+		Short:   "Cancel ongoing partition movements",
 		Long: `Cancel ongoing partition movements.
 
 By default, this command cancels all the partition movements in the cluster. 
@@ -25,55 +33,57 @@ To ensure that you do not accidentally cancel all partition movements, this
 command prompts users for confirmation before issuing the cancellation request. 
 You can use "--no-confirm" to disable the confirmation prompt:
 
-    rpk cluster partitions movement-cancel --no-confirm
+    rpk cluster partitions move-cancel --no-confirm
 
 If "--node" is set, this command will only stop the partition movements 
 occurring in the specified node:
 
-    rpk cluster partitions movement-cancel --node 1
+    rpk cluster partitions move-cancel --node 1
 `,
 		Args: cobra.ExactArgs(0),
-		Run: func(cmd *cobra.Command, args []string) {
-			p, err := p.LoadVirtualProfile(fs)
-			out.MaybeDie(err, "unable to load config: %v", err)
-			out.CheckExitCloudAdmin(p)
-
-			cl, err := adminapi.NewClient(fs, p)
-			out.MaybeDie(err, "unable to initialize admin client: %v", err)
-
-			var movements []adminapi.PartitionsMovementResult
-			if node >= 0 {
-				if !noConfirm {
-					confirmed, err := out.Confirm("Confirm cancellation of partition movements in node %v?", node)
-					out.MaybeDie(err, "unable to confirm partition movements cancel: %v", err)
-					if !confirmed {
-						out.Exit("Command execution canceled.")
-					}
-				}
-				movements, err = cl.CancelNodePartitionsMovement(cmd.Context(), node)
-				out.MaybeDie(err, "unable to cancel partition movements in node %v: %v", node, err)
-			} else {
-				if !noConfirm {
-					confirmed, err := out.Confirm("Confirm cancellation of all partition movements in the cluster?")
-					out.MaybeDie(err, "unable to confirm partition movements cancel: %v", err)
-					if !confirmed {
-						out.Exit("Command execution canceled.")
-					}
-				}
-				movements, err = cl.CancelAllPartitionsMovement(cmd.Context())
-				out.MaybeDie(err, "unable to cancel partition movements: %v", err)
-			}
-
-			if len(movements) == 0 {
-				fmt.Println("There are no ongoing partition movements to cancel")
-				return
-			}
-			printMovementsResult(movements)
-		},
+		Run:  m.runMovementCancel,
 	}
-	cmd.Flags().IntVar(&node, "node", -1, "ID of a specific node on which to cancel ongoing partition movements")
-	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+	cmd.Flags().IntVar(&m.node, "node", -1, "ID of a specific node on which to cancel ongoing partition movements")
+	cmd.Flags().BoolVar(&m.noConfirm, "no-confirm", false, "Disable confirmation prompt")
 	return cmd
+}
+
+func (m *movementCancelHandler) runMovementCancel(cmd *cobra.Command, _ []string) {
+	p, err := m.p.LoadVirtualProfile(m.fs)
+	out.MaybeDie(err, "unable to load config: %v", err)
+	out.CheckExitCloudAdmin(p)
+
+	cl, err := adminapi.NewClient(m.fs, p)
+	out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+	var movements []adminapi.PartitionsMovementResult
+	if m.node >= 0 {
+		if !m.noConfirm {
+			confirmed, err := out.Confirm("Confirm cancellation of partition movements in node %v?", m.node)
+			out.MaybeDie(err, "unable to confirm partition movements cancel: %v", err)
+			if !confirmed {
+				out.Exit("Command execution canceled.")
+			}
+		}
+		movements, err = cl.CancelNodePartitionsMovement(cmd.Context(), m.node)
+		out.MaybeDie(err, "unable to cancel partition movements in node %v: %v", m.node, err)
+	} else {
+		if !m.noConfirm {
+			confirmed, err := out.Confirm("Confirm cancellation of all partition movements in the cluster?")
+			out.MaybeDie(err, "unable to confirm partition movements cancel: %v", err)
+			if !confirmed {
+				out.Exit("Command execution canceled.")
+			}
+		}
+		movements, err = cl.CancelAllPartitionsMovement(cmd.Context())
+		out.MaybeDie(err, "unable to cancel partition movements: %v", err)
+	}
+
+	if len(movements) == 0 {
+		fmt.Println("There are no ongoing partition movements to cancel")
+		return
+	}
+	printMovementsResult(movements)
 }
 
 func printMovementsResult(movements []adminapi.PartitionsMovementResult) {

--- a/src/go/rpk/pkg/cli/cluster/partitions/cancel_hidden.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/cancel_hidden.go
@@ -1,0 +1,38 @@
+package partitions
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newMovementCancelCommandHidden(fs afero.Fs, p *config.Params) *cobra.Command {
+	m := &movementCancelHandler{
+		fs: fs,
+		p:  p,
+	}
+	cmd := &cobra.Command{
+		Use:    "movement-cancel",
+		Short:  "Cancel ongoing partition movements",
+		Hidden: true,
+		Long: `Cancel ongoing partition movements.
+
+By default, this command cancels all the partition movements in the cluster.
+To ensure that you do not accidentally cancel all partition movements, this
+command prompts users for confirmation before issuing the cancellation request.
+You can use "--no-confirm" to disable the confirmation prompt:
+
+    rpk cluster partitions movement-cancel --no-confirm
+
+If "--node" is set, this command will only stop the partition movements
+occurring in the specified node:
+
+    rpk cluster partitions movement-cancel --node 1
+`,
+		Args: cobra.ExactArgs(0),
+		Run:  m.runMovementCancel,
+	}
+	cmd.Flags().IntVar(&m.node, "node", -1, "ID of a specific node on which to cancel ongoing partition movements")
+	cmd.Flags().BoolVar(&m.noConfirm, "no-confirm", false, "Disable confirmation prompt")
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/cluster/partitions/list.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/list.go
@@ -1,0 +1,197 @@
+package partitions
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/docker/go-units"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/types"
+)
+
+func newListPartitionMovementsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		completion       int
+		all              bool
+		human            bool
+		partitions       []string
+		response         []adminapi.ReconfigurationsResponse
+		filteredResponse []adminapi.ReconfigurationsResponse
+	)
+	cmd := &cobra.Command{
+		Use:   "move-status",
+		Short: "Show ongoing partition movements",
+		Long:  helpListMovement,
+		Run: func(cmd *cobra.Command, topics []string) {
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+			out.CheckExitCloudAdmin(p)
+
+			// If partition(s) is specified but no topic(s) is specified, exit.
+			if len(topics) <= 0 && len(partitions) > 0 {
+				out.Die("specify at least one topic when --partition is used, exiting.")
+			}
+
+			cl, err := adminapi.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			response, err = cl.Reconfigurations(cmd.Context())
+			out.MaybeDie(err, "unable to list partition movements: %v\n", err)
+
+			if len(response) == 0 {
+				out.Exit("There are no ongoing partition movements.")
+			}
+
+			for _, t := range topics {
+				nt := strings.Split(t, "/")
+				if len(nt) > 2 {
+					fmt.Printf("invalid format for topic %s, skipping.\n", t)
+					continue
+				}
+				for _, r := range response {
+					isKafkaNs := len(nt) == 1 && r.Ns == "kafka" && r.Topic == t
+					isInternalNs := len(nt) == 2 && r.Ns == nt[0] && r.Topic == nt[1]
+
+					if isKafkaNs || isInternalNs {
+						if len(partitions) == 0 || contains(partitions, strconv.Itoa(r.PartitionID)) {
+							filteredResponse = append(filteredResponse, r)
+						}
+					}
+				}
+			}
+			if len(filteredResponse) > 0 {
+				response = filteredResponse
+			}
+
+			sizeFn := func(size int) string {
+				if human {
+					return units.HumanSize(float64(size))
+				}
+				return strconv.Itoa(size)
+			}
+
+			f := func(rr *adminapi.ReconfigurationsResponse) interface{} {
+				var (
+					newReplica []int
+					oldReplica []int
+				)
+				nt := rr.Ns + "/" + rr.Topic
+				if rr.PartitionSize > 0 {
+					completion = rr.BytesMoved * 100 / rr.PartitionSize
+				}
+				for _, r := range rr.NewReplicas {
+					newReplica = append(newReplica, r.NodeID)
+				}
+				for _, r := range rr.PreviousReplicas {
+					oldReplica = append(oldReplica, r.NodeID)
+				}
+				return struct {
+					NT             string
+					PartitionID    int
+					MovingFrom     []int
+					MovingTo       []int
+					Completion     int
+					PartitionSize  string
+					BytesMoved     string
+					BytesRemaining string
+				}{
+					nt,
+					rr.PartitionID,
+					oldReplica,
+					newReplica,
+					completion,
+					sizeFn(rr.PartitionSize),
+					sizeFn(rr.BytesMoved),
+					sizeFn(rr.BytesLeft),
+				}
+			}
+
+			types.Sort(response)
+
+			out.Header("Partition movements", true, true, func() {
+				headers := []string{"Namespace-Topic", "Partition", "Moving-from", "Moving-to", "Completion-%", "Partition-size", "Bytes-moved", "Bytes-remaining"}
+				tw := out.NewTable(headers...)
+				defer tw.Flush()
+				for _, tps := range response {
+					tw.PrintStructFields(f(&tps))
+				}
+			})
+
+			out.Header("Reconciliation statuses", all, true, func() {
+				var j int
+				for _, p := range response {
+					fmt.Printf("%s\n", p.Ns+"/"+p.Topic+"/"+strconv.Itoa(p.PartitionID))
+					headers := []string{"Node-id", "Core", "Type", "Retry-number", "Revision", "Status"}
+					tw := out.NewTable(headers...)
+					for _, rs := range p.ReconciliationStatuses {
+						var row []interface{}
+						row = append(row, rs.NodeID)
+						for _, s := range rs.Operations {
+							row = append(row, s.Core, s.Type, s.RetryNumber, s.Revision, s.Status)
+						}
+						tw.Print(row...)
+					}
+					tw.Flush()
+					j++
+					if j < len(response) {
+						fmt.Println()
+					}
+				}
+			})
+		},
+	}
+
+	cmd.Flags().BoolVarP(&all, "print-all", "a", false, "Print internal states about movements for debugging")
+	cmd.Flags().BoolVarP(&human, "human-readable", "H", false, "Print the partition size in a human-readable form")
+	cmd.Flags().StringSliceVarP(&partitions, "partition", "p", nil, "Partitions to print the ongoing movements (repeatable)")
+
+	return cmd
+}
+
+// This function returns true when a partition that movement is
+// ongoing is a requested partition by the --partition option.
+func contains(pReq []string, pRes string) bool {
+	for _, p := range pReq {
+		if p == pRes {
+			return true
+		}
+	}
+	return false
+}
+
+const helpListMovement = `Show ongoing partition movements.
+
+By default this command lists all the ongoing partition movements in the cluster.
+Topics can be specified to print the move status of specific topics. By default,
+this command assumes the "kafka" namespace, but you can use a "namespace/" to
+specify internal namespaces.
+
+    rpk cluster partitions move-status
+    rpk cluster partitions move-status foo bar kafka_internal/tx
+
+The "--partition / -p" flag can be used with topics to additional filter
+requested partitions:
+
+    rpk cluster partitions move-status foo bar --partition 0,1,2
+
+The output contains the following columns, where PARTITION-SIZE is in bytes.
+Using -H, it prints the partition size in a human-readable format
+
+    NAMESPACE-TOPIC
+    PARTITION
+    MOVING-FROM
+    MOVING-TO
+    COMPLETION-%
+    PARTITION-SIZE
+    BYTES-MOVED
+    BYTES-REMAINING
+
+Using "--print-all / -a" the command additionally prints "RECONCILIATION STATUSES"
+which reveals internal states on how the ongoing reconciliations work for debugging
+purposes. That is, reported errors don't necessarily mean real problems.
+`

--- a/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
@@ -17,6 +17,7 @@ func NewPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.AddCommand(
 		newBalancerStatusCommand(fs, p),
 		newMovementCancelCommand(fs, p),
+		newMovementCancelCommandHidden(fs, p),
 		newListPartitionMovementsCommand(fs, p),
 	)
 	return cmd

--- a/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
@@ -17,6 +17,7 @@ func NewPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.AddCommand(
 		newBalancerStatusCommand(fs, p),
 		newMovementCancelCommand(fs, p),
+		newListPartitionMovementsCommand(fs, p),
 	)
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/topic/describe.go
+++ b/src/go/rpk/pkg/cli/topic/describe.go
@@ -12,7 +12,6 @@ package topic
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -87,7 +86,7 @@ partitions section. By default, the summary and configs sections are printed.
 				t = resp.Topics[0]
 			}
 
-			header("SUMMARY", summary, withSection, func() {
+			out.Header("SUMMARY", summary, withSection, func() {
 				tw := out.NewTabWriter()
 				defer tw.Flush()
 				tw.PrintColumn("NAME", *t.Topic)
@@ -104,7 +103,7 @@ partitions section. By default, the summary and configs sections are printed.
 				}
 			})
 
-			header("CONFIGS", configs, withSection, func() {
+			out.Header("CONFIGS", configs, withSection, func() {
 				req := kmsg.NewPtrDescribeConfigsRequest()
 				reqResource := kmsg.NewDescribeConfigsRequestResource()
 				reqResource.ResourceType = kmsg.ConfigResourceTypeTopic
@@ -140,7 +139,7 @@ partitions section. By default, the summary and configs sections are printed.
 				return
 			}
 
-			header("PARTITIONS", partitions, withSection, func() {
+			out.Header("PARTITIONS", partitions, withSection, func() {
 				offsets := listStartEndOffsets(cl, topic, len(t.Partitions), stable)
 
 				tw := out.NewTable(describePartitionsHeaders(
@@ -175,21 +174,6 @@ partitions section. By default, the summary and configs sections are printed.
 	cmd.Flags().BoolVar(&stable, "stable", false, "Include the stable offsets column in the partitions section; only relevant if you produce to this topic transactionally")
 
 	return cmd
-}
-
-// header prints a header section with a given name and executes a callback
-// function (fn).
-// If 'b' is false, nothing is printed.
-// If 'withSection' is true, the section name is printed before executing 'fn'.
-func header(name string, b, withSection bool, fn func()) {
-	if !b {
-		return
-	}
-	if withSection {
-		out.Section(name)
-		defer fmt.Println()
-	}
-	fn()
 }
 
 // We optionally include the following columns:

--- a/src/go/rpk/pkg/cli/topic/describe_storage.go
+++ b/src/go/rpk/pkg/cli/topic/describe_storage.go
@@ -120,7 +120,7 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			}
 			withSections := sections > 1
 
-			header("SUMMARY", summary, withSections, func() {
+			out.Header("SUMMARY", summary, withSections, func() {
 				tw := out.NewTabWriter()
 				defer tw.Flush()
 				tw.PrintColumn("NAME", topic)
@@ -141,7 +141,7 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				tw.PrintColumn("LAST-UPLOAD", humanReadable(lastUpload, human, humanTime))
 			})
 
-			header("OFFSETS", offset, withSections, func() {
+			out.Header("OFFSETS", offset, withSections, func() {
 				tw := out.NewTable("PARTITION", "CLOUD-START", "CLOUD-LAST", "LOCAL-START", "LOCAL-LAST")
 				defer tw.Flush()
 				for _, r := range report {
@@ -155,7 +155,7 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				}
 			})
 
-			header("SIZE", size, withSections, func() {
+			out.Header("SIZE", size, withSections, func() {
 				tw := out.NewTable("PARTITION", "CLOUD-BYTES", "LOCAL-BYTES", "TOTAL-BYTES", "CLOUD-SEGMENTS", "LOCAL-SEGMENTS")
 				defer tw.Flush()
 				for _, r := range report {
@@ -170,7 +170,7 @@ func newDescribeStorageCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				}
 			})
 
-			header("SYNC", syncF, withSections, func() {
+			out.Header("SYNC", syncF, withSections, func() {
 				isRrr := report[0].CloudStatus.CloudStorageMode == "read_replica"
 				headers := []string{"PARTITION", "LAST-SEGMENT-UPLOAD", "LAST-MANIFEST-UPLOAD", "METADATA-UPDATE-PENDING"}
 				if isRrr {

--- a/src/go/rpk/pkg/out/out.go
+++ b/src/go/rpk/pkg/out/out.go
@@ -44,6 +44,21 @@ func Confirm(msg string, args ...interface{}) (bool, error) {
 	}, &confirmation)
 }
 
+// Header prints a header section with a given name and executes a callback
+// function (fn).
+// If 'b' is false, nothing is printed.
+// If 'withSection' is true, the section name is printed before executing 'fn'.
+func Header(name string, b, withSection bool, fn func()) {
+	if !b {
+		return
+	}
+	if withSection {
+		Section(name)
+		defer fmt.Println()
+	}
+	fn()
+}
+
 // Pick prompts the user to pick one of many options, returning the selected
 // option or an error.
 func Pick(options []string, msg string, args ...interface{}) (string, error) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13258
Fixes: https://github.com/redpanda-data/redpanda/issues/13380,