### PR TITLE
[v23.2.x] rpk/bugfix: enable back setting tls struct values in set commands

### DIFF
--- a/src/go/rpk/pkg/config/config_test.go
+++ b/src/go/rpk/pkg/config/config_test.go
@@ -357,6 +357,30 @@ tune_cpu: true`,
 			},
 		},
 		{
+			name:  "set kafka tls to a value",
+			key:   "rpk.kafka_api.tls",
+			value: "{cert_file: /etc/redpanda/certs/cert.pem, key_file: /etc/redpanda/certs/node.key, truststore_file: /etc/redpanda/certs/ca.crt}",
+			check: func(st *testing.T, y *RedpandaYaml) {
+				require.Exactly(st, &TLS{
+					KeyFile:        "/etc/redpanda/certs/node.key",
+					CertFile:       "/etc/redpanda/certs/cert.pem",
+					TruststoreFile: "/etc/redpanda/certs/ca.crt",
+				}, y.Rpk.KafkaAPI.TLS)
+			},
+		},
+		{
+			name:  "set admin tls to a value",
+			key:   "rpk.admin_api.tls",
+			value: "{cert_file: /etc/redpanda/certs/cert.pem, key_file: /etc/redpanda/certs/node.key, truststore_file: /etc/redpanda/certs/ca.crt}",
+			check: func(st *testing.T, y *RedpandaYaml) {
+				require.Exactly(st, &TLS{
+					KeyFile:        "/etc/redpanda/certs/node.key",
+					CertFile:       "/etc/redpanda/certs/cert.pem",
+					TruststoreFile: "/etc/redpanda/certs/ca.crt",
+				}, y.Rpk.AdminAPI.TLS)
+			},
+		},
+		{
 			name:  "set tls=null leaves tls null",
 			key:   "rpk.kafka_api.tls",
 			value: "null",

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -1449,7 +1449,11 @@ func Set[T any](p *T, key, value string) error {
 		case "false":
 			value = "null"
 		default:
-			return fmt.Errorf("%s must be true or {}", key)
+			// If the final tag is 'tls', it might be a value. So we continue
+			// and handle below.
+			if finalTag != "tls" {
+				return fmt.Errorf("%s must be true or {}", key)
+			}
 		}
 		if finalTag == "enabled" {
 			tags = tags[:len(tags)-1]


### PR DESCRIPTION
*Manual Backport of https://github.com/redpanda-data/redpanda/pull/13343*

There was a bug introduced in 23.2 that made
setting a TLS struct value impossible via set
commands (rpk profile set, rpk redpanda config set). We were just checking for the empty/boolean case.

(cherry picked from commit f8d04d55b482d10bb94bf88a289b7ec639405481)

Fixes #13378 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* rpk/bugfix: enable back setting TLS struct values in set commands