### PR TITLE
tests/docker: Change base image base to jammy

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM public.ecr.aws/docker/library/ubuntu:kinetic-20230412 as base
+FROM public.ecr.aws/docker/library/ubuntu:jammy-20230816 as base
 
 ENV TZ="UTC" \
     DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
kinetic reached eol ref https://wiki.ubuntu.com/Releases
from https://gallery.ecr.aws/docker/library/ubuntu

ref redpanda-data/devprod#843

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [X] v23.1.x
- [X] v22.3.x

## Release Notes

* none
