### PR TITLE
cmake/oss: upgrade wasmtime

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -108,7 +108,10 @@ fetch_dep(hdrhistogram
 FetchContent_Declare(
   wasmtime
   GIT_REPOSITORY https://github.com/bytecodealliance/wasmtime
-  GIT_TAG 8efcb9851602287fd07a1a1e91501f51f2653d7e
+  GIT_TAG f433e783147f1ec0fd2959752004a248b6139b3a
+  # Remove all default features we don't use any of them.
+  PATCH_COMMAND
+    sed -i "s/default \\\\= \\\\['jitdump', 'wat', 'wasi', 'cache', 'parallel\\\\-compilation'\\\\]/default = []/g" crates/c-api/Cargo.toml
   GIT_PROGRESS TRUE
   USES_TERMINAL_DOWNLOAD TRUE
   OVERRIDE_FIND_PACKAGE


### PR DESCRIPTION
Also remove the default features, we don't use anyof them

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
