### PR TITLE
rptest: add ability to retrieve public metrics from redpanda cloud

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -508,8 +508,6 @@ class HighThroughputTest(RedpandaTest):
                    timeout_sec=restart_timeout,
                    backoff_sec=1)
 
-    # Temporary ignore until TS metrics can be queried via public_metrics
-    @ignore  # https://github.com/redpanda-data/cloudv2/issues/8845
     @cluster(num_nodes=2, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_disrupt_cloud_storage(self):
         """

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -656,8 +656,6 @@ class HighThroughputTest(RedpandaTest):
         )
         self.logger.info(f"{topic_partitions_on_node()} partitions moved")
 
-    # Temporary ignore until TS metrics can be queried via public_metrics
-    @ignore  # https://github.com/redpanda-data/cloudv2/issues/8845
     @cluster(num_nodes=3, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_cloud_cache_thrash(self):
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1539,6 +1539,36 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
     def all_up(self):
         return self._cloud_cluster.isAlive
 
+    def metrics(
+            self,
+            node,
+            metrics_endpoint: MetricsEndpoint = MetricsEndpoint.PUBLIC_METRICS
+    ):
+        text = self._cloud_cluster.get_public_metrics()
+        return text_string_to_metric_families(text)
+
+    def metric_sum(
+            self,
+            metric_name,
+            metrics_endpoint: MetricsEndpoint = MetricsEndpoint.PUBLIC_METRICS,
+            ns=None,
+            topic=None,
+            nodes=None):
+        """Returns sum of metrics values of a given metric name.
+        """
+
+        count = 0
+        metrics = self.metrics(None, metrics_endpoint=metrics_endpoint)
+        for family in metrics:
+            for sample in family.samples:
+                if ns and sample.labels["namespace"] != ns:
+                    continue
+                if topic and sample.labels["topic"] != topic:
+                    continue
+                if sample.name == metric_name:
+                    count += int(sample.value)
+        return count
+
 
 class RedpandaService(RedpandaServiceBase):
     def __init__(self,

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -167,15 +167,24 @@ class RpCloudApiClient(object):
             self._token = j['access_token']
         return self._token
 
-    def _http_get(self, endpoint='', base_url=None, **kwargs):
-        token = self._get_token()
-        headers = {
-            'Authorization': f'Bearer {token}',
-            'Accept': 'application/json'
-        }
+    def _http_get(self,
+                  endpoint='',
+                  base_url=None,
+                  override_headers=None,
+                  text_response=False,
+                  **kwargs):
+        headers = override_headers
+        if headers is None:
+            token = self._get_token()
+            headers = {
+                'Authorization': f'Bearer {token}',
+                'Accept': 'application/json'
+            }
         _base = base_url if base_url else self._config.api_url
         resp = requests.get(f'{_base}{endpoint}', headers=headers, **kwargs)
         _r = self._handle_error(resp)
+        if text_response:
+            return _r if _r is None else _r.text
         return _r if _r is None else _r.json()
 
     def _http_post(self, base_url=None, endpoint='', **kwargs):

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -1,3 +1,4 @@
+import base64
 import collections
 import json
 import os
@@ -609,6 +610,26 @@ class CloudCluster():
                                "testing is not supported at this time.")
 
         return
+
+    def get_public_metrics(self):
+        """Public metrics endpoint for prometheus text format.
+
+        :return: string or None if failure
+        """
+
+        cluster = self._get_cluster(self.config.id)
+        base_url = cluster['status']['listeners']['redpandaConsole'][
+            'default']['urls'][0]
+        username = cluster['spec']['consolePrometheusCredentials']['username']
+        password = cluster['spec']['consolePrometheusCredentials']['password']
+        b64 = base64.b64encode(bytes(f'{username}:{password}', 'utf-8'))
+        token = b64.decode('utf-8')
+        headers = {'Authorization': f'Basic {token}'}
+        return self.cloudv2._http_get(
+            endpoint=f'/api/cloud/prometheus/public_metrics',
+            base_url=base_url,
+            override_headers=headers,
+            text_response=True)
 
     def update_cluster_acls(self, superuser):
         if superuser is not None and not self.clusterUserExists(


### PR DESCRIPTION
Enable redpanda cloud metrics summary so redpanda cloud tests `test_disrupt_cloud_storage` and `test_cloud_cache_thrash` can run.

Fixes https://github.com/redpanda-data/cloudv2/issues/8845

I verified with:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  --test-runner-timeout=3600000 \
  tests/rptest/redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_disrupt_cloud_storage
```

Where output had line showing `metric_sum()` retrieving value `287`:
```
[INFO  - 2023-09-13 15:30:41,092 - si_utils - nodes_report_cloud_segments - lineno:483]: Cluster metrics report 287 / 1000 cloud segments
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none