### PR TITLE
transform/processor: fix use-after-move

### DIFF
--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -43,7 +43,7 @@ processor::processor(
   , _error_callback(std::move(cb))
   , _probe(p)
   , _task(ss::now())
-  , _logger(tlog, ss::format("{}/{}", meta.name(), _ntp.tp.partition)) {
+  , _logger(tlog, ss::format("{}/{}", _meta.name(), _ntp.tp.partition())) {
     vassert(
       _sinks.size() == 1,
       "expected only a single sink, got: {}",


### PR DESCRIPTION
Using the moved string results in the empty string being added to the
logger

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
