### PR TITLE
Modify tiered storage upload parameters in high throughput test

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -508,6 +508,7 @@ class HighThroughputTest(RedpandaTest):
                    timeout_sec=restart_timeout,
                    backoff_sec=1)
 
+    @ignore
     @cluster(num_nodes=2, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_disrupt_cloud_storage(self):
         """


### PR DESCRIPTION
Recently this test was unignored but now it is failing in the nightly cloud tests. This patch fixes the issue where the test was timing out before the total number of expected segments was uploaded.
 
https://github.com/redpanda-data/cloudv2/issues/8193

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
