### PR TITLE
rpk/transform: Fix delete endpoint

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_transform.go
+++ b/src/go/rpk/pkg/adminapi/api_transform.go
@@ -16,14 +16,9 @@ import (
 
 const (
 	baseTransformEndpoint = "/v1/transform/"
-	deleteSuffix          = "delete"
 )
-
-type transformDeleteRequest struct {
-	Name string `json:"name"`
-}
 
 // Delete a wasm transform in a cluster.
 func (a *AdminAPI) DeleteWasmTransform(ctx context.Context, name string) error {
-	return a.sendToLeader(ctx, http.MethodPost, baseTransformEndpoint+deleteSuffix, transformDeleteRequest{name}, nil)
+	return a.sendToLeader(ctx, http.MethodDelete, baseTransformEndpoint+name, nil, nil)
 }


### PR DESCRIPTION
The API slightly changed for deleting transforms and now it's more of a
proper REST endpoint.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
