### PR TITLE
json/json: rjson_serialize(milliseconds) casting fix

### DIFF
--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -97,7 +97,7 @@ void read_value(
 
 inline void
 read_value(json::Value const& v, std::chrono::milliseconds& target) {
-    target = std::chrono::milliseconds(v.GetUint64());
+    target = std::chrono::milliseconds(v.GetInt64());
 }
 
 template<typename T>

--- a/src/v/json/json.cc
+++ b/src/v/json/json.cc
@@ -83,13 +83,13 @@ void rjson_serialize(
 
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const std::chrono::milliseconds& v) {
-    uint64_t _tmp = v.count();
+    auto _tmp = v.count();
     rjson_serialize(w, _tmp);
 }
 
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const std::chrono::seconds& v) {
-    uint64_t _tmp = v.count();
+    auto _tmp = v.count();
     rjson_serialize(w, _tmp);
 }
 


### PR DESCRIPTION
chrono types are signed, -1 is a valid value for log_retention_ms.

this change remove the silent cast to unsigned that was producing erroneous values in json responses

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes #13432 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none 