### PR TITLE
Increase topic_memory_per_partition to 4 MiB

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -141,7 +141,7 @@ configuration::configuration()
       "topic_memory_per_partition",
       "Required memory per partition when creating topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      1_MiB,
+      4_MiB,
       {
         .min = 1,      // Must be nonzero, it's a divisor
         .max = 100_MiB // Rough 'sanity' limit: a machine with 1GB RAM must be

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -73,6 +73,6 @@ rp_test(
   SOURCES fetch_plan_bench.cc
   LIBRARIES Seastar::seastar_perf_testing Boost::unit_test_framework v::application
   # the args below are just to keep it fast
-  ARGS "-c 1 --duration=1 --runs=1 --memory=1G"
+  ARGS "-c 1 --duration=1 --runs=1 --memory=4G"
   LABELS kafka
 )


### PR DESCRIPTION
Increase this value from 1 to 4 MiB based on the observation that 1 MiB is not enough to prevent OOMs on some high-load + high-partition workloads.

Fixes #13460.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* The default value for topic_memory_per_partition is increased to 4 MiB. This means that Redpanda must be allocated at least 4 MiB of memory for every partition replica (partition count * replication factor). If this limit is not met, new partitions cannot be created.