### PR TITLE
rpk/transform: introduce list command

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_transform.go
+++ b/src/go/rpk/pkg/adminapi/api_transform.go
@@ -27,3 +27,34 @@ type transformDeleteRequest struct {
 func (a *AdminAPI) DeleteWasmTransform(ctx context.Context, name string) error {
 	return a.sendToLeader(ctx, http.MethodPost, baseTransformEndpoint+deleteSuffix, transformDeleteRequest{name}, nil)
 }
+
+// PartitionTransformStatus is the status of a single transform that is running on an input partition.
+type PartitionTransformStatus struct {
+	NodeID    int `json:"node_id"`
+	Partition int `json:"partition"`
+	Core      int `json:"core"`
+	// Status is an enum of: ["running", "inactive", "errored", "unknown"].
+	Status string `json:"status"`
+}
+
+// EnvironmentVariable is a configuration key/value that can be injected into to a data transform.
+type EnvironmentVariable struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// TransformMetadata is the metadata for a live running transform on a cluster.
+type TransformMetadata struct {
+	Name         string                     `json:"name"`
+	InputTopic   string                     `json:"input_topic"`
+	OutputTopics []string                   `json:"output_topics"`
+	Status       []PartitionTransformStatus `json:"status"`
+	Environment  []EnvironmentVariable      `json:"environment"`
+}
+
+// ListWasmTransforms lists the transforms that are running on a cluster.
+func (a *AdminAPI) ListWasmTransforms(ctx context.Context) ([]TransformMetadata, error) {
+	resp := []TransformMetadata{}
+	err := a.sendAny(ctx, http.MethodGet, baseTransformEndpoint, nil, &resp)
+	return resp, err
+}

--- a/src/go/rpk/pkg/cli/transform/list.go
+++ b/src/go/rpk/pkg/cli/transform/list.go
@@ -1,0 +1,153 @@
+/*
+* Copyright 2023 Redpanda Data, Inc.
+*
+* Use of this software is governed by the Business Source License
+* included in the file licenses/BSL.md
+*
+* As of the Change Date specified in that file, in accordance with
+* the Business Source License, use of this software will be governed
+* by the Apache License, Version 2.0
+ */
+
+package transform
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var detailed bool
+	cmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List data transforms",
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			f := p.Formatter
+			if h, ok := f.Help([]string{}); ok {
+				out.Exit(h)
+			}
+
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			api, err := adminapi.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin api client: %v", err)
+
+			l, err := api.ListWasmTransforms(cmd.Context())
+			out.MaybeDie(err, "unable to list transforms: %v", err)
+
+			if detailed {
+				d := detailView(l)
+				printDetailed(f, d, os.Stdout)
+			} else {
+				s := summarizedView(l)
+				printSummary(f, s, os.Stdout)
+			}
+		},
+	}
+	p.InstallFormatFlag(cmd)
+	cmd.Flags().BoolVarP(&detailed, "detailed", "d", false, "Print per-partition information for data transforms")
+	return cmd
+}
+
+type (
+	detailedTransformMetadata struct {
+		Name         string                              `json:"name"`
+		InputTopic   string                              `json:"input_topic"`
+		OutputTopics []string                            `json:"output_topics"`
+		Environment  map[string]string                   `json:"environment"`
+		Status       []adminapi.PartitionTransformStatus `json:"status"`
+	}
+	summarizedTransformMetadata struct {
+		Name         string            `json:"name"`
+		InputTopic   string            `json:"input_topic"`
+		OutputTopics []string          `json:"output_topics"`
+		Environment  map[string]string `json:"environment"`
+		Running      string            `json:"running"`
+	}
+)
+
+func makeEnvMap(env []adminapi.EnvironmentVariable) map[string]string {
+	out := make(map[string]string)
+	for _, entry := range env {
+		out[entry.Key] = entry.Value
+	}
+	return out
+}
+
+func summarizedView(metadata []adminapi.TransformMetadata) (resp []summarizedTransformMetadata) {
+	for _, meta := range metadata {
+		total := len(meta.Status)
+		running := 0
+		for _, v := range meta.Status {
+			if v.Status == "running" {
+				running++
+			}
+		}
+		resp = append(resp, summarizedTransformMetadata{
+			Name:         meta.Name,
+			InputTopic:   meta.InputTopic,
+			OutputTopics: meta.OutputTopics,
+			Environment:  makeEnvMap(meta.Environment),
+			Running:      fmt.Sprintf("%d / %d", running, total),
+		})
+	}
+	return
+}
+
+func printSummary(f config.OutFormatter, s []summarizedTransformMetadata, w io.Writer) {
+	if isText, _, t, err := f.Format(s); !isText {
+		out.MaybeDie(err, "unable to print in the requested format %q: %v", f.Kind, err)
+		fmt.Fprintf(w, "%s\n", t)
+		return
+	}
+	tw := out.NewTableTo(w, "Name", "Input Topic", "Output Topic", "Running")
+	defer tw.Flush()
+	for _, m := range s {
+		tw.Print(m.Name, m.InputTopic, strings.Join(m.OutputTopics, ", "), m.Running)
+	}
+}
+
+func detailView(metadata []adminapi.TransformMetadata) (resp []detailedTransformMetadata) {
+	for _, meta := range metadata {
+		resp = append(resp, detailedTransformMetadata{
+			Name:         meta.Name,
+			InputTopic:   meta.InputTopic,
+			OutputTopics: meta.OutputTopics,
+			Environment:  makeEnvMap(meta.Environment),
+			Status:       meta.Status,
+		})
+	}
+	return
+}
+
+func printDetailed(f config.OutFormatter, d []detailedTransformMetadata, w io.Writer) {
+	if isText, _, s, err := f.Format(d); !isText {
+		out.MaybeDie(err, "unable to print in the requested format %q: %v", f.Kind, err)
+		fmt.Fprintf(w, "%s\n", s)
+		return
+	}
+	tw := out.NewTabWriterTo(w)
+	defer tw.Flush()
+	for i, m := range d {
+		if i > 0 {
+			tw.Line()
+		}
+		tw.Print(fmt.Sprintf("%s, %s → %s", m.Name, m.InputTopic, strings.Join(m.OutputTopics, ", ")))
+		// add an empty column to provide an indent
+		tw.Print("", "PARTITION", "NODE", "CORE", "STATUS")
+		for _, p := range m.Status {
+			tw.Print("", p.Partition, p.NodeID, p.Core, p.Status)
+		}
+	}
+}

--- a/src/go/rpk/pkg/cli/transform/list_test.go
+++ b/src/go/rpk/pkg/cli/transform/list_test.go
@@ -1,0 +1,128 @@
+package transform
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"gopkg.in/yaml.v3"
+
+	"github.com/stretchr/testify/require"
+)
+
+func setupTestData() []adminapi.TransformMetadata {
+	return []adminapi.TransformMetadata{
+		{
+			Name:         "foo2bar",
+			InputTopic:   "foo",
+			OutputTopics: []string{"bar"},
+			Environment: []adminapi.EnvironmentVariable{
+				{Key: "FLUBBER", Value: "enabled"},
+			},
+			Status: []adminapi.PartitionTransformStatus{
+				{
+					NodeID:    0,
+					Partition: 1,
+					Core:      0,
+					Status:    "running",
+				},
+				{
+					NodeID:    0,
+					Partition: 2,
+					Core:      1,
+					Status:    "running",
+				},
+				{
+					NodeID:    1,
+					Partition: 3,
+					Core:      4,
+					Status:    "inactive",
+				},
+			},
+		},
+		{
+			Name:         "scrubber",
+			InputTopic:   "pii",
+			OutputTopics: []string{"cleaned", "munged"},
+			Environment: []adminapi.EnvironmentVariable{
+				{Key: "FLUX_CAPACITOR", Value: "disabled"},
+			},
+			Status: []adminapi.PartitionTransformStatus{
+				{
+					NodeID:    0,
+					Partition: 1,
+					Core:      0,
+					Status:    "errored",
+				},
+			},
+		},
+	}
+}
+
+type testCase struct {
+	Kind   string
+	Output string
+}
+
+func JSON(t *testing.T, o any) testCase {
+	expected, err := json.Marshal(o)
+	require.NoError(t, err)
+	return testCase{Kind: "json", Output: string(expected) + "\n"}
+}
+
+func YAML(t *testing.T, o any) testCase {
+	expected, err := yaml.Marshal(o)
+	require.NoError(t, err)
+	return testCase{Kind: "yaml", Output: string(expected) + "\n"}
+}
+
+func Text(s string) testCase {
+	s = strings.TrimSpace(s)
+	return testCase{Kind: "text", Output: s + "\n"}
+}
+
+func TestPrintSummaryView(t *testing.T) {
+	s := summarizedView(setupTestData())
+	cases := []testCase{
+		Text(`
+NAME      INPUT TOPIC  OUTPUT TOPIC     RUNNING
+foo2bar   foo          bar              2 / 3
+scrubber  pii          cleaned, munged  0 / 1
+`),
+		JSON(t, s),
+		YAML(t, s),
+	}
+	for _, c := range cases {
+		f := config.OutFormatter{Kind: c.Kind}
+		b := &strings.Builder{}
+		printSummary(f, s, b)
+		require.Equal(t, c.Output, b.String())
+	}
+}
+
+func TestPrintDetailView(t *testing.T) {
+	d := detailView(setupTestData())
+	cases := []testCase{
+		Text(`
+foo2bar, foo → bar
+      PARTITION  NODE  CORE  STATUS
+      1          0     0     running
+      2          0     1     running
+      3          1     4     inactive
+
+scrubber, pii → cleaned, munged
+      PARTITION  NODE  CORE  STATUS
+      1          0     0     errored
+`),
+		JSON(t, d),
+		YAML(t, d),
+	}
+	for _, c := range cases {
+		f := config.OutFormatter{Kind: c.Kind}
+		b := &strings.Builder{}
+		printDetailed(f, d, b)
+		require.Equal(t, c.Output, b.String())
+	}
+}

--- a/src/go/rpk/pkg/cli/transform/transform.go
+++ b/src/go/rpk/pkg/cli/transform/transform.go
@@ -24,6 +24,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	p.InstallKafkaFlags(cmd)
 	cmd.AddCommand(
 		newDeleteCommand(fs, p),
+		newListCommand(fs, p),
 	)
 	return cmd
 }


### PR DESCRIPTION
Support listing the metadata from the broker Admin API endpoint

Supports text, json & yaml output formats

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
