### PR TITLE
rpk: improved err msg in rpk tune --output-script

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/tune/tune.go
+++ b/src/go/rpk/pkg/cli/redpanda/tune/tune.go
@@ -93,6 +93,11 @@ To learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.
 			out.MaybeDie(err, "unable to load config: %v", err)
 			var tunerFactory factory.TunersFactory
 			if outTuneScriptFile != "" {
+				isDir, err := afero.IsDir(fs, outTuneScriptFile)
+				out.MaybeDie(err, "unable to check if %q is a dir or a file: %v", outTuneScriptFile, err)
+				if isDir {
+					out.Die("please use a filename instead of a directory name in --output-script")
+				}
 				tunerFactory = factory.NewScriptRenderingTunersFactory(fs, y.Rpk.Tuners, outTuneScriptFile, timeout)
 			} else {
 				tunerFactory = factory.NewDirectExecutorTunersFactory(fs, y.Rpk.Tuners, timeout)


### PR DESCRIPTION
If the user used a directory it would fail and panic without giving any meaningful error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Bug Fixes

* rpk: prevent panic when using a directory instead of a filename in `rpk redpanda tune --output-script`
