### PR TITLE
TLS Certificate Metrics

### DIFF
--- a/src/v/cloud_roles/aws_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_refresh_impl.cc
@@ -202,7 +202,7 @@ ss::future<api_response> aws_refresh_impl::fetch_instance_metadata_token() {
     token_request.target("/latest/api/token");
 
     co_return co_await make_request(
-      co_await make_api_client(), std::move(token_request));
+      co_await make_api_client("aws"), std::move(token_request));
 }
 
 ss::future<api_response> aws_refresh_impl::make_request_with_token(
@@ -210,7 +210,8 @@ ss::future<api_response> aws_refresh_impl::make_request_with_token(
     if (token.has_value()) {
         add_metadata_token_to_request(req, token.value());
     }
-    co_return co_await make_request(co_await make_api_client(), std::move(req));
+    co_return co_await make_request(
+      co_await make_api_client("aws"), std::move(req));
 }
 
 std::ostream& aws_refresh_impl::print(std::ostream& os) const {

--- a/src/v/cloud_roles/aws_sts_refresh_impl.cc
+++ b/src/v/cloud_roles/aws_sts_refresh_impl.cc
@@ -142,7 +142,7 @@ ss::future<api_response> aws_sts_refresh_impl::fetch_credentials() {
     }
 
     co_return co_await request_with_payload(
-      co_await make_api_client(tls_enabled),
+      co_await make_api_client("aws_sts", tls_enabled),
       std::move(assume_req),
       std::move(body));
 }

--- a/src/v/cloud_roles/gcp_refresh_impl.cc
+++ b/src/v/cloud_roles/gcp_refresh_impl.cc
@@ -52,7 +52,7 @@ ss::future<api_response> gcp_refresh_impl::fetch_credentials() {
       metadata_flavor::header_name.data(), metadata_flavor::value.data());
 
     co_return co_await make_request(
-      co_await make_api_client(), std::move(oauth_req));
+      co_await make_api_client("gcp"), std::move(oauth_req));
 }
 
 api_response_parse_result gcp_refresh_impl::parse_response(iobuf response) {

--- a/src/v/cloud_roles/refresh_credentials.h
+++ b/src/v/cloud_roles/refresh_credentials.h
@@ -71,8 +71,9 @@ public:
 
     protected:
         /// Returns an http client with the API host and port applied
-        ss::future<http::client>
-        make_api_client(client_tls_enabled enable_tls = client_tls_enabled::no);
+        ss::future<http::client> make_api_client(
+          ss::sstring name = "",
+          client_tls_enabled enable_tls = client_tls_enabled::no);
 
         /// Helper to parse the iobuf returned from API into a credentials
         /// object, customized to API response structure
@@ -104,7 +105,7 @@ public:
     private:
         /// Initializes certificate_credentials on first client creation.
         /// Subsequent clients which are created will reuse the certs.
-        ss::future<> init_tls_certs();
+        ss::future<> init_tls_certs(ss::sstring name);
 
         /// The address to query for credentials. Can be overridden using env
         /// variable `RP_SI_CREDS_API_ADDRESS`

--- a/src/v/net/tls_certificate_probe.h
+++ b/src/v/net/tls_certificate_probe.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/bytes.h"
+#include "config/tls_config.h"
+#include "metrics/metrics.h"
+#include "seastarx.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/net/tls.hh>
+
+#include <chrono>
+#include <exception>
+#include <iosfwd>
+
+namespace net {
+
+class tls_certificate_probe {
+    using tls_serial_number
+      = named_type<uint32_t, struct tls_serial_number_tag>;
+
+public:
+    using clock_type = ss::lowres_system_clock;
+    tls_certificate_probe() { reset(); }
+    tls_certificate_probe(const tls_certificate_probe&) = delete;
+    tls_certificate_probe& operator=(const tls_certificate_probe&) = delete;
+    tls_certificate_probe(tls_certificate_probe&&) = delete;
+    tls_certificate_probe& operator=(tls_certificate_probe&&) = delete;
+    ~tls_certificate_probe() = default;
+
+    void loaded(
+      const ss::tls::certificate_credentials& creds, std::exception_ptr ex);
+
+    void setup_metrics(std::string_view area, std::string_view detail);
+
+private:
+    metrics::internal_metric_groups _metrics;
+    metrics::public_metric_groups _public_metrics;
+    clock_type::time_point _load_time{};
+    clock_type::time_point _cert_expiry_time{clock_type::time_point::max()};
+    clock_type::time_point _ca_expiry_time{clock_type::time_point::max()};
+    tls_serial_number _cert_serial;
+    tls_serial_number _ca_serial;
+    bool _cert_loaded{false};
+
+    bool cert_valid() const {
+        auto now = clock_type::now();
+        return _cert_loaded && now < _ca_expiry_time && now < _cert_expiry_time;
+    }
+
+    void reset() {
+        _cert_loaded = false;
+        _cert_expiry_time = clock_type::time_point::max();
+        _ca_expiry_time = clock_type::time_point::max();
+        _cert_serial = {};
+        _ca_serial = {};
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const tls_certificate_probe& p);
+};
+
+ss::future<ss::shared_ptr<ss::tls::server_credentials>>
+build_reloadable_server_credentials_with_probe(
+  config::tls_config tls_config,
+  ss::sstring service,
+  ss::sstring listener_name,
+  ss::tls::reload_callback cb = {});
+
+template<typename T>
+concept TLSCreds = std::is_base_of<ss::tls::certificate_credentials, T>::value;
+
+template<TLSCreds T>
+ss::future<ss::shared_ptr<T>> build_reloadable_credentials_with_probe(
+  ss::tls::credentials_builder builder,
+  ss::sstring area,
+  ss::sstring detail,
+  ss::tls::reload_callback cb = {});
+
+}; // namespace net

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -76,6 +76,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "net/server.h"
+#include "net/tls_certificate_probe.h"
 #include "pandaproxy/rest/api.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/schema_registry/api.h"
@@ -1744,7 +1745,8 @@ void application::wire_up_redpanda_services(
                 = config::shard_local_cfg().kafka_rpc_server_stream_recv_buf;
               auto& tls_config = config::node().kafka_api_tls.value();
               for (const auto& ep : config::node().kafka_api()) {
-                  ss::shared_ptr<ss::tls::server_credentials> credentails;
+                  ss::shared_ptr<ss::tls::server_credentials> credentials
+                    = nullptr;
                   // find credentials for this endpoint
                   auto it = find_if(
                     tls_config.begin(),
@@ -1753,30 +1755,27 @@ void application::wire_up_redpanda_services(
                         return cfg.name == ep.name;
                     });
                   // if tls is configured for this endpoint build reloadable
-                  // credentails
+                  // credentials
                   if (it != tls_config.end()) {
                       syschecks::systemd_message(
                         "Building TLS credentials for kafka")
                         .get();
-                      auto kafka_builder
-                        = it->config.get_credentials_builder().get0();
-                      credentails
-                        = kafka_builder
-                            ? kafka_builder
-                                ->build_reloadable_server_credentials(
-                                  [this, name = it->name](
-                                    const std::unordered_set<ss::sstring>&
-                                      updated,
-                                    const std::exception_ptr& eptr) {
-                                      rpc::log_certificate_reload_event(
-                                        _log, "Kafka RPC TLS", updated, eptr);
-                                  })
-                                .get0()
-                            : nullptr;
+                      credentials
+                        = net::build_reloadable_server_credentials_with_probe(
+                            it->config,
+                            "kafka",
+                            it->name,
+                            [this](
+                              const std::unordered_set<ss::sstring>& updated,
+                              const std::exception_ptr& eptr) {
+                                rpc::log_certificate_reload_event(
+                                  _log, "Kafka RPC TLS", updated, eptr);
+                            })
+                            .get();
                   }
 
                   c.addrs.emplace_back(
-                    ep.name, net::resolve_dns(ep.address).get0(), credentails);
+                    ep.name, net::resolve_dns(ep.address).get(), credentials);
               }
 
               c.disable_metrics = net::metrics_disabled(
@@ -1968,22 +1967,18 @@ void application::wire_up_bootstrap_services() {
                 = config::shard_local_cfg().rpc_server_tcp_recv_buf;
               c.tcp_send_buf
                 = config::shard_local_cfg().rpc_server_tcp_send_buf;
-              auto rpc_builder = config::node()
-                                   .rpc_server_tls()
-                                   .get_credentials_builder()
-                                   .get0();
               auto credentials
-                = rpc_builder
-                    ? rpc_builder
-                        ->build_reloadable_server_credentials(
-                          [this](
-                            const std::unordered_set<ss::sstring>& updated,
-                            const std::exception_ptr& eptr) {
-                              rpc::log_certificate_reload_event(
-                                _log, "Internal RPC TLS", updated, eptr);
-                          })
-                        .get0()
-                    : nullptr;
+                = net::build_reloadable_server_credentials_with_probe(
+                    config::node().rpc_server_tls(),
+                    "rpc",
+                    "",
+                    [this](
+                      const std::unordered_set<ss::sstring>& updated,
+                      const std::exception_ptr& eptr) {
+                        rpc::log_certificate_reload_event(
+                          _log, "Internal RPC TLS", updated, eptr);
+                    })
+                    .get();
               c.addrs.emplace_back(rpc_server_addr, credentials);
           });
       })

--- a/tests/docker/ducktape-deps/tool-pkgs
+++ b/tests/docker/ducktape-deps/tool-pkgs
@@ -27,4 +27,5 @@ apt-get install -qq \
   llvm \
   python3-pip \
   libzstd-dev \
-  pkg-config
+  pkg-config \
+  faketime

--- a/tests/rptest/tests/tls_metrics_test.py
+++ b/tests/rptest/tests/tls_metrics_test.py
@@ -1,0 +1,325 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import json
+import socket
+import time
+from datetime import datetime, timedelta
+from typing import Optional, Callable
+
+from ducktape.cluster.cluster import ClusterNode
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import SecurityConfig, TLSProvider, SchemaRegistryConfig, PandaproxyConfig
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
+from rptest.services.redpanda import MetricSamples, MetricsEndpoint, RedpandaService
+from rptest.services import tls
+from rptest.tests.pandaproxy_test import User, PandaProxyTLSProvider
+from rptest.util import wait_until_result
+
+# Basic configs to enable TLS for internal RPC and Admin API
+RPC_TLS_CONFIG = dict(enabled=True,
+                      require_client_auth=True,
+                      key_file=RedpandaService.TLS_SERVER_KEY_FILE,
+                      cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
+                      truststore_file=RedpandaService.TLS_CA_CRT_FILE)
+
+ADMIN_TLS_CONFIG = dict(name='iplistener',
+                        enabled=True,
+                        require_client_auth=True,
+                        key_file=RedpandaService.TLS_SERVER_KEY_FILE,
+                        cert_file=RedpandaService.TLS_SERVER_CRT_FILE,
+                        truststore_file=RedpandaService.TLS_CA_CRT_FILE)
+
+
+class FaketimeTLSProvider(TLSProvider):
+    def __init__(self, tls, broker_faketime='-0d', client_faketime='-0d'):
+        self.tls = tls
+        self.broker_faketime = broker_faketime
+        self.client_faketime = client_faketime
+
+    @property
+    def ca(self):
+        return self.tls.ca
+
+    def create_broker_cert(self, redpanda, node):
+        assert node in redpanda.nodes
+        return self.tls.create_cert(node.name, faketime=self.broker_faketime)
+
+    def create_service_client_cert(self, _, name):
+        return self.tls.create_cert(socket.gethostname(),
+                                    name=name,
+                                    common_name=name,
+                                    faketime=self.client_faketime)
+
+
+class TLSMetricsTestBase(RedpandaTest):
+    CERT_METRICS: list[str] = [
+        'truststore_expires_at_timestamp_seconds',
+        'certificate_expires_at_timestamp_seconds',
+        'loaded_at_timestamp_seconds',
+        'certificate_valid',
+        'certificate_serial',
+    ]
+
+    EXPECTED_LABELS: list[str] = [
+        'area',
+        'detail',
+        'shard',
+    ]
+
+    def __init__(self,
+                 *args,
+                 broker_faketime='-0d',
+                 client_faketime='-0d',
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.broker_faketime = broker_faketime
+        self.client_faketime = client_faketime
+
+        self.security = SecurityConfig()
+        su_username, su_password, su_algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+        self.admin_user = User(0)
+        self.admin_user.username = su_username
+        self.admin_user.password = su_password
+        self.admin_user.algorithm = su_algorithm
+
+        self.schema_registry_config = SchemaRegistryConfig()
+        self.schema_registry_config.require_client_auth = True
+        self.pandaproxy_config = PandaproxyConfig()
+        self.pandaproxy_config.require_client_auth = True
+
+        self.tls = None
+
+    def setUp(self):
+        assert self.tls is not None
+
+        self.security.require_client_auth = True
+        self.security.kafka_enable_authorization = True
+        self.security.enable_sasl = True
+        self.schema_registry_config.authn_method = 'http_basic'
+        self.pandaproxy_config.authn_method = 'http_basic'
+
+        client_cert = self.tls.create_cert(
+            socket.gethostname(),
+            common_name=self.admin_user.username,
+            name='test_client_tls')
+
+        self.security.tls_provider = FaketimeTLSProvider(
+            self.tls,
+            broker_faketime=self.broker_faketime,
+            client_faketime=self.client_faketime)
+        self.schema_registry_config.client_key = client_cert.key
+        self.schema_registry_config.client_crt = client_cert.crt
+        self.pandaproxy_config.client_key = client_cert.key
+        self.pandaproxy_config.client_crt = client_cert.crt
+
+        self.redpanda.set_security_settings(self.security)
+        self.redpanda.set_schema_registry_settings(self.schema_registry_config)
+        self.redpanda.set_pandaproxy_settings(self.pandaproxy_config)
+
+        super().setUp()
+
+    def _get_metrics_from_node(
+        self,
+        node: ClusterNode,
+        patterns: list[str],
+        endpoint=MetricsEndpoint.METRICS
+    ) -> Optional[dict[str, MetricSamples]]:
+        def get_metrics_from_node_sync(patterns: list[str]):
+            samples = self.redpanda.metrics_samples(
+                patterns,
+                [node],
+                endpoint,
+            )
+            success = samples is not None
+            return success, samples
+
+        try:
+            return wait_until_result(
+                lambda: get_metrics_from_node_sync(patterns),
+                timeout_sec=2,
+                backoff_sec=.1)
+        except TimeoutError as e:
+            return None
+
+    def _unpack_samples(self, metric_samples):
+        return {
+            k: [{
+                'value': s.value,
+                'labels': s.labels
+            } for s in metric_samples[k].samples]
+            for k in metric_samples.keys()
+        }
+
+    def _days_from_now(self, days):
+        return (datetime.now() + timedelta(days=days)).timestamp()
+
+
+class TLSMetricsTest(TLSMetricsTestBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tls = tls.TLSCertManager(self.logger)
+
+    def setUp(self):
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    def test_metrics(self):
+        """
+        Test presence of certificate metrics
+        """
+        node = self.redpanda.nodes[0]
+        metrics_samples = self._get_metrics_from_node(node, self.CERT_METRICS)
+        assert metrics_samples is not None
+        assert sorted(metrics_samples.keys()) == sorted(self.CERT_METRICS)
+
+    @cluster(num_nodes=3)
+    def test_public_metrics(self):
+        """
+        Test presense of certificate metrics on public endpoint
+        """
+        node = self.redpanda.nodes[0]
+        metrics_samples = self._get_metrics_from_node(
+            node,
+            self.CERT_METRICS,
+            endpoint=MetricsEndpoint.PUBLIC_METRICS,
+        )
+        assert metrics_samples is not None
+        assert sorted(metrics_samples.keys()) == sorted(self.CERT_METRICS)
+
+    @cluster(num_nodes=3)
+    def test_labels(self):
+        """
+        Test presense of expected labels on metrics
+        """
+        node = self.redpanda.nodes[1]
+        metrics_samples = self._get_metrics_from_node(node, self.CERT_METRICS)
+        assert metrics_samples is not None
+        metrics = self._unpack_samples(metrics_samples)
+        for name in metrics.keys():
+            assert (all([
+                sorted(m['labels'].keys()) == sorted(self.EXPECTED_LABELS)
+                for m in metrics[name]
+            ]))
+
+        # expect metrics to be emitted exclusively from shard0
+        for name in metrics.keys():
+            assert (all(
+                [int(m['labels']['shard']) == 0 for m in metrics[name]]))
+
+    @cluster(num_nodes=3)
+    def test_services(self):
+        """
+        Test that metrics are successfully enabled for various services.
+        """
+        self.redpanda.stop()
+
+        # Set up TLS for RPC and Admin API (iplistener)
+        cfg_overrides = {}
+
+        def set_cfg(node):
+            cfg_overrides[node] = dict(rpc_server_tls=RPC_TLS_CONFIG,
+                                       admin_api_tls=ADMIN_TLS_CONFIG)
+
+        self.redpanda.for_nodes(self.redpanda.nodes, set_cfg)
+        self.redpanda.start(node_config_overrides=cfg_overrides)
+
+        node = self.redpanda.nodes[0]
+        metric = self.CERT_METRICS[0]
+        metrics_samples = self._get_metrics_from_node(
+            node,
+            [metric],
+            endpoint=MetricsEndpoint.PUBLIC_METRICS,
+        )
+
+        assert metrics_samples is not None
+        vals = self._unpack_samples(metrics_samples)
+        areas = [v['labels']['area'] for v in vals[metric]]
+        self.logger.debug(f"Areas w/ TLS enabled: {areas}")
+
+        assert 'kafka' in areas
+        assert 'schema_registry' in areas
+        assert 'rpc' in areas
+        assert 'rest_proxy' in areas
+        assert 'admin' in areas
+
+
+class TLSMetricsTestChain(TLSMetricsTestBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.tls = tls.TLSChainCACertManager(self.logger, chain_len=4)
+
+    def setUp(self):
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    def test_cert_chain_metrics(self):
+        """
+        Test various behaviors given a longer chained truststore
+        """
+        node = self.redpanda.nodes[0]
+
+        metrics_samples = self._get_metrics_from_node(node, self.CERT_METRICS)
+        assert metrics_samples is not None
+        assert sorted(metrics_samples.keys()) == sorted(
+            self.CERT_METRICS), f"Missing metrics: {metrics_samples.keys()}"
+
+        metric_values = self._unpack_samples(metrics_samples)
+
+        assert len(metric_values['loaded_at_timestamp_seconds']
+                   ) > 0, "loaded_at is not present"
+        assert all([
+            int(v['value']) == 1 for v in metric_values['certificate_valid']
+        ]), "Cert not valid"
+        assert all([
+            int(time.time()) < v['value']
+            and v['value'] <= self._days_from_now(self.tls.ca_expiry_days)
+            for v in metric_values['truststore_expires_at_timestamp_seconds']
+        ]), "Trustore expiry should be that of shortest-lived CA in the chain"
+        assert all([
+            int(time.time()) < v['value']
+            and v['value'] <= self._days_from_now(self.tls.cert_expiry_days)
+            for v in metric_values['certificate_expires_at_timestamp_seconds']
+        ]), "Certificate expiry should reflect configured value"
+        assert all([
+            int(v['value']) == 3 for v in metric_values['certificate_serial']
+        ])
+
+
+class TLSMetricsTestExpiring(TLSMetricsTestBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, broker_faketime='-23.995h', **kwargs)
+        self.tls = tls.TLSCertManager(self.logger, cert_expiry_days=1)
+
+    def setUp(self):
+        super().setUp()
+
+    @cluster(num_nodes=3)
+    def test_detect_expired_cert(self):
+        """
+        Test that metrics detect an expired certificate
+        """
+        node = self.redpanda.nodes[0]
+
+        metric_values = self._unpack_samples(
+            self._get_metrics_from_node(node, ['certificate_valid']))
+        assert all(
+            v['value']
+            for v in metric_values['certificate_valid']), "Cert(s) not valid"
+
+        time.sleep(20)
+
+        metric_values = self._unpack_samples(
+            self._get_metrics_from_node(node, ['certificate_valid']))
+        assert all(
+            not v['value'] for v in
+            metric_values['certificate_valid']), "Certs should have expired"


### PR DESCRIPTION
This PR introduces a number of new Prometheus metrics allowing administrators
to track and monitor TLS issues as they arise. The metrics are

- `truststore_expires_at_timestamp_seconds`
    - The expiration time (unix timestamp) of the shortest-lived CA in
       the installed CA chain
- `certificate_expires_at_timestamp_seconds`
    - The expiration time (unix timestamp) of the installed server cert
- `certificate_serial`
    - The serial number of the installed server cert
- `loaded_at_timestamp_seconds`
    - The last time (unix timestamp) certificates were loaded for a given
       service.
- `certificate_valid`
    - Whether the installed certificate is still valid

This PR also introduces a new ducktape pseudo-service to generate and manage CA
for the purpose of testing the above.

Fixes https://github.com/redpanda-data/core-internal/issues/714

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* Introduce Prometheus metrics for tracking TLS cert/CA expiration

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
