### PR TITLE
Locked config properties poc

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -57,6 +57,22 @@ configuration::configuration()
        .example = "268435456",
        .visibility = visibility::tunable},
       std::nullopt)
+  , log_segment_size_locked_min(
+      *this,
+      "log_segment_size_locked_min",
+      "Lower bound on topic segment.bytes:  reject topics with lower values",
+      {.needs_restart = needs_restart::no,
+       .example = "16777216",
+       .visibility = visibility::tunable},
+      1_MiB)
+  , log_segment_size_locked_max(
+      *this,
+      "log_segment_size_locked_max",
+      "Upper bound on topic segment.bytes: reject topics with higher values",
+      {.needs_restart = needs_restart::no,
+       .example = "268435456",
+       .visibility = visibility::tunable},
+      std::nullopt)
   , log_segment_size_jitter_percent(
       *this,
       "log_segment_size_jitter_percent",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -48,6 +48,8 @@ struct configuration final : public config_store {
     bounded_property<uint64_t> log_segment_size;
     property<std::optional<uint64_t>> log_segment_size_min;
     property<std::optional<uint64_t>> log_segment_size_max;
+    property<std::optional<uint64_t>> log_segment_size_locked_min;
+    property<std::optional<uint64_t>> log_segment_size_locked_max;
     bounded_property<uint16_t> log_segment_size_jitter_percent;
     bounded_property<uint64_t> compacted_log_segment_size;
     property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -81,7 +81,8 @@ using validators = make_validator_types<
   cleanup_policy_validator,
   remote_read_and_write_are_not_supported_for_read_replica,
   batch_max_bytes_limits,
-  subject_name_strategy_validator>;
+  subject_name_strategy_validator,
+  locked_segment_size_validator>;
 
 static std::vector<creatable_topic_configs>
 properties_to_result_configs(config_map_t config_map) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1172,6 +1172,17 @@ size_t disk_log_impl::max_segment_size() const {
         result = std::min(*max_limit, result);
     }
 
+    auto min_locked_limit
+      = config::shard_local_cfg().log_segment_size_locked_min();
+    auto max_locked_limit
+      = config::shard_local_cfg().log_segment_size_locked_max();
+    if (min_locked_limit) {
+        result = std::max(*min_locked_limit, result);
+    }
+    if (max_locked_limit) {
+        result = std::min(*max_locked_limit, result);
+    }
+
     return result;
 }
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 import json
 import logging
+import os
 import pprint
 import random
 import re
@@ -1821,3 +1822,83 @@ class ClusterConfigLegacyDefaultTest(RedpandaTest, ClusterConfigHelpersMixin):
         self.redpanda.set_cluster_config({self.key: expected})
 
         self._check_value_everywhere(self.key, expected)
+
+
+class LockedConfigsTest(RedpandaTest):
+    SEGMENT_SIZE = 134217728
+    LOCKED_SEGMENT_SIZE_MIN = SEGMENT_SIZE // 2
+    LOCKED_SEGMENT_SIZE_MAX = SEGMENT_SIZE * 2
+    topics = [TopicSpec(segment_bytes=SEGMENT_SIZE)]
+
+    def __init__(self, *args, **kwargs):
+        super(LockedConfigsTest, self).__init__(extra_rp_conf={
+            "log_segment_size_locked_min":
+            self.LOCKED_SEGMENT_SIZE_MIN
+        },
+                                                *args,
+                                                **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_locked_configs(self):
+        admin = Admin(self.redpanda)
+        target_broker = self.redpanda.nodes[0]
+
+        # Reset locked min to the max, expect 409 HTTP status
+        try:
+            admin.patch_cluster_config(upsert={
+                'log_segment_size_locked_min':
+                self.LOCKED_SEGMENT_SIZE_MAX
+            },
+                                       node=target_broker)
+        except requests.exceptions.HTTPError as ex:
+            if ex.response.status_code != requests.codes.conflict:
+                raise
+
+        # Locked min should still be the previous value
+        res = admin.get_cluster_config(node=target_broker)
+        assert res[
+            'log_segment_size_locked_min'] == self.LOCKED_SEGMENT_SIZE_MIN
+
+        # Set locked max, expect success
+        patch_result = admin.patch_cluster_config(upsert={
+            'log_segment_size_locked_max':
+            self.LOCKED_SEGMENT_SIZE_MAX
+        },
+                                                  node=target_broker)
+        wait_for_version_sync(admin, self.redpanda,
+                              patch_result['config_version'])
+
+    @cluster(num_nodes=3)
+    def test_locked_configs_restart(self):
+        # Tests that locked configs persist between broker restart.
+
+        admin = Admin(self.redpanda)
+        target_broker = self.redpanda.nodes[0]
+
+        # After first boot, the locked config should be in the bootstrap file
+        # because we pre-set locked configs in rp_exta_conf. The locked config
+        # should be returned by the Admin API
+        res = admin.get_cluster_config(node=target_broker)
+        assert res[
+            'log_segment_size_locked_min'] == self.LOCKED_SEGMENT_SIZE_MIN
+
+        # restart
+        self.redpanda.restart_nodes([target_broker])
+
+        # After restart, the locked config should still be reported
+        res = admin.get_cluster_config(node=target_broker)
+        assert res[
+            'log_segment_size_locked_min'] == self.LOCKED_SEGMENT_SIZE_MIN
+
+        # Locked configs should also appear in the config cache file
+        cache_path = f"{self.redpanda.DATA_DIR}/config_cache.yaml"
+        assert target_broker.account.exists(cache_path)
+
+        cached_cluster_config = {}
+        with tempfile.TemporaryDirectory() as d:
+            target_broker.account.copy_from(cache_path, d)
+            with open(os.path.join(d, "config_cache.yaml")) as f:
+                cached_cluster_config = yaml.full_load(f.read())
+
+        assert cached_cluster_config[
+            'log_segment_size_locked_min'] == self.LOCKED_SEGMENT_SIZE_MIN


### PR DESCRIPTION
A PoC for locked properties. This demos:
1. Creating locked range with min/max
2. Some properties, such as `log_segment_size_locked_min/max` take precedence over deprecated configs
3. Setting and checking locked range in Admin API `PUT /cluster_config`
4. Fetching locked range in Admin API `GET /cluster_config`
5. Locked configs persist between broker restarts
6. Locked configs appear in `config_cache.yaml`
7. Kafka APIs, such as CreateTopics, should check for locked properties

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none