### PR TITLE
TS Read Guardrails: Constrain tiered-storage resource consumption with memory limits

### DIFF
--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -37,9 +37,9 @@ materialized_resources::materialized_resources()
   , _max_segment_readers_per_shard(
       config::shard_local_cfg()
         .cloud_storage_max_segment_readers_per_shard.bind())
-  , _max_partition_readers_per_shard(
+  , _max_concurrent_hydrations_per_shard(
       config::shard_local_cfg()
-        .cloud_storage_max_partition_readers_per_shard.bind())
+        .cloud_storage_max_concurrent_hydrations_per_shard.bind())
   , _storage_read_buffer_size(
       config::shard_local_cfg().storage_read_buffer_size.bind())
   , _storage_read_readahead_count(
@@ -60,7 +60,7 @@ materialized_resources::materialized_resources()
     _max_segment_readers_per_shard.watch(update_max_mem);
     _storage_read_buffer_size.watch(update_max_mem);
     _storage_read_readahead_count.watch(update_max_mem);
-    _max_partition_readers_per_shard.watch([this]() {
+    _max_concurrent_hydrations_per_shard.watch([this]() {
         // The 'max_connections' parameter can't be changed without restarting
         // redpanda.
         _hydration_units.set_capacity(max_parallel_hydrations());

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -78,20 +78,19 @@ private:
     ss::timer<ss::lowres_clock> _stm_timer;
     simple_time_jitter<ss::lowres_clock> _stm_jitter;
 
-    config::binding<uint32_t> _max_partitions_per_shard;
     config::binding<std::optional<uint32_t>> _max_segment_readers_per_shard;
     config::binding<std::optional<uint32_t>> _max_partition_readers_per_shard;
-    config::binding<std::optional<uint32_t>> _max_segments_per_shard;
+    config::binding<size_t> _storage_read_buffer_size;
+    config::binding<int16_t> _storage_read_readahead_count;
 
-    size_t max_segment_readers() const;
+    size_t max_memory_utilization() const;
     size_t max_parallel_hydrations() const;
-    size_t max_segments() const;
 
     /// How many remote_segment_batch_reader instances exist
     size_t current_segment_readers() const;
 
     /// How many partition_record_batch_reader_impl instances exist
-    size_t current_partition_readers() const;
+    size_t current_ongoing_hydrations() const;
 
     /// How many materialized_segment_state instances exist
     size_t current_segments() const;

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -68,6 +68,11 @@ public:
 
     ts_read_path_probe& get_read_path_probe();
 
+    /// Acquire hydration units
+    ///
+    /// The undrlying semaphore limits number of parallel hydrations
+    ss::future<ssx::semaphore_units> get_hydration_units(size_t n);
+
 private:
     /// Timer use to periodically evict stale segment readers
     ss::timer<ss::lowres_clock> _stm_timer;
@@ -79,7 +84,7 @@ private:
     config::binding<std::optional<uint32_t>> _max_segments_per_shard;
 
     size_t max_segment_readers() const;
-    size_t max_partition_readers() const;
+    size_t max_parallel_hydrations() const;
     size_t max_segments() const;
 
     /// How many remote_segment_batch_reader instances exist
@@ -138,6 +143,7 @@ private:
     ss::gate _gate;
 
     adjustable_semaphore _mem_units;
+    adjustable_semaphore _hydration_units;
 
     /// Size of the materialized_manifest_cache
     config::binding<size_t> _manifest_meta_size;

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -79,7 +79,8 @@ private:
     simple_time_jitter<ss::lowres_clock> _stm_jitter;
 
     config::binding<std::optional<uint32_t>> _max_segment_readers_per_shard;
-    config::binding<std::optional<uint32_t>> _max_partition_readers_per_shard;
+    config::binding<std::optional<uint32_t>>
+      _max_concurrent_hydrations_per_shard;
     config::binding<size_t> _storage_read_buffer_size;
     config::binding<int16_t> _storage_read_readahead_count;
 

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -60,7 +60,7 @@ public:
 
     ss::future<segment_reader_units> get_segment_reader_units();
 
-    ss::future<ssx::semaphore_units> get_partition_reader_units(size_t);
+    ss::future<ssx::semaphore_units> get_partition_reader_units();
 
     ss::future<segment_units> get_segment_units();
 
@@ -137,23 +137,7 @@ private:
     /// Gate for background eviction
     ss::gate _gate;
 
-    /// Size limit on the cache of remote_segment_batch_reader instances,
-    /// per shard.  These are limited because they consume a lot of memory
-    /// with their read buffer.
-    adjustable_semaphore _segment_reader_units;
-
-    /// Concurrency limit on how many partition_record_batch_reader_impl may be
-    /// instantiated at once on one shard.  This is a de-facto limit on how many
-    /// concurrent reads may be done.  We need this in addition to
-    /// segment_reader_units, because that is a soft limit (guides trimming),
-    /// whereas this is a hard limit (readers will not be created unless units
-    /// are available), and can be enforced very early in the lifetime of a
-    /// kafka fetch/timequery request.
-    adjustable_semaphore _partition_reader_units;
-
-    /// Concurrency limit on how many segments may be materialized at
-    /// once: this will trigger faster trimming under pressure.
-    adjustable_semaphore _segment_units;
+    adjustable_semaphore _mem_units;
 
     /// Size of the materialized_manifest_cache
     config::binding<size_t> _manifest_meta_size;

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -497,6 +497,7 @@ private:
       const try_consume_stream& cons_str,
       retry_chain_node& parent,
       const std::string_view stream_label,
+      bool acquire_hydration_units,
       DownloadLatencyMeasurementFn download_latency_measurement,
       FailedDownloadMetricFn failed_download_metric,
       DownloadBackoffMetricFn download_backoff_metric,

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1059,6 +1059,11 @@ void remote_partition::return_segment_reader(
     }
 }
 
+size_t remote_partition::reader_mem_use_estimate() noexcept {
+    return sizeof(storage::translating_reader)
+           + sizeof(partition_record_batch_reader_impl);
+}
+
 ss::future<storage::translating_reader> remote_partition::make_reader(
   storage::log_reader_config config,
   std::optional<model::timeout_clock::time_point> deadline) {
@@ -1069,7 +1074,7 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
       config,
       _segments.size());
 
-    auto units = co_await _api.materialized().get_partition_reader_units(1);
+    auto units = co_await _api.materialized().get_partition_reader_units();
     auto ot_state = ss::make_lw_shared<storage::offset_translator_state>(
       get_ntp());
     auto impl = std::make_unique<partition_record_batch_reader_impl>(

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -91,6 +91,8 @@ public:
       storage::log_reader_config config,
       std::optional<model::timeout_clock::time_point> deadline = std::nullopt);
 
+    static size_t reader_mem_use_estimate() noexcept;
+
     /// Look up offset from timestamp
     ss::future<std::optional<storage::timequery_result>>
     timequery(storage::timequery_config cfg);

--- a/src/v/cloud_storage/remote_probe.cc
+++ b/src/v/cloud_storage/remote_probe.cc
@@ -209,7 +209,7 @@ remote_probe::remote_probe(
               .aggregate({sm::shard_label}),
             sm::make_gauge(
               "partition_readers",
-              [&ms] { return ms.current_partition_readers(); },
+              [&ms] { return ms.current_ongoing_hydrations(); },
               sm::description(
                 "Number of partition reader instances (number of current "
                 "fetch/timequery requests reading from tiered storage)"))

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -365,6 +365,16 @@ remote_segment::maybe_get_offsets(kafka::offset kafka_offset) {
     return pos;
 }
 
+size_t remote_segment::estimate_memory_use() const {
+    // NOTE: this is imprecise and doesn't account for certain
+    // things (e.g. chunks api)
+    size_t res = sizeof(remote_segment);
+    if (_index) {
+        res += _index->estimate_memory_use();
+    }
+    return res;
+}
+
 std::optional<offset_index::find_result>
 remote_segment::maybe_get_offsets(model::timestamp ts) {
     if (!_index) {

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -132,6 +132,9 @@ public:
     /// file is not present in cache, the returned file handle is unopened.
     ss::future<ss::file> materialize_chunk(chunk_start_offset_t);
 
+    /// Return memory occupied by the object
+    size_t estimate_memory_use() const;
+
     retry_chain_node* get_retry_chain_node() { return &_rtc; }
 
     bool download_in_progress() const noexcept {

--- a/src/v/cloud_storage/remote_segment_index.cc
+++ b/src/v/cloud_storage/remote_segment_index.cc
@@ -39,6 +39,11 @@ offset_index::offset_index(
   , _time_index(initial_time.value())
   , _min_file_pos_step(file_pos_step) {}
 
+size_t offset_index::estimate_memory_use() const {
+    return _file_index.mem_use() + _rp_index.mem_use() + _kaf_index.mem_use()
+           + _time_index.mem_use();
+}
+
 void offset_index::add(
   model::offset rp_offset,
   kafka::offset kaf_offset,

--- a/src/v/cloud_storage/remote_segment_index.h
+++ b/src/v/cloud_storage/remote_segment_index.h
@@ -69,6 +69,9 @@ public:
         int64_t file_pos;
     };
 
+    /// Estimate memory usage by the index
+    size_t estimate_memory_use() const;
+
     /// Find index entry which is strictly lower than the redpanda offset
     ///
     /// The returned value has rp_offset less than upper_bound.

--- a/src/v/cloud_storage/segment_state.h
+++ b/src/v/cloud_storage/segment_state.h
@@ -66,6 +66,8 @@ struct materialized_segment_state {
     ss::lowres_clock::time_point atime;
     /// List hook for the list of all materalized segments
     intrusive_list_hook _hook;
+    /// Set to true if the memory allocation overshot the threshold
+    bool overcommit{false};
 
     /// Removes object from list that it is part of. Used to isolate the object
     /// before stopping it, so that the stop method is only called from one

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1836,14 +1836,20 @@ configuration::configuration()
   , cloud_storage_max_partition_readers_per_shard(
       *this,
       "cloud_storage_max_partition_readers_per_shard",
-      "Maximum concurrent partition readers of remote data per CPU core.  If "
-      "unset, "
-      "value of `topic_partitions_per_shard` is used, i.e. one reader per "
-      "partition if the shard is at its maximum partition capacity.  These "
-      "readers have the"
-      "lifetime of a Kafka consume request, so this property controls how many "
-      "consume"
-      "requests to remote data can make progress at the same time.",
+      "Maximum concurrent segment hydrations of remote data per CPU core.  If "
+      "unset, value of `cloud_storage_max_connections / 2` is used, which "
+      "means that half of available S3 bandwidth could be used to download "
+      "data from S3. If the cloud storage "
+      "cache is empty every new segment reader will require a download. This "
+      "will lead to 1:1 mapping between number of partitions scanned by the "
+      "fetch request and number of parallel "
+      "downloads. If this value is too large the downloads can affect other "
+      "workloads. In case of any problem caused by the tiered-storage reads "
+      "this value can be lowered. "
+      "This will only affect segment hydrations (downloads) but won't affect "
+      "cached segments. If fetch request is reading from the tiered-storage "
+      "cache its concurrency will only "
+      "be limited by available memory.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
   , cloud_storage_max_materialized_segments_per_shard(
@@ -1851,7 +1857,7 @@ configuration::configuration()
       "cloud_storage_max_materialized_segments_per_shard",
       "Maximum concurrent readers of remote data per CPU core.  If unset, "
       "value of `topic_partitions_per_shard` multiplied by 2 is used.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      {.visibility = visibility::deprecated},
       std::nullopt)
   , cloud_storage_cache_chunk_size(
       *this,

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1836,6 +1836,13 @@ configuration::configuration()
   , cloud_storage_max_partition_readers_per_shard(
       *this,
       "cloud_storage_max_partition_readers_per_shard",
+      "Maximum partition readers per shard (deprecated)",
+      {.needs_restart = needs_restart::no,
+       .visibility = visibility::deprecated},
+      std::nullopt)
+  , cloud_storage_max_concurrent_hydrations_per_shard(
+      *this,
+      "cloud_storage_max_concurrent_hydrations_per_shard",
       "Maximum concurrent segment hydrations of remote data per CPU core.  If "
       "unset, value of `cloud_storage_max_connections / 2` is used, which "
       "means that half of available S3 bandwidth could be used to download "

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -352,6 +352,8 @@ struct configuration final : public config_store {
     property<std::optional<uint32_t>>
       cloud_storage_max_partition_readers_per_shard;
     property<std::optional<uint32_t>>
+      cloud_storage_max_concurrent_hydrations_per_shard;
+    property<std::optional<uint32_t>>
       cloud_storage_max_materialized_segments_per_shard;
     property<uint64_t> cloud_storage_cache_chunk_size;
     property<double> cloud_storage_hydrated_chunks_per_segment_ratio;

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -23,7 +23,7 @@ struct memory_groups {
     }
     /// \brief includes raft & all services
     static size_t rpc_total_memory() {
-        // 30%
+        // 20%
         return ss::memory::stats().total_memory() * .20;
     }
 
@@ -48,6 +48,11 @@ struct memory_groups {
     }
 
     static size_t recovery_max_memory() {
+        return ss::memory::stats().total_memory() * .10;
+    }
+
+    /// Max memory that both cloud storage uploads and read-path could use
+    static size_t tiered_storage_max_memory() {
         return ss::memory::stats().total_memory() * .10;
     }
 };


### PR DESCRIPTION
Count memory resources explicitly, instead of counting objects. Fixes https://github.com/redpanda-data/redpanda/issues/13419

### Problem description

Previously the read path of the tiered-storage had separate limits on:
- number of segment readers (which are used to read data from cached files, property name: `cloud_storage_max_segment_readers_per_shard`)
- number of materialized segments (objects that represent cloud storage segment in Redpanda, property name: `cloud_storage_max_materialized_segments_per_shard`)
- number of partition readers (property name: `cloud_storage_max_partition_readers_per_shard`)

The last parameter was actually used to limit number of parallel fetch requests handled by the tiered-storage per shard. Partition readers are transient objects which are created per fetch request. Because of that the configuration parameter `cloud_storage_max_partition_readers_per_shard` actually limits read side concurrency. In practice it is useful to limit concurrent hydrations of segments from S3. Having too many concurrent hydrations could be a performance hit because Redpanda downloads at least one chunk per segment hydration and it writes this chunk to disk. With 32MiB per chunk and 20 hydrated segments we will be downloading 640MiB of data. And if the same happens on 10 shards we will end up fetching 10GiB of data. We will also create 320 file streams to write hydrated chunks to disk. This will use around 25MiB per shard only for file I/O.

The `cloud_storage_max_materialized_segments_per_shard` is not actually useful in practice because materialized segments may actually read from cache or hydrate from S3. They contain materialized indexes which are occupying significant amount of memory.

The first parameter `cloud_storage_max_segment_readers_per_shard` limits number of segment readers. The segment readers are used by partition readers. They are also not transient. They can be cached which may lead to large number of these readers being created simultaneously. This parameter limits number of concurrent readers. By default each reader require around 1.2MiB (the default buffer size is 128KiB and default readahead is 10). In case of "wide" fetch requests we will be creating a reader per partition use it and then cache it for the next fetch request. If "wide" fetch touches 1000 partitions we will be caching 1000 readers which will require more than GiB of memory.

The default values for these parameters depend on `partitions_per_shard` parameter. The defaults for readers are equal to it and number of materialized segments is double the number of partitions per shard. So the values are quite high. With these settings we saw that 
- Tiered-storage may consume too much memory because of tiered-storage (esp. with "wide" reads).
- Tiered-storage may suffocate either disk or network.

We mitigated the second problem by using `cloud_storage_max_partition_readers_per_shard` to limit parallel hydrations. The first problem can usually be solved by limiting buffer size and readahead.

In short, every component of the tiered-storage works correctly but together they can still create a problematic situation by using too much resources. 

### Changes

To solve problems described above we need to optimize resource usage by the Tiered-Storage. In some cases we may use fewer resources but for the most part we need to always enforce some limits on:

- Network bandwidth.
- Disk bandwidth.
- Memory.

This PR deals with memory directly and with other two resources indirectly. 

First of all, configuration parameters `cloud_storage_max_materialized_segments_per_shard` and `cloud_storage_max_partition_readers_per_shard` are depricated. Tiered-storage creates its own memory group and claims 10% of available memory per shard. 

Inside `materizlied_resources` class we had three different semaphores for segment readers, partition readers, and materialized segments. These three semaphores are replaced with one that tracks memory. The semaphore (`_mem_units`) is initialized using current amount of memory reserved by tiered-storage (10%). When the TS creates an object (either a reader or segment) it computes it's size estimate and acquires units from this semaphore. The amount of acquired units is equal to computed size of the object.

For some objects we can compute the size relatively precisely. For instance, the memory requirements of the segment reader are dominated by the `input_stream` buffer which is `readahead * buffer-size`. We're using this size as an estimate. The partition reader has constant size. The size of the materialized segment is not known in advance because it contains the index. It's estimated using a constant and then, when the actual segment is materialized we're adjusting the acquired units. 

New configuration parameter `cloud_storage_max_concurrent_hydrations_per_shard` is introduced. It's used to limit number of simultaneously hydrated segments in the `cloud_storage::remote`. The parameter `cloud_storage_max_segment_readers_per_shard` is not deprecated. When it's set in the config TS will adjust its memory requirements to fit that many readers. This parameter can't be used to make TS use more than 10% of shard memory. It can only lower memory requirements. 

These changes allow us to limit network/disk usage as well but not directly. In the followup PRs the explicit limits will be added. Another area of improvement is dynamic feedback for TS from the Kafka layer. Some parameters can be adjusted depending on read workload for great effect (buffering and prefetch).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Limit tired-storage memory usage instead of limiting number of objects
* Limit read-path parallelism explicitly using `cloud_storage_max_concurrent_hydrations_per_shard` configuration parameter
* Deprecated `cloud_storage_max_materialized_segments_per_shard` configuration parameter
* Deprecated `cloud_storage_max_partition_readers_per_shard`