### PR TITLE
rptest: Hotfix for tier default value needed before cluster creation

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -328,6 +328,10 @@ class CloudCluster():
         self.config.type = self.config.type.upper()
         self.config.provider = self.config.provider.upper()
         self.config.network = self.config.network.lower()
+        # Handle default value for tier
+        if self.config.config_profile_name == 'default':
+            self.config.config_profile_name = TIER_DEFAULTS[
+                self.config.provider]
         # Init API client
         self.cloudv2 = RpCloudApiClient(self.config, logger)
 
@@ -665,10 +669,6 @@ class CloudCluster():
 
         if not self.isPublicNetwork:
             self.current.connection_type = 'private'
-        # Handle default values
-        if self.config.config_profile_name == 'default':
-            self.config.config_profile_name = TIER_DEFAULTS[
-                self.config.provider]
 
         if self.config.id != '':
             # Cluster already exist


### PR DESCRIPTION
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
