### PR TITLE
Ext4 detection

### DIFF
--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -51,10 +51,12 @@ ss::future<> disk(const ss::sstring& path) {
     return ss::check_direct_io_support(path).then([path] {
         return ss::file_system_at(path).then([path](auto fs) {
             checklog.info0("Detected file system type is {}", to_string(fs));
-            // all of ext2, 3 and 4 are detected as ext2, so we just assume an
-            // ext2 detection means ext4 for now, see:
+            // Currently, all of ext2, 3 and 4 are detected as ext2, so we just
+            // assume an ext2 detection means ext4 for now, see:
             // https://github.com/redpanda-data/redpanda/issues/13469
-            if (fs == ss::fs_type::ext2) {
+            // We also still check for ext4, since if that is returned it means
+            // that seastar has been fixed to be able to detect ext4.
+            if (fs == ss::fs_type::ext2 || fs == ss::fs_type::ext4) {
                 checklog.warn(
                   "Path: `{}' is on ext4, not XFS. This will probably work, "
                   "but Redpanda is only tested on XFS and XFS is recommended "

--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -22,27 +22,25 @@
 
 namespace {
 ss::sstring to_string(ss::fs_type fs) {
-    return [fs]() {
-        switch (fs) {
-        case ss::fs_type::other:
-            return "other";
-        case ss::fs_type::xfs:
-            return "xfs";
-        case ss::fs_type::ext2:
-            return "ext2";
-        case ss::fs_type::ext3:
-            return "ext3";
-        case ss::fs_type::ext4:
-            return "ext4";
-        case ss::fs_type::btrfs:
-            return "btrfs";
-        case ss::fs_type::hfs:
-            return "hfs";
-        case ss::fs_type::tmpfs:
-            return "tmpfs";
-        };
-        return "bad_enum";
-    }();
+    switch (fs) {
+    case ss::fs_type::other:
+        return "other";
+    case ss::fs_type::xfs:
+        return "xfs";
+    case ss::fs_type::ext2:
+        return "ext2";
+    case ss::fs_type::ext3:
+        return "ext3";
+    case ss::fs_type::ext4:
+        return "ext4";
+    case ss::fs_type::btrfs:
+        return "btrfs";
+    case ss::fs_type::hfs:
+        return "hfs";
+    case ss::fs_type::tmpfs:
+        return "tmpfs";
+    };
+    return "bad_enum";
 }
 } // namespace
 

--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -53,6 +53,9 @@ ss::future<> disk(const ss::sstring& path) {
     return ss::check_direct_io_support(path).then([path] {
         return ss::file_system_at(path).then([path](auto fs) {
             checklog.info0("Detected file system type is {}", to_string(fs));
+            // all of ext2, 3 and 4 are detected as ext2, so we just assume an
+            // ext2 detection means ext4 for now, see:
+            // https://github.com/redpanda-data/redpanda/issues/13469
             if (fs == ss::fs_type::ext2) {
                 checklog.warn(
                   "Path: `{}' is on ext4, not XFS. This will probably work, "

--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -53,6 +53,7 @@ ss::future<> disk(const ss::sstring& path) {
     return ss::check_direct_io_support(path).then([path] {
         return ss::file_system_at(path).then([path](auto fs) {
             checklog.info0("Detected file system type is {}", to_string(fs));
+            if (fs == ss::fs_type::ext2) {
                 checklog.warn(
                   "Path: `{}' is on ext4, not XFS. This will probably work, "
                   "but Redpanda is only tested on XFS and XFS is recommended "


### PR DESCRIPTION
Assume that ext filesystems are ext4

Due to scylladb/seastar#251 all of ext2, ext3 and ext4 will be
detected as ext2 (they shared the same superblock magic number).

This leads to an erroneous warning claiming that you are not running
on ext4 nor XFS. For now, we will simply that assume any ext detection
means ext4, as ext2 and 3 use is very limited as ext4 was rolled out
more than 15 years ago and almost entirely supplanted use of the
earlier variants.

A partial fix for:

https://github.com/redpanda-data/redpanda/issues/13469

A more involved fix may follow to resolve seastar#251.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* ext4 is no longer incorrectly detected as ext2 (all of ext2, 3 and 4 are assumed to be ext4).

