### PR TITLE
rpk: add cpu_profile to debug bundle

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -40,6 +40,7 @@ type bundleParams struct {
 	controllerLogLimitBytes int
 	timeout                 time.Duration
 	metricsInterval         time.Duration
+	cpuProfilerTimeout      time.Duration
 }
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -55,8 +56,9 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		controllerLogsSizeLimit string
 		namespace               string
 
-		timeout         time.Duration
-		metricsInterval time.Duration
+		timeout            time.Duration
+		metricsInterval    time.Duration
+		cpuProfilerTimeout time.Duration
 	)
 	cmd := &cobra.Command{
 		Use:   "bundle",
@@ -103,6 +105,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				controllerLogLimitBytes: int(controllerLogsLimit),
 				timeout:                 timeout,
 				metricsInterval:         metricsInterval,
+				cpuProfilerTimeout:      cpuProfilerTimeout,
 			}
 
 			// to execute the appropriate bundle we look for
@@ -136,6 +139,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	f.StringVar(&controllerLogsSizeLimit, "controller-logs-size-limit", "20MB", "The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB)")
 	f.StringVar(&uploadURL, "upload-url", "", "If provided, where to upload the bundle in addition to creating a copy on disk")
 	f.StringVarP(&namespace, "namespace", "n", "redpanda", "The namespace to use to collect the resources from (k8s only)")
+	f.DurationVar(&cpuProfilerTimeout, "cpu-profiler-timeout", 10*time.Second, "For how long to collect samples for the cpu profiler (e.g. 30s, 1.5m)")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -130,7 +130,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveResourceUsageData(ps, bp.y),
 		saveNTPDrift(ps),
 		saveSyslog(ps),
-		saveSingleAdminAPICalls(ctx, ps, bp.fs, bp.p, addrs, bp.metricsInterval),
+		saveSingleAdminAPICalls(ctx, ps, bp.fs, bp.p, addrs, bp.metricsInterval, bp.cpuProfilerTimeout),
 		saveClusterAdminAPICalls(ctx, ps, bp.fs, bp.p, addrs),
 		saveDNSData(ctx, ps),
 		saveDiskUsage(ctx, ps, bp.y),


### PR DESCRIPTION
This commit adds the result of
GET /v1/debug/cpu_profile to both debug bundles
(k8s and bare metal).

It automatically handles toggling the cpu_profiler and introduces a new flag for the profiler
recollection peiod.

Fixes #13175

In Draft because we might introduce a new query param to toggle the cpu_profiler based on a timeout. https://github.com/redpanda-data/redpanda/issues/13175#issuecomment-1722271934

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* rpk debug bundle now collects the result of the CPU profiler.
