### PR TITLE
tests/upgrade_test: test_rolling_upgrade race fix

### DIFF
--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -286,7 +286,6 @@ class UpgradeWithWorkloadTest(EndToEndTest):
         self.start_consumer(num_nodes=1)
         self.await_startup(min_records=self.producer_msgs_per_sec)
 
-    @ok_to_fail
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_rolling_upgrade(self):
         self.installer.install(self.redpanda.nodes, RedpandaInstaller.HEAD)

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -469,7 +469,7 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
         # Verify all data readable
         verify()
 
-        # Pick some arbitrary partition to write data to via a new-verison node
+        # Pick some arbitrary partition to write data to via a new-version node
         newdata_p = 0
 
         # There might not be any partitions with leadership on new version
@@ -533,6 +533,11 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
                 target_bytes=local_retention_bytes + segment_bytes,
                 timeout_sec=60)
 
+        # capture the cloud storage state to run a progress check later
+        bucket_view = BucketView(self.redpanda)
+        manifest_mid_upgrade = bucket_view.manifest_for_ntp(
+            topic=topic, partition=newdata_p)
+
         # Move leadership to the old version node and check the partition is readable
         # from there.
         admin.transfer_leadership_to(namespace="kafka",
@@ -544,10 +549,6 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
 
         # Verify all data readable
         verify()
-
-        bucket_view = BucketView(self.redpanda)
-        manifest_mid_upgrade = bucket_view.manifest_for_ntp(
-            topic=topic, partition=newdata_p)
 
         # Finish the upgrade
         self.redpanda.rolling_restart_nodes([self.redpanda.nodes[-1]],


### PR DESCRIPTION
a race between test and redpanda to read/modify insync_offset on a manifest.

the fix is to read the cloud storage manifest before producing to the partition

Fixes #13181

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
