### PR TITLE
Support returning controller partition status

### DIFF
--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -16,7 +16,9 @@
 #include "cluster/fwd.h"
 #include "cluster/node_status_table.h"
 #include "cluster/scheduling/leader_balancer.h"
+#include "cluster/types.h"
 #include "model/fundamental.h"
+#include "model/metadata.h"
 #include "raft/fwd.h"
 #include "rpc/fwd.h"
 #include "security/fwd.h"
@@ -183,6 +185,11 @@ public:
     }
 
     model::offset get_dirty_offset() const { return _raft0->dirty_offset(); }
+
+    ss::future<result<std::vector<partition_state>>>
+    get_controller_partition_state();
+    ss::future<result<partition_state_reply>>
+    do_get_controller_partition_state(model::node_id id);
 
     static const bytes invariants_key;
 


### PR DESCRIPTION
Added handling for returning `redpanda/controller/0` partition status from `/v1/debug/partition/{namespace}/{topic}/{partition}`

Fixes: https://github.com/redpanda-data/core-internal/issues/733

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none