### PR TITLE
rpk: support producing using Schema Registry

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -8,13 +8,16 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.45.25
 	github.com/beevik/ntp v1.3.0
+	github.com/bufbuild/protocompile v0.6.0
 	github.com/coreos/go-systemd/v22 v22.5.0
 	github.com/docker/docker v24.0.6+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/docker/go-units v0.5.0
 	github.com/fatih/color v1.15.0
+	github.com/hamba/avro/v2 v2.16.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/lestrrat-go/jwx v1.2.26
+	github.com/linkedin/goavro/v2 v2.12.0
 	github.com/lorenzosaino/go-sysctl v0.3.1
 	github.com/moby/term v0.5.0
 	github.com/opencontainers/go-digest v1.0.0
@@ -43,6 +46,7 @@ require (
 	golang.org/x/sync v0.4.0
 	golang.org/x/sys v0.13.0
 	golang.org/x/term v0.13.0
+	google.golang.org/protobuf v1.31.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.28.2
 	k8s.io/apimachinery v0.28.2
@@ -67,6 +71,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -90,6 +95,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
@@ -109,7 +115,6 @@ require (
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.14.0 // indirect
 	google.golang.org/appengine v1.6.8 // indirect
-	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.0.3 // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -58,6 +58,8 @@ github.com/aws/aws-sdk-go v1.45.25 h1:c4fLlh5sLdK2DCRTY1z0hyuJZU4ygxX8m1FswL6/nF
 github.com/aws/aws-sdk-go v1.45.25/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/beevik/ntp v1.3.0 h1:/w5VhpW5BGKS37vFm1p9oVk/t4HnnkKZAZIubHM6F7Q=
 github.com/beevik/ntp v1.3.0/go.mod h1:vD6h1um4kzXpqmLTuu0cCLcC+NfvC0IC+ltmEDA8E78=
+github.com/bufbuild/protocompile v0.6.0 h1:Uu7WiSQ6Yj9DbkdnOe7U4mNKp58y9WDMKDn28/ZlunY=
+github.com/bufbuild/protocompile v0.6.0/go.mod h1:YNP35qEYoYGme7QMtz5SBCoN4kL4g12jTtjuzRNdjpE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -149,6 +151,9 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
+github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 h1:0VpGH+cDhbDtdcweoyCVsF3fhN8kejK6rFe/2FFX2nU=
@@ -190,6 +195,8 @@ github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8/go.mod h1:dvDLG8qkwmyD9a/MJJN3XJcT3xFxOKAvTZGvuZmac9g=
+github.com/hamba/avro/v2 v2.16.0 h1:0XhyP65Hs8iMLtdSR0v7ZrwRjsbIZdvr7KzYgmx1Mbo=
+github.com/hamba/avro/v2 v2.16.0/go.mod h1:Q9YK+qxAhtVrNqOhwlZTATLgLA8qxG2vtvkhK8fJ7Jo=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -242,6 +249,8 @@ github.com/lestrrat-go/jwx v1.2.26/go.mod h1:MaiCdGbn3/cckbOFSCluJlJMmp9dmZm5hDu
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
+github.com/linkedin/goavro/v2 v2.12.0 h1:rIQQSj8jdAUlKQh6DttK8wCRv4t4QO09g1C4aBWXslg=
+github.com/linkedin/goavro/v2 v2.12.0/go.mod h1:KXx+erlq+RPlGSPmLF7xGo6SAbh8sCQ53x064+ioxhk=
 github.com/lorenzosaino/go-sysctl v0.3.1 h1:3phX80tdITw2fJjZlwbXQnDWs4S30beNcMbw0cn0HtY=
 github.com/lorenzosaino/go-sysctl v0.3.1/go.mod h1:5grcsBRpspKknNS1qzt1eIeRDLrhpKZAtz8Fcuvs1Rc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
@@ -264,6 +273,8 @@ github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQ
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -324,6 +335,7 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=

--- a/src/go/rpk/pkg/serde/avro.go
+++ b/src/go/rpk/pkg/serde/avro.go
@@ -1,0 +1,95 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package serde
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hamba/avro/v2"
+	"github.com/linkedin/goavro/v2"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+// newAvroEncoder will generate a serializer function that can encode the
+// provided record using the specified schema. If the schema includes
+// references, it retrieves them using the supplied client. The generated
+// function returns the record encoded in the protobuf wire format.
+func newAvroEncoder(ctx context.Context, cl *sr.Client, schema *sr.Schema, schemaID int) (serdeFunc, error) {
+	schemaStr := schema.Schema
+	if len(schema.References) > 0 {
+		err := parseReferences(ctx, cl, schema)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse references: %v", err)
+		}
+
+		// We use hamba/avro to for the schema reference resolution.
+		refCodec, err := avro.Parse(schema.Schema)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse schema: %v", err)
+		}
+		schemaStr = refCodec.String()
+	}
+
+	// And goavro to manage unknown data types.
+	codec, err := goavro.NewCodec(schemaStr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse schema: %v", err)
+	}
+
+	return func(record []byte) ([]byte, error) {
+		native, _, err := codec.NativeFromTextual(record)
+		if err != nil {
+			return nil, fmt.Errorf("unable to parse record with the provided schema: %v", err)
+		}
+
+		binary, err := codec.BinaryFromNative(nil, native)
+		if err != nil {
+			return nil, fmt.Errorf("unable to binary encode the record: %v", err)
+		}
+
+		// Append the magic byte + the schema ID bytes.
+		var serdeHeader sr.ConfluentHeader
+		h, err := serdeHeader.AppendEncode(nil, schemaID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("unable to append header: %v", err)
+		}
+		return append(h, binary...), nil
+	}, nil
+}
+
+// parseReferences uses hamba/avro Parse method to parse every reference. We
+// don't need to store the references since the library already cache these
+// schemas and use it later for handling references in the parent schema.
+func parseReferences(ctx context.Context, cl *sr.Client, schema *sr.Schema) error {
+	if len(schema.References) == 0 {
+		_, err := avro.Parse(schema.Schema)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	for _, ref := range schema.References {
+		r, err := cl.SchemaByVersion(ctx, ref.Subject, ref.Version)
+		if err != nil {
+			return err
+		}
+		refSchema := r.Schema
+		err = parseReferences(ctx, cl, &refSchema)
+		if err != nil {
+			return fmt.Errorf("unable to parse schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
+		}
+	}
+	_, err := avro.Parse(schema.Schema)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/serde/avro_test.go
+++ b/src/go/rpk/pkg/serde/avro_test.go
@@ -1,0 +1,344 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package serde
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/linkedin/goavro/v2"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+func Test_encodeAvroRecordNoReferences(t *testing.T) {
+	tests := []struct {
+		name      string
+		schema    string
+		schemaID  int
+		record    string
+		expRecord string
+		expErr    bool // error building the Serde.
+		expEncErr bool // error encoding the record.
+	}{
+		{
+			name: "Valid record and schema",
+			schema: `
+{
+  "type":"record",
+  "name":"test",
+  "fields":
+    [{
+      "name":"name",
+      "type":"string"
+    }]
+}`,
+			schemaID:  906,
+			record:    `{"name":"redpanda"}`,
+			expRecord: `{"name":"redpanda"}`,
+		}, {
+			name: "Valid nested record and schema",
+			schema: `
+{
+   "type":"record",
+   "name":"test",
+   "fields":[
+      {
+         "name":"name",
+         "type":"string"
+      },
+      {
+         "name":"complex",
+         "type":{
+            "type":"record",
+            "name":"nestedSchemaName",
+            "fields":[
+               {
+                  "name":"list",
+                  "type":{"type":"array", "items":"int"}
+               }
+            ]
+         }
+      }
+   ]
+}`,
+			schemaID:  906,
+			record:    `{"name":"redpanda","complex":{"list":[1,2,3,4]}}`,
+			expRecord: `{"name":"redpanda","complex":{"list":[1,2,3,4]}}`,
+		}, {
+			name: "Valid empty record with default null in schema",
+			schema: `
+{
+  "type":"record",
+  "name":"test",
+  "fields":
+    [{
+      "name" :"name",
+      "type" :["null"],
+      "default":null
+    }]
+}`,
+			schemaID:  1,
+			record:    "{}",
+			expRecord: `{"name":null}`,
+		}, {
+			name: "Invalid record for a valid schema",
+			schema: `
+{
+  "type":"record",
+  "name":"test",
+  "fields":
+    [{
+      "name":"name",
+      "type":"string"
+    }]
+}`,
+			schemaID:  2,
+			record:    `{"notValid":123}`,
+			expEncErr: true,
+		}, {
+			name: "Invalid schema",
+			schema: `
+{
+  "typezz":"record",
+  "name":"test",
+  "fields":
+    [{
+      "name":"name"
+    }]
+}`,
+			schemaID: 2,
+			expErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			noopCl, _ := sr.NewClient()
+			schema := sr.Schema{
+				Schema: tt.schema,
+			}
+			serde, err := NewSerde(context.Background(), noopCl, &schema, tt.schemaID, "")
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			got, err := serde.EncodeRecord([]byte(tt.record))
+			if tt.expEncErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Validate Magic Byte.
+			require.Equal(t, uint8(0), got[0])
+
+			var serdeHeader sr.ConfluentHeader
+			id, encRecord, err := serdeHeader.DecodeID(got)
+			require.NoError(t, err)
+			require.Equal(t, tt.schemaID, id)
+			if len(got) == 5 {
+				return // It's an empty record.
+			}
+
+			// Validate encoded record. Decode and compare to original:
+			codec, err := goavro.NewCodec(tt.schema)
+			require.NoError(t, err)
+			native, _, err := codec.NativeFromBinary(encRecord)
+			require.NoError(t, err)
+			gotDecoded, err := codec.TextualFromNative(nil, native)
+			if err != nil {
+				return
+			}
+
+			// To avoid any mismatch in the decode order of the elements, we
+			// better unmarshal and compare the unmarshaled records.
+			var gotU, expU map[string]any
+			err = json.Unmarshal(gotDecoded, &gotU)
+			require.NoError(t, err)
+			err = json.Unmarshal([]byte(tt.expRecord), &expU)
+			require.NoError(t, err)
+
+			require.Equal(t, expU, gotU)
+		})
+	}
+}
+
+func Test_encodeAvroRecordWithReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   *sr.Schema
+		schemaID int
+		record   string
+	}{
+		{
+			name:     "single reference",
+			schemaID: 123,
+			record:   `{"name":"redpanda","telephone":{"number":12341234,"identifier":"home"}}`,
+			schema: &sr.Schema{
+				Schema: `{
+   "type":"record",
+   "name":"test",
+   "fields":[
+      {
+         "name":"name",
+         "type":"string"
+      },
+      {
+         "name":"telephone",
+         "type":"telephone"
+      }
+   ]
+}`,
+				References: []sr.SchemaReference{
+					{
+						Name:    "telephone",
+						Subject: "single",
+						Version: 0,
+					},
+				},
+			},
+		}, {
+			name:     "multiple single reference",
+			schemaID: 123,
+			record:   `{"name":"redpanda","telephone":{"number":12341234,"identifier":"home"},"coordinates":{"longitude":12547930,"latitude":-81.716652}}`,
+			schema: &sr.Schema{
+				Schema: `{
+   "type":"record",
+   "name":"test",
+   "fields":[
+      {
+         "name":"name",
+         "type":"string"
+      },
+      {
+         "name":"telephone",
+         "type":"telephone"
+      },
+      {
+         "name":"coordinates",
+         "type":"coordinates"
+      }
+   ]
+}`,
+				References: []sr.SchemaReference{
+					{
+						Name:    "telephone",
+						Subject: "single",
+						Version: 0,
+					},
+					{
+						Name:    "coordinates",
+						Subject: "single",
+						Version: 1,
+					},
+				},
+			},
+		}, {
+			name:     "nested references",
+			schemaID: 123,
+			record:   `{"name":"redpanda","telephone":{"number":12341234,"identifier":"home","owner":{"lastname":"panda"}}}`,
+			schema: &sr.Schema{
+				Schema: `{
+   "type":"record",
+   "name":"test",
+   "fields":[
+      {
+         "name":"name",
+         "type":"string"
+      },
+      {
+         "name":"telephone",
+         "type":"telephoneOwner"
+      }
+   ]
+}`,
+				References: []sr.SchemaReference{
+					{
+						Name:    "telephoneOwner",
+						Subject: "nested",
+						Version: 1,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(avroReferenceHandler())
+			defer ts.Close()
+
+			fs := afero.NewMemMapFs()
+			params := &config.Params{ConfigFlag: "/some/path/redpanda.yaml"}
+			p, err := params.LoadVirtualProfile(fs)
+			require.NoError(t, err)
+
+			p.SR.Addresses = []string{ts.URL}
+
+			client, err := schemaregistry.NewClient(fs, p)
+			require.NoError(t, err)
+
+			tt.schema.Type = sr.TypeAvro
+			serde, err := NewSerde(context.Background(), client, tt.schema, tt.schemaID, "")
+			require.NoError(t, err)
+
+			got, err := serde.EncodeRecord([]byte(tt.record))
+			require.NoError(t, err)
+
+			// Validate Magic Byte.
+			require.Equal(t, uint8(0), got[0])
+
+			var serdeHeader sr.ConfluentHeader
+			id, _, err := serdeHeader.DecodeID(got)
+			require.NoError(t, err)
+			require.Equal(t, tt.schemaID, id)
+			if len(got) == 5 {
+				return // It's an empty record.
+			}
+
+			// We stop here, we will add test for decoding once we support
+			// decoding with references.
+		})
+	}
+}
+
+var avroReferenceMap = map[string]string{
+	"single-0": `{"schema":"{\"type\":\"record\",\"name\":\"telephone\",\"fields\":[{\"name\":\"number\",\"type\":\"int\"},{\"name\":\"identifier\",\"type\":\"string\"}]}"}`,
+	"single-1": `{"schema":"{\"type\":\"record\",\"name\":\"coordinates\",\"fields\":[{\"name\":\"longitude\",\"type\":\"long\"},{\"name\":\"latitude\",\"type\":\"float\"}]}"}`,
+	"nested-1": `{"references":[{"name":"owner","subject":"nested","version":2}],"schema":"{\"type\":\"record\",\"name\":\"telephoneOwner\",\"fields\":[{\"name\":\"number\",\"type\":\"int\"},{\"name\":\"identifier\",\"type\":\"string\"},{\"name\":\"owner\",\"type\":\"owner\"}]}"}`,
+	"nested-2": `{"schema":"{\"type\":\"record\",\"name\":\"owner\",\"fields\":[{\"name\":\"lastname\",\"type\":\"string\"}]}"}`,
+}
+
+func avroReferenceHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Split the URL path by '/' to get individual path segments of
+		segments := strings.Split(r.URL.Path, "/")
+
+		// /subjects/{subject}/versions/{version}"
+		if len(segments) >= 4 && segments[1] == "subjects" && segments[3] == "versions" {
+			subject := segments[2]
+			version := segments[4]
+			id := subject + "-" + version
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(avroReferenceMap[id]))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}
+}

--- a/src/go/rpk/pkg/serde/proto.go
+++ b/src/go/rpk/pkg/serde/proto.go
@@ -1,0 +1,125 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package serde
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bufbuild/protocompile"
+	"github.com/twmb/franz-go/pkg/sr"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+// newAvroEncoder will generate a serializer function using the specified
+// schema. It utilizes the message type identified by protoFQN. If the schema
+// includes references, it retrieves them using the supplied client. The
+// generated function returns the record encoded in the protobuf wire format.
+func newProtoEncoder(ctx context.Context, cl *sr.Client, schema *sr.Schema, protoFQN string, schemaID int) (serdeFunc, error) {
+	if protoFQN == "" {
+		return nil, fmt.Errorf("please provide the protobuf message name")
+	}
+	// Compile the Schema Registry proto. //
+	const inMemFileName = "tmp.proto"
+	accessorMap := make(map[string]string)
+	// This is the original schema.
+	accessorMap[inMemFileName] = schema.Schema
+
+	// And we add the rest of schemas if we have references.
+	if len(schema.References) > 0 {
+		err := mapReferences(ctx, cl, schema, accessorMap)
+		if err != nil {
+			return nil, fmt.Errorf("unable to map references: %v", err)
+		}
+	}
+
+	compiler := protocompile.Compiler{
+		Resolver: &protocompile.SourceResolver{
+			Accessor: protocompile.SourceAccessorFromMap(accessorMap),
+		},
+		SourceInfoMode: protocompile.SourceInfoStandard,
+	}
+	compiled, err := compiler.Compile(ctx, inMemFileName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to compile the given schema: %v", err)
+	}
+
+	// Create proto message with runtime information. //
+	d := compiled.FindFileByPath(inMemFileName).FindDescriptorByName(protoreflect.FullName(protoFQN))
+	if d == nil {
+		return nil, fmt.Errorf("unable to find message with name %q", protoFQN)
+	}
+	msgDescriptor, ok := d.(protoreflect.MessageDescriptor)
+	if !ok {
+		return nil, fmt.Errorf("unable to process message with name %q", protoFQN)
+	}
+	message := dynamicpb.NewMessage(msgDescriptor)
+
+	o := protojson.UnmarshalOptions{
+		Resolver: compiled.AsResolver(),
+	}
+	return func(record []byte) ([]byte, error) {
+		// Unmarshal the record into the proto message. //
+		err = o.Unmarshal(record, message)
+		if err != nil {
+			return nil, fmt.Errorf("unable to decode the record into the given schema: %v", err)
+		}
+
+		// Encode the proto message to protobuf wire format. //
+		binary, err := proto.Marshal(message)
+		if err != nil {
+			return nil, fmt.Errorf("unable to encode the record: %v", err)
+		}
+
+		// Add schema registry wire format header. //
+		var serdeHeader sr.ConfluentHeader
+		h, _ := serdeHeader.AppendEncode(nil, schemaID, messageIndex(msgDescriptor))
+		return append(h, binary...), nil
+	}, nil
+}
+
+// messageIndex traverse the message descriptor to get the list of
+// message-indexes which is needed in the wire format.
+func messageIndex(d protoreflect.MessageDescriptor) []int {
+	idx := []int{d.Index()}
+	if parent := d.Parent(); parent != nil {
+		pmsg, ok := parent.(protoreflect.MessageDescriptor)
+		// If !ok, we have reached the top, and it's a FileDescriptor.
+		if !ok {
+			return idx
+		}
+		return append(messageIndex(pmsg), idx...)
+	}
+	return idx
+}
+
+// mapReferences recursively inserts the schema references into the given
+// refMap. It uses the client to retrieve the schema references.
+func mapReferences(ctx context.Context, cl *sr.Client, schema *sr.Schema, refMap map[string]string) error {
+	if len(schema.References) == 0 {
+		return nil
+	}
+	for _, ref := range schema.References {
+		r, err := cl.SchemaByVersion(ctx, ref.Subject, ref.Version)
+		if err != nil {
+			return fmt.Errorf("unable to get reference schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
+		}
+		refMap[ref.Name] = r.Schema.Schema
+		refSchema := r.Schema
+		err = mapReferences(ctx, cl, &refSchema, refMap)
+		if err != nil {
+			return fmt.Errorf("unable to map schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
+		}
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/serde/proto_test.go
+++ b/src/go/rpk/pkg/serde/proto_test.go
@@ -1,0 +1,399 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package serde
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+// For now, it just tests that it successfully encodes the message and that the
+// first bytes match the expected wire format. When we add decoding, we should
+// add the test for the record.
+func Test_encodeProtoRecordNoReferences(t *testing.T) {
+	const testSimpleSchema = `syntax = "proto3";
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  bool isAdmin = 3;
+  optional string email = 4;
+}`
+	const testComplexSchema = `syntax = "proto3";
+
+message Person {
+  message PhoneNumber {
+    string number = 1;
+    .Person.PhoneType type = 2;
+  }
+  enum PhoneType {
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
+  }
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+  repeated .Person.PhoneNumber phones = 4;
+}
+
+message AddressBook {
+  repeated .Person people = 1;
+}`
+	const testPackageSchema = `syntax = "proto3";
+package foo.bar;
+
+message Person {
+  message PhoneNumber {
+    string number = 1;
+    foo.bar.Person.PhoneType type = 2;
+  }
+  enum PhoneType {
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
+  }
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+  repeated foo.bar.Person.PhoneNumber phones = 4;
+}`
+
+	const testNestedSchema = `syntax = "proto3";
+
+message Person {
+   message Unused {
+       string foo = 1;
+  }
+
+  message PhoneNumber {
+    string number = 1;
+    .Person.PhoneNumber.PhoneBrand brand = 2;
+	optional .Person.PhoneNumber.PhoneCondition condition = 3;
+
+	message PhoneCondition {
+       bool damaged = 1;
+    }
+
+	message PhoneBrand {
+       string brand = 1;
+       int32 year = 2;
+    }
+  }
+
+  string name = 1;
+  .Person.PhoneNumber phone = 2;
+}`
+
+	tests := []struct {
+		name      string
+		schema    string
+		msgType   string
+		record    string
+		schemaID  int
+		expIdx    []int
+		expErr    bool // error building the Serde.
+		expEncErr bool // error encoding the record.
+	}{
+		{
+			name:     "simple - complete record",
+			schema:   testSimpleSchema,
+			msgType:  "Person",
+			schemaID: 1,
+			record:   `{"name":"igor","id":123,"isAdmin":true,"email":"test@redpanda.com"}`,
+			expIdx:   []int{0},
+		}, {
+			name:     "simple - without optional field",
+			schema:   testSimpleSchema,
+			msgType:  "Person",
+			schemaID: 2,
+			record:   `{"name":"igor","id":123,"isAdmin":true}`,
+			expIdx:   []int{0},
+		}, {
+			name:      "simple - bad record",
+			schema:    testSimpleSchema,
+			msgType:   "Person",
+			record:    `{"thisIsNotValid":"igor","id":123,"isAdmin":true}`,
+			expEncErr: true,
+		}, {
+			name:    "simple - msg type not found",
+			schema:  testSimpleSchema,
+			msgType: "NotFoo",
+			record:  `{"name":"igor","id":123,"isAdmin":true}`,
+			expErr:  true,
+		}, {
+			name:     "complex - complete record, using index 0 message",
+			schema:   testComplexSchema,
+			msgType:  "Person",
+			schemaID: 3,
+			record:   `{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"1111","type":0},{"number":"2222","type":1},{"number":"33333","type":2}]}`,
+			expIdx:   []int{0},
+		}, {
+			name:     "complex - complete record, using index 1 message",
+			schema:   testComplexSchema,
+			msgType:  "AddressBook",
+			schemaID: 4,
+			record:   `{"people":[{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"111","type":2}]},{"name":"igor","id":321,"email":"igor@redpanda.com","phones":[{"number":"1231231","type":0},{"number":"2222333","type":1}]}]}`,
+			expIdx:   []int{1},
+		}, {
+			name:     "complex - nested record",
+			schema:   testComplexSchema,
+			msgType:  "Person.PhoneNumber",
+			schemaID: 5,
+			record:   `{"number":"111","type":2}`,
+			expIdx:   []int{0, 0},
+		}, {
+			name:     "package - complete record",
+			schema:   testPackageSchema,
+			msgType:  "foo.bar.Person",
+			schemaID: 6,
+			record:   `{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"1111","type":0},{"number":"2222","type":1},{"number":"33333","type":2}]}`,
+			expIdx:   []int{0},
+		}, {
+			name:     "package - complete record with fqn message type",
+			schema:   testPackageSchema,
+			msgType:  "foo.bar.Person",
+			schemaID: 7,
+			record:   `{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"1111","type":0},{"number":"2222","type":1},{"number":"33333","type":2}]}`,
+			expIdx:   []int{0},
+		}, {
+			name:     "package - nested record with fqn message type",
+			schema:   testPackageSchema,
+			msgType:  "foo.bar.Person",
+			schemaID: 8,
+			record:   `{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"1111","type":0},{"number":"2222","type":1},{"number":"33333","type":2}]}`,
+			expIdx:   []int{0},
+		}, {
+			name:     "nested - complete record",
+			schema:   testNestedSchema,
+			msgType:  "Person",
+			schemaID: 9,
+			record:   `{"name":"foo","phone":{"number":"123","brand":{"brand":"pandaPhone","year":2023},"condition":{"damaged":true}}}`,
+			expIdx:   []int{0},
+		}, {
+			name:     "nested - nested record",
+			schema:   testNestedSchema,
+			msgType:  "Person.PhoneNumber.PhoneBrand",
+			schemaID: 10,
+			record:   `{"brand":"pandaPhone","year":2023}`,
+			expIdx:   []int{0, 1, 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			noopCl, _ := sr.NewClient()
+			schema := sr.Schema{
+				Schema: tt.schema,
+				Type:   sr.TypeProtobuf,
+			}
+			serde, err := NewSerde(context.Background(), noopCl, &schema, tt.schemaID, tt.msgType)
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			got, err := serde.EncodeRecord([]byte(tt.record))
+			if tt.expEncErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Validate magic byte.
+			require.Equal(t, uint8(0), got[0])
+
+			// Validate schema registry wire format.
+			var serdeHeader sr.ConfluentHeader
+			id, rest, err := serdeHeader.DecodeID(got)
+			require.NoError(t, err)
+			require.Equal(t, tt.schemaID, id)
+
+			index, _, err := serdeHeader.DecodeIndex(rest, 3) // 3 is the most nested element in this test.
+			require.NoError(t, err)
+			require.Equal(t, tt.expIdx, index)
+		})
+	}
+}
+
+const testSingleReference = `syntax = "proto3";
+
+import "person.proto";
+
+message AddressBook {
+  repeated .Person people = 1;
+}`
+
+const testNestedReference = `syntax = "proto3";
+
+import "nestedPerson.proto";
+
+message AddressBook {
+  repeated .Person people = 1;
+}`
+
+const testPersonReference = `syntax = "proto3";
+
+message Person {
+  message PhoneNumber {
+    string number = 1;
+    .Person.PhoneType type = 2;
+  }
+  enum PhoneType {
+    PHONE_TYPE_UNSPECIFIED = 0;
+    PHONE_TYPE_MOBILE = 1;
+    PHONE_TYPE_HOME = 2;
+    PHONE_TYPE_WORK = 3;
+  }
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+  repeated .Person.PhoneNumber phones = 4;
+}`
+
+const testPersonNested = `syntax = "proto3";
+
+import "phoneNumber.proto";
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+  repeated PhoneNumber phones = 4;
+}`
+
+const testPhoneNumberReference = `syntax = "proto3";
+
+message PhoneNumber {
+  string number = 1;
+}`
+
+func Test_encodeProtoRecordWithReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   *sr.Schema
+		schemaID int
+		msgType  string
+		record   string
+		expIdx   []int
+		expErr   bool
+	}{
+		{
+			name:     "single reference",
+			schemaID: 906,
+			msgType:  "AddressBook",
+			expIdx:   []int{0},
+			record:   `{"people":[{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"111","type":2}]},{"name":"igor","id":321,"email":"igor@redpanda.com","phones":[{"number":"1231231","type":0},{"number":"2222333","type":1}]}]}`,
+			schema: &sr.Schema{
+				Schema: testSingleReference,
+				References: []sr.SchemaReference{
+					{
+						Name:    "person.proto",
+						Subject: "phone",
+						Version: 0,
+					},
+				},
+			},
+		}, {
+			name:     "nested reference",
+			schemaID: 906,
+			msgType:  "AddressBook",
+			expIdx:   []int{0},
+			record:   `{"people":[{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"111"}]},{"name":"igor","id":321,"email":"igor@redpanda.com","phones":[{"number":"1231231"},{"number":"2222333"}]}]}`,
+			schema: &sr.Schema{
+				Schema: testNestedReference,
+				References: []sr.SchemaReference{
+					{
+						Name:    "nestedPerson.proto",
+						Subject: "phone",
+						Version: 1,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(protoReferenceHandler())
+			defer ts.Close()
+
+			fs := afero.NewMemMapFs()
+			params := &config.Params{ConfigFlag: "/some/path/redpanda.yaml"}
+			p, err := params.LoadVirtualProfile(fs)
+			require.NoError(t, err)
+
+			p.SR.Addresses = []string{ts.URL}
+
+			cl, err := schemaregistry.NewClient(fs, p)
+			require.NoError(t, err)
+
+			tt.schema.Type = sr.TypeProtobuf
+			serde, err := NewSerde(context.Background(), cl, tt.schema, tt.schemaID, tt.msgType)
+			require.NoError(t, err)
+
+			got, err := serde.EncodeRecord([]byte(tt.record))
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Validate magic byte.
+			require.Equal(t, uint8(0), got[0])
+
+			// Validate schema registry wire format.
+			var serdeHeader sr.ConfluentHeader
+			id, rest, err := serdeHeader.DecodeID(got)
+			require.NoError(t, err)
+			require.Equal(t, tt.schemaID, id)
+
+			index, _, err := serdeHeader.DecodeIndex(rest, 3) // 3 is the most nested element in this test.
+			require.NoError(t, err)
+			require.Equal(t, tt.expIdx, index)
+		})
+	}
+}
+
+var protoReferenceMap = map[string]string{
+	"phone-0":  fmt.Sprintf(`{"schema":%q}`, testPersonReference),
+	"phone-1":  fmt.Sprintf(`{"schema":%q,"references":[{"name":"phoneNumber.proto","subject":"number","version":0}]}`, testPersonNested),
+	"number-0": fmt.Sprintf(`{"schema":%q}`, testPhoneNumberReference),
+}
+
+func protoReferenceHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Split the URL path by '/' to get individual path segments of
+		segments := strings.Split(r.URL.Path, "/")
+
+		// /subjects/{subject}/versions/{version}"
+		if len(segments) >= 4 && segments[1] == "subjects" && segments[3] == "versions" {
+			subject := segments[2]
+			version := segments[4]
+			id := subject + "-" + version
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(protoReferenceMap[id]))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}
+}

--- a/src/go/rpk/pkg/serde/serde.go
+++ b/src/go/rpk/pkg/serde/serde.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package serde
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+// serdeFunc is a encoding/decoding function.
+type serdeFunc func([]byte) ([]byte, error)
+
+// Serde is a protobuf or avro serializer/deserializer.
+type Serde struct {
+	encodeFn serdeFunc
+}
+
+// NewSerde will build a de/serializer based on the schema type. For Protobuf
+// schemas, it will use the FQN to find the message type. Each encoded record
+// will contain the schema registry wire format bytes (Magic number, Schema ID
+// and Index for Proto).
+func NewSerde(ctx context.Context, cl *sr.Client, schema *sr.Schema, schemaID int, protoFQN string) (*Serde, error) {
+	switch schema.Type {
+	case sr.TypeAvro:
+		encFn, err := newAvroEncoder(ctx, cl, schema, schemaID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to build avro encoder: %v", err)
+		}
+		return &Serde{encFn}, nil
+	case sr.TypeProtobuf:
+		encFn, err := newProtoEncoder(ctx, cl, schema, protoFQN, schemaID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to build protobuf encoder: %v", err)
+		}
+		return &Serde{encFn}, nil
+	default:
+		return nil, fmt.Errorf("schema with ID %v contains an unsupported schema type %v", schemaID, schema.Type)
+	}
+}
+
+// EncodeRecord will encode the given record using the internal encodeFn.
+func (s *Serde) EncodeRecord(record []byte) ([]byte, error) {
+	if s.encodeFn == nil {
+		return nil, errors.New("encoder not found")
+	}
+	return s.encodeFn(record)
+}


### PR DESCRIPTION
This PR introduces a way to encode messages in rpk while producing, using Schema Registry:

### Usage:

It introduces `--schema-id`/`--schema-key-id`, a new set of flags in `rpk topic produce` that lets rpk know that you want to use the schema with the given ID to encode your message. rpk will query the schema registry for the schema, and decode accordingly.

For PROTOBUF messages, there is an additional flag `--proto-msg-type` that lets you select which message you want to use to encode the message since in Proto, it is ok to have multiple message types in a single schema.

rpk expects JSON messages and produces binary encoded messages to the topic.

**AVRO**

Let's say you have the following schema in `/tmp/sample.avro`:
```
{
  "type": "record",
  "name": "sensor_sample",
  "fields": [
    {
      "name": "timestamp",
      "type": "long",
      "logicalType": "timestamp-millis"
    },
    {
      "name": "value",
      "type": "long"
    }
  ]
}
```

You would register the schema using `rpk registry`:
```
$ rpk registry schema create demo-sr --schema /tmp/sample.avro                                              
SUBJECT  VERSION  ID    TYPE
demo-sr  1        1     AVRO
```

Now you can produce using the schema ID **1**:

```
$ echo -n '{"timestamp":1693342644703,"value":123}' | rpk topic produce demo --schema-id 1
```

**PROTOBUF**
Same procedure, given that you have the given Schema with ID 4:
```
syntax = "proto3";
package foo.bar;

message Person {
  string name = 1;
  int32 id = 2;  // Unique ID number for this person.
  string email = 3;

  enum PhoneType {
    PHONE_TYPE_UNSPECIFIED = 0;
    PHONE_TYPE_MOBILE = 1;
    PHONE_TYPE_HOME = 2;
    PHONE_TYPE_WORK = 3;
  }

  message PhoneNumber {
    string number = 1;
    PhoneType type = 2;
  }

  repeated PhoneNumber phones = 4;
}

message AddressBook {
  repeated Person people = 1;
}
```

You may use the message `AddressBook` or the message `Person`, both are part of the package `foo.bar`, so to use it you will:

```
# Asuming that you have a valid message in /tmp/msg.json:
$ cat /tmp/msg.json | rpk topic produce demoProto --schema-id 4 --proto-msg-type foo.bar.AddressBook
```

You may also use different schemas or message types for the record key:

```
$ cat /tmp/msg | rpk topic produce newKeys --schema-id 4 --schema-key-id 3 --proto-msg-type foo.bar.Person --proto-key-msg-type foo.bar.Person.PhoneNumber -f "%k{json} %v{json}"
```

### Technical notes:

- The first commit corresponds to a bump in the dependencies used by this feature and fixing some breaking changes.
- We also support references and we have tests in place for this, and in a following PR, we will add to rpk the ability to decode these messages. In that PR, I'll include the relevant ducktape tests for this.
- When encoding, rpk add the wire format bits to the message (Magic Byte + Schema ID + [optional] proto message index)
- I manually tested this feature with Console and Console can successfully decode the message:
  
![image](https://github.com/redpanda-data/redpanda/assets/59714880/8a8c2cc9-6f6a-457f-aa86-936752b90311)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Features

* rpk now supports encoding messages with a given schema stored in the schema registry.

