### PR TITLE
[v23.1.x] rpk: improved err msg in rpk tune --output-script

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/tune.go
@@ -98,6 +98,11 @@ To learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.
 			out.MaybeDie(err, "unable to load config: %v", err)
 			var tunerFactory factory.TunersFactory
 			if outTuneScriptFile != "" {
+				isDir, err := afero.IsDir(fs, outTuneScriptFile)
+				out.MaybeDie(err, "unable to check if %q is a dir or a file: %v", outTuneScriptFile, err)
+				if isDir {
+					out.Die("please use a filename instead of a directory name in --output-script")
+				}
 				tunerFactory = factory.NewScriptRenderingTunersFactory(
 					fs, *cfg, outTuneScriptFile, timeout)
 			} else {


### PR DESCRIPTION
Manual Backport of https://github.com/redpanda-data/redpanda/pull/13473

Fixes #13541
## Backports Required
- [X] none - this is a backport


## Release Notes

### Bug Fixes

* rpk: prevent panic when using a directory instead of a filename in `rpk redpanda tune --output-script`
