### PR TITLE
[v22.3.x] rpk: improved err msg in rpk tune --output-script

### DIFF
--- a/src/go/rpk/pkg/cli/cmd/redpanda/tune/tune.go
+++ b/src/go/rpk/pkg/cli/cmd/redpanda/tune/tune.go
@@ -101,6 +101,11 @@ To learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.
 				tunerFactory = factory.NewScriptRenderingTunersFactory(
 					fs, *cfg, outTuneScriptFile, timeout)
 			} else {
+				isDir, err := afero.IsDir(fs, outTuneScriptFile)
+				out.MaybeDie(err, "unable to check if %q is a dir or a file: %v", outTuneScriptFile, err)
+				if isDir {
+					out.Die("please use a filename instead of a directory name in --output-script")
+				}
 				tunerFactory = factory.NewDirectExecutorTunersFactory(
 					fs, *cfg, timeout)
 			}


### PR DESCRIPTION
If the user used a directory it would fail without giving any meaningful error.

Manual Backport of PR #13473

Fixes #13540

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* rpk: prevent panic when using a directory instead of a filename in rpk redpanda tune --output-script
