### PR TITLE
kafka: Expose per handler produce/fetch metrics on public_metrics

### DIFF
--- a/src/v/kafka/server/handlers/handler_probe.cc
+++ b/src/v/kafka/server/handlers/handler_probe.cc
@@ -12,6 +12,8 @@
 #include "kafka/server/handlers/handler_probe.h"
 
 #include "config/configuration.h"
+#include "kafka/protocol/schemata/fetch_request.h"
+#include "kafka/protocol/schemata/produce_request.h"
 #include "kafka/server/handlers/handler_interface.h"
 #include "kafka/server/logger.h"
 #include "prometheus/prometheus_sanitize.h"
@@ -34,6 +36,10 @@ handler_probe_manager::handler_probe_manager()
 
         if (handler_for_key(key) || i == unknown_handler_key) {
             _probes[i].setup_metrics(_metrics, key);
+
+            if (key == produce_api::key || key == fetch_api::key) {
+                _probes[i].setup_public_metrics(_public_metrics, key);
+            }
         }
     }
 }
@@ -108,6 +114,32 @@ void handler_probe::setup_metrics(
           labels,
           [this] { return _latency.internal_histogram_logform(); })
           .aggregate(aggregate_labels),
+      });
+}
+
+// For public metrics we only expose a small subset of the metrics for produce
+// and fetch requests to keep the count of metrics low
+void handler_probe::setup_public_metrics(
+  ssx::metrics::metric_groups& metrics, api_key key) {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_public_metrics()) {
+        return;
+    }
+
+    const char* handler_name = handler_for_key(key).value()->name();
+
+    std::vector<sm::label_instance> labels{sm::label("handler")(handler_name)};
+
+    metrics.add_group(
+      prometheus_sanitize::metrics_name("kafka_handler"),
+      {
+        sm::make_histogram(
+          "latency_seconds",
+          sm::description("Latency histogram of kafka requests"),
+          labels,
+          [this] { return _latency.public_histogram_logform(); })
+          .aggregate({sm::shard_label}),
       });
 }
 

--- a/src/v/kafka/server/handlers/handler_probe.h
+++ b/src/v/kafka/server/handlers/handler_probe.h
@@ -34,6 +34,7 @@ public:
     handler_probe& operator=(handler_probe&&) = delete;
     ~handler_probe() = default;
     void setup_metrics(ssx::metrics::metric_groups&, api_key);
+    void setup_public_metrics(ssx::metrics::metric_groups&, api_key);
 
     void sample_in_progress();
     void request_completed() {
@@ -94,6 +95,8 @@ public:
 private:
     ssx::metrics::metric_groups _metrics
       = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
     std::vector<handler_probe> _probes;
 };
 


### PR DESCRIPTION
Exposes the produce and fetch per handler metrics on the public_metrics endpoint.

These will eventually replace the existing produce and fetch latency metrics on the public endpoint (as those measure non-meaningful latency intervals).

Ref https://github.com/redpanda-data/redpanda/issues/13363

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* Export per handler produce/fetch metrics on the public_metrics endpoint
