### PR TITLE
Allow setting mechanism for bootstrap user

### DIFF
--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -32,8 +32,11 @@
 #include "rpc/types.h"
 #include "security/authorizer.h"
 #include "security/scram_algorithm.h"
+#include "security/scram_authenticator.h"
 
 #include <seastar/core/coroutine.hh>
+
+#include <boost/algorithm/string/split.hpp>
 
 #include <regex>
 
@@ -322,24 +325,38 @@ security_frontend::get_bootstrap_user_creds_from_env() {
         return {};
     }
 
-    ss::sstring creds_str = creds_str_ptr;
-    auto colon = creds_str.find(":");
-    if (colon == ss::sstring::npos || colon == creds_str.size() - 1) {
+    std::string_view creds = creds_str_ptr;
+    std::vector<std::string_view> parts;
+    parts.reserve(3);
+    boost::algorithm::split(parts, creds, [](char c) { return c == ':'; });
+    if (
+      !(parts.size() == 2 || parts.size() == 3) || parts[0].empty()
+      || parts[1].empty()) {
         // Malformed value.  Do not log the value, it may be malformed
         // but it is still a secret.
         vlog(
           clusterlog.warn,
-          "Invalid value of {} (expected \"username:password\")",
+          "Invalid value of {} (expected \"username:password[:mechanism]\")",
           bootstrap_user_env_key);
         return {};
     }
-
-    auto username = security::credential_user{creds_str.substr(0, colon)};
-    auto password = creds_str.substr(colon + 1);
-    auto credentials = security::scram_sha256::make_credentials(
-      password, security::scram_sha256::min_iterations);
+    std::variant<security::scram_sha256, security::scram_sha512> scram;
+    if (parts.size() == 3) {
+        if (parts[2] == security::scram_sha512_authenticator::name) {
+            scram = security::scram_sha512{};
+        } else if (parts[2] != security::scram_sha256_authenticator::name) {
+            throw std::invalid_argument(
+              fmt::format("Invalid SCRAM mechanism: {}", parts[2]));
+        }
+    }
     return std::optional<user_and_credential>(
-      std::in_place, std::move(username), std::move(credentials));
+      std::in_place,
+      security::credential_user{parts[0]},
+      ss::visit(scram, [&](auto const& scram) {
+          using scram_t = std::decay_t<decltype(scram)>;
+          return scram_t::make_credentials(
+            ss::sstring{parts[1]}, scram_t::min_iterations);
+      }));
 }
 
 ss::future<result<model::offset>> security_frontend::get_leader_committed(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This changes `RP_BOOTSTRAP_USER` handling so that 3 values are parsed: username, password, and mechanism.

- Rejects empty username or password
- Selects SCRAM-SHA-512 if and only if there is a 3rd part that matches the mechanism name
- Is backwards compatible

The following values are acceptable:

```
username:password:SCRAM-SHA-512
username:password:SCRAM-SHA-256 
username:password:SCRAM-SHA-xxx # defaults to SCRAM-SHA-256
username:password:scramSha512 # defaults to SCRAM-SHA-256
username:password:scram-sha-512 # defaults to SCRAM-SHA-256
username:password: # defaults to SCRAM-SHA-256
```

The following values will result in a warning thrown to the log (and no user created):

```
username:password::
username
:password
```

Fixes #8820 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* The SASL mechanism of the bootstrap SCRAM user can now be set with `RP_BOOTSTRAP_USER=username:password:mechanism` (`SCRAM-SHA-512`, or defaults to `SCRAM-SHA-256`)
