### PR TITLE
cloud_storage: Add S3 download throughput limit

### DIFF
--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -95,13 +95,13 @@ get_storage_device_throughput() {
 // for the node. Doesn't take into account hardware configuration.
 inline throughput_limit get_hard_throughput_limit() {
     auto hard_limit = config::shard_local_cfg()
-                        .cloud_storage_max_download_throughput_per_shard()
+                        .cloud_storage_max_throughput_per_shard()
                         .value_or(0)
                       * ss::smp::count;
 
     if (hard_limit == 0) {
         // Run tiered-storage without throttling by setting
-        // 'cloud_storage_max_download_throughput_per_shard' to nullopt
+        // 'cloud_storage_max_throughput_per_shard' to nullopt
         return {};
     }
 
@@ -116,7 +116,7 @@ inline throughput_limit get_hard_throughput_limit() {
 inline throughput_limit
 get_throughput_limit(std::optional<size_t> device_throughput) {
     auto hard_limit = config::shard_local_cfg()
-                        .cloud_storage_max_download_throughput_per_shard()
+                        .cloud_storage_max_throughput_per_shard()
                         .value_or(0)
                       * ss::smp::count;
 
@@ -128,7 +128,7 @@ get_throughput_limit(std::optional<size_t> device_throughput) {
       || hard_limit == 0) {
         // Run tiered-storage without throttling by setting
         // 'cloud_storage_throughput_limit_percent' to nullopt or
-        // 'cloud_storage_max_download_throughput_per_shard' to nullopt
+        // 'cloud_storage_max_throughput_per_shard' to nullopt
         return throughput_limit{};
     }
 
@@ -175,8 +175,7 @@ materialized_resources::materialized_resources()
       get_hard_throughput_limit().download_shard_throughput_limit,
       "ts-segment-downloads")
   , _throughput_shard_limit_config(
-      config::shard_local_cfg()
-        .cloud_storage_max_download_throughput_per_shard.bind())
+      config::shard_local_cfg().cloud_storage_max_throughput_per_shard.bind())
   , _relative_throughput(
       config::shard_local_cfg().cloud_storage_throughput_limit_percent.bind()) {
     auto update_max_mem = [this]() {

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -119,6 +119,9 @@ private:
     /// Consume from _eviction_list
     ss::future<> run_eviction_loop();
 
+    /// Set bandwidth for tiered-storage scheduling_group
+    ss::future<> set_disk_max_bandwidth();
+
     /// Try to evict segment readers until `target_free` units are available in
     /// _reader_units, i.e. available for new readers to be created.
     void trim_segment_readers(size_t target_free);

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -173,8 +173,8 @@ private:
 
     ts_read_path_probe _read_path_probe;
     token_bucket<> _throughput_limit;
-    config::binding<size_t> _throughput_shard_limit_config;
-    config::binding<size_t> _relative_throughput;
+    config::binding<std::optional<size_t>> _throughput_shard_limit_config;
+    config::binding<std::optional<size_t>> _relative_throughput;
     bool _throttling_disabled{false};
     std::optional<size_t> _device_throughput;
 };

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -176,6 +176,7 @@ private:
     config::binding<size_t> _throughput_shard_limit_config;
     config::binding<size_t> _relative_throughput;
     bool _throttling_disabled{false};
+    std::optional<size_t> _device_throughput;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -120,7 +120,13 @@ private:
     ss::future<> run_eviction_loop();
 
     /// Set bandwidth for tiered-storage scheduling_group
-    ss::future<> set_disk_max_bandwidth();
+    ss::future<> set_disk_max_bandwidth(size_t tput);
+
+    /// Set download bandwidth for cloud storage API
+    void set_net_max_bandwidth(size_t tput);
+
+    /// Recalculate and reset throughput limits
+    ss::future<> update_throughput();
 
     /// Try to evict segment readers until `target_free` units are available in
     /// _reader_units, i.e. available for new readers to be created.
@@ -167,7 +173,9 @@ private:
 
     ts_read_path_probe _read_path_probe;
     token_bucket<> _throughput_limit;
-    config::binding<size_t> _throughput_limit_config;
+    config::binding<size_t> _throughput_shard_limit_config;
+    config::binding<size_t> _relative_throughput;
+    bool _throttling_disabled{false};
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/read_path_probes.cc
+++ b/src/v/cloud_storage/read_path_probes.cc
@@ -139,6 +139,13 @@ ts_read_path_probe::ts_read_path_probe() {
           },
           sm::description("Chunk hydration latency histogram"))
           .aggregate(aggregate_labels),
+
+        sm::make_counter(
+          "downloads_throttled_sum",
+          [this] { return get_downloads_throttled_sum(); },
+          sm::description("Total amount of throttling applied to cloud storage "
+                          "downloads"))
+          .aggregate(aggregate_labels),
       });
 }
 

--- a/src/v/cloud_storage/read_path_probes.cc
+++ b/src/v/cloud_storage/read_path_probes.cc
@@ -63,90 +63,107 @@ partition_probe::partition_probe(const model::ntp& ntp) {
 }
 
 ts_read_path_probe::ts_read_path_probe() {
-    if (config::shard_local_cfg().disable_metrics()) {
-        return;
-    }
-
     namespace sm = ss::metrics;
     auto aggregate_labels = std::vector<sm::label>{sm::shard_label};
 
-    _metrics.add_group(
-      prometheus_sanitize::metrics_name("cloud_storage:read_path"),
-      {
-        sm::make_gauge(
-          "materialized_segments",
-          [this] { return _cur_materialized_segments; },
-          sm::description("Current number of materialized remote segments"))
-          .aggregate(aggregate_labels),
+    if (!config::shard_local_cfg().disable_public_metrics()) {
+        _public_metrics.add_group(
+          prometheus_sanitize::metrics_name("cloud_storage_limits"),
+          {
+            sm::make_counter(
+              "downloads_throttled_sum",
+              [this] { return get_downloads_throttled_sum(); },
+              sm::description(
+                "Total amount of throttling applied to cloud storage "
+                "downloads"))
+              .aggregate(aggregate_labels),
+          });
+    }
 
-        sm::make_gauge(
-          "readers",
-          [this] { return _cur_readers; },
-          sm::description("Current number of remote partition readers"))
-          .aggregate(aggregate_labels),
+    if (!config::shard_local_cfg().disable_metrics()) {
+        _metrics.add_group(
+          prometheus_sanitize::metrics_name("cloud_storage:read_path"),
+          {
+            sm::make_gauge(
+              "materialized_segments",
+              [this] { return _cur_materialized_segments; },
+              sm::description("Current number of materialized remote segments"))
+              .aggregate(aggregate_labels),
 
-        sm::make_gauge(
-          "spillover_manifest_bytes",
-          [this] { return _spillover_manifest_bytes; },
-          sm::description("Total amount of memory used by spillover manifests"))
-          .aggregate(aggregate_labels),
+            sm::make_gauge(
+              "readers",
+              [this] { return _cur_readers; },
+              sm::description("Current number of remote partition readers"))
+              .aggregate(aggregate_labels),
 
-        sm::make_gauge(
-          "spillover_manifest_instances",
-          [this] { return _spillover_manifest_instances; },
-          sm::description(
-            "Total number of spillover manifests stored in memory"))
-          .aggregate(aggregate_labels),
+            sm::make_gauge(
+              "spillover_manifest_bytes",
+              [this] { return _spillover_manifest_bytes; },
+              sm::description(
+                "Total amount of memory used by spillover manifests"))
+              .aggregate(aggregate_labels),
 
-        sm::make_counter(
-          "spillover_manifest_hydrated",
-          [this] { return _spillover_manifest_hydrated; },
-          sm::description(
-            "Number of times spillover manifests were saved to the cache"))
-          .aggregate(aggregate_labels),
+            sm::make_gauge(
+              "spillover_manifest_instances",
+              [this] { return _spillover_manifest_instances; },
+              sm::description(
+                "Total number of spillover manifests stored in memory"))
+              .aggregate(aggregate_labels),
 
-        sm::make_counter(
-          "spillover_manifest_materialized",
-          [this] { return _spillover_manifest_materialized; },
-          sm::description(
-            "Number of times spillover manifests were loaded from the cache"))
-          .aggregate(aggregate_labels),
+            sm::make_counter(
+              "spillover_manifest_hydrated",
+              [this] { return _spillover_manifest_hydrated; },
+              sm::description(
+                "Number of times spillover manifests were saved to the cache"))
+              .aggregate(aggregate_labels),
 
-        sm::make_gauge(
-          "segment_readers",
-          [this] { return _cur_segment_readers; },
-          sm::description("Current number of remote segment readers"))
-          .aggregate(aggregate_labels),
+            sm::make_counter(
+              "spillover_manifest_materialized",
+              [this] { return _spillover_manifest_materialized; },
+              sm::description("Number of times spillover manifests were loaded "
+                              "from the cache"))
+              .aggregate(aggregate_labels),
 
-        sm::make_histogram(
-          "spillover_manifest_latency",
-          [this] { return _spillover_mat_latency.public_histogram_logform(); },
-          sm::description(
-            "Spillover manifest materialization latency histogram"))
-          .aggregate(aggregate_labels),
+            sm::make_gauge(
+              "segment_readers",
+              [this] { return _cur_segment_readers; },
+              sm::description("Current number of remote segment readers"))
+              .aggregate(aggregate_labels),
 
-        sm::make_counter(
-          "chunks_hydrated",
-          [this] { return _chunks_hydrated; },
-          sm::description("Total number of hydrated chunks (some may have been "
-                          "evicted from the cache)"))
-          .aggregate(aggregate_labels),
+            sm::make_histogram(
+              "spillover_manifest_latency",
+              [this] {
+                  return _spillover_mat_latency.public_histogram_logform();
+              },
+              sm::description(
+                "Spillover manifest materialization latency histogram"))
+              .aggregate(aggregate_labels),
 
-        sm::make_histogram(
-          "chunk_hydration_latency",
-          [this] {
-              return _chunk_hydration_latency.public_histogram_logform();
-          },
-          sm::description("Chunk hydration latency histogram"))
-          .aggregate(aggregate_labels),
+            sm::make_counter(
+              "chunks_hydrated",
+              [this] { return _chunks_hydrated; },
+              sm::description(
+                "Total number of hydrated chunks (some may have been "
+                "evicted from the cache)"))
+              .aggregate(aggregate_labels),
 
-        sm::make_counter(
-          "downloads_throttled_sum",
-          [this] { return get_downloads_throttled_sum(); },
-          sm::description("Total amount of throttling applied to cloud storage "
-                          "downloads"))
-          .aggregate(aggregate_labels),
-      });
+            sm::make_histogram(
+              "chunk_hydration_latency",
+              [this] {
+                  return _chunk_hydration_latency.public_histogram_logform();
+              },
+              sm::description("Chunk hydration latency histogram"))
+              .aggregate(aggregate_labels),
+
+            sm::make_counter(
+              "downloads_throttled_sum",
+              [this] { return get_downloads_throttled_sum(); },
+              sm::description(
+                "Total amount of throttling applied to cloud storage "
+                "downloads"))
+              .aggregate(aggregate_labels),
+          });
+    }
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/read_path_probes.h
+++ b/src/v/cloud_storage/read_path_probes.h
@@ -73,6 +73,12 @@ public:
         return _chunk_hydration_latency.auto_measure();
     }
 
+    void download_throttled(size_t value) { _downloads_throttled_sum += value; }
+
+    auto get_downloads_throttled_sum() const noexcept {
+        return _downloads_throttled_sum;
+    }
+
 private:
     int32_t _cur_materialized_segments = 0;
 
@@ -88,6 +94,7 @@ private:
 
     size_t _chunks_hydrated = 0;
     hist_t _chunk_hydration_latency;
+    size_t _downloads_throttled_sum = 0;
 
     ssx::metrics::metric_groups _metrics
       = ssx::metrics::metric_groups::make_internal();

--- a/src/v/cloud_storage/read_path_probes.h
+++ b/src/v/cloud_storage/read_path_probes.h
@@ -98,6 +98,8 @@ private:
 
     ssx::metrics::metric_groups _metrics
       = ssx::metrics::metric_groups::make_internal();
+    ssx::metrics::metric_groups _public_metrics
+      = ssx::metrics::metric_groups::make_public();
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -722,8 +722,11 @@ ss::future<download_result> remote::download_stream(
               resp.value()->get_headers().at(
                 boost::beast::http::field::content_length));
             try {
+                auto underlying_st = resp.value()->as_input_stream();
+                auto throttled_st = _materialized->throttle_download(
+                  std::move(underlying_st), _as);
                 uint64_t content_length = co_await cons_str(
-                  length, resp.value()->as_input_stream());
+                  length, std::move(throttled_st));
                 _probe.successful_download();
                 _probe.register_download_size(content_length);
                 co_return download_result::success;

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -12,6 +12,7 @@
 #include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
 #include "cloud_storage/base_manifest.h"
+#include "cloud_storage/materialized_resources.h"
 #include "cloud_storage/offset_translation_layer.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/remote.h"
@@ -21,6 +22,7 @@
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/client_pool.h"
 #include "config/configuration.h"
+#include "config/node_config.h"
 #include "model/metadata.h"
 #include "seastarx.h"
 #include "storage/directories.h"
@@ -29,9 +31,11 @@
 #include "test_utils/tmp_dir.h"
 #include "utils/retry_chain_node.h"
 
+#include <seastar/core/app-template.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/io_priority_class.hh>
 #include <seastar/core/iostream.hh>
+#include <seastar/core/resource.hh>
 #include <seastar/core/temporary_buffer.hh>
 #include <seastar/core/thread.hh>
 #include <seastar/testing/test_case.hh>
@@ -1029,4 +1033,84 @@ FIXTURE_TEST(test_filter_lifetime_2, remote_fixture) { // NOLINT
     auto subscription = remote.local().subscribe(*flt);
     flt.reset();
     BOOST_REQUIRE_THROW(subscription.get(), ss::broken_promise);
+}
+
+struct throttle_low_limit {
+    throttle_low_limit() {
+        config::shard_local_cfg()
+          .cloud_storage_max_download_throughput_per_shard.set_value(
+            manifest_payload.size());
+        vlog(
+          test_log.info,
+          "CONF throughput: {}",
+          config::shard_local_cfg()
+            .cloud_storage_max_download_throughput_per_shard());
+    }
+    ~throttle_low_limit() {
+        config::shard_local_cfg()
+          .cloud_storage_max_download_throughput_per_shard.reset();
+    }
+};
+
+using throttle_remote_fixture = remote_fixture_base<throttle_low_limit>;
+
+FIXTURE_TEST(
+  test_download_segment_throttle, throttle_remote_fixture) { // NOLINT
+    set_expectations_and_listen({});
+    auto bucket = cloud_storage_clients::bucket_name("bucket");
+    auto subscription = remote.local().subscribe(allow_all);
+    auto name = segment_name("1-2-v1.log");
+    auto path = generate_remote_segment_path(
+      manifest_ntp, manifest_revision, name, model::term_id{123});
+    uint64_t clen = manifest_payload.size();
+    auto reset_stream =
+      []() -> ss::future<std::unique_ptr<storage::stream_provider>> {
+        iobuf out;
+        out.append(manifest_payload.data(), manifest_payload.size());
+        co_return std::make_unique<storage::segment_reader_handle>(
+          make_iobuf_input_stream(std::move(out)));
+    };
+    retry_chain_node fib(never_abort, 100ms, 20ms);
+    auto upl_res = remote.local()
+                     .upload_segment(
+                       bucket, path, clen, reset_stream, fib, always_continue)
+                     .get();
+    BOOST_REQUIRE(upl_res == upload_result::success);
+
+    auto download_one = [](cloud_storage::remote& api, auto path, auto bucket) {
+        retry_chain_node fib(never_abort, 100ms, 20ms);
+        iobuf downloaded;
+        auto try_consume = [&downloaded](
+                             uint64_t len, ss::input_stream<char> is) {
+            downloaded.clear();
+            auto rds = make_iobuf_ref_output_stream(downloaded);
+            return ss::do_with(
+              std::move(rds),
+              std::move(is),
+              [&downloaded](auto& rds, auto& is) {
+                  return ss::copy(is, rds).then(
+                    [&downloaded] { return downloaded.size_bytes(); });
+              });
+        };
+        auto dnl_res
+          = api.download_segment(bucket, path, try_consume, fib).get();
+
+        BOOST_REQUIRE(dnl_res == download_result::success);
+        iobuf_parser p(std::move(downloaded));
+        auto actual = p.read_string(p.bytes_left());
+        // segment and manifest has the same synthetic payload in this test
+        BOOST_REQUIRE(actual == manifest_payload);
+    };
+    download_one(remote.local(), path, bucket);
+    auto s1 = remote.local()
+                .materialized()
+                .get_read_path_probe()
+                .get_downloads_throttled_sum();
+    BOOST_REQUIRE(s1 == 0);
+    download_one(remote.local(), path, bucket);
+    auto s2 = remote.local()
+                .materialized()
+                .get_read_path_probe()
+                .get_downloads_throttled_sum();
+    BOOST_REQUIRE(s2 > 0);
 }

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -1038,17 +1038,16 @@ FIXTURE_TEST(test_filter_lifetime_2, remote_fixture) { // NOLINT
 struct throttle_low_limit {
     throttle_low_limit() {
         config::shard_local_cfg()
-          .cloud_storage_max_download_throughput_per_shard.set_value(
+          .cloud_storage_max_throughput_per_shard.set_value(
             manifest_payload.size());
         vlog(
           test_log.info,
           "CONF throughput: {}",
-          config::shard_local_cfg()
-            .cloud_storage_max_download_throughput_per_shard());
+          config::shard_local_cfg().cloud_storage_max_throughput_per_shard());
     }
     ~throttle_low_limit() {
         config::shard_local_cfg()
-          .cloud_storage_max_download_throughput_per_shard.reset();
+          .cloud_storage_max_throughput_per_shard.reset();
     }
 };
 
@@ -1120,14 +1119,14 @@ struct no_throttle {
         config::shard_local_cfg()
           .cloud_storage_throughput_limit_percent.set_value(0);
         config::shard_local_cfg()
-          .cloud_storage_max_download_throughput_per_shard.set_value(
+          .cloud_storage_max_throughput_per_shard.set_value(
             manifest_payload.size());
     }
     ~no_throttle() {
         config::shard_local_cfg()
           .cloud_storage_throughput_limit_percent.reset();
         config::shard_local_cfg()
-          .cloud_storage_max_download_throughput_per_shard.reset();
+          .cloud_storage_max_throughput_per_shard.reset();
     }
 };
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1582,6 +1582,12 @@ configuration::configuration()
       "cloud_storage_segment_size_target/2",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
+  , cloud_storage_max_download_throughput_per_shard(
+      *this,
+      "cloud_storage_max_download_throughput_per_shard",
+      "Max S3 download throughput per shard",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1_GiB)
   , cloud_storage_graceful_transfer_timeout_ms(
       *this,
       "cloud_storage_graceful_transfer_timeout_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1585,9 +1585,31 @@ configuration::configuration()
   , cloud_storage_max_download_throughput_per_shard(
       *this,
       "cloud_storage_max_download_throughput_per_shard",
-      "Max S3 download throughput per shard",
+      "Max throughput used by tiered-storage per shard in bytes per second. "
+      "This value is an upper bound of the throughput available to the "
+      "tiered-storage subsystem. This parameter is intended to be used as a "
+      "safeguard and in tests when "
+      "we need to set precise throughput value independent of actual storage "
+      "media. "
+      "Please use 'cloud_storage_throughput_limit_percent' instead of this "
+      "parameter in the production environment.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB)
+  , cloud_storage_throughput_limit_percent(
+      *this,
+      "cloud_storage_throughput_limit_percent",
+      "Max throughput used by tiered-storage per node expressed as a "
+      "percentage of the disk bandwidth. If the server has several disks "
+      "Redpanda will take into account only the one which is used to store "
+      "tiered-storage cache. Note that even if the tiered-storage is allowed "
+      "to use full bandwidth of the disk (100%) it won't necessary use it in "
+      "full. The actual usage depend on your workload and the state of the "
+      "tiered-storage cache. This parameter is a safeguard that prevents "
+      "tiered-storage from using too many system resources and not a "
+      "performance tuning knob.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      50,
+      {.min = 0, .max = 100})
   , cloud_storage_graceful_transfer_timeout_ms(
       *this,
       "cloud_storage_graceful_transfer_timeout_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1582,9 +1582,9 @@ configuration::configuration()
       "cloud_storage_segment_size_target/2",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
-  , cloud_storage_max_download_throughput_per_shard(
+  , cloud_storage_max_throughput_per_shard(
       *this,
-      "cloud_storage_max_download_throughput_per_shard",
+      "cloud_storage_max_throughput_per_shard",
       "Max throughput used by tiered-storage per shard in bytes per second. "
       "This value is an upper bound of the throughput available to the "
       "tiered-storage subsystem. This parameter is intended to be used as a "

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -310,8 +310,7 @@ struct configuration final : public config_store {
     property<size_t> cloud_storage_recovery_temporary_retention_bytes_default;
     property<std::optional<size_t>> cloud_storage_segment_size_target;
     property<std::optional<size_t>> cloud_storage_segment_size_min;
-    property<std::optional<size_t>>
-      cloud_storage_max_download_throughput_per_shard;
+    property<std::optional<size_t>> cloud_storage_max_throughput_per_shard;
     bounded_property<std::optional<size_t>>
       cloud_storage_throughput_limit_percent;
     property<std::optional<std::chrono::milliseconds>>

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -310,8 +310,10 @@ struct configuration final : public config_store {
     property<size_t> cloud_storage_recovery_temporary_retention_bytes_default;
     property<std::optional<size_t>> cloud_storage_segment_size_target;
     property<std::optional<size_t>> cloud_storage_segment_size_min;
-    property<size_t> cloud_storage_max_download_throughput_per_shard;
-    bounded_property<size_t> cloud_storage_throughput_limit_percent;
+    property<std::optional<size_t>>
+      cloud_storage_max_download_throughput_per_shard;
+    bounded_property<std::optional<size_t>>
+      cloud_storage_throughput_limit_percent;
     property<std::optional<std::chrono::milliseconds>>
       cloud_storage_graceful_transfer_timeout_ms;
     enum_property<model::cloud_storage_backend> cloud_storage_backend;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -311,6 +311,7 @@ struct configuration final : public config_store {
     property<std::optional<size_t>> cloud_storage_segment_size_target;
     property<std::optional<size_t>> cloud_storage_segment_size_min;
     property<size_t> cloud_storage_max_download_throughput_per_shard;
+    bounded_property<size_t> cloud_storage_throughput_limit_percent;
     property<std::optional<std::chrono::milliseconds>>
       cloud_storage_graceful_transfer_timeout_ms;
     enum_property<model::cloud_storage_backend> cloud_storage_backend;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -310,6 +310,7 @@ struct configuration final : public config_store {
     property<size_t> cloud_storage_recovery_temporary_retention_bytes_default;
     property<std::optional<size_t>> cloud_storage_segment_size_target;
     property<std::optional<size_t>> cloud_storage_segment_size_min;
+    property<size_t> cloud_storage_max_download_throughput_per_shard;
     property<std::optional<std::chrono::milliseconds>>
       cloud_storage_graceful_transfer_timeout_ms;
     enum_property<model::cloud_storage_backend> cloud_storage_backend;

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -389,7 +389,9 @@ class SISettings:
                  cloud_storage_spillover_manifest_max_segments: Optional[
                      int] = None,
                  fast_uploads=False,
-                 retention_local_strict=True):
+                 retention_local_strict=True,
+                 cloud_storage_max_download_throughput_per_shard: Optional[
+                     int] = None):
         """
         :param fast_uploads: if true, set low upload intervals to help tests run
                              quickly when they wait for uploads to complete.
@@ -439,6 +441,7 @@ class SISettings:
         self.cloud_storage_housekeeping_interval_ms = cloud_storage_housekeeping_interval_ms
         self.cloud_storage_spillover_manifest_max_segments = cloud_storage_spillover_manifest_max_segments
         self.retention_local_strict = retention_local_strict
+        self.cloud_storage_max_download_throughput_per_shard = cloud_storage_max_download_throughput_per_shard
 
         if fast_uploads:
             self.cloud_storage_segment_max_upload_interval_sec = 10
@@ -579,6 +582,10 @@ class SISettings:
                 'cloud_storage_spillover_manifest_max_segments'] = self.cloud_storage_spillover_manifest_max_segments
 
         conf['retention_local_strict'] = self.retention_local_strict
+
+        if self.cloud_storage_max_download_throughput_per_shard:
+            conf[
+                'cloud_storage_max_download_throughput_per_shard'] = self.cloud_storage_max_download_throughput_per_shard
 
         return conf
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -670,8 +670,8 @@ class SecurityConfig:
     # sasl is required
     def sasl_enabled(self):
         return (self.kafka_enable_authorization is None and self.enable_sasl
-                and self.endpoint_authn_method is None
-                ) or self.endpoint_authn_method == "sasl"
+                and self.endpoint_authn_method
+                is None) or self.endpoint_authn_method == "sasl"
 
     # principal is extracted from mtls distinguished name
     def mtls_identity_enabled(self):
@@ -2401,8 +2401,10 @@ class RedpandaService(RedpandaServiceBase):
             admin_client = self._admin
 
         patch_result = admin_client.patch_cluster_config(
-            upsert={k: v
-                    for k, v in values.items() if v is not None},
+            upsert={
+                k: v
+                for k, v in values.items() if v is not None
+            },
             remove=[k for k, v in values.items() if v is None])
         new_version = patch_result['config_version']
 

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1203,7 +1203,7 @@ class EndToEndThrottlingTest(RedpandaTest):
             log_segment_size=1024,
             fast_uploads=True,
             # Set small throughput limit to trigger throttling
-            cloud_storage_max_download_throughput_per_shard=5 * 1024 * 1024)
+            cloud_storage_max_throughput_per_shard=5 * 1024 * 1024)
 
         super(EndToEndThrottlingTest,
               self).__init__(test_context=test_context,

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -105,36 +105,40 @@ def num_manifests_downloaded(test_self):
     return s
 
 
+def all_uploads_done(rpk, topic, redpanda, logger):
+    topic_description = rpk.describe_topic(topic)
+    partition = next(topic_description)
+
+    hwm = partition.high_watermark
+
+    manifest = None
+    try:
+        bucket = BucketView(redpanda)
+        manifest = bucket.manifest_for_ntp(topic, partition.id)
+    except Exception as e:
+        logger.info(f"Exception thrown while retrieving the manifest: {e}")
+        return False
+
+    top_segment = max(manifest['segments'].values(),
+                      key=lambda seg: seg['base_offset'])
+    uploaded_raft_offset = top_segment['committed_offset']
+    uploaded_kafka_offset = uploaded_raft_offset - top_segment[
+        'delta_offset_end']
+    logger.info(
+        f"Remote HWM {uploaded_kafka_offset} (raft {uploaded_raft_offset}), local hwm {hwm}"
+    )
+
+    # -1 because uploaded offset is inclusive, hwm is exclusive
+    if uploaded_kafka_offset < (hwm - 1):
+        return False
+
+    return True
+
+
 class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
     def _all_uploads_done(self):
-        topic_description = self.rpk.describe_topic(self.topic)
-        partition = next(topic_description)
-
-        hwm = partition.high_watermark
-
-        manifest = None
-        try:
-            bucket = BucketView(self.redpanda)
-            manifest = bucket.manifest_for_ntp(self.topic, partition.id)
-        except Exception as e:
-            self.logger.info(
-                f"Exception thrown while retrieving the manifest: {e}")
-            return False
-
-        top_segment = max(manifest['segments'].values(),
-                          key=lambda seg: seg['base_offset'])
-        uploaded_raft_offset = top_segment['committed_offset']
-        uploaded_kafka_offset = uploaded_raft_offset - top_segment[
-            'delta_offset_end']
-        self.logger.info(
-            f"Remote HWM {uploaded_kafka_offset} (raft {uploaded_raft_offset}), local hwm {hwm}"
-        )
-
-        # -1 because uploaded offset is inclusive, hwm is exclusive
-        if uploaded_kafka_offset < (hwm - 1):
-            return False
-
-        return True
+        return all_uploads_done(self.rpk, self.topic, self.redpanda,
+                                self.logger)
 
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=get_cloud_storage_type())
@@ -1187,3 +1191,104 @@ class EndToEndSpilloverTest(RedpandaTest):
 
         self.logger.info("Restart consumer")
         self.consume()
+
+
+class EndToEndThrottlingTest(RedpandaTest):
+    topics = (TopicSpec(partition_count=8,
+                        cleanup_policy=TopicSpec.CLEANUP_DELETE), )
+
+    def __init__(self, test_context):
+        self.si_settings = SISettings(
+            test_context,
+            log_segment_size=1024,
+            fast_uploads=True,
+            # Set small throughput limit to trigger throttling
+            cloud_storage_max_download_throughput_per_shard=5 * 1024 * 1024)
+
+        super(EndToEndThrottlingTest,
+              self).__init__(test_context=test_context,
+                             si_settings=self.si_settings)
+
+        self.rpk = RpkTool(self.redpanda)
+        # 1.3GiB
+        self.msg_size = 1024 * 128
+        self.msg_count = 10000
+
+    def get_throttling_metric(self):
+        return self.redpanda.metric_sum(
+            "vectorized_cloud_storage_read_path_downloads_throttled_sum_total")
+
+    def produce(self):
+        topic_name = self.topics[0].name
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       topic_name,
+                                       msg_size=self.msg_size,
+                                       msg_count=self.msg_count)
+
+        producer.start()
+        producer.wait()
+        producer.free()
+
+        wait_until(self._all_uploads_done, timeout_sec=180, backoff_sec=10)
+
+    def _all_uploads_done(self):
+        return all_uploads_done(self.rpk, self.topic, self.redpanda,
+                                self.logger)
+
+    def consume(self):
+        topic_name = self.topics[0].name
+        consumer = KgoVerifierSeqConsumer(self.test_context,
+                                          self.redpanda,
+                                          topic_name,
+                                          msg_size=self.msg_size,
+                                          debug_logs=True,
+                                          trace_logs=True)
+        consumer.start()
+
+        consumer.wait(timeout_sec=300)
+
+        assert consumer.consumer_status.validator.invalid_reads == 0
+        assert consumer.consumer_status.validator.valid_reads >= self.msg_count
+
+        consumer.free()
+
+    @cluster(num_nodes=4)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_throttling(self, cloud_storage_type):
+
+        self.logger.info("Start producer")
+        self.produce()
+
+        self.logger.info("Remove local data")
+
+        rpk = RpkTool(self.redpanda)
+        num_partitions = self.topics[0].partition_count
+        topic_name = self.topics[0].name
+        rpk.alter_topic_config(topic_name, 'retention.local.target.bytes',
+                               0x1000)
+
+        for pix in range(0, num_partitions):
+            wait_for_local_storage_truncate(self.redpanda,
+                                            self.topic,
+                                            target_bytes=0x2000,
+                                            partition_idx=pix,
+                                            timeout_sec=30)
+
+        self.logger.info("Start consumer")
+        self.consume()
+
+        self.logger.info("Stop nodes")
+        for node in self.redpanda.nodes:
+            self.redpanda.stop_node(node, timeout=120)
+
+        self.logger.info("Start nodes")
+        for node in self.redpanda.nodes:
+            self.redpanda.start_node(node, timeout=120)
+
+        self.logger.info("Restart consumer")
+        self.consume()
+
+        times_throttled = self.get_throttling_metric()
+        self.logger.info(f"Consumer was throttled {times_throttled} times")
+        assert times_throttled > 0, f"Expected consumer to be throttled, metric value: {times_throttled}"


### PR DESCRIPTION
Add new configuration parameters `cloud_storage_max_download_throughput_per_shard` and `cloud_storage_throughput_limit_percent` that adds throughput limits for downloads. 

Implement throttled `input_stream` and use it for segment downloads.

The `cloud_storage_max_download_throughput_per_shard` parameter is a hard limit. By default it's set to 1GiB/second per shard. This value is intentionally too large. The parameter is mostly used for testing (it's difficult to setup the throttling using the value expressed in number of percent).

The `cloud_storage_throughput_limit_percent` is a relative throughput limit. The value is expressed as relative to disk speed. The disk speed is provided to redpanda using the `--io-properties-file` parameter. The code fetches the throughput value for the mountpoint which is used for cloud storage cache. The value is used to compute the throughput limit. If the process fails or the value is not available the hard limit is used.

It is possible to disable throttling of tiered-storage completely by setting `cloud_storage_max_download_throughput_per_shard = 0` or `cloud_storage_throughput_limit_percent = 0`. Normally, this shouldn't be done because it allows us to download more data than we can write to disk. This may cause write amplification because some data will be removed from disk before Redpanda will read it. For some deployments it makes sense to set the last parameter to high value (e.g. 100%). This might be the case if the tiered-storage cache is located on a dedicated partition and is the only user of the storage device.

This PR does not include dynamic control of buffering parameters.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* Add per-shard download throughput limit for the tiered-storage