### PR TITLE
rpk: Add URP and leaderless counts to `rpk cluster health`

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_cluster.go
+++ b/src/go/rpk/pkg/adminapi/api_cluster.go
@@ -22,7 +22,9 @@ type ClusterHealthOverview struct {
 	AllNodes                  []int    `json:"all_nodes"`
 	NodesDown                 []int    `json:"nodes_down"`
 	LeaderlessPartitions      []string `json:"leaderless_partitions"`
+	LeaderlessCount           *int     `json:"leaderless_count,omitempty"`
 	UnderReplicatedPartitions []string `json:"under_replicated_partitions"`
+	UnderReplicatedCount      *int     `json:"under_replicated_count,omitempty"`
 }
 
 // PartitionBalancerStatus is the status of the partition auto balancer.

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -79,9 +79,15 @@ func printHealthOverview(hov *adminapi.ClusterHealthOverview) {
 	urp := "Under-replicated partitions:"
 	if hov.LeaderlessCount != nil {
 		lp = fmt.Sprintf("Leaderless partitions (%v):", *hov.LeaderlessCount)
+		if *hov.LeaderlessCount > len(hov.LeaderlessPartitions) {
+			hov.LeaderlessPartitions = append(hov.LeaderlessPartitions, "...truncated")
+		}
 	}
 	if hov.UnderReplicatedCount != nil {
 		urp = fmt.Sprintf("Under-replicated partitions (%v):", *hov.UnderReplicatedCount)
+		if *hov.UnderReplicatedCount > len(hov.UnderReplicatedPartitions) {
+			hov.UnderReplicatedPartitions = append(hov.UnderReplicatedPartitions, "...truncated")
+		}
 	}
 
 	tw := out.NewTable()

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -72,13 +72,25 @@ following conditions are met:
 func printHealthOverview(hov *adminapi.ClusterHealthOverview) {
 	types.Sort(hov)
 	out.Section("CLUSTER HEALTH OVERVIEW")
-	overviewFormat := `Healthy:                     %v
-Unhealthy reasons:           %v
-Controller ID:               %v
-All nodes:                   %v
-Nodes down:                  %v
-Leaderless partitions:       %v
-Under-replicated partitions: %v
-`
-	fmt.Printf(overviewFormat, hov.IsHealthy, hov.UnhealthyReasons, hov.ControllerID, hov.AllNodes, hov.NodesDown, hov.LeaderlessPartitions, hov.UnderReplicatedPartitions)
+
+	// leaderless partitions and under-replicated counts are available starting
+	// v23.3.
+	lp := "Leaderless partitions:"
+	urp := "Under-replicated partitions:"
+	if hov.LeaderlessCount != nil {
+		lp = fmt.Sprintf("Leaderless partitions (%v):", *hov.LeaderlessCount)
+	}
+	if hov.UnderReplicatedCount != nil {
+		urp = fmt.Sprintf("Under-replicated partitions (%v):", *hov.UnderReplicatedCount)
+	}
+
+	tw := out.NewTable()
+	defer tw.Flush()
+	tw.Print("Healthy:", hov.IsHealthy)
+	tw.Print("Unhealthy reasons:", hov.UnhealthyReasons)
+	tw.Print("Controller ID:", hov.ControllerID)
+	tw.Print("All nodes:", hov.AllNodes)
+	tw.Print("Nodes down:", hov.NodesDown)
+	tw.Print(lp, hov.LeaderlessPartitions)
+	tw.Print(urp, hov.UnderReplicatedPartitions)
 }

--- a/src/go/rpk/pkg/out/out.go
+++ b/src/go/rpk/pkg/out/out.go
@@ -201,7 +201,9 @@ func NewTableTo(w io.Writer, headers ...string) *TabWriter {
 		iheaders = append(iheaders, strings.ToUpper(header))
 	}
 	t := NewTabWriterTo(w)
-	t.Print(iheaders...)
+	if len(iheaders) > 0 {
+		t.Print(iheaders...)
+	}
 	return t
 }
 


### PR DESCRIPTION
Introduced in https://github.com/redpanda-data/redpanda/pull/13296

Fixes https://github.com/redpanda-data/redpanda/issues/13399

**Example:**
```
CLUSTER HEALTH OVERVIEW
=======================
Healthy:                          true
Unhealthy reasons:                []
Controller ID:                    1
All nodes:                        [1 2 3]
Nodes down:                       []
Leaderless partitions (0):        []
Under-replicated partitions (0):  []
```

```
CLUSTER HEALTH OVERVIEW
=======================
Healthy:                          false
Unhealthy reasons:                [leaderless_partitions under_replicated_partitions]
Controller ID:                    1
All nodes:                        [1 2 3]
Nodes down:                       []
Leaderless partitions (2):        [foobar/0, foobar/1]
Under-replicated partitions (1):  [kafka/tz/143]

```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements
* `rpk cluster health` now shows the count of under-replicated partitions and leaderless partitions (if any).
