### PR TITLE
Create test using OMB and variable number of partitions

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -1152,7 +1152,6 @@ class HighThroughputTest(RedpandaTest):
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_ht004_minpartomb(self):
-        produce_bps = self.config.ingress_rate_scaled / 2
         validator_overrides = {
             OMBSampleConfigurations.E2E_LATENCY_50PCT:
             [OMBSampleConfigurations.lte(51)],
@@ -1165,14 +1164,16 @@ class HighThroughputTest(RedpandaTest):
             "topics": 1,
             "partitions_per_topic": partitions_per_topic,
             "subscriptions_per_topic": 1,
-            "consumer_per_subscription": 1,
+            "consumer_per_subscription": 3,
             "producers_per_topic": 1,
-            "producer_rate": int(produce_bps / (4 * KiB)),
-            "message_size": 4 * KiB,
-            "payload_file": "payload/payload-4Kb.data",
+            "producer_rate": int(self.config.ingress_rate_scaled / 8),
+            "message_size": 8 * KiB,
             "consumer_backlog_size_GB": 0,
             "test_duration_minutes": 1,
             "warmup_duration_minutes": 1,
+            "use_randomized_payloads": True,
+            "random_bytes_ratio": 0.5,
+            "randomized_payload_pool_size": 100,
         }
 
         benchmark = OpenMessagingBenchmark(

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -48,7 +48,7 @@ def get_tier_name(config):
         if config['config_profile_name'] == "default":
             return CloudTierName(TIER_DEFAULTS[_provider])
         else:
-            return CloudTierName(_provider)
+            return CloudTierName(config['config_profile_name'])
 
 
 class CloudTierName(Enum):

--- a/tests/rptest/services/templates/omb_workload.yaml
+++ b/tests/rptest/services/templates/omb_workload.yaml
@@ -4,7 +4,9 @@ topics: {{topics}}
 partitionsPerTopic: {{partitions_per_topic}}
 {% if message_size is defined %}
 messageSize: {{message_size}}
-payloadFile: {{payload_file}}
+useRandomizedPayloads: {{use_randomized_payloads}}
+randomBytesRatio: {{random_bytes_ratio}}
+randomizedPayloadPoolSize: {{randomized_payload_pool_size}}
 {% else %}
 messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"


### PR DESCRIPTION
Test uses OMB and broker-based numbers of producers/consumers to test latency with min/max number of partitions

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
