### PR TITLE
raft: skip unsuppressing heartbeats if we lose leadership

### DIFF
--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -422,6 +422,7 @@ public:
 
         suppress_heartbeats_guard(suppress_heartbeats_guard&& other) noexcept
           : _parent(other._parent)
+          , _term(other._term)
           , _target(other._target) {
             other._parent = nullptr;
         }
@@ -436,9 +437,11 @@ public:
 
     private:
         consensus* _parent = nullptr;
+        model::term_id _term;
         vnode _target;
     };
 
+    // precondition: is_elected_leader() must be true.
     suppress_heartbeats_guard suppress_heartbeats(vnode);
 
     void update_heartbeat_status(vnode, bool);

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -155,14 +155,17 @@ ss::future<> recovery_stm::do_recover(ss::io_priority_class iopc) {
         co_return;
     }
 
+    if (is_recovery_finished()) {
+        _stop_requested = true;
+        co_return;
+    }
+
     auto flush = should_flush(follower_committed_match_index);
     if (flush == flush_after_append::yes) {
         _recovered_bytes_since_flush = 0;
     }
 
     co_await replicate(std::move(*reader), flush, std::move(read_memory_units));
-
-    meta = get_follower_meta();
 }
 
 flush_after_append

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -146,6 +146,7 @@ void follower_index_metadata::reset() {
     last_sent_seq = follower_req_seq{0};
     last_received_seq = follower_req_seq{0};
     last_successful_received_seq = follower_req_seq{0};
+    suppress_heartbeats_count = 0;
     last_sent_protocol_meta.reset();
 }
 


### PR DESCRIPTION
If we lose leadership while heartbeats are suppressed, `follower_index_metadata` for a follower can get recreated, leading to suppress/unsuppress mismatch. Skip unsuppressing if we have lost leadership.

Fixes https://github.com/redpanda-data/redpanda/issues/13305

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none