### PR TITLE
config: enable locked configuration properties

### DIFF
--- a/src/v/cluster/tests/manual_log_deletion_test.cc
+++ b/src/v/cluster/tests/manual_log_deletion_test.cc
@@ -33,7 +33,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
     manual_deletion_fixture()
       : gr(
         raft::group_id(0), 3, model::cleanup_policy_bitflags::deletion, 1_KiB) {
-        config::shard_local_cfg().log_segment_size_min.set_value(
+        config::shard_local_cfg().log_segment_size_locked_min.set_value(
           std::optional<uint64_t>());
         gr.enable_all();
         auto& members = gr.get_members();
@@ -53,7 +53,7 @@ struct manual_deletion_fixture : public raft_test_fixture {
                 gr.disable_node(id);
             }
         }
-        config::shard_local_cfg().log_segment_size_min.reset();
+        config::shard_local_cfg().log_segment_size_locked_min.reset();
     }
 
     void maybe_init_eviction_stm(model::node_id id) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -39,24 +39,26 @@ configuration::configuration()
      .visibility = visibility::tunable},
     128_MiB,
     {.min = 1_MiB})
-  , log_segment_size_min(
+  , log_segment_size_min(*this, "log_segment_size_min")
+  , log_segment_size_max(*this, "log_segment_size_max")
+  , log_segment_size_locked_min(
       *this,
-      "log_segment_size_min",
-      "Lower bound on topic segment.bytes: lower values will be clamped to "
-      "this limit",
+      "log_segment_size_locked_min",
+      "Lower bound on topic segment.bytes:  reject topics with lower values",
       {.needs_restart = needs_restart::no,
        .example = "16777216",
-       .visibility = visibility::tunable},
-      1_MiB)
-  , log_segment_size_max(
+       .visibility = visibility::user},
+      1_MiB,
+      validate_locked_min<uint64_t>)
+  , log_segment_size_locked_max(
       *this,
-      "log_segment_size_max",
-      "Upper bound on topic segment.bytes: higher values will be clamped to "
-      "this limit",
+      "log_segment_size_locked_max",
+      "Upper bound on topic segment.bytes: reject topics with higher values",
       {.needs_restart = needs_restart::no,
        .example = "268435456",
-       .visibility = visibility::tunable},
-      std::nullopt)
+       .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<uint64_t>)
   , log_segment_size_jitter_percent(
       *this,
       "log_segment_size_jitter_percent",
@@ -92,24 +94,26 @@ configuration::configuration()
        .visibility = visibility::user},
       std::chrono::weeks{2},
       {.min = 60s})
-  , log_segment_ms_min(
+  , log_segment_ms_min(*this, "log_segment_ms_min")
+  , log_segment_ms_max(*this, "log_segment_ms_max")
+  , log_segment_ms_locked_min(
       *this,
-      "log_segment_ms_min",
-      "Lower bound on topic segment.ms: lower values will be clamped to this "
-      "value",
+      "log_segment_ms_locked_min",
+      "Lower bound on topic segment.ms; Reject topics with lower values",
       {.needs_restart = needs_restart::no,
        .example = "60000",
-       .visibility = visibility::tunable},
-      60s)
-  , log_segment_ms_max(
+       .visibility = visibility::user},
+      60s,
+      validate_locked_min<std::chrono::milliseconds>)
+  , log_segment_ms_locked_max(
       *this,
-      "log_segment_ms_max",
-      "Upper bound on topic segment.ms: higher values will be clamped to this "
-      "value",
+      "log_segment_ms_locked_max",
+      "Upper bound on topic segment.ms; Reject topics with higher values",
       {.needs_restart = needs_restart::no,
        .example = "31536000000",
-       .visibility = visibility::tunable},
-      24h * 365)
+       .visibility = visibility::user},
+      24h * 365,
+      validate_locked_max<std::chrono::milliseconds>)
   , rpc_server_listen_backlog(
       *this,
       "rpc_server_listen_backlog",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -762,6 +762,22 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1,
       {.min = 1, .oddeven = odd_even_constraint::odd})
+  , default_topic_replication_locked_min(
+      *this,
+      "default_topic_replications_locked_min",
+      "Lower bound on default replication factor; Reject topics with lower "
+      "values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_min<int16_t>)
+  , default_topic_replication_locked_max(
+      *this,
+      "default_topic_replications_locked_max",
+      "Upper bound on default replication factor; Reject topics with higher "
+      "values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<int16_t>)
   , transaction_coordinator_replication(
       *this, "transaction_coordinator_replication")
   , id_allocator_replication(*this, "id_allocator_replication")
@@ -822,6 +838,22 @@ configuration::configuration()
       "Default number of partitions per topic",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1)
+  , default_topic_partitions_locked_min(
+      *this,
+      "default_topic_partitions_locked_min",
+      "Lower bound on default_topic_partitions; Reject topics with lower "
+      "values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_min<int32_t>)
+  , default_topic_partitions_locked_max(
+      *this,
+      "default_topic_partitions_locked_max",
+      "Upper bound on default_topic_partitions; Reject topics with lower "
+      "values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<int32_t>)
   , disable_batch_cache(
       *this,
       "disable_batch_cache",
@@ -921,6 +953,12 @@ configuration::configuration()
       "Allow topic auto creation",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , auto_create_topics_enabled_locked(
+      *this,
+      "auto_create_topics_enabled_locked",
+      "If set, reject changes to auto_create_topics_enabled",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      auto_create_topics_enabled.bind())
   , enable_pid_file(
       *this,
       "enable_pid_file",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1353,12 +1353,26 @@ configuration::configuration()
       "Default remote read config value for new topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , cloud_storage_enable_remote_read_locked(
+      *this,
+      "cloud_storage_enable_remote_read_locked",
+      "If set, the remote read config value is unmodifiable; Reject topics "
+      "with a different value",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      cloud_storage_enable_remote_read.bind())
   , cloud_storage_enable_remote_write(
       *this,
       "cloud_storage_enable_remote_write",
       "Default remote write value for new topics",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , cloud_storage_enable_remote_write_locked(
+      *this,
+      "cloud_storage_enable_remote_write_locked",
+      "If set, the remote write config value is unmodifiable; Reject topics "
+      "with a different value",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      cloud_storage_enable_remote_write.bind())
   , cloud_storage_access_key(
       *this,
       "cloud_storage_access_key",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -78,6 +78,26 @@ configuration::configuration()
        .visibility = visibility::tunable},
       256_MiB,
       {.min = 1_MiB})
+  , compacted_log_segment_size_locked_min(
+      *this,
+      "compacted_log_segment_size_locked_min",
+      "Lower bound on compacted_log_segment_size; Reject topics with lower "
+      "values",
+      {.needs_restart = needs_restart::no,
+       .example = "268435456",
+       .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_min<uint64_t>)
+  , compacted_log_segment_size_locked_max(
+      *this,
+      "compacted_log_segment_size_locked_max",
+      "Upper bound on compacted_log_segment_size; Reject topics with lower "
+      "values",
+      {.needs_restart = needs_restart::no,
+       .example = "268435456",
+       .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<uint64_t>)
   , readers_cache_eviction_timeout_ms(
       *this,
       "readers_cache_eviction_timeout_ms",
@@ -498,6 +518,13 @@ configuration::configuration()
        .example = "compact,delete",
        .visibility = visibility::user},
       model::cleanup_policy_bitflags::deletion)
+  , log_cleanup_policy_locked(
+      *this,
+      "log_cleanup_policy_locked",
+      "if true, the default topic cleanup policy is unmodifiable; Reject "
+      "topics with different values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      log_cleanup_policy.bind())
   , log_message_timestamp_type(
       *this,
       "log_message_timestamp_type",
@@ -661,6 +688,20 @@ configuration::configuration()
        .visibility = visibility::user,
        .aliases = {"delete_retention_ms"}},
       7 * 24h)
+  , log_retention_ms_locked_min(
+      *this,
+      "delete_retention_ms_locked_min",
+      "Lower bound on delete_retention_ms; Reject topics with lower values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_min<std::chrono::milliseconds>)
+  , log_retention_ms_locked_max(
+      *this,
+      "delete_retention_ms_locked_max",
+      "Upper bound on delete_retention_ms; Reject topics with higher values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<std::chrono::milliseconds>)
   , log_compaction_interval_ms(
       *this,
       "log_compaction_interval_ms",
@@ -680,6 +721,20 @@ configuration::configuration()
       "Default max bytes per partition on disk before triggering a compaction",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
+  , retention_bytes_locked_min(
+      *this,
+      "retention_bytes_locked_min",
+      "Lower bound on retention_bytes; reject topics with lower values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_min<size_t>)
+  , retention_bytes_locked_max(
+      *this,
+      "retention_bytes_locked_max",
+      "Upper bound on retention_bytes; reject topics with higher values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<size_t>)
   , group_topic_partitions(
       *this,
       "group_topic_partitions",
@@ -1738,6 +1793,22 @@ configuration::configuration()
       "write enabled",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
+  , retention_local_target_bytes_default_locked_min(
+      *this,
+      "retention_local_target_bytes_default_locked_min",
+      "Lower bound on retention_local_target_bytes_default; Reject topics with "
+      "lower values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_min<size_t>)
+  , retention_local_target_bytes_default_locked_max(
+      *this,
+      "retention_local_target_bytes_default_locked_max",
+      "Upper bound on retention_local_target_bytes_default; Reject topics with "
+      "higher values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<size_t>)
   , retention_local_target_ms_default(
       *this,
       "retention_local_target_ms_default",
@@ -1745,6 +1816,22 @@ configuration::configuration()
       "write enabled",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       24h)
+  , retention_local_target_ms_default_locked_min(
+      *this,
+      "retention_local_target_ms_default_locked_min",
+      "Lower bound on retention_local_target_ms_default; Reject topics with "
+      "lower values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_min<std::chrono::milliseconds>)
+  , retention_local_target_ms_default_locked_max(
+      *this,
+      "retention_local_target_ms_default_locked_max",
+      "Upper bound on retention_local_target_ms_default; Reject topics with "
+      "higher values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<std::chrono::milliseconds>)
   , retention_local_strict(
       *this,
       "retention_local_strict",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -534,6 +534,13 @@ configuration::configuration()
        .visibility = visibility::user},
       model::timestamp_type::create_time,
       {model::timestamp_type::create_time, model::timestamp_type::append_time})
+  , log_message_timestamp_type_locked(
+      *this,
+      "log_message_timestamp_type_locked",
+      "If true, the default topic messages timestamp type is unmodifiable; "
+      "Reject topics with different values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      log_message_timestamp_type.bind())
   , log_message_timestamp_alert_before_ms(
       *this,
       "log_message_timestamp_alert_before_ms",
@@ -570,6 +577,13 @@ configuration::configuration()
        model::compression::lz4,
        model::compression::zstd,
        model::compression::producer})
+  , log_compression_type_locked(
+      *this,
+      "log_compression_type_locked",
+      "If set, the default topic compression type is unmodifiable; Reject "
+      "topics with a different value",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      log_compression_type.bind())
   , fetch_max_bytes(
       *this,
       "fetch_max_bytes",
@@ -1195,6 +1209,20 @@ configuration::configuration()
       "limit applies to compressed batch size",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_MiB)
+  , kafka_batch_max_bytes_locked_min(
+      *this,
+      "kafka_batch_max_bytes_locked_min",
+      "Lower bound on kafka_batch_max_bytes; Reject topics with lower values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_min<uint32_t>)
+  , kafka_batch_max_bytes_locked_max(
+      *this,
+      "kafka_batch_max_bytes_locked_max",
+      "Upper bound on kafka_batch_max_bytes; Reject topics with higher values",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      validate_locked_max<uint32_t>)
   , kafka_nodelete_topics(
       *this,
       "kafka_nodelete_topics",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -270,7 +270,9 @@ struct configuration final : public config_store {
     // Archival storage
     property<bool> cloud_storage_enabled;
     property<bool> cloud_storage_enable_remote_read;
+    locked_equal_property<bool> cloud_storage_enable_remote_read_locked;
     property<bool> cloud_storage_enable_remote_write;
+    locked_equal_property<bool> cloud_storage_enable_remote_write_locked;
     property<std::optional<ss::sstring>> cloud_storage_access_key;
     property<std::optional<ss::sstring>> cloud_storage_secret_key;
     property<std::optional<ss::sstring>> cloud_storage_region;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -52,6 +52,8 @@ struct configuration final : public config_store {
     locked_range_property<uint64_t> log_segment_size_locked_max;
     bounded_property<uint16_t> log_segment_size_jitter_percent;
     bounded_property<uint64_t> compacted_log_segment_size;
+    locked_range_property<uint64_t> compacted_log_segment_size_locked_min;
+    locked_range_property<uint64_t> compacted_log_segment_size_locked_max;
     property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;
     bounded_property<std::optional<std::chrono::milliseconds>> log_segment_ms;
     deprecated_property log_segment_ms_min;
@@ -129,6 +131,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
     property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;
     property<model::cleanup_policy_bitflags> log_cleanup_policy;
+    locked_equal_property<model::cleanup_policy_bitflags>
+      log_cleanup_policy_locked;
     enum_property<model::timestamp_type> log_message_timestamp_type;
     bounded_property<std::optional<std::chrono::milliseconds>>
       log_message_timestamp_alert_before_ms;
@@ -152,10 +156,16 @@ struct configuration final : public config_store {
     property<uint32_t> abort_index_segment_size;
     // same as log.retention.ms in kafka
     retention_duration_property log_retention_ms;
+    locked_range_property<std::chrono::milliseconds>
+      log_retention_ms_locked_min;
+    locked_range_property<std::chrono::milliseconds>
+      log_retention_ms_locked_max;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
     property<bool> log_disable_housekeeping_for_tests;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
+    locked_range_property<size_t> retention_bytes_locked_min;
+    locked_range_property<size_t> retention_bytes_locked_max;
     property<int32_t> group_topic_partitions;
     bounded_property<int16_t> default_topic_replication;
     deprecated_property transaction_coordinator_replication;
@@ -342,7 +352,15 @@ struct configuration final : public config_store {
     // Defaults for local retention for partitions of topics with
     // cloud storage read and write enabled
     property<std::optional<size_t>> retention_local_target_bytes_default;
+    locked_range_property<size_t>
+      retention_local_target_bytes_default_locked_min;
+    locked_range_property<size_t>
+      retention_local_target_bytes_default_locked_max;
     property<std::chrono::milliseconds> retention_local_target_ms_default;
+    locked_range_property<std::chrono::milliseconds>
+      retention_local_target_ms_default_locked_min;
+    locked_range_property<std::chrono::milliseconds>
+      retention_local_target_ms_default_locked_max;
     property<bool> retention_local_strict;
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
     bounded_property<std::optional<double>, numeric_bounds>

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -46,14 +46,18 @@ namespace config {
 struct configuration final : public config_store {
     // WAL
     bounded_property<uint64_t> log_segment_size;
-    property<std::optional<uint64_t>> log_segment_size_min;
-    property<std::optional<uint64_t>> log_segment_size_max;
+    deprecated_property log_segment_size_min;
+    deprecated_property log_segment_size_max;
+    locked_range_property<uint64_t> log_segment_size_locked_min;
+    locked_range_property<uint64_t> log_segment_size_locked_max;
     bounded_property<uint16_t> log_segment_size_jitter_percent;
     bounded_property<uint64_t> compacted_log_segment_size;
     property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;
     bounded_property<std::optional<std::chrono::milliseconds>> log_segment_ms;
-    property<std::chrono::milliseconds> log_segment_ms_min;
-    property<std::chrono::milliseconds> log_segment_ms_max;
+    deprecated_property log_segment_ms_min;
+    deprecated_property log_segment_ms_max;
+    locked_range_property<std::chrono::milliseconds> log_segment_ms_locked_min;
+    locked_range_property<std::chrono::milliseconds> log_segment_ms_locked_max;
 
     // Network
     bounded_property<std::optional<int>> rpc_server_listen_backlog;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -134,11 +134,14 @@ struct configuration final : public config_store {
     locked_equal_property<model::cleanup_policy_bitflags>
       log_cleanup_policy_locked;
     enum_property<model::timestamp_type> log_message_timestamp_type;
+    locked_equal_property<model::timestamp_type>
+      log_message_timestamp_type_locked;
     bounded_property<std::optional<std::chrono::milliseconds>>
       log_message_timestamp_alert_before_ms;
     bounded_property<std::chrono::milliseconds>
       log_message_timestamp_alert_after_ms;
     enum_property<model::compression> log_compression_type;
+    locked_equal_property<model::compression> log_compression_type_locked;
     property<size_t> fetch_max_bytes;
     property<bool> use_fetch_scheduler_group;
     property<std::chrono::milliseconds> metadata_status_wait_timeout_ms;
@@ -243,6 +246,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> node_management_operation_timeout_ms;
     property<uint32_t> kafka_request_max_bytes;
     property<uint32_t> kafka_batch_max_bytes;
+    locked_range_property<uint32_t> kafka_batch_max_bytes_locked_min;
+    locked_range_property<uint32_t> kafka_batch_max_bytes_locked_max;
     property<std::vector<ss::sstring>> kafka_nodelete_topics;
     property<std::vector<ss::sstring>> kafka_noproduce_topics;
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -171,6 +171,8 @@ struct configuration final : public config_store {
     locked_range_property<size_t> retention_bytes_locked_max;
     property<int32_t> group_topic_partitions;
     bounded_property<int16_t> default_topic_replication;
+    locked_range_property<int16_t> default_topic_replication_locked_min;
+    locked_range_property<int16_t> default_topic_replication_locked_max;
     deprecated_property transaction_coordinator_replication;
     deprecated_property id_allocator_replication;
     property<int32_t> transaction_coordinator_partitions;
@@ -185,6 +187,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> create_topic_timeout_ms;
     property<std::chrono::milliseconds> wait_for_leader_timeout_ms;
     property<int32_t> default_topic_partitions;
+    locked_range_property<int32_t> default_topic_partitions_locked_min;
+    locked_range_property<int32_t> default_topic_partitions_locked_max;
     property<bool> disable_batch_cache;
     property<std::chrono::milliseconds> raft_election_timeout_ms;
     property<std::chrono::milliseconds> kafka_group_recovery_timeout_ms;
@@ -202,6 +206,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> reclaim_stable_window;
     property<size_t> reclaim_batch_cache_min_free;
     property<bool> auto_create_topics_enabled;
+    locked_equal_property<bool> auto_create_topics_enabled_locked;
     property<bool> enable_pid_file;
     property<std::chrono::milliseconds> kvstore_flush_interval;
     property<size_t> kvstore_max_segment_size;

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -10,7 +10,8 @@ set(srcs
     seed_server_property_test.cc
     cloud_credentials_source_test.cc
     validator_tests.cc
-    throughput_control_group_test.cc)
+    throughput_control_group_test.cc
+    locked_configs_test.cc)
 
 rp_test(
   UNIT_TEST

--- a/src/v/config/tests/locked_configs_test.cc
+++ b/src/v/config/tests/locked_configs_test.cc
@@ -1,0 +1,182 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/config_store.h"
+#include "config/property.h"
+#include "config/validators.h"
+#include "model/fundamental.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <chrono>
+#include <limits>
+#include <optional>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr static int32_t LOCKED_MIN = 2048;
+constexpr static int32_t LOCKED_MAX = 4096;
+constexpr static std::chrono::milliseconds LOCKED_MIN_MS = 1s;
+constexpr static std::chrono::milliseconds LOCKED_MAX_MS = 5s;
+
+template<typename T>
+struct test_locked_equal_property : public config::locked_equal_property<T> {
+    // Overloads a protected constructor so the lock is automatically set
+    test_locked_equal_property(
+      config::config_store& conf,
+      std::string_view name,
+      std::string_view desc,
+      config::base_property::metadata meta,
+      config::binding<T> original_config)
+      : config::locked_equal_property<T>(
+        conf, name, desc, meta, std::move(original_config), true) {}
+};
+
+struct test_config : public config::config_store {
+    config::locked_range_property<int32_t> locked_min_int;
+    config::locked_range_property<int32_t> locked_max_int;
+    config::locked_range_property<std::chrono::milliseconds> locked_min_ms;
+    config::locked_range_property<std::chrono::milliseconds> locked_max_ms;
+    config::property<model::cleanup_policy_bitflags> original_enum;
+    test_locked_equal_property<model::cleanup_policy_bitflags> locked_enum;
+    config::property<ss::sstring> original_str;
+    test_locked_equal_property<ss::sstring> locked_str;
+
+    test_config()
+      : locked_min_int(
+        *this,
+        "locked_min_int",
+        "A locked integral property with lower bound",
+        {},
+        LOCKED_MIN,
+        config::validate_locked_min<int32_t>)
+      , locked_max_int(
+          *this,
+          "locked_max_int",
+          "A locked integral property with upper bound",
+          {},
+          LOCKED_MAX,
+          config::validate_locked_max<int32_t>)
+      , locked_min_ms(
+          *this,
+          "locked_min_ms",
+          "A locked milliseconds property with lower bound",
+          {},
+          LOCKED_MIN_MS,
+          config::validate_locked_min<std::chrono::milliseconds>)
+      , locked_max_ms(
+          *this,
+          "locked_max_ms",
+          "A locked milliseconds property with upper bound",
+          {},
+          LOCKED_MAX_MS,
+          config::validate_locked_max<std::chrono::milliseconds>)
+      , original_enum(
+          *this,
+          "original_enum",
+          "An enumertaion property",
+          {.needs_restart = config::needs_restart::no},
+          model::cleanup_policy_bitflags::deletion)
+      , locked_enum(
+          *this,
+          "locked_enum",
+          "A locked enumertaion property",
+          {},
+          original_enum.bind())
+      , original_str(
+          *this,
+          "original_str",
+          "A string property",
+          {.needs_restart = config::needs_restart::no},
+          ss::sstring("panda"))
+      , locked_str(
+          *this,
+          "locked_str",
+          "A locked string property",
+          {},
+          original_str.bind()) {}
+};
+
+SEASTAR_THREAD_TEST_CASE(locked_integral_properties) {
+    auto cfg = test_config();
+
+    std::vector<int32_t> valid_values = {LOCKED_MIN + 1, LOCKED_MAX - 1};
+    std::vector<int32_t> invalid_min_values = {
+      LOCKED_MIN - 1, -1, 0, std::numeric_limits<int32_t>::min()};
+    std::vector<int32_t> invalid_max_values = {
+      LOCKED_MAX + 1, std::numeric_limits<int32_t>::max()};
+
+    bool satisfied = false;
+
+    for (const auto& v : valid_values) {
+        satisfied = cfg.locked_min_int.validate_lock(v);
+        BOOST_CHECK(satisfied);
+
+        satisfied = cfg.locked_max_int.validate_lock(v);
+        BOOST_CHECK(satisfied);
+    }
+
+    for (const auto& v : invalid_min_values) {
+        satisfied = cfg.locked_min_int.validate_lock(v);
+        BOOST_CHECK(!satisfied);
+    }
+
+    for (const auto& v : invalid_max_values) {
+        satisfied = cfg.locked_max_int.validate_lock(v);
+        BOOST_CHECK(!satisfied);
+    }
+
+    std::vector<std::chrono::milliseconds> valid_ms_values = {
+      LOCKED_MIN_MS + 1ms, LOCKED_MAX_MS - 1ms};
+    std::vector<std::chrono::milliseconds> invalid_min_ms_values = {
+      LOCKED_MIN_MS - 1ms, 0ms, -1ms};
+
+    for (const auto& v : valid_ms_values) {
+        satisfied = cfg.locked_min_ms.validate_lock(v);
+        BOOST_CHECK(satisfied);
+
+        satisfied = cfg.locked_max_ms.validate_lock(v);
+        BOOST_CHECK(satisfied);
+    }
+
+    for (const auto& v : invalid_min_ms_values) {
+        satisfied = cfg.locked_min_ms.validate_lock(v);
+        BOOST_CHECK(!satisfied);
+    }
+
+    std::chrono::milliseconds invalid_max_ms_value = LOCKED_MAX_MS + 1ms;
+    satisfied = cfg.locked_max_ms.validate_lock(invalid_max_ms_value);
+    BOOST_CHECK(!satisfied);
+}
+
+SEASTAR_THREAD_TEST_CASE(locked_nonintegral_properties) {
+    auto cfg = test_config();
+
+    bool satisfied = false;
+
+    // Valid test
+    satisfied = cfg.locked_enum.validate_lock(cfg.original_enum.value());
+    BOOST_CHECK(satisfied);
+
+    satisfied = cfg.locked_str.validate_lock(cfg.original_str.value());
+    BOOST_CHECK(satisfied);
+
+    // Invalid test
+    satisfied = cfg.locked_enum.validate_lock(
+      model::cleanup_policy_bitflags::compaction);
+    BOOST_CHECK(!satisfied);
+
+    ss::sstring str("red");
+    satisfied = cfg.locked_str.validate_lock(str);
+    BOOST_CHECK(!satisfied);
+}
+
+} // namespace

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -41,4 +41,22 @@ validate_non_empty_string_vec(const std::vector<ss::sstring>&);
 std::optional<ss::sstring>
 validate_non_empty_string_opt(const std::optional<ss::sstring>&);
 
+template<typename T>
+bool validate_locked_min(const std::optional<T>& locked_min, const T& value) {
+    if (locked_min) {
+        return value > *locked_min;
+    } else {
+        return true;
+    }
+}
+
+template<typename T>
+bool validate_locked_max(const std::optional<T>& locked_max, const T& value) {
+    if (locked_max) {
+        return value < *locked_max;
+    } else {
+        return true;
+    }
+}
+
 }; // namespace config

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -244,11 +244,12 @@ struct noop_validator {
 struct segment_size_validator {
     std::optional<ss::sstring> operator()(const size_t& value) {
         // use reasonable defaults even if they are not set in configuration
-        size_t min
-          = config::shard_local_cfg().log_segment_size_min.value().value_or(1);
-        size_t max
-          = config::shard_local_cfg().log_segment_size_max.value().value_or(
-            std::numeric_limits<size_t>::max());
+        size_t min = config::shard_local_cfg()
+                       .log_segment_size_locked_min.value()
+                       .value_or(1);
+        size_t max = config::shard_local_cfg()
+                       .log_segment_size_locked_max.value()
+                       .value_or(std::numeric_limits<size_t>::max());
 
         if (value < min || value > max) {
             return fmt::format(

--- a/src/v/storage/tests/storage_e2e_fixture_test.cc
+++ b/src/v/storage/tests/storage_e2e_fixture_test.cc
@@ -45,8 +45,10 @@ ss::future<> produce_to_fixture(
 } // namespace
 
 FIXTURE_TEST(test_compaction_segment_ms, storage_e2e_fixture) {
-    test_local_cfg.get("log_segment_ms_min")
-      .set_value(std::chrono::duration_cast<std::chrono::milliseconds>(1ms));
+    auto segment_lifetime_min
+      = std::chrono::duration_cast<std::chrono::milliseconds>(1ms);
+    test_local_cfg.get("log_segment_ms_locked_min")
+      .set_value(std::make_optional(segment_lifetime_min));
     const auto topic_name = model::topic("tapioca");
     const auto ntp = model::ntp(model::kafka_namespace, topic_name, 0);
 

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -1298,9 +1298,9 @@ FIXTURE_TEST(check_max_segment_size_limits, storage_test_fixture) {
     // Apply limits to the effective segment size: we may configure
     // something different per-topic, but at runtime the effective
     // segment size will be clamped to this range.
-    config::shard_local_cfg().log_segment_size_min.set_value(
+    config::shard_local_cfg().log_segment_size_locked_min.set_value(
       std::make_optional(50_KiB));
-    config::shard_local_cfg().log_segment_size_max.set_value(
+    config::shard_local_cfg().log_segment_size_locked_max.set_value(
       std::make_optional(200_KiB));
 
     std::exception_ptr ex;
@@ -1351,8 +1351,8 @@ FIXTURE_TEST(check_max_segment_size_limits, storage_test_fixture) {
         ex = std::current_exception();
     }
 
-    config::shard_local_cfg().log_segment_size_min.reset();
-    config::shard_local_cfg().log_segment_size_max.reset();
+    config::shard_local_cfg().log_segment_size_locked_min.reset();
+    config::shard_local_cfg().log_segment_size_locked_max.reset();
 
     if (ex) {
         throw ex;

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -206,7 +206,7 @@ public:
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg().get("disable_metrics").set_value(true);
             config::shard_local_cfg()
-              .get("log_segment_size_min")
+              .get("log_segment_size_locked_min")
               .set_value(std::optional<uint64_t>{});
         }).get0();
         feature_table.start().get();
@@ -223,7 +223,9 @@ public:
         feature_table.stop().get();
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg().get("disable_metrics").reset();
-            config::shard_local_cfg().get("log_segment_size_min").reset();
+            config::shard_local_cfg()
+              .get("log_segment_size_locked_min")
+              .reset();
         }).get();
     }
 

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -301,7 +301,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 # cloud segments as possible. To that end, bounding the segment
                 # size isn't productive.
                 'cloud_storage_segment_size_min': 1,
-                'log_segment_size_min': 1024,
+                'log_segment_size_locked_min': 1024,
 
                 # Disable segment merging: when we create many small segments
                 # to pad out tiered storage metadata, we don't want them to

--- a/tests/rptest/tests/alter_topic_configuration_test.py
+++ b/tests/rptest/tests/alter_topic_configuration_test.py
@@ -142,7 +142,7 @@ class AlterTopicConfiguration(RedpandaTest):
         topic = self.topics[0].name
         kafka_tools = KafkaCliTools(self.redpanda)
         initial_spec = kafka_tools.describe_topic(topic)
-        self.redpanda.set_cluster_config({"log_segment_size_min": 1024})
+        self.redpanda.set_cluster_config({"log_segment_size_locked_min": 1024})
         try:
             self.client().alter_topic_configs(
                 topic, {TopicSpec.PROPERTY_SEGMENT_SIZE: 16})
@@ -154,7 +154,8 @@ class AlterTopicConfiguration(RedpandaTest):
         ).segment_bytes, "segment.bytes shouldn't be changed to invalid value"
 
         # change min segment bytes redpanda property
-        self.redpanda.set_cluster_config({"log_segment_size_min": 1024 * 1024})
+        self.redpanda.set_cluster_config(
+            {"log_segment_size_locked_min": 1024 * 1024})
         # try setting value that is smaller than requested min
         try:
             self.client().alter_topic_configs(
@@ -172,7 +173,7 @@ class AlterTopicConfiguration(RedpandaTest):
             topic).segment_bytes == valid_segment_size
 
         self.redpanda.set_cluster_config(
-            {"log_segment_size_max": 10 * 1024 * 1024})
+            {"log_segment_size_locked_max": 10 * 1024 * 1024})
         # try to set value greater than max allowed segment size
         try:
             self.client().alter_topic_configs(

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -878,7 +878,7 @@ class ShadowIndexingManyPartitionsTest(PreallocNodesTest):
                 # Avoid segment merging so we can generate many segments
                 # quickly.
                 "cloud_storage_enable_segment_merging": False,
-                'log_segment_size_min': 1024,
+                'log_segment_size_locked_min': 1024,
                 'cloud_storage_cache_chunk_size': self.chunk_size,
             },
             environment={'__REDPANDA_TOPIC_REC_DL_CHECK_MILLIS': 5000},

--- a/tests/rptest/tests/log_segment_ms_test.py
+++ b/tests/rptest/tests/log_segment_ms_test.py
@@ -153,8 +153,8 @@ class SegmentMsTest(RedpandaTest):
             use_alter_cfg,
             num_messages,
             extra_cluster_cfg={
-                'log_segment_ms_min': TEST_LOG_SEGMENT_MIN,
-                'log_segment_ms_max': TEST_LOG_SEGMENT_MAX
+                'log_segment_ms_locked_min': TEST_LOG_SEGMENT_MIN,
+                'log_segment_ms_locked_max': TEST_LOG_SEGMENT_MAX
             })
         assert abs((stop_count - start_count) - TEST_NUM_SEGMENTS) <= ERROR_MARGIN, \
                                        f"{stop_count=}-{start_count=} != {TEST_NUM_SEGMENTS=} +-{ERROR_MARGIN=}"
@@ -204,7 +204,7 @@ class SegmentMsTest(RedpandaTest):
     def test_segment_rolling_with_retention(self):
         self.redpanda.set_cluster_config({
             "log_segment_ms": None,
-            "log_segment_ms_min": 10000
+            "log_segment_ms_locked_min": 10000
         })
         topic = TopicSpec(segment_bytes=(1024 * 1024),
                           replication_factor=1,
@@ -275,7 +275,7 @@ class SegmentMsTest(RedpandaTest):
     def test_segment_rolling_with_retention_consumer(self):
         self.redpanda.set_cluster_config({
             "log_segment_ms": None,
-            "log_segment_ms_min": 10000
+            "log_segment_ms_locked_min": 10000
         })
         topic = TopicSpec(segment_bytes=(1024 * 1024),
                           replication_factor=1,

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -307,7 +307,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
             # staying in one place.
             'enable_leader_balancer':
             False,
-            'log_segment_size_min':
+            'log_segment_size_locked_min':
             32 * 1024,
             'cloud_storage_cache_chunk_size':
             self.chunk_size


### PR DESCRIPTION
Enable users to lock a cluster-level property to a value. This patch adds locked properties to a sub-set of cluster-level configs. Specifically, those that are settable via the Kafka CreateTopics API and/or reported by the DescribeConfigs API. This patch also deprecates some configs for the storage sub-system, `log_segment_size_min/max` and `log_segment_ms_min/max`.

Fixes: https://github.com/redpanda-data/redpanda/issues/13571

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
