### PR TITLE
rpk: misc improvements

### DIFF
--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -396,6 +396,15 @@ var xflags = map[string]xflag{
 		},
 	},
 
+	"globals.command_timeout": {
+		"globals.command_timeout",
+		"30s",
+		xkindGlobal,
+		func(v string, y *RpkYaml) error {
+			return y.Globals.CommandTimeout.UnmarshalText([]byte(v))
+		},
+	},
+
 	"globals.dial_timeout": {
 		"globals.dial_timeout",
 		"3s",
@@ -654,6 +663,10 @@ globals.no_default_cluster=false
   A boolean that disables rpk from talking to localhost:9092 if no other
   cluster is specified.
 
+globals.command_timeout=30s
+  A duration that rpk will wait for a command to complete before timing out,
+  for certain commands.
+
 globals.dial_timeout=3s
   A duration that rpk will wait for a connection to be established before
   timing out.
@@ -710,6 +723,7 @@ cloud.client_id=somestring
 cloud.client_secret=somelongerstring
 globals.prompt="%n"
 globals.no_default_cluster=boolean
+globals.command_timeout=(30s,1m)
 globals.dial_timeout=duration(3s,1m,2h)
 globals.request_timeout_overhead=duration(10s,1m,2h)
 globals.retry_timeout=duration(30s,1m,2h)

--- a/src/go/rpk/pkg/config/rpk_yaml.go
+++ b/src/go/rpk/pkg/config/rpk_yaml.go
@@ -103,6 +103,10 @@ type (
 		// profile when no other is selected.
 		NoDefaultCluster bool `json:"no_default_cluster" yaml:"no_default_cluster"`
 
+		// CommandTimeout is how long to allow commands to run, for
+		// certain potentially-slow commands.
+		CommandTimeout Duration `json:"command_timeout" yaml:"command_timeout"`
+
 		// DialTimeout is how long we allow for initiating a connection
 		// to brokers for the Admin API and Kafka API.
 		DialTimeout Duration `json:"dial_timeout" yaml:"dial_timeout"`
@@ -341,3 +345,15 @@ func (d *Duration) UnmarshalText(text []byte) error {
 }
 
 func (*Duration) YamlTypeNameForTest() string { return "duration" }
+
+/////////////////////
+// GLOBALS GETTERS //
+/////////////////////
+
+// GetCommandTimeout returns the command timeout, or 10s if none is set.
+func (g *RpkGlobals) GetCommandTimeout() time.Duration {
+	if g.CommandTimeout.Duration == 0 {
+		return 10 * time.Second
+	}
+	return g.CommandTimeout.Duration
+}

--- a/src/go/rpk/pkg/config/rpk_yaml_test.go
+++ b/src/go/rpk/pkg/config/rpk_yaml_test.go
@@ -25,7 +25,7 @@ func TestRpkYamlVersion(t *testing.T) {
 	shastr := hex.EncodeToString(sha[:])
 
 	const (
-		v1sha = "0f2a75ecffb99a005778d4d6bf6227f3cf5500dcf35d5fdde39db09564a9e7a4" // 23-08-11
+		v1sha = "ea2f0078e624de8ac29416cf9449bb72938f86028d4663d5de8bd23fe0be275f" // 23-08-11
 	)
 
 	if shastr != v1sha {

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -670,10 +670,11 @@ func (nsa *NamedAuthNSocketAddress) UnmarshalYAML(n *yaml.Node) error {
 
 func (t *TLS) UnmarshalYAML(n *yaml.Node) error {
 	var internal struct {
-		KeyFile        weakString `yaml:"key_file"`
-		CertFile       weakString `yaml:"cert_file"`
-		CAFile         weakString `yaml:"ca_file"`
-		TruststoreFile weakString `yaml:"truststore_file"` // BACKCOMPAT 23-05-01 we deserialize truststore_file into ca_file
+		KeyFile            weakString `yaml:"key_file"`
+		CertFile           weakString `yaml:"cert_file"`
+		CAFile             weakString `yaml:"ca_file"`
+		InsecureSkipVerify bool       `yaml:"insecure_skip_verify"`
+		TruststoreFile     weakString `yaml:"truststore_file"` // BACKCOMPAT 23-05-01 we deserialize truststore_file into ca_file
 	}
 
 	if err := n.Decode(&internal); err != nil {
@@ -682,6 +683,7 @@ func (t *TLS) UnmarshalYAML(n *yaml.Node) error {
 	t.KeyFile = string(internal.KeyFile)
 	t.CertFile = string(internal.CertFile)
 	t.TruststoreFile = string(internal.TruststoreFile)
+	t.InsecureSkipVerify = internal.InsecureSkipVerify
 	if internal.CAFile != "" {
 		t.TruststoreFile = string(internal.CAFile)
 	}

--- a/src/go/rpk/pkg/kafka/client_franz.go
+++ b/src/go/rpk/pkg/kafka/client_franz.go
@@ -27,6 +27,7 @@ import (
 	"github.com/twmb/franz-go/pkg/kgo"
 	"github.com/twmb/franz-go/pkg/kmsg"
 	koauth "github.com/twmb/franz-go/pkg/sasl/oauth"
+	"github.com/twmb/franz-go/pkg/sasl/plain"
 	"github.com/twmb/franz-go/pkg/sasl/scram"
 	"github.com/twmb/franz-go/plugin/kzap"
 )
@@ -129,8 +130,13 @@ func NewFranzClient(fs afero.Fs, p *config.RpkProfile, extraOpts ...kgo.Opt) (*k
 				opts = append(opts, kgo.SASL(a.AsSha256Mechanism()))
 			case "SCRAM-SHA-512":
 				opts = append(opts, kgo.SASL(a.AsSha512Mechanism()))
+			case "PLAIN":
+				opts = append(opts, kgo.SASL((&plain.Auth{
+					User: k.SASL.User,
+					Pass: k.SASL.Password,
+				}).AsMechanism()))
 			default:
-				return nil, fmt.Errorf("unknown SASL mechanism %q, supported: [SCRAM-SHA-256, SCRAM-SHA-512]", name)
+				return nil, fmt.Errorf("unknown SASL mechanism %q, supported: [SCRAM-SHA-256, SCRAM-SHA-512, PLAIN]", name)
 			}
 		}
 	}


### PR DESCRIPTION

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* `rpk` now supports `insecure_skip_verify` when talking to tls endpoints
* `rpk` now supports `globals.command_timeout` to control total command timeout for certain commands