### PR TITLE
cloud_storage_clients/s3: handle HEAD slow downs

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -384,6 +384,10 @@ ss::future<ResultT> parse_head_error_response(
         if (hdr.result() == boost::beast::http::status::not_found) {
             code = "NoSuchKey";
             msg = "Not found";
+        } else if (
+          hdr.result() == boost::beast::http::status::service_unavailable) {
+            code = "SlowDown";
+            msg = ss::sstring(hdr.reason().data(), hdr.reason().size());
         } else {
             code = "Unknown";
             msg = ss::sstring(hdr.reason().data(), hdr.reason().size());


### PR DESCRIPTION
S3 may return a 503 Service Unavailable response to HeadObject requests in order to signal the client to back off. Previously, this wasn't handled and resulted to an error log being printed each time such a response was received for a HeadObject request.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Bug Fixes
* Fix handling of slow down responses for HeadObject requests
