### PR TITLE
tests: increase rpk timeout in partition balancer maintenance test

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -48,15 +48,15 @@ class RpkException(Exception):
 
     def __str__(self):
         if self.stderr:
-            err = f" error: {self.stderr}"
+            err = f"; stderr: {self.stderr}"
         else:
             err = ""
         if self.returncode:
-            retcode = f" returncode: {self.returncode}"
+            retcode = f"; returncode: {self.returncode}"
         else:
             retcode = ""
         if self.stdout:
-            stdout = f" stdout: {self.stdout}"
+            stdout = f"; stdout: {self.stdout}"
         else:
             stdout = ""
         return f"RpkException<{self.msg}{err}{stdout}{retcode}>"
@@ -921,9 +921,9 @@ class RpkTool:
         except subprocess.TimeoutExpired:
             p.kill()
             output, stderr = p.communicate()
-            raise RpkException(
-                f"command {' '.join(cmd)} timed out, output: {output} \n error: {stderr}",
-                stderr, None, output)
+            raise RpkException(f"command `{' '.join(cmd)}' timed out",
+                               stdout=output,
+                               stderr=stderr)
 
         self._redpanda.logger.debug(f'\n{output}')
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -959,7 +959,7 @@ class RpkTool:
             cmd.append("--wait")
         return self._execute(cmd)
 
-    def cluster_maintenance_disable(self, node):
+    def cluster_maintenance_disable(self, node, timeout=None):
         node_id = self._redpanda.node_id(node) if isinstance(
             node, ClusterNode) else node
         cmd = [
@@ -967,7 +967,7 @@ class RpkTool:
             self._admin_host(), "cluster", "maintenance", "disable",
             str(node_id)
         ]
-        return self._execute(cmd)
+        return self._execute(cmd, timeout=timeout)
 
     def cluster_maintenance_status(self):
         """

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -807,8 +807,11 @@ class PartitionBalancerTest(PartitionBalancerService):
                        timeout_sec=120,
                        backoff_sec=10)
 
-            # return back to normal
-            rpk.cluster_maintenance_disable(node)
+            # return back to normal.
+            # rpk will make 3 admin requests with 10 second timeout, so with 1 problematic node,
+            # worst case it will hang for 30 seconds, which also happens to be the default RpkTool
+            # timeout. Therefore we need a larger timeout than that.
+            rpk.cluster_maintenance_disable(node, timeout=35)
             # use raw admin interface to avoid waiting for the killed node
             admin.patch_cluster_config(
                 {"raft_learner_recovery_rate": 100_000_000})


### PR DESCRIPTION
Rpk will make 3 admin requests with 10 second timeout, so with 1 problematic node, worst case it will hang for 30 seconds, which also happens to be the default RpkTool timeout. Therefore we need a larger timeout than that.

Fixes https://github.com/redpanda-data/redpanda/issues/10848

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes
* none