### PR TITLE
cloud_storage: scrub segment metadata

### DIFF
--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -67,7 +67,7 @@ scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
           .remaining = quota};
     }
 
-    vlog(_logger.debug, "Starting scrub ...");
+    vlog(_logger.info, "Starting scrub ...");
 
     // TODO: make the timeout dynamic
     retry_chain_node anomaly_detection_rtc(1min, 100ms, &rtc_node);
@@ -95,7 +95,7 @@ scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
 
     if (detect_result.status == cloud_storage::scrub_status::failed) {
         vlog(
-          _logger.debug,
+          _logger.info,
           "Scrub failed after {} operations. Will retry ...",
           detect_result.ops);
         co_return run_result{
@@ -112,10 +112,11 @@ scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
     }
 
     vlog(
-      _logger.debug,
+      _logger.info,
       "Scrub finished with status {} and detected {}",
       detect_result.status,
       detect_result.detected);
+
     auto replicate_result = co_await _archiver.process_anomalies(
       model::timestamp::now(),
       detect_result.status,

--- a/src/v/cloud_storage/anomalies_detector.h
+++ b/src/v/cloud_storage/anomalies_detector.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/fwd.h"
+#include "cloud_storage/spillover_manifest.h"
 #include "cloud_storage/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -52,13 +53,13 @@ public:
 
     ss::future<result> run(retry_chain_node&);
 
-    ss::future<anomalies_detector::result> download_and_check_spill_manifest(
+private:
+    ss::future<std::optional<spillover_manifest>> download_spill_manifest(
       const ss::sstring& path, retry_chain_node& rtc_node);
 
     ss::future<anomalies_detector::result> check_manifest(
       const partition_manifest& manifest, retry_chain_node& rtc_node);
 
-private:
     cloud_storage_clients::bucket_name _bucket;
     model::ntp _ntp;
     model::initial_revision_id _initial_rev;

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2574,11 +2574,20 @@ void partition_manifest::process_anomalies(
                == _spillover_manifests.end();
     });
 
+    // TODO: check if the offset range is covered by some other segment
     auto first_kafka_offset = full_log_start_kafka_offset();
     auto& missing_segs = _detected_anomalies.missing_segments;
     erase_if(missing_segs, [&first_kafka_offset](const auto& meta) {
         return meta.next_kafka_offset() <= first_kafka_offset;
     });
+
+    // TODO: check if the segment still exists
+    auto& segment_meta_anomalies
+      = _detected_anomalies.segment_metadata_anomalies;
+    erase_if(
+      segment_meta_anomalies, [&first_kafka_offset](const auto& anomaly_meta) {
+          return anomaly_meta.at.next_kafka_offset() <= first_kafka_offset;
+      });
 
     _last_partition_scrub = scrub_timestamp;
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -327,6 +327,11 @@ public:
     bool contains(const key& key) const;
     bool contains(const segment_name& name) const;
 
+    /// Check if the provided offset range matches any segment in the manifest
+    /// exactly.
+    bool segment_with_offset_range_exists(
+      model::offset base, model::offset committed) const;
+
     /// Add new segment to the manifest
     bool add(segment_meta meta);
     bool add(const segment_name& name, const segment_meta& meta);

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -143,9 +143,44 @@ std::ostream& operator<<(std::ostream& o, const scrub_status& s) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, const anomaly_type& t) {
+    switch (t) {
+    case anomaly_type::missing_delta:
+        o << "{missing_delta}";
+        break;
+    case anomaly_type::non_monotonical_delta:
+        o << "{non_monotonical_delta}";
+        break;
+    case anomaly_type::end_delta_smaller:
+        o << "{end_delta_smaller}";
+        break;
+    case anomaly_type::committed_smaller:
+        o << "{committed_smaller}";
+        break;
+    case anomaly_type::offset_gap:
+        o << "{offset_gap}";
+        break;
+    case anomaly_type::offset_overlap:
+        o << "{offset_overlap}";
+        break;
+    }
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const anomaly_meta& meta) {
+    fmt::print(
+      o,
+      "{{type: {}, at: {}, previous: {}}}",
+      meta.type,
+      meta.at,
+      meta.previous);
+    return o;
+}
+
 bool anomalies::has_value() const {
     return missing_partition_manifest || missing_spillover_manifests.size() > 0
-           || missing_segments.size() > 0;
+           || missing_segments.size() > 0
+           || segment_metadata_anomalies.size() > 0;
 }
 
 anomalies& anomalies::operator+=(anomalies&& other) {
@@ -156,6 +191,9 @@ anomalies& anomalies::operator+=(anomalies&& other) {
     missing_segments.insert(
       std::make_move_iterator(other.missing_segments.begin()),
       std::make_move_iterator(other.missing_segments.end()));
+    segment_metadata_anomalies.insert(
+      std::make_move_iterator(other.segment_metadata_anomalies.begin()),
+      std::make_move_iterator(other.segment_metadata_anomalies.end()));
 
     return *this;
 }
@@ -168,10 +206,11 @@ std::ostream& operator<<(std::ostream& o, const anomalies& a) {
     fmt::print(
       o,
       "{{missing_partition_manifest: {}, missing_spillover_manifests: {}, "
-      "missing_segments:{}}}",
+      "missing_segments: {}, segment_metadata_anomalies: {}}}",
       a.missing_partition_manifest,
       a.missing_spillover_manifests.size(),
-      a.missing_segments.size());
+      a.missing_segments.size(),
+      a.segment_metadata_anomalies.size());
 
     return o;
 }

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -365,6 +365,13 @@ struct anomaly_meta
 
 std::ostream& operator<<(std::ostream& o, const anomaly_meta&);
 
+using segment_meta_anomalies = absl::node_hash_set<anomaly_meta>;
+
+void scrub_segment_meta(
+  const segment_meta& current,
+  const std::optional<segment_meta>& previous,
+  segment_meta_anomalies& detected);
+
 struct anomalies
   : serde::envelope<anomalies, serde::version<0>, serde::compat_version<0>> {
     // Missing partition manifests
@@ -376,7 +383,7 @@ struct anomalies
     // Segments referenced by the manifests which were not found
     absl::node_hash_set<segment_meta> missing_segments;
     // Segments that have metadata anomalies (e.g. gaps or overlaps)
-    absl::node_hash_set<anomaly_meta> segment_metadata_anomalies;
+    segment_meta_anomalies segment_metadata_anomalies;
 
     auto serde_fields() {
         return std::tie(

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -389,6 +389,66 @@
         }
       }
     },
+    "segment_meta": {
+      "id": "segment_meta",
+      "description": "Metadata for an uploaded segment",
+      "properties": {
+        "base_offset": {
+          "type": "long"
+        },
+        "committed_offset": {
+          "type": "long"
+        },
+        "delta_offset": {
+          "type": "long",
+          "nullable": true
+        },
+        "delta_offset_end": {
+          "type": "long",
+          "nullable": true
+        },
+        "base_timestamp": {
+          "type": "long"
+        },
+        "max_timestamp": {
+          "type": "long"
+        },
+        "size_bytes": {
+          "type": "long"
+        },
+        "is_compacted": {
+          "type": "boolean"
+        },
+        "archiver_term": {
+          "type": "long"
+        },
+        "segment_term": {
+          "type": "long"
+        },
+        "ntp_revision": {
+          "type": "long"
+        }
+      }
+    },
+    "metadata_anomaly": {
+      "id": "metadata_anomaly",
+      "description": "Description of a metadata anomaly",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "explanation": {
+          "type": "string"
+        },
+        "at_segment": {
+          "type": "segment_meta"
+        },
+        "previous_segment": {
+          "type": "segment_meta",
+          "nullable": true
+        }
+      }
+    },
     "cloud_storage_partition_anomalies": {
       "id": "cloud_storage_partition_anomalies",
       "description": "Anomalies detected by the cloud storage scrubber",
@@ -417,6 +477,11 @@
         "missing_segments": {
           "type": "array",
           "items": {"type": "string"},
+          "nullable": true
+        },
+        "segment_metadata_anomalies": {
+          "type": "array",
+          "items": {"type": "metadata_anomaly"},
           "nullable": true
         }
       }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -5147,6 +5147,132 @@ map_status_to_json(cluster::partition_cloud_storage_status status) {
 
     return json;
 }
+
+ss::httpd::shadow_indexing_json::segment_meta
+map_segment_meta_to_json(const cloud_storage::segment_meta& meta) {
+    ss::httpd::shadow_indexing_json::segment_meta json;
+    json.base_offset = meta.base_offset();
+    json.committed_offset = meta.committed_offset();
+
+    if (meta.delta_offset != model::offset_delta{}) {
+        json.delta_offset = meta.delta_offset;
+    }
+    if (meta.delta_offset_end != model::offset_delta{}) {
+        json.delta_offset_end = meta.delta_offset_end;
+    }
+
+    json.base_timestamp = meta.base_timestamp();
+    json.max_timestamp = meta.max_timestamp();
+
+    json.size_bytes = meta.size_bytes;
+    json.is_compacted = meta.is_compacted;
+
+    json.archiver_term = meta.archiver_term();
+    json.segment_term = meta.segment_term();
+    json.ntp_revision = meta.ntp_revision();
+
+    return json;
+}
+
+ss::httpd::shadow_indexing_json::metadata_anomaly
+map_metadata_anomaly_to_json(const cloud_storage::anomaly_meta& meta) {
+    ss::httpd::shadow_indexing_json::metadata_anomaly json;
+    switch (meta.type) {
+    case cloud_storage::anomaly_type::missing_delta: {
+        json.type = "missing_delta";
+        json.explanation = "Segment is missing delta offset";
+        json.at_segment = map_segment_meta_to_json(meta.at);
+        if (meta.previous) {
+            json.previous_segment = map_segment_meta_to_json(*meta.previous);
+        }
+
+        break;
+    }
+    case cloud_storage::anomaly_type::non_monotonical_delta: {
+        if (!meta.previous) {
+            vlog(
+              logger.error,
+              "Invalid anomaly metadata of type {} at {}",
+              meta.type,
+              meta.at);
+            return json;
+        }
+
+        json.type = "non_monotonical_delta";
+        json.explanation = ssx::sformat(
+          "Segment has lower delta than previous: {} < {}",
+          meta.at.delta_offset,
+          meta.previous->delta_offset);
+        json.at_segment = map_segment_meta_to_json(meta.at);
+        json.previous_segment = map_segment_meta_to_json(*meta.previous);
+
+        break;
+    }
+    case cloud_storage::anomaly_type::end_delta_smaller: {
+        json.type = "end_delta_smaller";
+        json.explanation = ssx::sformat(
+          "Segment has end delta offset lower than start delta offset: {} < {}",
+          meta.at.delta_offset_end,
+          meta.at.delta_offset);
+        json.at_segment = map_segment_meta_to_json(meta.at);
+
+        break;
+    }
+    case cloud_storage::anomaly_type::committed_smaller: {
+        json.type = "committed_smaller";
+        json.explanation = ssx::sformat(
+          "Segment has committed offset lower start offset: {} < {}",
+          meta.at.committed_offset,
+          meta.at.base_offset);
+        json.at_segment = map_segment_meta_to_json(meta.at);
+
+        break;
+    }
+    case cloud_storage::anomaly_type::offset_gap: {
+        if (!meta.previous) {
+            vlog(
+              logger.error,
+              "Invalid anomaly metadata of type {} at {}",
+              meta.type,
+              meta.at);
+            return json;
+        }
+
+        json.type = "offset_gap";
+        json.explanation = ssx::sformat(
+          "Gap between offsets in interval ({}, {})",
+          meta.previous->committed_offset(),
+          meta.at.base_offset());
+        json.at_segment = map_segment_meta_to_json(meta.at);
+        json.previous_segment = map_segment_meta_to_json(*meta.previous);
+
+        break;
+    }
+    case cloud_storage::anomaly_type::offset_overlap: {
+        if (!meta.previous) {
+            vlog(
+              logger.error,
+              "Invalid anomaly metadata of type {} at {}",
+              meta.type,
+              meta.at);
+            return json;
+        }
+
+        json.type = "offest_overlap";
+        json.explanation = ssx::sformat(
+          "Overlapping offset in interval [{}, {}]",
+          meta.at.base_offset(),
+          meta.previous->committed_offset());
+        json.at_segment = map_segment_meta_to_json(meta.at);
+        json.previous_segment = map_segment_meta_to_json(*meta.previous);
+
+        break;
+    }
+    }
+
+    return json;
+}
+
 ss::httpd::shadow_indexing_json::cloud_storage_partition_anomalies
 map_anomalies_to_json(
   const model::ntp& ntp,
@@ -5180,6 +5306,15 @@ map_anomalies_to_json(
              ++iter) {
             json.missing_segments.push(
               tmp.generate_segment_path(*iter)().string());
+        }
+    }
+
+    if (detected.segment_metadata_anomalies.size() > 0) {
+        const auto& segment_meta_anomalies
+          = detected.segment_metadata_anomalies;
+        for (const auto& a : segment_meta_anomalies) {
+            json.segment_metadata_anomalies.push(
+              map_metadata_anomaly_to_json(a));
         }
     }
 

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -18,10 +18,12 @@ from rptest.utils.si_utils import parse_s3_segment_path, quiesce_uploads, Bucket
 from ducktape.mark import matrix
 from ducktape.utils.util import wait_until
 
+import json
 import random
+import time
 
-# Attempts to compute the retention point for the cloud log will fail
-# after a spillover manifest is manually removed.
+#Attempts to compute the retention point for the cloud log will fail
+#after a spillover manifest is manually removed.
 SCRUBBER_LOG_ALLOW_LIST = [
     r"cloud_storage - .* failed to download manifest {key_not_found}",
     r"cloud_storage - .* failed to download manifest.*cloud_storage::error_outcome:2",
@@ -49,8 +51,6 @@ class CloudStorageScrubberTest(RedpandaTest):
             cloud_storage_housekeeping_interval_ms=1000 * 30,
             fast_uploads=True)
 
-        self.bucket_name = self.si_settings.cloud_storage_bucket
-
         super().__init__(test_context=test_context,
                          extra_rp_conf={
                              "cloud_storage_enable_scrubbing":
@@ -61,6 +61,9 @@ class CloudStorageScrubberTest(RedpandaTest):
                              5 * 1000,
                          },
                          si_settings=self.si_settings)
+
+        self.bucket_name = self.si_settings.cloud_storage_bucket
+        self.rpk = RpkTool(self.redpanda)
 
     def _produce(self):
         msg_count = self.to_produce * self.partition_count // self.message_size
@@ -107,7 +110,8 @@ class CloudStorageScrubberTest(RedpandaTest):
 
             if ("missing_partition_manifest" not in anomalies
                     and "missing_spillover_manifests" not in anomalies
-                    and "missing_segments" not in anomalies):
+                    and "missing_segments" not in anomalies
+                    and "segment_metadata_anomalies" not in anomalies):
                 anomalies = None
 
             anomalies_per_ntpr[ntpr] = anomalies
@@ -164,7 +168,7 @@ class CloudStorageScrubberTest(RedpandaTest):
         wait_until(ntpr_missing_segment,
                    timeout_sec=self.scrub_timeout,
                    backoff_sec=2,
-                   err_msg="Missing spillover manifest anomaly not reported")
+                   err_msg="Missing segment anomaly not reported")
 
     def _delete_spillover_manifest_and_await_anomaly(self):
         pid = random.randint(0, 2)
@@ -259,6 +263,77 @@ class CloudStorageScrubberTest(RedpandaTest):
                    backoff_sec=2,
                    err_msg="Reported anomalies changed after full restart")
 
+    def _assert_segment_metadata_anomalies(self):
+        self.logger.info(
+            "Fudging manifest and waiting on segment metadata anomalies")
+
+        view = BucketView(self.redpanda)
+        manifest = view.manifest_for_ntp(topic=self.topic, partition=0)
+
+        sorted_segments = sorted(manifest['segments'].items(),
+                                 key=lambda entry: entry[1]['base_offset'])
+        assert len(
+            sorted_segments
+        ) > 2, f"Not enough segments in manifest: {json.dumps(manifest)}"
+
+        # Remove the metadata for the penultimate segment, thus creating an offset gap
+        # for the scrubber to detect
+        seg_to_remove_name, seg_to_remove_meta = sorted_segments[-2]
+        manifest['segments'].pop(seg_to_remove_name)
+        self.logger.info(f"Removing segment with meta {seg_to_remove_meta}")
+
+        detect_at_seg_meta = sorted_segments[-1][1]
+        self.logger.info(f"Anomaly should be detected at {detect_at_seg_meta}")
+
+        # Forcefully reset the manifest. Remote writes are disabled first
+        # to make this operation safe.
+        json_man = json.dumps(manifest)
+        self.logger.info(f"Re-setting manifest to:{json_man}")
+
+        self.rpk.alter_topic_config(self.topic, 'redpanda.remote.write',
+                                    'false')
+        time.sleep(1)
+
+        admin = Admin(self.redpanda)
+        admin.unsafe_reset_cloud_metadata(self.topic, 0, manifest)
+
+        self.rpk.alter_topic_config(self.topic, 'redpanda.remote.write',
+                                    'true')
+
+        ntpr = NTPR(ns="kafka",
+                    topic=self.topic,
+                    partition=0,
+                    revision=seg_to_remove_meta["ntp_revision"])
+
+        def gap_reported():
+            anomalies_per_ntpr = self._collect_anomalies()
+            self.logger.debug(f"Reported anomalies {anomalies_per_ntpr}")
+
+            if ntpr not in anomalies_per_ntpr:
+                return False
+
+            if anomalies_per_ntpr[ntpr] is None:
+                return False
+
+            if "segment_metadata_anomalies" not in anomalies_per_ntpr[ntpr]:
+                return False
+
+            seg_meta_anomalies = anomalies_per_ntpr[ntpr][
+                "segment_metadata_anomalies"]
+
+            for meta in seg_meta_anomalies:
+                if (meta["type"] == "offset_gap"
+                        and meta["at_segment"]["base_offset"]
+                        == detect_at_seg_meta["base_offset"]):
+                    return True
+
+        wait_until(
+            gap_reported,
+            # A new manifest needs to be uploaded, so the timeout is more generous
+            timeout_sec=self.scrub_timeout + 10,
+            backoff_sec=2,
+            err_msg="Gap not reported")
+
     @cluster(num_nodes=4, log_allow_list=SCRUBBER_LOG_ALLOW_LIST)
     @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_scrubber(self, cloud_storage_type):
@@ -267,9 +342,13 @@ class CloudStorageScrubberTest(RedpandaTest):
         self._delete_spillover_manifest_and_await_anomaly()
         self._delete_segment_and_await_anomaly()
 
+        self._assert_segment_metadata_anomalies()
+
         self._assert_anomalies_stable_after_leader_shuffle()
         self._assert_anomalies_stable_after_restart()
 
-        # The test deletes segments, so rp-storage-tool will also
-        # pick up on it.
-        self.redpanda.si_settings.set_expected_damage({"missing_segments"})
+        # This test deletes segments, spillover manifests
+        # and fudges the manifest. rp-storage-tool also picks
+        # up on some of these things.
+        self.redpanda.si_settings.set_expected_damage(
+            {"missing_segments", "metadata_offset_gaps"})


### PR DESCRIPTION
This PR introduces scrubbing of segment metadata.

In addition to missing segments and spills we can now detect:
* bad or missing deltas
* incorrect offsets within a segment
* offset gaps and overlaps

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
