### PR TITLE
utils: fix gate_guard move-assign operator

### DIFF
--- a/src/v/utils/gate_guard.h
+++ b/src/v/utils/gate_guard.h
@@ -37,11 +37,11 @@ struct gate_guard final {
         o._g = nullptr;
     }
     gate_guard& operator=(gate_guard&& o) noexcept {
-        if (this == &o) {
-            return *this;
+        if (this != &o) {
+            this->~gate_guard();
+            _g = o._g;
+            o._g = nullptr;
         }
-        _g = o._g;
-        o._g = nullptr;
         return *this;
     }
     gate_guard(const gate_guard&) = delete;

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ rp_test(
     constexpr_string_switch.cc
     filtered_lower_bound_test.cc
     fragmented_vector_test.cc
+    gate_guard_test.cc
     human_test.cc
     move_canary_test.cc
     moving_average_test.cc

--- a/src/v/utils/tests/gate_guard_test.cc
+++ b/src/v/utils/tests/gate_guard_test.cc
@@ -1,0 +1,26 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "utils/gate_guard.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(gate_guard_move_assign) {
+    ss::gate gate1;
+    ss::gate gate2;
+    {
+        gate_guard g1{gate1};
+        gate_guard g2{gate2};
+        BOOST_CHECK_EQUAL(gate1.get_count(), 1);
+        BOOST_CHECK_EQUAL(gate2.get_count(), 1);
+        g1 = std::move(g2);
+    }
+    BOOST_CHECK_EQUAL(gate1.get_count(), 0);
+    BOOST_CHECK_EQUAL(gate2.get_count(), 0);
+}


### PR DESCRIPTION
It must leave() the original gate first.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes
* none

