### PR TITLE
archival: batch delete segments during gc in stm region

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -542,6 +542,12 @@ private:
     ss::future<cloud_storage::upload_result>
     delete_segment(const remote_segment_path& path);
 
+    using lw_segment_meta = cloud_storage::partition_manifest::lw_segment_meta;
+    /// Delete segment data and metadata from object storage and return the
+    /// number of successfully delted segments.
+    ss::future<size_t>
+    delete_segments(const std::vector<lw_segment_meta>& lw_metas);
+
     /// If true, we are holding up trimming of local storage
     bool local_storage_pressure() const;
 

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -534,14 +534,6 @@ private:
     /// abort source fires.
     ss::future<> sync_manifest_until_abort();
 
-    /// Delete a segment and its transaction metadata from S3.
-    /// The transaction metadata is only deleted if the segment
-    /// deletion was successful.
-    ///
-    /// Throws if an abort was requested.
-    ss::future<cloud_storage::upload_result>
-    delete_segment(const remote_segment_path& path);
-
     using lw_segment_meta = cloud_storage::partition_manifest::lw_segment_meta;
     /// Delete segment data and metadata from object storage and return the
     /// number of successfully delted segments.

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -496,21 +496,18 @@ FIXTURE_TEST(test_retention, archiver_fixture) {
 
     for (auto [url, req] : get_targets()) {
         vlog(test_log.info, "{} {}", req.method, req.url);
+        if (url == "/?delete") {
+            vlog(test_log.info, "Batch delete body: {}", req.content);
+        }
     }
 
     for (const auto& [url, deletion_expected] : segment_urls) {
         auto urlstr = url().string();
-        auto expected_delete_paths = {
-          urlstr, urlstr + ".index", urlstr + ".tx"};
+        auto expected_delete_paths = {urlstr, urlstr + ".index"};
+        auto [req_begin, req_end] = get_targets().equal_range("/?delete");
+        BOOST_REQUIRE_EQUAL(std::distance(req_begin, req_end), 1);
         for (const auto& p : expected_delete_paths) {
-            auto [req_begin, req_end] = get_targets().equal_range("/" + p);
-            auto entity_deleted = std::find_if(
-                                    req_begin,
-                                    req_end,
-                                    [](auto entry) {
-                                        return entry.second.method == "DELETE";
-                                    })
-                                  != req_end;
+            const bool entity_deleted = req_begin->second.content.contains(p);
             BOOST_REQUIRE(entity_deleted == deletion_expected);
         }
     }

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -201,7 +201,10 @@ partition_manifest::lw_segment_meta::convert(const segment_meta& m) {
       .segment_term = m.segment_term,
       .size_bytes = m.sname_format == segment_name_format::v1 ? 0
                                                               : m.size_bytes,
-      .sname_format = m.sname_format};
+      .sname_format = m.sname_format,
+      .may_have_tx_index = m.sname_format == segment_name_format::v3
+                           && m.metadata_size_hint != 0,
+    };
 }
 
 segment_meta partition_manifest::lw_segment_meta::convert(
@@ -2245,6 +2248,9 @@ void partition_manifest::serialize_removed_segment_meta(
     w.Key("sname_format");
     using name_format_type = std::underlying_type<segment_name_format>::type;
     w.Int64(static_cast<name_format_type>(meta.sname_format));
+
+    w.Key("has_tx_index");
+    w.Bool(meta.may_have_tx_index);
 
     w.EndObject();
 }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -88,7 +88,7 @@ public:
     struct lw_segment_meta
       : serde::envelope<
           lw_segment_meta,
-          serde::version<0>,
+          serde::version<1>,
           serde::compat_version<0>> {
         model::initial_revision_id ntp_revision;
         model::offset base_offset;
@@ -102,6 +102,10 @@ public:
         size_t size_bytes;
 
         segment_name_format sname_format{segment_name_format::v1};
+
+        /// True if segment may contain aborted txs index. If set to false we
+        /// can avoid an extra DELETE request to the object store.
+        bool may_have_tx_index = true;
 
         auto operator<=>(const lw_segment_meta&) const = default;
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Garbage collection of segments from the STM region was done one file at a time. This is not ideal as it blocks other maintenance work done by the archival service. This PR improves that by refactoring batching logic added in #11150 (when spillover metadata exists) and using the code for the STM region too.

Beside batching, #11150 contains an additional improvement for deleting `.tx` files only when they are expected to exist. To have a single code path for deleting segments, I extended the `lw_segment_meta` to add this additional bit of information and using it to record information about what needs to be deleted. As I understand, that was the initial reason behind `lw_segment_meta`. To store as little information as needed for deleting data from object storage later.

Fixes #12706

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
