### PR TITLE
rpk: integrate profiles with `rpk container`

### DIFF
--- a/src/go/rpk/pkg/cli/container/common/client.go
+++ b/src/go/rpk/pkg/cli/container/common/client.go
@@ -101,7 +101,7 @@ type dockerClient struct {
 	*client.Client
 }
 
-func NewDockerClient() (Client, error) {
+func NewDockerClient(ctx context.Context) (Client, error) {
 	// First, we check if DOCKER_HOST is present or if /var/run/docker.sock
 	// exists. If either of these conditions is met, we can safely start the
 	// client using the pre-set client.FromEnv.
@@ -126,7 +126,7 @@ func NewDockerClient() (Client, error) {
 			return nil, err
 		}
 	}
-	c.NegotiateAPIVersion(context.Background())
+	c.NegotiateAPIVersion(ctx)
 	return &dockerClient{c}, nil
 }
 

--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -42,16 +42,17 @@ const (
 )
 
 type NodeState struct {
-	Status        string
-	Running       bool
-	ConfigFile    string
-	HostRPCPort   uint
-	HostKafkaPort uint
-	HostAdminPort uint
-	HostProxyPort uint
-	ID            uint
-	ContainerIP   string
-	ContainerID   string
+	Status         string
+	Running        bool
+	ConfigFile     string
+	HostRPCPort    uint
+	HostKafkaPort  uint
+	HostAdminPort  uint
+	HostProxyPort  uint
+	HostSchemaPort uint
+	ID             uint
+	ContainerIP    string
+	ContainerID    string
 }
 
 func ListenAddresses(ip string, internalPort, externalPort uint) string {
@@ -167,16 +168,24 @@ func GetState(c Client, nodeID uint) (*NodeState, error) {
 	if err != nil {
 		return nil, err
 	}
+	hostSchemaPort, err := getHostPort(
+		config.DefaultSchemaRegPort,
+		containerJSON,
+	)
+	if err != nil {
+		return nil, err
+	}
 	return &NodeState{
-		Running:       containerJSON.State.Running,
-		Status:        containerJSON.State.Status,
-		ContainerID:   containerJSON.ID,
-		ContainerIP:   ipAddress,
-		HostKafkaPort: hostKafkaPort,
-		HostRPCPort:   hostRPCPort,
-		HostAdminPort: hostAdminPort,
-		HostProxyPort: hostProxyPort,
-		ID:            nodeID,
+		Running:        containerJSON.State.Running,
+		Status:         containerJSON.State.Status,
+		ContainerID:    containerJSON.ID,
+		ContainerIP:    ipAddress,
+		HostKafkaPort:  hostKafkaPort,
+		HostRPCPort:    hostRPCPort,
+		HostAdminPort:  hostAdminPort,
+		HostProxyPort:  hostProxyPort,
+		HostSchemaPort: hostSchemaPort,
+		ID:             nodeID,
 	}, nil
 }
 

--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -487,7 +487,7 @@ func CreateProfile(fs afero.Fs, c Client, y *config.RpkYaml) error {
 
 	profile := config.RpkProfile{
 		Name:        ContainerProfileName,
-		Description: "Automatically generated profile from running 'rpk container start'",
+		Description: "Automatically generated profile from 'rpk container start'",
 		KafkaAPI: config.RpkKafkaAPI{
 			Brokers: kaAddresses,
 		},
@@ -504,10 +504,11 @@ func CreateProfile(fs afero.Fs, c Client, y *config.RpkYaml) error {
 	if err != nil {
 		return err
 	}
-	fmt.Printf("Created %q profile.\n", ContainerProfileName)
 	return nil
 }
 
 const ContainerProfileName = "rpk-container"
 
+// ErrContainerProfileExists is returned when we attempt to create a container
+// profile but a profile named 'rpk-container' already exists.
 var ErrContainerProfileExists = fmt.Errorf("%q profile already exists", ContainerProfileName)

--- a/src/go/rpk/pkg/cli/container/container.go
+++ b/src/go/rpk/pkg/cli/container/container.go
@@ -23,7 +23,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 	command.AddCommand(newStartCommand(fs, p))
 	command.AddCommand(newStopCommand())
-	command.AddCommand(newPurgeCommand())
+	command.AddCommand(newPurgeCommand(fs, p))
 	command.AddCommand(newStatusCommand())
 
 	return command

--- a/src/go/rpk/pkg/cli/container/container.go
+++ b/src/go/rpk/pkg/cli/container/container.go
@@ -10,16 +10,18 @@
 package container
 
 import (
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-func NewCommand() *cobra.Command {
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "container",
 		Short: "Manage a local container cluster",
 	}
 
-	command.AddCommand(newStartCommand())
+	command.AddCommand(newStartCommand(fs, p))
 	command.AddCommand(newStopCommand())
 	command.AddCommand(newPurgeCommand())
 	command.AddCommand(newStatusCommand())

--- a/src/go/rpk/pkg/cli/container/container.go
+++ b/src/go/rpk/pkg/cli/container/container.go
@@ -24,7 +24,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	command.AddCommand(newStartCommand(fs, p))
 	command.AddCommand(newStopCommand())
 	command.AddCommand(newPurgeCommand(fs, p))
-	command.AddCommand(newStatusCommand())
+	command.AddCommand(newStatusCommand(fs, p))
 
 	return command
 }

--- a/src/go/rpk/pkg/cli/container/purge.go
+++ b/src/go/rpk/pkg/cli/container/purge.go
@@ -12,43 +12,71 @@ package container
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/docker/docker/api/types"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/profile"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
 
-func newPurgeCommand() *cobra.Command {
+func newPurgeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "purge",
 		Short: "Stop and remove an existing local container cluster's data",
-		RunE: func(_ *cobra.Command, _ []string) error {
+		RunE: func(*cobra.Command, []string) error {
 			c, err := common.NewDockerClient()
 			if err != nil {
 				return err
 			}
 			defer c.Close()
-			return common.WrapIfConnErr(purgeCluster(c))
+			purged, err := purgeCluster(c)
+			if err != nil {
+				return common.WrapIfConnErr(err)
+			}
+			if !purged {
+				return nil
+			}
+			cfg, err := p.Load(fs)
+			if err != nil {
+				return fmt.Errorf("unable to load config: %v", err)
+			}
+			y, ok := cfg.ActualRpkYaml()
+			if !ok || y.Profile(containerProfileName) == nil {
+				// rpk.yaml file nor profile exist, we exit.
+				return nil
+			}
+			cleared, err := profile.DeleteProfile(fs, y, containerProfileName)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "unable to delete %q profile: %v; you may delete the profile manually running 'rpk profile delete %v'", containerProfileName, err, containerProfileName)
+			}
+			fmt.Printf("Deleted %q profile.\n", containerProfileName)
+			if cleared {
+				fmt.Println("This was the selected profile; rpk will use defaults until a new profile is selected or a new container is created.")
+			}
+			return nil
 		},
 	}
 
 	return command
 }
 
-func purgeCluster(c common.Client) error {
+func purgeCluster(c common.Client) (purged bool, rerr error) {
 	nodes, err := common.GetExistingNodes(c)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if len(nodes) == 0 {
 		fmt.Print("No nodes to remove.\nYou may start a new local cluster with 'rpk container start'\n")
-		return nil
+		return false, nil
 	}
 	err = stopCluster(c)
 	if err != nil {
-		return err
+		return false, err
 	}
 	grp, _ := errgroup.WithContext(context.Background())
 	for _, node := range nodes {
@@ -83,12 +111,12 @@ func purgeCluster(c common.Client) error {
 	}
 	err = grp.Wait()
 	if err != nil {
-		return err
+		return false, err
 	}
 	err = common.RemoveNetwork(c)
 	if err != nil {
-		return err
+		return false, err
 	}
 	fmt.Println("Deleted cluster data.")
-	return nil
+	return true, nil
 }

--- a/src/go/rpk/pkg/cli/container/purge.go
+++ b/src/go/rpk/pkg/cli/container/purge.go
@@ -29,8 +29,8 @@ func newPurgeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "purge",
 		Short: "Stop and remove an existing local container cluster's data",
-		Run: func(*cobra.Command, []string) {
-			c, err := common.NewDockerClient()
+		Run: func(cmd *cobra.Command, _ []string) {
+			c, err := common.NewDockerClient(cmd.Context())
 			out.MaybeDie(err, "unable to create docker client: %v", err)
 			defer c.Close()
 
@@ -44,16 +44,16 @@ func newPurgeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "unable to load config: %v", err)
 
 			y, ok := cfg.ActualRpkYaml()
-			if !ok || y.Profile(containerProfileName) == nil {
+			if !ok || y.Profile(common.ContainerProfileName) == nil {
 				// rpk.yaml file nor profile exist, we exit.
 				return
 			}
-			cleared, err := profile.DeleteProfile(fs, y, containerProfileName)
+			cleared, err := profile.DeleteProfile(fs, y, common.ContainerProfileName)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "unable to delete %q profile: %v; you may delete the profile manually running 'rpk profile delete %v'", containerProfileName, err, containerProfileName)
+				fmt.Fprintf(os.Stderr, "unable to delete %q profile: %v; you may delete the profile manually running 'rpk profile delete %v'", common.ContainerProfileName, err, common.ContainerProfileName)
 				return
 			}
-			fmt.Printf("Deleted %q profile.\n", containerProfileName)
+			fmt.Printf("Deleted %q profile.\n", common.ContainerProfileName)
 			if cleared {
 				fmt.Println("This was the selected profile; rpk will use defaults until a new profile is selected or a new container is created.")
 			}

--- a/src/go/rpk/pkg/cli/container/purge.go
+++ b/src/go/rpk/pkg/cli/container/purge.go
@@ -53,7 +53,7 @@ func newPurgeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				fmt.Fprintf(os.Stderr, "unable to delete %q profile: %v; you may delete the profile manually running 'rpk profile delete %v'", common.ContainerProfileName, err, common.ContainerProfileName)
 				return
 			}
-			fmt.Printf("Deleted %q profile.\n", common.ContainerProfileName)
+			fmt.Printf("Deleted profile %q.\n", common.ContainerProfileName)
 			if cleared {
 				fmt.Println("This was the selected profile; rpk will use defaults until a new profile is selected or a new container is created.")
 			}

--- a/src/go/rpk/pkg/cli/container/status.go
+++ b/src/go/rpk/pkg/cli/container/status.go
@@ -18,8 +18,8 @@ func newStatusCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "status",
 		Short: "Get status",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			c, err := common.NewDockerClient()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			c, err := common.NewDockerClient(cmd.Context())
 			if err != nil {
 				return err
 			}

--- a/src/go/rpk/pkg/cli/container/status.go
+++ b/src/go/rpk/pkg/cli/container/status.go
@@ -11,26 +11,33 @@ package container
 
 import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
-func newStatusCommand() *cobra.Command {
+func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "status",
 		Short: "Get status",
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		Run: func(cmd *cobra.Command, _ []string) {
 			c, err := common.NewDockerClient(cmd.Context())
-			if err != nil {
-				return err
-			}
+			out.MaybeDieErr(err)
 			defer c.Close()
 
 			nodes, err := renderClusterInfo(c)
-			if err != nil {
-				return common.WrapIfConnErr(err)
+			out.MaybeDieErr(common.WrapIfConnErr(err))
+
+			cfg, err := p.Load(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+
+			y, ok := cfg.ActualRpkYaml()
+			var withProfile bool
+			if ok && y.Profile(common.ContainerProfileName) != nil && y.CurrentProfile == common.ContainerProfileName {
+				withProfile = true
 			}
-			renderClusterInteract(nodes)
-			return nil
+			renderClusterInteract(nodes, withProfile)
 		},
 	}
 

--- a/src/go/rpk/pkg/cli/container/stop.go
+++ b/src/go/rpk/pkg/cli/container/stop.go
@@ -23,8 +23,8 @@ func newStopCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop an existing local container cluster",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			c, err := common.NewDockerClient()
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			c, err := common.NewDockerClient(cmd.Context())
 			if err != nil {
 				return err
 			}

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -93,10 +93,6 @@ rpk always switches to the newly created profile.
 				out.Die("profile name cannot be empty unless using --from-cloud")
 			}
 
-			if (fromCloud != "" && fromRedpanda != "") || (fromCloud != "" && fromProfile != "") || (fromRedpanda != "" && fromProfile != "") {
-				out.Die("can only use one of --from-cloud, --from-redpanda, or --from-profile")
-			}
-
 			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			defer cancel()
 			name, msg, err := createProfile(ctx, fs, y, cfg, fromRedpanda, fromProfile, fromCloud, set, name, description)
@@ -118,6 +114,8 @@ rpk always switches to the newly created profile.
 	cmd.Flags().Lookup("from-cloud").NoOptDefVal = "prompt"
 
 	cmd.RegisterFlagCompletionFunc("set", validSetArgs)
+
+	cmd.MarkFlagsMutuallyExclusive("from-redpanda", "from-cloud", "from-profile")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -166,7 +166,7 @@ func createProfile(
 		err = container.CreateProfile(fs, c, y) //nolint:contextcheck // No need to pass the context, the underlying functions use a context with timeout.
 
 		if err != nil {
-			return "", "", fmt.Errorf("unable to create profile from running rpk container: %v", err)
+			return "", "", fmt.Errorf("unable to create profile from rpk container: %v", err)
 		}
 		return container.ContainerProfileName, "", nil
 	case fromCloud != "":

--- a/src/go/rpk/pkg/cli/profile/delete.go
+++ b/src/go/rpk/pkg/cli/profile/delete.go
@@ -40,7 +40,7 @@ is selected.
 			}
 
 			name := args[0]
-			cleared, err := deleteProfile(fs, y, name)
+			cleared, err := DeleteProfile(fs, y, name)
 			out.MaybeDieErr(err)
 			fmt.Printf("Deleted profile %q.\n", name)
 			if cleared {
@@ -50,7 +50,7 @@ is selected.
 	}
 }
 
-func deleteProfile(
+func DeleteProfile(
 	fs afero.Fs,
 	y *config.RpkYaml,
 	name string,

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -100,7 +100,7 @@ func Execute() {
 		acl.NewCommand(fs, p),
 		cloud.NewCommand(fs, p, osExec),
 		cluster.NewCommand(fs, p),
-		container.NewCommand(),
+		container.NewCommand(fs, p),
 		profile.NewCommand(fs, p),
 		debug.NewCommand(fs, p),
 		generate.NewCommand(fs, p),


### PR DESCRIPTION
This PR introduces a new behaviour to `rpk container`:

Now, when the user creates a container using `rpk container start`, rpk will create and use a profile with the kafka broker and admin API and schema registry addresses so the user can start using rpk seamlessly without having to worry about the flags nor the environment variables

### Examples
```
$ rpk container start -n 3
Checking for a local image...
Creating network redpanda
Starting cluster...
Waiting for the cluster to be ready...

Cluster started!
NODE-ID  STATUS   KAFKA-ADDRESS    ADMIN-ADDRESS    PROXY-ADDRESS
0        running  127.0.0.1:36131  127.0.0.1:46387  127.0.0.1:44137
1        running  127.0.0.1:38361  127.0.0.1:44093  127.0.0.1:42481
2        running  127.0.0.1:40911  127.0.0.1:37757  127.0.0.1:36899

Created "rpk-container" profile.

You can use rpk to interact with this cluster. E.g:

    rpk cluster info
    rpk cluster health

$ rpk cluster info 
CLUSTER
=======
redpanda.feb945f2-8bb7-4212-b0a6-80aee86b7d35

BROKERS
=======
ID    HOST       PORT
0*    127.0.0.1  36131
1     127.0.0.1  38361
2     127.0.0.1  40911
```

We also delete the profile when the user deletes the cluster:

```
$ rpk container purge
Stopping node 0
Stopping node 2
Stopping node 1
Removed container rp-node-2 (node 2)
Removed container rp-node-1 (node 1)
Removed container rp-node-0 (node 0)
Deleted cluster data.
Deleted "rpk-container" profile.
This was the selected profile; rpk will use defaults until a new profile is selected or a new container is created.
```

When querying the cluster status, we chose to display the flags based on the current profile: if the profile is not the rpk-container profile, then we display the flags:

```
$ rpk profile current
default
$rpk container status
NODE-ID  STATUS   KAFKA-ADDRESS    ADMIN-ADDRESS    PROXY-ADDRESS
0        running  127.0.0.1:45969  127.0.0.1:46365  127.0.0.1:37121

You can use rpk to interact with this cluster. E.g:

    rpk cluster info -X brokers=127.0.0.1:45969
    rpk cluster health -X admin.hosts=127.0.0.1:46365

You may also set an environment variable with the comma-separated list of
broker and admin API addresses:

    export RPK_BROKERS="127.0.0.1:45969"
    export RPK_ADMIN_HOSTS="127.0.0.1:46365"
    rpk cluster info
    rpk cluster health

$ rpk profile use rpk-container 
Set current profile to "rpk-container".

$ rpk container status         
NODE-ID  STATUS   KAFKA-ADDRESS    ADMIN-ADDRESS    PROXY-ADDRESS
0        running  127.0.0.1:45969  127.0.0.1:46365  127.0.0.1:37121

You can use rpk to interact with this cluster. E.g:

    rpk cluster info
    rpk cluster health
``` 

Lastly, this PR also includes a way to create a profile from a running cluster created using rpk container:

```
$ rpk profile create --from-rpk-container 
Created and switched to new profile "rpk-container".

$ rpk profile print
name: rpk-container
description: Automatically generated profile from running 'rpk container start'
kafka_api:
    brokers:
        - 127.0.0.1:45969
admin_api:
    addresses:
        - 127.0.0.1:46365
schema_registry:
    addresses:
        - 127.0.0.1:45479
```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* rpk now will create a profile when you run `rpk container create`.
