### PR TITLE
log_manager::housekeeping_scan iteration with suspension point fix

### DIFF
--- a/src/v/storage/log_housekeeping_meta.h
+++ b/src/v/storage/log_housekeeping_meta.h
@@ -19,6 +19,7 @@ struct log_housekeeping_meta {
     enum class bitflags : uint32_t {
         none = 0,
         compacted = 1U,
+        lifetime_checked = 0b10,
     };
     explicit log_housekeeping_meta(ss::shared_ptr<log> l) noexcept
       : handle(std::move(l)) {}

--- a/src/v/storage/log_housekeeping_meta.h
+++ b/src/v/storage/log_housekeeping_meta.h
@@ -19,7 +19,7 @@ struct log_housekeeping_meta {
     enum class bitflags : uint32_t {
         none = 0,
         compacted = 1U,
-        lifetime_checked = 0b10,
+        lifetime_checked = 1U << 1U,
     };
     explicit log_housekeeping_meta(ss::shared_ptr<log> l) noexcept
       : handle(std::move(l)) {}

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -196,6 +196,10 @@ ss::future<>
 log_manager::housekeeping_scan(model::timestamp collection_threshold) {
     using bflags = log_housekeeping_meta::bitflags;
 
+    static constexpr auto is_not_set = [](bflags var, auto flag) {
+        return (var & flag) != flag;
+    };
+
     if (_logs_list.empty()) {
         co_return;
     }

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -200,10 +200,6 @@ log_manager::housekeeping_scan(model::timestamp collection_threshold) {
         return (var & flag) != flag;
     };
 
-    if (_logs_list.empty()) {
-        co_return;
-    }
-
     // reset flags for the next two loops, segment_ms and compaction.
     // since there are suspension points during the traversal of _logs_list, the
     // algorithm is: mark the logs visited, rotate _logs_list, op, and loop


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes iteration over a suspension point for apply_segment_ms() by introducing a new flag, bflags::lifetime_checked, and marking log handles as it rotates _logs_list.

Fixes #13589 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* fixes a use_after_free due to interaction with iterators and suspension points. 