### PR TITLE
[v23.2.x] c/pb_backend: schedule tick immediately if health report is available

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -401,6 +401,11 @@ void health_monitor_backend::abort_current_refresh() {
     }
 }
 
+bool health_monitor_backend::contains_node_health_report(
+  model::node_id id) const {
+    return _reports.contains(id);
+}
+
 void health_monitor_backend::on_leadership_changed(
   raft::group_id group, model::term_id, std::optional<model::node_id>) {
     // we are only interested in raft0 leadership notifications

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -82,6 +82,8 @@ public:
 
     bool does_raft0_have_leader();
 
+    bool contains_node_health_report(model::node_id) const;
+
 private:
     /**
      * Struct used to track pending refresh request, it gives ability

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -186,9 +186,19 @@ void partition_balancer_backend::on_members_update(
 
         maybe_rearm_timer(/*now = */ true);
     }
-    // Don't schedule tick on node addition, because the node health report
-    // won't be ready so we won't be able to do anything. Wait instead for a
-    // health monitor notification.
+    // Only schedule tick on node addition if health report is already
+    // available
+    if (
+      state == model::membership_state::active
+      && _health_monitor.contains_node_health_report(id)) {
+        vlog(
+          clusterlog.debug,
+          "node {} state notification: {}, scheduling tick as health report "
+          "for node is already present",
+          id,
+          state);
+        maybe_rearm_timer(/*now = */ true);
+    }
 }
 
 void partition_balancer_backend::on_topic_table_update() {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13616
Fixes: https://github.com/redpanda-data/redpanda/issues/13642,