### PR TITLE
c/topics_frontend: create partition constraints on allocator shard

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1237,12 +1237,12 @@ ss::future<topics_frontend::capacity_info> topics_frontend::get_health_info(
 
     co_return info;
 }
-
-partition_constraints topics_frontend::get_partition_constraints(
+namespace {
+partition_constraints get_partition_constraints(
   model::partition_id id,
   cluster::replication_factor new_replication_factor,
   double max_disk_usage_ratio,
-  const capacity_info& info) const {
+  const topics_frontend::capacity_info& info) {
     allocation_constraints allocation_constraints;
 
     // Add constraint on least disk usage
@@ -1260,6 +1260,7 @@ partition_constraints topics_frontend::get_partition_constraints(
 
     return {id, new_replication_factor, std::move(allocation_constraints)};
 }
+} // namespace
 
 ss::future<std::error_code> topics_frontend::increase_replication_factor(
   model::topic_namespace topic,
@@ -1293,16 +1294,10 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
 
     std::optional<std::error_code> error;
 
-    auto healt_report = co_await get_health_info(topic, partition_count);
+    auto health_report = co_await get_health_info(topic, partition_count);
 
     auto hard_max_disk_usage_ratio = (100 - _hard_max_disk_usage_ratio())
                                      / 100.0;
-
-    auto partition_constraints = get_partition_constraints(
-      model::partition_id(0),
-      new_replication_factor,
-      hard_max_disk_usage_ratio,
-      healt_report);
 
     co_await ss::max_concurrent_for_each(
       tp_metadata->get_assignments(),
@@ -1311,9 +1306,10 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
        &units,
        &new_assignments,
        &error,
-       &partition_constraints,
        topic,
-       new_replication_factor](partition_assignment& assignment) {
+       new_replication_factor,
+       h_report = std::move(health_report),
+       hard_max_disk_usage_ratio](partition_assignment& assignment) {
           if (error) {
               return ss::now();
           }
@@ -1331,14 +1327,18 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
               return ss::now();
           }
 
-          partition_constraints.partition_id = p_id;
-
           return _allocator
             .invoke_on(
               partition_allocator::shard,
-              [topic,
-               partition_constraints,
-               assignment = std::move(assignment)](partition_allocator& al) {
+              [new_rf = new_replication_factor,
+               topic,
+               disk_max_usage = hard_max_disk_usage_ratio,
+               assignment = std::move(assignment),
+               p_id,
+               h_report](partition_allocator& al) {
+                  auto partition_constraints = get_partition_constraints(
+                    p_id, new_rf, disk_max_usage, h_report);
+
                   return al.reallocate_partition(
                     topic,
                     partition_constraints,

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -38,6 +38,10 @@ namespace cluster {
 // on every core
 class topics_frontend {
 public:
+    struct capacity_info {
+        absl::flat_hash_map<model::node_id, node_disk_space> node_disk_reports;
+        absl::flat_hash_map<model::partition_id, int64_t> ntp_sizes;
+    };
     topics_frontend(
       model::node_id,
       ss::sharded<controller_stm>&,
@@ -207,17 +211,6 @@ private:
     ss::future<std::vector<move_cancellation_result>>
       do_cancel_moving_partition_replicas(
         std::vector<model::ntp>, model::timeout_clock::time_point);
-
-    struct capacity_info {
-        absl::flat_hash_map<model::node_id, node_disk_space> node_disk_reports;
-        absl::flat_hash_map<model::partition_id, int64_t> ntp_sizes;
-    };
-
-    partition_constraints get_partition_constraints(
-      model::partition_id id,
-      cluster::replication_factor new_replication_factor,
-      double max_disk_usage_ratio,
-      const capacity_info& info) const;
 
     ss::future<capacity_info> get_health_info(
       model::topic_namespace topic, int32_t partition_count) const;


### PR DESCRIPTION
Changed `topics_fronted::change_replication_factor` code to create partition allocation constraints directly on the partition allocator shard. Constraints holds seastar shared pointers and they can not be referenced cross shards like it was previously.

Fixes: #13395

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none