### PR TITLE
controller: force reconfiguration from all replicas gone scenario

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1229,7 +1229,8 @@ controller_backend::process_partition_reconfiguration(
      * created with cancel/abort type of deltas.
      */
     vassert(
-      type == topic_table_delta::op_type::update,
+      type == topic_table_delta::op_type::update
+        || type == topic_table_delta::op_type::force_update,
       "Invalid reconciliation loop state. Partition replicas should not be "
       "removed before finishing update, ntp: {}, current operation: {}, "
       "target_assignment: {}",

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -79,6 +79,8 @@ std::string_view to_string_view(feature f) {
         return "raft_coordinated_recovery";
     case feature::cloud_storage_scrubbing:
         return "cloud_storage_scrubbing";
+    case feature::enhanced_force_reconfiguration:
+        return "enhanced_force_reconfiguration";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -64,6 +64,7 @@ enum class feature : std::uint64_t {
     lightweight_heartbeats = 1ULL << 30U,
     raft_coordinated_recovery = 1ULL << 31U,
     cloud_storage_scrubbing = 1ULL << 32U,
+    enhanced_force_reconfiguration = 1ULL << 33U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -298,6 +299,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{11},
     "cloud_storage_scrubbing",
     feature::cloud_storage_scrubbing,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{11},
+    "enhanced_force_reconfiguration",
+    feature::enhanced_force_reconfiguration,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always}};
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3010,8 +3010,12 @@ admin_server::force_set_partition_replicas_handler(
               replicas);
             co_return ss::json::json_void();
         }
-
-        if (!cluster::is_proper_subset(replicas, current_replicas)) {
+        auto relax_restrictions
+          = _controller->get_feature_table().local().is_active(
+            features::feature::enhanced_force_reconfiguration);
+        if (
+          !relax_restrictions
+          && !cluster::is_proper_subset(replicas, current_replicas)) {
             throw ss::httpd::bad_request_exception(fmt::format(
               "Target assignment {} is not a proper subset of current {}, "
               "choose a proper subset of existing replicas.",

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -16,6 +16,8 @@ from ducktape.utils.util import wait_until
 from random import shuffle
 import time
 from rptest.tests.partition_movement import PartitionMovementMixin
+from rptest.services.admin import Replica
+from rptest.clients.kcl import KCL
 
 
 class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
@@ -207,3 +209,73 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
         self.redpanda._admin.await_stable_leader(topic=self.topic,
                                                  replication=len(alive) + 1,
                                                  hosts=self._alive_nodes())
+
+    @cluster(num_nodes=7)
+    @matrix(target_replica_set_size=[1, 3])
+    def test_reconfiguring_all_replicas_lost(self, target_replica_set_size):
+        self.start_redpanda(num_nodes=4)
+        assert self.redpanda
+
+        # create a topic with rf = 1
+        self.topic = "topic"
+        self.client().create_topic(
+            TopicSpec(name=self.topic, replication_factor=1))
+
+        kcl = KCL(self.redpanda)
+
+        # produce some data.
+        self.start_producer(acks=1)
+        self.await_num_produced(min_records=10000)
+        self.producer.stop()
+
+        def get_stable_lso():
+            def get_lso():
+                try:
+                    partitions = kcl.list_offsets([self.topic])
+                    if len(partitions) == 0:
+                        return -1
+                    return partitions[0].end_offset
+                except:
+                    return -1
+
+            wait_until(
+                lambda: get_lso() != -1,
+                timeout_sec=30,
+                backoff_sec=1,
+                err_msg=
+                f"Partition {self.topic}/0 couldn't achieve a stable lso")
+
+            return get_lso()
+
+        lso = get_stable_lso()
+        assert lso >= 10001, f"Partition {self.topic}/0 has incorrect lso {lso}"
+
+        # kill the broker hosting the replica
+        (killed, alive) = self._stop_majority_nodes(replication=1)
+        assert len(killed) == 1
+        assert len(alive) == 0
+
+        self._wait_until_no_leader()
+
+        # force reconfigure to target replica set size
+        assert target_replica_set_size <= len(self._alive_nodes())
+        new_replicas = [
+            Replica(dict(node_id=self.redpanda.node_id(replica), core=0)) for
+            replica in self.redpanda.started_nodes()[:target_replica_set_size]
+        ]
+        self._force_reconfiguration(new_replicas=new_replicas)
+
+        self.redpanda._admin.await_stable_leader(
+            topic=self.topic,
+            replication=target_replica_set_size,
+            hosts=self._alive_nodes())
+
+        # Ensure it is empty
+        lso = get_stable_lso()
+        assert lso == 0, f"Partition {self.topic}/0 has incorrect lso {lso}"
+
+        # check if we can produce/consume with new replicas from a client perspective
+        self.start_producer()
+        self.await_num_produced(min_records=10000)
+        self.start_consumer()
+        self.run_validation()


### PR DESCRIPTION
With these changes, controller now supports recovering from an all replicas lost scenario using force reconfiguration. A typical example is a broker hosting rf=1 partition is dead and cannot be recovered. 

Without this support, an operator has to delete the entire topic (hence all partitions) to recover the topic controller state and fix the replica assignment.

Example invocation for reconfiguring partition `foo/0` with only replica on node_id=1

```
curl -X POST http://localhost:9644/v1/debug/partitions/kafka/foo/0/force_replicas -H 'Content-Type: application/json' --data '[{"node_id": 0, "core": 0},{"node_id": 2, "core": 0}]'
```

After force reconfiguration, the partition is now reset to rf=2 on brokers (0, 2).


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* Force reconfiguration now supports recovering from all replicas lost scenario. The replicas are reset with empty logs (no data) on the (broker, shard) destinations passed in the reconfiguration command.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.


### Improvements

* Short description of how this PR improves existing behavior.

-->
