### PR TITLE
Modify authz return path

### DIFF
--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -249,7 +249,7 @@ public:
       security::acl_operation operation,
       const T& name,
       authz_quiet quiet = authz_quiet{false}) {
-        return _conn->authorized(operation, name, quiet);
+        return bool(_conn->authorized(operation, name, quiet));
     }
 
     cluster::security_frontend& security_frontend() const {

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -49,15 +49,15 @@ std::optional<std::reference_wrapper<const acl_entry>> acl_entry_set::find(
 }
 
 bool acl_matches::empty() const {
-    if (wildcards && !wildcards->get().empty()) {
+    if (wildcards && !wildcards->acl_entry_set.get().empty()) {
         return false;
     }
-    if (literals && !literals->get().empty()) {
+    if (literals && !literals->acl_entry_set.get().empty()) {
         return false;
     }
     return std::all_of(
       prefixes.cbegin(), prefixes.cend(), [](const entry_set_ref& e) {
-          return e.get().empty();
+          return e.acl_entry_set.get().empty();
       });
 }
 
@@ -67,19 +67,22 @@ bool acl_matches::contains(
   const acl_host& host,
   acl_permission perm) const {
     for (const auto& entries : prefixes) {
-        if (entries.get().contains(operation, principal, host, perm)) {
+        if (entries.acl_entry_set.get().contains(
+              operation, principal, host, perm)) {
             return true;
         }
     }
 
     if (wildcards) {
-        if (wildcards->get().contains(operation, principal, host, perm)) {
+        if (wildcards->acl_entry_set.get().contains(
+              operation, principal, host, perm)) {
             return true;
         }
     }
 
     if (literals) {
-        if (literals->get().contains(operation, principal, host, perm)) {
+        if (literals->acl_entry_set.get().contains(
+              operation, principal, host, perm)) {
             return true;
         }
     }
@@ -96,7 +99,7 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
 
     opt_entry_set wildcards;
     if (const auto it = _acls.find(wildcard_pattern); it != _acls.end()) {
-        wildcards = it->second;
+        wildcards = {it->first, it->second};
     }
 
     const resource_pattern literal_pattern(
@@ -104,7 +107,7 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
 
     opt_entry_set literals;
     if (const auto it = _acls.find(literal_pattern); it != _acls.end()) {
-        literals = it->second;
+        literals = {it->first, it->second};
     }
 
     /*
@@ -121,7 +124,7 @@ acl_store::find(resource_type resource, const ss::sstring& name) const {
 
         for (; it != end; ++it) {
             if (std::string_view(name).starts_with(it->first.name())) {
-                prefixes.emplace_back(it->second);
+                prefixes.emplace_back(it->first, it->second);
             }
         }
     }

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -61,33 +61,36 @@ bool acl_matches::empty() const {
       });
 }
 
-bool acl_matches::contains(
+std::optional<acl_matches::acl_match> acl_matches::find(
   acl_operation operation,
   const acl_principal& principal,
   const acl_host& host,
   acl_permission perm) const {
     for (const auto& entries : prefixes) {
-        if (entries.acl_entry_set.get().contains(
-              operation, principal, host, perm)) {
-            return true;
+        if (auto entry = entries.acl_entry_set.get().find(
+              operation, principal, host, perm);
+            entry.has_value()) {
+            return {{entries.resource, *entry}};
         }
     }
 
     if (wildcards) {
-        if (wildcards->acl_entry_set.get().contains(
-              operation, principal, host, perm)) {
-            return true;
+        if (auto entry = wildcards->acl_entry_set.get().find(
+              operation, principal, host, perm);
+            entry.has_value()) {
+            return {{wildcards->resource, *entry}};
         }
     }
 
     if (literals) {
-        if (literals->acl_entry_set.get().contains(
-              operation, principal, host, perm)) {
-            return true;
+        if (auto entry = literals->acl_entry_set.get().find(
+              operation, principal, host, perm);
+            entry.has_value()) {
+            return {{literals->resource, *entry}};
         }
     }
 
-    return false;
+    return std::nullopt;
 }
 
 acl_matches

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -80,6 +80,11 @@ public:
 
     using entry_set_ref = acl_entry_set_match;
 
+    struct acl_match {
+        std::reference_wrapper<const resource_pattern> resource;
+        acl_entry_set::const_reference acl;
+    };
+
     acl_matches(
       std::optional<entry_set_ref> wildcards,
       std::optional<entry_set_ref> literals,

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -73,7 +73,12 @@ private:
  */
 class acl_matches {
 public:
-    using entry_set_ref = std::reference_wrapper<const acl_entry_set>;
+    struct acl_entry_set_match {
+        std::reference_wrapper<const resource_pattern> resource;
+        std::reference_wrapper<const acl_entry_set> acl_entry_set;
+    };
+
+    using entry_set_ref = acl_entry_set_match;
 
     acl_matches(
       std::optional<entry_set_ref> wildcards,

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -101,11 +101,19 @@ public:
 
     bool empty() const;
 
-    bool contains(
+    std::optional<acl_match> find(
       acl_operation operation,
       const acl_principal& principal,
       const acl_host& host,
       acl_permission perm) const;
+
+    bool contains(
+      acl_operation operation,
+      const acl_principal& principal,
+      const acl_host& host,
+      acl_permission perm) const {
+        return find(operation, principal, host, perm).has_value();
+    }
 
 private:
     std::optional<entry_set_ref> wildcards;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds the `auth_result` structure and returns it from the authorizer security subsystem.  This structure contains all the necessary metadata needed for audit logging in regards to which ACL and resource pattern was matched that resulted in
the authZ decision (if any matched).

Force push `5cbd88a`:
- Changed auth_result to hold an `ss::sstring` vs `std::string_view`

Force push `e5b05bc`:
- Updates from PR comments

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
