### PR TITLE
[backport] [v23.1.x] config: enable crash_loop_limit by default

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -142,7 +142,7 @@ node_config::node_config() noexcept
       "operator intervention is needed to startup the broker. Limit is not "
       "enforced in developer mode.",
       {.visibility = visibility::user},
-      std::nullopt)
+      5)
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -139,7 +139,8 @@ node_config::node_config() noexcept
       *this,
       "crash_loop_limit",
       "Maximum consecutive crashes (unclean shutdowns) allowed after which "
-      "operator intervention is needed to startup the broker.",
+      "operator intervention is needed to startup the broker. Limit is not "
+      "enforced in developer mode.",
       {.visibility = visibility::user},
       std::nullopt)
   , _advertised_rpc_api(

--- a/tests/rptest/tests/crash_loop_checks_test.py
+++ b/tests/rptest/tests/crash_loop_checks_test.py
@@ -37,7 +37,8 @@ class CrashLoopChecksTest(RedpandaTest):
                              num_brokers=1,
                              extra_node_conf={
                                  "crash_loop_limit":
-                                 CrashLoopChecksTest.CRASH_LOOP_LIMIT
+                                 CrashLoopChecksTest.CRASH_LOOP_LIMIT,
+                                 "developer_mode": False
                              })
 
     def remove_crash_loop_tracker_file(self, broker):


### PR DESCRIPTION
Defaults to 5. If a broker shuts down uncleanly 5 times back to back, it is considered to be in a crash loop.

Crash loop limit enforcement is disabled in developer mode which is also set by rpk's dev-container mode.
The idea is that crash_loop_limit tracking has value only when running at scale and disabling it prevents inadverdent lockups (and hence better UX) when running in container mode / CI etc.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes https://github.com/redpanda-data/redpanda/issues/13534

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Features

* crash_loop_limit now defaults to 5. If a broker uncleanly shutdowns for 5 times back to back, it is considered to be in a crash loop mode and Redpanda refuses to start up and may need a manual intervention. This enforcement is disabled in developer mode and rpk's dev-container mode.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
