### PR TITLE
[backport] [v23.2.x] tx/compaction: ensure last batch in a segment is not compacted way

### DIFF
--- a/src/v/storage/compacted_index.h
+++ b/src/v/storage/compacted_index.h
@@ -29,17 +29,19 @@ struct compaction_key : bytes {
       : bytes(std::move(b)) {}
 };
 
-inline compaction_key
-prefix_with_batch_type(model::record_batch_type type, bytes_view key) {
+inline compaction_key enhance_key(
+  model::record_batch_type type, bool is_control_batch, bytes_view key) {
     auto bt_le = ss::cpu_to_le(
       static_cast<std::underlying_type<model::record_batch_type>::type>(type));
-    auto enriched_key = ss::uninitialized_string<bytes>(
-      sizeof(bt_le) + key.size());
+    auto ctrl_le = ss::cpu_to_le(static_cast<int8_t>(is_control_batch));
+    auto total_size = sizeof(bt_le) + key.size() + sizeof(ctrl_le);
+    auto enriched_key = ss::uninitialized_string<bytes>(total_size);
     auto out = enriched_key.begin();
     out = std::copy_n(
       reinterpret_cast<const char*>(&bt_le), sizeof(bt_le), out);
+    out = std::copy_n(
+      reinterpret_cast<const char*>(&ctrl_le), sizeof(ctrl_le), out);
     std::copy_n(key.begin(), key.size(), out);
-
     return compaction_key(std::move(enriched_key));
 }
 
@@ -70,7 +72,10 @@ struct compacted_index {
         // 1 - introduced a key being a tuple of batch_type and the key content
         //  of footer
         // 2 - 64-bit size and keys fields
-        static constexpr int8_t current_version = 2;
+        // 3 - add control bit to the key prefix so control batches cannot
+        // compact
+        //  data batches with same key
+        static constexpr int8_t current_version = 3;
 
         uint64_t size{0};
         uint64_t keys{0};

--- a/src/v/storage/compacted_index_writer.h
+++ b/src/v/storage/compacted_index_writer.h
@@ -66,6 +66,7 @@ public:
 
         virtual ss::future<> index(
           model::record_batch_type,
+          bool is_control_batch,
           const iobuf& key, // default format in record batch
           model::offset base_offset,
           int32_t offset_delta)
@@ -73,6 +74,7 @@ public:
 
         virtual ss::future<> index(
           model::record_batch_type,
+          bool is_control_batch,
           bytes&& key, // default format in record batch
           model::offset base_offset,
           int32_t offset_delta)
@@ -100,10 +102,18 @@ public:
     // accepts a compaction_key which is already prefixed with batch_type
     ss::future<> index(const compaction_key& b, model::offset, int32_t);
 
-    ss::future<>
-    index(model::record_batch_type, const iobuf& key, model::offset, int32_t);
-    ss::future<>
-    index(model::record_batch_type, bytes&&, model::offset, int32_t);
+    ss::future<> index(
+      model::record_batch_type,
+      bool is_control_batch,
+      const iobuf& key,
+      model::offset,
+      int32_t);
+    ss::future<> index(
+      model::record_batch_type,
+      bool is_control_batch,
+      bytes&&,
+      model::offset,
+      int32_t);
 
     ss::future<> append(compacted_index::entry);
 
@@ -137,10 +147,11 @@ compacted_index_writer::release() && {
 }
 inline ss::future<> compacted_index_writer::index(
   model::record_batch_type batch_type,
+  bool is_control_batch,
   const iobuf& b,
   model::offset base_offset,
   int32_t delta) {
-    return _impl->index(batch_type, b, base_offset, delta);
+    return _impl->index(batch_type, is_control_batch, b, base_offset, delta);
 }
 inline ss::future<> compacted_index_writer::index(
   const compaction_key& b, model::offset base_offset, int32_t delta) {
@@ -148,10 +159,12 @@ inline ss::future<> compacted_index_writer::index(
 }
 inline ss::future<> compacted_index_writer::index(
   model::record_batch_type batch_type,
+  bool is_control_batch,
   bytes&& b,
   model::offset base_offset,
   int32_t delta) {
-    return _impl->index(batch_type, std::move(b), base_offset, delta);
+    return _impl->index(
+      batch_type, is_control_batch, std::move(b), base_offset, delta);
 }
 inline ss::future<> compacted_index_writer::truncate(model::offset o) {
     return _impl->truncate(o);

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -318,8 +318,11 @@ ss::future<> index_rebuilder_reducer::do_index(model::record_batch&& b) {
     return ss::do_with(std::move(b), [this](model::record_batch& b) {
         return model::for_each_record(
           b,
-          [this, bt = b.header().type, o = b.base_offset()](model::record& r) {
-              return _w->index(bt, r.key(), o, r.offset_delta());
+          [this,
+           bt = b.header().type,
+           ctrl = b.header().attrs.is_control(),
+           o = b.base_offset()](model::record& r) {
+              return _w->index(bt, ctrl, r.key(), o, r.offset_delta());
           });
     });
 }

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -130,11 +130,22 @@ copy_data_segment_reducer::filter(model::record_batch&& batch) {
     // All the data batches retained until this point are committed.
     // From this point on, these batches are treated like non transaction
     // batches by subsequent compactions.
-    // Client implementations treat transactional batches differently
-    // from non transactional batches. For transactional batches an
-    // additional filter is applied to check if they fall in the
-    // aborted list of transactions. Marking these batches here as
-    // non transactional means that clients skip that extra check.
+    //
+    // We also do this so client does not apply aborted transactions for
+    // this batch. Broker passes a list of aborted transaction ranges to
+    // the client in the fetch response and the client collates that list
+    // with the list of fetched data batches. If any of the data batches
+    // with matching PIDs fall in the aborted transaction ranges, they are
+    // filtered out. Since compaction effectively removes all aborted data
+    // batches, there is no use of sending aborted ranges for compacted
+    // segments. Marking the batch as non transactional lets the fetch logic
+    // know the boundary between compacted and non compacted segments.
+
+    // An ideal way to do this is by invalidating aborted transaction metadata
+    // after compaction but currently we have no atomic way of doing it.
+    // Aborted transaction metadata lifecyle is completely decoupled from
+    // segment lifecycle and once that is fixed, we can undo unsetting the
+    // transactional bit.
     auto& hdr = batch.header();
     bool hdr_changed = false;
     if (hdr.attrs.is_transactional()) {
@@ -408,6 +419,20 @@ ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {
     if (is_tx) {
         if (is_control) {
             // tx_commit / tx_abort / unknown
+
+            // Control batches are not discarded but are compacted in the same
+            // manner as other data batches. This approach prevents the
+            // elimination of the last batch within a segment when it happens to
+            // be a control batch. If the final batch in a segment is discarded,
+            // and there are no subsequent data batches, it could lead to
+            // clients being unable to advance their consumable offset until the
+            // Last Stable Offset (LSO) is reached, creating the perception of a
+            // stuck consumer unable to make progress.
+
+            // However, this situation is not problematic when the last batch is
+            // an aborted data batch. This is because we can guarantee the
+            // presence of user consumable batches following it, specifically
+            // the abort control batch, ensuring continuous consumer progress.
             handle_tx_control_batch(b);
         } else if (is_data) {
             // User produced data batches in tx scope..

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -205,7 +205,6 @@ public:
 
     struct stats {
         size_t _tx_data_batches_discarded{0};
-        size_t _tx_control_batches_discarded{0};
         size_t _non_tx_control_batches_discarded{0};
         size_t _all_batches_discarded{0};
         size_t _num_aborted_txes{0};
@@ -216,13 +215,12 @@ public:
               os,
               "{{ all_batches: {}, aborted_txs: {}, all "
               "discarded batches: {}, tx data batches discarded: {}, tx "
-              "control batches discarded {}, non tx control batches discarded: "
+              "non tx control batches discarded: "
               "{}}}",
               s._all_batches,
               s._num_aborted_txes,
               s._all_batches_discarded,
               s._tx_data_batches_discarded,
-              s._tx_control_batches_discarded,
               s._non_tx_control_batches_discarded);
             return os;
         }
@@ -231,7 +229,7 @@ public:
     stats end_of_stream() { return _stats; }
 
 private:
-    bool handle_tx_control_batch(const model::record_batch&);
+    void handle_tx_control_batch(const model::record_batch&);
     bool handle_tx_data_batch(const model::record_batch&);
     bool handle_non_tx_control_batch(const model::record_batch&);
     void consume_aborted_txs(model::offset);

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -453,9 +453,12 @@ ss::future<> segment::do_compaction_index_batch(const model::record_batch& b) {
     auto& w = compaction_index();
     return model::for_each_record(
       b,
-      [o = b.base_offset(), batch_type = b.header().type, &w](
-        const model::record& r) {
-          return w.index(batch_type, r.key(), o, r.offset_delta());
+      [o = b.base_offset(),
+       batch_type = b.header().type,
+       is_control_batch = b.header().attrs.is_control(),
+       &w](const model::record& r) {
+          return w.index(
+            batch_type, is_control_batch, r.key(), o, r.offset_delta());
       });
 }
 ss::future<> segment::compaction_index_batch(const model::record_batch& b) {

--- a/src/v/storage/spill_key_index.cc
+++ b/src/v/storage/spill_key_index.cc
@@ -153,12 +153,19 @@ ss::future<> spill_key_index::add_key(compaction_key b, value_type v) {
 
 ss::future<> spill_key_index::index(
   model::record_batch_type batch_type,
+  bool is_control_batch,
   bytes&& b,
   model::offset base_offset,
   int32_t delta) {
     return ss::try_with_gate(
-      _gate, [this, batch_type, b = std::move(b), base_offset, delta]() {
-          auto key = prefix_with_batch_type(batch_type, b);
+      _gate,
+      [this,
+       batch_type,
+       is_control_batch,
+       b = std::move(b),
+       base_offset,
+       delta]() {
+          auto key = enhance_key(batch_type, is_control_batch, b);
           if (auto it = _midx.find(key); it != _midx.end()) {
               auto& pair = it->second;
               // must use both base+delta, since we only want to keep the
@@ -178,11 +185,13 @@ ss::future<> spill_key_index::index(
 }
 ss::future<> spill_key_index::index(
   model::record_batch_type batch_type,
+  bool is_control_batch,
   const iobuf& key,
   model::offset base_offset,
   int32_t delta) {
     return index(
       batch_type,
+      is_control_batch,
       iobuf_to_bytes(key), // makes a copy, but we need deterministic keys
       base_offset,
       delta);

--- a/src/v/storage/spill_key_index.h
+++ b/src/v/storage/spill_key_index.h
@@ -66,10 +66,18 @@ public:
 
     // public
     ss::future<> index(
-      model::record_batch_type, const iobuf& key, model::offset, int32_t) final;
+      model::record_batch_type,
+      bool is_control_batch,
+      const iobuf& key,
+      model::offset,
+      int32_t) final;
     ss::future<> index(const compaction_key& b, model::offset, int32_t) final;
-    ss::future<>
-    index(model::record_batch_type, bytes&&, model::offset, int32_t) final;
+    ss::future<> index(
+      model::record_batch_type,
+      bool is_control_batch,
+      bytes&&,
+      model::offset,
+      int32_t) final;
     ss::future<> truncate(model::offset) final;
     ss::future<> append(compacted_index::entry) final;
     ss::future<> close() final;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2315,8 +2315,12 @@ void write_batch(
   storage::log log,
   ss::sstring key,
   int value,
-  model::record_batch_type batch_type) {
+  model::record_batch_type batch_type,
+  bool is_control) {
     storage::record_batch_builder builder(batch_type, model::offset(0));
+    if (is_control) {
+        builder.set_control_type();
+    }
 
     builder.add_raw_kv(serde::to_iobuf(std::move(key)), serde::to_iobuf(value));
 
@@ -2332,8 +2336,9 @@ void write_batch(
     std::move(reader).for_each_ref(log.make_appender(cfg), cfg.timeout).get0();
 }
 
-absl::flat_hash_map<std::pair<model::record_batch_type, ss::sstring>, int>
-compact_in_memory(storage::log log) {
+absl::
+  flat_hash_map<std::tuple<model::record_batch_type, bool, ss::sstring>, int>
+  compact_in_memory(storage::log log) {
     auto rdr = log
                  .make_reader(storage::log_reader_config(
                    model::offset(0),
@@ -2341,18 +2346,22 @@ compact_in_memory(storage::log log) {
                    ss::default_priority_class()))
                  .get();
 
-    absl::flat_hash_map<std::pair<model::record_batch_type, ss::sstring>, int>
+    absl::flat_hash_map<
+      std::tuple<model::record_batch_type, bool, ss::sstring>,
+      int>
       ret;
     auto batches = model::consume_reader_to_memory(
                      std::move(rdr), model::no_timeout)
                      .get();
 
     for (auto& b : batches) {
-        b.for_each_record([&ret, bt = b.header().type](model::record r) {
-            auto k = std::make_pair(
-              bt, serde::from_iobuf<ss::sstring>(r.key().copy()));
-            ret.insert_or_assign(k, serde::from_iobuf<int>(r.value().copy()));
-        });
+        b.for_each_record(
+          [&ret, bt = b.header().type, ctrl = b.header().attrs.is_control()](
+            model::record r) {
+              auto k = std::make_tuple(
+                bt, ctrl, serde::from_iobuf<ss::sstring>(r.key().copy()));
+              ret.insert_or_assign(k, serde::from_iobuf<int>(r.value().copy()));
+          });
     }
 
     return ret;
@@ -2381,21 +2390,23 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
     auto disk_log = get_disk_log(log);
 
     // the same key but three different batch types
-    write_batch(log, "key_1", 1, model::record_batch_type::raft_data);
-    write_batch(log, "key_1", 10, model::record_batch_type::tm_update);
-    write_batch(log, "key_1", 100, model::record_batch_type::tx_fence);
+    write_batch(log, "key_1", 1, model::record_batch_type::raft_data, false);
+    write_batch(log, "key_1", 1, model::record_batch_type::raft_data, true);
+    write_batch(log, "key_1", 10, model::record_batch_type::tm_update, false);
+    write_batch(log, "key_1", 100, model::record_batch_type::tx_fence, false);
 
-    write_batch(log, "key_1", 2, model::record_batch_type::raft_data);
-    write_batch(log, "key_1", 3, model::record_batch_type::raft_data);
-    write_batch(log, "key_1", 4, model::record_batch_type::raft_data);
+    write_batch(log, "key_1", 2, model::record_batch_type::raft_data, false);
+    write_batch(log, "key_1", 3, model::record_batch_type::raft_data, false);
+    write_batch(log, "key_1", 4, model::record_batch_type::raft_data, false);
+    write_batch(log, "key_1", 4, model::record_batch_type::raft_data, true);
 
-    write_batch(log, "key_1", 20, model::record_batch_type::tm_update);
-    write_batch(log, "key_1", 30, model::record_batch_type::tm_update);
-    write_batch(log, "key_1", 40, model::record_batch_type::tm_update);
+    write_batch(log, "key_1", 20, model::record_batch_type::tm_update, false);
+    write_batch(log, "key_1", 30, model::record_batch_type::tm_update, false);
+    write_batch(log, "key_1", 40, model::record_batch_type::tm_update, false);
 
-    write_batch(log, "key_1", 200, model::record_batch_type::tm_update);
-    write_batch(log, "key_1", 300, model::record_batch_type::tm_update);
-    write_batch(log, "key_1", 400, model::record_batch_type::tm_update);
+    write_batch(log, "key_1", 200, model::record_batch_type::tm_update, false);
+    write_batch(log, "key_1", 300, model::record_batch_type::tm_update, false);
+    write_batch(log, "key_1", 400, model::record_batch_type::tm_update, false);
 
     disk_log->force_roll(ss::default_priority_class()).get();
 
@@ -2411,7 +2422,7 @@ FIXTURE_TEST(test_compacting_batches_of_different_types, storage_test_fixture) {
       as);
     auto before_compaction = compact_in_memory(log);
 
-    BOOST_REQUIRE_EQUAL(before_compaction.size(), 3);
+    BOOST_REQUIRE_EQUAL(before_compaction.size(), 4);
     // compact
     log.housekeeping(c_cfg).get0();
     auto after_compaction = compact_in_memory(log);

--- a/tests/java/verifiers/src/main/java/io/vectorized/compaction/idempotency/IdempotentWorkload.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/compaction/idempotency/IdempotentWorkload.java
@@ -303,17 +303,13 @@ public class IdempotentWorkload extends GatedWorkload {
     consumer.assign(tps);
     consumer.seekToEnd(tps);
     long end = consumer.position(tp);
-    long written = -1;
-    synchronized (this) {
-      partition.endOffset = end;
-      written = partition.writtenOffset;
-    }
+    synchronized (this) { partition.endOffset = end; }
     consumer.seekToBeginning(tps);
 
     long lastOffset = -1;
     long lastOpId = -1;
 
-    while (consumer.position(tp) < end && consumer.position(tp) <= written) {
+    while (consumer.position(tp) < end) {
       synchronized (this) { partition.readPosition = consumer.position(tp); }
       ConsumerRecords<String, String> records
           = consumer.poll(Duration.ofMillis(10000));

--- a/tests/java/verifiers/src/main/java/io/vectorized/compaction/tx/TxUniqueKeysWorkload.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/compaction/tx/TxUniqueKeysWorkload.java
@@ -310,18 +310,14 @@ public class TxUniqueKeysWorkload extends GatedWorkload {
     consumer.assign(tps);
     consumer.seekToEnd(tps);
     long end = consumer.position(tp);
-    long written = -1;
-    synchronized (this) {
-      partition.endOffset = end;
-      written = partition.writtenOffset;
-    }
+    synchronized (this) { partition.endOffset = end; }
     consumer.seekToBeginning(tps);
 
     long lastOffset = -1;
     long lastOpId = -1;
     long lastTxId = -1;
 
-    while (consumer.position(tp) < end && consumer.position(tp) <= written) {
+    while (consumer.position(tp) < end) {
       synchronized (this) { partition.readPosition = consumer.position(tp); }
       ConsumerRecords<String, String> records
           = consumer.poll(Duration.ofMillis(10000));

--- a/tests/java/verifiers/src/main/java/io/vectorized/compaction/tx/TxWorkload.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/compaction/tx/TxWorkload.java
@@ -364,17 +364,13 @@ public class TxWorkload extends GatedWorkload {
     consumer.assign(tps);
     consumer.seekToEnd(tps);
     long end = consumer.position(tp);
-    long written = -1;
-    synchronized (this) {
-      partition.endOffset = end;
-      written = partition.writtenOffset;
-    }
+    synchronized (this) { partition.endOffset = end; }
     consumer.seekToBeginning(tps);
 
     long lastOffset = -1;
     long lastOpId = -1;
 
-    while (consumer.position(tp) < end && consumer.position(tp) <= written) {
+    while (consumer.position(tp) < end) {
       synchronized (this) { partition.readPosition = consumer.position(tp); }
       ConsumerRecords<String, String> records
           = consumer.poll(Duration.ofMillis(10000));


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/13609

With this PR, control batches are not discarded but are compacted in the same manner as other data batches. This approach prevents the elimination of the last batch within a segment when it happens to be a control batch. If the final batch in a segment is discarded, and there are no subsequent data batches, it could lead to clients being unable to advance their consumed offset until the LSO, creating the perception of a stuck consumer unable to make progress.

However, this situation is not problematic when the last batch is an aborted data batch. This is because we can guarantee the presence of user consumable batches following it (in the next segment), specifically the abort control batch (or maybe other interleaved committed batches), ensuring continuous consumer progress.

Fixes https://github.com/redpanda-data/redpanda/issues/13640


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixes a case when a control batch is the last user batch in a segment and the log and is being compacted away. This gave a perception of consumption hang from a client POV but in reality there is nothing to consume after that point. Not discarding such batches lets the consumer offset make progress and reach LSO.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
