### PR TITLE
rpk: fix typo in decommission-status

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
@@ -91,7 +91,7 @@ using 'rpk cluster config get partition_autobalancing_mode'.
 
 			if dbs.Finished {
 				if dbs.ReplicasLeft == 0 {
-					out.Exit("Note %d is decommissioned successfully.", broker)
+					out.Exit("Node %d is decommissioned successfully.", broker)
 				} else {
 					out.Exit("Node %d is decommissioned but there are %d replicas left, which may be an issue inside Redpanda. Please describe how you encountered this at https://github.com/redpanda-data/redpanda/issues/new?assignees=&labels=kind%2Fbug&template=01_bug_report.md", broker, dbs.ReplicasLeft)
 				}


### PR DESCRIPTION
```
Note %d is decommissioned successfully
```
to
```
Node %d is decommissioned successfully
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* None
