### PR TITLE
k8s: Error out when annotation can not be set

### DIFF
--- a/src/go/k8s/controllers/cluster.redpanda.com/topic_controller.go
+++ b/src/go/k8s/controllers/cluster.redpanda.com/topic_controller.go
@@ -570,7 +570,7 @@ func (r *TopicReconciler) createKafkaClient(ctx context.Context, topic *v1alpha1
 func (r *TopicReconciler) recordErrorEvent(err error, topic *v1alpha1.Topic, eventType, message string, args ...any) error {
 	if r.EventRecorder != nil {
 		var eventArgs []any
-		copy(args, eventArgs)
+		copy(eventArgs, args)
 		eventArgs = append(eventArgs, err.Error())
 		r.EventRecorder.AnnotatedEventf(topic,
 			map[string]string{v2.GroupVersion.Group + "/revision": topic.ResourceVersion},

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -338,7 +338,7 @@ func (r *ClusterReconciler) handlePodFinalizer(
 			// if the pod is not being deleted, set the finalizer
 			if err = r.setPodFinalizer(ctx, pod, log); err != nil {
 				//nolint:goerr113 // not going to use wrapped static error here this time
-				return fmt.Errorf(`unable to set the finalizer on pod "%s": %d`, pod.Name, err)
+				return fmt.Errorf(`unable to set the finalizer on pod "%s": %w`, pod.Name, err)
 			}
 			continue
 		}

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -194,7 +194,7 @@ func (r *ClusterReconciler) Reconcile(
 
 	if vectorizedCluster.Status.CurrentReplicas >= 1 {
 		if err = r.setPodNodeIDAnnotation(ctx, &vectorizedCluster, log, ar); err != nil {
-			return ctrl.Result{}, fmt.Errorf("setting pod node_id annotation: %w", err)
+			log.Error(err, "setting pod node_id annotation")
 		}
 	}
 
@@ -464,6 +464,8 @@ func (r *ClusterReconciler) setPodNodeIDAnnotation(
 	if err != nil {
 		return fmt.Errorf("unable to fetch PodList: %w", err)
 	}
+
+	var combinedErrors error
 	for i := range pods.Items {
 		pod := &pods.Items[i]
 		if pod.Annotations == nil {
@@ -473,7 +475,7 @@ func (r *ClusterReconciler) setPodNodeIDAnnotation(
 
 		nodeID, err := r.fetchAdminNodeID(ctx, rp, pod, ar)
 		if err != nil {
-			log.Error(err, `cannot fetch node id for node-id annotation`)
+			combinedErrors = errors.Join(combinedErrors, fmt.Errorf(`cannot fetch node id for "%s" node-id annotation: %w`, pod.Name, err))
 			continue
 		}
 
@@ -487,22 +489,25 @@ func (r *ClusterReconciler) setPodNodeIDAnnotation(
 		if annotationExist {
 			oldNodeID, err = strconv.Atoi(nodeIDStrAnnotation)
 			if err != nil {
-				return fmt.Errorf("unable to convert node ID (%s) to int: %w", nodeIDStrAnnotation, err)
+				combinedErrors = errors.Join(combinedErrors, fmt.Errorf("unable to convert node ID (%s) to int: %w", nodeIDStrAnnotation, err))
+				continue
 			}
 
 			log.WithValues("pod-name", pod.Name, "old-node-id", oldNodeID).Info("decommission old node-id")
 			if err = r.decommissionBroker(ctx, rp, oldNodeID, log, ar); err != nil {
-				return fmt.Errorf("unable to decommission broker: %w", err)
+				combinedErrors = errors.Join(combinedErrors, fmt.Errorf("unable to decommission broker: %w", err))
+				continue
 			}
 		}
 
 		log.WithValues("pod-name", pod.Name, "new-node-id", nodeID).Info("setting node-id annotation")
 		pod.Annotations[resources.PodAnnotationNodeIDKey] = realNodeIDStr
 		if err := r.Update(ctx, pod, &client.UpdateOptions{}); err != nil {
-			return fmt.Errorf(`unable to update pod "%s" with node-id annotation: %w`, pod.Name, err)
+			combinedErrors = errors.Join(combinedErrors, fmt.Errorf(`unable to update pod "%s" with node-id annotation: %w`, pod.Name, err))
+			continue
 		}
 	}
-	return nil
+	return combinedErrors
 }
 
 func (r *ClusterReconciler) setPodNodeIDLabel(

--- a/src/go/k8s/controllers/redpanda/cluster_controller.go
+++ b/src/go/k8s/controllers/redpanda/cluster_controller.go
@@ -265,7 +265,10 @@ func (r *ClusterReconciler) Reconcile(
 
 	// The following should be at the last part as it requires AdminAPI to be running
 	if err := r.setPodNodeIDAnnotation(ctx, &vectorizedCluster, log, ar); err != nil {
-		return ctrl.Result{}, fmt.Errorf("setting pod node_id annotation: %w", err)
+		log.Error(err, "setting pod node_id annotation after reconciling resources")
+		return ctrl.Result{
+			RequeueAfter: 4 * time.Second,
+		}, nil
 	}
 	if err := r.setPodNodeIDLabel(ctx, &vectorizedCluster, log, ar); err != nil {
 		return ctrl.Result{}, fmt.Errorf("setting pod node_id label: %w", err)

--- a/src/go/k8s/controllers/test/cluster_controller_scale_test.go
+++ b/src/go/k8s/controllers/test/cluster_controller_scale_test.go
@@ -132,6 +132,7 @@ var _ = Describe("Redpanda cluster scale resource", func() {
 
 			By("Scaling down only when decommissioning is done")
 			Expect(testAdminAPI.RemoveBroker(2)).To(BeTrue())
+			testAdminAPI.AddGhostBroker(admin.Broker{NodeID: 2, MembershipStatus: admin.MembershipStatusDraining})
 			Eventually(resourceDataGetter(key, &sts, func() interface{} {
 				return *sts.Spec.Replicas
 			}), timeout, interval).Should(Equal(int32(2)))
@@ -142,6 +143,7 @@ var _ = Describe("Redpanda cluster scale resource", func() {
 
 			By("Removing the other node as well when done")
 			Expect(testAdminAPI.RemoveBroker(1)).To(BeTrue())
+			testAdminAPI.AddGhostBroker(admin.Broker{NodeID: 1, MembershipStatus: admin.MembershipStatusDraining})
 			Eventually(resourceDataGetter(key, &sts, func() interface{} {
 				return *sts.Spec.Replicas
 			}), timeout, interval).Should(Equal(int32(1)))

--- a/src/go/k8s/hack/get-redpanda-info.sh
+++ b/src/go/k8s/hack/get-redpanda-info.sh
@@ -44,6 +44,12 @@ for cl in $(kubectl -n $script_namespace get cluster --output=jsonpath='{.items.
   done
 done
 
+kubectl get -n $script_namespace certificates -o yaml >$ARTIFACTS_PATH/certificates.yaml
+kubectl get -n $script_namespace certificatesigningrequests -o yaml >$ARTIFACTS_PATH/certificatesigningrequests.yaml
+kubectl get -n $script_namespace issuers -o yaml >$ARTIFACTS_PATH/issuers.yaml
+kubectl get clusterissuers -o yaml >$ARTIFACTS_PATH/all-clusterissuers.yaml
+kubectl get -n $script_namespace certificaterequests -o yaml >$ARTIFACTS_PATH/certificaterequests.yaml
+
 kubectl get events -n $script_namespace --sort-by metadata.creationTimestamp >$ARTIFACTS_PATH/events.txt
 kubectl get events --sort-by metadata.creationTimestamp -A >$ARTIFACTS_PATH/all-events.txt
 kubectl describe node >$ARTIFACTS_PATH/described-nodes.txt

--- a/src/go/k8s/hack/get-redpanda-info.sh
+++ b/src/go/k8s/hack/get-redpanda-info.sh
@@ -44,7 +44,7 @@ for cl in $(kubectl -n $script_namespace get cluster --output=jsonpath='{.items.
   done
 done
 
-kubectl get events --sort-by metadata.creationTimestamp >$ARTIFACTS_PATH/events.txt
+kubectl get events -n $script_namespace --sort-by metadata.creationTimestamp >$ARTIFACTS_PATH/events.txt
 kubectl get events --sort-by metadata.creationTimestamp -A >$ARTIFACTS_PATH/all-events.txt
 kubectl describe node >$ARTIFACTS_PATH/described-nodes.txt
 kubectl get pod -A -o yaml >$ARTIFACTS_PATH/all-pods.yaml

--- a/src/go/k8s/hack/get-redpanda-info.sh
+++ b/src/go/k8s/hack/get-redpanda-info.sh
@@ -50,6 +50,9 @@ kubectl get -n $script_namespace issuers -o yaml >$ARTIFACTS_PATH/issuers.yaml
 kubectl get clusterissuers -o yaml >$ARTIFACTS_PATH/all-clusterissuers.yaml
 kubectl get -n $script_namespace certificaterequests -o yaml >$ARTIFACTS_PATH/certificaterequests.yaml
 
+kubectl get -n $script_namespace sts -o yaml >$ARTIFACTS_PATH/sts.yaml
+kubectl get -n $script_namespace redpanda -o yaml >$ARTIFACTS_PATH/redpandas.yaml
+
 kubectl get events -n $script_namespace --sort-by metadata.creationTimestamp >$ARTIFACTS_PATH/events.txt
 kubectl get events --sort-by metadata.creationTimestamp -A >$ARTIFACTS_PATH/all-events.txt
 kubectl describe node >$ARTIFACTS_PATH/described-nodes.txt

--- a/src/go/k8s/kind-for-v2.yaml
+++ b/src/go/k8s/kind-for-v2.yaml
@@ -9,3 +9,7 @@ nodes:
   image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
 - role: worker
   image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+- role: worker
+  image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315
+- role: worker
+  image: kindest/node:v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -10,6 +10,7 @@ testDirs:
 kindConfig: ./kind.yaml
 kindNodeCache: false
 commands:
+  - command: kubectl taint node kind-control-plane node-role.kubernetes.io/master- node-role.kubernetes.io/control-plane-
   - command: "mkdir -p tests/_e2e_artifacts"
   - command: "./hack/install-cert-manager.sh tests/_e2e_artifacts"
     background: true

--- a/src/go/k8s/kuttl-test.yaml
+++ b/src/go/k8s/kuttl-test.yaml
@@ -11,8 +11,6 @@ kindConfig: ./kind.yaml
 kindNodeCache: false
 commands:
   - command: "mkdir -p tests/_e2e_artifacts"
-  - command: "kubectl taint nodes -l node-role.kubernetes.io/master= node-role.kubernetes.io/master:NoSchedule-"
-    ignoreFailure: true
   - command: "./hack/install-cert-manager.sh tests/_e2e_artifacts"
     background: true
     ignoreFailure: true
@@ -23,9 +21,9 @@ commands:
     background: true
   - command: "./hack/wait-for-webhook-ready.sh"
 artifactsDir: tests/_e2e_artifacts
-timeout: 390
+timeout: 300
 reportFormat: xml
-parallel: 4
+parallel: 2
 namespace: redpanda-system
 suppress:
   - events

--- a/src/go/k8s/kuttl-v2-test.yaml
+++ b/src/go/k8s/kuttl-v2-test.yaml
@@ -5,7 +5,7 @@ kindContainers:
   - localhost/redpanda-operator:dev
 testDirs:
   - ./tests/e2e-v2
-kindConfig: ./kind.yaml
+kindConfig: ./kind-for-v2.yaml
 kindNodeCache: false
 commands:
   - command: mkdir -p tests/_e2e_artifacts_v2

--- a/src/go/k8s/pkg/resources/certmanager/pki.go
+++ b/src/go/k8s/pkg/resources/certmanager/pki.go
@@ -12,6 +12,7 @@ package certmanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -79,14 +80,16 @@ func (r *PkiReconciler) Ensure(ctx context.Context) error {
 	}
 	toApply = append(toApply, res...)
 
+	var joinedErrors error
 	for _, res := range toApply {
 		err := res.Ensure(ctx)
 		if err != nil {
 			r.logger.Error(err, "Failed to reconcile pki")
+			joinedErrors = errors.Join(joinedErrors, err)
 		}
 	}
 
-	return nil
+	return joinedErrors
 }
 
 func (r *PkiReconciler) Key() types.NamespacedName {

--- a/src/go/k8s/tests/e2e/admin-api-tls/02-clean.yaml
+++ b/src/go/k8s/tests/e2e/admin-api-tls/02-clean.yaml
@@ -13,3 +13,8 @@ delete:
     kind: Job
     name: call-admin-api-tls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: call-admin-api-tls
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/admin-api/02-clean.yaml
+++ b/src/go/k8s/tests/e2e/admin-api/02-clean.yaml
@@ -13,3 +13,8 @@ delete:
     kind: Job
     name: call-admin-api
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: call-admin-api
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/03-clean.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-bootstrap/03-clean.yaml
@@ -17,7 +17,17 @@ delete:
     kind: Job
     name: get-centralized-config-bootstrap-1
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-bootstrap-1
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-centralized-config-bootstrap-2
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-bootstrap-2
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/centralized-configuration-drift/04-clean.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-drift/04-clean.yaml
@@ -17,11 +17,26 @@ delete:
     kind: Job
     name: external-change
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: external-change
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-centralized-config-1-drift
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-1-drift
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-centralized-config-2-drift
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-2-drift
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/centralized-configuration-tls/06-clean.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-tls/06-clean.yaml
@@ -17,7 +17,17 @@ delete:
     kind: Job
     name: get-centralized-config-tls-1
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-tls-1
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-centralized-config-tls-2
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-tls-2
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/centralized-configuration-upgrade/04-clean.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration-upgrade/04-clean.yaml
@@ -17,3 +17,8 @@ delete:
     kind: Job
     name: get-centralized-config
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/centralized-configuration/05-clean.yaml
+++ b/src/go/k8s/tests/e2e/centralized-configuration/05-clean.yaml
@@ -17,7 +17,17 @@ delete:
     kind: Job
     name: get-centralized-config-1
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-1
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-centralized-config-2
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-2
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/confluent-schema-registry/04-clean.yaml
+++ b/src/go/k8s/tests/e2e/confluent-schema-registry/04-clean.yaml
@@ -17,7 +17,17 @@ delete:
     kind: Job
     name: create-schema
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrive-schema
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrive-schema
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/console-admin-api/04-cleanup.yaml
+++ b/src/go/k8s/tests/e2e/console-admin-api/04-cleanup.yaml
@@ -21,7 +21,17 @@ delete:
     kind: Job
     name: call-console-admin-api
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: call-console-admin-api
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: check-version
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: check-version
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/console-kafka-mtls/07-cleanup.yaml
+++ b/src/go/k8s/tests/e2e/console-kafka-mtls/07-cleanup.yaml
@@ -21,11 +21,26 @@ delete:
     kind: Job
     name: call-console-kafka-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: call-console-kafka-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-test-topic-kafka-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-test-topic-kafka-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-schema-with-tls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-with-tls
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/console/03-cleanup.yaml
+++ b/src/go/k8s/tests/e2e/console/03-cleanup.yaml
@@ -21,3 +21,8 @@ delete:
     kind: Job
     name: call-console
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: call-console
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/05-clean.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer-with-client-auth/05-clean.yaml
@@ -13,9 +13,19 @@ delete:
     kind: Job
     name: create-test-topic-with-client-auth
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-test-topic-with-client-auth
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-schema-with-client-auth
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-with-client-auth
     namespace: redpanda-system
   - apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/src/go/k8s/tests/e2e/create-topic-given-issuer/05-clean.yaml
+++ b/src/go/k8s/tests/e2e/create-topic-given-issuer/05-clean.yaml
@@ -13,9 +13,19 @@ delete:
     kind: Job
     name: create-test-topic-given-issuer
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-test-topic-given-issuer
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-schema-given-issuer
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-given-issuer
     namespace: redpanda-system
   - apiVersion: cert-manager.io/v1
     kind: ClusterIssuer

--- a/src/go/k8s/tests/e2e/decommission/07-clean.yaml
+++ b/src/go/k8s/tests/e2e/decommission/07-clean.yaml
@@ -21,7 +21,17 @@ delete:
     kind: Job
     name: get-broker-count
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-broker-count
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-broker-count-again
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-broker-count-again
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/explicit-ports-tls/02-clean.yaml
+++ b/src/go/k8s/tests/e2e/explicit-ports-tls/02-clean.yaml
@@ -13,6 +13,11 @@ delete:
     kind: Job
     name: explicit-ports-tls-check
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: explicit-ports-tls-check
+    namespace: redpanda-system
   - apiVersion: cert-manager.io/v1
     kind: Issuer
     name: explicit-port-tls-issuer

--- a/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/external-connectivity/00-assert.yaml
@@ -1,3 +1,14 @@
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: external-connectivity
+status:
+  replicas: 1
+  restarting: false
+  conditions:
+    - type: ClusterConfigured
+      status: "True"
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/src/go/k8s/tests/e2e/kafkaapi-client-auth/06-clean.yaml
+++ b/src/go/k8s/tests/e2e/kafkaapi-client-auth/06-clean.yaml
@@ -13,15 +13,35 @@ delete:
     kind: Job
     name: create-topic-with-client-auth
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-topic-with-client-auth
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: produce-message-with-client-auth
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: produce-message-with-client-auth
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: consume-message-with-client-auth
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: consume-message-with-client-auth
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-metrics-with-client-auth
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-metrics-with-client-auth
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/lost-redpanda-decommission/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/lost-redpanda-decommission/00-assert.yaml
@@ -4,7 +4,7 @@ kind: Cluster
 metadata:
   name: lost-rp-decommission
 status:
-  version: "v23.2.3"
+  version: "v23.2.10"
   readyReplicas: 3
   replicas: 3
   upgrading: false

--- a/src/go/k8s/tests/e2e/lost-redpanda-decommission/00-cluster.yaml
+++ b/src/go/k8s/tests/e2e/lost-redpanda-decommission/00-cluster.yaml
@@ -4,7 +4,7 @@ metadata:
   name: lost-rp-decommission
 spec:
   image: "redpandadata/redpanda"
-  version: "v23.2.3"
+  version: "v23.2.10"
   replicas: 3
   resources:
     requests:

--- a/src/go/k8s/tests/e2e/lost-redpanda-decommission/02-assert.yaml
+++ b/src/go/k8s/tests/e2e/lost-redpanda-decommission/02-assert.yaml
@@ -1,0 +1,4 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+collectors:
+  - command: ../../../hack/get-redpanda-info.sh

--- a/src/go/k8s/tests/e2e/lost-redpanda-decommission/02-clean.yaml
+++ b/src/go/k8s/tests/e2e/lost-redpanda-decommission/02-clean.yaml
@@ -1,0 +1,19 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+  - apiVersion: redpanda.vectorized.io/v1alpha1
+    kind: Cluster
+    name: lost-rp-decommission
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: datadir-lost-rp-decommission-0
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: datadir-lost-rp-decommission-1
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: datadir-lost-rp-decommission-2
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/managed-decommission/00-assert.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/00-assert.yaml
@@ -17,6 +17,20 @@ metadata:
   annotations:
     operator.redpanda.com/node-id: "0"
 ---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: managed-decommission-1
+  annotations:
+    operator.redpanda.com/node-id: "1"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: managed-decommission-2
+  annotations:
+    operator.redpanda.com/node-id: "2"
+---
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 collectors:

--- a/src/go/k8s/tests/e2e/managed-decommission/03-clean.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/03-clean.yaml
@@ -21,3 +21,8 @@ delete:
     kind: Job
     name: get-broker-count-managed-decom
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-broker-count-managed-decom
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/managed-decommission/03-clean.yaml
+++ b/src/go/k8s/tests/e2e/managed-decommission/03-clean.yaml
@@ -13,6 +13,10 @@ delete:
     kind: PersistentVolumeClaim
     name: datadir-decommission-1
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: PersistentVolumeClaim
+    name: datadir-decommission-2
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-broker-count-managed-decom

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/04-clean.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-sasl/04-clean.yaml
@@ -13,11 +13,26 @@ delete:
     kind: Job
     name: create-test-topic-with-pp-sasl
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-test-topic-with-pp-sasl
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: produce-message-with-pp-sasl
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: produce-message-with-pp-sasl
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: consume-message-with-pp-sasl
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: consume-message-with-pp-sasl
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client-external-ca/10-clean.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client-external-ca/10-clean.yaml
@@ -13,25 +13,55 @@ delete:
     kind: Job
     name: create-test-topic-pp-ext-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-test-topic-pp-ext-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: produce-message-pp-ext-mtls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: produce-message-pp-ext-mtls
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: consume-message-pp-ext-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: consume-message-pp-ext-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-topic-test-pp-ext-mtls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-topic-test-pp-ext-mtls
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-topic-test-updated-ca-pp-ext-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-topic-test-updated-ca-pp-ext-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-topic-test-untrusted-ca-pp-ext-mtls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-topic-test-untrusted-ca-pp-ext-mtls
     namespace: redpanda-system
   - apiVersion: v1
     kind: Secret

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/04-clean.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume-tls-client/04-clean.yaml
@@ -13,11 +13,26 @@ delete:
     kind: Job
     name: create-test-topic-with-pp-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-test-topic-with-pp-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: produce-message-with-pp-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: produce-message-with-pp-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: consume-message-with-pp-mtls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: consume-message-with-pp-mtls
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/pandaproxy-produce-consume/04-clean.yaml
+++ b/src/go/k8s/tests/e2e/pandaproxy-produce-consume/04-clean.yaml
@@ -13,11 +13,26 @@ delete:
     kind: Job
     name: create-test-topic-with-pp
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-test-topic-with-pp
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: produce-message-using-pp
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: produce-message-using-pp
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: consume-message-using-pp
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: consume-message-using-pp
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/produce-tls/04-clean.yaml
+++ b/src/go/k8s/tests/e2e/produce-tls/04-clean.yaml
@@ -13,7 +13,17 @@ delete:
     kind: Job
     name: create-test-topic-long-name
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-test-topic-long-name
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: produce-message-long-name
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: produce-message-long-name
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry-sasl/12-clean.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry-sasl/12-clean.yaml
@@ -13,35 +13,80 @@ delete:
     kind: Job
     name: create-schema-rp-sasl
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-rp-sasl
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-rp-sasl
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-rp-sasl
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: delete-schema-rp-sasl
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: delete-schema-rp-sasl
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-schema-with-tls-rp-sasl
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-with-tls-rp-sasl
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-with-tls-rp-sasl
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-with-tls-rp-sasl
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: delete-schema-with-tls-rp-sasl
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: delete-schema-with-tls-rp-sasl
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-schema-with-client-tls-rp-sasl
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-with-client-tls-rp-sasl
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-with-client-tls-rp-sasl
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-with-client-tls-rp-sasl
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: delete-schema-with-client-tls-rp-sasl
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: delete-schema-with-client-tls-rp-sasl
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/redpanda-schema-registry/12-clean.yaml
+++ b/src/go/k8s/tests/e2e/redpanda-schema-registry/12-clean.yaml
@@ -13,35 +13,80 @@ delete:
     kind: Job
     name: create-schema-rp
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-rp
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-rp
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-rp
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: delete-schema-rp
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: delete-schema-rp
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-schema-with-tls-rp
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-with-tls-rp
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-with-tls-rp
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-with-tls-rp
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: delete-schema-with-tls-rp
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: delete-schema-with-tls-rp
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-schema-with-client-tls-rp
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-with-client-tls-rp
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-with-client-tls-rp
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-with-client-tls-rp
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: delete-schema-with-client-tls-rp
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: delete-schema-with-client-tls-rp
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/regressions/02-clean.yaml
+++ b/src/go/k8s/tests/e2e/regressions/02-clean.yaml
@@ -13,3 +13,8 @@ delete:
     kind: Job
     name: call-controller-status
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: call-controller-status
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/schema-registry-tls-client-external-ca/08-clean.yaml
+++ b/src/go/k8s/tests/e2e/schema-registry-tls-client-external-ca/08-clean.yaml
@@ -13,21 +13,46 @@ delete:
     kind: Job
     name: create-schema-client-external-ca-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-client-external-ca-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-client-external-ca-mtls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-client-external-ca-mtls
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-schema-client-without-cert
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-client-without-cert
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-client-external-updated-ca-mtls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-client-external-updated-ca-mtls
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: retrieve-schema-untrusted-client
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: retrieve-schema-untrusted-client
     namespace: redpanda-system
   - apiVersion: v1
     kind: Secret

--- a/src/go/k8s/tests/e2e/shared-tls-cert/02-clean.yaml
+++ b/src/go/k8s/tests/e2e/shared-tls-cert/02-clean.yaml
@@ -13,3 +13,8 @@ delete:
     kind: Job
     name: call-endpoints-shared-tls
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: call-endpoints-shared-tls
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/superusers-prefix/02-cleanup.yaml
+++ b/src/go/k8s/tests/e2e/superusers-prefix/02-cleanup.yaml
@@ -17,3 +17,8 @@ delete:
     kind: Job
     name: set-superuser-password
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: set-superuser-password
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/update-image-and-node-port/09-clean.yaml
+++ b/src/go/k8s/tests/e2e/update-image-and-node-port/09-clean.yaml
@@ -25,7 +25,17 @@ delete:
     kind: Job
     name: wait-for-v23-1-11
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: wait-for-v23-1-11
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: wait-for-tip-of-the-dev
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: wait-for-tip-of-the-dev
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth-external-ca/12-clean.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth-external-ca/12-clean.yaml
@@ -17,27 +17,62 @@ delete:
     kind: Job
     name: create-schema-update-img-external-client-ca
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-schema-update-img-external-client-ca
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: create-topic-update-img-external-client-ca
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: create-topic-update-img-external-client-ca
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-schema-update-img-external-client-ca
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-schema-update-img-external-client-ca
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: produce-msg-update-img-external-client-ca
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: produce-msg-update-img-external-client-ca
     namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-topic-failure-update-img-external-client-ca
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-topic-failure-update-img-external-client-ca
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-schema-failure-update-img-external-client-ca
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-schema-failure-update-img-external-client-ca
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: call-console-update-img-external-client-ca
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: call-console-update-img-external-client-ca
     namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/update-image-tls-client-auth-no-external-ca/09-clean.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-client-auth-no-external-ca/09-clean.yaml
@@ -21,3 +21,21 @@ delete:
     kind: Deployment
     name: kminion-no-ext-ca
     namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: wait-for-v23-1-11-mtls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: wait-for-v23-1-11-mtls
+    namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: wait-for-tip-of-the-dev-mtls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: wait-for-tip-of-the-dev-mtls
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/update-image-tls-no-client-auth/09-clean.yaml
+++ b/src/go/k8s/tests/e2e/update-image-tls-no-client-auth/09-clean.yaml
@@ -21,3 +21,21 @@ delete:
     kind: Deployment
     name: kminion-admin-tls
     namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: wait-for-v23-1-11-tls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: wait-for-v23-1-11-tls
+    namespace: redpanda-system
+  - apiVersion: batch/v1
+    kind: Job
+    name: wait-for-tip-of-the-dev-tls
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: wait-for-tip-of-the-dev-tls
+    namespace: redpanda-system

--- a/src/go/k8s/tests/e2e/user-specified-serviceaccount-name/01-clean.yaml
+++ b/src/go/k8s/tests/e2e/user-specified-serviceaccount-name/01-clean.yaml
@@ -17,7 +17,17 @@ delete:
     kind: Job
     name: get-centralized-config-1
     namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-1
+    namespace: redpanda-system
   - apiVersion: batch/v1
     kind: Job
     name: get-centralized-config-2
+    namespace: redpanda-system
+  - apiVersion: v1
+    kind: Pod
+    labels:
+      job-name: get-centralized-config-2
     namespace: redpanda-system


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Given the following operator logic
https://github.com/redpanda-data/redpanda/blob/51766019d6e85b7252a0c637043fc5d9edbc4673/src/go/k8s/controllers/redpanda/cluster_controller.go#L266-L275
The chain of events that causes wrong decommission logic is:
* `setPodNodeIDAnnotation` failed to get the Redpanda Node ID
* `setPodNodeIDAnnotation` does not return an error, but only it logs it out
* `setPodNodeIDLabel` was able to get Redpanda Node ID, so broker was able to boot up and register its Node ID
* `decommissionGhostBrokers` is performing filtering based on Pod annotation which is incorrect

Logs from the wrong execution:
```
{"level":"info","ts":"2023-09-27T06:51:41.644Z","logger":"ClusterReconciler.Reconcile.setPodNodeIDLabel","msg":"setting node-id label","controller":"cluster","controllerGroup":"redpanda.vectorized.io","controllerKind":"Cluster","Cluster":{"name":"repanda-cluster","namespace":"redpanda"},"namespace":"redpanda","name":"repanda-cluster","reconcileID":"57bf8b57-60b5-4248-bedd-3ffcaa5c4e07","pod-name":"repanda-cluster-1","new-node-id":3}
{"level":"info","ts":"2023-09-27T06:51:41.718Z","logger":"ClusterReconciler.Reconcile.setPodNodeIDAnnotation","msg":"decommission old node-id","controller":"cluster","controllerGroup":"redpanda.vectorized.io","controllerKind":"Cluster","Cluster":{"name":"repanda-cluster","namespace":"redpanda"},"namespace":"redpanda","name":"repanda-cluster","reconcileID":"fa64d3d8-02cf-4c1f-8a67-13a2dfb339ea","pod-name":"repanda-cluster-1","old-node-id":1}
{"level":"info","ts":"2023-09-27T06:51:41.758Z","logger":"ClusterReconciler.Reconcile.setPodNodeIDAnnotation","msg":"setting node-id annotation","controller":"cluster","controllerGroup":"redpanda.vectorized.io","controllerKind":"Cluster","Cluster":{"name":"repanda-cluster","namespace":"redpanda"},"namespace":"redpanda","name":"repanda-cluster","reconcileID":"fa64d3d8-02cf-4c1f-8a67-13a2dfb339ea","pod-name":"repanda-cluster-1","new-node-id":3}
{"level":"error","ts":"2023-09-27T06:51:42.497Z","msg":"Reconciler error","controller":"cluster","controllerGroup":"redpanda.vectorized.io","controllerKind":"Cluster","Cluster":{"name":"repanda-cluster","namespace":"redpanda"},"namespace":"redpanda","name":"repanda-cluster","reconcileID":"fa64d3d8-02cf-4c1f-8a67-13a2dfb339ea","error":"deleting ghost brokers: failed to decommission ghost broker: request PUT http://repanda-cluster-0.repanda-cluster.redpanda.svc.cluster.local/.:9644/v1/brokers/1/decommission failed: Bad Request, body: \"{\\\"message\\\": \\\"can not update broker 1 state, invalid state transition requested\\\", \\\"code\\\": 400}\"\n"}
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* do not allow unsafe decommission procedure if annotation was not changed

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
