### PR TITLE
services/redpanda.py: make _get_object_storage_report dynamic

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3639,7 +3639,7 @@ class RedpandaService(RedpandaServiceBase):
 
     def _get_object_storage_report(self,
                                    tolerate_empty_object_storage=False,
-                                   timeout=60) -> dict[str, str | list[str]]:
+                                   timeout=300) -> dict[str, str | list[str]]:
         """
         Uses rp-storage-tool to get the object storage report.
         If the cluster is running the tool could see some inconsistencies and report anomalies,
@@ -3694,12 +3694,17 @@ class RedpandaService(RedpandaServiceBase):
 
         bucket = self.si_settings.cloud_storage_bucket
         environment = ' '.join(f'{k}=\"{v}\"' for k, v in vars.items())
+        bucket_arity = len(list(self.get_objects_from_si()))
+        effective_timeout = min(bucket_arity * 3, timeout)
+        self.logger.info(
+            f"num objects in the {bucket=}: {bucket_arity}, will apply {effective_timeout=}"
+        )
         output, stderr = ssh_output_stderr(
             self,
             node,
             f"{environment} rp-storage-tool --backend {backend} scan-metadata --source {bucket}",
             allow_fail=True,
-            timeout_sec=timeout)
+            timeout_sec=effective_timeout)
 
         # if stderr contains a WARN logline, log it as DEBUG, since this is mostly related to debugging rp-storage-tool itself
         if re.search(b'\[\S+ WARN', stderr) is not None:
@@ -3720,7 +3725,7 @@ class RedpandaService(RedpandaServiceBase):
 
     def raise_on_cloud_storage_inconsistencies(self,
                                                inconsistencies: list[str],
-                                               run_timeout=60):
+                                               run_timeout=300):
         """
         like stop_and_scrub_object_storage, use rp-storage-tool to explicitly check for inconsistencies,
         but without stopping the cluster.
@@ -3737,7 +3742,7 @@ class RedpandaService(RedpandaServiceBase):
                 f"Object storage reports fatal anomalies of type {fatal_anomalies}"
             )
 
-    def stop_and_scrub_object_storage(self, run_timeout=60):
+    def stop_and_scrub_object_storage(self, run_timeout=300):
         # Before stopping, ensure that all tiered storage partitions
         # have uploaded at least a manifest: we do not require that they
         # have uploaded until the head of their log, just that they have

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3694,8 +3694,8 @@ class RedpandaService(RedpandaServiceBase):
 
         bucket = self.si_settings.cloud_storage_bucket
         environment = ' '.join(f'{k}=\"{v}\"' for k, v in vars.items())
-        bucket_arity = len(list(self.get_objects_from_si()))
-        effective_timeout = min(bucket_arity * 3, timeout)
+        bucket_arity = sum(1 for _ in self.get_objects_from_si())
+        effective_timeout = min(max(bucket_arity * 5, 20), timeout)
         self.logger.info(
             f"num objects in the {bucket=}: {bucket_arity}, will apply {effective_timeout=}"
         )


### PR DESCRIPTION
Use the number of objects to apply a timeout, raise the default timeout to 5 minutes

It uses the number of objects, but a better metric would be to the aggregate size of objects

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes #13236 #12320

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none