### PR TITLE
[v23.2.x] kafka: Expose per handler produce/fetch metrics on public_metrics

### DIFF
--- a/src/v/kafka/server/handlers/handler_probe.h
+++ b/src/v/kafka/server/handlers/handler_probe.h
@@ -34,6 +34,7 @@ public:
     handler_probe& operator=(handler_probe&&) = delete;
     ~handler_probe() = default;
     void setup_metrics(ss::metrics::metric_groups&, api_key);
+    void setup_public_metrics(ss::metrics::metric_groups&, api_key);
 
     void sample_in_progress();
     void request_completed() {
@@ -93,6 +94,8 @@ public:
 
 private:
     ss::metrics::metric_groups _metrics;
+    ss::metrics::metric_groups _public_metrics{
+      ssx::metrics::public_metrics_handle};
     std::vector<handler_probe> _probes;
 };
 


### PR DESCRIPTION
Backport of PR: https://github.com/redpanda-data/redpanda/pull/13549

Fixes: https://github.com/redpanda-data/redpanda/issues/13721