### PR TITLE
Make maintenance mode opaque to the partition balancer

### DIFF
--- a/src/v/cluster/drain_manager.cc
+++ b/src/v/cluster/drain_manager.cc
@@ -130,20 +130,10 @@ ss::future<> drain_manager::task() {
             break;
         }
 
-        const auto draining = _draining;
-        try {
-            if (draining) {
-                co_await do_drain();
-            } else {
-                co_await do_restore();
-            }
-        } catch (...) {
-            vlog(
-              clusterlog.warn,
-              "Draining task {{{}}} experienced error: {}",
-              draining ? "drain" : "restore",
-              std::current_exception());
-            _status.errors = true;
+        if (_draining) {
+            co_await do_drain();
+        } else {
+            co_await do_restore();
         }
         _status.finished = true;
     }

--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -94,7 +94,9 @@ private:
 
     ss::sharded<cluster::partition_manager>& _partition_manager;
     std::optional<ss::future<>> _drain;
-    bool _draining{false};
+    bool _draining_requested{false};
+    bool _restore_requested{false};
+    bool _drained{false};
     ssx::semaphore _sem{0, "c/drain-mgr"};
     drain_status _status;
     ss::abort_source _abort;

--- a/src/v/cluster/drain_manager.h
+++ b/src/v/cluster/drain_manager.h
@@ -72,15 +72,11 @@ public:
 
     /*
      * Start draining this broker.
-     *
-     * Invoke this on each core.
      */
     ss::future<> drain();
 
     /*
      * Restore broker to a non-drain[ing] state.
-     *
-     * Invoke this on each core.
      */
     ss::future<> restore();
 

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -381,9 +381,7 @@ ss::future<> partition_balancer_backend::do_tick() {
         _cur_term->last_status = partition_balancer_status::in_progress;
     } else if (plan_data.status == planner_status::waiting_for_reports) {
         _cur_term->last_status = partition_balancer_status::starting;
-    } else if (
-      plan_data.failed_actions_count > 0
-      || plan_data.status == planner_status::waiting_for_maintenance_end) {
+    } else if (plan_data.failed_actions_count > 0) {
         _cur_term->last_status = partition_balancer_status::stalled;
     } else {
         _cur_term->last_status = partition_balancer_status::ready;

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -63,7 +63,6 @@ public:
     enum class status {
         empty,
         actions_planned,
-        waiting_for_maintenance_end,
         waiting_for_reports,
         missing_sizes,
     };

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -743,11 +743,13 @@ FIXTURE_TEST(
     auto plan_data = planner.plan_actions(hr, as).get();
 
     check_violations(plan_data, unavailable_nodes, {});
-    BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 0);
-    BOOST_REQUIRE(
-      plan_data.status
-      == cluster::partition_balancer_planner::status::
-        waiting_for_maintenance_end);
+    BOOST_REQUIRE_EQUAL(plan_data.reassignments.size(), 1);
+
+    std::unordered_set<model::node_id> expected_nodes(
+      {model::node_id(1), model::node_id(2), model::node_id(3)});
+
+    auto new_replicas = plan_data.reassignments.front().allocated.replicas();
+    check_expected_assignments(new_replicas, expected_nodes);
 }
 
 /*

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2594,21 +2594,15 @@ void admin_server::register_broker_routes() {
     register_route<superuser>(
       ss::httpd::broker_json::start_local_maintenance,
       [this](std::unique_ptr<ss::http::request>) {
-          return _controller->get_drain_manager()
-            .invoke_on_all(
-              [](cluster::drain_manager& dm) { return dm.drain(); })
-            .then(
-              [] { return ss::json::json_return_type(ss::json::json_void()); });
+          return _controller->get_drain_manager().local().drain().then(
+            [] { return ss::json::json_return_type(ss::json::json_void()); });
       });
 
     register_route<superuser>(
       ss::httpd::broker_json::stop_local_maintenance,
       [this](std::unique_ptr<ss::http::request>) {
-          return _controller->get_drain_manager()
-            .invoke_on_all(
-              [](cluster::drain_manager& dm) { return dm.restore(); })
-            .then(
-              [] { return ss::json::json_return_type(ss::json::json_void()); });
+          return _controller->get_drain_manager().local().restore().then(
+            [] { return ss::json::json_return_type(ss::json::json_void()); });
       });
 
     register_route<superuser>(

--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -747,14 +747,12 @@ class PartitionBalancerTest(PartitionBalancerService):
     @matrix(kill_same_node=[True, False])
     def test_maintenance_mode(self, kill_same_node):
         """
-        Test interaction with maintenance mode: the balancer should not schedule
-        any movements as long as there is a node in maintenance mode.
+        Test interaction with maintenance mode: the mode should not interfere
+        with partition balancer.
         Test scenario is as follows:
         * enable maintenance mode on some node
         * kill a node (the same or some other)
-        * check that we don't move any partitions and node switched to maintenance
-          mode smoothly
-        * turn maintenance mode off, check that partition balancing resumes
+        * check that balancing works
         """
         self.start_redpanda(num_nodes=5)
 
@@ -798,7 +796,6 @@ class PartitionBalancerTest(PartitionBalancerService):
                 ])
 
             ns.make_unavailable(to_kill)
-            self.wait_until_status(lambda s: s["status"] == "stalled")
 
             if kill_same_node:
                 ns.make_available()
@@ -807,11 +804,6 @@ class PartitionBalancerTest(PartitionBalancerService):
                        timeout_sec=120,
                        backoff_sec=10)
 
-            # return back to normal.
-            # rpk will make 3 admin requests with 10 second timeout, so with 1 problematic node,
-            # worst case it will hang for 30 seconds, which also happens to be the default RpkTool
-            # timeout. Therefore we need a larger timeout than that.
-            rpk.cluster_maintenance_disable(node, timeout=35)
             # use raw admin interface to avoid waiting for the killed node
             admin.patch_cluster_config(
                 {"raft_learner_recovery_rate": 100_000_000})


### PR DESCRIPTION
Maintenance mode (triggers re-election to move leadership from the partitions hosted on the node in maintenance mode) doesn't do anything which couldn't happen naturally in the cluster when the mode is off.
    
So the balancer can't be affected if it ignores the mode.

Fixes #12069

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none