### PR TITLE
net: fix shutdown and accept connection race

### DIFF
--- a/src/v/net/server.h
+++ b/src/v/net/server.h
@@ -125,7 +125,7 @@ public:
      * stopping the server without waiting for downstream services to stop
      * requests processing
      */
-    void shutdown_input();
+    ss::future<> shutdown_input();
     ss::future<> wait_for_shutdown();
     /**
      * Stop function is a nop when `shutdown_input` was previously called. Left
@@ -171,6 +171,7 @@ private:
     std::vector<std::unique_ptr<listener>> _listeners;
     boost::intrusive::list<net::connection> _connections;
     ss::abort_source _as;
+    ss::gate _accept_gate;
     ss::gate _conn_gate;
     hist_t _hist;
     std::unique_ptr<server_probe> _probe;


### PR DESCRIPTION
server is shutdown in 2 phases. A synchronous call to `shutdown_input` where the listening sockets are closed followed a call to `wait_for_shutdown` and waiting on the return future. This leaves an opportunity for a race condition to occur.

Specifically, when the following sequence of events is observed:

1. `server::accept_finish` coroutine is called and suspended just before a new connection is added to the `server::_connections` list.

2. `server::shutdown_input` is called, connections from `server::_connections` are closed. Note that the incoming connection caused by the event above isn't yet added to that list.

3. `server::accept_finish` coroutine is resumed, the `server::_conn_gate` is open and the connection is serviced as usual.

4. `server::wait_for_shutdown` is called, and is waiting on `_conn_gate.close`. Eventually our connection is aborted, but not timely.

The non-invasive solution is to check `server::_as` before servicing connections.

Fixes #12659

---

Marking as papercut for now but might be worth back-porting. Don't have enough context about the release cycles yet.

---

Following the logs from this failure helped https://buildkite.com/redpanda/redpanda/builds/37323#018ab3ec-5d75-483f-8d20-0bab3173270b

```
INFO  2023-09-20 19:12:13,071 [shard 1] kafka - server.cc:289 - kafka rpc protocol - Shutting down 0 connections
... a few moments later
TRACE 2023-09-20 19:12:13,078 [shard 1] kafka - server.cc:267 - kafka rpc protocol - Incoming connection from 172.16.16.23:39396 on "dnslistener"
TRACE 2023-09-20 19:12:13,098 [shard 1] kafka - requests.cc:94 - [172.16.16.23:39396] processing name:produce, key:0, version:7 for producer-1, mem_units: 40886, ctx_size: 16423
```

When the ducktape test is tearing down and the producer is stopped the server stops too. (didn't check this, I'm conjecturing)

---

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
