### PR TITLE
tests: clean all nodes on first start in Redpanda service

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1898,7 +1898,13 @@ class RedpandaService(RedpandaServiceBase):
                     f"Error cleaning node {node.account.hostname}:")
                 raise
 
-        self.for_nodes(to_start, clean_one)
+        if first_start:
+            # Clean all nodes on the first start because the test can choose to initialize
+            # the cluster with a smaller node subset and start other nodes later with
+            # redpanda.start_node() (which doesn't invoke clean_node)
+            self.for_nodes(self.nodes, clean_one)
+        else:
+            self.for_nodes(to_start, clean_one)
 
         if first_start:
             self.write_tls_certs()


### PR DESCRIPTION
The test can choose to initialize the cluster with a smaller node subset and start other nodes later with redpanda.start_node() (which doesn't invoke clean_node)

Fixes https://github.com/redpanda-data/redpanda/issues/13372

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

