### PR TITLE
ducky/partition_balancer_test: fix full_node_test

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -722,6 +722,12 @@ class PartitionBalancerTest(PartitionBalancerService):
             nonlocal ready_appeared_at
             if s["status"] == "ready":
                 if ready_appeared_at is None:
+                    # Disable leader balancer after partition balancer has finished its work,
+                    # because leadership transfers will create new segments that can cause disk
+                    # usage to go over limit again even after we've verified that everything
+                    # is stable.
+                    self.redpanda.set_cluster_config(
+                        {"enable_leader_balancer": False})
                     ready_appeared_at = time.time()
                 else:
                     # ready status is stable for 11 seconds, should be enough for 3 ticks to pass


### PR DESCRIPTION
Disable leader balancer after partition balancer has finished its work, because leadership transfers will create new segments that can cause disk usage to go over limit again even after we've verified that everything is stable.

Fixes https://github.com/redpanda-data/redpanda/issues/9788

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes
* none
