### PR TITLE
rptest: ignore missing ntp manifest in v22 upgrade test

### DIFF
--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -628,6 +628,9 @@ class CreateTopicUpgradeTest(RedpandaTest):
                                                       'DEFAULT_CONFIG')
         assert described['redpanda.remote.read'] == ('false', 'DEFAULT_CONFIG')
 
+        # Nothing in this test guarantees that partition manifests will be uploaded.
+        self.redpanda.si_settings.set_expected_damage({"ntpr_no_manifest"})
+
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))


### PR DESCRIPTION
Nothing in this test guarantees that the partition manifest will be uploaded before its end, so it's appropriate to just ignore the anomaly.

Fixes #13646

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

