### PR TITLE
tests: adjusted timeouts in test_flipping_leadership test

### DIFF
--- a/tests/rptest/tests/consumer_offsets_consistency_test.py
+++ b/tests/rptest/tests/consumer_offsets_consistency_test.py
@@ -42,6 +42,10 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
                              **kwargs)
         self.rpk = RpkTool(self.redpanda)
 
+    @property
+    def timeout_sec(self):
+        return 45 if not self.debug_mode else 90
+
     def get_offsets(self, group_name):
         offsets = {}
 
@@ -51,7 +55,7 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
 
         gd = wait_until_result(
             do_describe,
-            timeout_sec=30,
+            timeout_sec=self.timeout_sec,
             backoff_sec=0.5,
             err_msg="RPK failed to get consumer group offsets",
             retry_on_exc=True)
@@ -79,7 +83,7 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
 
         group_list_res = wait_until_result(
             do_list_groups,
-            timeout_sec=30,
+            timeout_sec=self.timeout_sec,
             backoff_sec=0.5,
             err_msg="RPK failed to list consumer groups",
             retry_on_exc=True)
@@ -117,7 +121,7 @@ class ConsumerOffsetsConsistencyTest(PreallocNodesTest):
         producer.start(clean=False)
 
         wait_until(lambda: producer.produce_status.acked > 10,
-                   timeout_sec=30,
+                   timeout_sec=self.timeout_sec,
                    backoff_sec=0.5)
 
         consumer = KgoVerifierConsumerGroupConsumer(


### PR DESCRIPTION
Made timeouts a bit longer for release builds and much longer for slow debug builds.

Fixes: #13401

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none