### PR TITLE
tests/workload_upgrade_runner_test: re-enabled test

### DIFF
--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -164,8 +164,9 @@ class RedpandaUpgradeTest(PreallocNodesTest):
         workloads: list[PWorkload] = [
             DummyWorkload(self),
             MinimalWorkload(self),
-            LicenseWorkload(self),
             ProducerConsumerWorkload(self),
+            # NOTE: due to issue/13180 the next workload is temporarily disabled
+            # LicenseWorkload(self),
         ]
 
         # setup self as context for the workloads

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -247,7 +247,6 @@ class RedpandaUpgradeTest(PreallocNodesTest):
     def cluster_version(self) -> int:
         return Admin(self.redpanda).get_features()['cluster_version']
 
-    @ok_to_fail
     @skip_debug_mode
     @cluster(num_nodes=4)
     # TODO(vlad): Allow this test on ABS once we have at least two versions


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Only LicenceWorkload is failing in the set of workloads.

Since the framework is useful to catch inconsistencies during an upgrade, this pr temporarily disables LicenceWorkload to re-enable the rest of the test

Related to #13180 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none