### PR TITLE
ht-phase-2: Block s3 TS bucket using a bucket policy

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py
+++ b/tests/rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py
@@ -1,0 +1,21 @@
+class cloudv2_object_store_blocked:
+    """Temporary block writes to a cloudv2 TS bucket"""
+    def __init__(self, rp, logger):
+        self.logger = logger
+        cluster_id = rp._cloud_cluster.config.id
+        network_id = rp._cloud_cluster.current.network_id
+        self._cloud_provider_client = rp._cloud_cluster.provider_cli
+        self._vpc_id = self._cloud_provider_client.get_vpc_by_network_id(
+            network_id)['VpcId']
+        self._bucket_name = f'redpanda-cloud-storage-{cluster_id}'
+
+    def __enter__(self):
+        """apply a blocking policy"""
+        self.logger.debug(f'Blocking access to {self._bucket_name}')
+        self._cloud_provider_client.block_bucket_from_vpc(
+            self._bucket_name, self._vpc_id)
+
+    def __exit__(self, type, value, traceback):
+        """remove block policy"""
+        self.logger.debug(f'Unblocking access to {self._bucket_name}')
+        self._cloud_provider_client.unblock_bucket_from_vpc(self._bucket_name)

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -38,6 +38,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import firewall_blocked
 from rptest.utils.node_operations import NodeDecommissionWaiter
 from rptest.utils.si_utils import nodes_report_cloud_segments
+from rptest.redpanda_cloud_tests.cloudv2_object_store_blocked import cloudv2_object_store_blocked
 
 KiB = 1024
 MiB = KiB * KiB
@@ -597,13 +598,25 @@ class HighThroughputTest(RedpandaTest):
                    backoff_sec=5)
         self.logger.info(f"Blocking S3 traffic for all nodes")
         self.last_num_errors = 0
-        with firewall_blocked(self.redpanda.nodes, self.s3_port):
-            # wait for the first cloud related failure + one minute
-            wait_until(lambda: not self._cloud_storage_no_new_errors(
-                self.redpanda, self.logger),
-                       timeout_sec=600,
-                       backoff_sec=10)
-            time.sleep(60)
+        cloud_tier = get_tier_name(get_cloud_globals(self._ctx.globals))
+
+        if cloud_tier == CloudTierName.DOCKER:
+            with firewall_blocked(self.redpanda.nodes, self.s3_port):
+                # wait for the first cloud related failure + one minute
+                wait_until(lambda: not self._cloud_storage_no_new_errors(
+                    self.redpanda, self.logger),
+                           timeout_sec=600,
+                           backoff_sec=10)
+                time.sleep(60)
+        else:
+            with cloudv2_object_store_blocked(self.redpanda, self.logger):
+                # wait for the first cloud related failure + one minute
+                wait_until(lambda: not self._cloud_storage_no_new_errors(
+                    self.redpanda, self.logger),
+                           timeout_sec=600,
+                           backoff_sec=10)
+                time.sleep(60)
+
         # make sure nothing is crashed
         wait_until(self.redpanda.healthy, timeout_sec=60, backoff_sec=1)
         self.logger.info(f"Waiting for S3 errors to cease")


### PR DESCRIPTION
Add ability to block write access to tiered storage s3 bucket. This is required for high throughputs phase 2 testing

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

- none
