### PR TITLE
rptest: fuzz create topic config properties

### DIFF
--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -88,6 +88,20 @@ def _choice_random_user(ctx, prefix):
     return _random_choice(prefix, ctx.admin().list_users())
 
 
+TOPIC_PROPERTIES = {
+    TopicSpec.PROPERTY_CLEANUP_POLICY:
+    lambda: random.choice(["delete", "compact"]),
+    TopicSpec.PROPERTY_TIMESTAMP_TYPE:
+    lambda: random.choice(["CreateTime", "LogAppendTime"]),
+    TopicSpec.PROPERTY_SEGMENT_SIZE:
+    lambda: random.randint(10 * 2**20, 512 * 2**20),
+    TopicSpec.PROPERTY_RETENTION_BYTES:
+    lambda: random.randint(10 * 2**20, 512 * 2**20),
+    TopicSpec.PROPERTY_RETENTION_TIME:
+    lambda: random.randint(10000, 1000000),
+}
+
+
 # topic operations
 class CreateTopicOperation(Operation):
     def __init__(self, prefix, max_partitions, min_replication,
@@ -97,12 +111,18 @@ class CreateTopicOperation(Operation):
         self.partitions = random.randint(1, max_partitions)
         self.rf = random.choice(
             [x for x in range(min_replication, max_replication + 1, 2)])
+        self.config = {
+            k: v()
+            for k, v in TOPIC_PROPERTIES.items()
+            if random.choice([True, False])
+        }
 
     def execute(self, ctx):
         ctx.redpanda.logger.info(
             f"Creating topic with name {self.topic}, replication: {self.rf} partitions: {self.partitions}"
         )
-        ctx.rpk().create_topic(self.topic, self.partitions, self.rf)
+        ctx.rpk().create_topic(self.topic, self.partitions, self.rf,
+                               self.config)
         return True
 
     def validate(self, ctx):
@@ -110,7 +130,11 @@ class CreateTopicOperation(Operation):
             return False
         ctx.redpanda.logger.info(f"Validating topic {self.topic} creation")
         topics = ctx.rpk().list_topics()
-        return self.topic in topics
+        if self.topic not in topics:
+            return False
+        else:
+            desc = ctx.rpk().describe_topic_configs(self.topic)
+            return all([desc[k][0] == str(v) for k, v in self.config.items()])
 
     def describe(self):
         return {
@@ -119,6 +143,7 @@ class CreateTopicOperation(Operation):
                 "name": self.topic,
                 "replication_factor": self.topic,
                 "partitions": self.topic,
+                "config": self.config,
             }
         }
 
@@ -182,20 +207,6 @@ class DeleteTopicOperation(Operation):
 
 
 class UpdateTopicOperation(Operation):
-
-    properties = {
-        TopicSpec.PROPERTY_CLEANUP_POLICY:
-        lambda: random.choice(['delete', 'compact']),
-        TopicSpec.PROPERTY_TIMESTAMP_TYPE:
-        lambda: random.choice(['CreateTime', 'LogAppendTime']),
-        TopicSpec.PROPERTY_SEGMENT_SIZE:
-        lambda: random.randint(10 * 2**20, 512 * 2**20),
-        TopicSpec.PROPERTY_RETENTION_BYTES:
-        lambda: random.randint(10 * 2**20, 512 * 2**20),
-        TopicSpec.PROPERTY_RETENTION_TIME:
-        lambda: random.randint(10000, 1000000)
-    }
-
     def __init__(self, prefix):
         self.prefix = prefix
         self.topic = None
@@ -207,9 +218,8 @@ class UpdateTopicOperation(Operation):
             self.topic = _choice_random_topic(ctx, prefix=self.prefix)
             if self.topic is None:
                 return False
-            self.property = random.choice(
-                list(UpdateTopicOperation.properties.keys()))
-            self.value = UpdateTopicOperation.properties[self.property]()
+            self.property = random.choice(list(TOPIC_PROPERTIES.keys()))
+            self.value = TOPIC_PROPERTIES[self.property]()
 
         ctx.redpanda.logger.info(
             f"Updating topic: {self.topic} with: {self.property}={self.value}")

--- a/tests/rptest/services/admin_ops_fuzzer.py
+++ b/tests/rptest/services/admin_ops_fuzzer.py
@@ -700,7 +700,6 @@ class AdminOperationsFuzzer():
 
     def execute_one(self):
         op_type, op = self.make_random_operation()
-        self.append_to_history(op)
 
         def validate_result():
             try:
@@ -732,6 +731,8 @@ class AdminOperationsFuzzer():
             self.redpanda.logger.error(f"Operation: {op.describe()} failed",
                                        exc_info=True)
             raise e
+        finally:
+            self.append_to_history(op)
 
     def execute_with_retries(self, op_type, op):
         self.redpanda.logger.info(


### PR DESCRIPTION
More fuzzing the better. Now this successfully catches the issue described #13588 too.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
