### PR TITLE
cloud_storage: Match requests using URL during topic recovery tests

### DIFF
--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -175,6 +175,18 @@ s3_imposter_fixture::get_requests() const {
     return _requests;
 }
 
+std::vector<http_test_utils::request_info> s3_imposter_fixture::get_requests(
+  s3_imposter_fixture::req_pred_t predicate) const {
+    std::vector<http_test_utils::request_info> matching_requests;
+    matching_requests.reserve(_requests.size());
+    std::copy_if(
+      _requests.cbegin(),
+      _requests.cend(),
+      std::back_inserter(matching_requests),
+      std::move(predicate));
+    return matching_requests;
+}
+
 const std::multimap<ss::sstring, http_test_utils::request_info>&
 s3_imposter_fixture::get_targets() const {
     return _targets;

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -72,6 +72,13 @@ public:
     /// Access all http requests ordered by time
     const std::vector<http_test_utils::request_info>& get_requests() const;
 
+    using req_pred_t
+      = std::function<bool(const http_test_utils::request_info&)>;
+
+    /// Access http requests matching the given predicate
+    std::vector<http_test_utils::request_info>
+    get_requests(req_pred_t predicate) const;
+
     /// Access all http requests ordered by target url
     const std::multimap<ss::sstring, http_test_utils::request_info>&
     get_targets() const;

--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -117,6 +117,11 @@ generate_no_manifests_expectations(
     return expectations;
 }
 
+bool is_manifest_list_request(const http_test_utils::request_info& req) {
+    return req.method == "GET" && req.url.starts_with("/?list-type=2&prefix=")
+           && req.url.ends_with("0000000/");
+}
+
 } // namespace
 
 class fixture
@@ -151,13 +156,16 @@ public:
     }
 
     using equals = ss::bool_class<struct equals_tag>;
-    void wait_for_n_requests(size_t n, equals e = equals::no) {
-        tests::cooperative_spin_wait_with_timeout(10s, [this, n, e] {
-            if (e) {
-                return get_requests().size() == n;
-            } else {
-                return get_requests().size() >= n;
-            }
+    void wait_for_n_requests(
+      size_t n,
+      equals e = equals::no,
+      std::optional<req_pred_t> predicate = std::nullopt) {
+        tests::cooperative_spin_wait_with_timeout(10s, [this, n, e, predicate] {
+            const auto matching_requests_size
+              = predicate ? get_requests(predicate.value()).size()
+                          : get_requests().size();
+            return e ? matching_requests_size == n
+                     : matching_requests_size >= n;
         }).get();
     }
 
@@ -217,7 +225,7 @@ FIXTURE_TEST(recovery_with_no_topics_exits_early, fixture) {
     BOOST_REQUIRE_EQUAL(result, expected);
 
     // Wait until one request is received, to list bucket for manifest files
-    wait_for_n_requests(16, equals::yes);
+    wait_for_n_requests(16, equals::yes, is_manifest_list_request);
 
     const auto& list_topics_req = get_requests()[0];
     BOOST_REQUIRE_EQUAL(list_topics_req.url, "/?list-type=2&prefix=00000000/");
@@ -291,7 +299,7 @@ FIXTURE_TEST(recovery_with_existing_topic, fixture) {
       .message = "recovery started"};
 
     BOOST_REQUIRE_EQUAL(result, expected);
-    wait_for_n_requests(16, equals::no);
+    wait_for_n_requests(16, equals::yes, is_manifest_list_request);
 
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
         return service.local().is_active() == false;
@@ -388,7 +396,7 @@ FIXTURE_TEST(recovery_with_topic_name_pattern_without_match, fixture) {
 
     start_recovery(R"JSON({"topic_names_pattern": "abc*"})JSON");
 
-    wait_for_n_requests(16, equals::yes);
+    wait_for_n_requests(16, equals::yes, is_manifest_list_request);
 
     auto& service = app.topic_recovery_service;
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {


### PR DESCRIPTION
FIXES https://github.com/redpanda-data/redpanda/issues/13794

In topic recovery tests some assertions simply wait for a count of requests made to S3 imposter. This may cause tests to fail when requests not related to the test are observed by the imposter, throwing off the expected count.

This change adds an optional predicate to the assertion so that the request count can be matched after filtering for specific requests by URL, method etc.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
