### PR TITLE
cloud_storage: fix error logging on shutdown

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2114,6 +2114,12 @@ ss::future<> ntp_archiver::apply_archive_retention() {
       retention_bytes, retention_ms);
 
     if (res.has_error()) {
+        if (res.error() == cloud_storage::error_outcome::shutting_down) {
+            vlog(
+              _rtclog.debug,
+              "Search for archive retention point failed as Redpanda is "
+              "shutting down");
+        }
         vlog(
           _rtclog.error,
           "Failed to compute archive retention: {}",
@@ -2157,6 +2163,13 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
     }
     auto backlog = co_await _manifest_view->get_retention_backlog();
     if (backlog.has_failure()) {
+        if (backlog.error() == cloud_storage::error_outcome::shutting_down) {
+            vlog(
+              _rtclog.debug,
+              "Skipping archive GC as Redpanda is shutting down");
+            co_return;
+        }
+
         vlog(
           _rtclog.error,
           "Failed to create GC backlog for the archive: {}",
@@ -2250,6 +2263,13 @@ ss::future<> ntp_archiver::garbage_collect_archive() {
         manifests_to_remove.push_back(path());
         auto res = co_await cursor->next();
         if (res.has_failure()) {
+            if (res.error() == cloud_storage::error_outcome::shutting_down) {
+                vlog(
+                  _rtclog.debug,
+                  "Stopping archive GC as Redpanda is shutting down");
+                co_return;
+            }
+
             vlog(
               _rtclog.error,
               "Failed to load next spillover manifest: {}",

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -483,6 +483,10 @@ private:
         // Find manifest that contains requested offset or timestamp
         auto cur = co_await _partition->_manifest_view->get_cursor(query);
         if (cur.has_failure()) {
+            if (cur.error() == error_outcome::shutting_down) {
+                co_return;
+            }
+
             if (
               cur.error() == error_outcome::out_of_range
               && std::holds_alternative<kafka::offset>(query)) {
@@ -884,11 +888,6 @@ ss::future<std::optional<kafka::offset>>
 remote_partition::get_term_last_offset(model::term_id term) const {
     const auto res = co_await _manifest_view->get_term_last_offset(term);
     if (res.has_error()) {
-        vlog(
-          _ctxlog.error,
-          "Failed to get last offset from term {}: {}",
-          term,
-          res.error());
         throw std::system_error(res.error());
     } else {
         co_return res.value();
@@ -936,6 +935,10 @@ remote_partition::aborted_transactions(offset_range offsets) {
         meta_to_materialize.clear();
         auto cur_res = co_await _manifest_view->get_cursor(offsets.begin);
         if (cur_res.has_failure()) {
+            if (cur_res.error() == error_outcome::shutting_down) {
+                throw std::runtime_error("Async manifest view shutting down");
+            }
+
             vlog(
               _ctxlog.error,
               "Failed to traverse archive part of the log: {}",

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -855,26 +855,16 @@ ss::future<> remote_segment::run_hydrate_bg() {
                 }
                 _wait_list.pop_front();
             }
-        } catch (const ss::broken_condition_variable&) {
-            vlog(_ctxlog.debug, "Hydration loop shut down");
-            set_waiter_errors(std::current_exception());
-            break;
-        } catch (const ss::abort_requested_exception&) {
-            vlog(_ctxlog.debug, "Hydration loop shut down");
-            set_waiter_errors(std::current_exception());
-            break;
-        } catch (const ss::gate_closed_exception&) {
-            vlog(_ctxlog.debug, "Hydration loop shut down");
-            set_waiter_errors(std::current_exception());
-            break;
-        } catch (const ss::broken_semaphore&) {
-            vlog(_ctxlog.debug, "Hydration loop shut down");
-            set_waiter_errors(std::current_exception());
-            break;
         } catch (...) {
             const auto err = std::current_exception();
-            vlog(_ctxlog.error, "Error in hydration loop: {}", err);
             set_waiter_errors(err);
+
+            if (ssx::is_shutdown_exception(err)) {
+                vlog(_ctxlog.debug, "Hydration loop shut down");
+                break;
+            } else {
+                vlog(_ctxlog.error, "Error in hydration loop: {}", err);
+            }
         }
     }
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -867,6 +867,10 @@ ss::future<> remote_segment::run_hydrate_bg() {
             vlog(_ctxlog.debug, "Hydration loop shut down");
             set_waiter_errors(std::current_exception());
             break;
+        } catch (const ss::broken_semaphore&) {
+            vlog(_ctxlog.debug, "Hydration loop shut down");
+            set_waiter_errors(std::current_exception());
+            break;
         } catch (...) {
             const auto err = std::current_exception();
             vlog(_ctxlog.error, "Error in hydration loop: {}", err);

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -233,6 +233,7 @@ enum class error_outcome {
     repeat,
     timed_out,
     out_of_range,
+    shutting_down
 };
 
 struct error_outcome_category final : public std::error_category {
@@ -264,6 +265,8 @@ struct error_outcome_category final : public std::error_category {
             return "cloud storage operation timed out";
         case error_outcome::out_of_range:
             return "cloud storage out of range";
+        case error_outcome::shutting_down:
+            return "shutting down";
         default:
             return "unknown";
         }


### PR DESCRIPTION
Previously, `async_manifest_view` would print lots of error logs on
shutdown. This is because we first shut-down the client pool and then
stop the async manifest view. The result is that calls into remote throw
`ss::broken_semaphore`, then `async_manifest_view` would flatten that to
`error_outcome::failure` and error log it in various places.

This patch adds a new error outcome: `shutting_down` and teaches the
`async_manifest_view` how to handle it without error logging. We map the
shut down exceptions to this new error code in
`async_manifest_view::hydrate_manifest`. From there, upstream call sites
have been updated. The next patch will teach external users of
`async_manifest_view` to handle the new error code.

This fixes all instances of bad error logs coming from the `async_manifest_view` during shut-down:
Fixes #13697
Fixes #13345

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Bug Fixes
* Stop logging errors on shutdown of the tiered storage subsystem
