### PR TITLE
[v23.2.x] rptest: ignore missing ntp manifest in v22 upgrade test

### DIFF
--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -628,6 +628,9 @@ class CreateTopicUpgradeTest(RedpandaTest):
                                                       'DEFAULT_CONFIG')
         assert described['redpanda.remote.read'] == ('false', 'DEFAULT_CONFIG')
 
+        # Nothing in this test guarantees that partition manifests will be uploaded.
+        self.redpanda.si_settings.set_expected_damage({"ntpr_no_manifest"})
+
     @cluster(num_nodes=3)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13752
Fixes: https://github.com/redpanda-data/redpanda/issues/13808,