### PR TITLE
cloud_storage: add default eq operator for cloud serde types

### DIFF
--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -187,7 +187,9 @@ void scrub_segment_meta(
       previous && previous->delta_offset != model::offset_delta{}
       && current.delta_offset == model::offset_delta{}) {
         detected.insert(anomaly_meta{
-          .type = anomaly_type::missing_delta, .previous = previous});
+          .type = anomaly_type::missing_delta,
+          .at = current,
+          .previous = previous});
     }
 
     // The delta offset field of a segment should always be greater or

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -318,6 +318,8 @@ struct spillover_manifest_path_components
         return std::tie(base, last, base_kafka, next_kafka, base_ts, last_ts);
     }
 
+    bool operator==(spillover_manifest_path_components const&) const = default;
+
     template<typename H>
     friend H AbslHashValue(H h, const spillover_manifest_path_components& c) {
         return H::combine(
@@ -354,6 +356,8 @@ struct anomaly_meta
     anomaly_type type;
     segment_meta at;
     std::optional<segment_meta> previous;
+
+    bool operator==(anomaly_meta const&) const = default;
 
     auto serde_fields() { return std::tie(type, at, previous); }
 
@@ -396,6 +400,8 @@ struct anomalies
     bool has_value() const;
 
     anomalies& operator+=(anomalies&&);
+
+    bool operator==(anomalies const&) const = default;
 };
 
 std::ostream& operator<<(std::ostream& o, const anomalies& a);


### PR DESCRIPTION
When a type inherits from `serde::envelope` and doesn't define it's own comparison operator, `serde::envelope::operator==` ends up being used. Weirdness ensues after that.

Fixes #13760

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

