### PR TITLE
Kip 368 (SASL reauthentication)

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1143,6 +1143,19 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {"DEFAULT"},
       security::validate_kerberos_mapping_rules)
+  , kafka_sasl_max_reauth_ms(
+      *this,
+      "kafka_sasl_max_reauth_ms",
+      "The maximum time between Kafka client reauthentications. If a client "
+      "has not reauthenticated a connection within this time frame, that "
+      "connection is torn down. Without this, a connection could live long "
+      "after the client's credentials are expired or revoked. Session expiry "
+      "is disabled if the value is null.",
+      {.needs_restart = needs_restart::no,
+       .example = "1000",
+       .visibility = visibility::user},
+      std::nullopt,
+      {.min = 1000ms})
   , kafka_enable_authorization(
       *this,
       "kafka_enable_authorization",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -229,6 +229,8 @@ struct configuration final : public config_store {
     property<ss::sstring> sasl_kerberos_keytab;
     property<ss::sstring> sasl_kerberos_principal;
     property<std::vector<ss::sstring>> sasl_kerberos_principal_mapping;
+    bounded_property<std::optional<std::chrono::milliseconds>>
+      kafka_sasl_max_reauth_ms;
     property<std::optional<bool>> kafka_enable_authorization;
     property<std::optional<std::vector<ss::sstring>>>
       kafka_mtls_principal_mapping_rules;

--- a/src/v/kafka/sasl_probe.h
+++ b/src/v/kafka/sasl_probe.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/configuration.h"
+#include "metrics/metrics.h"
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/metrics.hh>
+
+namespace kafka {
+class sasl_probe {
+public:
+    sasl_probe() = default;
+    sasl_probe(const sasl_probe&) = delete;
+    sasl_probe& operator=(const sasl_probe&) = delete;
+    sasl_probe(sasl_probe&&) = delete;
+    sasl_probe& operator=(sasl_probe&&) = delete;
+    ~sasl_probe() = default;
+
+    void setup_metrics(std::string_view name) {
+        namespace sm = ss::metrics;
+
+        auto setup = [this](const std::vector<sm::label>& aggregate_labels) {
+            std::vector<sm::metric_definition> defs;
+            defs.emplace_back(
+              sm::make_counter(
+                "session_expiration_total",
+                [this] { return _session_expiration_count; },
+                sm::description("Total number of SASL session expirations"))
+                .aggregate(aggregate_labels));
+            defs.emplace_back(
+              sm::make_counter(
+                "session_reauth_attempts_total",
+                [this] { return _session_reauth_attempts; },
+                sm::description(
+                  "Total number of SASL reauthentication attempts"))
+                .aggregate(aggregate_labels));
+            return defs;
+        };
+
+        if (!config::shard_local_cfg().disable_metrics()) {
+            _metrics.add_group(
+              prometheus_sanitize::metrics_name(ssx::sformat("{}:sasl", name)),
+              setup(
+                config::shard_local_cfg().aggregate_metrics()
+                  ? std::vector<sm::label>{sm::shard_label}
+                  : std::vector<sm::label>{}));
+        }
+
+        if (!config::shard_local_cfg().disable_public_metrics()) {
+            _public_metrics.add_group(
+              prometheus_sanitize::metrics_name(ssx::sformat("{}:sasl", name)),
+              setup(std::vector<sm::label>{sm::shard_label}));
+        }
+    }
+
+    void session_expired() { ++_session_expiration_count; }
+    void session_reauth() { ++_session_reauth_attempts; }
+
+private:
+    metrics::internal_metric_groups _metrics;
+    metrics::public_metric_groups _public_metrics;
+    uint32_t _session_expiration_count{0};
+    uint32_t _session_reauth_attempts{0};
+};
+
+}; // namespace kafka

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -135,6 +135,7 @@ ss::future<> connection_context::process_one_request() {
     } catch (const sasl_session_expired_exception& e) {
         vlog(
           klog.warn, "SASL session expired for {} - {}", conn->addr, e.what());
+        _server.sasl_probe().session_expired();
         conn->shutdown_input();
     } catch (const std::bad_alloc&) {
         // In general, dispatch_method_once does not throw, but bad_allocs are

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -132,6 +132,10 @@ ss::future<> connection_context::process_one_request() {
           conn->addr,
           e.what());
         conn->shutdown_input();
+    } catch (const sasl_session_expired_exception& e) {
+        vlog(
+          klog.warn, "SASL session expired for {} - {}", conn->addr, e.what());
+        conn->shutdown_input();
     } catch (const std::bad_alloc&) {
         // In general, dispatch_method_once does not throw, but bad_allocs are
         // an exception. Log it cleanly to avoid this bubbling up as an

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -46,6 +46,12 @@ public:
       : std::runtime_error(m) {}
 };
 
+class sasl_session_expired_exception : public std::runtime_error {
+public:
+    explicit sasl_session_expired_exception(const std::string& m)
+      : std::runtime_error(m) {}
+};
+
 /*
  * authz failures should be quiet or logged at a reduced severity level.
  */

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -103,6 +103,7 @@ public:
     protocol::decoder& reader() { return _reader; }
 
     latency_probe& probe() { return _conn->server().latency_probe(); }
+    sasl_probe& sasl_probe() { return _conn->server().sasl_probe(); }
 
     // used to reach for server_probe::produce_bad_timestamp
     net::server_probe& server_probe() { return _conn->server().probe(); }

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -282,6 +282,13 @@ process_result_stages process_request(
           ctx.respond(sasl_authenticate_response(std::move(data))));
     }
 
+    if (ctx.sasl() && ctx.sasl()->expired()) [[unlikely]] {
+        throw sasl_session_expired_exception(fmt::format(
+          "Session for client '{}' expired after {}",
+          ctx.header().client_id.value_or(""),
+          ctx.sasl()->max_reauth()));
+    }
+
     if (auto handler = handler_for_key(key)) {
         return process_generic(*handler, std::move(ctx), g, sres);
     }

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -258,6 +258,7 @@ process_result_stages process_request(
         vlog(
           klog.debug,
           "SASL reauthentication detected - resetting authn server");
+        ctx.sasl_probe().session_reauth();
         ctx.sasl()->reset();
     }
     /*

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -146,6 +146,7 @@ server::server(
         * config::shard_local_cfg().kafka_memory_share_for_fetch()),
       "kafka/server-mem-fetch")
   , _probe(std::make_unique<class latency_probe>())
+  , _sasl_probe(std::make_unique<class sasl_probe>())
   , _thread_worker(tw)
   , _replica_selector(
       std::make_unique<rack_aware_replica_selector>(_metadata_cache.local()))
@@ -160,6 +161,8 @@ server::server(
     setup_metrics();
     _probe->setup_metrics();
     _probe->setup_public_metrics();
+
+    _sasl_probe->setup_metrics(cfg->local().name);
 }
 
 void server::setup_metrics() {

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -16,6 +16,7 @@
 #include "features/feature_table.h"
 #include "kafka/latency_probe.h"
 #include "kafka/protocol/types.h"
+#include "kafka/sasl_probe.h"
 #include "kafka/server/fetch_metadata_cache.hh"
 #include "kafka/server/fetch_session_cache.h"
 #include "kafka/server/fwd.h"
@@ -173,6 +174,8 @@ public:
 
     latency_probe& latency_probe() { return *_probe; }
 
+    sasl_probe& sasl_probe() { return *_sasl_probe; }
+
     ssx::singleton_thread_worker& thread_worker() { return _thread_worker; }
 
     const std::unique_ptr<pandaproxy::schema_registry::api>& schema_registry() {
@@ -236,6 +239,7 @@ private:
     handler_probe_manager _handler_probes;
     metrics::internal_metric_groups _metrics;
     std::unique_ptr<class latency_probe> _probe;
+    std::unique_ptr<class sasl_probe> _sasl_probe;
     ssx::singleton_thread_worker& _thread_worker;
     std::unique_ptr<replica_selector> _replica_selector;
     const std::unique_ptr<pandaproxy::schema_registry::api>& _schema_registry;

--- a/src/v/security/gssapi_authenticator.h
+++ b/src/v/security/gssapi_authenticator.h
@@ -13,9 +13,13 @@
 #include "security/sasl_authentication.h"
 #include "ssx/fwd.h"
 
+#include <seastar/core/lowres_clock.hh>
+
 namespace security {
 
 class gssapi_authenticator final : public sasl_mechanism {
+    using clock_type = ss::lowres_clock;
+
 public:
     enum class state { init = 0, more, ssfcap, ssfreq, complete, failed };
     static constexpr const char* name = "GSSAPI";
@@ -36,12 +40,22 @@ public:
         return _principal;
     }
 
+    std::optional<std::chrono::milliseconds>
+    credential_expires_in_ms() const override {
+        if (_session_expiry.has_value()) {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(
+              _session_expiry.value() - clock_type::now());
+        }
+        return std::nullopt;
+    }
+
 private:
     friend std::ostream&
     operator<<(std::ostream& os, gssapi_authenticator::state const s);
 
     ssx::singleton_thread_worker& _worker;
     security::acl_principal _principal;
+    std::optional<clock_type::time_point> _session_expiry;
     state _state{state::init};
     class impl;
     std::unique_ptr<impl> _impl;

--- a/src/v/security/request_auth.cc
+++ b/src/v/security/request_auth.cc
@@ -176,7 +176,7 @@ request_auth_result request_authenticator::do_authenticate(
             throw ss::httpd::base_exception(
               "Unauthorized", ss::http::reply::status_type::unauthorized);
         }
-        auto principal = res.assume_value().name();
+        auto principal = res.assume_value().principal.name();
         const auto& superusers = _superusers();
         auto found = std::find(superusers.begin(), superusers.end(), principal);
         bool superuser = (found != superusers.end()) || (!require_auth);

--- a/src/v/security/sasl_authentication.h
+++ b/src/v/security/sasl_authentication.h
@@ -84,7 +84,16 @@ public:
     sasl_mechanism& mechanism() { return *_mechanism; }
 
     ss::future<result<bytes>> authenticate(bytes data) {
-        return _mechanism->authenticate(std::move(data));
+        auto res = co_await _mechanism->authenticate(std::move(data));
+        if (res) {
+            set_expiry(_mechanism->credential_expires_in_ms());
+        }
+        co_return res;
+    }
+
+    void reset() {
+        set_state(sasl_state::initial);
+        _mechanism = nullptr;
     }
 
     void set_mechanism(std::unique_ptr<sasl_mechanism> m) {

--- a/src/v/security/sasl_authentication.h
+++ b/src/v/security/sasl_authentication.h
@@ -12,6 +12,7 @@
 #include "security/acl.h"
 #include "vassert.h"
 
+#include <seastar/core/lowres_clock.hh>
 
 #include <chrono>
 #include <memory>
@@ -40,6 +41,8 @@ public:
  * SASL server protocol manager.
  */
 class sasl_server final {
+    using clock_type = ss::lowres_clock;
+
 public:
     enum class sasl_state {
         initial,
@@ -49,13 +52,33 @@ public:
         failed,
     };
 
-    explicit sasl_server(sasl_state state)
-      : _state(state) {}
+    explicit sasl_server(
+      sasl_state state,
+      std::optional<std::chrono::milliseconds> max_reauth = std::nullopt)
+      : _state(state)
+      , _max_reauth_ms(max_reauth) {}
 
     sasl_state state() const { return _state; }
     void set_state(sasl_state state) { _state = state; }
 
     bool complete() const { return _state == sasl_state::complete; }
+    bool expired() const {
+        return _max_reauth_ms && clock_type::now() > _session_expiry;
+    }
+
+    std::chrono::milliseconds session_lifetime_ms() const {
+        using namespace std::chrono_literals;
+        if (!_max_reauth_ms.has_value()) {
+            return 0ms;
+        }
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+          _session_expiry - clock_type::now());
+    }
+
+    std::chrono::milliseconds max_reauth() const {
+        using namespace std::chrono_literals;
+        return _max_reauth_ms.value_or(0ms);
+    }
 
     bool has_mechanism() const { return bool(_mechanism); }
     sasl_mechanism& mechanism() { return *_mechanism; }
@@ -78,6 +101,16 @@ private:
     sasl_state _state;
     std::unique_ptr<sasl_mechanism> _mechanism;
     bool _handshake_v0{false};
+    std::optional<std::chrono::milliseconds> _max_reauth_ms;
+    clock_type::time_point _session_expiry{};
+
+    void set_expiry(std::optional<std::chrono::milliseconds> cred_expiry_ms) {
+        using namespace std::chrono_literals;
+        auto offset = cred_expiry_ms
+                        ? std::min(max_reauth(), cred_expiry_ms.value())
+                        : max_reauth();
+        _session_expiry = clock_type::now() + offset;
+    }
 };
 
 // inline because the function is pretty small and clang complains about

--- a/src/v/security/sasl_authentication.h
+++ b/src/v/security/sasl_authentication.h
@@ -12,7 +12,10 @@
 #include "security/acl.h"
 #include "vassert.h"
 
+
+#include <chrono>
 #include <memory>
+#include <optional>
 #include <string_view>
 
 namespace security {
@@ -27,6 +30,10 @@ public:
     virtual bool failed() const = 0;
     virtual const acl_principal& principal() const = 0;
     virtual ss::future<result<bytes>> authenticate(bytes) = 0;
+    virtual std::optional<std::chrono::milliseconds>
+    credential_expires_in_ms() const {
+        return std::nullopt;
+    }
 };
 
 /*

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -236,6 +236,8 @@ COPY --chown=0:0 --chmod=0755 tests/setup.py /root/tests/
 RUN python3 -m pip install --upgrade --force pip && \
     python3 -m pip install --force --no-cache-dir -e /root/tests/
 
+RUN python3 -m pip install --force-reinstall --no-cache-dir --no-binary :all: confluent-kafka==2.2.0
+
 # seastar addrress to line utility depends on 'file' pkg
 RUN apt update && \
     apt install -y file && \

--- a/tests/docker/ducktape-deps/librdkafka
+++ b/tests/docker/ducktape-deps/librdkafka
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 mkdir /opt/librdkafka
-curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.0.2.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
+curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.2.0.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
 cd /opt/librdkafka
 ./configure
 make -j$(nproc)

--- a/tests/rptest/clients/python_librdkafka.py
+++ b/tests/rptest/clients/python_librdkafka.py
@@ -35,6 +35,11 @@ class PythonLibrdkafka:
         self._algorithm = algorithm
         self._tls_cert = tls_cert
         self._oauth_config = oauth_config
+        self._oauth_count = 0
+
+    @property
+    def oauth_count(self):
+        return self._oauth_count
 
     def brokers(self):
         client = AdminClient(self._get_config())
@@ -146,6 +151,7 @@ class PythonLibrdkafka:
             self._redpanda.logger.info(
                 f"response status: {resp.status_code}, body: {resp.content}")
             token = resp.json()
+            self._oauth_count += 1
             return token['access_token'], time.time() + float(
                 token['expires_in'])
         except Exception as e:

--- a/tests/rptest/tests/sasl_reauth_test.py
+++ b/tests/rptest/tests/sasl_reauth_test.py
@@ -1,0 +1,176 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import json
+from typing import Optional
+
+from rptest.clients.python_librdkafka import PythonLibrdkafka
+from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda import SecurityConfig
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RedpandaService
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda import MetricSamples, MetricsEndpoint, SecurityConfig
+from rptest.util import wait_until_result
+
+from ducktape.utils.util import wait_until
+from ducktape.cluster.cluster import ClusterNode
+
+import typing
+
+EXAMPLE_TOPIC = 'foo'
+
+REAUTH_METRIC = "sasl_session_reauth_attempts_total"
+EXPIRATION_METRIC = "sasl_session_expiration_total"
+
+
+def get_metrics_from_node(
+    redpanda: RedpandaService,
+    node: ClusterNode,
+    patterns: list[str],
+    endpoint: MetricsEndpoint = MetricsEndpoint.METRICS
+) -> Optional[dict[str, MetricSamples]]:
+    def get_metrics_from_node_sync(patterns: list[str]):
+        samples = redpanda.metrics_samples(patterns, [node], endpoint)
+        success = samples is not None
+        return success, samples
+
+    try:
+        return wait_until_result(lambda: get_metrics_from_node_sync(patterns),
+                                 timeout_sec=2,
+                                 backoff_sec=.1)
+    except TimeoutError as e:
+        return None
+
+
+def get_sasl_metrics(redpanda: RedpandaService,
+                     endpoint: MetricsEndpoint = MetricsEndpoint.METRICS):
+    sasl_metrics = [
+        EXPIRATION_METRIC,
+        REAUTH_METRIC,
+    ]
+    node_samples = []
+    for node in redpanda.nodes:
+        samples = get_metrics_from_node(redpanda, node, sasl_metrics, endpoint)
+        node_samples.append(samples)
+
+    result = {}
+    for samples in node_samples:
+        for k in samples.keys():
+            result[k] = result.get(k, 0) + sum(
+                [int(s.value) for s in samples[k].samples])
+    return result
+
+
+class SASLReauthBase(RedpandaTest):
+    def __init__(self,
+                 conn_max_reauth: typing.Union[int, None] = 8000,
+                 **kwargs):
+        security = SecurityConfig()
+        security.enable_sasl = True
+        super().__init__(
+            num_brokers=3,
+            security=security,
+            extra_rp_conf={'kafka_sasl_max_reauth_ms': conn_max_reauth},
+            **kwargs)
+
+        self.su_username, self.su_password, self.su_algorithm = self.redpanda.SUPERUSER_CREDENTIALS
+
+        self.rpk = RpkTool(self.redpanda,
+                           username=self.su_username,
+                           password=self.su_password,
+                           sasl_mechanism=self.su_algorithm)
+
+    def make_su_client(self):
+        return PythonLibrdkafka(self.redpanda,
+                                username=self.su_username,
+                                password=self.su_password,
+                                algorithm=self.su_algorithm)
+
+
+class ReauthConfigTest(SASLReauthBase):
+    """
+    Tests that kafka_sasl_max_reauth_ms{null} produces original behavior
+    i.e. no reauth, no session expiry
+
+    Also tests reauth when enabled after cluster startup
+    """
+
+    MAX_REAUTH_MS = 2000
+    PRODUCE_DURATION_S = MAX_REAUTH_MS * 2 / 1000
+    PRODUCE_INTERVAL_S = 0.1
+    PRODUCE_ITER = int(PRODUCE_DURATION_S / PRODUCE_INTERVAL_S)
+
+    def __init__(self, test_context, **kwargs):
+        super().__init__(test_context=test_context,
+                         conn_max_reauth=None,
+                         **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_reauth_disabled(self):
+        self.rpk.create_topic(EXAMPLE_TOPIC)
+        su_client = self.make_su_client()
+        producer = su_client.get_producer()
+        producer.poll(1.0)
+
+        expected_topics = set([EXAMPLE_TOPIC])
+        wait_until(lambda: set(producer.list_topics(timeout=5).topics.keys())
+                   == expected_topics,
+                   timeout_sec=5)
+
+        for i in range(0, self.PRODUCE_ITER):
+            producer.poll(0.0)
+            producer.produce(topic=EXAMPLE_TOPIC, key='bar', value=str(i))
+            time.sleep(self.PRODUCE_INTERVAL_S)
+
+        producer.flush(timeout=5)
+
+        metrics = get_sasl_metrics(self.redpanda)
+        self.redpanda.logger.debug(f"SASL metrics: {metrics}")
+        assert (EXPIRATION_METRIC in metrics.keys())
+        assert (metrics[EXPIRATION_METRIC] == 0
+                ), "SCRAM sessions should not expire"
+        assert (REAUTH_METRIC in metrics.keys())
+        assert (metrics[REAUTH_METRIC] == 0
+                ), "Expected no reauths with max_reauth = NULL"
+
+    @cluster(num_nodes=3)
+    def test_enable_after_start(self):
+        '''
+        We should be able to enable reauthentication on a live cluster
+        '''
+        new_cfg = {'kafka_sasl_max_reauth_ms': self.MAX_REAUTH_MS}
+        self.redpanda.set_cluster_config(new_cfg)
+
+        self.rpk.create_topic(EXAMPLE_TOPIC)
+        su_client = self.make_su_client()
+        producer = su_client.get_producer()
+        producer.poll(1.0)
+
+        expected_topics = set([EXAMPLE_TOPIC])
+        wait_until(lambda: set(producer.list_topics(timeout=5).topics.keys())
+                   == expected_topics,
+                   timeout_sec=5)
+
+        for i in range(0, self.PRODUCE_ITER):
+            producer.poll(0.0)
+            producer.produce(topic=EXAMPLE_TOPIC, key='bar', value=str(i))
+            time.sleep(self.PRODUCE_INTERVAL_S)
+
+        producer.flush(timeout=5)
+
+        metrics = get_sasl_metrics(self.redpanda)
+        self.redpanda.logger.debug(f"SASL metrics: {metrics}")
+        assert (EXPIRATION_METRIC in metrics.keys())
+        assert (metrics[EXPIRATION_METRIC] == 0
+                ), "Client should reauth before session expiry"
+        assert (REAUTH_METRIC in metrics.keys())
+        assert (metrics[REAUTH_METRIC]
+                > 0), "Expected client reauth on some broker..."

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -15,9 +15,9 @@ setup(
     install_requires=[
         'ducktape@git+https://github.com/redpanda-data/ducktape.git@62e0285f6b3a2f22fd4a43b5fdbc13be8d4290d9',
         'prometheus-client==0.9.0', 'pyyaml==6.0', 'kafka-python==2.0.2',
-        'crc32c==2.2', 'confluent-kafka==2.0.2', 'zstandard==0.15.2',
-        'xxhash==2.0.2', 'protobuf==4.21.8', 'fastavro==1.4.9',
-        'psutil==5.9.0', 'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
+        'crc32c==2.2', 'zstandard==0.15.2', 'xxhash==2.0.2',
+        'protobuf==4.21.8', 'fastavro==1.4.9', 'psutil==5.9.0',
+        'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
         'jump-consistent-hash==3.2.0', 'azure-storage-blob==12.14.1',
         'kafkatest@git+https://github.com/apache/kafka.git@3.2.0#egg=kafkatest&subdirectory=tests',
         'grpcio==1.57.0', 'grpcio-tools==1.57', 'grpcio-status==1.57.0',


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR implements most of [KIP-368](https://cwiki.apache.org/confluence/display/KAFKA/KIP-368%3A+Allow+SASL+Connections+to+Periodically+Re-Authenticate).

This PR also bumps kafka client ducktape dependencies to a version that supports reauthentication.

Fixes https://github.com/redpanda-data/core-internal/issues/775

TODO:

- [x] The KIP describes some metrics related to reauthentication; these could also help with testing.
   - Punt to https://github.com/redpanda-data/core-internal/issues/802
- [x] OAUTHBEARER support in general is WIP - some additional logic is required here to feed token expiration time into session lifetime calculation. Implementation and tests (based on POC OIDC support) are at the head of [this branch](https://github.com/oleiman/redpanda/tree/kip-368-oauth)
- [x] Test Kerberos/GSSAPI
   - ~~CI not currently supported. Needs a manual smoke test. Results to follow~~
   - ~~Update: Some challenges here:~~
     -  ~~Had some issues setting up ADDS last week - as yet unresolved~~
     - ~~Ducktape/kerberos bits are working fine, but we don't have a client available that supports both GSSAPI and kip-368~~

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* Add broker support for SASL reauthentication. To enable, config `connections_max_reauth_ms > 0`.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.



### Improvements

* Short description of how this PR improves existing behavior.

-->
