### PR TITLE
archival: Audit meta in adjacent merger uploads

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -71,6 +71,40 @@ constexpr auto housekeeping_jit = 5ms;
 
 namespace archival {
 
+static bool segment_meta_matches_stats(
+  const cloud_storage::segment_meta& meta,
+  const cloud_storage::segment_record_stats& stats,
+  retry_chain_logger& ctxlog) {
+    // Validate segment content. The 'stats' is computed when
+    // the actual segment is scanned and represents the 'ground truth' about
+    // its content. The 'meta' is the expected segment metadata. We
+    // shouldn't replicate it if it doesn't match the 'stats'.
+    if (
+      meta.size_bytes != stats.size_bytes
+      || meta.base_offset != stats.base_rp_offset
+      || meta.committed_offset != stats.last_rp_offset
+      || static_cast<size_t>(meta.delta_offset_end - meta.delta_offset)
+           != stats.total_conf_records) {
+        vlog(
+          ctxlog.error,
+          "Metadata of the uploaded segment [size: {}, base: {}, last: {}, "
+          "begin delta: {}, end delta: {}] "
+          "doesn't match the segment [size: {}, base: {}, last: {}, total "
+          "config records: {}]",
+          meta.size_bytes,
+          meta.base_offset,
+          meta.committed_offset,
+          meta.delta_offset,
+          meta.delta_offset_end,
+          stats.size_bytes,
+          stats.base_rp_offset,
+          stats.last_rp_offset,
+          stats.total_conf_records);
+        return false;
+    }
+    return true;
+}
+
 ntp_archiver_upload_result::ntp_archiver_upload_result(
   cloud_storage::upload_result r)
   : _result(r) {}
@@ -1752,21 +1786,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
             if (
               upload.upload_kind == segment_upload_kind::non_compacted
               && upload.meta.has_value()) {
-                if (
-                  upload.meta->size_bytes != stats.size_bytes
-                  || upload.meta->base_offset != stats.base_rp_offset
-                  || upload.meta->committed_offset != stats.last_rp_offset) {
-                    vlog(
-                      _rtclog.error,
-                      "Metadata of the uploaded segment [size: {}, base: {}, "
-                      "last: {}] doesn't match the segment [size: {}, base: "
-                      "{}, last: {}]",
-                      upload.meta->size_bytes,
-                      upload.meta->base_offset,
-                      upload.meta->committed_offset,
-                      stats.size_bytes,
-                      stats.base_rp_offset,
-                      stats.last_rp_offset);
+                if (!segment_meta_matches_stats(*upload.meta, stats, _rtclog)) {
                     break;
                 }
             }
@@ -2935,6 +2955,21 @@ ss::future<bool> ntp_archiver::do_upload_local(
       .sname_format = cloud_storage::segment_name_format::v3,
       .metadata_size_hint = tx_size,
     };
+
+    const bool checks_disabled
+      = config::shard_local_cfg()
+          .cloud_storage_disable_upload_consistency_checks.value();
+
+    if (!checks_disabled && upl_res.has_record_stats()) {
+        auto stats = upl_res.record_stats();
+        // Validate segment content. The 'stats' is computed when
+        // the actual segment is scanned and represents the 'ground truth' about
+        // its content. The 'meta' is the expected segment metadata. We
+        // shouldn't replicate it if it doesn't match the 'stats'.
+        if (!segment_meta_matches_stats(meta, stats, _rtclog)) {
+            co_return false;
+        }
+    }
 
     auto deadline = ss::lowres_clock::now() + _conf->manifest_upload_timeout;
     auto error = co_await _parent.archival_meta_stm()->add_segments(


### PR DESCRIPTION
The 'ntp_archiver_service::upload' method is used by the adjacent segment merger. It's an api for external services that need to upload segments. The problem is that this method doesn't utilize the segment stats to validate segment metadata. Normal upload path uses these stats to check if the replicated metadata is correct.

This PR adds similar check to the 'upload' method.
Fixes https://github.com/redpanda-data/redpanda/issues/13834

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md##pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none