### PR TITLE
Config constraints PoC

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     rjson_serialization.cc
     validators.cc
     throughput_control_group.cc
+    property_constraints.cc
   DEPS
     v::json
     v::model

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2513,7 +2513,15 @@ configuration::configuration()
       "The sample period for the CPU profiler",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       100ms,
-      {.min = 1ms}) {}
+      {.min = 1ms})
+  , constraints(
+      *this,
+      "constraints",
+      "A sequence of constraints for cluster-level configs",
+      {.needs_restart = needs_restart::no,
+       .example
+       = R"([{'name': 'default_topic_replication','type': 'restrict','min': 3}])",
+       .visibility = visibility::user}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -18,6 +18,7 @@
 #include "config/data_directory_path.h"
 #include "config/endpoint_tls_config.h"
 #include "config/property.h"
+#include "config/property_constraints.h"
 #include "config/throughput_control_group.h"
 #include "config/tls_config.h"
 #include "model/compression.h"
@@ -484,6 +485,7 @@ struct configuration final : public config_store {
     // debug controls
     property<bool> cpu_profiler_enabled;
     bounded_property<std::chrono::milliseconds> cpu_profiler_sample_period_ms;
+    one_or_many_property<constraint_t> constraints;
 
     configuration();
 

--- a/src/v/config/property_constraints.cc
+++ b/src/v/config/property_constraints.cc
@@ -1,0 +1,165 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/property_constraints.h"
+
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+
+#include <seastar/util/log.hh>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+namespace config {
+
+std::string_view to_string_view(constraint_type type) {
+    switch (type) {
+    case constraint_type::none:
+        return "none";
+    case constraint_type::_restrict:
+        return "restrict";
+    case constraint_type::clamp:
+        return "clamp";
+    }
+
+    return "invalid";
+}
+
+template<>
+std::optional<constraint_type>
+from_string_view<constraint_type>(std::string_view sv) {
+    return string_switch<std::optional<constraint_type>>(sv)
+      .match("none", constraint_type::none)
+      .match("restrict", constraint_type::_restrict)
+      .match("clamp", constraint_type::clamp)
+      .default_match(constraint_type::none);
+}
+
+// This is where all the type conversions happen
+std::shared_ptr<constraint_validator_t> constraint_validator_map(
+  ss::sstring& name,
+  std::optional<ss::sstring> min_str_opt,
+  std::optional<ss::sstring> max_str_opt,
+  constraint_enabled_t enabled) {
+    auto& cfg = config::shard_local_cfg();
+
+    if (name == "log_cleanup_policy") {
+        auto def_val = cfg.log_cleanup_policy.default_value();
+        return std::make_shared<
+          constraint_validator_enabled<model::cleanup_policy_bitflags>>(
+          std::move(enabled),
+          cfg.log_cleanup_policy.bind(),
+          [def_val{std::move(def_val)}](
+            const cluster::topic_configuration& topic_cfg) {
+              if (topic_cfg.properties.cleanup_policy_bitflags) {
+                  return *topic_cfg.properties.cleanup_policy_bitflags;
+              } else {
+                  return def_val;
+              }
+          });
+    } else if (name == "log_retention_ms") {
+        std::optional<std::chrono::milliseconds> min_opt{std::nullopt},
+          max_opt{std::nullopt};
+        if (min_str_opt) {
+            min_opt = std::chrono::milliseconds{std::stol(*min_str_opt)};
+        }
+        if (max_str_opt) {
+            max_opt = std::chrono::milliseconds{std::stol(*max_str_opt)};
+        }
+        auto def_val = *cfg.log_retention_ms.default_value();
+        return std::make_shared<
+          constraint_validator_range<std::chrono::milliseconds>>(
+          std::move(min_opt),
+          std::move(max_opt),
+          [def_val{std::move(def_val)}](
+            const cluster::topic_configuration& topic_cfg)
+            -> std::chrono::milliseconds {
+              if (topic_cfg.properties.retention_duration
+                    .has_optional_value()) {
+                  return topic_cfg.properties.retention_duration.value();
+              } else {
+                  return def_val;
+              }
+          });
+    } else {
+        return nullptr;
+    }
+}
+
+} // namespace config
+
+namespace YAML {
+
+Node convert<config::constraint_t>::encode(const type& rhs) {
+    Node node;
+    node["name"] = rhs.name;
+    node["type"] = ss::sstring(config::to_string_view(rhs.type));
+    if (rhs.validator != nullptr) {
+        rhs.validator->encode_yaml(node);
+    }
+    return node;
+}
+
+bool convert<config::constraint_t>::decode(const Node& node, type& rhs) {
+    for (const auto& s : {"name", "type"}) {
+        if (!node[s]) {
+            return false;
+        }
+    }
+
+    rhs.name = node["name"].as<ss::sstring>();
+    rhs.type = config::from_string_view<config::constraint_type>(
+                 node["type"].as<ss::sstring>())
+                 .value();
+
+    std::optional<ss::sstring> min_str_opt{std::nullopt},
+      max_str_opt{std::nullopt};
+    if (node["min"]) {
+        min_str_opt = node["min"].as<ss::sstring>();
+    }
+
+    if (node["max"]) {
+        max_str_opt = node["max"].as<ss::sstring>();
+    }
+
+    config::constraint_enabled_t enabled{config::constraint_enabled_t::no};
+    if (node["enabled"] && node["enabled"].as<bool>()) {
+        enabled = config::constraint_enabled_t::yes;
+    }
+
+    rhs.validator = constraint_validator_map(
+      rhs.name,
+      std::move(min_str_opt),
+      std::move(max_str_opt),
+      std::move(enabled));
+    return true;
+}
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_t& constraint) {
+    w.StartObject();
+    w.Key("name");
+    w.String(constraint.name);
+    w.Key("type");
+    auto type_str = ss::sstring(config::to_string_view(constraint.type));
+    w.String(type_str);
+    if (constraint.validator != nullptr) {
+        constraint.validator->rjson_serialize(w);
+    }
+    w.EndObject();
+}
+
+} // namespace json

--- a/src/v/config/property_constraints.h
+++ b/src/v/config/property_constraints.h
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/convert.h"
+#include "config/from_string_view.h"
+#include "config/property.h"
+#include "json/_include_first.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <fmt/format.h>
+#include <yaml-cpp/node/node.h>
+
+#include <memory>
+#include <string>
+
+namespace cluster {
+struct topic_configuration;
+} // namespace cluster
+
+namespace config {
+
+struct constraint_validator_t {
+    virtual bool validate(const cluster::topic_configuration&) const = 0;
+    virtual void encode_yaml(YAML::Node&) const = 0;
+    virtual void rjson_serialize(json::Writer<json::StringBuffer>&) const = 0;
+    virtual void print(std::ostream&) const = 0;
+    virtual ~constraint_validator_t() = default;
+};
+
+template<typename T>
+struct constraint_validator_range : public constraint_validator_t {
+    using handle_t =
+      typename ss::noncopyable_function<T(const cluster::topic_configuration&)>;
+
+    std::optional<T> min;
+    std::optional<T> max;
+    handle_t handler;
+
+    constraint_validator_range(
+      std::optional<T> min, std::optional<T> max, handle_t handle)
+      : min{std::move(min)}
+      , max{std::move(max)}
+      , handler{std::move(handle)} {}
+
+    virtual bool validate(const cluster::topic_configuration& topic_cfg) const {
+        T topic_val = handler(topic_cfg);
+
+        if (min && *min > topic_val) {
+            return false;
+        }
+
+        if (max && *max < topic_val) {
+            return false;
+        }
+
+        return true;
+    }
+
+    virtual void encode_yaml(YAML::Node& n) const {
+        if (min) {
+            n["min"] = *min;
+        }
+
+        if (max) {
+            n["max"] = *max;
+        }
+    }
+
+    virtual void rjson_serialize(json::Writer<json::StringBuffer>& w) const {
+        w.Key("min");
+        if (min) {
+            w.String(fmt::format("{}", *min));
+        } else {
+            w.String("null");
+        }
+
+        w.Key("max");
+        if (max) {
+            w.String(fmt::format("{}", *max));
+        } else {
+            w.String("null");
+        }
+    }
+
+    virtual void print(std::ostream& os) const {
+        os << "min:";
+        if (min) {
+            os << *min;
+        } else {
+            os << "null";
+        }
+
+        os << ", max:";
+        if (max) {
+            os << *max;
+        } else {
+            os << "null";
+        }
+    }
+};
+
+using constraint_enabled_t = ss::bool_class<struct constraint_enabled_tag>;
+template<typename T>
+struct constraint_validator_enabled : public constraint_validator_t {
+    using handle_t =
+      typename ss::noncopyable_function<T(const cluster::topic_configuration&)>;
+
+    constraint_enabled_t enabled;
+    binding<T> original_property;
+    handle_t handler;
+
+    constraint_validator_enabled(
+      constraint_enabled_t enabled, binding<T> original, handle_t handle)
+      : enabled{std::move(enabled)}
+      , original_property{std::move(original)}
+      , handler{std::move(handle)} {}
+
+    virtual bool validate(const cluster::topic_configuration& topic_cfg) const {
+        T topic_val = handler(topic_cfg);
+        return topic_val == original_property();
+    }
+
+    virtual void encode_yaml(YAML::Node& n) const {
+        n["enabled"] = enabled == constraint_enabled_t::yes ? true : false;
+    }
+
+    virtual void rjson_serialize(json::Writer<json::StringBuffer>& w) const {
+        w.Key("enabled");
+        enabled == constraint_enabled_t::yes ? w.String("true")
+                                             : w.String("false");
+    }
+
+    virtual void print(std::ostream& os) const {
+        os << "enabled:"
+           << (enabled == constraint_enabled_t::yes ? "true" : "false");
+    }
+};
+
+std::shared_ptr<constraint_validator_t> constraint_validator_map(
+  ss::sstring& name,
+  std::optional<ss::sstring> min_str_opt,
+  std::optional<ss::sstring> max_str_opt,
+  constraint_enabled_t enabled);
+
+enum class constraint_type {
+    none = 0,
+    _restrict = 1,
+    clamp = 2,
+};
+
+std::string_view to_string_view(constraint_type type);
+
+template<>
+std::optional<constraint_type>
+from_string_view<constraint_type>(std::string_view sv);
+
+struct constraint_t {
+    ss::sstring name;
+    constraint_type type;
+    std::shared_ptr<constraint_validator_t> validator;
+
+    constraint_t()
+      : name{"undefined"}
+      , type{constraint_type::none}
+      , validator{nullptr} {}
+
+    constraint_t(
+      ss::sstring name,
+      constraint_type type,
+      std::shared_ptr<constraint_validator_t> validator)
+      : name{name}
+      , type{type}
+      , validator{validator} {}
+
+    bool validate(const cluster::topic_configuration& topic_cfg) const {
+        if (validator != nullptr) {
+            return validator->validate(topic_cfg);
+        }
+        return true;
+    }
+
+    friend bool operator==(const constraint_t&, const constraint_t&) = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const constraint_t& constraint) {
+        os << "name:" << constraint.name << ","
+           << "type:" << to_string_view(constraint.type) << ",";
+        if (constraint.validator != nullptr) {
+            constraint.validator->print(os);
+        }
+        return os;
+    }
+};
+
+namespace detail {
+
+template<>
+consteval std::string_view property_type_name<constraint_t>() {
+    return "config::constraint_t";
+}
+
+} // namespace detail
+
+} // namespace config
+
+namespace YAML {
+template<>
+struct convert<config::constraint_t> {
+    using type = config::constraint_t;
+    static Node encode(const type& rhs);
+    static bool decode(const Node& node, type& rhs);
+};
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_t& constraint);
+
+} // namespace json


### PR DESCRIPTION
A PoC for config constraints. This demos:
1. Creating constraints for integral and non-integral properties
3. Setting and checking constraint in Admin API `PUT /cluster_config`
4. Fetching constraint in Admin API `GET /cluster_config`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none