### PR TITLE
k/protocol && utils/fragmented_vector improvements

### DIFF
--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1284,19 +1284,9 @@ if ({{ cond }}) {
 {%- set fname = field.name %}
 {%- endif %}
 {%- if field.is_array %}
-{%- if field.nullable() %}
-{%- if flex %}
-{{ fname }} = reader.read_nullable_flex_array([version](protocol::decoder& reader) {
-{%- else %}
-{{ fname }} = reader.read_nullable_array([version](protocol::decoder& reader) {
-{%- endif %}
-{%- else %}
-{%- if flex %}
-{{ fname }} = reader.read_flex_array([version](protocol::decoder& reader) {
-{%- else %}
-{{ fname }} = reader.read_array([version](protocol::decoder& reader) {
-{%- endif %}
-{%- endif %}
+{%- set nullable = "nullable_" if field.nullable() else "" %}
+{%- set flex = "flex_" if flex else "" %}
+{{ fname }} = reader.read_{{nullable}}{{flex}}array([version](protocol::decoder& reader) {
     (void)version;
 {%- if field.type().value_type().is_struct %}
     {{ field.type().value_type().name }} v;

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1286,7 +1286,8 @@ if ({{ cond }}) {
 {%- if field.is_array %}
 {%- set nullable = "nullable_" if field.nullable() else "" %}
 {%- set flex = "flex_" if flex else "" %}
-{{ fname }} = reader.read_{{nullable}}{{flex}}array([version](protocol::decoder& reader) {
+{%- set container = (field.type_name_parts() | list)[1] %}
+{{ fname }} = reader.read_{{nullable}}{{flex}}array<{{ container }}>([version](protocol::decoder& reader) {
     (void)version;
 {%- if field.type().value_type().is_struct %}
     {{ field.type().value_type().name }} v;

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -1024,17 +1024,13 @@ class Field:
 
     @property
     def type_name(self):
-        name, default_value = self._redpanda_type()
+        gen = self.type_name_parts()
+        name = next(gen)
         if isinstance(self._type, ArrayType):
-            assert default_value is None  # not supported
-            if name in enable_fragmentation_resistance:
-                name = f'large_fragment_vector<{name}>'
-            else:
-                name = f'std::vector<{name}>'
+            name = f'{next(gen)}<{name}>'
         if self.nullable():
-            assert default_value is None  # not supported
-            return f"std::optional<{name}>", None
-        return name, default_value
+            return f'{next(gen)}<{name}>', None
+        return name, next(gen)
 
     def type_name_parts(self):
         """
@@ -1044,10 +1040,14 @@ class Field:
         yield name
         if isinstance(self._type, ArrayType):
             assert default_value is None  # not supported
-            yield "std::vector"
+            if name in enable_fragmentation_resistance:
+                yield "large_fragment_vector"
+            else:
+                yield "std::vector"
         if self.nullable():
             assert default_value is None  # not supported
             yield "std::optional"
+        yield default_value
 
     @property
     def value_type(self):

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -35,6 +35,22 @@ class input_stream;
 
 namespace kafka::protocol {
 
+namespace detail {
+
+template<typename Container>
+concept push_backable = requires(Container c) {
+    typename Container::value_type;
+    c.push_back(std::declval<typename Container::value_type>());
+};
+
+template<typename Container>
+concept reserveable = requires(Container c) {
+    typename Container::value_type;
+    c.reserve(size_t{});
+};
+
+} // namespace detail
+
 class decoder {
 public:
     explicit decoder(iobuf io) noexcept
@@ -175,50 +191,62 @@ public:
     }
 
     template<
+      template<typename...> typename Container = std::vector,
       typename ElementParser,
       typename T = std::invoke_result_t<ElementParser, decoder&>>
-    std::vector<T> read_array(ElementParser&& parser) {
+    requires detail::push_backable<Container<T>>
+    Container<T> read_array(ElementParser&& parser) {
         auto len = read_int32();
         if (len < 0) {
             throw std::out_of_range(
               "Attempt to read array with negative length");
         }
-        return do_read_array(len, std::forward<ElementParser>(parser));
+        return do_read_array<Container>(
+          len, std::forward<ElementParser>(parser));
     }
 
     template<
+      template<typename...> typename Container = std::vector,
       typename ElementParser,
       typename T = std::invoke_result_t<ElementParser, decoder&>>
-    std::vector<T> read_flex_array(ElementParser&& parser) {
+    requires detail::push_backable<Container<T>>
+    Container<T> read_flex_array(ElementParser&& parser) {
         auto len = read_unsigned_varint();
         if (len == 0) {
             throw std::out_of_range(
               "Attempt to read non-null flex array with 0 length");
         }
-        return do_read_array(len - 1, std::forward<ElementParser>(parser));
+        return do_read_array<Container>(
+          len - 1, std::forward<ElementParser>(parser));
     }
 
     template<
+      template<typename...> typename Container = std::vector,
       typename ElementParser,
       typename T = std::invoke_result_t<ElementParser, decoder&>>
-    std::optional<std::vector<T>> read_nullable_array(ElementParser&& parser) {
+    requires detail::push_backable<Container<T>>
+    std::optional<Container<T>> read_nullable_array(ElementParser&& parser) {
         auto len = read_int32();
         if (len < 0) {
             return std::nullopt;
         }
-        return do_read_array(len, std::forward<ElementParser>(parser));
+        return do_read_array<Container>(
+          len, std::forward<ElementParser>(parser));
     }
 
     template<
+      template<typename...> typename Container = std::vector,
       typename ElementParser,
       typename T = std::invoke_result_t<ElementParser, decoder&>>
-    std::optional<std::vector<T>>
+    requires detail::push_backable<Container<T>>
+    std::optional<Container<T>>
     read_nullable_flex_array(ElementParser&& parser) {
         auto len = read_unsigned_varint();
         if (len == 0) {
             return std::nullopt;
         }
-        return do_read_array(len - 1, std::forward<ElementParser>(parser));
+        return do_read_array<Container>(
+          len - 1, std::forward<ElementParser>(parser));
     }
 
     // Only relevent when reading flex requests
@@ -270,17 +298,21 @@ private:
     }
 
     template<
+      template<typename...> typename Container = std::vector,
       typename ElementParser,
       typename T = std::invoke_result_t<ElementParser, decoder&>>
     requires requires(ElementParser parser, decoder& rr) {
         { parser(rr) } -> std::same_as<T>;
+        detail::push_backable<Container<T>>;
     }
-    std::vector<T> do_read_array(int32_t len, ElementParser&& parser) {
+    Container<T> do_read_array(int32_t len, ElementParser&& parser) {
         if (len < 0) {
             throw std::out_of_range("Attempt to parse array w/ negative len");
         }
-        std::vector<T> res;
-        res.reserve(len);
+        Container<T> res;
+        if constexpr (detail::reserveable<Container<T>>) {
+            res.reserve(len);
+        }
         while (len-- > 0) {
             res.push_back(parser(*this));
         }

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -208,19 +208,6 @@ public:
     static size_t elements_per_fragment() { return elems_per_frag; }
 
     /**
-     * Assign from a std::vector.
-     */
-    fragmented_vector& operator=(const std::vector<T>& rhs) noexcept {
-        clear();
-
-        for (auto& e : rhs) {
-            push_back(e);
-        }
-
-        return *this;
-    }
-
-    /**
      * Remove all elements from the vector.
      *
      * Unlike std::vector, this also releases all the memory from

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -247,6 +247,7 @@ public:
         iter() = default;
 
         reference operator*() const { return _vec->operator[](_index); }
+        pointer operator->() const { return &_vec->operator[](_index); }
 
         iter& operator+=(ssize_t n) {
             _index += n;
@@ -279,8 +280,6 @@ public:
             --*this;
             return tmp;
         }
-
-        pointer operator->() const { return &_vec->operator[](_index); }
 
         iter operator+(difference_type offset) { return iter{*this} += offset; }
         iter operator-(difference_type offset) { return iter{*this} -= offset; }

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -235,6 +235,7 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_access) {
 
     BOOST_CHECK_EQUAL(*vec.begin(), foo{2});
     BOOST_CHECK_EQUAL((*vec.begin()).a, 2);
+    BOOST_CHECK_EQUAL(vec.begin()->a, 2);
 }
 
 /**

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -335,23 +335,6 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_vector_clear) {
 
     v = make<int, 8>({5, 5, 5, 5});
     BOOST_CHECK_EQUAL(v->size(), 4);
-
-    v.u = std::vector{1, 2, 3};
-    BOOST_CHECK_EQUAL(v->size(), 3);
-}
-
-BOOST_AUTO_TEST_CASE(fragmented_vector_vector_assign) {
-    std::vector vin0{1, 2, 3};
-    std::vector vin1{4, 5};
-
-    checker<int, 8> v;
-    BOOST_CHECK_EQUAL(v, (make({})));
-
-    v.get() = std::vector{1};
-    BOOST_CHECK_EQUAL(v, (make({1})));
-
-    v.get() = std::vector{2, 3, 4};
-    BOOST_CHECK_EQUAL(v, (make({2, 3, 4})));
 }
 
 BOOST_AUTO_TEST_CASE(fragmented_vector_pop_back_n) {

--- a/src/v/utils/tests/fragmented_vector_test.cc
+++ b/src/v/utils/tests/fragmented_vector_test.cc
@@ -220,6 +220,23 @@ BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_types) {
                   decltype(v)::const_iterator>);
 }
 
+struct foo {
+    int a;
+    friend std::ostream& operator<<(std::ostream& os, foo const& f) {
+        return os << f.a;
+    }
+    friend auto operator<=>(foo const&, foo const&) = default;
+};
+
+BOOST_AUTO_TEST_CASE(fragmented_vector_iterator_access) {
+    using vtype = fragmented_vector<foo, 8>;
+    auto vec = vtype{};
+    vec.push_back(foo{2});
+
+    BOOST_CHECK_EQUAL(*vec.begin(), foo{2});
+    BOOST_CHECK_EQUAL((*vec.begin()).a, 2);
+}
+
 /**
  * Get a fragmented vector for elements of size E, with max_fragment_size F.
  */


### PR DESCRIPTION
`k/protocol/wire/read_array` now supports a template parameter for return type instead of `std::vector`.
* Requires `push_backable`
* Conditionally reserves space where `container::reserve` is supported

Rebase #11181

* Drop the last commit since which container to use is contentious
* Don't add `fragmented_vector::operator->` since it was added in #11691
* Improve `make_fragmented_vector` in `tx_range_manifest_test.cc`

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

