### PR TITLE
rpk/transform: introduce init command

### DIFF
--- a/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
+++ b/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
@@ -142,7 +142,7 @@ type Downloader interface {
 
 // HTTPDownloader downloads a buildpack over HTTP.
 type HTTPDownloader struct {
-	Client httpapi.Client
+	Client *httpapi.Client
 }
 
 // Download implements the Downloader interface for HTTPDownloader.

--- a/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
+++ b/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
@@ -20,10 +20,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
@@ -138,6 +140,19 @@ func (bp *Buildpack) IsUpToDate(fs afero.Fs) (bool, error) {
 // Downloader is an abstraction over getting a buildpack into a io.Writer.
 type Downloader interface {
 	Download(ctx context.Context, bp *Buildpack, w io.Writer) error
+}
+
+// NewDownloader creates a new default downloader over HTTP with progress reporting.
+func NewDownloader() Downloader {
+	return &ProgressDownloader{
+		Underlying: &HTTPDownloader{
+			Client: httpapi.NewClient(
+				httpapi.HTTPClient(&http.Client{
+					Timeout: 120 * time.Second,
+				}),
+			),
+		},
+	}
 }
 
 // HTTPDownloader downloads a buildpack over HTTP.

--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -1,0 +1,256 @@
+/*
+* Copyright 2023 Redpanda Data, Inc.
+*
+* Use of this software is governed by the Business Source License
+* included in the file licenses/BSL.md
+*
+* As of the Change Date specified in that file, in accordance with
+* the Business Source License, use of this software will be governed
+* by the Apache License, Version 2.0
+ */
+
+package transform
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/transform/buildpack"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/transform/project"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/transform/template"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+type optionalBool struct {
+	ok *bool
+}
+
+func (b *optionalBool) Set(s string) error {
+	if strings.ToLower(s) == "prompt" {
+		b.ok = nil
+		return nil
+	}
+	v, err := strconv.ParseBool(s)
+	b.ok = &v
+	return err
+}
+
+func (*optionalBool) Type() string {
+	return "bool"
+}
+
+func (b *optionalBool) String() string {
+	if b.ok == nil {
+		return "prompt"
+	}
+	return strconv.FormatBool(*b.ok)
+}
+
+func (*optionalBool) IsBoolFlag() bool { return true }
+
+func newInitializeCommand(fs afero.Fs) *cobra.Command {
+	var (
+		name    string
+		lang    project.WasmLang
+		install optionalBool
+	)
+	cmd := &cobra.Command{
+		Use:   "init [DIRECTORY]",
+		Short: "Initialize a transform",
+		Long: `Initialize a transform.
+
+Creates a new transform using a template in the current directory.
+
+A new directory can be created by specifying it in the command, like:
+
+  rpk transform init foobar
+
+Will initialize a transform project in the foobar directory.
+		`,
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			path, err := computeProjectDirectory(fs, args)
+			out.MaybeDie(err, "unable to determine project directory: %v", err)
+			c := filepath.Join(path, project.ConfigFileName)
+			ok, err := afero.Exists(fs, c)
+			out.MaybeDie(err, "unable to determine if %q exists: %v", c, err)
+			if ok {
+				out.Die("there is already a transform at %q, please delete it before retrying", c)
+			}
+			for name == "" {
+				suggestion := filepath.Base(path)
+				if suggestion == "." {
+					suggestion = ""
+				}
+				name, err = out.PromptWithSuggestion(suggestion, "name this transform:")
+				out.MaybeDie(err, "unable to determine project name: %v", err)
+			}
+			if lang == "" {
+				langVal, err := out.Pick(project.AllWasmLangs, "select a language:")
+				out.MaybeDie(err, "unable to determine transform language: %v", err)
+				lang = project.WasmLang(langVal)
+			}
+			p := transformProject{Name: name, Lang: lang, Path: path}
+
+			fmt.Printf("generating project in %s...\n", p.Path)
+			err = executeGenerate(fs, p)
+			out.MaybeDie(err, "unable to generate all manifest files: %v", err)
+			fmt.Println("created project in", p.Path)
+
+			if install.ok == nil {
+				ok, err = out.Confirm("install dependencies?")
+				install.ok = &ok
+				out.MaybeDie(err, "unable to determine if dependencies should be installed: %v", err)
+			}
+			if *install.ok {
+				fmt.Println("installing dependencies...")
+				err = installDeps(cmd.Context(), fs, p)
+				out.MaybeDie(err, "unable to install dependencies: %v", err)
+				fmt.Println("dependencies installed")
+			}
+
+			cwd, err := os.Getwd()
+			out.MaybeDie(err, "unable to get current directory: %v", err)
+			fmt.Println("deploy your transform using:")
+			if cwd != path {
+				rel, err := filepath.Rel(cwd, path)
+				if err == nil {
+					fmt.Println("\tcd", rel)
+				}
+			}
+			fmt.Println("\trpk transform build")
+			fmt.Println("\trpk transform deploy")
+		},
+	}
+	cmd.Flags().VarP(&lang, "language", "l", "The language used to develop the transform")
+	cmd.Flags().Var(&install, "install-deps", "If dependencies should be installed for the project")
+	cmd.Flags().StringVar(&name, "name", "", "The name of the transform")
+	return cmd
+}
+
+func computeProjectDirectory(fs afero.Fs, args []string) (string, error) {
+	var path string
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("unable to determine current working directory: %v", err)
+	}
+	cwd, err = filepath.Abs(cwd)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine absolute path for %q: %v", path, err)
+	}
+	if len(args) == 0 {
+		return cwd, nil
+	}
+	path = args[0]
+	ok, err := afero.Exists(fs, path)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine if %q exists: %v", path, err)
+	}
+	if !ok {
+		if err := fs.MkdirAll(path, os.ModeDir|os.ModePerm); err != nil {
+			return "", fmt.Errorf("unable to create directory %q: %v", path, err)
+		}
+	}
+	path, err = filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine absolute path for %q: %v", path, err)
+	}
+	f, err := fs.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine if %q exists: %v", path, err)
+	}
+	if !f.IsDir() {
+		return "", fmt.Errorf("please remove file %q to initialize a transform there", path)
+	}
+	return path, nil
+}
+
+type transformProject struct {
+	Name string
+	Path string
+	Lang project.WasmLang
+}
+
+type genFile struct {
+	name    string
+	content string
+}
+
+func generateManifest(p transformProject) (map[string][]genFile, error) {
+	if p.Lang == project.WasmLangTinygo {
+		rpConfig, err := project.MarshalConfig(project.Config{Name: p.Name, Language: p.Lang})
+		if err != nil {
+			return nil, err
+		}
+		return map[string][]genFile{
+			p.Path: {
+				genFile{name: project.ConfigFileName, content: string(rpConfig)},
+				genFile{name: "transform.go", content: template.WasmGoMain()},
+				genFile{name: "go.mod", content: template.WasmGoModule(p.Name)},
+				genFile{name: "README.md", content: template.WasmGoReadme()},
+			},
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown language %q", p.Lang)
+}
+
+func executeGenerate(fs afero.Fs, p transformProject) error {
+	manifest, err := generateManifest(p)
+	if err != nil {
+		return err
+	}
+	for dir, templates := range manifest {
+		if err := fs.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		for _, template := range templates {
+			file := filepath.Join(dir, template.name)
+			if err := afero.WriteFile(fs, file, []byte(template.content), os.FileMode(0o644)); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
+	if p.Lang == project.WasmLangTinygo {
+		ok, err := buildpack.Tinygo.IsUpToDate(fs)
+		if err != nil {
+			return fmt.Errorf("unable to determine if tinygo buildpack is up to date: %v", err)
+		}
+		if !ok {
+			dl := buildpack.NewDownloader()
+			if err := buildpack.Tinygo.Download(ctx, dl, fs); err != nil {
+				return fmt.Errorf("unable to install tinygo buildpack: %v", err)
+			}
+		}
+		g, err := exec.LookPath("go")
+		if err != nil {
+			return fmt.Errorf("go is not available on $PATH, please download and install it: https://go.dev/doc/install")
+		}
+		runGoCli := func(args ...string) error {
+			c := exec.CommandContext(ctx, g, args...)
+			c.Stderr = os.Stderr
+			c.Stdin = os.Stdin
+			c.Stdout = os.Stdout
+			c.Dir = p.Path
+			return c.Run()
+		}
+		if err := runGoCli("get", "github.com/redpanda-data/redpanda/src/go/transform-sdk"); err != nil {
+			return fmt.Errorf("unable to go get redpanda transform-sdk: %v", err)
+		}
+		if err := runGoCli("mod", "tidy"); err != nil {
+			return fmt.Errorf("unable to run go mod tidy: %v", err)
+		}
+		return nil
+	}
+	return fmt.Errorf("Unknown language %q", p.Lang)
+}

--- a/src/go/rpk/pkg/cli/transform/project/project.go
+++ b/src/go/rpk/pkg/cli/transform/project/project.go
@@ -1,0 +1,73 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package project
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/afero"
+	"gopkg.in/yaml.v3"
+)
+
+type WasmLang string
+
+const (
+	WasmLangTinygo WasmLang = "tinygo"
+)
+
+var AllWasmLangs = []string{"tinygo"}
+
+func (l *WasmLang) Set(str string) error {
+	lower := strings.ToLower(str)
+	for _, s := range AllWasmLangs {
+		if lower == s {
+			*l = WasmLang(s)
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown language: %q", str)
+}
+
+func (l WasmLang) String() string {
+	return string(l)
+}
+
+func (WasmLang) Type() string {
+	return "string"
+}
+
+type Config struct {
+	Name        string            `yaml:"name"`
+	Description string            `yaml:"description,omitempty"`
+	InputTopic  string            `yaml:"input-topic"`
+	OutputTopic string            `yaml:"output-topic"`
+	Language    WasmLang          `yaml:"language"`
+	Env         map[string]string `yaml:"env,omitempty"`
+}
+
+var ConfigFileName = "transform.yaml"
+
+func MarshalConfig(c Config) ([]byte, error) {
+	return yaml.Marshal(c)
+}
+
+func UnmarshalConfig(b []byte, c *Config) error {
+	return yaml.Unmarshal(b, c)
+}
+
+func LoadCfg(fs afero.Fs) (c Config, err error) {
+	b, err := afero.ReadFile(fs, ConfigFileName)
+	if err != nil {
+		return c, err
+	}
+	err = UnmarshalConfig(b, &c)
+	return c, err
+}

--- a/src/go/rpk/pkg/cli/transform/template/golang/README.md
+++ b/src/go/rpk/pkg/cli/transform/template/golang/README.md
@@ -1,0 +1,15 @@
+# Redpanda Golang WASM Transform
+
+To get started you first need to have at least go 1.20 installed.
+
+You can get started by modifying the <code>transform.go</code> file
+with your logic.
+
+Once you're ready to test out your transform live you need to:
+
+1. Make sure you have a container running via <code>rpk container start</code>
+1. Run <code>rpk transform build</code>
+1. Create your topics via <code>rpk topic create</code>
+1. Run <code>rpk transform deploy</code>
+1. Then use <code>rpk topic produce</code> and <code>rpk topic consume</code>
+   to see your transformation live!

--- a/src/go/rpk/pkg/cli/transform/template/golang/transform.gosrc
+++ b/src/go/rpk/pkg/cli/transform/template/golang/transform.gosrc
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+)
+
+func main() {
+        // Register your transform function. 
+        // This is a good place to perform other setup too.
+	redpanda.OnRecordWritten(doTransform)
+}
+
+// doTransform is where you read the record that was written, and then you can
+// return new records that will be written to the output topic
+func doTransform(e redpanda.WriteEvent) ([]redpanda.Record, error) {
+	return []redpanda.Record{e.Record()}, nil
+}

--- a/src/go/rpk/pkg/cli/transform/template/golang_template.go
+++ b/src/go/rpk/pkg/cli/transform/template/golang_template.go
@@ -1,0 +1,38 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package template
+
+import (
+	_ "embed"
+	"fmt"
+)
+
+//go:embed golang/transform.gosrc
+var wasmMainFile string
+
+func WasmGoMain() string {
+	return wasmMainFile
+}
+
+const wasmGoModFile = `module %s
+
+go 1.20
+`
+
+func WasmGoModule(name string) string {
+	return fmt.Sprintf(wasmGoModFile, name)
+}
+
+//go:embed golang/README.md
+var wasmGoReadme string
+
+func WasmGoReadme() string {
+	return wasmGoReadme
+}

--- a/src/go/rpk/pkg/cli/transform/transform.go
+++ b/src/go/rpk/pkg/cli/transform/transform.go
@@ -25,6 +25,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.AddCommand(
 		newDeleteCommand(fs, p),
 		newListCommand(fs, p),
+		newInitializeCommand(fs),
 	)
 	return cmd
 }

--- a/src/go/rpk/pkg/out/out.go
+++ b/src/go/rpk/pkg/out/out.go
@@ -84,9 +84,15 @@ func PickIndex(options []string, msg string, args ...interface{}) (int, error) {
 
 // Prompt prompts the user for input, returning the input or an error.
 func Prompt(msg string, args ...interface{}) (string, error) {
+	return PromptWithSuggestion("", msg, args...)
+}
+
+// PromptWithSuggestion prompts the user for input, giving a default choice, returning the input or an error.
+func PromptWithSuggestion(defaultInput string, msg string, args ...interface{}) (string, error) {
 	var input string
 	err := survey.AskOne(&survey.Input{
 		Message: fmt.Sprintf(msg, args...),
+		Default: defaultInput,
 	}, &input)
 	return input, err
 }


### PR DESCRIPTION
Introduce the init command for data transformed

This will initialize a go project. 

More information is available in the [RFC](https://docs.google.com/document/d/1l9wuOmR_iQoDS-02FUQhOJ6mzV02H26Xmd5bAd8QB6Q/edit#heading=h.erwed2nknsfv)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
