### PR TITLE
Redpanda-Operator: additional roles required by helmreleases added

### DIFF
--- a/src/go/k8s/config/rbac/bases/operator/role.yaml
+++ b/src/go/k8s/config/rbac/bases/operator/role.yaml
@@ -7,6 +7,18 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -94,6 +106,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - endpoints
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create
@@ -102,6 +121,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - limitranges
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:
@@ -149,10 +175,31 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
   - pods/status
   verbs:
   - patch
   - update
+- apiGroups:
+  - ""
+  resources:
+  - replicationcontrollers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - resourcequotas
+  verbs:
+  - get
+  - list
 - apiGroups:
   - ""
   resources:
@@ -214,9 +261,33 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
   - clusterroles
   verbs:
   - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/src/go/k8s/controllers/redpanda/redpanda_controller.go
+++ b/src/go/k8s/controllers/redpanda/redpanda_controller.go
@@ -85,6 +85,31 @@ type RedpandaReconciler struct {
 // +kubebuilder:rbac:groups="monitoring.coreos.com",namespace=default,resources=servicemonitors,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,namespace=default,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 
+// additional k8s resources required by flux (Cluster Scope)
+// The redpanda chart requires, for rack-awareness, that we have access to cluster scope resources.
+// So for a redpanda resource to enable rack-awareness the operator requires permissions
+// at the cluster scope.
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete
+
+// additional K8s resources (Cluster Scope) defined in rbac.yaml for the redpanda chart (rpk-bundle)
+// The redpanda chart requires, for rack-awareness, that we have access to cluster scope resources.
+// So for a redpanda resource to enable rack-awareness the operator requires permissions
+// at the cluster scope.
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=endpoints,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=events,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=limitranges,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=pods/log,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=replicationcontrollers,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=resourcequotas,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;
+// +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
+
 // redpanda resources
 // +kubebuilder:rbac:groups=cluster.redpanda.com,namespace=default,resources=redpandas,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=cluster.redpanda.com,namespace=default,resources=redpandas/status,verbs=get;update;patch


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Fixes #13825 (2nd -part)


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
* Enable creation of rbac clusterroles and bindings for redpandas when rbac is enabled. 
