### PR TITLE
[v23.2.x] k8s: make proper v2 tests for roll-back upgrade

### DIFF
--- a/src/go/k8s/tests/e2e-v2/upgrade-rollback/00-create-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/upgrade-rollback/00-create-redpanda.yaml
@@ -7,5 +7,7 @@ spec:
   chartRef:
     chartVersion: "5.3.2"
   clusterSpec:
+    image:
+      tag: v23.2.3
     statefulset:
       replicas: 1

--- a/src/go/k8s/tests/e2e-v2/upgrade-rollback/02-upgrade-good-redpanda.yaml
+++ b/src/go/k8s/tests/e2e-v2/upgrade-rollback/02-upgrade-good-redpanda.yaml
@@ -5,10 +5,10 @@ metadata:
   name: redpanda
 spec:
   chartRef:
-    timeout: 2m
+    timeout: 3m
     chartVersion: "5.3.2"
   clusterSpec:
     image:
-      tag: v23.2.3
+      tag: v23.2.10
     statefulset:
       replicas: 1


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13870
Fixes: https://github.com/redpanda-data/redpanda/issues/13875,