### PR TITLE
rptest: Update s3 blocking for cloud tests and fix BYOC cluster deletion

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py
+++ b/tests/rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py
@@ -1,3 +1,6 @@
+from rptest.services.redpanda_cloud import CLOUD_TYPE_BYOC, CLOUD_TYPE_FMC
+
+
 class cloudv2_object_store_blocked:
     """Temporary block writes to a cloudv2 TS bucket"""
     def __init__(self, rp, logger):
@@ -5,8 +8,15 @@ class cloudv2_object_store_blocked:
         cluster_id = rp._cloud_cluster.config.id
         network_id = rp._cloud_cluster.current.network_id
         self._cloud_provider_client = rp._cloud_cluster.provider_cli
-        self._vpc_id = self._cloud_provider_client.get_vpc_by_network_id(
-            network_id)['VpcId']
+        # This is different for BYOC and FMC
+        if rp._cloud_cluster.config.type == CLOUD_TYPE_BYOC:
+            self._vpc_id = self._cloud_provider_client.get_vpc_by_network_id(
+                network_id)['VpcId']
+        elif rp._cloud_cluster.config.type == CLOUD_TYPE_FMC:
+            _net = rp._cloud_cluster._get_network()
+            _info = _net['status']['created']['providerNetworkDetails'][
+                'cloudProvider'][rp._cloud_cluster.config.provider.lower()]
+            self._vpc_id = _info['vpcId']
         self._bucket_name = f'redpanda-cloud-storage-{cluster_id}'
 
     def __enter__(self):

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -258,6 +258,16 @@ class HighThroughputTest(RedpandaTest):
             if item['type'] == 'topic':
                 self.rpk.delete_topic(item['spec'].name)
 
+    @cluster(num_nodes=0)
+    def test_cluster_cleanup(self):
+        """
+        This is not a test, but a cluster cleanup kicker
+        """
+        # Initiate cluster deletion
+        # Cluster will be deleted if configuration is enabled it
+        # and/or config.use_same_cluster and current.tests_finished set to True
+        self.redpanda._cloud_cluster.current.tests_finished = True
+
     def tearDown(self):
         # These tests may run on cloud ec2 instances where between each test
         # the same cluster is used. Therefore state between runs will still exist,
@@ -561,6 +571,7 @@ class HighThroughputTest(RedpandaTest):
                    timeout_sec=restart_timeout,
                    backoff_sec=1)
 
+    @ok_to_fail
     @cluster(num_nodes=2, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_disrupt_cloud_storage(self):
         """

--- a/tests/rptest/services/provider_clients/ec2_client.py
+++ b/tests/rptest/services/provider_clients/ec2_client.py
@@ -100,7 +100,7 @@ class EC2Client:
         _resp = self._cli.describe_vpcs(Filters=_filters)
         _vpcs = _resp[VPCS_LABEL]
         # Validate connection count
-        if len(_vpcs) < 0:
+        if len(_vpcs) < 1:
             self._log.error(
                 f"No VPC connection found for 'network-{network_id}'")
             return None

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -296,7 +296,11 @@ class LiveClusterParams:
     rp_vpc_id: str = None
     rp_owner_id: str = None
     vpc_peering_id: str = None
-
+    # Special flag that is checked on cluster deletion
+    # last test in the list should set this to True
+    # along with 'use_same_cluster' in config
+    # this will initiane cluster deletion
+    tests_finished: bool = False
     # Can't use mutables in defaults of dataclass
     # https://docs.python.org/3/library/dataclasses.html#dataclasses.field
     zones: list[str] = field(default_factory=list)
@@ -405,7 +409,8 @@ class CloudCluster():
 
         # prepare rpk plugin
         self.utils = CloudClusterUtils(context, self._logger,
-                                       self.provider_key, self.provider_secret)
+                                       self.provider_key, self.provider_secret,
+                                       self.config.provider)
         if self.config.type == CLOUD_TYPE_BYOC:
             # remove current plugin if any
             self.utils.rpk_plugin_uninstall('byoc', sudo=True)
@@ -502,6 +507,11 @@ class CloudCluster():
                     raise RuntimeError("Creation failed (state 'unknown') "
                                        f"for '{self.config.provider}'")
         return False
+
+    def _cluster_status(self, status):
+        _cluster = self.cloudv2._http_get(
+            endpoint=f'/api/v1/clusters/{self.config.id}')
+        return _cluster['state'] == status
 
     def _get_cluster_console_url(self):
         cluster = self.cloudv2._http_get(
@@ -849,23 +859,48 @@ class CloudCluster():
     def delete(self):
         """
         Deletes a cloud cluster and the namespace it belongs to.
+        Cluster delete is initiated via cluster nodes stop.
         """
-
         if self.config.id == '':
             self._logger.warn(f'cluster_id is empty, unable to delete cluster')
             return
-        elif not self.current.delete_cluster:
+        elif not self.config.delete_cluster:
             self._logger.warn(f'Cluster deletion skipped as configured')
             return
+        elif self.config.use_same_cluster:
+            # Check for tests finished flag only when same cluster used
+            if not self.current.tests_finished:
+                self._logger.info("Not all tests finished, skipped deletion")
+                return
+            else:
+                pass
 
+        self._logger.info("Deleting cluster")
         resp = self.cloudv2._http_get(
             endpoint=f'/api/v1/clusters/{self.config.id}')
         namespace_uuid = resp['namespaceUuid']
+
+        # For FMC, just delete the cluster and the rest will happen
+        # by itself
+
+        # For BYOC cluster deletion happens in 2 phases
+        # 1. Delete cluster
+        # 2. Wait for status "delete agent"
+        # 3. Use rpk to delete agent
 
         resp = self.cloudv2._http_delete(
             endpoint=f'/api/v1/clusters/{self.config.id}')
         self._logger.debug(f'resp: {json.dumps(resp)}')
         self.config.id = ''
+
+        if self.config.type == CLOUD_TYPE_BYOC:
+            wait_until(lambda: self._cluster_status('deleting_agent'),
+                       timeout_sec=self.CHECK_TIMEOUT_SEC,
+                       backoff_sec=self.CHECK_BACKOFF_SEC,
+                       err_msg='Timeout waiting for deletion '
+                       f'of cloud cluster {self.current.name}')
+            # Once deleted run agent delete
+            self.utils.rpk_cloud_agent_delete(self.config.id)
 
         # skip namespace deletion to avoid error because cluster delete not complete yet
         if self._delete_namespace:


### PR DESCRIPTION
  In case of BYOC cloud, account that handled VPCs are the same as
  ducktape running on and ec2 can be used
  In case of FMC, there is no direct access to Cloud AWS account from
  ducktape AWS Account.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none