### PR TITLE
transform: Support wasm binary CRUD

### DIFF
--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -183,6 +183,11 @@ ss::future<> health_manager::do_tick() {
               model::kafka_namespace, model::schema_registry_internal_tp.topic};
             ok = co_await ensure_topic_replication(schema_registry_nt);
         }
+
+        if (ok) {
+            ok = co_await ensure_topic_replication(
+              model::topic_namespace_view(model::wasm_binaries_internal_ntp));
+        }
     }
 
     _timer.arm(_tick_interval);

--- a/src/v/model/ktp.h
+++ b/src/v/model/ktp.h
@@ -122,6 +122,11 @@ public:
     }
 
     /**
+     * An explicit conversion operator of `as_tn_view`.
+     */
+    explicit operator topic_namespace_view() const { return as_tn_view(); }
+
+    /**
      * @brief Return a topic partition view corresponding to this object.
      *
      * Return a topic_partition_view over this object's topic and partition.

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -70,4 +70,7 @@ inline const model::ntp tx_registry_ntp(
 inline const model::topic_partition schema_registry_internal_tp{
   model::topic{"_schemas"}, model::partition_id{0}};
 
+inline const model::ntp wasm_binaries_internal_ntp(
+  model::redpanda_ns, model::topic("wasm_binaries"), model::partition_id(0));
+
 } // namespace model

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -42,6 +42,7 @@ public:
     client(
       model::node_id self,
       std::unique_ptr<partition_leader_cache>,
+      std::unique_ptr<topic_creator>,
       ss::sharded<::rpc::connection_cache>*,
       ss::sharded<local_service>*);
     client(client&&) = delete;
@@ -53,6 +54,15 @@ public:
     ss::future<cluster::errc>
       produce(model::topic_partition, ss::chunked_fifo<model::record_batch>);
 
+    ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
+    store_wasm_binary(iobuf, model::timeout_clock::duration timeout);
+
+    ss::future<cluster::errc>
+    delete_wasm_binary(uuid_t key, model::timeout_clock::duration timeout);
+
+    ss::future<result<iobuf, cluster::errc>>
+    load_wasm_binary(model::offset, model::timeout_clock::duration timeout);
+
     ss::future<> stop();
 
 private:
@@ -60,9 +70,29 @@ private:
     ss::future<produce_reply>
       do_remote_produce(model::node_id, produce_request);
 
+    ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
+    do_local_store_wasm_binary(iobuf, model::timeout_clock::duration timeout);
+    ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
+    do_remote_store_wasm_binary(
+      model::node_id, iobuf, model::timeout_clock::duration timeout);
+
+    ss::future<cluster::errc> do_local_delete_wasm_binary(
+      uuid_t key, model::timeout_clock::duration timeout);
+    ss::future<cluster::errc> do_remote_delete_wasm_binary(
+      model::node_id, uuid_t key, model::timeout_clock::duration timeout);
+
+    ss::future<result<iobuf, cluster::errc>> do_local_load_wasm_binary(
+      model::offset, model::timeout_clock::duration timeout);
+    ss::future<result<iobuf, cluster::errc>> do_remote_load_wasm_binary(
+      model::node_id, model::offset, model::timeout_clock::duration timeout);
+
+    ss::future<std::optional<model::node_id>> compute_wasm_binary_ntp_leader();
+    ss::future<bool> try_create_wasm_binary_ntp();
+
     model::node_id _self;
     // need partition_leaders_table to know which node owns the partitions
     std::unique_ptr<partition_leader_cache> _leaders;
+    std::unique_ptr<topic_creator> _topic_creator;
     ss::sharded<::rpc::connection_cache>* _connections;
     ss::sharded<local_service>* _local_service;
 };

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -79,6 +79,30 @@ public:
 };
 
 /**
+ * A component that can create topics.
+ */
+class topic_creator {
+public:
+    topic_creator() = default;
+    topic_creator(const topic_creator&) = default;
+    topic_creator(topic_creator&&) = delete;
+    topic_creator& operator=(const topic_creator&) = default;
+    topic_creator& operator=(topic_creator&&) = delete;
+    virtual ~topic_creator() = default;
+
+    static std::unique_ptr<topic_creator> make_default(cluster::controller*);
+
+    /**
+     * Create a topic.
+     */
+    virtual ss::future<cluster::errc> create_topic(
+      model::topic_namespace_view,
+      int32_t partition_count,
+      cluster::topic_properties)
+      = 0;
+};
+
+/**
  * Handles routing for shard local partitions.
  */
 class partition_manager {

--- a/src/v/transform/rpc/rpc.json
+++ b/src/v/transform/rpc/rpc.json
@@ -9,6 +9,21 @@
             "name": "produce",
             "input_type": "produce_request",
             "output_type": "produce_reply"
+        },
+        {
+            "name": "store_wasm_binary",
+            "input_type": "store_wasm_binary_request",
+            "output_type": "store_wasm_binary_reply"
+        },
+        {
+            "name": "load_wasm_binary",
+            "input_type": "load_wasm_binary_request",
+            "output_type": "load_wasm_binary_reply"
+        },
+        {
+            "name": "delete_wasm_binary",
+            "input_type": "delete_wasm_binary_request",
+            "output_type": "delete_wasm_binary_reply"
         }
     ]
 }

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -18,12 +18,16 @@
 #include "kafka/server/partition_proxy.h"
 #include "model/ktp.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
 #include "raft/errc.h"
 #include "raft/types.h"
+#include "storage/record_batch_builder.h"
 #include "transform/rpc/deps.h"
 #include "transform/rpc/serde.h"
+#include "utils/uuid.h"
 
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/future.hh>
@@ -33,16 +37,19 @@
 #include <algorithm>
 #include <iterator>
 #include <system_error>
+#include <utility>
 #include <vector>
 
 namespace transform::rpc {
 namespace {
+
 raft::replicate_options
 make_replicate_options(model::timeout_clock::duration timeout) {
     return {
       raft::consistency_level::quorum_ack,
       std::chrono::duration_cast<std::chrono::milliseconds>(timeout)};
 }
+
 cluster::errc map_errc(std::error_code ec) {
     if (ec.category() == cluster::error_category()) {
         return static_cast<cluster::errc>(ec.value());
@@ -58,6 +65,25 @@ cluster::errc map_errc(std::error_code ec) {
         }
     }
     return cluster::errc::replication_error;
+}
+
+iobuf make_iobuf(ss::sstring str) {
+    iobuf b;
+    b.append(str.data(), str.size());
+    return b;
+}
+
+iobuf make_iobuf(uuid_t uuid) {
+    iobuf b;
+    b.append(uuid.mutable_uuid().begin(), uuid.length);
+    return b;
+}
+model::record_header make_header(ss::sstring k, ss::sstring v) {
+    auto key = make_iobuf(std::move(k));
+    auto ks = int32_t(key.size_bytes());
+    auto value = make_iobuf(std::move(v));
+    auto vs = int32_t(value.size_bytes());
+    return {ks, std::move(key), vs, std::move(value)};
 }
 } // namespace
 
@@ -148,8 +174,23 @@ ss::future<result<model::offset, cluster::errc>> local_service::produce(
 }
 
 ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
-local_service::store_wasm_binary(iobuf, model::timeout_clock::duration) {
-    throw std::runtime_error("unimplemented");
+local_service::store_wasm_binary(
+  iobuf data, model::timeout_clock::duration timeout) {
+    uuid_t key = uuid_t::create();
+    storage::record_batch_builder b(
+      model::record_batch_type::raft_data, model::offset(0));
+    std::vector<model::record_header> headers;
+    headers.push_back(make_header("state", "live"));
+    b.add_raw_kw(make_iobuf(key), std::move(data), std::move(headers));
+    ss::chunked_fifo<model::record_batch> batches;
+    batches.push_back(std::move(b).build());
+    auto r = co_await produce(
+      model::wasm_binaries_internal_ntp, std::move(batches), timeout);
+    using result = result<stored_wasm_binary_metadata, cluster::errc>;
+    if (r.has_error()) {
+        co_return result(r.error());
+    }
+    co_return result(stored_wasm_binary_metadata(key, r.value()));
 }
 
 ss::future<cluster::errc>

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -11,6 +11,7 @@
 
 #include "cluster/fwd.h"
 #include "model/fundamental.h"
+#include "model/record_batch_reader.h"
 #include "transform/rpc/deps.h"
 #include "transform/rpc/rpc_service.h"
 #include "transform/rpc/serde.h"
@@ -53,6 +54,9 @@ private:
       model::any_ntp auto,
       ss::chunked_fifo<model::record_batch>,
       model::timeout_clock::duration);
+
+    ss::future<result<iobuf, cluster::errc>> consume_wasm_binary_reader(
+      model::record_batch_reader, model::timeout_clock::duration);
 
     std::unique_ptr<topic_metadata_cache> _metadata_cache;
     std::unique_ptr<partition_manager> _partition_manager;

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -15,6 +15,7 @@
 #include "transform/rpc/rpc_service.h"
 #include "transform/rpc/serde.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sharded.hh>
 
 #include <memory>
@@ -47,6 +48,11 @@ public:
 private:
     ss::future<transformed_topic_data_result>
       produce(transformed_topic_data, model::timeout_clock::duration);
+
+    ss::future<result<model::offset, cluster::errc>> produce(
+      model::any_ntp auto,
+      ss::chunked_fifo<model::record_batch>,
+      model::timeout_clock::duration);
 
     std::unique_ptr<topic_metadata_cache> _metadata_cache;
     std::unique_ptr<partition_manager> _partition_manager;

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -23,7 +23,7 @@ namespace transform::rpc {
 
 /**
  * A per core sharded service that handles custom data path requests for data
- * transforms.
+ * transforms and storage of wasm binaries.
  */
 class local_service {
 public:
@@ -34,6 +34,15 @@ public:
     ss::future<ss::chunked_fifo<transformed_topic_data_result>> produce(
       ss::chunked_fifo<transformed_topic_data> topic_data,
       model::timeout_clock::duration timeout);
+
+    ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
+    store_wasm_binary(iobuf, model::timeout_clock::duration timeout);
+
+    ss::future<cluster::errc>
+    delete_wasm_binary(uuid_t key, model::timeout_clock::duration timeout);
+
+    ss::future<result<iobuf, cluster::errc>>
+    load_wasm_binary(model::offset, model::timeout_clock::duration timeout);
 
 private:
     ss::future<transformed_topic_data_result>
@@ -57,6 +66,15 @@ public:
 
     ss::future<produce_reply>
     produce(produce_request&&, ::rpc::streaming_context&) override;
+
+    ss::future<store_wasm_binary_reply> store_wasm_binary(
+      store_wasm_binary_request&&, ::rpc::streaming_context&) override;
+
+    ss::future<load_wasm_binary_reply> load_wasm_binary(
+      load_wasm_binary_request&&, ::rpc::streaming_context&) override;
+
+    ss::future<delete_wasm_binary_reply> delete_wasm_binary(
+      delete_wasm_binary_request&&, ::rpc::streaming_context&) override;
 
 private:
     ss::sharded<local_service>* _service;

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -362,7 +362,7 @@ public:
         auto fplc = std::make_unique<fake_partition_leader_cache>();
         _fplc = fplc.get();
         _client = std::make_unique<rpc::client>(
-          self_node, std::move(fplc), &_conn_cache, &_local_services);
+          self_node, std::move(fplc), nullptr, &_conn_cache, &_local_services);
     }
     void TearDown() override {
         _client->stop().get();


### PR DESCRIPTION
This patch set supports storing Wasm binaries in an internal topic.

This topic is not user facing (it's in the Redpanda namespace) and uses internal RPCs for reading/writing.

The topic is compacted and we support deleting binaries by tombstoning.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
