### PR TITLE
cloud_storage: Log trim failure based on file type

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -209,6 +209,7 @@ private:
     struct trim_result {
         uint64_t deleted_size{0};
         size_t deleted_count{0};
+        bool trim_missed_tmp_files{false};
     };
 
     /// Ordinary trim: prioritze trimming data chunks, only delete indices etc


### PR DESCRIPTION
When an exhaustive trim fails, a common reason for this is .part files which were identified to be deleted but during the trim they were renamed to chunk/segment files.

This change adds a flag to the trim result, if the trim fails to free enough space and a tmp file was missed during the trim, the log is downgraded to INFO.

Additionally we catch filesystem error separately and if the error caught during a trim is not an FS error, it is logged as an error.

An FS error not related to a temp file is also logged as an error.

FIXES https://github.com/redpanda-data/redpanda/issues/13304

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
