### PR TITLE
admin_server: map `missing_node_rpc_client` to service unavailable

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1078,6 +1078,7 @@ ss::future<> admin_server::throw_on_error(
         case rpc::errc::disconnected_endpoint:
         case rpc::errc::exponential_backoff:
         case rpc::errc::shutting_down:
+        case rpc::errc::missing_node_rpc_client:
             throw ss::httpd::base_exception(
               fmt::format("Not ready: {}", ec.message()),
               ss::http::reply::status_type::service_unavailable);
@@ -1087,7 +1088,6 @@ ss::future<> admin_server::throw_on_error(
               fmt::format("Timeout: {}", ec.message()),
               ss::http::reply::status_type::gateway_timeout);
         case rpc::errc::service_error:
-        case rpc::errc::missing_node_rpc_client:
         case rpc::errc::method_not_found:
         case rpc::errc::version_not_supported:
         case rpc::errc::unknown:


### PR DESCRIPTION
It may sometimes happen that the admin API request will be processed while Redpanda is shutting down or it is in the middle of reconfiguration with stale metadata. In this case an RPC client to currently reported leader may no longer be available. In this case we should request client to retry.

Fixes: #13855

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none