### PR TITLE
serde: fix serde default comparison operator foot gun

### DIFF
--- a/src/v/cluster/node/types.h
+++ b/src/v/cluster/node/types.h
@@ -107,6 +107,8 @@ struct local_state
         uint64_t data_target_size{0};
         uint64_t data_current_size{0};
         uint64_t data_reclaimable_size{0};
+        friend bool operator==(const log_data_state&, const log_data_state&)
+          = default;
         friend std::ostream& operator<<(std::ostream&, const log_data_state&);
     };
     std::optional<log_data_state> log_data_size{std::nullopt};
@@ -121,6 +123,7 @@ struct local_state
     void set_disk(storage::disk);
     void set_disks(std::vector<storage::disk>);
 
+    friend bool operator==(const local_state&, const local_state&) = default;
     friend std::ostream& operator<<(std::ostream&, const local_state&);
 };
 

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -474,19 +474,39 @@ void roundtrip_test(T a) {
         err = std::current_exception();
     }
 
-    // On failures, log the type and the content of the buffer.
-    if (err || original != from_serde) {
-        std::cerr << "Failed serde roundtrip on " << typeid(T).name()
-                  << std::endl;
-        std::cerr << "Dump " << serde_out.size_bytes()
-                  << " bytes: " << serde_out.hexdump(1024) << std::endl;
-    }
+    if constexpr (std::equality_comparable<T>) {
+        // On failures, log the type and the content of the buffer.
+        if (err || original != from_serde) {
+            std::cerr << "Failed serde roundtrip on " << typeid(T).name()
+                      << std::endl;
+            std::cerr << "Dump " << serde_out.size_bytes()
+                      << " bytes: " << serde_out.hexdump(1024) << std::endl;
+        }
 
-    if (err) {
-        std::rethrow_exception(err);
-    }
+        if (err) {
+            std::rethrow_exception(err);
+        }
 
-    BOOST_REQUIRE(original == from_serde);
+        BOOST_REQUIRE(original == from_serde);
+    } else {
+        auto serde_out_after_roundtrip = serde::to_iobuf(from_serde);
+        if (err || serde_out_after_roundtrip != serde_out) {
+            std::cerr << "Failed serde roundtrip on " << typeid(T).name()
+                      << std::endl;
+            std::cerr << "Iobuf before " << serde_out.size_bytes()
+                      << " bytes: " << serde_out.hexdump(1024) << std::endl;
+            std::cerr << "Iobuf after "
+                      << serde_out_after_roundtrip.size_bytes()
+                      << " bytes: " << serde_out_after_roundtrip.hexdump(1024)
+                      << std::endl;
+        }
+
+        if (err) {
+            std::rethrow_exception(err);
+        }
+
+        BOOST_REQUIRE(serde_out_after_roundtrip == serde_out);
+    }
 }
 
 template<typename T>
@@ -2194,7 +2214,9 @@ void serde_roundtrip_cmd(Key key, Value value) {
     auto deserialized_cmd = std::get<Cmd>(deserialized);
 
     BOOST_REQUIRE(deserialized_cmd.key == cmd.key);
-    BOOST_REQUIRE(deserialized_cmd.value == cmd.value);
+    if constexpr (std::equality_comparable<Value>) {
+        BOOST_REQUIRE(deserialized_cmd.value == cmd.value);
+    }
 }
 
 template<typename Cmd, typename Key, typename Value>
@@ -2207,7 +2229,10 @@ void adl_roundtrip_cmd(Key key, Value value) {
     auto deserialized_cmd = std::get<Cmd>(deserialized);
 
     BOOST_REQUIRE(deserialized_cmd.key == cmd.key);
-    BOOST_REQUIRE(deserialized_cmd.value == cmd.value);
+
+    if constexpr (std::equality_comparable<Value>) {
+        BOOST_REQUIRE(deserialized_cmd.value == cmd.value);
+    }
 }
 
 template<typename Cmd, typename Key, typename Value>

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2035,6 +2035,7 @@ struct nt_revision
         return H::combine(std::move(h), ntr.nt, ntr.initial_revision_id);
     }
 
+    friend bool operator==(const nt_revision& lhs, const nt_revision& rhs);
     friend std::ostream& operator<<(std::ostream&, const nt_revision&);
 
     auto serde_fields() { return std::tie(nt, initial_revision_id); }

--- a/src/v/features/feature_table_snapshot.h
+++ b/src/v/features/feature_table_snapshot.h
@@ -37,6 +37,10 @@ struct feature_state_snapshot
     feature_state::state state;
 
     auto serde_fields() { return std::tie(name, state); }
+
+    friend bool
+    operator==(const feature_state_snapshot&, const feature_state_snapshot&)
+      = default;
 };
 
 /**
@@ -68,6 +72,10 @@ struct feature_table_snapshot
 
     /// Key for storing the snapshot in the shard 0 kvstore.
     static bytes kvstore_key();
+
+    friend bool
+    operator==(const feature_table_snapshot&, const feature_table_snapshot&)
+      = default;
 };
 
 } // namespace features

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -65,6 +65,7 @@ struct usage
     auto serde_fields() {
         return std::tie(bytes_sent, bytes_received, bytes_cloud_storage);
     }
+    friend bool operator==(const usage&, const usage&) = default;
     friend std::ostream& operator<<(std::ostream& os, const usage& u) {
         fmt::print(
           os,

--- a/src/v/net/unresolved_address.h
+++ b/src/v/net/unresolved_address.h
@@ -44,8 +44,7 @@ public:
     inet_family family() const { return _family; }
 
     bool operator==(const unresolved_address& other) const = default;
-    friend bool operator<(const unresolved_address&, const unresolved_address&)
-      = default;
+    std::strong_ordering operator<=>(const unresolved_address&) const = default;
 
     auto serde_fields() { return std::tie(_host, _port, _family); }
 

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -483,6 +483,11 @@ public:
         return tmp;
     }
 
+    friend bool operator==(
+      const deltafor_encoder<TVal, DeltaStep, use_nttp_deltastep, delta_alg>&,
+      const deltafor_encoder<TVal, DeltaStep, use_nttp_deltastep, delta_alg>&)
+      = default;
+
 private:
     static_assert(
       row_width == 16,


### PR DESCRIPTION
Previously, if a sub-class of envelope did not define its own equality
operator, the comparison would ignore all state from the derived class
and use the defaulted comparison operator of `serde::envelope`. This
caused comparison to behave in unexpected ways.

```
struct foo : serde::envelope<foo, ...> {
  int x;
};

void compare() {
  return foo{.x = 1} == foo{.x = 2}; // oops - uses serde::envelope::operator== and ingnores foo::x
}
```

The goal of this patch is to force serde types to overload their
comparison operators iff they wish to be comparable. To this end, the
implementation of said operators in `serde::envelope` is templated in
order to distinguish implict calls when the operator is generated for
the base class and accidental calls from sub classes that didn't
implement their operators. The spaceship operator covers all possible
comparison operators apart from equality.

In order to get this change to compile, I also had to default the
comparison operator for a number of existing serde types.

Shoutout to @travisdowns for the clever suggestions of templating the envelope operators.

Fixes #13816

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [X] v23.1.x
- [ ] v22.3.x

## Release Notes
### Bug Fixes
* Fix a quirk in our serialisation and deserialisation framework which could cause comparisons
to ignore members of "wire" types.
