### PR TITLE
archival: same term sync-ing

### DIFF
--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -40,4 +40,21 @@ else()
       ARGS "-- -c 1"
       LABELS archival
     )
+
+    rp_test(
+      UNIT_TEST
+      GTEST
+      BINARY_NAME gtest_archival
+      SOURCES
+        archival_metadata_stm_gtest.cc
+      LIBRARIES
+        v::raft
+        v::raft_fixture
+        v::cluster
+        v::cloud_roles
+        v::http_test_utils
+        v::gtest_main
+      LABELS archival
+      ARGS "-- -c 1"
+    )
 endif()

--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -161,3 +161,159 @@ TEST_F_CORO(archival_metadata_stm_gtest_fixture, test_archival_stm_happy_path) {
       get_leader_stm().get_dirty(),
       cluster::archival_metadata_stm::state_dirty::clean);
 }
+
+TEST_F_CORO(
+  archival_metadata_stm_gtest_fixture,
+  test_same_term_sync_pending_replication_success) {
+    /*
+     * Test that archival_metadata_stm::sync is able to sync
+     * within the same term and that it will wait for on-going
+     * replication futures to complete before doing so. To simulate
+     * this scenario we introduce a small delay on append entries
+     * response processing.
+     */
+
+    ss::abort_source never_abort;
+
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(segment_meta{
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(99),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+
+    co_await start();
+
+    auto res = co_await with_leader(
+      10s, [this, &m, &never_abort](raft::raft_node_instance&) {
+          return get_leader_stm().add_segments(
+            m, std::nullopt, ss::lowres_clock::now() + 10s, never_abort);
+      });
+
+    ASSERT_TRUE_CORO(!res);
+
+    auto [plagued_node, delay_applied] = co_await with_leader(
+      10s, [](raft::raft_node_instance& node) {
+          raft::response_delay fail{
+            .length = 100ms, .on_applied = ss::promise<>{}};
+
+          auto delay_applied = fail.on_applied->get_future();
+          node.inject_failure(raft::msg_type::append_entries, std::move(fail));
+          return std::make_tuple(node.get_vnode(), std::move(delay_applied));
+      });
+
+    m.clear();
+    m.push_back(segment_meta{
+      .base_offset = model::offset(100),
+      .committed_offset = model::offset(199),
+      .archiver_term = model::term_id(2),
+      .segment_term = model::term_id(1)});
+
+    auto slow_replication_fut = with_leader(
+      10s,
+      [this, &m, &never_abort, &plagued_node](raft::raft_node_instance& node) {
+          if (node.get_vnode() != plagued_node) {
+              throw std::runtime_error{"Leadership moved"};
+          }
+
+          return get_leader_stm().add_segments(
+            m, std::nullopt, ss::lowres_clock::now() + 10s, never_abort);
+      });
+
+    co_await std::move(delay_applied);
+
+    auto synced = co_await with_leader(
+      10s, [this, &plagued_node](raft::raft_node_instance& node) mutable {
+          if (node.get_vnode() != plagued_node) {
+              throw std::runtime_error{"Leadership moved"};
+          }
+
+          return get_leader_stm().sync(10s);
+      });
+
+    ASSERT_TRUE_CORO(synced);
+
+    auto slow_replication_res = co_await std::move(slow_replication_fut);
+    ASSERT_TRUE_CORO(!slow_replication_res);
+
+    auto [committed_offset, term] = co_await with_leader(
+      10s, [](raft::raft_node_instance& node) mutable {
+          return std::make_tuple(
+            node.raft()->committed_offset(), node.raft()->term());
+      });
+
+    ASSERT_EQ_CORO(committed_offset, model::offset{2});
+    ASSERT_EQ_CORO(term, model::term_id{1});
+}
+
+TEST_F_CORO(
+  archival_metadata_stm_gtest_fixture,
+  test_same_term_sync_pending_replication_failure) {
+    /*
+     * Similar to the previous test, but in this case the injected replication
+     * delay is enough for leadership to reliably move and cause the replication
+     * to error. Sync will fail in this case.
+     */
+    ss::abort_source never_abort;
+
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(segment_meta{
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(99),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+
+    co_await start();
+
+    auto res = co_await with_leader(
+      10s, [this, &m, &never_abort](raft::raft_node_instance&) {
+          return get_leader_stm().add_segments(
+            m, std::nullopt, ss::lowres_clock::now() + 10s, never_abort);
+      });
+
+    ASSERT_TRUE_CORO(!res);
+
+    auto [plagued_node, delay_applied] = co_await with_leader(
+      10s, [](raft::raft_node_instance& node) {
+          raft::response_delay fail{
+            .length = 5s, .on_applied = ss::promise<>{}};
+
+          auto delay_applied = fail.on_applied->get_future();
+          node.inject_failure(raft::msg_type::append_entries, std::move(fail));
+          return std::make_tuple(node.get_vnode(), std::move(delay_applied));
+      });
+
+    m.clear();
+    m.push_back(segment_meta{
+      .base_offset = model::offset(100),
+      .committed_offset = model::offset(199),
+      .archiver_term = model::term_id(2),
+      .segment_term = model::term_id(1)});
+
+    auto slow_replication_fut = with_leader(
+      10s,
+      [this, &m, &never_abort, &plagued_node](raft::raft_node_instance& node) {
+          if (node.get_vnode() != plagued_node) {
+              throw std::runtime_error{"Leadership moved"};
+          }
+
+          return get_leader_stm().add_segments(
+            m, std::nullopt, ss::lowres_clock::now() + 10s, never_abort);
+      });
+
+    co_await std::move(delay_applied);
+
+    auto synced = co_await with_leader(
+      10s, [this, &plagued_node](raft::raft_node_instance& node) mutable {
+          if (node.get_vnode() != plagued_node) {
+              throw std::runtime_error{"Leadership moved"};
+          }
+
+          return get_leader_stm().sync(10s);
+      });
+
+    ASSERT_FALSE_CORO(synced);
+
+    auto slow_replication_res = co_await std::move(slow_replication_fut);
+    ASSERT_TRUE_CORO(slow_replication_res);
+}

--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -1,0 +1,163 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cloud_storage/remote.h"
+#include "cloud_storage/types.h"
+#include "cloud_storage_clients/client_pool.h"
+#include "cluster/archival_metadata_stm.h"
+#include "raft/tests/raft_fixture.h"
+#include "test_utils/test.h"
+
+#include <seastar/coroutine/parallel_for_each.hh>
+
+using cloud_storage::segment_name;
+using segment_meta = cloud_storage::partition_manifest::segment_meta;
+
+namespace {
+ss::logger fixture_logger{"archival_stm_fixture"};
+
+constexpr const char* httpd_host_name = "127.0.0.1";
+constexpr uint16_t httpd_port_number = 4442;
+
+cloud_storage_clients::s3_configuration get_configuration() {
+    net::unresolved_address server_addr(httpd_host_name, httpd_port_number);
+    cloud_storage_clients::s3_configuration conf;
+    conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);
+    conf.access_key = cloud_roles::public_key_str("acess-key");
+    conf.secret_key = cloud_roles::private_key_str("secret-key");
+    conf.region = cloud_roles::aws_region_name("us-east-1");
+    conf.server_addr = server_addr;
+    conf.disable_metrics = net::metrics_disabled::yes;
+    conf.disable_public_metrics = net::public_metrics_disabled::yes;
+    conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
+      net::metrics_disabled::yes,
+      net::public_metrics_disabled::yes,
+      cloud_roles::aws_region_name{"us-east-1"},
+      cloud_storage_clients::endpoint_url{httpd_host_name});
+    return conf;
+}
+
+constexpr model::cloud_credentials_source config_file{
+  model::cloud_credentials_source::config_file};
+} // namespace
+
+struct archival_stm_node {
+    archival_stm_node() = default;
+
+    ss::shared_ptr<cluster::archival_metadata_stm> archival_stm;
+    ss::sharded<cloud_storage_clients::client_pool> client_pool;
+    ss::sharded<cloud_storage::remote> remote;
+};
+
+class archival_metadata_stm_gtest_fixture : public raft::raft_fixture {
+public:
+    static constexpr auto node_count = 3;
+
+    seastar::future<> TearDownAsync() override {
+        co_await seastar::coroutine::parallel_for_each(
+          _archival_stm_nodes, [](archival_stm_node& node) {
+              return node.remote.stop().then(
+                [&node]() { return node.client_pool.stop(); });
+          });
+
+        co_await raft::raft_fixture::TearDownAsync();
+    }
+
+    ss::future<> start() {
+        for (auto i = 0; i < node_count; ++i) {
+            add_node(model::node_id(i), model::revision_id(0));
+        }
+
+        for (auto& [id, node] : nodes()) {
+            auto& stm_node = _archival_stm_nodes.at(id());
+
+            co_await stm_node.client_pool.start(
+              10, ss::sharded_parameter([]() { return get_configuration(); }));
+
+            co_await stm_node.remote.start(
+              std::ref(stm_node.client_pool),
+              ss::sharded_parameter([] { return get_configuration(); }),
+              ss::sharded_parameter([] { return config_file; }));
+
+            co_await node->initialise(all_vnodes());
+
+            raft::state_machine_manager_builder builder;
+            auto stm = builder.create_stm<cluster::archival_metadata_stm>(
+              node->raft().get(),
+              stm_node.remote.local(),
+              node->get_feature_table().local(),
+              fixture_logger);
+
+            stm_node.archival_stm = std::move(stm);
+
+            vlog(fixture_logger.info, "Starting node {}", id);
+
+            co_await node->start(std::move(builder));
+        }
+    }
+
+    cluster::archival_metadata_stm& get_leader_stm() {
+        const auto leader = get_leader();
+        if (!leader) {
+            throw std::runtime_error{"No leader"};
+        }
+
+        auto ptr = _archival_stm_nodes.at(*leader).archival_stm;
+        if (!ptr) {
+            throw std::runtime_error{
+              ssx::sformat("Achival stm for node {} not initialised", *leader)};
+        }
+
+        return *ptr;
+    }
+
+private:
+    std::array<archival_stm_node, node_count> _archival_stm_nodes;
+};
+
+TEST_F_CORO(archival_metadata_stm_gtest_fixture, test_archival_stm_happy_path) {
+    ss::abort_source never_abort;
+
+    co_await start();
+
+    std::vector<cloud_storage::segment_meta> m;
+    m.push_back(segment_meta{
+      .base_offset = model::offset(0),
+      .committed_offset = model::offset(99),
+      .archiver_term = model::term_id(1),
+      .segment_term = model::term_id(1)});
+
+    co_await wait_for_leader(10s);
+
+    ASSERT_EQ_CORO(
+      get_leader_stm().get_dirty(),
+      cluster::archival_metadata_stm::state_dirty::dirty);
+
+    co_await get_leader_stm().add_segments(
+      m, std::nullopt, ss::lowres_clock::now() + 10s, never_abort);
+
+    ASSERT_EQ_CORO(get_leader_stm().manifest().size(), 1);
+    ASSERT_EQ_CORO(
+      get_leader_stm().manifest().begin()->base_offset, model::offset(0));
+    ASSERT_EQ_CORO(
+      get_leader_stm().manifest().begin()->committed_offset, model::offset(99));
+
+    ASSERT_EQ_CORO(
+      get_leader_stm().get_dirty(),
+      cluster::archival_metadata_stm::state_dirty::dirty);
+
+    co_await get_leader_stm().mark_clean(
+      ss::lowres_clock::now() + 10s,
+      get_leader_stm().get_insync_offset(),
+      never_abort);
+
+    ASSERT_EQ_CORO(
+      get_leader_stm().get_dirty(),
+      cluster::archival_metadata_stm::state_dirty::clean);
+}

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -483,7 +483,7 @@ template<supported_stm_snapshot T>
 ss::future<bool> persisted_stm<T>::wait_no_throw(
   model::offset offset,
   model::timeout_clock::time_point deadline,
-  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+  std::optional<std::reference_wrapper<ss::abort_source>> as) noexcept {
     return wait(offset, deadline, as)
       .then([] { return true; })
       .handle_exception_type([](const ss::abort_requested_exception&) {

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -195,7 +195,8 @@ public:
     ss::future<bool> wait_no_throw(
       model::offset offset,
       model::timeout_clock::time_point,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      std::optional<std::reference_wrapper<ss::abort_source>>
+      = std::nullopt) noexcept;
 
     model::offset max_collectible_offset() override;
     ss::future<fragmented_vector<model::tx_range>>

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -82,3 +82,8 @@ rp_test(
   ARGS "-c 1 --duration=1 --runs=1 --memory=1G"
   LABELS raft
 )
+
+v_cc_library(
+    NAME raft_fixture
+    SRCS raft_fixture.cc
+    DEPS Seastar::seastar v::raft v::gtest_main)

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -29,7 +29,7 @@ using namespace raft;
 
 TEST_F_CORO(raft_fixture, test_single_node_can_elect_leader) {
     auto& n0 = add_node(model::node_id(0), model::revision_id(0));
-    co_await n0.start({n0.get_vnode()});
+    co_await n0.init_and_start({n0.get_vnode()});
     auto leader = co_await wait_for_leader(10s);
 
     ASSERT_EQ_CORO(leader, model::node_id(0));
@@ -90,7 +90,7 @@ TEST_F_CORO(raft_fixture, validate_recovery) {
     ASSERT_TRUE_CORO(result.has_value());
 
     auto& new_n3 = add_node(model::node_id(3), model::revision_id(0));
-    co_await new_n3.start(all_vnodes());
+    co_await new_n3.init_and_start(all_vnodes());
 
     // wait for committed offset to propagate
     auto committed_offset = leader_node.raft()->committed_offset();
@@ -119,8 +119,8 @@ TEST_F_CORO(raft_fixture, validate_adding_nodes_to_cluster) {
     auto& n1 = add_node(model::node_id(1), model::revision_id(0));
     auto& n2 = add_node(model::node_id(2), model::revision_id(0));
     // start other two nodes with empty configuration
-    co_await n1.start({});
-    co_await n2.start({});
+    co_await n1.init_and_start({});
+    co_await n2.init_and_start({});
 
     // update group configuration
     co_await leader_node.raft()->replace_configuration(

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -291,7 +291,7 @@ in_memory_test_protocol::dispatch(model::node_id id, ReqT req) {
 }
 
 ss::future<result<vote_reply>> in_memory_test_protocol::vote(
-  model::node_id id, vote_request&& req, rpc::client_opts opts) {
+  model::node_id id, vote_request&& req, rpc::client_opts) {
     return dispatch<vote_request, vote_reply>(id, req);
 };
 
@@ -567,8 +567,9 @@ std::optional<model::node_id> raft_fixture::get_leader() const {
 }
 
 ss::future<> raft_fixture::create_simple_group(size_t number_of_nodes) {
-    for (auto id = 0; id < number_of_nodes; ++id) {
-        add_node(model::node_id(id), model::revision_id{0});
+    for (size_t id = 0; id < number_of_nodes; ++id) {
+        add_node(
+          model::node_id(static_cast<int32_t>(id)), model::revision_id{0});
     }
 
     co_await ss::coroutine::parallel_for_each(_nodes, [this](auto& pair) {

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -212,8 +212,10 @@ ss::future<> channel::dispatch_loop() {
     }
 }
 
-in_memory_test_protocol::in_memory_test_protocol(raft_node_map& node_map)
-  : _nodes(node_map) {}
+in_memory_test_protocol::in_memory_test_protocol(
+  raft_node_map& node_map, prefix_logger& logger)
+  : _nodes(node_map)
+  , _logger(logger) {}
 
 channel& in_memory_test_protocol::get_channel(model::node_id id) {
     auto it = _channels.find(id);
@@ -230,6 +232,15 @@ channel& in_memory_test_protocol::get_channel(model::node_id id) {
     }
     return *it->second;
 }
+
+void in_memory_test_protocol::inject_failure(msg_type type, failure_t failure) {
+    _failures.emplace(type, std::move(failure));
+}
+
+void in_memory_test_protocol::remove_failure(msg_type type) {
+    _failures.erase(type);
+}
+
 ss::future<> in_memory_test_protocol::stop() {
     for (auto& [_, ch] : _channels) {
         co_await ch->stop();
@@ -281,8 +292,24 @@ in_memory_test_protocol::dispatch(model::node_id id, ReqT req) {
     iobuf buffer;
     co_await serde::write_async(buffer, std::move(req));
     try {
-        auto resp = co_await node_channel.exchange(
-          map_msg_type<ReqT>(), std::move(buffer));
+        const auto msg_type = map_msg_type<ReqT>();
+
+        if (auto iter = _failures.find(msg_type); iter != _failures.end()) {
+            auto& fail = iter->second;
+            co_await ss::visit(fail, [this, msg_type](response_delay& f) {
+                vlog(
+                  _logger.info,
+                  "Injecting response delay of length {} for {}",
+                  f.length,
+                  msg_type);
+                if (f.on_applied) {
+                    f.on_applied->set_value();
+                }
+                return ss::sleep(f.length);
+            });
+        }
+
+        auto resp = co_await node_channel.exchange(msg_type, std::move(buffer));
         iobuf_parser parser(std::move(resp));
         co_return co_await serde::read_async<RespT>(parser);
     } catch (const seastar::gate_closed_exception&) {
@@ -340,9 +367,10 @@ raft_node_instance::raft_node_instance(
   leader_update_clb_t leader_update_clb)
   : _id(id)
   , _revision(revision)
+  , _logger(test_log, fmt::format("[node: {}]", _id))
   , _base_directory(fmt::format(
       "test_raft_{}_{}", _id, random_generators::gen_alphanum_string(12)))
-  , _protocol(ss::make_shared<in_memory_test_protocol>(node_map))
+  , _protocol(ss::make_shared<in_memory_test_protocol>(node_map, _logger))
   , _features(feature_table)
   , _recovery_mem_quota([] {
       return raft::recovery_memory_quota::configuration{
@@ -353,8 +381,7 @@ raft_node_instance::raft_node_instance(
   })
   , _recovery_scheduler(
       config::mock_binding<size_t>(64), config::mock_binding(10ms))
-  , _leader_clb(std::move(leader_update_clb))
-  , _logger(test_log, fmt::format("[node: {}]", _id)) {
+  , _leader_clb(std::move(leader_update_clb)) {
     config::shard_local_cfg().disable_metrics.set_value(true);
 }
 
@@ -486,6 +513,14 @@ raft_node_instance::random_batch_base_offset(model::offset max) {
     }
 
     co_return batches.front().base_offset();
+}
+
+void raft_node_instance::inject_failure(msg_type type, failure_t failure) {
+    _protocol->inject_failure(type, std::move(failure));
+}
+
+void raft_node_instance::remove_failure(msg_type type) {
+    _protocol->remove_failure(type);
 }
 
 seastar::future<> raft_fixture::TearDownAsync() {

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -76,10 +76,12 @@ ss::future<> channel::stop() {
     if (!_as.abort_requested()) {
         _as.request_abort();
         _new_messages.broken();
+
+        co_await _gate.close();
+
         for (auto& m : _messages) {
             m.resp_data.set_exception(ss::abort_requested_exception());
         }
-        co_await _gate.close();
     }
 }
 

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -90,9 +90,16 @@ struct raft_node_map {
       node_for(model::node_id) = 0;
 };
 
+struct response_delay {
+    std::chrono::milliseconds length;
+    std::optional<ss::promise<>> on_applied;
+};
+
+using failure_t = std::variant<response_delay>;
+
 class in_memory_test_protocol : public consensus_client_protocol::impl {
 public:
-    explicit in_memory_test_protocol(raft_node_map&);
+    explicit in_memory_test_protocol(raft_node_map&, prefix_logger&);
 
     ss::future<result<vote_reply>>
     vote(model::node_id, vote_request&&, rpc::client_opts) final;
@@ -127,6 +134,9 @@ public:
 
     channel& get_channel(model::node_id id);
 
+    void inject_failure(msg_type type, failure_t failure);
+    void remove_failure(msg_type type);
+
     ss::future<> stop();
 
 private:
@@ -134,7 +144,9 @@ private:
     ss::future<result<RespT>> dispatch(model::node_id, ReqT req);
     ss::gate _gate;
     absl::flat_hash_map<model::node_id, std::unique_ptr<channel>> _channels;
+    absl::flat_hash_map<msg_type, failure_t> _failures;
     raft_node_map& _nodes;
+    prefix_logger& _logger;
 };
 
 /**
@@ -198,9 +210,13 @@ public:
 
     ss::future<model::offset> random_batch_base_offset(model::offset max);
 
+    void inject_failure(msg_type type, failure_t failure);
+    void remove_failure(msg_type type);
+
 private:
     model::node_id _id;
     model::revision_id _revision;
+    prefix_logger _logger;
     ss::sstring _base_directory;
     ss::shared_ptr<in_memory_test_protocol> _protocol;
     ss::sharded<storage::api> _storage;
@@ -212,7 +228,6 @@ private:
     recovery_scheduler _recovery_scheduler;
     std::unique_ptr<heartbeat_manager> _hb_manager;
     leader_update_clb_t _leader_clb;
-    prefix_logger _logger;
     ss::lw_shared_ptr<consensus> _raft;
     bool started = false;
 };

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -148,6 +148,7 @@ public:
       model::node_id id,
       model::revision_id revision,
       raft_node_map& node_map,
+      ss::sharded<features::feature_table>& feature_table,
       leader_update_clb_t leader_update_clb);
 
     raft_node_instance(const raft_node_instance&) = delete;
@@ -157,6 +158,10 @@ public:
     ~raft_node_instance() = default;
 
     ss::lw_shared_ptr<consensus> raft() { return _raft; }
+
+    ss::sharded<features::feature_table>& get_feature_table() {
+        return _features;
+    }
 
     ss::future<> start(
       std::vector<raft::vnode> initial_nodes,
@@ -192,7 +197,7 @@ private:
     ss::sharded<storage::api> _storage;
     config::binding<std::chrono::milliseconds> _election_timeout
       = config::mock_binding(500ms);
-    ss::sharded<features::feature_table> _features;
+    ss::sharded<features::feature_table>& _features;
     ss::sharded<coordinated_recovery_throttle> _recovery_throttle;
     recovery_memory_quota _recovery_mem_quota;
     recovery_scheduler _recovery_scheduler;
@@ -406,6 +411,8 @@ private:
     ss::logger _logger;
 
     absl::flat_hash_map<model::node_id, leadership_status> _leaders_view;
+
+    ss::sharded<features::feature_table> _features;
 };
 
 std::ostream& operator<<(std::ostream& o, msg_type type);

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -163,10 +163,19 @@ public:
         return _features;
     }
 
-    ss::future<> start(
+    // Initialise the node instance and create the consensus instance
+    ss::future<> initialise(std::vector<raft::vnode> initial_nodes);
+
+    // Start the node instance with an optionally provided state machine builder
+    ss::future<>
+    start(std::optional<raft::state_machine_manager_builder> builder);
+
+    // Initialise and start the node instance
+    ss::future<> init_and_start(
       std::vector<raft::vnode> initial_nodes,
       std::optional<raft::state_machine_manager_builder> builder
       = std::nullopt);
+
     ss::future<> stop();
 
     ss::future<> remove_data();

--- a/src/v/raft/tests/raft_reconfiguration_test.cc
+++ b/src/v/raft/tests/raft_reconfiguration_test.cc
@@ -184,7 +184,7 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
             model::node_id(initial_size + i), model::revision_id(0));
           current_nodes.push_back(n.get_vnode());
           added_nodes.emplace(n.get_vnode());
-          return n.start({});
+          return n.init_and_start({});
       });
 
     ASSERT_EQ_CORO(

--- a/src/v/raft/tests/stm_manager_test.cc
+++ b/src/v/raft/tests/stm_manager_test.cc
@@ -306,7 +306,7 @@ TEST_F_CORO(state_machine_manager_fixture, test_basic_apply) {
         raft::state_machine_manager_builder builder;
         auto kv_stm = builder.create_stm<simple_kv>(*node);
         auto other_kv_stm = builder.create_stm<other_simple_kv>(*node);
-        co_await node->start(all_vnodes(), std::move(builder));
+        co_await node->init_and_start(all_vnodes(), std::move(builder));
         stms.push_back(kv_stm);
         stms.push_back(ss::dynamic_pointer_cast<simple_kv>(other_kv_stm));
     }
@@ -331,7 +331,7 @@ TEST_F_CORO(state_machine_manager_fixture, test_apply_throwing_exception) {
         raft::state_machine_manager_builder builder;
         auto kv_stm = builder.create_stm<simple_kv>(*node);
         auto throwing_kv_stm = builder.create_stm<throwing_kv>(*node);
-        co_await node->start(all_vnodes(), std::move(builder));
+        co_await node->init_and_start(all_vnodes(), std::move(builder));
         stms.push_back(kv_stm);
         stms.push_back(ss::dynamic_pointer_cast<simple_kv>(throwing_kv_stm));
     }
@@ -356,7 +356,7 @@ TEST_F_CORO(state_machine_manager_fixture, test_recovery_without_snapshot) {
         raft::state_machine_manager_builder builder;
         auto kv_stm = builder.create_stm<simple_kv>(*node);
         auto throwing_kv_stm = builder.create_stm<throwing_kv>(*node);
-        co_await node->start(all_vnodes(), std::move(builder));
+        co_await node->init_and_start(all_vnodes(), std::move(builder));
         stms.push_back(kv_stm);
         stms.push_back(ss::dynamic_pointer_cast<simple_kv>(throwing_kv_stm));
     }
@@ -377,7 +377,7 @@ TEST_F_CORO(state_machine_manager_fixture, test_recovery_without_snapshot) {
     raft::state_machine_manager_builder builder;
     auto kv_stm = builder.create_stm<simple_kv>(new_node);
     auto throwing_kv_stm = builder.create_stm<throwing_kv>(new_node);
-    co_await new_node.start(all_vnodes(), std::move(builder));
+    co_await new_node.init_and_start(all_vnodes(), std::move(builder));
     auto committed_offset = co_await with_leader(
       10s,
       [](raft_node_instance& node) { return node.raft()->committed_offset(); });
@@ -400,7 +400,7 @@ TEST_F_CORO(state_machine_manager_fixture, test_recovery_from_snapshot) {
         raft::state_machine_manager_builder builder;
         auto kv_stm = builder.create_stm<simple_kv>(*node);
         auto throwing_kv_stm = builder.create_stm<throwing_kv>(*node);
-        co_await node->start(all_vnodes(), std::move(builder));
+        co_await node->init_and_start(all_vnodes(), std::move(builder));
         stms.push_back(kv_stm);
         stms.push_back(ss::dynamic_pointer_cast<simple_kv>(throwing_kv_stm));
     }
@@ -449,7 +449,7 @@ TEST_F_CORO(state_machine_manager_fixture, test_recovery_from_snapshot) {
     raft::state_machine_manager_builder builder;
     auto kv_stm = builder.create_stm<simple_kv>(new_node);
     auto throwing_kv_stm = builder.create_stm<throwing_kv>(new_node);
-    co_await new_node.start({}, std::move(builder));
+    co_await new_node.init_and_start({}, std::move(builder));
 
     co_await with_leader(
       10s, [vn = new_node.get_vnode()](raft_node_instance& node) {
@@ -476,7 +476,7 @@ TEST_F_CORO(
         raft::state_machine_manager_builder builder;
         stms.push_back(builder.create_stm<local_snapshot_stm>(*node));
 
-        co_await node->start(all_vnodes(), std::move(builder));
+        co_await node->init_and_start(all_vnodes(), std::move(builder));
     }
 
     auto expected = co_await build_random_state(1000);
@@ -521,7 +521,7 @@ TEST_F_CORO(
     raft::state_machine_manager_builder builder;
     auto new_stm = builder.create_stm<local_snapshot_stm>(new_node);
 
-    co_await new_node.start({}, std::move(builder));
+    co_await new_node.init_and_start({}, std::move(builder));
 
     co_await with_leader(
       10s, [vn = new_node.get_vnode()](raft_node_instance& node) {


### PR DESCRIPTION
Previously, the archival STM used `persisted_stm::sync` in order to
ensure that its log is up to date before issuing new commands. This
works fine for leadership changes since they imply a term change.

However, the archiver may need to sync during the same term. We've seen
scenarios like this:

> Upload loop picks 4 candidates, uploads to cloud storage and
replicates a batch with 4 new segments. After the replication command
succeeds, the topic retention is updated. This re-starts the archiver.
When the archiver restarts it picks the same 4 segments and replicates
the addition commands again. Finally, the partition manifest detects
this, refuses the commands and prints the error log.

The previous sync method does not support such cases sync they happen in
the same term. To fix this, the archival STM now implements its own sync
method. If it detects that the term has changed, it will maintain the
pre-existing behaviour: sync up to the latest term. Otherwise, it will
use the cached last offset of the last replicated batch and wait on its
application.

Fixes https://github.com/redpanda-data/redpanda/issues/13753
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Bug Fixes
* Fix a bug where archival would not sync it's state correctly before proceeding with new segment uploads.
This could happen when updating the a topic's config.
