### PR TITLE
c/md_dissemination: fixed retrying leadership dissemination

### DIFF
--- a/src/v/cluster/metadata_dissemination_service.cc
+++ b/src/v/cluster/metadata_dissemination_service.cc
@@ -410,13 +410,19 @@ ss::future<> metadata_dissemination_service::update_leaders_with_health_report(
 
 ss::future<> metadata_dissemination_service::dispatch_one_update(
   model::node_id target_id, update_retry_meta& meta) {
+    // copy updates to make retries possible
+    ss::chunked_fifo<ntp_leader_revision> updates;
+    updates.reserve(meta.updates.size());
+    std::copy(
+      meta.updates.begin(), meta.updates.end(), std::back_inserter(updates));
+
     return _clients.local()
       .with_node_client<metadata_dissemination_rpc_client_protocol>(
         _self.id(),
         ss::this_shard_id(),
         target_id,
         _dissemination_interval,
-        [this, updates = std::move(meta.updates), target_id](
+        [this, updates = std::move(updates), target_id](
           metadata_dissemination_rpc_client_protocol proto) mutable {
             vlog(
               clusterlog.trace,


### PR DESCRIPTION
After change from `std::vector` to `ss::chunked_fifo` to keep the updates in metadata dissemination service `update_metadata` we lost ability to retry metadata dissemination requests as pending updates were moved to lambda capture list. This way the next retry did not have any updates to deliver.

Fixes: #13051
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none