### PR TITLE
kafka: Initial work for adding support for audit logging

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1282,6 +1282,65 @@ configuration::configuration()
        .example = "false",
        .visibility = visibility::user},
       true)
+  , audit_enabled(
+      *this,
+      "audit_enabled",
+      "Enable/Disable audit logging.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
+  , audit_log_num_partitions(
+      *this,
+      "audit_log_num_partitions",
+      "Number of partitions for the internal audit log topic. Attempt to "
+      "create topic is only performed if it doesn't already exist, disable and "
+      "re-enable auditing for changes to take affect",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      12)
+  , audit_log_replication_factor(
+      *this,
+      "audit_log_replication_factor",
+      "Replication factor of the internal audit log topic. Attempt to create "
+      "topic is only performed if it doesn't already exist, disable and "
+      "re-enable auditing for changes to take affect",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      3)
+  , audit_client_max_buffer_size(
+      *this,
+      "audit_client_max_buffer_size",
+      "Maximum number of bytes the internal audit client will allocate for "
+      "audit log records. Disable and re-enable auditing for changes to take "
+      "affect",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      1_MiB)
+  , audit_queue_drain_interval_ms(
+      *this,
+      "audit_queue_drain_interval_ms",
+      "Frequency in which per shard audit logs are batched to client for write "
+      "to audit log. Longer intervals allow for greater change for coalescing "
+      "duplicates (great for high throughput auditing scenarios) but increase "
+      "the risk of data loss during hard shutdowns.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      500ms)
+  , audit_max_queue_elements_per_shard(
+      *this,
+      "audit_max_queue_elements_per_shard",
+      "Maximum number of allowed elements in the audit buffers, per shard. "
+      "Once this value is reached, any request handlers that cannot enqueue "
+      "audit messages will return a non retryable error to the client. Note "
+      "that this only will occur when handling requests that are currently "
+      "enabled for auditing.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100000)
+  , audit_enabled_event_types(
+      *this,
+      "audit_enabled_event_types",
+      "List of event classes that will be audited, options are: "
+      "[management, produce, consume, describe, heartbeat, authenticate]. "
+      "Please refer to the documentation to know exactly which request(s) map "
+      "to a particular audit event type.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      {"management"},
+      validate_audit_event_types)
   , cloud_storage_enabled(
       *this,
       "cloud_storage_enabled",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -253,6 +253,15 @@ struct configuration final : public config_store {
     bounded_property<std::optional<size_t>> kafka_rpc_server_stream_recv_buf;
     property<bool> kafka_enable_describe_log_dirs_remote_storage;
 
+    // Audit logging
+    property<bool> audit_enabled;
+    property<int32_t> audit_log_num_partitions;
+    property<int16_t> audit_log_replication_factor;
+    property<size_t> audit_client_max_buffer_size;
+    property<std::chrono::milliseconds> audit_queue_drain_interval_ms;
+    property<size_t> audit_max_queue_elements_per_shard;
+    property<std::vector<ss::sstring>> audit_enabled_event_types;
+
     // Archival storage
     property<bool> cloud_storage_enabled;
     property<bool> cloud_storage_enable_remote_read;

--- a/src/v/config/tests/validator_tests.cc
+++ b/src/v/config/tests/validator_tests.cc
@@ -83,3 +83,20 @@ SEASTAR_THREAD_TEST_CASE(test_empty_string_opt) {
     BOOST_TEST(!validate_non_empty_string_opt("apple").has_value());
     BOOST_TEST(validate_non_empty_string_opt("").has_value());
 }
+
+SEASTAR_THREAD_TEST_CASE(test_audit_event_types) {
+    using config::validate_audit_event_types;
+    BOOST_TEST(!validate_audit_event_types({"management",
+                                            "produce",
+                                            "consume",
+                                            "describe",
+                                            "heartbeat",
+                                            "authenticate"})
+                  .has_value());
+    std::vector<ss::sstring> random_strings{"asdf", "fda", "hello", "world"};
+    BOOST_TEST(validate_audit_event_types(random_strings).has_value());
+
+    std::vector<ss::sstring> one_bad_apple{
+      "management", "consume", "hello world", "heartbeat"};
+    BOOST_TEST(validate_audit_event_types(one_bad_apple).has_value());
+}

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -145,4 +145,23 @@ validate_non_empty_string_opt(const std::optional<ss::sstring>& os) {
         return std::nullopt;
     }
 }
+
+std::optional<ss::sstring>
+validate_audit_event_types(const std::vector<ss::sstring>& vs) {
+    /// TODO: Should match stringified enums in kafka/types.h
+    static const absl::flat_hash_set<ss::sstring> audit_event_types{
+      "management",
+      "produce",
+      "consume",
+      "describe",
+      "heartbeat",
+      "authenticate"};
+
+    for (const auto& e : vs) {
+        if (!audit_event_types.contains(e)) {
+            return ss::format("Unsupported audit event type passed: {}", e);
+        }
+    }
+    return std::nullopt;
+}
 }; // namespace config

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -41,4 +41,7 @@ validate_non_empty_string_vec(const std::vector<ss::sstring>&);
 std::optional<ss::sstring>
 validate_non_empty_string_opt(const std::optional<ss::sstring>&);
 
+std::optional<ss::sstring>
+validate_audit_event_types(const std::vector<ss::sstring>& vs);
+
 }; // namespace config

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -32,6 +32,7 @@ v_cc_library(
   NAME kafka
   SRCS
     ${handlers_srcs}
+    server/audit_log_manager.cc
     server/requests.cc
     server/member.cc
     server/group_stm.cc
@@ -59,6 +60,7 @@ v_cc_library(
     v::kafka_protocol
     v::security
     v::pandaproxy_schema_registry
+    v::kafka_client
     absl::flat_hash_map
     absl::flat_hash_set
 )

--- a/src/v/kafka/client/CMakeLists.txt
+++ b/src/v/kafka/client/CMakeLists.txt
@@ -7,6 +7,7 @@ v_cc_library(
     client.cc
     client_fetch_batch_reader.cc
     configuration.cc
+    config_utils.cc
     consumer.cc
     fetcher.cc
     fetch_session.cc

--- a/src/v/kafka/client/config_utils.cc
+++ b/src/v/kafka/client/config_utils.cc
@@ -9,7 +9,7 @@
  * by the Apache License, Version 2.0
  */
 
-#include "pandaproxy/config_utils.h"
+#include "kafka/client/config_utils.h"
 
 #include "cluster/controller.h"
 #include "cluster/ephemeral_credential_frontend.h"
@@ -24,7 +24,7 @@
 
 #include <exception>
 
-namespace pandaproxy {
+namespace kafka::client {
 
 ss::future<std::unique_ptr<kafka::client::configuration>>
 create_client_credentials(
@@ -76,4 +76,4 @@ ss::future<> set_client_credentials(
     });
 }
 
-} // namespace pandaproxy
+} // namespace kafka::client

--- a/src/v/kafka/client/config_utils.cc
+++ b/src/v/kafka/client/config_utils.cc
@@ -66,6 +66,14 @@ create_client_credentials(
     co_return new_cfg;
 }
 
+void set_client_credentials(
+  kafka::client::configuration const& client_cfg,
+  kafka::client::client& client) {
+    client.config().sasl_mechanism.set_value(client_cfg.sasl_mechanism());
+    client.config().scram_username.set_value(client_cfg.scram_username());
+    client.config().scram_password.set_value(client_cfg.scram_password());
+}
+
 ss::future<> set_client_credentials(
   kafka::client::configuration const& client_cfg,
   ss::sharded<kafka::client::client>& client) {

--- a/src/v/kafka/client/config_utils.h
+++ b/src/v/kafka/client/config_utils.h
@@ -31,6 +31,10 @@ create_client_credentials(
   kafka::client::configuration const& client_cfg,
   security::acl_principal principal);
 
+void set_client_credentials(
+  kafka::client::configuration const& client_cfg,
+  kafka::client::client& client);
+
 ss::future<> set_client_credentials(
   kafka::client::configuration const& client_cfg,
   ss::sharded<kafka::client::client>& client);

--- a/src/v/kafka/client/config_utils.h
+++ b/src/v/kafka/client/config_utils.h
@@ -22,7 +22,7 @@
 
 #include <vector>
 
-namespace pandaproxy {
+namespace kafka::client {
 
 ss::future<std::unique_ptr<kafka::client::configuration>>
 create_client_credentials(
@@ -35,4 +35,4 @@ ss::future<> set_client_credentials(
   kafka::client::configuration const& client_cfg,
   ss::sharded<kafka::client::client>& client);
 
-} // namespace pandaproxy
+} // namespace kafka::client

--- a/src/v/kafka/client/test/CMakeLists.txt
+++ b/src/v/kafka/client/test/CMakeLists.txt
@@ -31,6 +31,7 @@ rp_test(
     produce.cc
     reconnect.cc
     retry.cc
+    test_config_utils.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     v::seastar_testing_main

--- a/src/v/kafka/client/test/test_config_utils.cc
+++ b/src/v/kafka/client/test/test_config_utils.cc
@@ -14,9 +14,9 @@
 #include "json/ostreamwrapper.h"
 #include "json/writer.h"
 #include "kafka/client/client.h"
+#include "kafka/client/config_utils.h"
 #include "kafka/client/configuration.h"
 #include "model/namespace.h"
-#include "pandaproxy/config_utils.h"
 #include "redpanda/tests/fixture.h"
 #include "security/acl.h"
 #include "security/ephemeral_credential_store.h"
@@ -30,8 +30,6 @@
 #include <yaml-cpp/emitter.h>
 
 #include <chrono>
-
-namespace pp = pandaproxy;
 
 namespace kafka::client {
 // BOOST_REQURE_EQUAL fails to find this if it's in the global namespace
@@ -81,7 +79,7 @@ FIXTURE_TEST(test_config_utils, redpanda_thread_fixture) {
       security::principal_type::ephemeral_user, "ephemeral_user"};
 
     const auto create_credentials = [&, this]() {
-        return pp::create_client_credentials(
+        return kafka::client::create_client_credentials(
           *app.controller, cluster_cfg, client_cfg, principal);
     };
 

--- a/src/v/kafka/server/audit_log_manager.cc
+++ b/src/v/kafka/server/audit_log_manager.cc
@@ -1,0 +1,596 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/audit_log_manager.h"
+
+#include "cluster/controller.h"
+#include "cluster/ephemeral_credential_frontend.h"
+#include "kafka/client/client.h"
+#include "kafka/client/config_utils.h"
+#include "kafka/server/handlers/topics/types.h"
+#include "security/acl.h"
+#include "security/ephemeral_credential_store.h"
+#include "storage/parser_utils.h"
+#include "utils/retry.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+
+#include <memory>
+
+namespace kafka {
+
+/// TODO: Create a new ephemeral user for the audit principal so even clients
+/// instantiated by pandaproxy cannot modify or produce to the audit topic
+static const security::acl_principal audit_principal{
+  security::principal_type::ephemeral_user, "__auditing"};
+
+/// Contains a kafka client and a sempahore to bound the memory allocated
+/// by it. This class may be allocated/deallocated on the owning shard depending
+/// on the value of the global audit toggle config option (audit_enabled)
+class audit_client {
+public:
+    static const auto shard_id = ss::shard_id{0};
+
+    audit_client(cluster::controller*, client::configuration&);
+
+    /// Initializes the client (with all necessary auth) and connects to the
+    /// remote broker. If successful requests to create audit topic and all
+    /// necessary ACLs will be made. produce() cannot be called until
+    /// initialization completes with success.
+    ss::future<> initialize();
+
+    /// Closes the gate and flushes all buffers before severing connection to
+    /// broker(s)
+    ss::future<> shutdown();
+
+    /// Produces to the audit topic, internal partitioner assigns partitions
+    /// to the batches provided. Blocks if semaphore is exhausted.
+    ss::future<> produce(std::vector<client::record_essence>);
+
+    bool is_initialized() const { return _is_initialized; }
+
+private:
+    ss::future<> configure();
+    ss::future<> mitigate_error(std::exception_ptr);
+    ss::future<> create_internal_topic();
+    ss::future<> set_auditing_permissions();
+    ss::future<> inform(model::node_id id);
+    ss::future<> do_inform(model::node_id id);
+
+private:
+    bool _has_ephemeral_credentials{false};
+    ss::abort_source _as;
+    ss::gate _gate;
+    bool _is_initialized{false};
+    ssx::semaphore _send_sem;
+    client::client _client;
+    cluster::controller* _controller;
+};
+
+/// Allocated only on the shard responsible for owning the kafka client, its
+/// lifetime is the duration of the audit_log_manager. Contains a gate/mutex to
+/// synchronize around actions around the internal client which may be
+/// started/stopped on demand.
+class audit_sink {
+public:
+    audit_sink(
+      audit_log_manager* audit_mgr,
+      cluster::controller* controller,
+      client::configuration& config) noexcept;
+
+    /// Starts a kafka::client if none is allocated, backgrounds the work
+    ss::future<> start();
+
+    /// Closes all gates, deallocates client returns when all has completed
+    ss::future<> stop();
+
+    /// Produce to the audit topic within the context of the internal locks,
+    /// ensuring toggling of the audit master switch happens in lock step with
+    /// calls to produce()
+    ss::future<> produce(std::vector<client::record_essence> records);
+
+    /// Allocates and connects, or deallocates and shuts down the audit client
+    void toggle(bool enabled);
+
+    /// Returns true if _client has a value
+    bool is_enabled() const { return _client != nullptr; }
+
+private:
+    ss::future<> do_toggle(bool enabled);
+
+    /// Primitives for ensuring background work and toggling of switch w/ async
+    /// work occur in lock step
+    ss::gate _gate;
+    mutex _mutex;
+
+    /// Reference to audit manager so synchronization with its fibers may occur.
+    /// Supports pausing and resuming these fibers so the client can safely be
+    /// deallocated when no more work is concurrently entering the system
+    audit_log_manager* _audit_mgr;
+
+    /// audit_client and members necessary to pass to its constructor
+    std::unique_ptr<audit_client> _client;
+    cluster::controller* _controller;
+    client::configuration& _config;
+};
+
+audit_client::audit_client(
+  cluster::controller* controller, client::configuration& client_config)
+  : _send_sem(
+    config::shard_local_cfg().audit_client_max_buffer_size(),
+    "audit_log_producer_semaphore")
+  , _client(
+      config::to_yaml(client_config, config::redact_secrets::no),
+      [this](std::exception_ptr eptr) { return mitigate_error(eptr); })
+  , _controller(controller) {}
+
+ss::future<> audit_client::initialize() {
+    static const auto base_backoff = 250ms;
+    exp_backoff_policy backoff_policy;
+    while (!_as.abort_requested()) {
+        try {
+            co_await configure();
+            _is_initialized = true;
+            break;
+        } catch (...) {
+            /// Sleep, then try again
+        }
+        auto next = backoff_policy.next_backoff();
+        co_await ss::sleep_abortable(base_backoff * next, _as)
+          .handle_exception_type([](const ss::sleep_aborted&) {});
+    }
+}
+
+ss::future<> audit_client::configure() {
+    try {
+        auto config = co_await client::create_client_credentials(
+          *_controller,
+          config::shard_local_cfg(),
+          _client.config(),
+          audit_principal);
+        set_client_credentials(*config, _client);
+
+        auto const& store
+          = _controller->get_ephemeral_credential_store().local();
+        _has_ephemeral_credentials = store.has(store.find(audit_principal));
+
+        co_await set_auditing_permissions();
+        co_await create_internal_topic();
+
+        /// Retries should be "infinite", to avoid dropping data, there is a
+        /// known issue within the client setting this value to size_t::max
+        _client.config().retries.set_value(10000);
+        vlog(klog.info, "Audit log client initialized");
+    } catch (...) {
+        vlog(
+          klog.warn,
+          "Audit log client failed to initialize: {}",
+          std::current_exception());
+        throw;
+    }
+}
+
+ss::future<> audit_client::set_auditing_permissions() {
+    /// Give permissions to create and write to the audit topic
+    security::acl_entry acl_create_entry{
+      audit_principal,
+      security::acl_host::wildcard_host(),
+      security::acl_operation::create,
+      security::acl_permission::allow};
+
+    security::acl_entry acl_write_entry{
+      audit_principal,
+      security::acl_host::wildcard_host(),
+      security::acl_operation::write,
+      security::acl_permission::allow};
+
+    security::resource_pattern audit_topic_pattern{
+      security::resource_type::topic,
+      model::kafka_audit_logging_topic,
+      security::pattern_type::literal};
+
+    /// TODO: Add rules for User:* deny to things like deleting the topic
+    /// and other unwanted behavior. User:* should be allowed to ::describe
+    /// and alter topic configs
+    co_await _controller->get_security_frontend().local().create_acls(
+      {security::acl_binding{audit_topic_pattern, acl_create_entry},
+       security::acl_binding{audit_topic_pattern, acl_write_entry}},
+      5s);
+}
+
+ss::future<> audit_client::mitigate_error(std::exception_ptr eptr) {
+    if (_gate.is_closed() || _as.abort_requested()) {
+        /// TODO: Investigate looping behavior on shutdown
+        co_return;
+    }
+    vlog(klog.trace, "mitigate_error: {}", eptr);
+    auto f = ss::now();
+    try {
+        std::rethrow_exception(eptr);
+    } catch (client::broker_error const& ex) {
+        if (
+          ex.error == error_code::sasl_authentication_failed
+          && _has_ephemeral_credentials) {
+            f = inform(ex.node_id).then([this]() { return _client.connect(); });
+        } else {
+            throw;
+        }
+    } catch (...) {
+        throw;
+    }
+    co_await std::move(f);
+}
+
+ss::future<> audit_client::inform(model::node_id id) {
+    vlog(klog.trace, "inform: {}", id);
+
+    // Inform a particular node
+    if (id != client::unknown_node_id) {
+        return do_inform(id);
+    }
+
+    // Inform all nodes
+    return seastar::parallel_for_each(
+      _controller->get_members_table().local().node_ids(),
+      [this](model::node_id id) { return do_inform(id); });
+}
+
+ss::future<> audit_client::do_inform(model::node_id id) {
+    auto& fe = _controller->get_ephemeral_credential_frontend().local();
+    auto ec = co_await fe.inform(id, audit_principal);
+    vlog(klog.info, "Informed: broker: {}, ec: {}", id, ec);
+}
+
+ss::future<> audit_client::create_internal_topic() {
+    constexpr std::string_view retain_forever = "-1";
+    constexpr std::string_view seven_days = "604800000";
+    creatable_topic audit_topic{
+      .name = model::kafka_audit_logging_topic,
+      .num_partitions = config::shard_local_cfg().audit_log_num_partitions(),
+      .replication_factor
+      = config::shard_local_cfg().audit_log_replication_factor(),
+      .assignments = {},
+      .configs = {
+        createable_topic_config{
+          .name = ss::sstring(topic_property_retention_bytes),
+          .value{retain_forever}},
+        createable_topic_config{
+          .name = ss::sstring(topic_property_retention_duration),
+          .value{seven_days}}}};
+    vlog(klog.info, "Creating audit log topic with settings: {}", audit_topic);
+    const auto resp = co_await _client.create_topic({std::move(audit_topic)});
+    if (resp.data.topics.size() != 1) {
+        throw std::runtime_error(
+          fmt::format("Unexpected create topics response: {}", resp.data));
+    }
+    const auto& topic = resp.data.topics[0];
+    if (topic.error_code == error_code::none) {
+        vlog(klog.debug, "Auditing: created audit log topic: {}", topic);
+    } else if (topic.error_code == error_code::topic_already_exists) {
+        vlog(klog.debug, "Auditing: topic already exists");
+        co_await _client.update_metadata();
+    } else {
+        if (topic.error_code == error_code::invalid_replication_factor) {
+            vlog(
+              klog.warn,
+              "Auditing: invalid replication factor on audit topic, "
+              "check/modify settings, then disable and re-enable "
+              "'audit_enabled'");
+        }
+        const auto msg = topic.error_message.has_value() ? *topic.error_message
+                                                         : "<no_err_msg>";
+        throw std::runtime_error(
+          fmt::format("{} - error_code: {}", msg, topic.error_code));
+    }
+}
+
+ss::future<> audit_client::shutdown() {
+    /// Repeated calls to shutdown() are possible, although unlikely
+    if (_as.abort_requested()) {
+        co_return;
+    }
+    vlog(klog.info, "Shutting down audit client");
+    _as.request_abort();
+    _send_sem.broken();
+    co_await _client.stop();
+    co_await _gate.close();
+}
+
+ss::future<>
+audit_client::produce(std::vector<client::record_essence> records) {
+    /// TODO: Produce with acks=1, atm -1 is hardcoded into client
+    const auto records_size = [](const auto& records) {
+        std::size_t size = 0;
+        for (const auto& r : records) {
+            if (r.value) {
+                /// auditing does not fill in any of the fields of the
+                /// record_essence other then the value member
+                size += r.value->size_bytes();
+            }
+        }
+        return size;
+    };
+
+    try {
+        const auto size_bytes = records_size(records);
+        auto units = co_await ss::get_units(_send_sem, size_bytes);
+        ssx::spawn_with_gate(
+          _gate,
+          [this,
+           units = std::move(units),
+           records = std::move(records)]() mutable {
+              return _client
+                .produce_records(
+                  model::kafka_audit_logging_topic, std::move(records))
+                .discard_result()
+                .handle_exception_type([](const client::partition_error& ex) {
+                    /// TODO: Possible optimization to retry with different
+                    /// partition strategy.
+                    ///
+                    /// If reached here non-mitigatable error occured, or
+                    /// attempts on mitigation had been used up.
+                    vlog(klog.error, "Audit records dropped, reason: {}", ex);
+                })
+                .finally([units = std::move(units)] {});
+          });
+    } catch (const ss::broken_semaphore&) {
+        vlog(
+          klog.debug,
+          "Shutting down the auditor kafka::client, semaphore broken");
+    }
+    co_return;
+}
+
+/// audit_sink
+
+audit_sink::audit_sink(
+  audit_log_manager* audit_mgr,
+  cluster::controller* controller,
+  client::configuration& config) noexcept
+  : _audit_mgr(audit_mgr)
+  , _controller(controller)
+  , _config(config) {}
+
+ss::future<> audit_sink::start() {
+    toggle(true);
+    return ss::now();
+}
+
+ss::future<> audit_sink::stop() {
+    _mutex.broken();
+    if (_client) {
+        co_await _client->shutdown();
+    }
+    co_await _gate.close();
+}
+
+ss::future<> audit_sink::produce(std::vector<client::record_essence> records) {
+    /// No locks/gates since the calls to this method are done in controlled
+    /// context of other synchronization primitives
+    vassert(_client, "produce() called on a null client");
+    co_await _client->produce(std::move(records));
+}
+
+void audit_sink::toggle(bool enabled) {
+    ssx::spawn_with_gate(
+      _gate, [this, enabled]() { return do_toggle(enabled); });
+}
+
+ss::future<> audit_sink::do_toggle(bool enabled) {
+    try {
+        ssx::semaphore_units lock;
+        if (enabled && !_client) {
+            lock = co_await _mutex.get_units();
+            _client = std::make_unique<audit_client>(_controller, _config);
+            co_await _client->initialize();
+            if (_client->is_initialized()) {
+                /// Only if shutdown succeeded before initializtion could
+                /// complete would this case evaluate to false
+                co_await _audit_mgr->resume();
+            }
+        } else if (!enabled && _client) {
+            /// Call to shutdown does not exist within the lock so that
+            /// shutting down isn't blocked on the lock held above in the
+            /// case initialize() doesn't complete. This is common if for
+            /// example the audit topic is improperly configured
+            /// intitialization will forever hang.
+            co_await _client->shutdown();
+            lock = co_await _mutex.get_units();
+            co_await _audit_mgr->pause();
+            _client.reset(nullptr);
+        }
+    } catch (const ss::broken_semaphore&) {
+        vlog(klog.info, "Failed to toggle audit status, shutting down");
+    } catch (...) {
+        vlog(
+          klog.error,
+          "Failed to toggle audit status: {}",
+          std::current_exception());
+    }
+}
+
+/// audit_log_manager
+
+void audit_log_manager::set_enabled_events() {
+    using underlying_enum_t = std::underlying_type_t<audit_event_type>;
+    _enabled_event_types = underlying_enum_t(0);
+    for (const auto& e : _audit_event_types()) {
+        const auto as_uint = underlying_enum_t(string_to_audit_event_type(e));
+        _enabled_event_types[as_uint] = true;
+    }
+    vassert(
+      !is_audit_event_enabled(audit_event_type::unknown),
+      "Unknown audit_event_type observed");
+}
+
+audit_log_manager::audit_log_manager(
+  cluster::controller* controller, client::configuration& client_config)
+  : _audit_enabled(config::shard_local_cfg().audit_enabled.bind())
+  , _queue_drain_interval_ms(
+      config::shard_local_cfg().audit_queue_drain_interval_ms.bind())
+  , _max_queue_elements_per_shard(
+      config::shard_local_cfg().audit_max_queue_elements_per_shard.bind())
+  , _audit_event_types(
+      config::shard_local_cfg().audit_enabled_event_types.bind())
+  , _controller(controller)
+  , _config(client_config) {
+    if (ss::this_shard_id() == audit_client::shard_id) {
+        _sink = std::make_unique<audit_sink>(this, controller, client_config);
+    }
+
+    _drain_timer.set_callback([this] {
+        ssx::spawn_with_gate(_gate, [this]() {
+            return ss::get_units(_active_drain, 1)
+              .then([this](auto units) mutable {
+                  return drain()
+                    .handle_exception([](std::exception_ptr e) {
+                        vlog(
+                          klog.warn,
+                          "Exception in audit_log_manager fiber: {}",
+                          e);
+                    })
+                    .finally([this, units = std::move(units)] {
+                        _drain_timer.arm(_queue_drain_interval_ms());
+                    });
+              });
+        });
+    });
+    set_enabled_events();
+    _audit_event_types.watch([this] { set_enabled_events(); });
+}
+
+audit_log_manager::~audit_log_manager() = default;
+
+bool audit_log_manager::is_audit_event_enabled(
+  audit_event_type event_type) const {
+    using underlying_enum_t = std::underlying_type_t<audit_event_type>;
+    return _enabled_event_types.test(underlying_enum_t(event_type));
+}
+
+ss::future<> audit_log_manager::start() {
+    if (ss::this_shard_id() != audit_client::shard_id) {
+        co_return;
+    }
+    _audit_enabled.watch([this] {
+        try {
+            _sink->toggle(_audit_enabled());
+        } catch (const ss::gate_closed_exception&) {
+            vlog(klog.debug, "Failed to toggle auditing state, shutting down");
+        } catch (...) {
+            vlog(
+              klog.error,
+              "Failed to toggle auditing state: {}",
+              std::current_exception());
+        }
+    });
+    if (_audit_enabled()) {
+        vlog(klog.info, "Starting audit_log_manager");
+        co_await _sink->start();
+    }
+}
+
+ss::future<> audit_log_manager::stop() {
+    _drain_timer.cancel();
+    _as.request_abort();
+    if (ss::this_shard_id() == audit_client::shard_id) {
+        vlog(klog.info, "Shutting down audit log manager");
+        co_await _sink->stop();
+    }
+    if (!_gate.is_closed()) {
+        /// Gate may already be closed if ::pause() had been called
+        co_await _gate.close();
+    }
+    if (_queue.size() > 0) {
+        vlog(
+          klog.debug,
+          "{} records were not pushed to the audit log before shutdown",
+          _queue.size());
+    }
+}
+
+ss::future<> audit_log_manager::pause() {
+    return container().invoke_on_all([](audit_log_manager& mgr) {
+        /// Wait until drain() has completed, with timer cancelled it can be
+        /// ensured no more work will be performed
+        return ss::get_units(mgr._active_drain, 1).then([&mgr](auto) {
+            mgr._drain_timer.cancel();
+        });
+    });
+}
+
+ss::future<> audit_log_manager::resume() {
+    return container().invoke_on_all([](audit_log_manager& mgr) {
+        /// If the timer is already armed that is a bug
+        vassert(
+          !mgr._drain_timer.armed(),
+          "Timer is already armed upon call to ::resume");
+        mgr._drain_timer.arm(mgr._queue_drain_interval_ms());
+    });
+}
+
+bool audit_log_manager::is_client_enabled() const {
+    vassert(
+      ss::this_shard_id() == audit_client::shard_id,
+      "Must be called on audit client shard");
+    return _sink->is_enabled();
+}
+
+bool audit_log_manager::do_enqueue_audit_event(
+  std::unique_ptr<security::audit::ocsf_base_impl> msg) {
+    auto& map = _queue.get<underlying_unordered_map>();
+    auto it = map.find(msg->key());
+    if (it == map.end()) {
+        if (_queue.size() >= _max_queue_elements_per_shard()) {
+            return false;
+        }
+        auto& list = _queue.get<underlying_list>();
+        list.push_back(std::move(msg));
+    } else {
+        auto now = security::audit::timestamp_t{
+          std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count()};
+        (*it)->increment(now);
+    }
+    return true;
+}
+
+ss::future<> audit_log_manager::drain() {
+    if (_queue.empty() || _as.abort_requested()) {
+        co_return;
+    }
+
+    /// Combine all batched audit msgs into record_essences
+    std::vector<client::record_essence> essences;
+    auto records = std::exchange(_queue, underlying_t{});
+    auto& records_seq = records.get<underlying_list>();
+    while (!records_seq.empty()) {
+        const auto& front = records_seq.front();
+        auto as_json = front->to_json();
+        records_seq.pop_front();
+        iobuf b;
+        b.append(as_json.c_str(), as_json.size());
+        essences.push_back(client::record_essence{.value = std::move(b)});
+        co_await ss::maybe_yield();
+    }
+
+    /// This call may block if the audit_clients semaphore is exhausted,
+    /// this represents the amount of memory used within its kafka::client
+    /// produce batch queue. If the semaphore blocks it will apply
+    /// backpressure here, and the \ref _queue will begin to fill closer to
+    /// capacity. When it hits capacity, enqueue_audit_event() will block.
+    co_await container().invoke_on(
+      audit_client::shard_id,
+      [recs = std::move(essences)](audit_log_manager& mgr) mutable {
+          return mgr._sink->produce(std::move(recs));
+      });
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/audit_log_manager.h
+++ b/src/v/kafka/server/audit_log_manager.h
@@ -1,0 +1,164 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+#include "cluster/fwd.h"
+#include "config/property.h"
+#include "kafka/client/fwd.h"
+#include "kafka/client/types.h"
+#include "kafka/server/logger.h"
+#include "kafka/types.h"
+#include "model/timeout_clock.h"
+#include "net/types.h"
+#include "security/audit/schemas/schemas.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+#include <boost/multi_index/hashed_index.hpp>
+#include <boost/multi_index/indexed_by.hpp>
+#include <boost/multi_index/key.hpp>
+#include <boost/multi_index/member.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index/sequenced_index.hpp>
+#include <boost/multi_index_container.hpp>
+
+using namespace std::chrono_literals;
+
+namespace kafka {
+
+template<typename T>
+concept InheritsFromOCSFBase
+  = std::is_base_of<security::audit::ocsf_base_event<T>, T>::value;
+
+class audit_sink;
+
+class audit_log_manager
+  : public ss::peering_sharded_service<audit_log_manager> {
+public:
+    audit_log_manager(
+      cluster::controller* controller, kafka::client::configuration&);
+
+    audit_log_manager(const audit_log_manager&) = delete;
+    audit_log_manager& operator=(const audit_log_manager&) = delete;
+    audit_log_manager(audit_log_manager&&) = delete;
+    audit_log_manager& operator=(audit_log_manager&&) = delete;
+    ~audit_log_manager();
+
+    /// Start the underlying kafka client and create the audit log topic
+    /// if necessary
+    ss::future<> start();
+
+    /// Shuts down the internal kafka client and stops all pending bg work
+    ss::future<> stop();
+
+    /// Enqueue an event to be produced onto an audit log partition
+    ///
+    /// Returns: bool representing if the audit msg was successfully moved into
+    /// the queue or not. If unsuccessful this means the audit subsystem cannot
+    /// publish messages. Consumers of this API should react accordingly, i.e.
+    /// return an error to the client.
+    template<InheritsFromOCSFBase T, typename... Args>
+    bool enqueue_audit_event(audit_event_type type, Args&&... args) {
+        if (!_audit_enabled() || !is_audit_event_enabled(type)) {
+            return true;
+        }
+        if (_as.abort_requested()) {
+            /// Prevent auditing new messages when shutdown starts that way the
+            /// queue may be entirely flushed before shutdown
+            return false;
+        }
+        return do_enqueue_audit_event(
+          std::make_unique<T>(std::forward<Args>(args)...));
+    }
+
+    /// Returns the number of items pending to be written to auditing log
+    ///
+    /// Note does not include records already sent to client
+    size_t pending_events() const { return _queue.size(); };
+
+    /// Returns true if the internal kafka client is allocated
+    ///
+    /// NOTE: Only works on shard_id{0}, use in unit tests
+    bool is_client_enabled() const;
+
+private:
+    ss::future<> drain();
+    ss::future<> pause();
+    ss::future<> resume();
+
+    bool is_audit_event_enabled(audit_event_type) const;
+    bool do_enqueue_audit_event(
+      std::unique_ptr<security::audit::ocsf_base_impl> msg);
+    void set_enabled_events();
+
+private:
+    /// Multi index container is efficent in terms of time and space, underlying
+    /// internal data structures are compact requiring only one node per
+    /// element. More info here:
+    /// https://www.boost.org/doc/libs/1_72_0/libs/multi_index/doc/performance.html
+    struct underlying_list {};
+    struct underlying_unordered_map {};
+    using underlying_t = boost::multi_index::multi_index_container<
+      std::unique_ptr<security::audit::ocsf_base_impl>,
+      boost::multi_index::indexed_by<
+        /// Sequenced list of entries
+        boost::multi_index::sequenced<boost::multi_index::tag<underlying_list>>,
+        /// Set of audit_messages using hashed representations as comparator
+        boost::multi_index::hashed_unique<
+          boost::multi_index::tag<underlying_unordered_map>,
+          boost::multi_index::const_mem_fun<
+            security::audit::ocsf_base_impl,
+            size_t,
+            &security::audit::ocsf_base_impl::key>>>>;
+
+    /// configuration options
+    config::binding<bool> _audit_enabled;
+    config::binding<std::chrono::milliseconds> _queue_drain_interval_ms;
+    config::binding<size_t> _max_queue_elements_per_shard;
+    config::binding<std::vector<ss::sstring>> _audit_event_types;
+    static constexpr auto enabled_set_bitlength
+      = std::underlying_type_t<audit_event_type>(
+        audit_event_type::num_elements);
+    std::bitset<enabled_set_bitlength> _enabled_event_types{0};
+
+    /// Shutdown primitives
+    ss::gate _gate;
+    ss::abort_source _as;
+
+    /// Main data structure and associated timer that fires thread to consume
+    /// from it. The data structure chosen is a boost::multi_index_container,
+    /// configured to be searchable by a hash of the element or by the sequence
+    /// of insertion.
+    ///
+    /// The chosen design provides two benefits:
+    /// 1. Uses shard local memory as a temporary cache to reduce the number of
+    /// calls to the producer shard.
+    ///
+    /// 2. The hashed_unique interface allows for quick detection of duplicates,
+    /// greatly reducing the number of messages to produce onto the audit
+    /// message topic. Helpful for when audit of produce_request is enabled,
+    /// since the quantity of auditable messages will be high and many requests
+    /// are identical and can be combined into one.
+    ss::timer<> _drain_timer;
+    underlying_t _queue;
+    ssx::semaphore _active_drain{1, "audit-drain"};
+
+    /// Single instance contains a kafka::client::client instance.
+    friend class audit_sink;
+    std::unique_ptr<audit_sink> _sink;
+
+    /// Other references
+    cluster::controller* _controller;
+    client::configuration& _config;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -26,5 +26,6 @@ class rm_group_frontend;
 class rm_group_proxy_impl;
 class usage_manager;
 class snc_quota_context;
+class audit_log_manager;
 
 } // namespace kafka

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -91,6 +91,7 @@ server::server(
   ss::sharded<snc_quota_manager>& snc_quota_mgr,
   ss::sharded<kafka::group_router>& router,
   ss::sharded<kafka::usage_manager>& usage_manager,
+  ss::sharded<kafka::audit_log_manager>& audit_mgr,
   ss::sharded<cluster::shard_table>& tbl,
   ss::sharded<cluster::partition_manager>& pm,
   ss::sharded<cluster::id_allocator_frontend>& id_allocator_frontend,
@@ -114,6 +115,7 @@ server::server(
   , _snc_quota_mgr(snc_quota_mgr)
   , _group_router(router)
   , _usage_manager(usage_manager)
+  , _audit_mgr(audit_mgr)
   , _shard_table(tbl)
   , _partition_manager(pm)
   , _fetch_session_cache(

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -55,6 +55,7 @@ public:
       ss::sharded<snc_quota_manager>&,
       ss::sharded<kafka::group_router>&,
       ss::sharded<kafka::usage_manager>&,
+      ss::sharded<kafka::audit_log_manager>&,
       ss::sharded<cluster::shard_table>&,
       ss::sharded<cluster::partition_manager>&,
       ss::sharded<cluster::id_allocator_frontend>&,
@@ -121,6 +122,7 @@ public:
     fetch_session_cache& fetch_sessions_cache() { return _fetch_session_cache; }
     quota_manager& quota_mgr() { return _quota_mgr.local(); }
     usage_manager& usage_mgr() { return _usage_manager.local(); }
+    audit_log_manager& audit_mgr() { return _audit_mgr.local(); }
     snc_quota_manager& snc_quota_mgr() { return _snc_quota_mgr.local(); }
     bool is_idempotence_enabled() const { return _is_idempotence_enabled; }
     bool are_transactions_enabled() const { return _are_transactions_enabled; }
@@ -199,6 +201,7 @@ private:
     ss::sharded<snc_quota_manager>& _snc_quota_mgr;
     ss::sharded<kafka::group_router>& _group_router;
     ss::sharded<kafka::usage_manager>& _usage_manager;
+    ss::sharded<kafka::audit_log_manager>& _audit_mgr;
     ss::sharded<cluster::shard_table>& _shard_table;
     ss::sharded<cluster::partition_manager>& _partition_manager;
     kafka::fetch_session_cache _fetch_session_cache;

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -55,7 +55,8 @@ set(srcs
   alter_config_test.cc
   produce_consume_test.cc
   group_metadata_serialization_test.cc
-  partition_reassignments_test.cc)
+  partition_reassignments_test.cc
+  audit_log_test.cc)
 
 rp_test(
   FIXTURE_TEST

--- a/src/v/kafka/server/tests/audit_log_test.cc
+++ b/src/v/kafka/server/tests/audit_log_test.cc
@@ -1,0 +1,169 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/types.h"
+#include "kafka/server/audit_log_manager.h"
+#include "kafka/types.h"
+#include "redpanda/tests/fixture.h"
+#include "security/audit/schemas/application_activity.h"
+#include "security/audit/schemas/iam.h"
+#include "security/audit/schemas/types.h"
+#include "test_utils/fixture.h"
+
+namespace sa = security::audit;
+
+bool enqueue_random_audit_event(
+  kafka::audit_log_manager& m, kafka::audit_event_type type) {
+    auto make_random_product = []() {
+        return sa::product{
+          .name = random_generators::gen_alphanum_string(10),
+          .vendor_name = random_generators::gen_alphanum_string(10),
+          .version = random_generators::gen_alphanum_string(10)};
+    };
+
+    auto now = sa::timestamp_t{
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now().time_since_epoch())
+        .count()};
+
+    return m.enqueue_audit_event<sa::application_lifecycle>(
+      type,
+      sa::application_lifecycle::activity_id(random_generators::get_int(0, 4)),
+      make_random_product(),
+      sa::severity_id(random_generators::get_int(0, 6)),
+      now);
+}
+
+ss::future<size_t> pending_audit_events(kafka::audit_log_manager& m) {
+    return m.container().map_reduce0(
+      [](const kafka::audit_log_manager& m) { return m.pending_events(); },
+      size_t(0),
+      std::plus<>());
+}
+
+FIXTURE_TEST(test_audit_init_phase, redpanda_thread_fixture) {
+    /// Initialize auditing configurations
+    ss::smp::invoke_on_all([] {
+        std::vector<ss::sstring> enabled_types{"management", "consume"};
+        config::shard_local_cfg().get("audit_enabled").set_value(false);
+        config::shard_local_cfg()
+          .get("audit_log_replication_factor")
+          .set_value(int16_t(1));
+        config::shard_local_cfg()
+          .get("audit_max_queue_elements_per_shard")
+          .set_value(size_t(5));
+        config::shard_local_cfg()
+          .get("audit_queue_drain_interval_ms")
+          .set_value(std::chrono::milliseconds(60000));
+        config::shard_local_cfg()
+          .get("audit_enabled_event_types")
+          .set_value(enabled_types);
+    }).get();
+
+    wait_for_controller_leadership().get0();
+    auto& audit_mgr = app.audit_mgr;
+
+    /// with auditing disabled, calls to enqueue should be no-ops
+    audit_mgr
+      .invoke_on_all([](kafka::audit_log_manager& m) {
+          for (auto i = 0; i < 20; ++i) {
+              BOOST_ASSERT(enqueue_random_audit_event(
+                m, kafka::audit_event_type::management));
+          }
+      })
+      .get0();
+
+    BOOST_CHECK_EQUAL(
+      pending_audit_events(audit_mgr.local()).get0(), size_t(0));
+
+    /// with auditing enabled, the system should block when the threshold of
+    /// 5 records has been surpassed
+    ss::smp::invoke_on_all([] {
+        config::shard_local_cfg().get("audit_enabled").set_value(true);
+    }).get();
+
+    /// With the switch enabled the audit topic should be created
+    wait_for_topics(
+      {cluster::topic_result(model::topic_namespace(
+        model::kafka_namespace, model::kafka_audit_logging_topic))})
+      .get();
+
+    /// Verify auditing can enqueue up until the max configured, and further
+    /// calls to enqueue return false, signifying action did not occur.
+    bool success = audit_mgr
+                     .map_reduce0(
+                       [](kafka::audit_log_manager& m) {
+                           bool success = true;
+                           for (auto i = 0; i < 20; ++i) {
+                               /// Should always return true, auditing is
+                               /// disabled
+                               bool enqueued = enqueue_random_audit_event(
+                                 m, kafka::audit_event_type::management);
+                               if (i >= 5) {
+                                   /// Assert that when the max is reached data
+                                   /// cannot be entered into the system
+                                   enqueued = !enqueued;
+                               }
+                               success = success && enqueued;
+                           }
+                           return success;
+                       },
+                       true,
+                       std::logical_and<>())
+                     .get0();
+
+    BOOST_CHECK(success);
+    BOOST_CHECK_EQUAL(
+      pending_audit_events(audit_mgr.local()).get0(),
+      size_t(5 * ss::smp::count));
+
+    /// Verify auditing doesn't enqueue the non configured types
+    BOOST_CHECK(enqueue_random_audit_event(
+      audit_mgr.local(), kafka::audit_event_type::authenticate));
+    BOOST_CHECK(enqueue_random_audit_event(
+      audit_mgr.local(), kafka::audit_event_type::describe));
+    BOOST_CHECK(!enqueue_random_audit_event(
+      audit_mgr.local(), kafka::audit_event_type::management));
+
+    /// Toggle the audit switch a few times
+    for (auto i = 0; i < 5; ++i) {
+        const bool val = i % 2 != 0;
+        ss::smp::invoke_on_all([val] {
+            config::shard_local_cfg().get("audit_enabled").set_value(val);
+        }).get0();
+        audit_mgr
+          .invoke_on(
+            0,
+            [val](kafka::audit_log_manager& m) {
+                return tests::cooperative_spin_wait_with_timeout(
+                  10s, [&m, val] { return m.is_client_enabled() == val; });
+            })
+          .get0();
+    }
+    /// Ensure in the off state even with buffers filled, no data is lost
+    BOOST_CHECK(!config::shard_local_cfg().audit_enabled());
+    BOOST_CHECK_EQUAL(
+      pending_audit_events(audit_mgr.local()).get0(),
+      size_t(5 * ss::smp::count));
+
+    const bool enqueued = audit_mgr
+                            .map_reduce0(
+                              [](kafka::audit_log_manager& m) {
+                                  return enqueue_random_audit_event(
+                                    m, kafka::audit_event_type::management);
+                              },
+                              true,
+                              std::logical_and<>())
+                            .get0();
+
+    BOOST_CHECK(enqueued);
+    BOOST_CHECK_EQUAL(
+      pending_audit_events(audit_mgr.local()).get0(),
+      size_t(5 * ss::smp::count));
+}

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -19,6 +19,7 @@
 #include "seastarx.h"
 #include "utils/base64.h"
 #include "utils/named_type.h"
+#include "utils/string_switch.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -137,6 +138,27 @@ struct partition_info {
     std::vector<replica_info> replicas;
     std::optional<model::node_id> leader;
 };
+
+enum class audit_event_type : std::uint8_t {
+    management = 0,
+    produce,
+    consume,
+    describe,
+    heartbeat,
+    authenticate,
+    unknown
+};
+
+inline audit_event_type string_to_audit_event_type(const std::string_view s) {
+    return string_switch<audit_event_type>(s)
+      .match("management", audit_event_type::management)
+      .match("produce", audit_event_type::produce)
+      .match("consume", audit_event_type::consume)
+      .match("describe", audit_event_type::describe)
+      .match("heartbeat", audit_event_type::heartbeat)
+      .match("authenticate", audit_event_type::authenticate)
+      .default_match(audit_event_type::unknown);
+}
 } // namespace kafka
 
 /*

--- a/src/v/kafka/types.h
+++ b/src/v/kafka/types.h
@@ -146,7 +146,8 @@ enum class audit_event_type : std::uint8_t {
     describe,
     heartbeat,
     authenticate,
-    unknown
+    unknown,
+    num_elements
 };
 
 inline audit_event_type string_to_audit_event_type(const std::string_view s) {

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -40,6 +40,8 @@ inline const model::topic kafka_consumer_offsets_topic("__consumer_offsets");
 inline const model::topic_namespace kafka_consumer_offsets_nt(
   model::kafka_namespace, kafka_consumer_offsets_topic);
 
+inline const model::topic kafka_audit_logging_topic("__audit_log");
+
 inline const model::topic tx_manager_topic("tx");
 inline const model::topic_namespace
   tx_manager_nt(model::kafka_internal_namespace, tx_manager_topic);

--- a/src/v/pandaproxy/CMakeLists.txt
+++ b/src/v/pandaproxy/CMakeLists.txt
@@ -6,7 +6,6 @@ v_cc_library(
     probe.cc
     server.cc
     kafka_client_cache.cc
-    config_utils.cc
   DEPS
     v::pandaproxy_parsing
     v::pandaproxy_json

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -12,10 +12,10 @@
 #include "cluster/controller.h"
 #include "cluster/ephemeral_credential_frontend.h"
 #include "cluster/members_table.h"
+#include "kafka/client/config_utils.h"
 #include "net/unresolved_address.h"
 #include "pandaproxy/api/api-doc/rest.json.hh"
 #include "pandaproxy/auth_utils.h"
-#include "pandaproxy/config_utils.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/parsing/exceptions.h"
 #include "pandaproxy/parsing/from_chars.h"
@@ -166,12 +166,12 @@ ss::future<> proxy::do_start() {
 }
 
 ss::future<> proxy::configure() {
-    auto config = co_await pandaproxy::create_client_credentials(
+    auto config = co_await kafka::client::create_client_credentials(
       *_controller,
       config::shard_local_cfg(),
       _client.local().config(),
       principal);
-    co_await set_client_credentials(*config, _client);
+    co_await kafka::client::set_client_credentials(*config, _client);
 
     auto const& store = _controller->get_ephemeral_credential_store().local();
     bool has_ephemeral_credentials = store.has(store.find(principal));

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -15,6 +15,7 @@
 #include "cluster/security_frontend.h"
 #include "kafka/client/brokers.h"
 #include "kafka/client/client_fetch_batch_reader.h"
+#include "kafka/client/config_utils.h"
 #include "kafka/client/exceptions.h"
 #include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/errors.h"
@@ -23,7 +24,6 @@
 #include "model/fundamental.h"
 #include "pandaproxy/api/api-doc/schema_registry.json.hh"
 #include "pandaproxy/auth_utils.h"
-#include "pandaproxy/config_utils.h"
 #include "pandaproxy/error.h"
 #include "pandaproxy/logger.h"
 #include "pandaproxy/schema_registry/configuration.h"
@@ -227,12 +227,12 @@ ss::future<> create_acls(cluster::security_frontend& security_fe) {
 }
 
 ss::future<> service::configure() {
-    auto config = co_await pandaproxy::create_client_credentials(
+    auto config = co_await kafka::client::create_client_credentials(
       *_controller,
       config::shard_local_cfg(),
       _client.local().config(),
       principal);
-    co_await set_client_credentials(*config, _client);
+    co_await kafka::client::set_client_credentials(*config, _client);
 
     auto const& store = _controller->get_ephemeral_credential_store().local();
     bool has_ephemeral_credentials = store.has(store.find(principal));

--- a/src/v/pandaproxy/test/CMakeLists.txt
+++ b/src/v/pandaproxy/test/CMakeLists.txt
@@ -19,13 +19,3 @@ rp_test(
   ARGS "-- -c 1"
   LABELS pandaproxy
 )
-
-rp_test(
-  FIXTURE_TEST
-  BINARY_NAME pandaproxy
-  SOURCES
-    test_config_utils.cc
-  DEFINITIONS BOOST_TEST_DYN_LINK
-  LIBRARIES v::seastar_testing_main v::application
-  LABELS pandaproxy
-)

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -62,6 +62,7 @@
 #include "features/fwd.h"
 #include "finjector/stress_fiber.h"
 #include "kafka/client/configuration.h"
+#include "kafka/server/audit_log_manager.h"
 #include "kafka/server/coordinator_ntp_mapper.h"
 #include "kafka/server/group_manager.h"
 #include "kafka/server/group_router.h"
@@ -179,6 +180,23 @@ set_sr_kafka_client_defaults(kafka::client::configuration& client_config) {
     if (!client_config.client_identifier.is_overriden()) {
         client_config.client_identifier.set_value(
           std::make_optional<ss::sstring>("schema_registry_client"));
+    }
+}
+
+static void set_auditing_kafka_client_defaults(
+  kafka::client::configuration& client_config) {
+    if (!client_config.produce_batch_delay.is_overriden()) {
+        client_config.produce_batch_delay.set_value(0ms);
+    }
+    if (!client_config.produce_batch_record_count.is_overriden()) {
+        client_config.produce_batch_record_count.set_value(int32_t(0));
+    }
+    if (!client_config.produce_batch_size_bytes.is_overriden()) {
+        client_config.produce_batch_size_bytes.set_value(int32_t(0));
+    }
+    if (!client_config.client_identifier.is_overriden()) {
+        client_config.client_identifier.set_value(
+          std::make_optional<ss::sstring>("audit_log_client"));
     }
 }
 
@@ -401,6 +419,7 @@ void application::initialize(
   std::optional<YAML::Node> proxy_client_cfg,
   std::optional<YAML::Node> schema_reg_cfg,
   std::optional<YAML::Node> schema_reg_client_cfg,
+  std::optional<YAML::Node> audit_log_client_cfg,
   std::optional<scheduling_groups> groups) {
     construct_service(
       _memory_sampling, std::ref(_log), ss::sharded_parameter([]() {
@@ -491,6 +510,9 @@ void application::initialize(
 
     if (schema_reg_client_cfg) {
         _schema_reg_client_config.emplace(*schema_reg_client_cfg);
+    }
+    if (audit_log_client_cfg) {
+        _audit_log_client_config.emplace(*audit_log_client_cfg);
     }
 }
 
@@ -712,6 +734,15 @@ void application::hydrate_config(const po::variables_map& cfg) {
         config_printer("schema_registry", *_schema_reg_config);
         config_printer("schema_registry_client", *_schema_reg_client_config);
     }
+    /// Auditing will be toggled via cluster config settings, internal audit
+    /// client options can be configured via local config properties
+    if (config["audit_log_client"]) {
+        _audit_log_client_config.emplace(config["audit_log_client"]);
+    } else {
+        set_local_kafka_client_config(_audit_log_client_config, config::node());
+    }
+    set_auditing_kafka_client_defaults(*_audit_log_client_config);
+    config_printer("audit_log_client", *_audit_log_client_config);
 }
 
 void application::check_environment() {
@@ -1339,6 +1370,11 @@ void application::wire_up_redpanda_services(
     construct_service(quota_mgr).get();
     construct_service(snc_quota_mgr).get();
 
+    syschecks::systemd_message("Creating auditing subsystem").get();
+    construct_service(
+      audit_mgr, controller.get(), std::ref(*_audit_log_client_config))
+      .get();
+
     syschecks::systemd_message("Creating metadata dissemination service").get();
     construct_service(
       md_dissemination_service,
@@ -1699,6 +1735,7 @@ void application::wire_up_redpanda_services(
         std::ref(snc_quota_mgr),
         std::ref(group_router),
         std::ref(usage_manager),
+        std::ref(audit_mgr),
         std::ref(shard_table),
         std::ref(partition_manager),
         std::ref(id_allocator_frontend),
@@ -2131,6 +2168,8 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
           "Started Schema Registry listening at {}",
           _schema_reg_config->schema_registry_api());
     }
+
+    audit_mgr.invoke_on_all(&kafka::audit_log_manager::start).get();
 
     start_kafka(node_id, app_signal);
     controller->set_ready().get();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -78,6 +78,7 @@ public:
       std::optional<YAML::Node> proxy_client_cfg = std::nullopt,
       std::optional<YAML::Node> schema_reg_cfg = std::nullopt,
       std::optional<YAML::Node> schema_reg_client_cfg = std::nullopt,
+      std::optional<YAML::Node> audit_log_client_cfg = std::nullopt,
       std::optional<scheduling_groups> = std::nullopt);
     void check_environment();
     void wire_up_and_start(::stop_signal&, bool test_mode = false);
@@ -130,6 +131,7 @@ public:
     ss::sharded<kafka::group_router> group_router;
     ss::sharded<kafka::quota_manager> quota_mgr;
     ss::sharded<kafka::snc_quota_manager> snc_quota_mgr;
+    ss::sharded<kafka::audit_log_manager> audit_mgr;
     ss::sharded<kafka::rm_group_frontend> rm_group_frontend;
     ss::sharded<kafka::usage_manager> usage_manager;
 
@@ -250,6 +252,7 @@ private:
     std::optional<pandaproxy::schema_registry::configuration>
       _schema_reg_config;
     std::optional<kafka::client::configuration> _schema_reg_client_config;
+    std::optional<kafka::client::configuration> _audit_log_client_config;
     scheduling_groups_probe _scheduling_groups_probe;
     ss::logger _log;
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -117,6 +117,7 @@ public:
           proxy_client_config(kafka_port),
           schema_reg_config(schema_reg_port),
           proxy_client_config(kafka_port),
+          audit_log_client_config(kafka_port),
           sch_groups);
         app.check_environment();
         app.wire_up_and_start(*app_signal, true);
@@ -407,6 +408,16 @@ public:
               .address = net::unresolved_address("127.0.0.1", listen_port)}});
         cfg.get("schema_registry_replication_factor")
           .set_value(std::make_optional<int16_t>(1));
+        return to_yaml(cfg, config::redact_secrets::no);
+    }
+
+    YAML::Node audit_log_client_config(
+      uint16_t kafka_api_port = config::node().kafka_api()[0].address.port()) {
+        kafka::client::configuration cfg;
+        net::unresolved_address kafka_api{
+          config::node().kafka_api()[0].address.host(), kafka_api_port};
+        cfg.brokers.set_value(
+          std::vector<net::unresolved_address>({kafka_api}));
         return to_yaml(cfg, config::redact_secrets::no);
     }
 

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -141,6 +141,7 @@ public:
             std::ref(app.snc_quota_mgr),
             std::ref(app.group_router),
             std::ref(app.usage_manager),
+            std::ref(app.audit_mgr),
             std::ref(app.shard_table),
             std::ref(app.partition_manager),
             std::ref(app.id_allocator_frontend),

--- a/src/v/security/audit/schemas/application_activity.h
+++ b/src/v/security/audit/schemas/application_activity.h
@@ -15,7 +15,7 @@
 #include "security/audit/schemas/types.h"
 
 namespace security::audit {
-class api_activity final : public ocsf_base_event {
+class api_activity final : public ocsf_base_event<api_activity> {
 public:
     enum class activity_id : uint8_t {
         unknown = 0,
@@ -118,7 +118,8 @@ private:
     }
 };
 
-class application_lifecycle final : public ocsf_base_event {
+class application_lifecycle final
+  : public ocsf_base_event<application_lifecycle> {
 public:
     enum class activity_id : uint8_t {
         unknown = 0,

--- a/src/v/security/audit/schemas/iam.h
+++ b/src/v/security/audit/schemas/iam.h
@@ -16,7 +16,7 @@
 #include "security/audit/schemas/types.h"
 
 namespace security::audit {
-class authentication final : public ocsf_base_event {
+class authentication final : public ocsf_base_event<authentication> {
 public:
     using used_cleartext = ss::bool_class<struct used_cleartext_tag>;
     using used_mfa = ss::bool_class<struct used_mfa_tag>;

--- a/src/v/security/audit/schemas/schemas.h
+++ b/src/v/security/audit/schemas/schemas.h
@@ -55,13 +55,10 @@ public:
     }
 
     size_t key() const noexcept final {
-        if (!_key) [[unlikely]] {
-            size_t h = 0;
-            boost::hash_combine(h, this->hash());
-            boost::hash_combine(h, this->base_hash());
-            _key.emplace(h);
-        }
-        return *_key;
+        size_t h = 0;
+        boost::hash_combine(h, this->hash());
+        boost::hash_combine(h, this->base_hash());
+        return h;
     }
 
     ss::sstring to_json() const final {
@@ -134,8 +131,6 @@ private:
     timestamp_t _start_time;
     timestamp_t _time;
     type_uid _type_uid;
-
-    mutable std::optional<size_t> _key;
 
     size_t base_hash() const {
         size_t h = 0;


### PR DESCRIPTION
This pull request adds the backbone for what will eventually be the mechanism for which audit events will be batched and produced onto the audit log. It introduces a new service called the `audit_log_manager` which is responsible for a few things:

1. Managing the lifetime of a single Kafka client, which is allocated/deallocated when the global audit switch is toggled.
2. Creation of the audit topic, its properties and corresponding ACLs
3. Contains a mechanism for coalescing non-unique events to decrease the number of audit messages that will be produced.
4. Spawns new fibers (one per core) to periodically consume the batched audit events and send to the core responsible for producing them. This reduces the number of calls to that core and allows the coalescing logic more time to remove non-unique events.

Although the logic stated above is included in this pull request, the global audit switch is defaulted to `false` and there are no call sites which will currently add any audit events to the `audit_log_manager`. Further work to introduce these audit points will exercise the code path.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
