### PR TITLE
schema_registry/store: Don't return a subject with no versions

### DIFF
--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -175,7 +175,12 @@ public:
         res.reserve(_subjects.size());
         for (const auto& sub : _subjects) {
             if (inc_del || !sub.second.deleted) {
-                res.push_back(sub.first);
+                auto has_version = absl::c_any_of(
+                  sub.second.versions,
+                  [inc_del](auto const& v) { return inc_del || !v.deleted; });
+                if (has_version) {
+                    res.push_back(sub.first);
+                }
             }
         }
         return res;


### PR DESCRIPTION
A subject may exist internally due to compatibility config or soft-deleted versions, but should not always be returned in the list of subjects.

This may fix #13376

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Bug Fixes

* Schema Registry: `GET /subjects` no longer returns a subject that has no versions or only deleted versions (unless `?deleted=true`)
