### PR TITLE
cloud_storage: add nodiscard to download and upload result

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1194,7 +1194,11 @@ ss::future<ntp_archiver_upload_result> ntp_archiver::upload_segment(
           _conf->cloud_storage_initial_backoff,
           &rtc.get());
 
-        co_await _remote.upload_object(
+        // If we fail to upload the index but successfully upload the segment,
+        // the read path will create the index on the fly while downloading the
+        // segment, so it is okay to ignore the index upload failure, we still
+        // want to advance the offsets because the segment did get uploaded.
+        std::ignore = co_await _remote.upload_object(
           _conf->bucket_name,
           cloud_storage_clients::object_key{index_path},
           idx_res->index.to_iobuf(),
@@ -2041,7 +2045,11 @@ ntp_archiver::maybe_truncate_manifest() {
             vlog(
               ctxlog.debug,
               "archival metadata STM update passed, re-uploading manifest");
-            co_await upload_manifest(sync_local_state_ctx_label);
+
+            // The manifest upload will be retried after some time because the
+            // STM will have the 'dirty' flag set. `upload_manifest` will log an
+            // error so it won't be invisible.
+            std::ignore = co_await upload_manifest(sync_local_state_ctx_label);
         }
         vlog(
           ctxlog.info,

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -68,14 +68,14 @@ enum class segment_name_format : int16_t {
 
 std::ostream& operator<<(std::ostream& o, const segment_name_format& r);
 
-enum class download_result : int32_t {
+enum class [[nodiscard]] download_result : int32_t {
     success,
     notfound,
     timedout,
     failed,
 };
 
-enum class upload_result : int32_t {
+enum class [[nodiscard]] upload_result : int32_t {
     success,
     timedout,
     failed,


### PR DESCRIPTION
Force callers to handle failures or to be explicit about why failures aren't important.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
