### PR TITLE
schema_registry: Fix error message for compatibility

### DIFF
--- a/src/v/pandaproxy/schema_registry/error.cc
+++ b/src/v/pandaproxy/schema_registry/error.cc
@@ -66,9 +66,9 @@ struct error_category final : std::error_category {
         case error_code::topic_parse_error:
             return "Unexpected data found in topic";
         case error_code::compatibility_level_invalid:
-            return "Invalid compatibility level. Valid values are none, "
-                   "backward, forward, full, backward_transitive, "
-                   "forward_transitive, and full_transitive";
+            return "Invalid compatibility level. Valid values are NONE, "
+                   "BACKWARD, FORWARD, FULL, BACKWARD_TRANSITIVE, "
+                   "FORWARD_TRANSITIVE, and FULL_TRANSITIVE";
         }
         return "(unrecognized error)";
     }


### PR DESCRIPTION
The compatibility levels must be specified in uppercase; improve the error message by uppercasing the levels.

Fixes #13873

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Schema Registry: Improve error message for invalid compatibility level