### PR TITLE
tests/redpanda: do not allow getting redpanda pid cmd to fail

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2930,9 +2930,7 @@ class RedpandaService(RedpandaServiceBase):
     def redpanda_pid(self, node, timeout=None, silent=True):
         try:
             cmd = "pgrep --list-full --exact redpanda"
-            for line in node.account.ssh_capture(cmd,
-                                                 allow_fail=True,
-                                                 timeout_sec=10):
+            for line in node.account.ssh_capture(cmd, timeout_sec=10):
                 # Ignore SSH commands that lookup the version of redpanda
                 # by running `redpanda --version` like in `self.get_version(node)`
                 if "--version" in line:


### PR DESCRIPTION
Setting `allow_fail` flag in ducktape `RemoteAccount::ssh_capture` makes the function to ignore an error. This prevented the `try except` block from intercepting an error and returning `None`.

By not allowing command to fail we make the error handling correct.

Fixes: #8362

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none