### PR TITLE
archival: Add offset_range_size method to the storage::log

### DIFF
--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -171,6 +171,15 @@ operator-(model::offset r, kafka::offset k) {
     return model::offset_delta{r() - k()};
 }
 
+/// \brief offset boundary type
+///
+/// indicate whether or not the offset that encodes the end of the offset
+/// range belongs to the offset range
+enum class boundary_type {
+    exclusive,
+    inclusive,
+};
+
 /// \brief cast to model::offset
 ///
 /// The purpose of this function is to mark every place where we converting

--- a/src/v/model/timeout_clock.h
+++ b/src/v/model/timeout_clock.h
@@ -35,4 +35,13 @@ time_from_now(model::timeout_clock::duration d) {
     return d < remaining ? now + d : model::no_timeout;
 }
 
+inline model::timeout_clock::duration
+time_until(model::timeout_clock::time_point deadline) {
+    const auto now = model::timeout_clock::now();
+    if (deadline < now) {
+        return model::timeout_clock::duration(0);
+    }
+    return deadline - now;
+}
+
 } // namespace model

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2167,6 +2167,20 @@ ss::future<log::offset_range_size_result_t> disk_log_impl::offset_range_size(
     };
 }
 
+bool disk_log_impl::is_compacted(
+  model::offset first, model::offset last) const {
+    for (auto it = _segs.lower_bound(first); it != _segs.end(); it++) {
+        const auto& lstat = it->get()->offsets();
+        if (lstat.base_offset > last) {
+            break;
+        }
+        if (it->get()->is_compacted_segment()) {
+            return true;
+        }
+    }
+    return false;
+}
+
 ss::future<model::record_batch_reader>
 disk_log_impl::make_reader(log_reader_config config) {
     vassert(!_closed, "make_reader on closed log - {}", *this);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1749,6 +1749,9 @@ disk_log_impl::make_reader(log_reader_config config) {
         return ss::make_ready_future<model::record_batch_reader>(
           std::move(empty));
     }
+    if (config.skip_readers_cache) {
+        return make_unchecked_reader(config);
+    }
     return make_cached_reader(config);
 }
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -84,6 +84,16 @@ public:
       model::offset last,
       ss::io_priority_class io_priority) override;
 
+    /// Find the offset range based on size requirements
+    ///
+    /// The 'first' offset should be the first offset of the batch. The 'target'
+    /// contains size requirements. The desired target size and smallest
+    /// acceptable size.
+    ss::future<offset_range_size_result_t> offset_range_size(
+      model::offset first,
+      offset_range_size_requirements_t target,
+      ss::io_priority_class io_priority) override;
+
     ss::future<model::record_batch_reader> make_reader(log_reader_config) final;
     ss::future<model::record_batch_reader> make_reader(timequery_config);
     // External synchronization: only one append can be performed at a time.

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -198,7 +198,7 @@ private:
     /// Compute file offset of the batch inside the segment
     ss::future<size_t> get_file_offset(
       ss::lw_shared_ptr<segment> s,
-      segment_index::entry index_entry,
+      std::optional<segment_index::entry> index_entry,
       model::offset target,
       model::boundary_type boundary,
       ss::io_priority_class priority);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -26,6 +26,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/io_priority_class.hh>
 
 #include <absl/container/flat_hash_map.h>
 
@@ -73,6 +74,15 @@ public:
     ss::future<> gc(gc_config) final;
 
     ss::future<model::offset> monitor_eviction(ss::abort_source&) final;
+
+    /// Compute number of bytes between the two offset (including both offsets)
+    ///
+    /// The 'first' offset should be the first offset of the batch. The 'last'
+    /// should be the last offset of the batch. The offset range is inclusive.
+    ss::future<offset_range_size_result_t> offset_range_size(
+      model::offset first,
+      model::offset last,
+      ss::io_priority_class io_priority) override;
 
     ss::future<model::record_batch_reader> make_reader(log_reader_config) final;
     ss::future<model::record_batch_reader> make_reader(timequery_config);
@@ -171,6 +181,14 @@ private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
     friend std::ostream& operator<<(std::ostream& o, const disk_log_impl& d);
+
+    /// Compute file offset of the batch inside the segment
+    ss::future<size_t> get_file_offset(
+      ss::lw_shared_ptr<segment> s,
+      segment_index::entry index_entry,
+      model::offset target,
+      bool is_inclusive,
+      ss::io_priority_class priority);
 
     ss::future<model::record_batch_reader>
       make_unchecked_reader(log_reader_config);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -94,6 +94,9 @@ public:
       offset_range_size_requirements_t target,
       ss::io_priority_class io_priority) override;
 
+    /// Return true if the offset range contains compacted data
+    bool is_compacted(model::offset first, model::offset last) const override;
+
     ss::future<model::record_batch_reader> make_reader(log_reader_config) final;
     ss::future<model::record_batch_reader> make_reader(timequery_config);
     // External synchronization: only one append can be performed at a time.

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -200,7 +200,7 @@ private:
       ss::lw_shared_ptr<segment> s,
       segment_index::entry index_entry,
       model::offset target,
-      bool is_inclusive,
+      model::boundary_type boundary,
       ss::io_priority_class priority);
 
     ss::future<model::record_batch_reader>

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -79,7 +79,7 @@ public:
     ///
     /// The 'first' offset should be the first offset of the batch. The 'last'
     /// should be the last offset of the batch. The offset range is inclusive.
-    ss::future<offset_range_size_result_t> offset_range_size(
+    ss::future<std::optional<offset_range_size_result_t>> offset_range_size(
       model::offset first,
       model::offset last,
       ss::io_priority_class io_priority) override;
@@ -89,7 +89,7 @@ public:
     /// The 'first' offset should be the first offset of the batch. The 'target'
     /// contains size requirements. The desired target size and smallest
     /// acceptable size.
-    ss::future<offset_range_size_result_t> offset_range_size(
+    ss::future<std::optional<offset_range_size_result_t>> offset_range_size(
       model::offset first,
       offset_range_size_requirements_t target,
       ss::io_priority_class io_priority) override;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -137,12 +137,21 @@ public:
         size_t min_size;
     };
 
+    /// Compute number of bytes between the two offset (including both offsets)
+    ///
+    /// The 'first' offset should be the first offset of the batch. The 'last'
+    /// should be the last offset of the batch. The offset range is inclusive.
     virtual ss::future<offset_range_size_result_t> offset_range_size(
       model::offset first,
       model::offset last,
       ss::io_priority_class io_priority)
       = 0;
 
+    /// Find the offset range based on size requirements
+    ///
+    /// The 'first' offset should be the first offset of the batch. The 'target'
+    /// contains size requirements. The desired target size and smallest
+    /// acceptable size.
     virtual ss::future<offset_range_size_result_t> offset_range_size(
       model::offset first,
       offset_range_size_requirements_t target,

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -143,6 +143,12 @@ public:
       ss::io_priority_class io_priority)
       = 0;
 
+    virtual ss::future<offset_range_size_result_t> offset_range_size(
+      model::offset first,
+      offset_range_size_requirements_t target,
+      ss::io_priority_class io_priority)
+      = 0;
+
     virtual ss::future<>
       update_configuration(ntp_config::default_overrides) = 0;
 

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -141,7 +141,8 @@ public:
     ///
     /// The 'first' offset should be the first offset of the batch. The 'last'
     /// should be the last offset of the batch. The offset range is inclusive.
-    virtual ss::future<offset_range_size_result_t> offset_range_size(
+    virtual ss::future<std::optional<offset_range_size_result_t>>
+    offset_range_size(
       model::offset first,
       model::offset last,
       ss::io_priority_class io_priority)
@@ -152,7 +153,8 @@ public:
     /// The 'first' offset should be the first offset of the batch. The 'target'
     /// contains size requirements. The desired target size and smallest
     /// acceptable size.
-    virtual ss::future<offset_range_size_result_t> offset_range_size(
+    virtual ss::future<std::optional<offset_range_size_result_t>>
+    offset_range_size(
       model::offset first,
       offset_range_size_requirements_t target,
       ss::io_priority_class io_priority)

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -149,6 +149,9 @@ public:
       ss::io_priority_class io_priority)
       = 0;
 
+    virtual bool is_compacted(model::offset first, model::offset last) const
+      = 0;
+
     virtual ss::future<>
       update_configuration(ntp_config::default_overrides) = 0;
 

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -126,6 +126,23 @@ public:
     virtual size_t size_bytes() const = 0;
     // Byte size of the log for all segments after offset 'o'
     virtual uint64_t size_bytes_after_offset(model::offset o) const = 0;
+
+    struct offset_range_size_result_t {
+        size_t on_disk_size;
+        model::offset last_offset;
+    };
+
+    struct offset_range_size_requirements_t {
+        size_t target_size;
+        size_t min_size;
+    };
+
+    virtual ss::future<offset_range_size_result_t> offset_range_size(
+      model::offset first,
+      model::offset last,
+      ss::io_priority_class io_priority)
+      = 0;
+
     virtual ss::future<>
       update_configuration(ntp_config::default_overrides) = 0;
 

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -97,6 +97,11 @@ readers_cache::get_reader(const log_reader_config& cfg) {
     if (_gate.is_closed()) {
         return std::nullopt;
     }
+    vassert(
+      cfg.skip_readers_cache == false,
+      "{} - invalid readers_cache request {}",
+      _ntp,
+      cfg);
     vlog(stlog.trace, "{} - trying to get reader for: {}", _ntp, cfg);
     intrusive_list<entry, &entry::_hook> to_evict;
     /**

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -10,6 +10,7 @@
 #include "storage/segment_index.h"
 
 #include "base/vassert.h"
+#include "model/fundamental.h"
 #include "model/timestamp.h"
 #include "serde/serde.h"
 #include "storage/index_state.h"
@@ -157,6 +158,41 @@ segment_index::find_nearest(model::timestamp t) {
     }
 
     return translate_index_entry(_state, *entry);
+}
+
+std::optional<segment_index::entry>
+segment_index::find_above_size_bytes(size_t distance) {
+    if (_state.empty()) {
+        return std::nullopt;
+    }
+    auto it = std::upper_bound(
+      std::begin(_state.position_index),
+      std::end(_state.position_index),
+      distance);
+
+    if (it == _state.position_index.end()) {
+        return std::nullopt;
+    }
+    int i = std::distance(_state.position_index.begin(), it);
+    return translate_index_entry(_state, _state.get_entry(i));
+}
+
+std::optional<segment_index::entry>
+segment_index::find_below_size_bytes(size_t distance) {
+    if (_state.empty()) {
+        return std::nullopt;
+    }
+    auto it = std::upper_bound(
+      std::begin(_state.position_index),
+      std::end(_state.position_index),
+      distance);
+
+    if (it != _state.position_index.begin()) {
+        it = std::prev(it);
+    }
+
+    int i = std::distance(_state.position_index.begin(), it);
+    return translate_index_entry(_state, _state.get_entry(i));
 }
 
 std::optional<segment_index::entry>

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -189,6 +189,8 @@ segment_index::find_below_size_bytes(size_t distance) {
 
     if (it != _state.position_index.begin()) {
         it = std::prev(it);
+    } else {
+        return std::nullopt;
     }
 
     int i = std::distance(_state.position_index.begin(), it);

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -153,6 +153,12 @@ public:
       size_t filepos);
     std::optional<entry> find_nearest(model::offset);
     std::optional<entry> find_nearest(model::timestamp);
+    /// Find entry by file offset (the value may overshoot or find precise
+    /// match)
+    std::optional<entry> find_above_size_bytes(size_t distance);
+    /// Find entry by file offset (the value will undershoot or find precise
+    /// match)
+    std::optional<entry> find_below_size_bytes(size_t distance);
 
     /// Fallback timestamp search for if the recorded max ts appears to be
     /// invalid, e.g. too far in the future

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -4077,6 +4077,12 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
 
 FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
 #ifdef NDEBUG
+    // This test generates 300 segments and creates a record batch map.
+    // Then it runs compaction and creates a second record batch map. Then it
+    // uses offset_range_size method to fetch segments of various sizes. We need
+    // to maps to be able to start on every offset, not only offsets that
+    // survived compaction. The pre-compaction map is used to pick starting
+    // point. The post-compaction map is used to calculate the expected size.
     size_t num_test_cases = 5000;
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3697,6 +3697,10 @@ FIXTURE_TEST(test_offset_range_size, storage_test_fixture) {
 
 FIXTURE_TEST(test_offset_range_size2, storage_test_fixture) {
 #ifdef NDEBUG
+    // This test generates 300 segments and creates a record batch map.
+    // Then it runs size-based offset_range_size method overload with
+    // randomly generated parameters 5000 times. The record batch map
+    // is used to find expected offset range size.
     size_t num_test_cases = 5000;
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3572,6 +3572,17 @@ struct batch_summary_accumulator {
     std::vector<size_t>* prev_size;
 };
 
+struct batch_size_accumulator {
+    ss::future<ss::stop_iteration> operator()(model::record_batch b) {
+        auto batch_size = b.data().size_bytes()
+                          + model::packed_record_batch_header_size;
+        *size_bytes += batch_size;
+        co_return ss::stop_iteration::no;
+    }
+    bool end_of_stream() const { return false; }
+    size_t* size_bytes;
+};
+
 FIXTURE_TEST(test_offset_range_size, storage_test_fixture) {
 #ifdef NDEBUG
     size_t num_test_cases = 5000;
@@ -4017,6 +4028,265 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
           ss::default_priority_class())
         .get(),
       std::invalid_argument);
+
+#endif
+};
+
+FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
+#ifdef NDEBUG
+    size_t num_test_cases = 5000;
+    auto cfg = default_log_config(test_dir);
+    ss::abort_source as;
+    storage::log_manager mgr = make_log_manager(cfg);
+    info("Configuration: {}", mgr.config());
+    auto deferred = ss::defer([&mgr]() mutable { mgr.stop().get(); });
+    auto ntp = model::ntp("kafka", "test-topic", 0);
+
+    storage::ntp_config::default_overrides overrides{
+      .cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction,
+    };
+    storage::ntp_config ntp_cfg(
+      ntp,
+      mgr.config().base_dir,
+      std::make_unique<storage::ntp_config::default_overrides>(overrides));
+
+    auto log = mgr.manage(std::move(ntp_cfg)).get();
+
+    model::offset first_segment_last_offset;
+    for (int i = 0; i < 300; i++) {
+        append_random_batches(
+          log, 10, model::term_id(0), key_limited_random_batch_generator());
+        if (first_segment_last_offset == model::offset{}) {
+            first_segment_last_offset = log->offsets().dirty_offset;
+        }
+        log->force_roll(ss::default_priority_class()).get();
+    }
+
+    // Build the maps before and after compaction (nc_ vs c_) to reflect the
+    // changes
+    std::vector<batch_summary> nc_summaries;
+    std::vector<size_t> nc_acc_size;
+    std::vector<size_t> nc_prev_size;
+
+    std::vector<batch_summary> c_summaries;
+    std::vector<size_t> c_acc_size;
+    std::vector<size_t> c_prev_size;
+
+    // Read non-compacted version
+    storage::log_reader_config nc_reader_cfg(
+      model::offset(0), model::offset::max(), ss::default_priority_class());
+    auto nc_reader = log->make_reader(nc_reader_cfg).get();
+    batch_summary_accumulator nc_acc{
+      .summaries = &nc_summaries,
+      .acc_size = &nc_acc_size,
+      .prev_size = &nc_prev_size,
+    };
+    std::move(nc_reader).consume(nc_acc, model::no_timeout).get();
+
+    // Compact topic
+    vlog(e2e_test_log.info, "Starting compaction");
+    storage::housekeeping_config h_cfg(
+      model::timestamp::min(),
+      std::nullopt,
+      log->offsets().committed_offset,
+      ss::default_priority_class(),
+      as);
+    log->housekeeping(h_cfg).get();
+
+    // Read compacted version
+    storage::log_reader_config c_reader_cfg(
+      model::offset(0), model::offset::max(), ss::default_priority_class());
+    auto c_reader = log->make_reader(c_reader_cfg).get();
+    batch_summary_accumulator c_acc{
+      .summaries = &c_summaries,
+      .acc_size = &c_acc_size,
+      .prev_size = &c_prev_size,
+    };
+    std::move(c_reader).consume(c_acc, model::no_timeout).get();
+
+    auto num_compacted = nc_summaries.size() - c_summaries.size();
+    vlog(
+      e2e_test_log.info,
+      "Number of compacted batches: {} (before {}, after {})",
+      num_compacted,
+      nc_summaries.size(),
+      c_summaries.size());
+    vlog(
+      e2e_test_log.info,
+      "Size before compaction {}, size after compaction {}",
+      nc_acc_size.back(),
+      c_acc_size.back());
+    BOOST_REQUIRE(num_compacted > 0);
+
+    for (const auto& s : c_summaries) {
+        vlog(
+          e2e_test_log.debug,
+          "compacted segment {}-{} size: {}",
+          s.base,
+          s.last,
+          s.batch_size);
+    }
+
+    for (size_t i = 0; i < num_test_cases; i++) {
+        // - pick 'base' randomly (use non-compacted list to make sure
+        //   that some requests are starting inside the gaps)
+        // - translate to compacted index
+        // - pick target upload size randomly
+        // - do the query
+        // - query the log and compare the result
+        auto base_ix = model::test::get_int((size_t)0, nc_summaries.size() - 1);
+        auto base = nc_summaries[base_ix].base;
+        // convert to compacted
+        auto c_it_base = std::lower_bound(
+          c_summaries.begin(),
+          c_summaries.end(),
+          batch_summary{.base = base},
+          [](const batch_summary& lhs, const batch_summary& rhs) {
+              return lhs.base < rhs.base;
+          });
+        auto c_ix_base = std::distance(c_summaries.begin(), c_it_base);
+        // we should use size after compaction in the query
+        auto max_size = c_acc_size.back() - c_prev_size[c_ix_base];
+        auto min_size = 1UL;
+        auto target_size = model::test::get_int(min_size, max_size);
+
+        vlog(
+          e2e_test_log.debug,
+          "NON-COMPACTED start offset: {}, COMPACTED start offset: {}, target "
+          "size: {}",
+          base,
+          c_summaries[c_ix_base].base,
+          c_ix_base,
+          target_size);
+
+        auto result = log
+                        ->offset_range_size(
+                          base,
+                          storage::log::offset_range_size_requirements_t{
+                            .target_size = target_size,
+                            .min_size = 0,
+                          },
+                          ss::default_priority_class())
+                        .get();
+
+        auto last_offset = result.last_offset;
+
+        size_t expected_size = 0;
+
+        storage::log_reader_config c_reader_cfg(
+          base, last_offset, ss::default_priority_class());
+        c_reader_cfg.skip_readers_cache = true;
+        c_reader_cfg.skip_batch_cache = true;
+        auto c_log_rdr = log->make_reader(std::move(c_reader_cfg)).get();
+        batch_size_accumulator c_size_acc{
+          .size_bytes = &expected_size,
+        };
+        std::move(c_log_rdr).consume(c_size_acc, model::no_timeout).get();
+        BOOST_REQUIRE_EQUAL(expected_size, result.on_disk_size);
+        BOOST_REQUIRE(result.on_disk_size >= target_size);
+    }
+
+    auto new_start_offset = model::next_offset(first_segment_last_offset);
+    log
+      ->truncate_prefix(storage::truncate_prefix_config(
+        new_start_offset, ss::default_priority_class()))
+      .get();
+
+    auto lstat = log->offsets();
+    BOOST_REQUIRE_EQUAL(lstat.start_offset, new_start_offset);
+
+    // Check that out of range access triggers exception.
+
+    BOOST_REQUIRE_THROW(
+      log
+        ->offset_range_size(
+          model::offset(0),
+          storage::log::offset_range_size_requirements_t{
+            .target_size = 0x10000,
+            .min_size = 1,
+          },
+          ss::default_priority_class())
+        .get(),
+      std::invalid_argument);
+
+    // Query committed offset of the last batch, expect
+    // no result.
+
+    auto res = log
+                 ->offset_range_size(
+                   nc_summaries.back().last,
+                   storage::log::offset_range_size_requirements_t{
+                     .target_size = 0x10000,
+                     .min_size = 0,
+                   },
+                   ss::default_priority_class())
+                 .get();
+
+    BOOST_REQUIRE_EQUAL(res.last_offset, model::offset{});
+
+    // Query offset out of range to trigger the exception.
+
+    BOOST_REQUIRE_THROW(
+      log
+        ->offset_range_size(
+          model::next_offset(c_summaries.back().last),
+          storage::log::offset_range_size_requirements_t{
+            .target_size = 0x10000,
+            .min_size = 0,
+          },
+          ss::default_priority_class())
+        .get(),
+      std::invalid_argument);
+
+    // Check that the last batch can be measured independently
+    res = log
+            ->offset_range_size(
+              c_summaries.back().base,
+              storage::log::offset_range_size_requirements_t{
+                .target_size = 0x10000,
+                .min_size = 0,
+              },
+              ss::default_priority_class())
+            .get();
+
+    // Only one batch is returned
+    BOOST_REQUIRE_EQUAL(res.last_offset, lstat.committed_offset);
+    BOOST_REQUIRE_EQUAL(
+      res.on_disk_size, c_acc_size.back() - c_prev_size.back());
+
+    // Check that we can measure the size of the log tail. This is needed for
+    // timed uploads.
+    size_t tail_length = 5;
+
+    for (size_t i = 0; i < tail_length; i++) {
+        auto ix_batch = c_summaries.size() - 1 - i;
+        res = log
+                ->offset_range_size(
+                  c_summaries.at(ix_batch).base,
+                  storage::log::offset_range_size_requirements_t{
+                    .target_size = 0x10000,
+                    .min_size = 0,
+                  },
+                  ss::default_priority_class())
+                .get();
+
+        BOOST_REQUIRE_EQUAL(res.last_offset, lstat.committed_offset);
+        BOOST_REQUIRE_EQUAL(
+          res.on_disk_size, c_acc_size.back() - c_prev_size.at(ix_batch));
+    }
+
+    // Check that the min_size is respected
+    res = log
+            ->offset_range_size(
+              c_summaries.back().base,
+              storage::log::offset_range_size_requirements_t{
+                .target_size = 0x10000,
+                .min_size = c_summaries.back().batch_size + 1,
+              },
+              ss::default_priority_class())
+            .get();
+
+    BOOST_REQUIRE_EQUAL(res.last_offset, model::offset{});
 
 #endif
 };

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -4023,9 +4023,17 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
           [](const batch_summary& lhs, const batch_summary& rhs) {
               return lhs.last < rhs.last;
           });
-        c_it_last = std::prev(c_it_last);
+        bool fully_compacted_range = false;
+        if (c_it_last != c_summaries.begin()) {
+            c_it_last = std::prev(c_it_last);
+        } else {
+            // fully compacted
+            fully_compacted_range = true;
+        }
         auto c_ix_last = std::distance(c_summaries.begin(), c_it_last);
-        auto expected_size = c_acc_size[c_ix_last] - c_prev_size[c_ix_base];
+        auto expected_size = fully_compacted_range
+                               ? 0
+                               : c_acc_size[c_ix_last] - c_prev_size[c_ix_base];
         vlog(
           e2e_test_log.debug,
           "NON-COMPACTED offset range: {}-{} (indexes: {}-{}), "

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3899,6 +3899,13 @@ FIXTURE_TEST(test_offset_range_size2, storage_test_fixture) {
 
 FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
 #ifdef NDEBUG
+    // This test generates 300 segments and creates a record batch map.
+    // Then it runs compaction and creates a second record batch map. Then it
+    // uses offset_range_size method to fetch segments of various sizes. The
+    // parameters for the method are picked up randomly from the pre-compaction
+    // map. The expected result (size of the offset range after compaction) is
+    // calculated using post-compaction batch map. Test checks various corner
+    // cases at the end.
     size_t num_test_cases = 5000;
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3585,11 +3585,16 @@ struct batch_size_accumulator {
 
 FIXTURE_TEST(test_offset_range_size, storage_test_fixture) {
 #ifdef NDEBUG
+    size_t num_test_cases = 5000;
+    size_t num_segments = 300;
+#else
+    size_t num_test_cases = 500;
+    size_t num_segments = 30;
+#endif
     // The test generates 300 segments with random data and the record batch map
     // for it. It generates parameters for the method randomly, invokes the
     // method and validates the result using the batch map. It also checks some
     // corner cases at the end of the test (out of range access, etc).
-    size_t num_test_cases = 5000;
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -3602,7 +3607,7 @@ FIXTURE_TEST(test_offset_range_size, storage_test_fixture) {
     auto log = mgr.manage(std::move(ntp_cfg)).get();
 
     model::offset first_segment_last_offset;
-    for (int i = 0; i < 300; i++) {
+    for (int i = 0; i < num_segments; i++) {
         append_random_batches(
           log,
           10,
@@ -3695,17 +3700,20 @@ FIXTURE_TEST(test_offset_range_size, storage_test_fixture) {
           ss::default_priority_class())
         .get()
       == std::nullopt);
-
-#endif
 };
 
 FIXTURE_TEST(test_offset_range_size2, storage_test_fixture) {
 #ifdef NDEBUG
+    size_t num_test_cases = 5000;
+    size_t num_segments = 300;
+#else
+    size_t num_test_cases = 500;
+    size_t num_segments = 30;
+#endif
     // This test generates 300 segments and creates a record batch map.
     // Then it runs size-based offset_range_size method overload with
     // randomly generated parameters 5000 times. The record batch map
     // is used to find expected offset range size.
-    size_t num_test_cases = 5000;
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -3718,7 +3726,7 @@ FIXTURE_TEST(test_offset_range_size2, storage_test_fixture) {
     auto log = mgr.manage(std::move(ntp_cfg)).get();
 
     model::offset first_segment_last_offset;
-    for (int i = 0; i < 300; i++) {
+    for (int i = 0; i < num_segments; i++) {
         append_random_batches(
           log,
           10,
@@ -3893,12 +3901,16 @@ FIXTURE_TEST(test_offset_range_size2, storage_test_fixture) {
           ss::default_priority_class())
         .get()
       == std::nullopt);
-
-#endif
 };
 
 FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
 #ifdef NDEBUG
+    size_t num_test_cases = 5000;
+    size_t num_segments = 300;
+#else
+    size_t num_test_cases = 500;
+    size_t num_segments = 30;
+#endif
     // This test generates 300 segments and creates a record batch map.
     // Then it runs compaction and creates a second record batch map. Then it
     // uses offset_range_size method to fetch segments of various sizes. The
@@ -3906,7 +3918,6 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
     // map. The expected result (size of the offset range after compaction) is
     // calculated using post-compaction batch map. Test checks various corner
     // cases at the end.
-    size_t num_test_cases = 5000;
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -3925,7 +3936,7 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
     auto log = mgr.manage(std::move(ntp_cfg)).get();
 
     model::offset first_segment_last_offset;
-    for (int i = 0; i < 300; i++) {
+    for (int i = 0; i < num_segments; i++) {
         append_random_batches(
           log, 10, model::term_id(i), key_limited_random_batch_generator());
         if (first_segment_last_offset == model::offset{}) {
@@ -4086,19 +4097,22 @@ FIXTURE_TEST(test_offset_range_size_compacted, storage_test_fixture) {
           ss::default_priority_class())
         .get()
       == std::nullopt);
-
-#endif
 };
 
 FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
 #ifdef NDEBUG
+    size_t num_test_cases = 5000;
+    size_t num_segments = 300;
+#else
+    size_t num_test_cases = 500;
+    size_t num_segments = 30;
+#endif
     // This test generates 300 segments and creates a record batch map.
     // Then it runs compaction and creates a second record batch map. Then it
     // uses offset_range_size method to fetch segments of various sizes. We need
     // to maps to be able to start on every offset, not only offsets that
     // survived compaction. The pre-compaction map is used to pick starting
     // point. The post-compaction map is used to calculate the expected size.
-    size_t num_test_cases = 5000;
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;
     storage::log_manager mgr = make_log_manager(cfg);
@@ -4117,7 +4131,7 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
     auto log = mgr.manage(std::move(ntp_cfg)).get();
 
     model::offset first_segment_last_offset;
-    for (int i = 0; i < 300; i++) {
+    for (int i = 0; i < num_segments; i++) {
         append_random_batches(
           log, 10, model::term_id(0), key_limited_random_batch_generator());
         if (first_segment_last_offset == model::offset{}) {
@@ -4351,12 +4365,14 @@ FIXTURE_TEST(test_offset_range_size2_compacted, storage_test_fixture) {
           ss::default_priority_class())
         .get()
       == std::nullopt);
-
-#endif
 };
 
 FIXTURE_TEST(test_offset_range_size_incremental, storage_test_fixture) {
 #ifdef NDEBUG
+    size_t num_segments = 300;
+#else
+    size_t num_segments = 30;
+#endif
     // This test attempts to consume the log incrementally using overload
     // of the offset_range_size that gets offset+size and returns size+last
     // offset; The idea is to get the size of the section and then to consume it
@@ -4393,7 +4409,7 @@ FIXTURE_TEST(test_offset_range_size_incremental, storage_test_fixture) {
     auto log = mgr.manage(std::move(ntp_cfg)).get();
 
     model::offset first_segment_last_offset;
-    for (int i = 0; i < 300; i++) {
+    for (int i = 0; i < num_segments; i++) {
         append_random_batches(
           log,
           10,
@@ -4484,6 +4500,4 @@ FIXTURE_TEST(test_offset_range_size_incremental, storage_test_fixture) {
             BOOST_REQUIRE_EQUAL(measured_size, res->on_disk_size);
         }
     }
-
-#endif
 };

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3585,6 +3585,10 @@ struct batch_size_accumulator {
 
 FIXTURE_TEST(test_offset_range_size, storage_test_fixture) {
 #ifdef NDEBUG
+    // The test generates 300 segments with random data and the record batch map
+    // for it. It generates parameters for the method randomly, invokes the
+    // method and validates the result using the batch map. It also checks some
+    // corner cases at the end of the test (out of range access, etc).
     size_t num_test_cases = 5000;
     auto cfg = default_log_config(test_dir);
     ss::abort_source as;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -336,6 +336,11 @@ struct log_reader_config {
 
     opt_client_address_t client_address;
 
+    // do not reuse cached readers. if this field is set to true the make_reader
+    // method will proceed with creating a new reader without checking the
+    // readers cache.
+    bool skip_readers_cache{false};
+
     log_reader_config(
       model::offset start_offset,
       model::offset max_offset,


### PR DESCRIPTION
This PR adds a `offset_range_size` methods to the `storage::log`. The implementation in `storage::disk_log_impl` uses segment indexes to find approximate location of the start of the range and approximate location of the last batch. Then it performs short scan to find the precise location.

There are two overloads of the method.
- First one accepts two offsets and returns the size of the range.
- Second one accepts start offset and target size. It finds the last offset of the range and its size.

The method is supposed to be used to create S3 uploads. Currently, the code reads from disk directly and therefore is coupled with the storage format and a lot of internal storage details. Our goal is to decouple local and remote storage by providing clear API boundary.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none