### PR TITLE
wasm: Introduce Factory + Engine Caching

### DIFF
--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -58,9 +58,6 @@ fake_source::read_batch(model::offset offset, ss::abort_source* as) {
 ss::future<> fake_source::push_batch(model::record_batch batch) {
     co_await _batches.push_eventually(std::move(batch));
 }
-std::string_view fake_wasm_engine::function_name() const {
-    return my_metadata.name();
-}
 uint64_t fake_wasm_engine::memory_usage_size_bytes() const {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     return 64_KiB;

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -66,6 +66,5 @@ uint64_t fake_wasm_engine::memory_usage_size_bytes() const {
     return 64_KiB;
 };
 ss::future<> fake_wasm_engine::start() { return ss::now(); }
-ss::future<> fake_wasm_engine::initialize() { return ss::now(); }
 ss::future<> fake_wasm_engine::stop() { return ss::now(); }
 } // namespace transform::testing

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -43,7 +43,6 @@ public:
     ss::future<> start() override;
     ss::future<> stop() override;
 
-    std::string_view function_name() const override;
     uint64_t memory_usage_size_bytes() const override;
 };
 

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -41,7 +41,6 @@ public:
     }
 
     ss::future<> start() override;
-    ss::future<> initialize() override;
     ss::future<> stop() override;
 
     std::string_view function_name() const override;

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -53,7 +53,6 @@ processor::processor(
 ss::future<> processor::start() {
     try {
         co_await _engine->start();
-        co_await _engine->initialize();
     } catch (const std::exception& ex) {
         vlog(_logger.warn, "error starting processor engine: {}", ex);
         _error_callback(_id, _ntp, _meta);

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -32,10 +32,14 @@ class mutex {
 public:
     using duration = typename ss::semaphore::duration;
     using time_point = typename ss::semaphore::time_point;
+    using units = typename ssx::semaphore_units;
 
-    // TODO constructor to pass through name & change callers.
+    // TODO: stop using this constructor and force usage of explicit names.
     mutex()
       : _sem(1, "mutex") {}
+
+    explicit mutex(ss::sstring name)
+      : _sem(1, std::move(name)) {}
 
     template<typename Func>
     auto with(Func&& func) noexcept {
@@ -56,13 +60,15 @@ public:
           });
     }
 
-    auto get_units() noexcept { return ss::get_units(_sem, 1); }
+    ss::future<units> get_units() noexcept { return ss::get_units(_sem, 1); }
 
-    auto get_units(ss::abort_source& as) noexcept {
+    ss::future<units> get_units(ss::abort_source& as) noexcept {
         return ss::get_units(_sem, 1, as);
     }
 
-    auto try_get_units() noexcept { return ss::try_get_units(_sem, 1); }
+    std::optional<units> try_get_units() noexcept {
+        return ss::try_get_units(_sem, 1);
+    }
 
     void broken() noexcept { _sem.broken(); }
 

--- a/src/v/wasm/CMakeLists.txt
+++ b/src/v/wasm/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   HDRS
     api.h
     fwd.h
+    cache.h
   SRCS
     api.cc
     ffi.cc
@@ -13,6 +14,7 @@ v_cc_library(
     transform_module.cc
     wasi.cc
     wasmtime.cc
+    cache.cc
   DEPS
     wasmtime
     v::storage

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -31,7 +31,6 @@ public:
     transform(model::record_batch batch, transform_probe* probe) = 0;
 
     virtual ss::future<> start() = 0;
-    virtual ss::future<> initialize() = 0;
     virtual ss::future<> stop() = 0;
 
     virtual std::string_view function_name() const = 0;

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -33,7 +33,6 @@ public:
     virtual ss::future<> start() = 0;
     virtual ss::future<> stop() = 0;
 
-    virtual std::string_view function_name() const = 0;
     virtual uint64_t memory_usage_size_bytes() const = 0;
 
     engine() = default;

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -86,7 +86,7 @@ public:
      * Create a factory for this transform and the corresponding source wasm
      * module.
      */
-    virtual ss::future<std::unique_ptr<factory>>
+    virtual ss::future<ss::shared_ptr<factory>>
     make_factory(model::transform_metadata, iobuf, ss::logger*) = 0;
     virtual ~runtime() = default;
 };

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -58,7 +58,7 @@ public:
     factory& operator=(const factory&) = delete;
     factory(factory&&) = delete;
     factory& operator=(factory&&) = delete;
-    virtual ss::future<std::unique_ptr<engine>> make_engine() = 0;
+    virtual ss::future<ss::shared_ptr<engine>> make_engine() = 0;
     virtual ~factory() = default;
 };
 

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -24,6 +24,8 @@ namespace wasm {
 /**
  * A wasm engine is a running VM loaded with a user module and capable of
  * transforming batches.
+ *
+ * A wasm engine is local to the core it was created on.
  */
 class engine {
 public:
@@ -50,6 +52,9 @@ public:
  * The idea is that factory has a cached version of the parsed module so the
  * parsing/validation of a wasm module can be only done once and then the
  * attaching to an engine becomes a very fast operation.
+ *
+ * This object is safe to use across multiple threads concurrently. It only uses
+ * local state (and a few std::shared_ptr) to create engines.
  */
 class factory {
 public:
@@ -85,6 +90,9 @@ public:
     /**
      * Create a factory for this transform and the corresponding source wasm
      * module.
+     *
+     * This must only be called on a single shard, but the resulting factory
+     * can be used on any shard and is thread-safe.
      */
     virtual ss::future<ss::shared_ptr<factory>>
     make_factory(model::transform_metadata, iobuf, ss::logger*) = 0;

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "wasm/cache.h"
+
+#include "wasm/logger.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+namespace wasm {
+
+namespace {
+
+/**
+ * Allows sharing an engine between multiple uses.
+ *
+ * Must live on a single core.
+ */
+class shared_engine : public engine {
+public:
+    explicit shared_engine(std::unique_ptr<engine> underlying)
+      : _underlying(std::move(underlying)) {}
+
+    ss::future<model::record_batch>
+    transform(model::record_batch batch, transform_probe* probe) override {
+        auto u = co_await _mu.get_units();
+        auto fut = co_await ss::coroutine::as_future<model::record_batch>(
+          _underlying->transform(std::move(batch), probe));
+        if (!fut.failed()) {
+            co_return fut.get();
+        }
+        // Restart the engine
+        try {
+            co_await _underlying->stop();
+            co_await _underlying->start();
+        } catch (...) {
+            vlog(
+              wasm_log.warn,
+              "failed to restart wasm engine: {}",
+              std::current_exception());
+        }
+        std::rethrow_exception(fut.get_exception());
+    }
+
+    ss::future<> start() override {
+        auto u = co_await _mu.get_units();
+        if (_ref_count++ == 0) {
+            co_await _underlying->start();
+        }
+    }
+    ss::future<> stop() override {
+        vassert(
+          _ref_count > 0, "expected a call to start before a call to stop");
+        auto u = co_await _mu.get_units();
+        if (--_ref_count == 0) {
+            co_await _underlying->stop();
+        }
+    }
+
+    uint64_t memory_usage_size_bytes() const override {
+        return _underlying->memory_usage_size_bytes();
+    }
+
+private:
+    mutex _mu;
+    size_t _ref_count = 0;
+    std::unique_ptr<engine> _underlying;
+};
+}
+
+
+}

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -13,8 +13,13 @@
 
 #include "wasm/logger.h"
 
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/weak_ptr.hh>
 #include <seastar/coroutine/as_future.hh>
+
+#include <absl/container/btree_set.h>
 
 namespace wasm {
 
@@ -26,12 +31,11 @@ namespace {
 constexpr auto gc_interval = std::chrono::minutes(10);
 
 template<typename Key, typename Value>
-ss::future<> gc_btree_map(absl::btree_map<Key, ss::shared_ptr<Value>>* cache) {
+ss::future<> gc_btree_map(absl::btree_map<Key, ss::weak_ptr<Value>>* cache) {
     auto it = cache->begin();
     while (it != cache->end()) {
-        // If the cache is the only thing holding a reference to the entry,
-        // then we can delete the factory from the cache.
-        if (it->second.use_count() == 1) {
+        // If the weak_ptr is `nullptr` then we can remove it from the cache.
+        if (!it->second) {
             it = cache->erase(it);
         } else {
             ++it;
@@ -53,10 +57,16 @@ ss::future<> gc_btree_map(absl::btree_map<Key, ss::shared_ptr<Value>>* cache) {
  *
  * Must live on a single core.
  */
-class shared_engine : public engine {
+class shared_engine
+  : public engine
+  , public ss::enable_shared_from_this<shared_engine>
+  , public ss::weakly_referencable<shared_engine> {
 public:
-    explicit shared_engine(ss::shared_ptr<engine> underlying)
-      : _underlying(std::move(underlying)) {}
+    explicit shared_engine(
+      ss::shared_ptr<engine> underlying,
+      ss::foreign_ptr<ss::shared_ptr<factory>> f)
+      : _underlying(std::move(underlying))
+      , _factory(std::move(f)) {}
 
     ss::future<model::record_batch>
     transform(model::record_batch batch, transform_probe* probe) override {
@@ -102,6 +112,8 @@ private:
     mutex _mu;
     size_t _ref_count = 0;
     ss::shared_ptr<engine> _underlying;
+    // This factory reference is here to keep the cache entry alive.
+    ss::foreign_ptr<ss::shared_ptr<factory>> _factory;
 };
 
 /**
@@ -166,23 +178,28 @@ private:
 /** A cache for engines on a particular core. */
 class engine_cache {
 public:
-    void put(model::offset offset, ss::shared_ptr<engine> engine) {
-        _cache.emplace(offset, std::move(engine));
+    void
+    put(model::offset offset, const ss::shared_ptr<shared_engine>& engine) {
+        auto [_, inserted] = _cache.insert_or_assign(
+          offset, engine->weak_from_this());
+        vassert(inserted, "expected engine to be inserted");
     }
 
     ss::future<mutex::units> lock() { return _mu.get_units(); }
 
     ss::shared_ptr<engine> get(model::offset offset) {
         auto it = _cache.find(offset);
-        if (it == _cache.end()) {
+        if (it == _cache.end() || !it->second) {
             return nullptr;
         }
-        return it->second;
+        return it->second->shared_from_this();
     }
+
+    ss::future<> gc() { return gc_btree_map(&_cache); }
 
 private:
     mutex _mu;
-    absl::btree_map<model::offset, ss::shared_ptr<engine>> _cache;
+    absl::btree_map<model::offset, ss::weak_ptr<shared_engine>> _cache;
 };
 
 /**
@@ -191,10 +208,13 @@ private:
  * Owned by a single core (shared zero) but can be used on any core to make an
  * engine local to that core.
  */
-class cached_factory : public factory {
+class cached_factory
+  : public factory
+  , public ss::enable_shared_from_this<cached_factory>
+  , public ss::weakly_referencable<cached_factory> {
 public:
     cached_factory(
-      ss::shared_ptr<factory> f,
+      ss::foreign_ptr<ss::shared_ptr<factory>> f,
       model::offset offset,
       ss::sharded<engine_cache>* e)
       : _offset(offset)
@@ -207,7 +227,7 @@ public:
         if (engine) {
             co_return engine;
         }
-        // Acquire the lock
+        // Acquire the lock for this core
         auto u = co_await _engine_cache->local().lock();
         // Double check nobody created one while we were grabbing the lock.
         engine = _engine_cache->local().get(_offset);
@@ -215,15 +235,28 @@ public:
             co_return engine;
         }
         // Create the actual engine and put it in the cache.
-        auto created = co_await _underlying->make_engine();
-        created = ss::make_shared<shared_engine>(std::move(created));
-        _engine_cache->local().put(_offset, std::move(created));
-        co_return _engine_cache->local().get(_offset);
+        //
+        // The multiplexing engine keeps a foreign reference to this factory
+        // because the factory exists only on a single shard and nothing is
+        // expected to keep a reference to a factory after the engine is
+        // created.
+        auto foreign_this = co_await foreign_from_this();
+        auto created = ss::make_shared<shared_engine>(
+          co_await _underlying->make_engine(), std::move(foreign_this));
+        _engine_cache->local().put(_offset, created);
+        co_return created;
+    }
+
+    ss::future<ss::foreign_ptr<ss::shared_ptr<factory>>> foreign_from_this() {
+        return ss::smp::submit_to(_underlying.get_owner_shard(), [this] {
+            return ss::make_foreign<ss::shared_ptr<factory>>(
+              shared_from_this());
+        });
     }
 
 private:
     model::offset _offset;
-    ss::shared_ptr<factory> _underlying;
+    ss::foreign_ptr<ss::shared_ptr<factory>> _underlying;
     ss::sharded<engine_cache>* _engine_cache;
 };
 
@@ -236,12 +269,14 @@ caching_runtime::~caching_runtime() = default;
 
 ss::future<> caching_runtime::start() {
     co_await _underlying->start();
+    co_await _engine_caches.start();
     _gc_timer.arm(gc_interval);
 }
 
 ss::future<> caching_runtime::stop() {
     _gc_timer.cancel();
     co_await _gate.close();
+    co_await _engine_caches.stop();
     co_await _underlying->stop();
 }
 
@@ -250,15 +285,15 @@ ss::future<ss::shared_ptr<factory>> caching_runtime::make_factory(
     model::offset offset = meta.source_ptr;
     // Look in the cache outside the lock
     auto it = _factory_cache.find(offset);
-    if (it != _factory_cache.end()) {
-        co_return it->second;
+    if (it != _factory_cache.end() && it->second) {
+        co_return it->second->shared_from_this();
     }
     auto lock = co_await factory_creation_lock_guard::acquire(
       &_factory_creation_mu_map, offset);
     // Look again in the cache with the lock
     it = _factory_cache.find(offset);
-    if (it != _factory_cache.end()) {
-        co_return it->second;
+    if (it != _factory_cache.end() && it->second) {
+        co_return it->second->shared_from_this();
     }
     // There is no factory and we're holding the lock,
     // time to create a new one.
@@ -266,17 +301,23 @@ ss::future<ss::shared_ptr<factory>> caching_runtime::make_factory(
       std::move(meta), std::move(binary), logger);
 
     // Now cache the factory and return the result.
+    //
+    // The underlying factory is wrapped in a foreign pointer because it could
+    // be accessed and used from any core (it's expected the caller of this
+    // function will wrap the factories in foreign pointers to hand out to other
+    // cores, and we can't do that here because of the inheritance).
     auto cached = ss::make_shared<cached_factory>(
-      std::move(factory), offset, &_engine_caches);
-    auto [_, inserted] = _factory_cache.emplace(offset, cached);
+      ss::make_foreign(std::move(factory)), offset, &_engine_caches);
+    auto [_, inserted] = _factory_cache.insert_or_assign(
+      offset, cached->weak_from_this());
     vassert(inserted, "expected factory to be inserted");
 
     co_return cached;
 }
 
 ss::future<> caching_runtime::do_gc() {
-    // TODO: GC engines too
-    auto fut = co_await ss::coroutine::as_future(gc_factories());
+    auto fut = co_await ss::coroutine::as_future(
+      ss::when_all_succeed(gc_factories(), gc_engines()));
     if (fut.failed()) {
         vlog(
           wasm_log.warn,
@@ -288,6 +329,10 @@ ss::future<> caching_runtime::do_gc() {
 
 ss::future<> caching_runtime::gc_factories() {
     return gc_btree_map(&_factory_cache);
+}
+
+ss::future<> caching_runtime::gc_engines() {
+    return _engine_caches.invoke_on_all(&engine_cache::gc);
 }
 
 } // namespace wasm

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -17,6 +17,10 @@
 
 namespace wasm {
 
+struct cached_factory {
+    ss::shared_ptr<factory> factory;
+};
+
 namespace {
 
 /**
@@ -74,7 +78,107 @@ private:
     size_t _ref_count = 0;
     std::unique_ptr<engine> _underlying;
 };
+
+/**
+ * A RAII scoped lock that ensures factory locks are deleted when there are no
+ * waiters.
+ */
+class factory_creation_lock_guard {
+public:
+    factory_creation_lock_guard(const factory_creation_lock_guard&) = delete;
+    factory_creation_lock_guard& operator=(const factory_creation_lock_guard&)
+      = delete;
+    factory_creation_lock_guard(factory_creation_lock_guard&&) noexcept
+      = default;
+    factory_creation_lock_guard&
+    operator=(factory_creation_lock_guard&&) noexcept
+      = default;
+
+    static ss::future<factory_creation_lock_guard> acquire(
+      absl::btree_map<model::offset, std::unique_ptr<mutex>>* mu_map,
+      model::offset offset) {
+        auto it = mu_map->find(offset);
+        mutex* mu = nullptr;
+        if (it == mu_map->end()) {
+            auto inserted = mu_map->emplace(offset, std::make_unique<mutex>());
+            vassert(inserted.second, "expected mutex to be inserted");
+            mu = inserted.first->second.get();
+        } else {
+            mu = it->second.get();
+        }
+        mutex::units units = co_await mu->get_units();
+        co_return factory_creation_lock_guard(
+          offset, mu_map, mu, std::move(units));
+    }
+
+    ~factory_creation_lock_guard() {
+        _underlying.return_all();
+        // If nothing is waiting on or holding the mutex, we can remove the lock
+        // from the map.
+        if (_mu->ready()) {
+            _mu_map->erase(_offset);
+        }
+    }
+
+private:
+    factory_creation_lock_guard(
+      model::offset offset,
+      absl::btree_map<model::offset, std::unique_ptr<mutex>>* mu_map,
+      mutex* mu,
+      mutex::units underlying)
+      : _offset(offset)
+      , _mu_map(mu_map)
+      , _mu(mu)
+      , _underlying(std::move(underlying)) {}
+
+    model::offset _offset;
+    absl::btree_map<model::offset, std::unique_ptr<mutex>>* _mu_map;
+    mutex* _mu;
+    mutex::units _underlying;
+};
+} // namespace
+
+caching_runtime::caching_runtime(std::unique_ptr<runtime> u)
+  : _underlying(std::move(u)) {}
+
+caching_runtime::~caching_runtime() = default;
+
+ss::future<> caching_runtime::start() {
+    co_await _underlying->start();
+    // TODO: Start a periodic timer to GC unused factories
 }
 
+ss::future<> caching_runtime::stop() { co_await _underlying->stop(); }
 
+ss::future<ss::shared_ptr<factory>> caching_runtime::make_factory(
+  model::transform_metadata meta, iobuf binary, ss::logger* logger) {
+    model::offset offset = meta.source_ptr;
+    // Look in the cache outside the lock
+    auto it = _factory_cache.find(offset);
+    if (it != _factory_cache.end()) {
+        // TODO: Use a factory that caches engines
+        co_return it->second->factory;
+    }
+    auto lock = co_await factory_creation_lock_guard::acquire(
+      &_factory_creation_mu_map, offset);
+    // Look again in the cache with the lock
+    it = _factory_cache.find(offset);
+    if (it != _factory_cache.end()) {
+        // TODO: Use a factory that caches engines
+        co_return it->second->factory;
+    }
+    // There is no factory and we're holding the lock,
+    // time to create a new one.
+    auto factory = co_await _underlying->make_factory(
+      std::move(meta), std::move(binary), logger);
+
+    // Now cache the factory and return the result.
+    auto cached = ss::make_shared<cached_factory>(std::move(factory));
+    auto [_, inserted] = _factory_cache.emplace(offset, cached);
+    vassert(inserted, "expected factory to be inserted");
+
+    // TODO: Use a factory that caches engines
+    co_return cached->factory;
 }
+
+} // namespace wasm

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -53,6 +53,10 @@ public:
     make_factory(model::transform_metadata, iobuf, ss::logger*) override;
 
 private:
+    /** GC factories and engines that are no longer in use. */
+    ss::future<> do_gc();
+    ss::future<> gc_factories();
+
     /*
      * This map holds locks for creating factories.
      *
@@ -64,6 +68,8 @@ private:
     std::unique_ptr<runtime> _underlying;
     absl::btree_map<model::offset, ss::shared_ptr<cached_factory>>
       _factory_cache;
+    ss::timer<ss::lowres_clock> _gc_timer;
+    ss::gate _gate;
 };
 
 } // namespace wasm

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -15,6 +15,7 @@
 #include "wasm/api.h"
 
 #include <seastar/core/sharded.hh>
+#include <seastar/core/weak_ptr.hh>
 
 #include <absl/container/btree_map.h>
 
@@ -59,6 +60,7 @@ private:
     /** GC factories and engines that are no longer in use. */
     ss::future<> do_gc();
     ss::future<> gc_factories();
+    ss::future<> gc_engines();
 
     /*
      * This map holds locks for creating factories.
@@ -69,8 +71,7 @@ private:
     absl::btree_map<model::offset, std::unique_ptr<mutex>>
       _factory_creation_mu_map;
     std::unique_ptr<runtime> _underlying;
-    absl::btree_map<model::offset, ss::shared_ptr<cached_factory>>
-      _factory_cache;
+    absl::btree_map<model::offset, ss::weak_ptr<cached_factory>> _factory_cache;
     ss::sharded<engine_cache> _engine_caches;
     ss::timer<ss::lowres_clock> _gc_timer;
     ss::gate _gate;

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "wasm/api.h"
+
+namespace wasm {}

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -14,6 +14,7 @@
 #include "utils/mutex.h"
 #include "wasm/api.h"
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/weak_ptr.hh>
 
@@ -41,6 +42,8 @@ class cached_factory;
 class caching_runtime : public runtime {
 public:
     explicit caching_runtime(std::unique_ptr<runtime>);
+    caching_runtime(
+      std::unique_ptr<runtime>, ss::lowres_clock::duration gc_interval);
     caching_runtime(const caching_runtime&) = delete;
     caching_runtime(caching_runtime&&) = delete;
     caching_runtime& operator=(const caching_runtime&) = delete;
@@ -73,6 +76,7 @@ private:
     std::unique_ptr<runtime> _underlying;
     absl::btree_map<model::offset, ss::weak_ptr<cached_factory>> _factory_cache;
     ss::sharded<engine_cache> _engine_caches;
+    ss::lowres_clock::duration _gc_interval;
     ss::timer<ss::lowres_clock> _gc_timer;
     ss::gate _gate;
 };

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -14,11 +14,14 @@
 #include "utils/mutex.h"
 #include "wasm/api.h"
 
+#include <seastar/core/sharded.hh>
+
 #include <absl/container/btree_map.h>
 
 namespace wasm {
 
-struct cached_factory;
+class engine_cache;
+class cached_factory;
 
 /**
  * A runtime that reuses factories and caches them per process as to share the
@@ -68,6 +71,7 @@ private:
     std::unique_ptr<runtime> _underlying;
     absl::btree_map<model::offset, ss::shared_ptr<cached_factory>>
       _factory_cache;
+    ss::sharded<engine_cache> _engine_caches;
     ss::timer<ss::lowres_clock> _gc_timer;
     ss::gate _gate;
 };

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -11,6 +11,59 @@
 
 #pragma once
 
+#include "utils/mutex.h"
 #include "wasm/api.h"
 
-namespace wasm {}
+#include <absl/container/btree_map.h>
+
+namespace wasm {
+
+struct cached_factory;
+
+/**
+ * A runtime that reuses factories and caches them per process as to share the
+ * executable memory.
+ *
+ * To enable this, this runtime can only create factories on a single shard
+ * (the same shard that it is created on, which is probably shard zero).
+ * However, factories that are created by this runtime can be used to create
+ * engines for any shard.
+ *
+ * Additionally, engines from this runtime's factories are reused within a
+ * single shard. Ramifications of this is that failures to a single engine cause
+ * the engine to be restarted and all users of a given engine must wait until
+ * it's restarted to use the engine.
+ */
+class caching_runtime : public runtime {
+public:
+    explicit caching_runtime(std::unique_ptr<runtime>);
+    caching_runtime(const caching_runtime&) = delete;
+    caching_runtime(caching_runtime&&) = delete;
+    caching_runtime& operator=(const caching_runtime&) = delete;
+    caching_runtime& operator=(caching_runtime&&) = delete;
+    ~caching_runtime() override;
+
+    ss::future<> start() override;
+    ss::future<> stop() override;
+
+    /**
+     * Create a factory, must be called only on a single shard.
+     */
+    ss::future<ss::shared_ptr<factory>>
+    make_factory(model::transform_metadata, iobuf, ss::logger*) override;
+
+private:
+    /*
+     * This map holds locks for creating factories.
+     *
+     * These mutexes are shortlived and should only live during the creation of
+     * factories.
+     */
+    absl::btree_map<model::offset, std::unique_ptr<mutex>>
+      _factory_creation_mu_map;
+    std::unique_ptr<runtime> _underlying;
+    absl::btree_map<model::offset, ss::shared_ptr<cached_factory>>
+      _factory_cache;
+};
+
+} // namespace wasm

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -60,10 +60,16 @@ public:
     make_factory(model::transform_metadata, iobuf, ss::logger*) override;
 
 private:
-    /** GC factories and engines that are no longer in use. */
-    ss::future<> do_gc();
-    ss::future<> gc_factories();
-    ss::future<> gc_engines();
+    friend class WasmCacheTest;
+
+    /**
+     * GC factories and engines that are no longer in use.
+     *
+     * Return the number of entries deleted (for testing).
+     */
+    ss::future<int64_t> do_gc();
+    ss::future<int64_t> gc_factories();
+    ss::future<int64_t> gc_engines();
 
     /*
      * This map holds locks for creating factories.

--- a/src/v/wasm/tests/CMakeLists.txt
+++ b/src/v/wasm/tests/CMakeLists.txt
@@ -53,6 +53,7 @@ rp_test(
   LIBRARIES 
     v::gtest_main
     v::wasm
+  ARGS "-- -c 1"
   LABELS wasm
 )
 
@@ -65,5 +66,20 @@ rp_test(
   LIBRARIES 
     v::gtest_main
     v::wasm
+  ARGS "-- -c 1"
+  LABELS wasm
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME wasm_cache
+  SOURCES
+    wasm_cache_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::model_test_utils
+    v::wasm
+  ARGS "-- -c 4"
   LABELS wasm
 )

--- a/src/v/wasm/tests/wasm_cache_test.cc
+++ b/src/v/wasm/tests/wasm_cache_test.cc
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "gmock/gmock.h"
+#include "model/fundamental.h"
+#include "model/tests/random_batch.h"
+#include "model/tests/randoms.h"
+#include "model/transform.h"
+#include "random/generators.h"
+#include "wasm/api.h"
+#include "wasm/cache.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/when_all.hh>
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <memory>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace wasm {
+
+namespace {
+// NOLINTNEXTLINE(*-avoid-non-const-global-variables,cert-err58-cpp)
+static ss::logger test_logger("wasm_cache_test_logger");
+
+struct state {
+    std::atomic_int factories = 0;
+    std::atomic_int engines = 0;
+    std::atomic_int running_engines = 0;
+    std::atomic_int engine_restarts = 0;
+
+    std::atomic_bool engine_transform_should_throw = false;
+};
+
+class fake_engine : public engine {
+public:
+    explicit fake_engine(state* state)
+      : _state(state) {
+        ++_state->engines;
+    }
+    fake_engine(const fake_engine&) = delete;
+    fake_engine(fake_engine&&) = delete;
+    fake_engine& operator=(const fake_engine&) = delete;
+    fake_engine& operator=(fake_engine&&) = delete;
+    ~fake_engine() override { --_state->engines; }
+
+    ss::future<> start() override {
+        ++_state->running_engines;
+        if (_has_been_stopped) {
+            ++_state->engine_restarts;
+        }
+        co_return;
+    }
+    ss::future<> stop() override {
+        --_state->running_engines;
+        _has_been_stopped = true;
+        co_return;
+    }
+
+    ss::future<model::record_batch>
+    transform(model::record_batch batch, transform_probe*) override {
+        if (_state->engine_transform_should_throw) {
+            throw std::runtime_error("test error");
+        }
+        co_return batch;
+    }
+
+    uint64_t memory_usage_size_bytes() const override { return 0; }
+
+private:
+    bool _has_been_stopped = false;
+    state* _state;
+};
+
+class fake_factory : public factory {
+public:
+    explicit fake_factory(state* state)
+      : _state(state) {
+        ++_state->factories;
+    }
+    fake_factory(const fake_factory&) = delete;
+    fake_factory(fake_factory&&) = delete;
+    fake_factory& operator=(const fake_factory&) = delete;
+    fake_factory& operator=(fake_factory&&) = delete;
+    ~fake_factory() noexcept override { --_state->factories; }
+
+    ss::future<ss::shared_ptr<engine>> make_engine() override {
+        co_return ss::make_shared<fake_engine>(_state);
+    }
+
+private:
+    state* _state;
+};
+
+class fake_runtime : public runtime {
+public:
+    ss::future<> start() override { co_return; }
+    ss::future<> stop() override { co_return; }
+
+    ss::future<ss::shared_ptr<factory>>
+    make_factory(model::transform_metadata, iobuf, ss::logger*) override {
+        co_return ss::make_shared<fake_factory>(&_state);
+    }
+
+    state* get_state() { return &_state; }
+
+private:
+    state _state;
+};
+
+class WasmCacheTest : public ::testing::Test {
+public:
+    static void SetUpTestSuite() {
+        vassert(ss::smp::count > 1, "This test expects multiple shards");
+    }
+
+    void SetUp() override {
+        auto fr = std::make_unique<fake_runtime>();
+        _fake_runtime = fr.get();
+        // Effectively disable the gc interval
+        _caching_runtime = std::make_unique<caching_runtime>(
+          std::move(fr), /*gc_interval=*/std::chrono::hours(1));
+        _caching_runtime->start().get();
+    }
+
+    void TearDown() override {
+        _caching_runtime->stop().get();
+        _fake_runtime = nullptr;
+        _caching_runtime = nullptr;
+    }
+
+    model::transform_metadata random_metadata() {
+        _offset = model::next_offset(_offset);
+        return {
+          .name = tests::random_named_string<model::transform_name>(),
+          .input_topic = model::random_topic_namespace(),
+          .output_topics = {model::random_topic_namespace()},
+          .environment = {},
+          .source_ptr = _offset,
+        };
+    }
+
+    ss::shared_ptr<factory> make_factory(model::transform_metadata metadata) {
+        return make_factory_async(std::move(metadata)).get();
+    }
+    ss::future<ss::shared_ptr<factory>>
+    make_factory_async(model::transform_metadata metadata) {
+        return _caching_runtime->make_factory(
+          std::move(metadata), _wasm_module.copy(), &test_logger);
+    }
+
+    template<typename Func>
+    void invoke_on_all(Func&& func) {
+        ss::smp::invoke_on_all([func = std::forward<Func>(func)]() mutable {
+            return ss::async(std::forward<Func>(func));
+        }).get();
+    }
+
+    auto* state() { return _fake_runtime->get_state(); }
+
+    model::record_batch random_batch() const {
+        return model::test::make_random_batch(model::test::record_batch_spec{});
+    }
+
+private:
+    iobuf _wasm_module = random_generators::make_iobuf();
+    model::offset _offset = model::offset(0);
+    fake_runtime* _fake_runtime;
+    std::unique_ptr<caching_runtime> _caching_runtime;
+};
+
+} // namespace
+
+void PrintTo(const ss::shared_ptr<factory>& f, std::ostream* os) {
+    *os << "factory{" << f.get() << "}";
+}
+
+void PrintTo(const ss::shared_ptr<engine>& f, std::ostream* os) {
+    *os << "engine{" << f.get() << "}";
+}
+
+TEST_F(WasmCacheTest, CachesFactories) {
+    auto meta = random_metadata();
+    auto factory_one = make_factory_async(meta);
+    auto factory_two = make_factory_async(meta);
+    EXPECT_EQ(factory_one.get(), factory_two.get());
+    EXPECT_EQ(state()->factories, 1);
+}
+
+TEST_F(WasmCacheTest, CachesEngines) {
+    auto meta = random_metadata();
+    auto factory = ss::make_foreign(make_factory(meta));
+    static thread_local ss::shared_ptr<engine> live_engine;
+    invoke_on_all([&factory] {
+        auto engine_one = factory->make_engine();
+        auto engine_two = factory->make_engine();
+        auto engine = engine_one.get();
+        EXPECT_EQ(engine, engine_two.get());
+        live_engine = engine;
+    });
+    EXPECT_EQ(state()->engines, ss::smp::count);
+
+    // This engine doesn't actually create new instances under the hood.
+    auto engine = factory->make_engine().get();
+    EXPECT_EQ(state()->engines, ss::smp::count);
+    engine = nullptr;
+    EXPECT_EQ(state()->engines, ss::smp::count);
+
+    invoke_on_all([] { live_engine = nullptr; });
+    EXPECT_EQ(state()->engines, 0);
+}
+
+TEST_F(WasmCacheTest, CanMultiplexEngines) {
+    auto meta = random_metadata();
+    auto factory = ss::make_foreign(make_factory(meta));
+    auto engine_one = factory->make_engine().get();
+    auto engine_two = factory->make_engine().get();
+    auto engine_three = factory->make_engine().get();
+    EXPECT_EQ(state()->engines, 1);
+    ss::when_all_succeed(
+      [&engine_two] { return engine_two->start(); },
+      [&engine_three] { return engine_three->start(); })
+      .get();
+    EXPECT_EQ(state()->running_engines, 1);
+    engine_one->start().get();
+    EXPECT_EQ(state()->running_engines, 1);
+    engine_one->stop().get();
+    EXPECT_EQ(state()->running_engines, 1);
+    ss::when_all_succeed(
+      [&engine_two] { return engine_two->stop(); },
+      [&engine_three] { return engine_three->stop(); })
+      .get();
+    EXPECT_EQ(state()->running_engines, 0);
+}
+
+TEST_F(WasmCacheTest, CanMultiplexTransforms) {
+    auto meta = random_metadata();
+    auto factory = ss::make_foreign(make_factory(meta));
+    auto engine_one = factory->make_engine().get();
+    auto engine_two = factory->make_engine().get();
+    engine_one->start().get();
+    engine_two->start().get();
+    state()->engine_transform_should_throw = true;
+    EXPECT_THROW(
+      engine_one->transform(random_batch(), nullptr).get(), std::runtime_error);
+    EXPECT_EQ(state()->engine_restarts, 1);
+    state()->engine_transform_should_throw = false;
+    EXPECT_NO_THROW(engine_two->transform(random_batch(), nullptr).get());
+    EXPECT_EQ(state()->engine_restarts, 1);
+    engine_one->stop().get();
+    engine_two->stop().get();
+    EXPECT_EQ(state()->running_engines, 0);
+}
+
+} // namespace wasm

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -145,7 +145,6 @@ void WasmTestFixture::load_wasm(const std::string& path) {
     }
     _engine = _factory->make_engine().get();
     _engine->start().get();
-    _engine->initialize().get();
 }
 
 model::record_batch WasmTestFixture::transform(const model::record_batch& b) {

--- a/src/v/wasm/tests/wasm_fixture.h
+++ b/src/v/wasm/tests/wasm_fixture.h
@@ -47,7 +47,7 @@ public:
 
 private:
     std::unique_ptr<wasm::runtime> _runtime;
-    std::unique_ptr<wasm::factory> _factory;
+    ss::shared_ptr<wasm::factory> _factory;
     std::unique_ptr<wasm::engine> _engine;
     std::unique_ptr<wasm::transform_probe> _probe;
     fake_schema_registry* _sr;

--- a/src/v/wasm/tests/wasm_fixture.h
+++ b/src/v/wasm/tests/wasm_fixture.h
@@ -48,7 +48,7 @@ public:
 private:
     std::unique_ptr<wasm::runtime> _runtime;
     ss::shared_ptr<wasm::factory> _factory;
-    std::unique_ptr<wasm::engine> _engine;
+    ss::shared_ptr<wasm::engine> _engine;
     std::unique_ptr<wasm::transform_probe> _probe;
     fake_schema_registry* _sr;
     model::transform_metadata _meta;

--- a/src/v/wasm/tests/wasm_transform_test.cc
+++ b/src/v/wasm/tests/wasm_transform_test.cc
@@ -36,12 +36,8 @@ TEST_F(WasmTestFixture, IdentityFunction) {
 TEST_F(WasmTestFixture, CanRestartEngine) {
     load_wasm("identity.wasm");
     engine()->stop().get();
-    // Can be restarted without initialization
-    engine()->start().get();
-    engine()->stop().get();
     // It still works after being restarted
     engine()->start().get();
-    engine()->initialize().get();
     auto batch = make_tiny_batch();
     auto transformed = transform(batch);
     ASSERT_EQ(transformed.copy_records(), batch.copy_records());

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -471,9 +471,7 @@ public:
         return wasmtime_memory_data_size(ctx, &memory_extern.of.memory);
     };
 
-    ss::future<> start() final { co_return; }
-
-    ss::future<> initialize() final { return initialize_wasi(); }
+    ss::future<> start() final { return initialize_wasi(); }
 
     ss::future<> stop() final { co_return; }
 

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -453,8 +453,6 @@ public:
 
     ~wasmtime_engine() override = default;
 
-    std::string_view function_name() const final { return _user_module_name; }
-
     uint64_t memory_usage_size_bytes() const final {
         std::string_view memory_export_name = "memory";
         auto* ctx = wasmtime_store_context(_store.get());

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -737,7 +737,7 @@ public:
 
     ss::future<> stop() override { return _alien_thread_pool.stop(); }
 
-    ss::future<std::unique_ptr<factory>> make_factory(
+    ss::future<ss::shared_ptr<factory>> make_factory(
       model::transform_metadata meta, iobuf buf, ss::logger* logger) override {
         auto user_module = co_await _alien_thread_pool.submit(
           [this, &meta, &buf] {
@@ -755,7 +755,7 @@ public:
               wasm_log.info("Finished compiling wasm module {}", meta.name);
               return user_module;
           });
-        co_return std::make_unique<wasmtime_engine_factory>(
+        co_return ss::make_shared<wasmtime_engine_factory>(
           _engine.get(),
           std::move(meta),
           user_module,

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -427,7 +427,6 @@ class wasmtime_engine : public engine {
 public:
     wasmtime_engine(
       ss::sstring user_module_name,
-      handle<wasmtime_linker_t, wasmtime_linker_delete> l,
       handle<wasmtime_store_t, wasmtime_store_delete> s,
       std::shared_ptr<wasmtime_module_t> user_module,
       std::unique_ptr<transform_module> transform_module,
@@ -443,7 +442,6 @@ public:
       , _transform_module(std::move(transform_module))
       , _sr_module(std::move(sr_module))
       , _wasi_module(std::move(wasi_module))
-      , _linker(std::move(l))
       , _instance(instance)
       , _alien_thread_pool(workers)
       , _host_function_environments(std::move(host_function_environments)) {}
@@ -622,7 +620,6 @@ private:
     std::unique_ptr<transform_module> _transform_module;
     std::unique_ptr<schema_registry_module> _sr_module;
     std::unique_ptr<wasi::preview1_module> _wasi_module;
-    handle<wasmtime_linker_t, wasmtime_linker_delete> _linker;
     wasmtime_instance_t _instance;
     ssx::sharded_thread_worker* _alien_thread_pool;
     std::vector<std::unique_ptr<host_function_environment>>
@@ -700,7 +697,6 @@ public:
               // pass back a closure to allocate the engine.
               return [this,
                       name = _meta.name(),
-                      linker = std::move(linker),
                       store = std::move(store),
                       xform_module = std::move(xform_module),
                       sr_module = std::move(sr_module),
@@ -709,7 +705,6 @@ public:
                       instance]() mutable {
                   return ss::make_shared<wasmtime_engine>(
                     std::move(name),
-                    std::move(linker),
                     std::move(store),
                     _module,
                     std::move(xform_module),


### PR DESCRIPTION
This patch set introduces a mechanism for caching factories (executable memory) and engines (linear vm memory).

We do this by wrapping a whole runtime and providing all the caching logic transparently.
Engines are able to be multiplexed on the same core as to reuse the memory resources.

Caching works via weak and shared pointers, otherwise the bookkeeping will be forced upon all callers.
When a weak pointer expires, we still have map entries holding the weak pointers, so there is a GC 
process to cleanup these entries that runs at a very low interval.

There are also a couple of PRs to cleanup mutex and remove some vestigal methods from the wasm engine API.


## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
