### PR TITLE
codeowners: remove devprod for /tools folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,6 @@ licenses           @emaxerrno @dswang
 /cmake                     @redpanda-data/devprod        @benpope
 /install-dependencies.sh   @redpanda-data/devprod
 /.yapfignore               @redpanda-data/devprod
-/tools                     @redpanda-data/devprod
 
 #
 # rpk


### PR DESCRIPTION
Most of the changes going to this folder are relevant to core's team and not to devprod. Instead of assigning reviewers from devprod, we'll wait for devprod folks to be manually assigned on an as-needed basis

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none