### PR TITLE
treewide: unify dependent_false implementations

### DIFF
--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -561,9 +561,6 @@ concept is_pair = requires(T x) {
 };
 
 template<typename T>
-struct dependent_false : std::false_type {};
-
-template<typename T>
 consteval std::string_view property_type_name() {
     using type = std::decay_t<T>;
     if constexpr (std::is_same_v<type, ss::sstring>) {
@@ -638,7 +635,8 @@ consteval std::string_view property_type_name() {
                              schema_id_validation_mode>) {
         return "string";
     } else {
-        static_assert(dependent_false<T>::value, "Type name not defined");
+        static_assert(
+          utils::unsupported_type<T>::value, "Type name not defined");
     }
 }
 

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -26,6 +26,7 @@
 #include "reflection/type_traits.h"
 #include "security/acl.h"
 #include "ssx/sformat.h"
+#include "utils/type_traits.h"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/smp.hh>
@@ -145,7 +146,7 @@ consteval describe_configs_type property_config_type() {
         return describe_configs_type::list;
     } else {
         static_assert(
-          config::detail::dependent_false<T>::value,
+          utils::unsupported_type<T>::value,
           "Type name is not supported in describe_configs_type");
     }
 }

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -26,6 +26,7 @@
 #include "seastarx.h"
 #include "storage/node.h"
 #include "utils/request_auth.h"
+#include "utils/type_traits.h"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/scheduling.hh>
@@ -51,12 +52,6 @@ enum class service_kind {
     http_proxy,
     schema_registry,
 };
-
-namespace detail {
-// Helper for static_assert-ing false below.
-template<auto V>
-struct dependent_false : std::false_type {};
-} // namespace detail
 
 namespace cloud_storage {
 struct topic_recovery_service;
@@ -121,7 +116,7 @@ private:
             auth_state.pass();
         } else {
             static_assert(
-              detail::dependent_false<required_auth>::value,
+              utils::unsupported_value<required_auth>::value,
               "Invalid auth_level");
         }
 

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -25,11 +25,6 @@
 
 namespace security {
 
-namespace details {
-template<class T>
-struct dependent_false : std::false_type {};
-} // namespace details
-
 // cluster is a resource type and the acl data model requires that resources
 // have names, so this is a fixed name for that resource.
 //
@@ -63,7 +58,7 @@ consteval resource_type get_resource_type() {
     } else if constexpr (std::is_same_v<T, kafka::transactional_id>) {
         return resource_type::transactional_id;
     } else {
-        static_assert(details::dependent_false<T>::value, "Unsupported type");
+        static_assert(utils::unsupported_type<T>::value, "Unsupported type");
     }
 }
 

--- a/src/v/serde/rw/chrono.h
+++ b/src/v/serde/rw/chrono.h
@@ -11,16 +11,11 @@
 
 #include "serde/logger.h"
 #include "serde/rw/rw.h"
+#include "utils/type_traits.h"
 
 #include <chrono>
 
 namespace serde {
-
-namespace detail {
-// Helper for static_assert-ing false below.
-template<typename T>
-struct dependent_false : std::false_type {};
-} // namespace detail
 
 template<class R, class P>
 int64_t checked_duration_cast_to_nanoseconds(
@@ -117,7 +112,7 @@ void tag_invoke(
 template<typename Clock, typename Duration>
 void write(iobuf&, std::chrono::time_point<Clock, Duration> t) {
     static_assert(
-      detail::dependent_false<decltype(t)>::value,
+      utils::unsupported_type<decltype(t)>::value,
       "Time point serialization is risky and can have unintended "
       "consequences. Check with Redpanda team before fixing this.");
 }
@@ -128,7 +123,7 @@ void read(
   std::chrono::time_point<Clock, Duration>& t,
   std::size_t const /* bytes_left_limit */) {
     static_assert(
-      detail::dependent_false<decltype(t)>::value,
+      utils::unsupported_type<decltype(t)>::value,
       "Time point serialization is risky and can have unintended "
       "consequences. Check with Redpanda team before fixing this.");
 }

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -258,12 +258,9 @@ private:
 
 using status_map = absl::flat_hash_map<std::string, lifecycle_status>;
 
-template<typename... Args>
-concept EmptyPack = sizeof...(Args) == 0;
-
 template<typename... Rest>
 void make_status_map(status_map& output)
-requires EmptyPack<Rest...>
+requires(sizeof...(Rest) == 0)
 {}
 
 template<typename... Rest>

--- a/src/v/utils/type_traits.h
+++ b/src/v/utils/type_traits.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <type_traits>
+
+namespace utils {
+
+/**
+ * A utility for statically asserting false.
+ *
+ * Example usage:
+ *
+ * ```
+ * template<typename T>
+ * void foo() {
+ *   if constexpr (...) {
+ *     // ...
+ *   } else {
+ *     static_assert(utils::unsupported_type<T>::value, "unsupported type");
+ *   }
+ * }
+ *
+ * ```
+ *
+ */
+template<class T>
+struct unsupported_type : std::false_type {};
+
+/**
+ * Similar to `unsupported_type` but for values instead of types.
+ *
+ * Example usage:
+ *
+ * enum class foo { bar, baz };
+ *
+ * template<foo value>
+ * void check() {
+ *   if constexpr (value == foo::bar) {
+ *     // ...
+ *   } else if constexpr (value == foo::baz) {
+ *     // ...
+ *   } else {
+ *     static_assert(utils::unsupported_value<value>::value, "supported foo");
+ *   }
+ * }
+ */
+template<auto V>
+struct unsupported_value : std::false_type {};
+
+} // namespace utils

--- a/src/v/wasm/ffi.h
+++ b/src/v/wasm/ffi.h
@@ -14,6 +14,7 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "reflection/type_traits.h"
+#include "utils/type_traits.h"
 #include "vassert.h"
 
 #include <cstdint>
@@ -196,8 +197,6 @@ enum class val_type { i32, i64 };
 std::ostream& operator<<(std::ostream& o, val_type vt);
 
 namespace detail {
-template<class T>
-struct dependent_false : std::false_type {};
 
 template<class T>
 struct is_array : std::false_type {};
@@ -230,7 +229,7 @@ void transform_type(std::vector<val_type>& types) {
     } else if constexpr (ss::is_future<Type>::value) {
         transform_type<typename Type::value_type>(types);
     } else {
-        static_assert(dependent_false<Type>::value, "Unknown type");
+        static_assert(utils::unsupported_type<Type>::value, "Unknown type");
     }
 }
 
@@ -279,7 +278,7 @@ std::tuple<Type> extract_parameter(
           mem, raw_params, idx);
         return std::tuple<Type>(underlying);
     } else {
-        static_assert(dependent_false<Type>::value, "Unknown type");
+        static_assert(utils::unsupported_type<Type>::value, "Unknown type");
     }
 }
 
@@ -296,7 +295,7 @@ constexpr size_t num_parameters() {
     } else if constexpr (reflection::is_rp_named_type<Type>) {
         return num_parameters<typename Type::type>();
     } else {
-        static_assert(dependent_false<Type>::value, "Unknown type");
+        static_assert(utils::unsupported_type<Type>::value, "Unknown type");
     }
 }
 

--- a/src/v/wasm/ffi.h
+++ b/src/v/wasm/ffi.h
@@ -298,14 +298,11 @@ constexpr size_t num_parameters() {
         static_assert(utils::unsupported_type<Type>::value, "Unknown type");
     }
 }
-
-template<typename... Args>
-concept EmptyPack = sizeof...(Args) == 0;
 } // namespace detail
 
 template<typename... Rest>
 void transform_types(std::vector<val_type>&)
-requires detail::EmptyPack<Rest...>
+requires(sizeof...(Rest) == 0)
 {
     // Nothing to do
 }
@@ -319,7 +316,7 @@ void transform_types(std::vector<val_type>& types) {
 template<typename... Rest>
 std::tuple<>
 extract_parameters(ffi::memory*, std::span<const uint64_t>, unsigned)
-requires detail::EmptyPack<Rest...>
+requires(sizeof...(Rest) == 0)
 {
     return std::make_tuple();
 }
@@ -334,7 +331,7 @@ std::tuple<Type, Rest...> extract_parameters(
 
 template<typename... Rest>
 constexpr size_t parameter_count()
-requires detail::EmptyPack<Rest...>
+requires(sizeof...(Rest) == 0)
 {
     return 0;
 }

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -13,6 +13,7 @@
 #include "model/record.h"
 #include "ssx/thread_worker.h"
 #include "storage/parser_utils.h"
+#include "utils/type_traits.h"
 #include "wasm/api.h"
 #include "wasm/errc.h"
 #include "wasm/ffi.h"
@@ -148,8 +149,7 @@ wasmtime_val_t convert_to_wasmtime(T value) {
           .kind = WASMTIME_I32, .of = {.i32 = static_cast<int32_t>(value)}};
     } else {
         static_assert(
-          ffi::detail::dependent_false<T>::value,
-          "Unsupported wasm result type");
+          utils::unsupported_type<T>::value, "Unsupported wasm result type");
     }
 }
 


### PR DESCRIPTION
Fixes: #12850

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
