### PR TITLE
cmake: Upgrade wasmtime

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -93,10 +93,10 @@ fetch_dep(hdrhistogram
 FetchContent_Declare(
   wasmtime
   GIT_REPOSITORY https://github.com/bytecodealliance/wasmtime
-  GIT_TAG f433e783147f1ec0fd2959752004a248b6139b3a
-  # Remove all default features we don't use any of them.
+  GIT_TAG ec07c89b9b57a2e4d377b3c730f1b8cf8e31bd3a
+  # Remove the features we don't use.
   PATCH_COMMAND
-    sed -i "s/default \\\\= \\\\['jitdump', 'wat', 'wasi', 'cache', 'parallel\\\\-compilation'\\\\]/default = []/g" crates/c-api/Cargo.toml
+    sed -i "s/default \\\\= \\\\['jitdump', 'wat', 'wasi', 'cache', 'parallel\\\\-compilation', 'async'\\\\]/default = ['async']/g" crates/c-api/Cargo.toml
   GIT_PROGRESS TRUE
   USES_TERMINAL_DOWNLOAD TRUE
   OVERRIDE_FIND_PACKAGE


### PR DESCRIPTION
Pulls in some fixes and a few c-api features we're going to need in
other PRs

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
