### PR TITLE
Various `rpc::connection_cache` fixes

### DIFF
--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -331,10 +331,12 @@ ss::future<> connection_cache::reset_client_backoff(
         return ss::now();
     }
 
-    return container().invoke_on(
-      *shard, [node_id](rpc::connection_cache& cache) mutable {
-          cache._cache.reset_client_backoff(node_id);
-      });
+    return ss::with_gate(_gate, [this, node_id, shard] {
+        return container().invoke_on(
+          *shard, [node_id](rpc::connection_cache& cache) mutable {
+              cache._cache.reset_client_backoff(node_id);
+          });
+    });
 }
 
 } // namespace rpc

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -196,8 +196,6 @@ ss::future<> connection_cache::stop() {
 ss::future<> connection_cache::apply_changes(
   connection_allocation_strategy::changes changes,
   std::optional<connection_config> config) {
-    auto units = co_await _coordinator_state->mtx.get_units();
-
     // Add connections we have the config for.
     if (config) {
         for (auto& con_add : changes.add_connections) {
@@ -250,7 +248,9 @@ ss::future<> connection_cache::remove_broker_client_coordinator(
     }
     auto holder = _gate.hold();
 
+    auto units = co_await _coordinator_state->mtx.get_units();
     auto& alloc_strat = _coordinator_state->alloc_strat;
+
     if (alloc_strat.has_connection_assignments_for(dest)) {
         auto changes = alloc_strat.remove_connection_assignments_for(dest);
         co_await apply_changes(changes, std::nullopt);
@@ -279,6 +279,7 @@ connection_cache::update_broker_client_coordinator(connection_config cfg) {
     }
     auto holder = _gate.hold();
 
+    auto units = co_await _coordinator_state->mtx.get_units();
     auto& alloc_strat = _coordinator_state->alloc_strat;
 
     if (!alloc_strat.has_connection_assignments_for(cfg.dest_node)) {

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -21,6 +21,7 @@
 #include "rpc/types.h"
 #include "utils/mutex.h"
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 
@@ -141,17 +142,25 @@ public:
               rpc::make_error_code(errc::missing_node_rpc_client));
         }
 
-        return container().invoke_on(
-          *shard,
-          [node_id, f = std::forward<Func>(f), connection_timeout](
-            connection_cache& cache) mutable {
-              if (cache.is_shutting_down()) {
-                  return ss::futurize<ret_t>::convert(
-                    rpc::make_error_code(errc::shutting_down));
-              }
+        return ss::with_gate(
+          _gate,
+          [this,
+           node_id,
+           connection_timeout,
+           shard,
+           f = std::forward<Func>(f)]() mutable {
+              return container().invoke_on(
+                *shard,
+                [node_id, f = std::forward<Func>(f), connection_timeout](
+                  connection_cache& cache) mutable {
+                    if (cache.is_shutting_down()) {
+                        return ss::futurize<ret_t>::convert(
+                          rpc::make_error_code(errc::shutting_down));
+                    }
 
-              return cache._cache.with_node_client<Protocol, Func>(
-                node_id, connection_timeout, std::forward<Func>(f));
+                    return cache._cache.with_node_client<Protocol, Func>(
+                      node_id, connection_timeout, std::forward<Func>(f));
+                });
           });
     }
 

--- a/src/v/rpc/connection_cache.h
+++ b/src/v/rpc/connection_cache.h
@@ -130,7 +130,7 @@ public:
       Func&& f) {
         using ret_t = result_wrap_t<std::invoke_result_t<Func, Protocol>>;
 
-        if (_gate.is_closed()) {
+        if (is_shutting_down()) {
             return ss::futurize<ret_t>::convert(
               rpc::make_error_code(errc::shutting_down));
         }
@@ -145,7 +145,7 @@ public:
           *shard,
           [node_id, f = std::forward<Func>(f), connection_timeout](
             connection_cache& cache) mutable {
-              if (cache._gate.is_closed()) {
+              if (cache.is_shutting_down()) {
                   return ss::futurize<ret_t>::convert(
                     rpc::make_error_code(errc::shutting_down));
               }

--- a/src/v/rpc/connection_set.cc
+++ b/src/v/rpc/connection_set.cc
@@ -27,7 +27,7 @@ ss::future<> connection_set::try_add_or_update(
             co_return;
         }
         // configuration changed, first remove the client
-        _connections.erase(connection);
+        co_await remove(node);
     }
 
     auto cert_creds = co_await maybe_build_reloadable_certificate_credentials(


### PR DESCRIPTION
Fixes the following within `rpc::connection_cache`;
- Fixes the assertion failure from #13447 .
- Avoids creating clients when the connection_cache is shutting down.
- Prevents the sharded connection_cache from being stopped while there are
in-flight tasks for it.
- Acquires the mutex before accessing any shared state on the coordinator shard.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
