### PR TITLE
Add topic config for fast partition movement

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -272,6 +272,16 @@ std::chrono::milliseconds
 metadata_cache::get_default_retention_local_target_ms() const {
     return config::shard_local_cfg().retention_local_target_ms_default();
 }
+std::optional<size_t>
+metadata_cache::get_default_initial_retention_local_target_bytes() const {
+    return config::shard_local_cfg()
+      .initial_retention_local_target_bytes_default();
+}
+std::chrono::milliseconds
+metadata_cache::get_default_initial_retention_local_target_ms() const {
+    return config::shard_local_cfg()
+      .initial_retention_local_target_ms_default();
+}
 
 uint32_t metadata_cache::get_default_batch_max_bytes() const {
     return config::shard_local_cfg().kafka_batch_max_bytes();

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -178,6 +178,10 @@ public:
     get_default_retention_duration() const;
     std::optional<size_t> get_default_retention_local_target_bytes() const;
     std::chrono::milliseconds get_default_retention_local_target_ms() const;
+    std::optional<size_t>
+    get_default_initial_retention_local_target_bytes() const;
+    std::chrono::milliseconds
+    get_default_initial_retention_local_target_ms() const;
     model::shadow_indexing_mode get_default_shadow_indexing_mode() const;
     uint32_t get_default_batch_max_bytes() const;
     std::optional<std::chrono::milliseconds> get_default_segment_ms() const;

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -553,6 +553,20 @@ ss::future<> topic_recovery_service::reset_topic_configurations() {
             = tristate<size_t>{
               config::shard_local_cfg().retention_local_target_bytes_default()};
 
+          update.properties.initial_retention_local_target_ms.op
+            = cluster::incremental_update_operation::set;
+          update.properties.initial_retention_local_target_ms.value
+            = tristate<std::chrono::milliseconds>{
+              config::shard_local_cfg()
+                .initial_retention_local_target_ms_default()};
+
+          update.properties.initial_retention_local_target_bytes.op
+            = cluster::incremental_update_operation::set;
+          update.properties.initial_retention_local_target_bytes.value
+            = tristate<size_t>{
+              config::shard_local_cfg()
+                .initial_retention_local_target_bytes_default()};
+
           vlog(
             cst_log.debug,
             "resetting topic properties for {} using update: {}",

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -741,6 +741,12 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     incremental_update(
       properties.record_value_subject_name_strategy_compat,
       overrides.record_value_subject_name_strategy_compat);
+    incremental_update(
+      properties.initial_retention_local_target_bytes,
+      overrides.initial_retention_local_target_bytes);
+    incremental_update(
+      properties.initial_retention_local_target_ms,
+      overrides.initial_retention_local_target_ms);
     // no configuration change, no need to generate delta
     if (properties == properties_snapshot) {
         co_return errc::success;

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -192,7 +192,9 @@ bool topic_properties::has_overrides() const {
            || record_value_schema_id_validation.has_value()
            || record_value_schema_id_validation_compat.has_value()
            || record_value_subject_name_strategy.has_value()
-           || record_value_subject_name_strategy_compat.has_value();
+           || record_value_subject_name_strategy_compat.has_value()
+           || initial_retention_local_target_bytes.is_engaged()
+           || initial_retention_local_target_ms.is_engaged();
 }
 
 bool topic_properties::requires_remote_erase() const {
@@ -219,6 +221,9 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.retention_local_target_ms = retention_local_target_ms;
     ret.remote_delete = remote_delete;
     ret.segment_ms = segment_ms;
+    ret.initial_retention_local_target_bytes
+      = initial_retention_local_target_bytes;
+    ret.initial_retention_local_target_ms = initial_retention_local_target_ms;
     return ret;
 }
 
@@ -250,6 +255,10 @@ storage::ntp_config topic_configuration::make_ntp_config(
             .retention_local_target_ms = properties.retention_local_target_ms,
             .remote_delete = properties.remote_delete,
             .segment_ms = properties.segment_ms,
+            .initial_retention_local_target_bytes
+            = properties.initial_retention_local_target_bytes,
+            .initial_retention_local_target_ms
+            = properties.initial_retention_local_target_ms,
           });
     }
     return {
@@ -366,7 +375,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "record_value_schema_id_validation: {},  "
       "record_value_schema_id_validation_compat: {}, "
       "record_value_subject_name_strategy: {}, "
-      "record_value_subject_name_strategy_compat: {}}}",
+      "record_value_subject_name_strategy_compat: {}, "
+      "initial_retention_local_target_bytes: {}, "
+      "initial_retention_local_target_ms: {}}}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -391,7 +402,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.record_value_schema_id_validation,
       properties.record_value_schema_id_validation_compat,
       properties.record_value_subject_name_strategy,
-      properties.record_value_subject_name_strategy_compat);
+      properties.record_value_subject_name_strategy_compat,
+      properties.initial_retention_local_target_bytes,
+      properties.initial_retention_local_target_ms);
 
     return o;
 }
@@ -655,7 +668,9 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       "record_value_schema_id_validation: {}"
       "record_value_schema_id_validation_compat: {}"
       "record_value_subject_name_strategy: {}"
-      "record_value_subject_name_strategy_compat: {}",
+      "record_value_subject_name_strategy_compat: {}, "
+      "initial_retention_local_target_bytes: {}, "
+      "initial_retention_local_target_ms: {}",
       i.compression,
       i.cleanup_policy_bitflags,
       i.compaction_strategy,
@@ -676,7 +691,9 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       i.record_value_schema_id_validation,
       i.record_value_schema_id_validation_compat,
       i.record_value_subject_name_strategy,
-      i.record_value_subject_name_strategy_compat);
+      i.record_value_subject_name_strategy_compat,
+      i.initial_retention_local_target_bytes,
+      i.initial_retention_local_target_ms);
     return o;
 }
 
@@ -1670,7 +1687,9 @@ void adl<cluster::incremental_topic_updates>::to(
       t.record_value_schema_id_validation,
       t.record_value_schema_id_validation_compat,
       t.record_value_subject_name_strategy,
-      t.record_value_subject_name_strategy_compat);
+      t.record_value_subject_name_strategy_compat,
+      t.initial_retention_local_target_bytes,
+      t.initial_retention_local_target_ms);
 }
 
 cluster::incremental_topic_updates
@@ -1779,6 +1798,16 @@ adl<cluster::incremental_topic_updates>::from(iobuf_parser& in) {
         updates.record_value_subject_name_strategy_compat
           = adl<cluster::property_update<std::optional<
             pandaproxy::schema_registry::subject_name_strategy>>>{}
+              .from(in);
+    }
+
+    if (
+      version
+      <= cluster::incremental_topic_updates::version_with_initial_retention) {
+        updates.initial_retention_local_target_bytes
+          = adl<cluster::property_update<tristate<size_t>>>{}.from(in);
+        updates.initial_retention_local_target_ms
+          = adl<cluster::property_update<tristate<std::chrono::milliseconds>>>{}
               .from(in);
     }
 
@@ -1972,6 +2001,7 @@ adl<cluster::remote_topic_properties>::from(iobuf_parser& parser) {
     return {remote_revision, remote_partition_count};
 }
 
+// adl is no longer used for serializing new topic properties
 void adl<cluster::topic_properties>::to(
   iobuf& out, cluster::topic_properties&& p) {
     reflection::serialize(
@@ -2044,7 +2074,9 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
-      std::nullopt};
+      std::nullopt,
+      tristate<size_t>{std::nullopt},
+      tristate<std::chrono::milliseconds>{std::nullopt}};
 }
 
 void adl<cluster::cluster_property_kv>::to(

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -348,6 +348,8 @@ struct compat_check<cluster::topic_properties> {
         json_write(record_value_schema_id_validation_compat);
         json_write(record_value_subject_name_strategy);
         json_write(record_value_subject_name_strategy_compat);
+        json_write(initial_retention_local_target_bytes);
+        json_write(initial_retention_local_target_ms);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -377,6 +379,8 @@ struct compat_check<cluster::topic_properties> {
         json_read(record_value_schema_id_validation_compat);
         json_read(record_value_subject_name_strategy);
         json_read(record_value_subject_name_strategy_compat);
+        json_read(initial_retention_local_target_bytes);
+        json_read(initial_retention_local_target_ms);
         return obj;
     }
 
@@ -399,6 +403,10 @@ struct compat_check<cluster::topic_properties> {
           std::nullopt};
 
         obj.segment_ms = tristate<std::chrono::milliseconds>{std::nullopt};
+        obj.initial_retention_local_target_bytes = tristate<size_t>{
+          std::nullopt};
+        obj.initial_retention_local_target_ms
+          = tristate<std::chrono::milliseconds>{std::nullopt};
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -469,6 +477,11 @@ struct compat_check<cluster::topic_configuration> {
         obj.properties.segment_ms = tristate<std::chrono::milliseconds>{
           std::nullopt};
 
+        obj.properties.initial_retention_local_target_bytes = tristate<size_t>{
+          std::nullopt};
+        obj.properties.initial_retention_local_target_ms
+          = tristate<std::chrono::milliseconds>{std::nullopt};
+
         if (cfg != obj) {
             throw compat_error(fmt::format(
               "Verify of {{cluster::topic_property}} decoding "
@@ -526,6 +539,11 @@ struct compat_check<cluster::create_topics_request> {
 
             topic.properties.segment_ms = tristate<std::chrono::milliseconds>{
               std::nullopt};
+
+            topic.properties.initial_retention_local_target_bytes
+              = tristate<size_t>{std::nullopt};
+            topic.properties.initial_retention_local_target_ms
+              = tristate<std::chrono::milliseconds>{std::nullopt};
         }
         if (req != obj) {
             throw compat_error(fmt::format(
@@ -584,6 +602,10 @@ struct compat_check<cluster::create_topics_reply> {
               = tristate<std::chrono::milliseconds>{std::nullopt};
             topic.properties.segment_ms = tristate<std::chrono::milliseconds>{
               std::nullopt};
+            topic.properties.initial_retention_local_target_bytes
+              = tristate<size_t>{std::nullopt};
+            topic.properties.initial_retention_local_target_ms
+              = tristate<std::chrono::milliseconds>{std::nullopt};
         }
         if (reply != obj) {
             throw compat_error(fmt::format(

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -622,7 +622,10 @@ struct instance_generator<cluster::topic_properties> {
           std::nullopt,
           std::nullopt,
           std::nullopt,
-          std::nullopt};
+          std::nullopt,
+          tests::random_tristate(
+            [] { return random_generators::get_int<size_t>(); }),
+          tests::random_tristate([] { return tests::random_duration_ms(); })};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -596,6 +596,14 @@ inline void rjson_serialize(
       w,
       "record_value_subject_name_strategy_compat",
       tps.record_value_subject_name_strategy_compat);
+    write_member(
+      w,
+      "initial_retention_local_target_bytes",
+      tps.initial_retention_local_target_bytes);
+    write_member(
+      w,
+      "initial_retention_local_target_ms",
+      tps.initial_retention_local_target_ms);
     w.EndObject();
 }
 
@@ -650,6 +658,14 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
       rd,
       "record_value_subject_name_strategy_compat",
       obj.record_value_subject_name_strategy_compat);
+    read_member(
+      rd,
+      "initial_retention_local_target_bytes",
+      obj.initial_retention_local_target_bytes);
+    read_member(
+      rd,
+      "initial_retention_local_target_ms",
+      obj.initial_retention_local_target_ms);
 }
 
 inline void rjson_serialize(

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -564,6 +564,38 @@ inline void rjson_serialize(
     write_member(w, "retention_local_target_ms", tps.retention_local_target_ms);
     write_member(w, "remote_delete", tps.remote_delete);
     write_member(w, "segment_ms", tps.segment_ms);
+    write_member(
+      w,
+      "record_key_schema_id_validation",
+      tps.record_key_schema_id_validation);
+    write_member(
+      w,
+      "record_key_schema_id_validation_compat",
+      tps.record_key_schema_id_validation_compat);
+    write_member(
+      w,
+      "record_key_subject_name_strategy",
+      tps.record_key_subject_name_strategy);
+    write_member(
+      w,
+      "record_key_subject_name_strategy_compat",
+      tps.record_key_subject_name_strategy_compat);
+    write_member(
+      w,
+      "record_value_schema_id_validation",
+      tps.record_value_schema_id_validation);
+    write_member(
+      w,
+      "record_value_schema_id_validation_compat",
+      tps.record_value_schema_id_validation_compat);
+    write_member(
+      w,
+      "record_value_subject_name_strategy",
+      tps.record_value_subject_name_strategy);
+    write_member(
+      w,
+      "record_value_subject_name_strategy_compat",
+      tps.record_value_subject_name_strategy_compat);
     w.EndObject();
 }
 
@@ -586,6 +618,38 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
     read_member(rd, "retention_local_target_ms", obj.retention_local_target_ms);
     read_member(rd, "remote_delete", obj.remote_delete);
     read_member(rd, "segment_ms", obj.segment_ms);
+    read_member(
+      rd,
+      "record_key_schema_id_validation",
+      obj.record_key_schema_id_validation);
+    read_member(
+      rd,
+      "record_key_schema_id_validation_compat",
+      obj.record_key_schema_id_validation_compat);
+    read_member(
+      rd,
+      "record_key_subject_name_strategy",
+      obj.record_key_subject_name_strategy);
+    read_member(
+      rd,
+      "record_key_subject_name_strategy_compat",
+      obj.record_key_subject_name_strategy_compat);
+    read_member(
+      rd,
+      "record_value_schema_id_validation",
+      obj.record_value_schema_id_validation);
+    read_member(
+      rd,
+      "record_value_schema_id_validation_compat",
+      obj.record_value_schema_id_validation_compat);
+    read_member(
+      rd,
+      "record_value_subject_name_strategy",
+      obj.record_value_subject_name_strategy);
+    read_member(
+      rd,
+      "record_value_subject_name_strategy_compat",
+      obj.record_value_subject_name_strategy_compat);
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1956,6 +1956,22 @@ configuration::configuration()
        .visibility = visibility::tunable},
       10,
       {.min = 1})
+  , initial_retention_local_target_bytes_default(
+      *this,
+      "initial_retention_local_target_bytes_default",
+      "Initial local retention size target for partitions of topics with cloud "
+      "storage "
+      "write enabled",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt)
+  , initial_retention_local_target_ms_default(
+      *this,
+      "initial_retention_local_target_ms_default",
+      "Initial local retention time target for partitions of topics with cloud "
+      "storage "
+      "write enabled",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      24h)
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -368,6 +368,10 @@ struct configuration final : public config_store {
     bounded_property<double, numeric_bounds> disk_reservation_percent;
     bounded_property<uint16_t> space_management_max_log_concurrency;
     bounded_property<uint16_t> space_management_max_segment_concurrency;
+    property<std::optional<size_t>>
+      initial_retention_local_target_bytes_default;
+    property<std::chrono::milliseconds>
+      initial_retention_local_target_ms_default;
 
     // Archival cache
     property<uint64_t> cloud_storage_cache_size;

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -232,6 +232,21 @@ create_topic_properties_update(
                   kafka::config_resource_operation::set);
                 continue;
             }
+            if (cfg.name == topic_property_initial_retention_local_target_ms) {
+                parse_and_set_tristate(
+                  update.properties.initial_retention_local_target_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set);
+                continue;
+            }
+            if (
+              cfg.name == topic_property_initial_retention_local_target_bytes) {
+                parse_and_set_tristate(
+                  update.properties.initial_retention_local_target_bytes,
+                  cfg.value,
+                  kafka::config_resource_operation::set);
+                continue;
+            }
             if (
               config::shard_local_cfg().enable_schema_id_validation()
               != pandaproxy::schema_registry::schema_id_validation_mode::none) {

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -59,7 +59,9 @@ static constexpr auto supported_configs = std::to_array(
    topic_property_record_value_schema_id_validation,
    topic_property_record_value_schema_id_validation_compat,
    topic_property_record_value_subject_name_strategy,
-   topic_property_record_value_subject_name_strategy_compat});
+   topic_property_record_value_subject_name_strategy_compat,
+   topic_property_initial_retention_local_target_bytes,
+   topic_property_initial_retention_local_target_ms});
 
 bool is_supported(std::string_view name) {
     return std::any_of(
@@ -210,6 +212,10 @@ ss::future<response_ptr> create_topics_handler::handle(
           [&ctx](const creatable_topic& t) {
               auto result = generate_successfull_result(t);
               if (ctx.header().version >= api_version(5)) {
+                  // TODO(Rob): it looks like get_default_properties is used
+                  // only there so there is a high chance of diverging
+                  // dry run's default_properties upposed to be used on
+                  // topic creation and the real deal
                   auto default_properties
                     = ctx.metadata_cache().get_default_properties();
                   result.configs = {properties_to_result_configs(

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -962,6 +962,35 @@ ss::future<response_ptr> describe_configs_handler::handle(
             }
             }
 
+            add_topic_config_if_requested(
+              resource,
+              result,
+              topic_property_initial_retention_local_target_bytes,
+              ctx.metadata_cache()
+                .get_default_initial_retention_local_target_bytes(),
+              topic_property_initial_retention_local_target_bytes,
+              topic_config->properties.initial_retention_local_target_bytes,
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg()
+                  .initial_retention_local_target_bytes_default.desc()));
+
+            add_topic_config_if_requested(
+              resource,
+              result,
+              topic_property_initial_retention_local_target_ms,
+              std::make_optional(
+                ctx.metadata_cache()
+                  .get_default_initial_retention_local_target_ms()),
+              topic_property_initial_retention_local_target_ms,
+              topic_config->properties.initial_retention_local_target_ms,
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg()
+                  .initial_retention_local_target_ms_default.desc()));
+
             break;
         }
 

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -242,6 +242,21 @@ create_topic_properties_update(
                 continue;
             }
             if (
+              cfg.name == topic_property_initial_retention_local_target_bytes) {
+                parse_and_set_tristate(
+                  update.properties.initial_retention_local_target_bytes,
+                  cfg.value,
+                  op);
+                continue;
+            }
+            if (cfg.name == topic_property_initial_retention_local_target_ms) {
+                parse_and_set_tristate(
+                  update.properties.initial_retention_local_target_ms,
+                  cfg.value,
+                  op);
+                continue;
+            }
+            if (
               config::shard_local_cfg().enable_schema_id_validation()
               != pandaproxy::schema_registry::schema_id_validation_mode::none) {
                 if (schema_id_validation_config_parser(cfg, op)) {
@@ -322,6 +337,15 @@ static ss::future<std::vector<resp_resource_t>> alter_broker_configuartion(
 
         bool errored = false;
         for (const auto& c : resource.configs) {
+            // mapping looks sane for kafka's properties
+            //   compression.type=producer sensitive=false
+            //   synonyms={DEFAULT_CONFIG:log_compression_type=producer}
+            // (configuration.cc doesn't know `compression.type` but known
+            // `log_compression_type`) but for redpanda's properties it returns
+            //   redpanda.remote.read=false sensitive=false
+            //   synonyms={DEFAULT_CONFIG:redpanda.remote.read=false}
+            // which looks wrong because configuration.cc doesn't know
+            // `redpanda.remote.read`
             auto mapped_name = map_config_name(c.name);
 
             // Validate int8_t is within range of config_resource_operation

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -187,6 +187,13 @@ to_cluster_type(const creatable_topic& t) {
     cfg.properties.segment_ms = get_tristate_value<std::chrono::milliseconds>(
       config_entries, topic_property_segment_ms);
 
+    cfg.properties.initial_retention_local_target_bytes
+      = get_tristate_value<size_t>(
+        config_entries, topic_property_initial_retention_local_target_bytes);
+    cfg.properties.initial_retention_local_target_ms
+      = get_tristate_value<std::chrono::milliseconds>(
+        config_entries, topic_property_initial_retention_local_target_ms);
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 
@@ -346,6 +353,14 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
         config_entries[topic_property_record_value_subject_name_strategy_compat]
           = from_config_type(
             properties.record_value_subject_name_strategy_compat);
+    }
+    if (properties.initial_retention_local_target_bytes.has_optional_value()) {
+        config_entries[topic_property_initial_retention_local_target_bytes]
+          = from_config_type(*properties.initial_retention_local_target_bytes);
+    }
+    if (properties.initial_retention_local_target_ms.has_optional_value()) {
+        config_entries[topic_property_initial_retention_local_target_ms]
+          = from_config_type(*properties.initial_retention_local_target_ms);
     }
 
     /// Final topic_property not encoded here is \ref remote_topic_properties,

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -94,6 +94,13 @@ static constexpr std::string_view
   topic_property_record_value_subject_name_strategy_compat
   = "confluent.value.subject.name.strategy";
 
+static constexpr std::string_view
+  topic_property_initial_retention_local_target_bytes
+  = "initial.retention.local.target.bytes";
+static constexpr std::string_view
+  topic_property_initial_retention_local_target_ms
+  = "initial.retention.local.target.ms";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 static constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -364,7 +364,9 @@ FIXTURE_TEST(
       "redpanda.value.schema.id.validation",
       "confluent.value.schema.validation",
       "redpanda.value.subject.name.strategy",
-      "confluent.value.subject.name.strategy"};
+      "confluent.value.subject.name.strategy",
+      "initial.retention.local.target.bytes",
+      "initial.retention.local.target.ms"};
 
     // All properties_request
     auto all_describe_resp = describe_configs(test_tp);

--- a/src/v/migrations/cloud_storage_config.cc
+++ b/src/v/migrations/cloud_storage_config.cc
@@ -50,6 +50,9 @@ ss::future<> cloud_storage_config::do_mutate() {
               model::shadow_indexing_mode::disabled))
             || config::shard_local_cfg().cloud_storage_enable_remote_write();
 
+        // This is a migration from retention_bytes to
+        // retention_local_target_bytes so we don't need to handle
+        // initial_retention_local_target_bytes
         if (
           props.retention_local_target_bytes.has_optional_value()
           || props.retention_local_target_ms.has_optional_value()) {

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -328,6 +328,12 @@ ss::future<> service::create_internal_topic() {
              .value{retain_forever}},
             {.name{
                ss::sstring{kafka::topic_property_retention_local_target_ms}},
+             .value{retain_forever}},
+            {.name{ss::sstring{
+               kafka::topic_property_initial_retention_local_target_bytes}},
+             .value{retain_forever}},
+            {.name{ss::sstring{
+               kafka::topic_property_initial_retention_local_target_ms}},
              .value{retain_forever}}}};
     };
     auto res = co_await _client.local().create_topic(make_internal_topic());

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -67,6 +67,10 @@ public:
         // time before rolling a segment, from first write
         tristate<std::chrono::milliseconds> segment_ms{std::nullopt};
 
+        tristate<size_t> initial_retention_local_target_bytes{std::nullopt};
+        tristate<std::chrono::milliseconds> initial_retention_local_target_ms{
+          std::nullopt};
+
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
     };

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -101,7 +101,9 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "{{compaction_strategy: {}, cleanup_policy_bitflags: {}, segment_size: "
       "{}, retention_bytes: {}, retention_time_ms: {}, recovery_enabled: {}, "
       "retention_local_target_bytes: {}, retention_local_target_ms: {}, "
-      "remote_delete: {}, segment_ms: {}}}",
+      "remote_delete: {}, segment_ms: {}, "
+      "initial_retention_local_target_bytes: {}, "
+      "initial_retention_local_target_ms: {}}}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -111,7 +113,9 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.retention_local_target_bytes,
       v.retention_local_target_ms,
       v.remote_delete,
-      v.segment_ms);
+      v.segment_ms,
+      v.initial_retention_local_target_bytes,
+      v.initial_retention_local_target_ms);
 
     return o;
 }

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -79,6 +79,9 @@ class TopicSpec:
     PROPERTY_RECORD_VALUE_SCHEMA_ID_VALIDATION_COMPAT = "confluent.value.schema.validation"
     PROPERTY_RECORD_VALUE_SUBJECT_NAME_STRATEGY_COMPAT = "confluent.value.subject.name.strategy"
 
+    PROPERTY_INITIAL_RETENTION_LOCAL_TARGET_BYTES = "initial.retention.local.target.bytes"
+    PROPERTY_INITIAL_RETENTION_LOCAL_TARGET_MS = "initial.retention.local.target.ms"
+
     def __init__(self,
                  *,
                  name=None,
@@ -103,7 +106,9 @@ class TopicSpec:
                  record_value_schema_id_validation=None,
                  record_value_schema_id_validation_compat=None,
                  record_value_subject_name_strategy=None,
-                 record_value_subject_name_strategy_compat=None):
+                 record_value_subject_name_strategy_compat=None,
+                 initial_retention_local_target_bytes=None,
+                 initial_retention_local_target_ms=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -127,6 +132,8 @@ class TopicSpec:
         self.record_value_schema_id_validation_compat = record_value_schema_id_validation_compat
         self.record_value_subject_name_strategy = record_value_subject_name_strategy
         self.record_value_subject_name_strategy_compat = record_value_subject_name_strategy_compat
+        self.initial_retention_local_target_bytes = initial_retention_local_target_bytes
+        self.initial_retention_local_target_ms = initial_retention_local_target_ms
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -202,7 +202,21 @@ class DescribeTopicsTest(RedpandaTest):
                 "io.confluent.kafka.serializers.subject.TopicNameStrategy",
                 doc_string=
                 "The subject name strategy for values if confluent.value.schema.validation is enabled"
-            )
+            ),
+            "initial.retention.local.target.bytes":
+            ConfigProperty(
+                config_type="LONG",
+                value="-1",
+                doc_string=
+                "Initial local retention size target for partitions of topics with cloud storage write enabled"
+            ),
+            "initial.retention.local.target.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="86400000",
+                doc_string=
+                "Initial local retention time target for partitions of topics with cloud storage write enabled"
+            ),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -425,7 +425,9 @@ class CreateSITopicsTest(RedpandaTest):
             'redpanda.remote.write': 'true',
             'redpanda.remote.read': 'true',
             'retention.local.target.bytes': '123456',
-            'retention.local.target.ms': '123456'
+            'retention.local.target.ms': '123456',
+            'initial.retention.local.target.bytes': '123456',
+            'initial.retention.local.target.ms': '123456'
         }
 
         for k, v in examples.items():


### PR DESCRIPTION
Add topic config for fast partition movement:

```
initial.retention.local.target.bytes
initial.retention.local.target.ms
```

Fixes #13708

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none