### PR TITLE
config: support configuration constraints

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     rjson_serialization.cc
     validators.cc
     throughput_control_group.cc
+    property_constraints.cc
   DEPS
     v::json
     v::model

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2664,7 +2664,17 @@ configuration::configuration()
       "The sample period for the CPU profiler",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       100ms,
-      {.min = 1ms}) {}
+      {.min = 1ms})
+  , constraints(
+      *this,
+      "constraints",
+      "A sequence of constraints for cluster-level configs",
+      {.needs_restart = needs_restart::no,
+       .example
+       = R"([{'name': 'default_topic_replications','type': 'restrict','min': 3, 'max': 9}])",
+       .visibility = visibility::user},
+      {},
+      validate_constraints) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -18,6 +18,7 @@
 #include "config/data_directory_path.h"
 #include "config/endpoint_tls_config.h"
 #include "config/property.h"
+#include "config/property_constraints.h"
 #include "config/throughput_control_group.h"
 #include "config/tls_config.h"
 #include "model/compression.h"
@@ -507,6 +508,7 @@ struct configuration final : public config_store {
     // debug controls
     property<bool> cpu_profiler_enabled;
     bounded_property<std::chrono::milliseconds> cpu_profiler_sample_period_ms;
+    one_or_many_property<constraint_t> constraints;
 
     configuration();
 

--- a/src/v/config/property_constraints.cc
+++ b/src/v/config/property_constraints.cc
@@ -1,0 +1,533 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/property_constraints.h"
+
+#include "cluster/types.h"
+#include "config/configuration.h"
+#include "model/fundamental.h"
+#include "vassert.h"
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+namespace config {
+
+std::string_view to_string_view(constraint_type type) {
+    switch (type) {
+    case constraint_type::none:
+        return "none";
+    case constraint_type::restrikt:
+        return "restrict";
+    case constraint_type::clamp:
+        return "clamp";
+    }
+}
+
+template<>
+std::optional<constraint_type>
+from_string_view<constraint_type>(std::string_view sv) {
+    return string_switch<std::optional<constraint_type>>(sv)
+      .match("none", constraint_type::none)
+      .match("restrict", constraint_type::restrikt)
+      .match("clamp", constraint_type::clamp);
+}
+
+namespace {
+template<typename T>
+struct range_values {
+    std::optional<T> min;
+    std::optional<T> max;
+
+    range_values(
+      std::optional<ss::sstring>& min_str,
+      std::optional<ss::sstring>& max_str,
+      ss::noncopyable_function<T(ss::sstring&)> type_converter)
+      : min{min_str ? std::make_optional(type_converter(*min_str)) : std::nullopt}
+      , max{
+          max_str ? std::make_optional(type_converter(*max_str))
+                  : std::nullopt} {}
+};
+
+model::shadow_indexing_mode drop_fetch(model::shadow_indexing_mode mode) {
+    if (mode == model::shadow_indexing_mode::full) {
+        return model::shadow_indexing_mode::archival;
+    } else if (mode == model::shadow_indexing_mode::fetch) {
+        return model::shadow_indexing_mode::disabled;
+    } else {
+        return mode;
+    }
+}
+
+model::shadow_indexing_mode drop_archival(model::shadow_indexing_mode mode) {
+    if (mode == model::shadow_indexing_mode::full) {
+        return model::shadow_indexing_mode::fetch;
+    } else if (mode == model::shadow_indexing_mode::archival) {
+        return model::shadow_indexing_mode::disabled;
+    } else {
+        return mode;
+    }
+}
+} // namespace
+
+// This is where all the type conversions happen
+ss::shared_ptr<constraint_validator_t> constraint_validator_map(
+  ss::sstring& name,
+  std::optional<ss::sstring> min_str_opt,
+  std::optional<ss::sstring> max_str_opt,
+  constraint_enabled_t enabled) {
+    auto& cfg = config::shard_local_cfg();
+
+    if (name == "log_cleanup_policy") {
+        return ss::make_shared<
+          constraint_validator_enabled<model::cleanup_policy_bitflags>>(
+          std::move(enabled),
+          cfg.log_cleanup_policy.bind(),
+          [](const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.cleanup_policy_bitflags.value_or(
+                model::cleanup_policy_bitflags::none);
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const model::cleanup_policy_bitflags& topic_val) {
+              topic_cfg.properties.cleanup_policy_bitflags = topic_val;
+          });
+    } else if (name == "log_retention_ms") {
+        auto range = range_values<std::chrono::milliseconds>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return std::chrono::milliseconds{std::stol(str_val)};
+          });
+        vassert(
+          cfg.log_retention_ms.default_value().has_value(),
+          "{} does not have a default value",
+          cfg.log_retention_ms.name());
+        auto def_val = *cfg.log_retention_ms.default_value();
+        return ss::make_shared<
+          constraint_validator_range<std::chrono::milliseconds>>(
+          std::move(range.min),
+          std::move(range.max),
+          [def_val{std::move(def_val)}](
+            const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.retention_duration
+                         .has_optional_value()
+                       ? topic_cfg.properties.retention_duration.value()
+                       : def_val;
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const std::chrono::milliseconds& topic_val) {
+              topic_cfg.properties.retention_duration
+                = tristate<std::chrono::milliseconds>(topic_val);
+          });
+    } else if (name == "log_segment_ms") {
+        auto range = range_values<std::chrono::milliseconds>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return std::chrono::milliseconds{std::stol(str_val)};
+          });
+        vassert(
+          cfg.log_segment_ms.default_value().has_value(),
+          "{} does not have a default value",
+          cfg.log_segment_ms.name());
+        auto def_val = *cfg.log_segment_ms.default_value();
+        return ss::make_shared<
+          constraint_validator_range<std::chrono::milliseconds>>(
+          std::move(range.min),
+          std::move(range.max),
+          [def_val{std::move(def_val)}](
+            const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.segment_ms.has_optional_value()
+                       ? topic_cfg.properties.segment_ms.value()
+                       : def_val;
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const std::chrono::milliseconds& topic_val) {
+              topic_cfg.properties.segment_ms
+                = tristate<std::chrono::milliseconds>(topic_val);
+          });
+    } else if (name == "log_segment_size") {
+        auto range = range_values<uint64_t>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return uint64_t{std::stoul(str_val)};
+          });
+        auto def_val = cfg.log_segment_size.default_value();
+        return ss::make_shared<constraint_validator_range<uint64_t>>(
+          std::move(range.min),
+          std::move(range.max),
+          [def_val{std::move(def_val)}](
+            const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.segment_size.value_or(def_val);
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const uint64_t& topic_val) {
+              topic_cfg.properties.segment_size = topic_val;
+          });
+    } else if (name == "retention_bytes") {
+        auto range = range_values<size_t>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return size_t{std::stoul(str_val)};
+          });
+        return ss::make_shared<constraint_validator_range<size_t>>(
+          std::move(range.min),
+          std::move(range.max),
+          [](const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.retention_bytes.has_optional_value()
+                       ? topic_cfg.properties.retention_bytes.value()
+                       : 0;
+          },
+          [](cluster::topic_configuration& topic_cfg, const size_t& topic_val) {
+              topic_cfg.properties.retention_bytes = tristate<size_t>(
+                topic_val);
+          });
+    } else if (name == "log_compression_type") {
+        return ss::make_shared<
+          constraint_validator_enabled<model::compression>>(
+          std::move(enabled),
+          cfg.log_compression_type.bind(),
+          [](const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.compression.value_or(
+                model::compression::none);
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const model::compression& topic_val) {
+              topic_cfg.properties.compression = topic_val;
+          });
+    } else if (name == "kafka_batch_max_bytes") {
+        auto range = range_values<uint32_t>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return static_cast<uint32_t>(std::stoul(str_val));
+          });
+        auto def_val = cfg.kafka_batch_max_bytes.default_value();
+        return ss::make_shared<constraint_validator_range<uint32_t>>(
+          std::move(range.min),
+          std::move(range.max),
+          [def_val{std::move(def_val)}](
+            const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.batch_max_bytes.value_or(def_val);
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const uint32_t& topic_val) {
+              topic_cfg.properties.batch_max_bytes = topic_val;
+          });
+    } else if (name == "log_message_timestamp_type") {
+        auto def_val = cfg.log_message_timestamp_type.default_value();
+        return ss::make_shared<
+          constraint_validator_enabled<model::timestamp_type>>(
+          std::move(enabled),
+          cfg.log_message_timestamp_type.bind(),
+          [def_val{std::move(def_val)}](
+            const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.timestamp_type.value_or(def_val);
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const model::timestamp_type& topic_val) {
+              topic_cfg.properties.timestamp_type = topic_val;
+          });
+    } else if (name == "cloud_storage_enable_remote_read") {
+        auto enable_remote_write
+          = cfg.cloud_storage_enable_remote_write.default_value();
+        return ss::make_shared<constraint_validator_enabled<bool>>(
+          std::move(enabled),
+          cfg.cloud_storage_enable_remote_read.bind(),
+          [](const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.shadow_indexing
+                       ? model::is_fetch_enabled(
+                         *topic_cfg.properties.shadow_indexing)
+                       : false;
+          },
+          [enable_remote_write](
+            cluster::topic_configuration& topic_cfg,
+            const bool& fetch_enabled) {
+              if (fetch_enabled) {
+                  if (topic_cfg.properties.shadow_indexing) {
+                      topic_cfg.properties.shadow_indexing
+                        = model::add_shadow_indexing_flag(
+                          *topic_cfg.properties.shadow_indexing,
+                          model::shadow_indexing_mode::fetch);
+                  } else {
+                      topic_cfg.properties.shadow_indexing
+                        = enable_remote_write
+                            ? model::shadow_indexing_mode::full
+                            : model::shadow_indexing_mode::fetch;
+                  }
+              } else {
+                  if (topic_cfg.properties.shadow_indexing) {
+                      topic_cfg.properties.shadow_indexing = drop_fetch(
+                        *topic_cfg.properties.shadow_indexing);
+                  } else {
+                      topic_cfg.properties.shadow_indexing
+                        = enable_remote_write
+                            ? model::shadow_indexing_mode::archival
+                            : model::shadow_indexing_mode::disabled;
+                  }
+              }
+          });
+    } else if (name == "cloud_storage_enable_remote_write") {
+        auto enable_remote_read
+          = cfg.cloud_storage_enable_remote_read.default_value();
+        return ss::make_shared<constraint_validator_enabled<bool>>(
+          std::move(enabled),
+          cfg.cloud_storage_enable_remote_write.bind(),
+          [](const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.shadow_indexing
+                       ? model::is_archival_enabled(
+                         *topic_cfg.properties.shadow_indexing)
+                       : false;
+          },
+          [enable_remote_read](
+            cluster::topic_configuration& topic_cfg,
+            const bool& archival_enabled) {
+              if (archival_enabled) {
+                  if (topic_cfg.properties.shadow_indexing) {
+                      topic_cfg.properties.shadow_indexing
+                        = model::add_shadow_indexing_flag(
+                          *topic_cfg.properties.shadow_indexing,
+                          model::shadow_indexing_mode::archival);
+                  } else {
+                      topic_cfg.properties.shadow_indexing
+                        = enable_remote_read
+                            ? model::shadow_indexing_mode::full
+                            : model::shadow_indexing_mode::archival;
+                  }
+              } else {
+                  if (topic_cfg.properties.shadow_indexing) {
+                      topic_cfg.properties.shadow_indexing = drop_archival(
+                        *topic_cfg.properties.shadow_indexing);
+                  } else {
+                      topic_cfg.properties.shadow_indexing
+                        = enable_remote_read
+                            ? model::shadow_indexing_mode::fetch
+                            : model::shadow_indexing_mode::disabled;
+                  }
+              }
+          });
+    } else if (name == "retention_local_target_bytes_default") {
+        auto range = range_values<size_t>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return uint64_t{std::stoul(str_val)};
+          });
+        return ss::make_shared<constraint_validator_range<uint64_t>>(
+          std::move(range.min),
+          std::move(range.max),
+          [](const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.retention_local_target_bytes
+                         .has_optional_value()
+                       ? topic_cfg.properties.retention_local_target_bytes
+                           .value()
+                       : 0;
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const uint64_t& topic_val) {
+              topic_cfg.properties.retention_local_target_bytes
+                = tristate<uint64_t>(topic_val);
+          });
+    } else if (name == "retention_local_target_ms_default") {
+        auto range = range_values<std::chrono::milliseconds>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return std::chrono::milliseconds{std::stol(str_val)};
+          });
+        auto def_val = cfg.retention_local_target_ms_default.default_value();
+        return ss::make_shared<
+          constraint_validator_range<std::chrono::milliseconds>>(
+          std::move(range.min),
+          std::move(range.max),
+          [def_val{std::move(def_val)}](
+            const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.properties.retention_local_target_ms
+                         .has_optional_value()
+                       ? topic_cfg.properties.retention_local_target_ms.value()
+                       : def_val;
+          },
+          [](
+            cluster::topic_configuration& topic_cfg,
+            const std::chrono::milliseconds& topic_val) {
+              topic_cfg.properties.retention_local_target_ms
+                = tristate<std::chrono::milliseconds>(topic_val);
+          });
+    } else if (name == "default_topic_replications") {
+        auto range = range_values<int16_t>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return static_cast<int16_t>(std::stoi(str_val));
+          });
+        return ss::make_shared<constraint_validator_range<int16_t>>(
+          std::move(range.min),
+          std::move(range.max),
+          [](const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.replication_factor;
+          },
+          [](
+            cluster::topic_configuration& topic_cfg, const int16_t& topic_val) {
+              topic_cfg.replication_factor = topic_val;
+          });
+    } else if (name == "default_topic_partitions") {
+        auto range = range_values<int32_t>(
+          min_str_opt, max_str_opt, [](ss::sstring& str_val) {
+              return int32_t{std::stoi(str_val)};
+          });
+        return ss::make_shared<constraint_validator_range<int32_t>>(
+          std::move(range.min),
+          std::move(range.max),
+          [](const cluster::topic_configuration& topic_cfg) {
+              return topic_cfg.partition_count;
+          },
+          [](
+            cluster::topic_configuration& topic_cfg, const int32_t& topic_val) {
+              topic_cfg.partition_count = topic_val;
+          });
+    } else {
+        return nullptr;
+    }
+}
+
+constraint_t::constraint_t(
+  ss::sstring name,
+  constraint_type type,
+  ss::shared_ptr<constraint_validator_t> validator)
+  : name{name}
+  , type{type}
+  , validator{validator} {}
+
+bool constraint_t::validate(
+  const cluster::topic_configuration& topic_cfg) const {
+    if (validator != nullptr) {
+        return validator->validate(topic_cfg);
+    }
+    return true;
+}
+
+void constraint_t::clamp(cluster::topic_configuration& topic_cfg) const {
+    if (validator != nullptr) {
+        validator->clamp(topic_cfg);
+    }
+}
+
+std::optional<ss::sstring> constraint_t::check() const {
+    // TODO(@NyaliaLui): Create a predefined map of supported constraints
+    // with their correct type mappings. Then check if the given name is
+    // in the map and return the necessary error message.
+
+    if (validator != nullptr) {
+        return validator->check(name);
+    }
+
+    return std::nullopt;
+}
+
+std::vector<constraint_t> predefined_constraints() {
+    std::vector<constraint_t> constraints;
+    constraints.reserve(2);
+
+    ss::sstring segment_size_name = "log_segment_size";
+    ss::sstring segment_ms_name = "log_segment_ms";
+
+    constraints.emplace_back(
+      segment_size_name,
+      constraint_type::clamp,
+      constraint_validator_map(
+        segment_size_name, "1048576", std::nullopt, constraint_enabled_t::no));
+    constraints.emplace_back(
+      segment_ms_name,
+      constraint_type::clamp,
+      constraint_validator_map(
+        segment_ms_name, "60000", "31536000000", constraint_enabled_t::no));
+
+    return constraints;
+}
+
+std::ostream& operator<<(std::ostream& os, const constraint_t& constraint) {
+    os << fmt::format(
+      "name: {}, type: {}", constraint.name, to_string_view(constraint.type));
+    if (constraint.validator != nullptr) {
+        constraint.validator->print(os);
+    }
+    return os;
+}
+
+} // namespace config
+
+namespace YAML {
+
+Node convert<config::constraint_t>::encode(const type& rhs) {
+    Node node;
+    node["name"] = rhs.name;
+    node["type"] = ss::sstring(config::to_string_view(rhs.type));
+    if (rhs.validator != nullptr) {
+        rhs.validator->encode_yaml(node);
+    }
+    return node;
+}
+
+bool convert<config::constraint_t>::decode(const Node& node, type& rhs) {
+    for (const auto& s : {"name", "type"}) {
+        if (!node[s]) {
+            return false;
+        }
+    }
+
+    rhs.name = node["name"].as<ss::sstring>();
+    rhs.type = config::from_string_view<config::constraint_type>(
+                 node["type"].as<ss::sstring>())
+                 .value();
+
+    std::optional<ss::sstring> min_str_opt{std::nullopt},
+      max_str_opt{std::nullopt};
+    if (node["min"] && !node["min"].IsNull()) {
+        min_str_opt = node["min"].as<ss::sstring>();
+    }
+
+    if (node["max"] && !node["max"].IsNull()) {
+        max_str_opt = node["max"].as<ss::sstring>();
+    }
+
+    config::constraint_enabled_t enabled{config::constraint_enabled_t::no};
+    if (node["enabled"] && node["enabled"].as<bool>()) {
+        enabled = config::constraint_enabled_t::yes;
+    }
+
+    auto validator = constraint_validator_map(
+      rhs.name,
+      std::move(min_str_opt),
+      std::move(max_str_opt),
+      std::move(enabled));
+
+    // A null validator means Redpanda does not support constraints for that
+    // config name
+    if (validator == nullptr) {
+        return false;
+    }
+
+    rhs.validator = std::move(validator);
+    return true;
+}
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_t& constraint) {
+    w.StartObject();
+    w.Key("name");
+    w.String(constraint.name);
+    w.Key("type");
+    auto type_str = ss::sstring(config::to_string_view(constraint.type));
+    w.String(type_str);
+    if (constraint.validator != nullptr) {
+        constraint.validator->to_json(w);
+    }
+    w.EndObject();
+}
+
+} // namespace json

--- a/src/v/config/property_constraints.h
+++ b/src/v/config/property_constraints.h
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/convert.h"
+#include "config/from_string_view.h"
+#include "config/property.h"
+#include "json/json.h"
+
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sstring.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+#include <fmt/format.h>
+#include <yaml-cpp/node/node.h>
+
+#include <string>
+
+namespace cluster {
+struct topic_configuration;
+} // namespace cluster
+
+namespace config {
+
+struct constraint_validator_t {
+    virtual bool validate(const cluster::topic_configuration&) const = 0;
+    virtual void clamp(cluster::topic_configuration&) const = 0;
+    virtual std::optional<ss::sstring> check(const ss::sstring&) const = 0;
+    virtual void encode_yaml(YAML::Node&) const = 0;
+    virtual void to_json(json::Writer<json::StringBuffer>&) const = 0;
+    virtual void print(std::ostream&) const = 0;
+    virtual ~constraint_validator_t() = default;
+};
+
+using constraint_enabled_t = ss::bool_class<struct constraint_enabled_tag>;
+
+ss::shared_ptr<constraint_validator_t> constraint_validator_map(
+  ss::sstring& name,
+  std::optional<ss::sstring> min_str_opt,
+  std::optional<ss::sstring> max_str_opt,
+  constraint_enabled_t enabled);
+
+template<typename T>
+struct constraint_validator_range : public constraint_validator_t {
+    using extractor_t =
+      typename ss::noncopyable_function<T(const cluster::topic_configuration&)>;
+    using clamper_t = typename ss::noncopyable_function<void(
+      cluster::topic_configuration&, const T&)>;
+
+    std::optional<T> min;
+    std::optional<T> max;
+    extractor_t value_extractor;
+    clamper_t clamper;
+
+    constraint_validator_range(
+      std::optional<T> min,
+      std::optional<T> max,
+      extractor_t value_extractor,
+      clamper_t clamper)
+      : min{std::move(min)}
+      , max{std::move(max)}
+      , value_extractor{std::move(value_extractor)}
+      , clamper{std::move(clamper)} {}
+
+    bool
+    validate(const cluster::topic_configuration& topic_cfg) const override {
+        T topic_val = value_extractor(topic_cfg);
+
+        if (min && *min > topic_val) {
+            return false;
+        }
+
+        if (max && *max < topic_val) {
+            return false;
+        }
+
+        return true;
+    }
+
+    void clamp(cluster::topic_configuration& topic_cfg) const override {
+        T topic_val = value_extractor(topic_cfg);
+        if (min) {
+            topic_val = std::max(*min, topic_val);
+        }
+        if (max) {
+            topic_val = std::min(*max, topic_val);
+        }
+        clamper(topic_cfg, topic_val);
+    }
+
+    std::optional<ss::sstring>
+    check(const ss::sstring& property_name) const override {
+        if ((min && max) && (*min > *max)) {
+            return fmt::format(
+              "Constraints failure: min > max: config {}", property_name);
+        }
+        return std::nullopt;
+    }
+
+    void encode_yaml(YAML::Node& n) const override {
+        if (min) {
+            n["min"] = *min;
+        }
+
+        if (max) {
+            n["max"] = *max;
+        }
+    }
+
+    void to_json(json::Writer<json::StringBuffer>& w) const override {
+        w.Key("min");
+        rjson_serialize<T>(w, min);
+
+        w.Key("max");
+        rjson_serialize<T>(w, max);
+    }
+
+    void print(std::ostream& os) const override {
+        os << fmt::format("min: {}, max: {}", min, max);
+    }
+};
+
+/*
+ * When enabled=True, this validator will check topic-level properties against
+ * the corresponding cluster-level property.
+ */
+template<typename T>
+struct constraint_validator_enabled : public constraint_validator_t {
+    using extractor_t =
+      typename ss::noncopyable_function<T(const cluster::topic_configuration&)>;
+    using clamper_t = typename ss::noncopyable_function<void(
+      cluster::topic_configuration&, const T&)>;
+
+    constraint_enabled_t enabled;
+    binding<T> original_property;
+    extractor_t value_extractor;
+    clamper_t clamper;
+
+    constraint_validator_enabled(
+      constraint_enabled_t enabled,
+      binding<T> original,
+      extractor_t value_extractor,
+      clamper_t clamper)
+      : enabled{std::move(enabled)}
+      , original_property{std::move(original)}
+      , value_extractor{std::move(value_extractor)}
+      , clamper{std::move(clamper)} {}
+
+    bool
+    validate(const cluster::topic_configuration& topic_cfg) const override {
+        if (enabled == constraint_enabled_t::yes) {
+            T topic_val = value_extractor(topic_cfg);
+            return topic_val == original_property();
+        } else {
+            return true;
+        }
+    }
+
+    void clamp(cluster::topic_configuration& topic_cfg) const override {
+        if (enabled == constraint_enabled_t::yes) {
+            T topic_val = value_extractor(topic_cfg);
+            topic_val = original_property();
+            clamper(topic_cfg, topic_val);
+        }
+    }
+
+    std::optional<ss::sstring> check(const ss::sstring&) const override {
+        return std::nullopt;
+    }
+
+    void encode_yaml(YAML::Node& n) const override {
+        n["enabled"] = enabled == constraint_enabled_t::yes;
+    }
+
+    void to_json(json::Writer<json::StringBuffer>& w) const override {
+        w.Key("enabled");
+        w.Bool(enabled == constraint_enabled_t::yes);
+    }
+
+    void print(std::ostream& os) const override {
+        os << "enabled: " << enabled;
+    }
+};
+
+enum class constraint_type {
+    none = 0,
+    restrikt = 1,
+    clamp = 2,
+};
+
+std::string_view to_string_view(constraint_type type);
+
+template<>
+std::optional<constraint_type>
+from_string_view<constraint_type>(std::string_view sv);
+
+struct constraint_t {
+    ss::sstring name;
+    constraint_type type;
+    ss::shared_ptr<constraint_validator_t> validator;
+
+    constraint_t() = default;
+    constraint_t(
+      ss::sstring name,
+      constraint_type type,
+      ss::shared_ptr<constraint_validator_t> validator);
+
+    bool validate(const cluster::topic_configuration& topic_cfg) const;
+    void clamp(cluster::topic_configuration& topic_cfg) const;
+    std::optional<ss::sstring> check() const;
+
+    friend bool operator==(const constraint_t&, const constraint_t&) = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const constraint_t& constraint);
+};
+
+std::vector<constraint_t> predefined_constraints();
+
+namespace detail {
+
+template<>
+consteval std::string_view property_type_name<constraint_t>() {
+    return "config::constraint_t";
+}
+
+} // namespace detail
+
+} // namespace config
+
+namespace YAML {
+template<>
+struct convert<config::constraint_t> {
+    using type = config::constraint_t;
+    static Node encode(const type& rhs);
+    static bool decode(const Node& node, type& rhs);
+};
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_t& constraint);
+
+} // namespace json

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -10,7 +10,8 @@ set(srcs
     seed_server_property_test.cc
     cloud_credentials_source_test.cc
     validator_tests.cc
-    throughput_control_group_test.cc)
+    throughput_control_group_test.cc
+    config_constraints_test.cc)
 
 rp_test(
   UNIT_TEST

--- a/src/v/config/tests/config_constraints_test.cc
+++ b/src/v/config/tests/config_constraints_test.cc
@@ -1,0 +1,153 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/tests/constraints_utils.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+namespace {
+
+SEASTAR_THREAD_TEST_CASE(test_constraint_validation) {
+    auto cfg = test_config();
+
+    cluster::topic_configuration topic_cfg;
+
+    // Check restrict constraints
+    {
+        auto& enum_constraint = cfg.restrict_constraints()[0];
+        topic_cfg.properties.cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::deletion;
+        BOOST_CHECK(enum_constraint.validate(topic_cfg));
+        topic_cfg.properties.cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::compaction;
+        BOOST_CHECK(!enum_constraint.validate(topic_cfg));
+
+        auto& integral_constraint = cfg.restrict_constraints()[1];
+        topic_cfg.replication_factor = LIMIT_MIN + 1;
+        BOOST_CHECK(integral_constraint.validate(topic_cfg));
+        topic_cfg.replication_factor = LIMIT_MAX - 1;
+        BOOST_CHECK(integral_constraint.validate(topic_cfg));
+        topic_cfg.replication_factor = LIMIT_MIN - 1;
+        BOOST_CHECK(!integral_constraint.validate(topic_cfg));
+        topic_cfg.replication_factor = LIMIT_MAX + 1;
+        BOOST_CHECK(!integral_constraint.validate(topic_cfg));
+
+        auto& ms_constraint = cfg.restrict_constraints()[2];
+        topic_cfg.properties.retention_duration
+          = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS + 1ms);
+        BOOST_CHECK(ms_constraint.validate(topic_cfg));
+        topic_cfg.properties.retention_duration
+          = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS - 1ms);
+        BOOST_CHECK(ms_constraint.validate(topic_cfg));
+        topic_cfg.properties.retention_duration
+          = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS - 1ms);
+        BOOST_CHECK(!ms_constraint.validate(topic_cfg));
+        topic_cfg.properties.retention_duration
+          = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS + 1ms);
+        BOOST_CHECK(!ms_constraint.validate(topic_cfg));
+    }
+
+    // Check clamp constraints
+    {
+        auto& enum_constraint = cfg.clamp_constraints()[0];
+        topic_cfg.properties.cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::deletion;
+        BOOST_CHECK(enum_constraint.validate(topic_cfg));
+        topic_cfg.properties.cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::compaction;
+        BOOST_CHECK(!enum_constraint.validate(topic_cfg));
+
+        auto& integral_constraint = cfg.clamp_constraints()[1];
+        topic_cfg.replication_factor = LIMIT_MIN + 1;
+        BOOST_CHECK(integral_constraint.validate(topic_cfg));
+        topic_cfg.replication_factor = LIMIT_MAX - 1;
+        BOOST_CHECK(integral_constraint.validate(topic_cfg));
+        topic_cfg.replication_factor = LIMIT_MIN - 1;
+        BOOST_CHECK(!integral_constraint.validate(topic_cfg));
+        topic_cfg.replication_factor = LIMIT_MAX + 1;
+        BOOST_CHECK(!integral_constraint.validate(topic_cfg));
+
+        auto& ms_constraint = cfg.clamp_constraints()[2];
+        topic_cfg.properties.retention_duration
+          = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS + 1ms);
+        BOOST_CHECK(ms_constraint.validate(topic_cfg));
+        topic_cfg.properties.retention_duration
+          = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS - 1ms);
+        BOOST_CHECK(ms_constraint.validate(topic_cfg));
+        topic_cfg.properties.retention_duration
+          = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS - 1ms);
+        BOOST_CHECK(!ms_constraint.validate(topic_cfg));
+        topic_cfg.properties.retention_duration
+          = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS + 1ms);
+        BOOST_CHECK(!ms_constraint.validate(topic_cfg));
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_constraint_clamping) {
+    auto cfg = test_config();
+
+    cluster::topic_configuration topic_cfg;
+
+    // Check enum clamp constraint
+    auto& enum_constraint = cfg.clamp_constraints()[0];
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::deletion;
+    enum_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(
+      topic_cfg.properties.cleanup_policy_bitflags, cfg.original_enum());
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    enum_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(
+      topic_cfg.properties.cleanup_policy_bitflags, cfg.original_enum());
+
+    // Check integral clamp constraint
+    auto& integral_constraint = cfg.clamp_constraints()[1];
+    topic_cfg.replication_factor = LIMIT_MIN + 1;
+    integral_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(topic_cfg.replication_factor, LIMIT_MIN + 1);
+    topic_cfg.replication_factor = LIMIT_MAX - 1;
+    integral_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(topic_cfg.replication_factor, LIMIT_MAX - 1);
+    topic_cfg.replication_factor = LIMIT_MIN - 1;
+    integral_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(topic_cfg.replication_factor, LIMIT_MIN);
+    topic_cfg.replication_factor = LIMIT_MAX + 1;
+    integral_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(topic_cfg.replication_factor, LIMIT_MAX);
+
+    // Check ms clamp constraint
+    auto& ms_constraint = cfg.clamp_constraints()[2];
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS + 1ms);
+    ms_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>(LIMIT_MIN_MS + 1ms));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS - 1ms);
+    ms_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>(LIMIT_MAX_MS - 1ms));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS - 1ms);
+    ms_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>(LIMIT_MIN_MS));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS + 1ms);
+    ms_constraint.clamp(topic_cfg);
+    BOOST_CHECK_EQUAL(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>(LIMIT_MAX_MS));
+}
+
+} // namespace

--- a/src/v/config/tests/constraints_utils.h
+++ b/src/v/config/tests/constraints_utils.h
@@ -1,0 +1,123 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/types.h"
+#include "config/config_store.h"
+#include "config/property.h"
+#include "config/property_constraints.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+#include <chrono>
+#include <optional>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr static int16_t LIMIT_MIN = 3;
+constexpr static int16_t LIMIT_MAX = 10;
+constexpr static std::chrono::milliseconds LIMIT_MIN_MS = 1s;
+constexpr static std::chrono::milliseconds LIMIT_MAX_MS = 5s;
+
+std::vector<config::constraint_t> make_constraints(
+  config::constraint_type type,
+  config::binding<model::cleanup_policy_bitflags> enum_binding) {
+    std::vector<config::constraint_t> res;
+    res.reserve(3);
+
+    res.emplace_back(
+      "log_cleanup_policy",
+      type,
+      ss::make_shared<
+        config::constraint_validator_enabled<model::cleanup_policy_bitflags>>(
+        config::constraint_enabled_t::yes,
+        enum_binding,
+        [](const cluster::topic_configuration& topic_cfg) {
+            return topic_cfg.properties.cleanup_policy_bitflags
+                     ? *topic_cfg.properties.cleanup_policy_bitflags
+                     : model::cleanup_policy_bitflags::none;
+        },
+        [](
+          cluster::topic_configuration& topic_cfg,
+          const model::cleanup_policy_bitflags& topic_val) {
+            topic_cfg.properties.cleanup_policy_bitflags = topic_val;
+        }));
+
+    res.emplace_back(
+      "default_topic_replications",
+      type,
+      ss::make_shared<config::constraint_validator_range<int16_t>>(
+        LIMIT_MIN,
+        LIMIT_MAX,
+        [](const cluster::topic_configuration& topic_cfg) {
+            return topic_cfg.replication_factor;
+        },
+        [](cluster::topic_configuration& topic_cfg, const int16_t& topic_val) {
+            topic_cfg.replication_factor = topic_val;
+        }));
+
+    res.emplace_back(
+      "log_retention_ms",
+      type,
+      ss::make_shared<
+        config::constraint_validator_range<std::chrono::milliseconds>>(
+        LIMIT_MIN_MS,
+        LIMIT_MAX_MS,
+        [](const cluster::topic_configuration& topic_cfg) {
+            if (topic_cfg.properties.retention_duration.has_optional_value()) {
+                return topic_cfg.properties.retention_duration.value();
+            } else {
+                return LIMIT_MIN_MS;
+            }
+        },
+        [](
+          cluster::topic_configuration& topic_cfg,
+          const std::chrono::milliseconds& topic_val) {
+            topic_cfg.properties.retention_duration
+              = tristate<std::chrono::milliseconds>(topic_val);
+        }));
+
+    return res;
+}
+
+struct test_config : public config::config_store {
+    config::property<model::cleanup_policy_bitflags> original_enum;
+    config::one_or_many_property<config::constraint_t> restrict_constraints;
+    config::one_or_many_property<config::constraint_t> clamp_constraints;
+
+    test_config()
+      : original_enum(
+        *this,
+        "log_cleanup_policy",
+        "An enumertaion property",
+        {.needs_restart = config::needs_restart::no},
+        model::cleanup_policy_bitflags::deletion)
+      , restrict_constraints(
+          *this,
+          "restrict_constraints",
+          "A sequence of constraints for testing configs with restrict "
+          "constraint "
+          "type",
+          {},
+          make_constraints(
+            config::constraint_type::restrikt, original_enum.bind()))
+      , clamp_constraints(
+          *this,
+          "clamp_constraints",
+          "A sequence of constraints for testing configs with clamp constraint "
+          "type",
+          {},
+          make_constraints(
+            config::constraint_type::clamp, original_enum.bind())) {}
+};
+
+} // namespace

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -164,4 +164,14 @@ validate_audit_event_types(const std::vector<ss::sstring>& vs) {
     }
     return std::nullopt;
 }
+
+std::optional<ss::sstring>
+validate_constraints(const std::vector<constraint_t>& constraints) {
+    for (const auto& constraint : constraints) {
+        if (auto err = constraint.check(); err) {
+            return err;
+        }
+    }
+    return std::nullopt;
+}
 }; // namespace config

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "config/client_group_byte_rate_quota.h"
+#include "config/property_constraints.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -43,5 +44,8 @@ validate_non_empty_string_opt(const std::optional<ss::sstring>&);
 
 std::optional<ss::sstring>
 validate_audit_event_types(const std::vector<ss::sstring>& vs);
+
+std::optional<ss::sstring>
+validate_constraints(const std::vector<constraint_t>&);
 
 }; // namespace config

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -553,7 +553,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         # using the cluster
         exclude_settings = {
             'enable_sasl', 'kafka_enable_authorization',
-            'kafka_mtls_principal_mapping_rules'
+            'kafka_mtls_principal_mapping_rules', 'constraints'
         }
 
         # Don't enable schema id validation: the interdepedencies are too complex and are tested elsewhere.

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -9,6 +9,7 @@
 from collections import namedtuple
 import json
 import logging
+import os
 import pprint
 import random
 import re
@@ -1855,3 +1856,77 @@ class ClusterConfigLegacyDefaultTest(RedpandaTest, ClusterConfigHelpersMixin):
         self.redpanda.set_cluster_config({self.key: expected})
 
         self._check_value_everywhere(self.key, expected)
+
+
+class ConfigConstraintsTest(RedpandaTest):
+    RETENTION_MS = 86400000  # 1 day
+    RETENTION_MS_MIN = RETENTION_MS // 2
+    RETENTION_MS_MAX = RETENTION_MS * 2
+    topics = [TopicSpec(retention_ms=RETENTION_MS)]
+
+    LOG_LIFETIME_CONSTRAINT = {
+        'name': 'log_retention_ms',
+        'type': 'restrict',
+        'min': RETENTION_MS_MIN,
+        'max': None
+    }
+    LOG_CLEANUP_CONSTRAINT = {
+        'name': 'log_cleanup_policy',
+        'type': 'restrict',
+        'enabled': True
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(ConfigConstraintsTest, self).__init__(extra_rp_conf={
+            "constraints":
+            [self.LOG_LIFETIME_CONSTRAINT, self.LOG_CLEANUP_CONSTRAINT]
+        },
+                                                    *args,
+                                                    **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_broker_restart(self):
+        # Check that configuration constraints persist between broker restart.
+
+        admin = Admin(self.redpanda)
+        target_broker = self.redpanda.nodes[0]
+
+        # After first boot, the preset constraints should be returned by the Admin API.
+        res = admin.get_cluster_config(node=target_broker)
+        assert 'constraints' in res
+        assert type(res['constraints']) == list
+        constraints = sorted(res['constraints'], key=lambda con: con['name'])
+        self.logger.debug(json.dumps(constraints, indent=2))
+        assert constraints[0] == self.LOG_CLEANUP_CONSTRAINT
+        assert constraints[1] == self.LOG_LIFETIME_CONSTRAINT
+
+        self.redpanda.restart_nodes([target_broker])
+
+        # Admin API should report the same constraints after restart
+        res = admin.get_cluster_config(node=target_broker)
+        assert 'constraints' in res
+        assert type(res['constraints']) == list
+        constraints = sorted(res['constraints'], key=lambda con: con['name'])
+        self.logger.debug(json.dumps(constraints, indent=2))
+        assert constraints[0] == self.LOG_CLEANUP_CONSTRAINT
+        assert constraints[1] == self.LOG_LIFETIME_CONSTRAINT
+
+        # Constraints should also appear in the config cache file
+        cache_path = f"{self.redpanda.DATA_DIR}/config_cache.yaml"
+        assert target_broker.account.exists(cache_path)
+
+        cached_cluster_config = {}
+        with tempfile.TemporaryDirectory() as d:
+            target_broker.account.copy_from(cache_path, d)
+            with open(os.path.join(d, "config_cache.yaml")) as f:
+                cached_cluster_config = yaml.full_load(f.read())
+
+        self.logger.debug(json.dumps(cached_cluster_config, indent=2))
+
+        assert 'constraints' in cached_cluster_config
+        assert type(cached_cluster_config['constraints']) == str
+        constraints = json.loads(cached_cluster_config['constraints'])
+        assert type(constraints) == list
+        constraints = sorted(constraints, key=lambda con: con['name'])
+        assert constraints[0] == self.LOG_CLEANUP_CONSTRAINT
+        assert constraints[1] == self.LOG_LIFETIME_CONSTRAINT


### PR DESCRIPTION
Enable users to set configuration constraints for cluster-level properties. This patch adds support for constraints for a sub-set of cluster-level configs. Specifically, those that are settable via the Kafka CreateTopics API or reported by the DescribeConfigs API. 

Fixes: https://github.com/redpanda-data/redpanda/issues/13571

Changes from force-push `498ffc4`:
- Removed changes in config_manager, that will come at a later PR
- Removed changes to controller_snapshot_test, that will come at a later PR
- Switched back to shared_ptr impl and made a follow-up ticket to improve config constraint architecture https://github.com/redpanda-data/redpanda/issues/14052

Changes from force-push `2caed1f`:
- Capture string->type conversions in a generic tuple
- Use predefined `rjson_serialize`
- Renamed some methods for readability
- Bring in the checks for min > max
- Use optional's methods
- Style changes for string switch and enums
- Use `add_shadow_indexing_flag()` method and `drop_` flags

Changes from force-push `a322744`:
- Log the property name in `constraints::check()`
- Remove `drop_` flags for shadow indexing mode, more info https://redpandadata.slack.com/archives/C04ASNM2ZLK/p1697463308123159?thread_ts=1697136266.997769&cid=C04ASNM2ZLK
- Rebase dev to resolve many conflicts

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none