### PR TITLE
node wise recovery

### DIFF
--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -262,9 +262,11 @@ inline bool is_proper_subset(
  * Subtracts second replica set from the first one. Result contains only brokers
  * that node_ids are present in the first list but not the other one
  */
+template<class T>
+requires std::is_same_v<T, model::broker_shard>
+         || std::is_same_v<T, model::node_id>
 inline std::vector<model::broker_shard> subtract_replica_sets_by_node_id(
-  const std::vector<model::broker_shard>& lhs,
-  const std::vector<model::broker_shard>& rhs) {
+  const std::vector<model::broker_shard>& lhs, const std::vector<T>& rhs) {
     std::vector<model::broker_shard> ret;
     std::copy_if(
       lhs.begin(),
@@ -274,13 +276,17 @@ inline std::vector<model::broker_shard> subtract_replica_sets_by_node_id(
           return std::find_if(
                    rhs.begin(),
                    rhs.end(),
-                   [&lhs_bs](const model::broker_shard& rhs_bs) {
-                       return rhs_bs.node_id == lhs_bs.node_id;
+                   [&lhs_bs](const T& entry) {
+                       if constexpr (std::is_same_v<T, model::broker_shard>) {
+                           return entry.node_id == lhs_bs.node_id;
+                       }
+                       return entry == lhs_bs.node_id;
                    })
                  == rhs.end();
       });
     return ret;
 }
+
 // check if replica set contains a node
 inline bool contains_node(
   const std::vector<model::broker_shard>& replicas, model::node_id id) {

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -211,23 +211,17 @@ subtract(const std::vector<T>& lhs, const std::vector<T>& rhs) {
     return ret;
 }
 
-inline std::vector<model::broker_shard> union_replica_sets(
-  const std::vector<model::broker_shard>& lhs,
-  const std::vector<model::broker_shard>& rhs) {
-    std::vector<model::broker_shard> ret;
-    // Inefficient but constant time for small replica sets.
+template<class T>
+inline std::vector<T>
+union_vectors(const std::vector<T>& lhs, const std::vector<T>& rhs) {
+    std::vector<T> ret;
+    // Inefficient but constant time for small vectors.
     std::copy_if(
-      lhs.begin(),
-      lhs.end(),
-      std::back_inserter(ret),
-      [&ret](const model::broker_shard& bs) {
+      lhs.begin(), lhs.end(), std::back_inserter(ret), [&ret](const T& bs) {
           return std::find(ret.begin(), ret.end(), bs) == ret.end();
       });
     std::copy_if(
-      rhs.begin(),
-      rhs.end(),
-      std::back_inserter(ret),
-      [&ret](const model::broker_shard& bs) {
+      rhs.begin(), rhs.end(), std::back_inserter(ret), [&ret](const T& bs) {
           return std::find(ret.begin(), ret.end(), bs) == ret.end();
       });
     return ret;

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -119,6 +119,7 @@ static constexpr int8_t register_node_uuid_cmd_type = 4;
 static constexpr int8_t add_node_cmd_type = 5;
 static constexpr int8_t update_node_cmd_type = 6;
 static constexpr int8_t remove_node_cmd_type = 7;
+static constexpr int8_t defunct_nodes_cmd_type = 8;
 
 // cluster config commands
 static constexpr int8_t cluster_config_delta_cmd_type = 0;
@@ -280,6 +281,14 @@ using delete_data_policy_cmd = controller_command<
   delete_data_policy_cmd_type,
   model::record_batch_type::data_policy_management_cmd,
   serde_opts::adl_and_serde>;
+
+// command to mark a list of node_ids as defunct
+using defunct_nodes_cmd = controller_command<
+  int8_t, // unused
+  defunct_node_cmd_data,
+  defunct_nodes_cmd_type,
+  model::record_batch_type::node_management_cmd,
+  serde_opts::serde_only>;
 
 using decommission_node_cmd = controller_command<
   model::node_id,

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -523,7 +523,7 @@ controller_api::get_global_reconciliation_state(
             // not longer updating
             continue;
         }
-        auto all_replicas = union_replica_sets(
+        auto all_replicas = union_vectors(
           it->second.get_previous_replicas(), it->second.get_target_replicas());
         for (const auto& r : all_replicas) {
             grouped_ntps[r.node_id].push_back(ntp);

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -52,7 +52,7 @@ struct features_t
 
 struct members_t
   : public serde::
-      envelope<members_t, serde::version<0>, serde::compat_version<0>> {
+      envelope<members_t, serde::version<1>, serde::compat_version<0>> {
     struct node_t
       : serde::envelope<node_t, serde::version<0>, serde::compat_version<0>> {
         model::broker broker;
@@ -85,6 +85,8 @@ struct members_t
     absl::node_hash_map<model::node_id, update_t> in_progress_updates;
 
     model::offset first_node_operation_command_offset;
+    absl::btree_map<model::ntp, std::vector<ntp_with_majority_loss>>
+      partitions_to_force_recover;
 
     friend bool operator==(const members_t&, const members_t&) = default;
 
@@ -96,7 +98,8 @@ struct members_t
           removed_nodes,
           removed_nodes_still_in_raft0,
           in_progress_updates,
-          first_node_operation_command_offset);
+          first_node_operation_command_offset,
+          partitions_to_force_recover);
     }
 };
 

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -78,6 +78,7 @@ enum class errc : int16_t {
     partition_disabled,
     invalid_partition_operation,
     concurrent_modification_error,
+    nodes_already_defunct,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -226,6 +227,8 @@ struct errc_category final : public std::error_category {
             return "Invalid partition operation";
         case errc::concurrent_modification_error:
             return "Concurrent modification error";
+        case errc::nodes_already_defunct:
+            return "Node(s) is in the list of existing defunct nodes.";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -77,6 +77,7 @@ enum class errc : int16_t {
     topic_disabled,
     partition_disabled,
     invalid_partition_operation,
+    concurrent_modification_error,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -223,6 +224,8 @@ struct errc_category final : public std::error_category {
             return "Partition disabled by user";
         case errc::invalid_partition_operation:
             return "Invalid partition operation";
+        case errc::concurrent_modification_error:
+            return "Concurrent modification error";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -844,8 +844,8 @@ ss::future<> members_manager::apply_snapshot(
         }
 
         // 8. reset force recovery partitions in balancer.
-        _pb_state.local().partitions_to_force_reconfigure()
-          = snap.partitions_to_force_recover;
+        _pb_state.local().reset_partitions_to_force_reconfigure(
+          snap.partitions_to_force_recover);
 
         _last_connection_update_offset = snap_offset;
     }

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -82,7 +82,8 @@ public:
       register_node_uuid_cmd,
       add_node_cmd,
       remove_node_cmd,
-      update_node_cfg_cmd>{};
+      update_node_cfg_cmd,
+      defunct_nodes_cmd>{};
     static constexpr ss::shard_id shard = 0;
     static constexpr size_t max_updates_queue_size = 100;
 

--- a/src/v/cluster/members_table.h
+++ b/src/v/cluster/members_table.h
@@ -32,6 +32,7 @@ public:
     size_t node_count() const;
 
     std::vector<model::node_id> node_ids() const;
+    std::vector<model::node_id> defunct_nodes() const;
 
     /// Returns single broker if exists in cache
     std::optional<std::reference_wrapper<const node_metadata>>
@@ -48,6 +49,7 @@ public:
 
     bool contains(model::node_id) const;
 
+    std::error_code apply(model::offset, defunct_nodes_cmd);
     std::error_code apply(model::offset, decommission_node_cmd);
     std::error_code apply(model::offset, recommission_node_cmd);
     std::error_code apply(model::offset, maintenance_mode_cmd);
@@ -69,6 +71,10 @@ public:
             return ss::now();
         }
     }
+
+    std::error_code validate_defunct_nodes(
+      const std::vector<model::node_id>& input,
+      bool ignore_existing_defunct_nodes) const;
 
     // NOTE: these are level-triggered (as opposed to edge-triggered)
     // notifications. So for example if you get a members_updated notification

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -91,6 +91,7 @@ public:
       const model::ntp&, ss::noncopyable_function<void(partition&)>);
 
     const partition_balancer_state& state() const { return _parent._state; }
+    partition_balancer_state& state() { return _parent._state; }
 
     const allocation_state::underlying_t& allocation_nodes() const {
         return _parent._partition_allocator.state().allocation_nodes();
@@ -99,17 +100,20 @@ public:
     const planner_config& config() const { return _parent._config; }
 
     bool can_add_cancellation() const {
-        return _reassignments.size() + _cancellations.size()
+        return _force_reassignments.size() + _reassignments.size()
+                 + _cancellations.size()
                < config().max_concurrent_actions;
     }
 
     bool can_add_reassignment() const {
         if (
           state().topics().updates_in_progress().size() + _reassignments.size()
+            + _force_reassignments.size()
           >= config().max_concurrent_actions) {
             return false;
         } else {
-            return _reassignments.size() + _cancellations.size()
+            return _force_reassignments.size() + _reassignments.size()
+                     + _cancellations.size()
                    < config().max_concurrent_actions;
         }
     }
@@ -168,9 +172,7 @@ private:
 
     template<typename Visitor>
     auto do_with_partition(
-      const model::ntp& ntp,
-      const std::vector<model::broker_shard>& orig_replicas,
-      Visitor&);
+      const model::ntp& ntp, const partition_assignment& assignment, Visitor&);
 
     void collect_actions(plan_data&);
 
@@ -212,6 +214,7 @@ private:
     partition_balancer_planner& _parent;
     absl::btree_map<model::ntp, partition_sizes> _ntp2sizes;
     absl::node_hash_map<model::ntp, reassignment_info> _reassignments;
+    absl::node_hash_map<model::ntp, allocated_partition> _force_reassignments;
     size_t _failed_actions_count = 0;
     // we track missing partition size info separately as it requires force
     // refresh of health report
@@ -571,6 +574,38 @@ private:
     request_context& _ctx;
 };
 
+class partition_balancer_planner::force_reassignable_partition {
+public:
+    const model::ntp& ntp() const { return _ntp; }
+    const std::vector<model::broker_shard>& replicas() const {
+        return _original_assignment.replicas;
+    };
+
+    void force_move_defunct_replicas(double max_disk_usage_ratio);
+
+private:
+    friend class request_context;
+
+    force_reassignable_partition(
+      model::ntp ntp,
+      std::optional<request_context::partition_sizes> sizes,
+      const partition_assignment& assignment,
+      request_context& ctx)
+      : _ntp(std::move(ntp))
+      , _sizes(std::move(sizes))
+      , _original_assignment(assignment)
+      , _ctx(ctx) {}
+
+    allocation_constraints
+    get_allocation_constraints(double max_disk_usage_ratio) const;
+
+    model::ntp _ntp;
+    std::optional<request_context::partition_sizes> _sizes;
+    const partition_assignment& _original_assignment;
+    request_context& _ctx;
+    result<allocated_partition> _reallocation = errc::allocation_error;
+};
+
 class partition_balancer_planner::moving_partition {
 public:
     const model::ntp& ntp() const { return _ntp; }
@@ -769,17 +804,21 @@ private:
     partition(T&& variant)
       : _variant(std::forward<T>(variant)) {}
 
-    std::variant<reassignable_partition, moving_partition, immutable_partition>
+    std::variant<
+      reassignable_partition,
+      force_reassignable_partition,
+      moving_partition,
+      immutable_partition>
       _variant;
 };
 
 template<typename Visitor>
 auto partition_balancer_planner::request_context::do_with_partition(
   const model::ntp& ntp,
-  const std::vector<model::broker_shard>& orig_replicas,
+  const partition_assignment& assignment,
   Visitor& visitor) {
     const bool is_disabled = _parent._state.topics().is_disabled(ntp);
-
+    const auto& orig_replicas = assignment.replicas;
     auto in_progress_it = _parent._state.topics().updates_in_progress().find(
       ntp);
     if (in_progress_it != _parent._state.topics().updates_in_progress().end()) {
@@ -845,6 +884,42 @@ auto partition_balancer_planner::request_context::do_with_partition(
         return visitor(part);
     }
 
+    // check if the ntp is to be force reconfigured.
+    auto topic_md = _parent._state.topics().get_topic_metadata(
+      model::topic_namespace_view{ntp});
+    const auto& force_reconfigurable_partitions
+      = _parent._state.partitions_to_force_reconfigure();
+    auto force_it = force_reconfigurable_partitions.find(ntp);
+    if (topic_md && force_it != force_reconfigurable_partitions.end()) {
+        auto topic_revision = topic_md.value().get_revision();
+        const auto& entries = force_it->second;
+        auto it = std::find_if(
+          entries.begin(), entries.end(), [&](const auto& entry) {
+              return entry.topic_revision == topic_revision
+                     && are_replica_sets_equal(entry.assignment, orig_replicas);
+          });
+
+        if (it != entries.end()) {
+            auto size_it = _ntp2sizes.find(ntp);
+            std::optional<request_context::partition_sizes> sizes;
+            if (size_it != _ntp2sizes.end()) {
+                sizes = size_it->second;
+            }
+            partition part{
+              force_reassignable_partition{ntp, sizes, assignment, *this}};
+
+            auto deferred = ss::defer([&] {
+                auto& force_reassignable
+                  = std::get<force_reassignable_partition>(part._variant);
+                if (force_reassignable._reallocation) {
+                    _force_reassignments.emplace(
+                      ntp, std::move(force_reassignable._reallocation.value()));
+                }
+            });
+            return visitor(part);
+        }
+    };
+
     auto size_it = _ntp2sizes.find(ntp);
     if (size_it == _ntp2sizes.end()) {
         partition part{immutable_partition{
@@ -903,7 +978,7 @@ ss::future<> partition_balancer_planner::request_context::for_each_partition(
         const auto& assignments = it->second.get_assignments();
         for (const auto& assignment : assignments) {
             auto ntp = model::ntp(it->first.ns, it->first.tp, assignment.id);
-            auto stop = do_with_partition(ntp, assignment.replicas, visitor);
+            auto stop = do_with_partition(ntp, assignment, visitor);
             if (stop == ss::stop_iteration::yes) {
                 co_return;
             }
@@ -938,7 +1013,7 @@ partition_balancer_planner::request_context::for_each_partition_random_order(
     for (const auto& part : partitions) {
         state().topics().check_topics_map_stable(start_rev);
         model::ntp ntp(part.tp_ns->ns, part.tp_ns->tp, part.assignment->id);
-        auto stop = do_with_partition(ntp, part.assignment->replicas, visitor);
+        auto stop = do_with_partition(ntp, *(part.assignment), visitor);
         if (stop == ss::stop_iteration::yes) {
             co_return;
         }
@@ -964,7 +1039,7 @@ ss::future<> partition_balancer_planner::request_context::with_partition(
         co_return;
     }
 
-    do_with_partition(ntp, it->replicas, visitor);
+    do_with_partition(ntp, *it, visitor);
 }
 
 allocation_constraints
@@ -1140,6 +1215,116 @@ void partition_balancer_planner::reassignable_partition::revert(
     }
 }
 
+allocation_constraints
+partition_balancer_planner::force_reassignable_partition::
+  get_allocation_constraints(double max_disk_usage_ratio) const {
+    allocation_constraints constraints;
+
+    // Add constraint on least disk usage
+    constraints.add(
+      least_disk_filled(max_disk_usage_ratio, _ctx.node_disk_reports));
+
+    if (_sizes) {
+        // Add constraint on partition max_disk_usage_ratio overfill
+        size_t upper_bound_for_partition_size
+          = _sizes.value().non_reclaimable
+            + _ctx.config().segment_fallocation_step;
+        constraints.add(disk_not_overflowed_by_partition(
+          max_disk_usage_ratio,
+          upper_bound_for_partition_size,
+          _ctx.node_disk_reports));
+    }
+
+    // Add constraint on unavailable nodes
+    constraints.add(distinct_from(_ctx.timed_out_unavailable_nodes));
+
+    if (!_ctx.defunct_nodes.empty()) {
+        // defunct nodes are explicitly marked dead by the operator
+        // add a constraint to move replicas away from these nodes.
+        constraints.add(distinct_from(_ctx.defunct_nodes));
+    }
+
+    // Add constraint on decommissioning nodes
+    if (!_ctx.decommissioning_nodes.empty()) {
+        constraints.add(distinct_from(_ctx.decommissioning_nodes));
+    }
+
+    return constraints;
+}
+
+void partition_balancer_planner::force_reassignable_partition::
+  force_move_defunct_replicas(double max_disk_usage_ratio) {
+    const auto& replicas = _original_assignment.replicas;
+    std::vector<model::node_id> replicas_to_remove;
+    replicas_to_remove.reserve(replicas.size());
+    for (auto& replica : _original_assignment.replicas) {
+        if (_ctx.defunct_nodes.contains(replica.node_id)) {
+            replicas_to_remove.push_back(replica.node_id);
+        }
+    }
+    vlog(
+      clusterlog.debug,
+      "Attempt to force reconfigure {} with replicas {}, replicas to be "
+      "removed: {}",
+      ntp(),
+      replicas,
+      replicas_to_remove);
+    auto constraints = get_allocation_constraints(max_disk_usage_ratio);
+    auto replicas_size = static_cast<uint16_t>(replicas.size());
+    model::topic_namespace tn{_ntp.ns, _ntp.tp.topic};
+    _reallocation = _ctx._parent._partition_allocator.reallocate_partition(
+      tn,
+      {_original_assignment.id, replicas_size, std::move(constraints)},
+      _original_assignment,
+      get_allocation_domain(tn),
+      replicas_to_remove);
+
+    if (_reallocation.has_error()) {
+        if (_ctx.increment_failure_count()) {
+            vlog(
+              clusterlog.info,
+              "allocation failure when force moving partition, ntp: {}, "
+              "replicas {}, error: {}",
+              _ntp,
+              replicas,
+              _reallocation.error());
+        }
+        return;
+    }
+
+    vlog(
+      clusterlog.debug,
+      "Attempt to force reconfigure {} with replicas {}, replicas to be "
+      "removed: {} "
+      "successful, new assignment: {}",
+      ntp(),
+      replicas,
+      replicas_to_remove,
+      _reallocation.value().replicas());
+
+    if (!_sizes) {
+        return;
+    }
+
+    auto& new_assignment = _reallocation.value().replicas();
+    auto replicas_added = subtract(new_assignment, replicas);
+    auto& sizes = _sizes.value();
+    for (auto& replica : replicas_to_remove) {
+        auto it = _ctx.node_disk_reports.find(replica);
+        if (it == _ctx.node_disk_reports.end()) {
+            continue;
+        }
+        it->second.released += sizes.get_current(replica);
+    }
+    for (auto& replica : replicas_added) {
+        auto it = _ctx.node_disk_reports.find(replica.node_id);
+        if (it == _ctx.node_disk_reports.end()) {
+            continue;
+        }
+        it->second.assigned += sizes.non_reclaimable;
+    }
+}
+
 /*
  * Function is trying to move ntp out of unavailable nodes
  * It can move to nodes that are violating soft_max_disk_usage_ratio constraint
@@ -1206,6 +1391,7 @@ ss::future<> partition_balancer_planner::get_node_drain_actions(
                   }
               }
           },
+          [&](force_reassignable_partition&) {},
           [&](immutable_partition& part) { part.report_failure(reason); });
 
         return ss::stop_iteration::no;
@@ -1283,7 +1469,8 @@ ss::future<> partition_balancer_planner::get_rack_constraint_repair_actions(
               [](immutable_partition& part) {
                   part.report_failure(change_reason::rack_constraint_repair);
               },
-              [](moving_partition&) {});
+              [](moving_partition&) {},
+              [](force_reassignable_partition&) {});
         });
         ++it;
     }
@@ -1638,6 +1825,33 @@ ss::future<> partition_balancer_planner::get_counts_rebalancing_actions(
     }
 }
 
+ss::future<>
+partition_balancer_planner::get_force_repair_actions(request_context& ctx) {
+    if (ctx.state().partitions_to_force_reconfigure().empty()) {
+        co_return;
+    }
+
+    auto it = ctx.state().ntps_to_force_recover_it_begin();
+    while (it != ctx.state().ntps_to_force_recover_it_end()) {
+        if (!ctx.can_add_reassignment()) {
+            co_return;
+        }
+        co_await ctx.with_partition(it->first, [&](partition& part) {
+            part.match_variant(
+              [&](force_reassignable_partition& part) {
+                  part.force_move_defunct_replicas(
+                    ctx.config().hard_max_disk_usage_ratio);
+              },
+              [&](reassignable_partition&) {},
+              [&](moving_partition&) {
+                  // ignore, wait for it to be canceled / finished.
+              },
+              [&](immutable_partition&) {});
+        });
+        ++it;
+    }
+}
+
 void partition_balancer_planner::request_context::collect_actions(
   partition_balancer_planner::plan_data& result) {
     result.reassignments.reserve(_reassignments.size());
@@ -1645,7 +1859,15 @@ void partition_balancer_planner::request_context::collect_actions(
         result.reassignments.push_back(ntp_reassignment{
           .ntp = ntp,
           .allocated = std::move(reallocated_meta.partition),
-          .reconfiguration_policy = reallocated_meta.reconfiguration_policy});
+          .reconfiguration_policy = reallocated_meta.reconfiguration_policy,
+          .type = ntp_reassignment_type::regular});
+    }
+
+    for (auto& [ntp, reallocated] : _force_reassignments) {
+        result.reassignments.push_back(ntp_reassignment{
+          .ntp = ntp,
+          .allocated = std::move(reallocated),
+          .type = ntp_reassignment_type::force});
     }
 
     result.failed_actions_count = _failed_actions_count;
@@ -1685,6 +1907,7 @@ partition_balancer_planner::plan_actions(
       result.violations.is_empty() && ctx.decommissioning_nodes.empty()
       && _state.ntps_with_broken_rack_constraint().empty()
       && _state.nodes_to_rebalance().empty()
+      && _state.partitions_to_force_reconfigure().empty()
       && !_config.ondemand_rebalance_requested) {
         result.status = status::empty;
         co_return result;
@@ -1707,6 +1930,7 @@ partition_balancer_planner::plan_actions(
         co_await get_full_node_actions(ctx);
     }
     co_await get_counts_rebalancing_actions(ctx);
+    co_await get_force_repair_actions(ctx);
 
     ctx.collect_actions(result);
     if (ctx._partitions_with_missing_size > 0) {

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -23,10 +23,13 @@
 
 namespace cluster {
 
+enum ntp_reassignment_type : int8_t { regular, force };
+
 struct ntp_reassignment {
     model::ntp ntp;
     allocated_partition allocated;
     reconfiguration_policy reconfiguration_policy;
+    ntp_reassignment_type type;
 };
 
 struct planner_config {
@@ -97,6 +100,7 @@ private:
     class request_context;
     class partition;
     class reassignable_partition;
+    class force_reassignable_partition;
     class moving_partition;
     class immutable_partition;
 
@@ -117,6 +121,7 @@ private:
     static ss::future<> get_rack_constraint_repair_actions(request_context&);
     static ss::future<> get_full_node_actions(request_context&);
     static ss::future<> get_counts_rebalancing_actions(request_context&);
+    static ss::future<> get_force_repair_actions(request_context&);
 
     static size_t calculate_full_disk_partition_move_priority(
       model::node_id, const reassignable_partition&, const request_context&);

--- a/src/v/cluster/partition_balancer_state.cc
+++ b/src/v/cluster/partition_balancer_state.cc
@@ -36,7 +36,7 @@ partition_balancer_state::partition_balancer_state(
   , _node_status(nst.local())
   , _probe(*this) {}
 
-void partition_balancer_state::handle_ntp_update(
+void partition_balancer_state::handle_ntp_move_begin_or_cancel(
   const model::ns& ns,
   const model::topic& tp,
   model::partition_id p_id,

--- a/src/v/cluster/partition_balancer_state.h
+++ b/src/v/cluster/partition_balancer_state.h
@@ -72,6 +72,10 @@ public:
       const std::vector<model::broker_shard>& prev,
       const std::vector<model::broker_shard>& next);
 
+    void handle_ntp_move_finish(
+      const model::ntp& ntp, const std::vector<model::broker_shard>& replicas);
+    void handle_ntp_delete(const model::ntp& ntp);
+
     void add_node_to_rebalance(model::node_id id) {
         _nodes_to_rebalance.insert(id);
     }
@@ -83,12 +87,35 @@ public:
     void add_partition_to_force_reconfigure(ntp_with_majority_loss entry) {
         const auto& [it, _] = _ntps_to_force_reconfigure.try_emplace(entry.ntp);
         it->second.push_back(std::move(entry));
+        _ntps_to_force_reconfigure_revision++;
     }
 
     using force_recoverable_partitions_t
       = absl::btree_map<model::ntp, std::vector<ntp_with_majority_loss>>;
     force_recoverable_partitions_t& partitions_to_force_reconfigure() {
         return _ntps_to_force_reconfigure;
+    }
+
+    void reset_partitions_to_force_reconfigure(
+      const force_recoverable_partitions_t& other) {
+        _ntps_to_force_reconfigure = other;
+        _ntps_to_force_reconfigure_revision++;
+    }
+
+    auto ntps_to_force_recover_it_begin() const {
+        return stable_iterator<
+          force_recoverable_partitions_t::const_iterator,
+          model::revision_id>(
+          [&]() { return _ntps_to_force_reconfigure_revision; },
+          _ntps_to_force_reconfigure.begin());
+    }
+
+    auto ntps_to_force_recover_it_end() const {
+        return stable_iterator<
+          force_recoverable_partitions_t::const_iterator,
+          model::revision_id>(
+          [&]() { return _ntps_to_force_reconfigure_revision; },
+          _ntps_to_force_reconfigure.end());
     }
 
     const auto& nodes_to_rebalance() const { return _nodes_to_rebalance; }
@@ -119,6 +146,7 @@ private:
     // A user approved list of ntps that should be force recovered.
     // Set as part of designating brokers as defunct.
     force_recoverable_partitions_t _ntps_to_force_reconfigure;
+    model::revision_id _ntps_to_force_reconfigure_revision;
     probe _probe;
 };
 

--- a/src/v/cluster/partition_balancer_state.h
+++ b/src/v/cluster/partition_balancer_state.h
@@ -65,7 +65,7 @@ public:
     /// Called when the replica set of an ntp changes. Note that this doesn't
     /// account for in-progress moves - the function is called only once when
     /// the move is started.
-    void handle_ntp_update(
+    void handle_ntp_move_begin_or_cancel(
       const model::ns&,
       const model::topic&,
       model::partition_id,

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -90,8 +90,9 @@ ss::future<std::error_code> topic_updates_dispatcher::do_topic_delete(
                 get_allocation_domain(tp_ns));
 
               for (const auto& p_as : *topic_assignments) {
-                  _partition_balancer_state.local().handle_ntp_update(
-                    tp_ns.ns, tp_ns.tp, p_as.id, p_as.replicas, {});
+                  _partition_balancer_state.local()
+                    .handle_ntp_move_begin_or_cancel(
+                      tp_ns.ns, tp_ns.tp, p_as.id, p_as.replicas, {});
               }
           }
 
@@ -126,7 +127,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
           assignments, get_allocation_domain(tp_ns));
         ss::chunked_fifo<ntp_leader> leaders;
         for (const auto& p_as : assignments) {
-            _partition_balancer_state.local().handle_ntp_update(
+            _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
               tp_ns.ns, tp_ns.tp, p_as.id, {}, p_as.replicas);
             leaders.emplace_back(
               model::ntp(tp_ns.ns, tp_ns.tp, p_as.id),
@@ -174,7 +175,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
         update_allocations_for_reconfiguration(
           p_as->replicas, cmd.value, get_allocation_domain(ntp));
 
-        _partition_balancer_state.local().handle_ntp_update(
+        _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
           ntp.ns, ntp.tp.topic, ntp.tp.partition, p_as->replicas, cmd.value);
     }
     co_return ec;
@@ -195,7 +196,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
         update_allocations_for_reconfiguration(
           p_as->replicas, cmd.value.replicas, get_allocation_domain(ntp));
 
-        _partition_balancer_state.local().handle_ntp_update(
+        _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
           ntp.ns,
           ntp.tp.topic,
           ntp.tp.partition,
@@ -238,7 +239,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
           _partition_allocator.local().remove_final_counts(
             to_remove, get_allocation_domain(ntp));
 
-          _partition_balancer_state.local().handle_ntp_update(
+          _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
             ntp.ns,
             ntp.tp.topic,
             ntp.tp.partition,
@@ -336,7 +337,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
           assignments, get_allocation_domain(tp_ns));
 
         for (const auto& p_as : assignments) {
-            _partition_balancer_state.local().handle_ntp_update(
+            _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
               tp_ns.ns, tp_ns.tp, p_as.id, {}, p_as.replicas);
         }
     }
@@ -361,7 +362,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
             update_allocations_for_reconfiguration(
               assigment_it->replicas, replicas, get_allocation_domain(ntp));
 
-            _partition_balancer_state.local().handle_ntp_update(
+            _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
               ntp.ns,
               ntp.tp.topic,
               ntp.tp.partition,
@@ -428,7 +429,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
           _partition_allocator.local().remove_final_counts(
             to_delete, get_allocation_domain(ntp));
 
-          _partition_balancer_state.local().handle_ntp_update(
+          _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
             ntp.ns,
             ntp.tp.topic,
             ntp.tp.partition,
@@ -455,7 +456,7 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
     update_allocations_for_reconfiguration(
       p_as->replicas, cmd.value.replicas, get_allocation_domain(ntp));
 
-    _partition_balancer_state.local().handle_ntp_update(
+    _partition_balancer_state.local().handle_ntp_move_begin_or_cancel(
       ntp.ns,
       ntp.tp.topic,
       ntp.tp.partition,

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -561,7 +561,7 @@ void topic_updates_dispatcher::deallocate_topic(
         auto it = in_progress.find(p_as.id);
         auto to_delete = it == in_progress.end()
                            ? p_as.replicas
-                           : union_replica_sets(it->second, p_as.replicas);
+                           : union_vectors(it->second, p_as.replicas);
         _partition_allocator.local().remove_allocations(to_delete, domain);
         _partition_allocator.local().remove_final_counts(p_as.replicas, domain);
         if (unlikely(clusterlog.is_enabled(ss::log_level::trace))) {

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -93,6 +93,8 @@ ss::future<std::error_code> topic_updates_dispatcher::do_topic_delete(
                   _partition_balancer_state.local()
                     .handle_ntp_move_begin_or_cancel(
                       tp_ns.ns, tp_ns.tp, p_as.id, p_as.replicas, {});
+                  _partition_balancer_state.local().handle_ntp_delete(
+                    {tp_ns.ns, tp_ns.tp, p_as.id});
               }
           }
 
@@ -312,6 +314,9 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
           }
           _partition_allocator.local().remove_allocations(
             to_delete, get_allocation_domain(ntp));
+
+          _partition_balancer_state.local().handle_ntp_move_finish(
+            ntp, command_replicas);
 
           return ec;
       });

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -927,6 +927,59 @@ topics_frontend::partitions_with_lost_majority(
     co_return errc::concurrent_modification_error;
 }
 
+ss::future<std::error_code>
+topics_frontend::force_recover_partitions_from_nodes(
+  std::vector<model::node_id> nodes,
+  fragmented_vector<ntp_with_majority_loss>
+    user_approved_force_recovery_partitions,
+  model::timeout_clock::time_point timeout) {
+    auto result = co_await stm_linearizable_barrier(timeout);
+    if (!result) {
+        co_return result.error();
+    }
+    auto validation_error = _members_table.local().validate_defunct_nodes(
+      nodes, false);
+    if (validation_error) {
+        co_return validation_error;
+    }
+    // check if the state of partitions to recover tallies with their
+    // current state.
+    const auto& topics = _topics.local();
+    auto reject = false;
+    for (const auto& entry : user_approved_force_recovery_partitions) {
+        // check if there is an in progress movemement, reject if so.
+        // this is a conservative check and can be relaxed.
+        auto in_progress_move = topics.is_update_in_progress(entry.ntp);
+        auto current_assignment = topics.get_partition_assignment(entry.ntp);
+        auto assignment_match = current_assignment
+                                && are_replica_sets_equal(
+                                  current_assignment->replicas,
+                                  entry.assignment);
+        if (in_progress_move || !assignment_match) {
+            vlog(
+              clusterlog.info,
+              "rejecting force recovery of partitions from brokers {}, ntp: "
+              "{}, move in progress: {}, expected replica set: {}, current "
+              "assignment: {}, the state may have changed since the original "
+              "request was made, try again.",
+              nodes,
+              entry.ntp,
+              entry.assignment,
+              current_assignment);
+            reject = true;
+        }
+    }
+    if (reject) {
+        co_return errc::invalid_request;
+    }
+    defunct_node_cmd_data data;
+    data.defunct_nodes = std::move(nodes);
+    data.user_approved_force_recovery_partitions = std::move(
+      user_approved_force_recovery_partitions);
+    defunct_nodes_cmd cmd(0, defunct_node_cmd_data(std::move(data)));
+    co_return co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
+}
+
 ss::future<std::error_code> topics_frontend::cancel_moving_partition_replicas(
   model::ntp ntp,
   model::timeout_clock::time_point timeout,

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -46,6 +46,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include <algorithm>
 #include <iterator>
@@ -861,6 +862,77 @@ ss::future<std::error_code> topics_frontend::force_update_partition_replicas(
 
     co_return co_await replicate_and_wait(
       _stm, _as, std::move(cmd), tout, term);
+}
+
+ss::future<result<fragmented_vector<ntp_with_majority_loss>>>
+topics_frontend::partitions_with_lost_majority(
+  std::vector<model::node_id> defunct_nodes) {
+    try {
+        fragmented_vector<ntp_with_majority_loss> result;
+        if (defunct_nodes.empty()) {
+            co_return result;
+        }
+        // Check if there are any non existent nodes in the input.
+        std::vector<model::node_id> missing_nodes;
+        missing_nodes.reserve(defunct_nodes.size());
+        for (const auto& defunct_node : defunct_nodes) {
+            if (!_members_table.local().contains(defunct_node)) {
+                missing_nodes.push_back(defunct_node);
+            }
+        }
+        if (!missing_nodes.empty()) {
+            vlog(
+              clusterlog.info,
+              "Invalid request, defunct nodes refer to non existent nodes: {}",
+              missing_nodes);
+            co_return errc::invalid_request;
+        }
+
+        const auto& topics = _topics.local();
+        for (auto it = topics.topics_iterator_begin();
+             it != topics.topics_iterator_end();
+             ++it) {
+            const auto& tn = it->first;
+            const auto& assignments = (it->second).get_assignments();
+            const auto topic_revision = it->second.get_revision();
+            for (const auto& assignment : assignments) {
+                const auto& current = assignment.replicas;
+                auto remaining = subtract_replica_sets_by_node_id(
+                  current, defunct_nodes);
+                auto lost_majority = remaining.size()
+                                     < (current.size() / 2) + 1;
+                if (!lost_majority) {
+                    continue;
+                }
+                model::ntp ntp(tn.ns, tn.tp, assignment.id);
+                if (topics.updates_in_progress().contains(ntp)) {
+                    // force reconfiguration does not support in progress
+                    // moves. this check can be relaxed once the limitation
+                    // is fixed.
+                    vlog(
+                      clusterlog.debug,
+                      "{} lost majority but skipping as an update is in "
+                      "progress.",
+                      ntp);
+                    continue;
+                }
+                result.emplace_back(
+                  std::move(ntp),
+                  topic_revision,
+                  assignment.replicas,
+                  defunct_nodes);
+                co_await ss::coroutine::maybe_yield();
+            }
+        }
+        co_return result;
+    } catch (const topic_table::concurrent_modification_error& e) {
+        // state changed while generating the plan, force caller to retry;
+        vlog(
+          clusterlog.info,
+          "Topic table state changed when generating force move plan: {}",
+          e.what());
+    }
+    co_return errc::concurrent_modification_error;
 }
 
 ss::future<std::error_code> topics_frontend::cancel_moving_partition_replicas(

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -98,6 +98,12 @@ public:
     ss::future<result<fragmented_vector<ntp_with_majority_loss>>>
     partitions_with_lost_majority(std::vector<model::node_id> defunct_nodes);
 
+    ss::future<std::error_code> force_recover_partitions_from_nodes(
+      std::vector<model::node_id> nodes,
+      fragmented_vector<ntp_with_majority_loss>
+        user_approved_force_recovery_partitions,
+      model::timeout_clock::time_point timeout);
+
     /**
      * This overload of move_partition_replicas will use the partition
      * allocator to generate a new replica set (i.e., a

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -92,9 +92,16 @@ public:
       std::optional<model::term_id> = std::nullopt);
 
     /**
-     * This overload of move_partition_replicas will use the partition allocator
-     * to generate a new replica set (i.e., a vector<broker_shard>) based on the
-     * given ntp and list of node ids.
+     * Given a list of defunct nodes, generates a list of ntps that lost
+     * majority due to unavailability of the nodes.
+     */
+    ss::future<result<fragmented_vector<ntp_with_majority_loss>>>
+    partitions_with_lost_majority(std::vector<model::node_id> defunct_nodes);
+
+    /**
+     * This overload of move_partition_replicas will use the partition
+     * allocator to generate a new replica set (i.e., a
+     * vector<broker_shard>) based on the given ntp and list of node ids.
      */
     ss::future<std::error_code> move_partition_replicas(
       model::ntp,

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1246,6 +1246,18 @@ operator<<(std::ostream& o, const add_paritions_tx_request::topic& t) {
     fmt::print(o, "{{topic: {}, partitions: {}}}", t.name, t.partitions);
     return o;
 }
+
+std::ostream& operator<<(std::ostream& o, const ntp_with_majority_loss& entry) {
+    fmt::print(
+      o,
+      "{{ ntp: {}, topic_revision: {}, replicas: {}, defunct nodes: {} }}",
+      entry.ntp,
+      entry.topic_revision,
+      entry.assignment,
+      entry.defunct_nodes);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1258,6 +1258,22 @@ std::ostream& operator<<(std::ostream& o, const ntp_with_majority_loss& entry) {
     return o;
 }
 
+defunct_node_cmd_data::defunct_node_cmd_data(const defunct_node_cmd_data& other)
+  : defunct_nodes(other.defunct_nodes) {
+    user_approved_force_recovery_partitions
+      = other.user_approved_force_recovery_partitions.copy();
+}
+
+defunct_node_cmd_data&
+defunct_node_cmd_data::operator=(const defunct_node_cmd_data& other) {
+    if (this != &other) {
+        defunct_nodes = other.defunct_nodes;
+        user_approved_force_recovery_partitions
+          = other.user_approved_force_recovery_partitions.copy();
+    }
+    return *this;
+}
+
 } // namespace cluster
 
 namespace reflection {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3150,6 +3150,40 @@ struct reconciliation_state_request
     auto serde_fields() { return std::tie(ntps); }
 };
 
+struct ntp_with_majority_loss
+  : serde::envelope<
+      ntp_with_majority_loss,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    ntp_with_majority_loss() = default;
+    explicit ntp_with_majority_loss(
+      model::ntp n,
+      model::revision_id r,
+      std::vector<model::broker_shard> replicas,
+      std::vector<model::node_id> dead_nodes)
+      : ntp(std::move(n))
+      , topic_revision(r)
+      , assignment(std::move(replicas))
+      , defunct_nodes(std::move(dead_nodes)) {}
+    model::ntp ntp;
+    model::revision_id topic_revision;
+    std::vector<model::broker_shard> assignment;
+    std::vector<model::node_id> defunct_nodes;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const ntp_with_majority_loss& s) {
+        return H::combine(
+          std::move(h), s.ntp, s.topic_revision, s.assignment, s.defunct_nodes);
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const ntp_with_majority_loss&);
+    bool operator==(const ntp_with_majority_loss& other) const = default;
+    auto serde_fields() {
+        return std::tie(ntp, topic_revision, assignment, defunct_nodes);
+    }
+};
+
 struct reconciliation_state_reply
   : serde::envelope<
       reconciliation_state_reply,

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -240,9 +240,34 @@ inline void rjson_serialize(
     w.EndArray();
 }
 
+template<typename T, typename V>
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const absl::flat_hash_map<T, V>& m) {
+    w.StartArray();
+    for (const auto& e : m) {
+        w.StartObject();
+        w.Key("key");
+        rjson_serialize(w, e.first);
+        w.Key("value");
+        rjson_serialize(w, e.second);
+        w.EndObject();
+    }
+    w.EndArray();
+}
+
 template<typename V>
 inline void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const absl::node_hash_set<V>& m) {
+    w.StartArray();
+    for (const V& e : m) {
+        rjson_serialize(w, e);
+    }
+    w.EndArray();
+}
+
+template<typename V>
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const absl::btree_set<V>& m) {
     w.StartArray();
     for (const V& e : m) {
         rjson_serialize(w, e);
@@ -272,8 +297,28 @@ inline void read_value(json::Value const& rd, absl::node_hash_map<T, V>& obj) {
     }
 }
 
+template<typename T, typename V>
+inline void read_value(json::Value const& rd, absl::flat_hash_map<T, V>& obj) {
+    for (const auto& e : rd.GetArray()) {
+        T key;
+        read_member(e, "key", key);
+        V value;
+        read_member(e, "value", value);
+        obj.emplace(std::move(key), std::move(value));
+    }
+}
+
 template<typename V>
 inline void read_value(json::Value const& rd, absl::node_hash_set<V>& obj) {
+    for (const auto& e : rd.GetArray()) {
+        auto v = V{};
+        read_value(e, v);
+        obj.insert(std::move(v));
+    }
+}
+
+template<typename V>
+inline void read_value(json::Value const& rd, absl::btree_set<V>& obj) {
     for (const auto& e : rd.GetArray()) {
         auto v = V{};
         read_value(e, v);

--- a/src/v/compat/partition_balancer_compat.h
+++ b/src/v/compat/partition_balancer_compat.h
@@ -27,12 +27,18 @@ GEN_COMPAT_CHECK_SERDE_ONLY(
       json_write(last_tick_time);
       json_write(status);
       json_write(violations);
+      json_write(decommission_realloc_failures);
+      json_write(partitions_pending_force_recovery_count);
+      json_write(partitions_pending_force_recovery_sample);
   },
   {
       json_read(error);
       json_read(last_tick_time);
       json_read(status);
       json_read(violations);
+      json_read(decommission_realloc_failures);
+      json_read(partitions_pending_force_recovery_count);
+      json_read(partitions_pending_force_recovery_sample);
   })
 
 } // namespace compat

--- a/src/v/compat/partition_balancer_generator.h
+++ b/src/v/compat/partition_balancer_generator.h
@@ -25,12 +25,24 @@ EMPTY_COMPAT_GENERATOR(cluster::partition_balancer_overview_request);
 template<>
 struct instance_generator<cluster::partition_balancer_overview_reply> {
     static cluster::partition_balancer_overview_reply random() {
+        auto generator = [] {
+            return std::make_pair(
+              tests::random_named_int<model::node_id>(),
+              tests::random_btree_set<model::ntp>(model::random_ntp));
+        };
         return {
           .error = instance_generator<cluster::errc>::random(),
           .last_tick_time = model::timestamp(
             random_generators::get_int<int64_t>()),
           .status = tests::random_balancer_status(),
-          .violations = tests::random_partition_balancer_violations()};
+          .violations = tests::random_partition_balancer_violations(),
+          .decommission_realloc_failures = tests::
+            random_flat_hash_map<model::node_id, absl::btree_set<model::ntp>>(
+              std::move(generator)),
+          .partitions_pending_force_recovery_count
+          = random_generators::get_int<size_t>(),
+          .partitions_pending_force_recovery_sample = tests::random_vector(
+            model::random_ntp)};
     }
 
     static std::vector<cluster::partition_balancer_overview_reply> limits() {

--- a/src/v/json/validator.h
+++ b/src/v/json/validator.h
@@ -49,7 +49,8 @@ private:
     ss::sstring _msg;
 };
 
-inline void validate(json::validator& validator, const json::Document& json) {
+inline void
+validate(json::validator& validator, const json::Document::ValueType& json) {
     validator.schema_validator.Reset();
     validator.schema_validator.ResetError();
 

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -96,6 +96,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::trackable_keys_limit_exceeded:
     case cluster::errc::invalid_partition_operation:
     case cluster::errc::concurrent_modification_error:
+    case cluster::errc::nodes_already_defunct:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -95,6 +95,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::transform_invalid_source:
     case cluster::errc::trackable_keys_limit_exceeded:
     case cluster::errc::invalid_partition_operation:
+    case cluster::errc::concurrent_modification_error:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -180,6 +180,14 @@ struct broker_endpoint final
  */
 enum class membership_state : int8_t { active, draining, removed };
 
+/**
+ * Indicates the liveness state of a broker. A broker is always functional
+ * by default unless explicitly marked as defunct by the user. Marking a
+ * node as defunct is currently irreversible. This should only be done if
+ * a node and its data is permanently irrecoverable.
+ */
+enum class liveness_state : int8_t { functional, defunct };
+
 /*
  * Broker maintenance mode
  */
@@ -187,6 +195,7 @@ enum class maintenance_state { active, inactive };
 
 std::ostream& operator<<(std::ostream&, membership_state);
 std::ostream& operator<<(std::ostream&, maintenance_state);
+std::ostream& operator<<(std::ostream&, liveness_state);
 
 class broker
   : public serde::

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -393,6 +393,16 @@ std::ostream& operator<<(std::ostream& o, maintenance_state st) {
     __builtin_unreachable();
 }
 
+std::ostream& operator<<(std::ostream& o, liveness_state state) {
+    switch (state) {
+    case liveness_state::functional:
+        return o << "functional";
+    case liveness_state::defunct:
+        return o << "defunct";
+    }
+    __builtin_unreachable();
+}
+
 std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs) {
     switch (cs) {
     case cloud_credentials_source::config_file:

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -278,6 +278,10 @@
                     "type": "string",
                     "description": "Broker membership status"
                 },
+                "liveness_status": {
+                    "type": "string",
+                    "description": "Current liveness state, functional unless opted in as defunct by operator"
+                },
                 "is_alive": {
                     "type": "boolean",
                     "description": "is node seen as alive by the cluster"

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -280,6 +280,17 @@
                 "current_reassignments_count": {
                     "type": "int",
                     "description": "current number of partition reassignments in progress"
+                },
+                "partitions_pending_force_recovery_count": {
+                    "type": "int",
+                    "description": "number of partitions pending force recovery"
+                },
+                "partitions_pending_force_recovery_sample": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "sample list of partitions pending force recovery"
                 }
             }
         },

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -378,6 +378,21 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/partitions/force_recover_from_nodes",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Force recovers partitions from input list of nodes, the nodes are marked defunct and all partitions are moved away from them.",
+                    "type": "void",
+                    "nickname": "force_recover_from_nodes",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": []
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -356,6 +356,28 @@
                     ]
                 }
             ]
+        },
+        {
+            "path": "/v1/partitions/majority_lost",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "List of partitions with lost majority given an input set of defunct nodes.",
+                    "type": "void",
+                    "nickname": "majority_lost",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "defunct_nodes",
+                            "in": "query",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {
@@ -642,6 +664,52 @@
                 "result": {
                     "type": "string",
                     "description": "Status of operation"
+                }
+            }
+        },
+        "ntp": {
+            "id": "ntp",
+            "description": "Partition metadata",
+            "properties": {
+                "ns": {
+                    "type": "string",
+                    "description": "Namespace"
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "Topic"
+                },
+                "partition": {
+                    "type": "long",
+                    "description": "Partition id"
+                }
+            }
+        },
+        "ntp_with_majority_loss": {
+            "id": "ntp_with_majority_loss",
+            "description": "ntp instance with lost majority due to defunct nodes.",
+            "properties": {
+                "ntp": {
+                    "type": "ntp",
+                    "description": "partition"
+                },
+                "topic_revision": {
+                    "type": "long",
+                    "description": "Revision of the topic this ntp is a part of."
+                },
+                "replicas": {
+                    "type": "array",
+                    "items": {
+                        "type": "assignment"
+                    },
+                    "description": "Replica assignments"
+                },
+                "defunct_nodes" : {
+                    "type": "array",
+                    "items": {
+                        "type": "int"
+                    },
+                    "description:": "Nodes that are no longer functional and irrecoverable. Such nodes are explicitly marked defunct by the user."
                 }
             }
         }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3201,6 +3201,10 @@ admin_server::force_set_partition_replicas_handler(
           "Feature not active yet, upgrade in progress?");
     }
 
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
+
     auto ntp = parse_ntp_from_request(req->param);
     if (ntp == model::controller_ntp) {
         throw ss::httpd::bad_request_exception(

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -4703,6 +4703,13 @@ admin_server::get_partition_balancer_status_handler(
     ret.current_reassignments_count
       = _controller->get_topics_state().local().updates_in_progress().size();
 
+    ret.partitions_pending_force_recovery_count
+      = overview.partitions_pending_force_recovery_count;
+    for (const auto& ntp : overview.partitions_pending_force_recovery_sample) {
+        ret.partitions_pending_force_recovery_sample.push(fmt::format(
+          "{}/{}/{}", ntp.ns(), ntp.tp.topic(), ntp.tp.partition()));
+    }
+
     co_return ss::json::json_return_type(ret);
 }
 

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3935,6 +3935,13 @@ parse_replicas_from_json(const json::Document::ValueType& value) {
 ss::future<ss::json::json_return_type>
 admin_server::force_recover_partitions_from_nodes(
   std::unique_ptr<ss::http::request> request) {
+    if (!_controller->get_feature_table().local().is_active(
+          features::feature::enhanced_force_reconfiguration)) {
+        throw ss::httpd::bad_request_exception(
+          "Required feature is not active yet which indicates the cluster has "
+          "not fully upgraded yet, retry after a successful upgrade.");
+    }
+
     if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
         throw co_await redirect_to_leader(*request, model::controller_ntp);
     }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1044,6 +1044,8 @@ get_brokers(cluster::controller* const controller) {
               }
               b.membership_status = fmt::format(
                 "{}", nm.state.get_membership_state());
+              b.liveness_status = fmt::format(
+                "{}", nm.state.get_liveness_state());
 
               // These fields are defaults that will be overwritten with
               // data from the health report.

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -459,6 +459,8 @@ private:
       get_partition_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       get_topic_partitions_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      get_majority_lost_partitions(std::unique_ptr<ss::http::request>);
 
     ss::future<ss::json::json_return_type>
       get_transactions_handler(std::unique_ptr<ss::http::request>);

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -461,6 +461,8 @@ private:
       get_topic_partitions_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       get_majority_lost_partitions(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      force_recover_partitions_from_nodes(std::unique_ptr<ss::http::request>);
 
     ss::future<ss::json::json_return_type>
       get_transactions_handler(std::unique_ptr<ss::http::request>);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -747,6 +747,19 @@ class Admin:
         path = f"partitions/{namespace}/{topic}/{partition}/unclean_abort_reconfiguration"
         return self._request('post', path, node=node)
 
+    def get_majority_lost_partitions_from_nodes(self,
+                                                defunct_brokers: list[int],
+                                                node=None):
+        assert defunct_brokers
+        brokers_csv = ','.join(str(b) for b in defunct_brokers)
+        path = f"partitions/majority_lost?defunct_nodes={brokers_csv}"
+        return self._request('get', path, node).json()
+
+    def force_recover_partitions_from_nodes(self, payload: dict, node=None):
+        assert payload
+        path = "partitions/force_recover_from_nodes"
+        return self._request('post', path, node, json=payload)
+
     def create_user(self, username, password, algorithm):
         self.redpanda.logger.debug(
             f"Creating user {username}:{password}:{algorithm}")


### PR DESCRIPTION
PRD:  [link](https://docs.google.com/document/d/1n83PvnxYR8oJdTrlHkVozoTBsVelSNA4diQ3-3AMqwc/edit#heading=h.5zvj0etnl8iy)

Given an input set of nodes, generates a move plan that force reconfigures all partitions that lost majority (or all replicas) due to the unavailability of these nodes. This is intended to be used as an escape hatch to bulk move all such majority lost partitions when nodes are dead and are irrecoverable.

Adds the following admin end points. Input for both is array of node_ids.              
                                                                            
- `GET /v1/partitions/majority_lost?defunct_nodes=<csv nodes>`   - Given an input set of defunct nodes, generates a list of partitions that should be force recovered (aka lost majority).

- `POST /v1/partitions/force_recover_from_nodes` - Submits the plan generated from above step and the partitions are eventually force recovered.                                 

Example invocations

```
curl -X GET http://localhost:9644/v1/partitions/majority_lost\?defunct_nodes\=0,1 

curl -X POST http://localhost:9644/v1/partitions/force_recover_from_nodes -H 'Content-Type: application/json' --data '{"defunct_nodes": [1], "partitions_to_force_recover": [{"ntp": {"ns": "kafka", "topic": "bar", "partition": 0}, "topic_revision": 26, "replicas": [{"node_id": 1, "core": 0}], "defunct_nodes": [1]}]}
```

`partitions_to_force_recover` part of the POST payload is the plan generated from GET. The plan is validated before generating the controller command that orchestrates the moves.

Monitoring: Balanacer status (`v1/cluster/partition_balancer/status`) now contains the following
* `partitions_pending_force_recovery_count` - # of partitions that are yet to be force recovered.
* `partitions_pending_force_recovery_sample` -  A sample list of partitions pending force recovery (limit capped to 10)

Notes on defunct nodes:

* This PR adds the concept of "defunct nodes", nodes that are not functional and explicitly marked defunct by the user. 
* Defunct nodes are generated from `force_replicas_from_nodes` commands, all the brokers marked as "defunct" in the request are marked defunct for future processing and this is irreversible for now.
* defunct nodes are considered unavailable from RP's perspective. This means replicas from these nodes are moved away by the balancer eventually and any list of user approved force recoverable partitions in the request are force reconfigured.
* liveness status of a broker (functional or defunct) can be checked in the /brokers end point.

Fixes: https://github.com/redpanda-data/planning/issues/84

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Features

* Adds node wise partition recovery functionality. Given an input set of node ids, force reconfigures all partitions that would lose majority if the input set of nodes are dead. Intended to bulk recover partitions that are stuck when majority of brokers hosting their replicas are dead and irrecoverable.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
