### PR TITLE
[v23.2.x] tests/redpanda: do not allow getting redpanda pid cmd to fail

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2811,9 +2811,7 @@ class RedpandaService(RedpandaServiceBase):
     def redpanda_pid(self, node):
         try:
             cmd = "pgrep --list-full --exact redpanda"
-            for line in node.account.ssh_capture(cmd,
-                                                 allow_fail=True,
-                                                 timeout_sec=10):
+            for line in node.account.ssh_capture(cmd, timeout_sec=10):
                 # Ignore SSH commands that lookup the version of redpanda
                 # by running `redpanda --version` like in `self.get_version(node)`
                 if "--version" in line:


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13920
Fixes: https://github.com/redpanda-data/redpanda/issues/13944,