### PR TITLE
kafka/client: Log client identifier

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -36,9 +36,13 @@ ss::future<shared_broker_t> make_broker(
       .then([node_id, addr](ss::lw_shared_ptr<transport> client) {
           return client->connect().then(
             [node_id, addr = std::move(addr), client] {
+                auto prefix = client->client_id().has_value()
+                                ? ssx::sformat("{}: ", *client->client_id())
+                                : "";
                 vlog(
                   kclog.info,
-                  "connected to broker:{} - {}:{}",
+                  "{}connected to broker:{} - {}:{}",
+                  prefix,
                   node_id,
                   addr.host(),
                   addr.port());

--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -63,14 +63,16 @@ public:
           .with([this, r{std::move(r)}]() mutable {
               vlog(
                 kclog.debug,
-                "Dispatch to node {}: {} req: {}",
+                "{}Dispatch to node {}: {} req: {}",
+                *this,
                 _node_id,
                 api_t::name,
                 r);
               return _client.dispatch(std::move(r)).then([this](Ret res) {
                   vlog(
                     kclog.debug,
-                    "Dispatch from node {}: {} res: {}",
+                    "{}Dispatch from node {}: {} res: {}",
+                    *this,
                     _node_id,
                     api_t::name,
                     res);
@@ -101,6 +103,14 @@ public:
     }
 
 private:
+    /// \brief Log the client ID if it exists, otherwise don't log
+    friend std::ostream& operator<<(std::ostream& os, broker const& b) {
+        if (b._client.client_id().has_value()) {
+            fmt::print(os, "{}: ", b._client.client_id().value());
+        }
+        return os;
+    }
+
     model::node_id _node_id;
     transport _client;
     // TODO(Ben): allow overlapped requests

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -191,6 +191,14 @@ private:
     /// \brief Apply metadata update
     ss::future<> apply(metadata_response res);
 
+    /// \brief Log the client ID if it exists, otherwise don't log
+    friend std::ostream& operator<<(std::ostream& os, client const& c) {
+        if (c._config.client_identifier().has_value()) {
+            fmt::print(os, "{}: ", c._config.client_identifier().value());
+        }
+        return os;
+    }
+
     /// \brief Client holds a copy of its configuration
     configuration _config;
     /// \brief Seeds are used when no brokers are connected.

--- a/src/v/kafka/client/client_fetch_batch_reader.cc
+++ b/src/v/kafka/client/client_fetch_batch_reader.cc
@@ -44,7 +44,8 @@ public:
         if (!_batch_reader || _batch_reader->is_end_of_stream()) {
             vlog(
               kclog.debug,
-              "fetch_batch_reader: fetch offset: {}",
+              "{}fetch_batch_reader: fetch offset: {}",
+              _client,
               _next_offset);
             auto res = co_await _client.fetch_partition(
               _tp,
@@ -52,7 +53,11 @@ public:
               1_MiB,
               std::chrono::duration_cast<std::chrono::milliseconds>(
                 t - model::timeout_clock::now()));
-            vlog(kclog.debug, "fetch_batch_reader: fetch result: {}", res);
+            vlog(
+              kclog.debug,
+              "{}fetch_batch_reader: fetch result: {}",
+              _client,
+              res);
             vassert(
               res.begin() != res.end() && ++res.begin() == res.end(),
               "Expected exactly one response from client::fetch_partition");
@@ -74,7 +79,11 @@ public:
               kafka::error_code::unknown_server_error, "No records returned");
         }
         _next_offset = ++data.back().last_offset();
-        vlog(kclog.debug, "fetch_batch_reader: next_offset: {}", _next_offset);
+        vlog(
+          kclog.debug,
+          "{}fetch_batch_reader: next_offset: {}",
+          _client,
+          _next_offset);
         co_return ret;
     }
 

--- a/src/v/kafka/client/sasl_client.cc
+++ b/src/v/kafka/client/sasl_client.cc
@@ -17,10 +17,14 @@ namespace kafka::client {
 
 ss::future<>
 do_authenticate(shared_broker_t broker, const configuration& config) {
+    auto prefix = config.client_identifier().has_value()
+                    ? ssx::sformat("{}: ", *config.client_identifier())
+                    : "";
     if (config.sasl_mechanism().empty()) {
         vlog(
           kclog.debug,
-          "Connecting to broker {} without authentication",
+          "{}Connecting to broker {} without authentication",
+          prefix,
           broker->id());
         co_return;
     }
@@ -40,7 +44,8 @@ do_authenticate(shared_broker_t broker, const configuration& config) {
 
     vlog(
       kclog.debug,
-      "Connecting to broker {} with authentication: {}:{}",
+      "{}Connecting to broker {} with authentication: {}:{}",
+      prefix,
       broker->id(),
       mechanism,
       username);

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -218,6 +218,8 @@ public:
         }
     }
 
+    std::optional<ss::sstring> const& client_id() const { return _client_id; }
+
 private:
     void write_header(protocol::encoder& wr, api_key key, api_version version) {
         wr.write(int16_t(key()));


### PR DESCRIPTION
Add the client identifier to logs, if it was provided.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* kafka/client logs now include the client identifier (e.g., `schema_registry_client`, `pandaproxy_client`)
