### PR TITLE
[v23.1.x] schema_registry/store: Don't return a subject with no versions

### DIFF
--- a/src/v/pandaproxy/schema_registry/store.h
+++ b/src/v/pandaproxy/schema_registry/store.h
@@ -174,7 +174,12 @@ public:
         res.reserve(_subjects.size());
         for (const auto& sub : _subjects) {
             if (inc_del || !sub.second.deleted) {
-                res.push_back(sub.first);
+                auto has_version = absl::c_any_of(
+                  sub.second.versions,
+                  [inc_del](auto const& v) { return inc_del || !v.deleted; });
+                if (has_version) {
+                    res.push_back(sub.first);
+                }
             }
         }
         return res;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/13911
Fixes: https://github.com/redpanda-data/redpanda/issues/13956,