### PR TITLE
rpk/transform/init: bail on empty name input

### DIFF
--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -84,13 +84,16 @@ Will initialize a transform project in the foobar directory.
 			if ok {
 				out.Die("there is already a transform at %q, please delete it before retrying", c)
 			}
-			for name == "" {
+			if name == "" {
 				suggestion := filepath.Base(path)
 				if suggestion == "." {
 					suggestion = ""
 				}
 				name, err = out.PromptWithSuggestion(suggestion, "name this transform:")
 				out.MaybeDie(err, "unable to determine project name: %v", err)
+				if name == "" {
+					out.Die("transform name is required")
+				}
 			}
 			if lang == "" {
 				langVal, err := out.Pick(project.AllWasmLangs, "select a language:")


### PR DESCRIPTION
This is the more common behavior in RPK, and we want to align this
command with that.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
