### PR TITLE
rpk/transform: Introduce build command

### DIFF
--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -108,7 +108,7 @@ func Execute() {
 		plugincmd.NewCommand(fs),
 		registry.NewCommand(fs, p),
 		topic.NewCommand(fs, p),
-		transform.NewCommand(fs, p),
+		transform.NewCommand(fs, p, osExec),
 		version.NewCommand(fs, p),
 
 		newStatusCommand(), // deprecated

--- a/src/go/rpk/pkg/cli/transform/build.go
+++ b/src/go/rpk/pkg/cli/transform/build.go
@@ -1,0 +1,86 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package transform
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/transform/buildpack"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/transform/project"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newBuildCommand(fs afero.Fs, execFn func(string, []string) error) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "build",
+		Short: "Build a transform",
+		Long: `Build a transform.
+
+This command looks in the current working directory for a transform.yaml file.
+
+Then depending on the language, will install the appropriate build plugin then 
+build a .wasm file.
+
+Extra arguments are passed directly to the underlying toolchain when it invoked.
+For example to add debug symbols and use the asyncify scheduler for tinygo:
+
+  rpk transform build -- -scheduler=asyncify -no-debug=false
+
+Language specific details:
+
+Tinygo - By default tinygo are release builds (-opt=2) and goroutines are disabled,
+for maximum performance.
+`,
+		Args: cobra.ArbitraryArgs,
+		Run: func(cmd *cobra.Command, extraArgs []string) {
+			cfg, err := project.LoadCfg(fs)
+			out.MaybeDie(err, "unable to find the transform, are you in the same directory as the %q?", project.ConfigFileName)
+			switch cfg.Language {
+			case project.WasmLangTinygo:
+				tinygo, err := buildpack.Tinygo.Install(cmd.Context(), fs)
+				out.MaybeDieErr(err)
+				// See https://tinygo.org/docs/guides/optimizing-binaries/
+				args := []string{
+					"build",
+					// We're targeting WASI environments
+					"-target", "wasi",
+					// Optimize these binaries to the max!
+					// We want LLVM to use all it's tricks to
+					// make our code fast.
+					"-opt", "2",
+					// Print out an error before aborting, this
+					// greatly aids debugging.
+					"-panic", "print",
+					// The default scheduler is asyncify, which uses
+					// Binaryen’s Asyncify Pass to enable goroutine
+					// and channel support. However, that makes code
+					// the code 10x slower in our benchmarks, so
+					// default to that off.
+					"-scheduler", "none",
+					// Debug symbols can make the size of binaries to be
+					// an order of magnitude larger, so we remove them.
+					"-no-debug",
+				}
+				// Tinygo's flags can be overridden, so passing flags through
+				// allows the user to customize the defaults (i.e. turn on debug
+				// symbols or the scheduler).
+				args = append(args, extraArgs...)
+				// Output using the project name, deploy expects this format.
+				args = append(args, "-o", fmt.Sprintf("%s.wasm", cfg.Name))
+				out.MaybeDieErr(execFn(tinygo, args))
+			default:
+				out.Die("unknown language: %q", cfg.Language)
+			}
+		},
+	}
+	return cmd
+}

--- a/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
+++ b/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
@@ -259,3 +259,21 @@ func (bp *Buildpack) DownloadTo(ctx context.Context, dl Downloader, basePath str
 
 	return g.Wait()
 }
+
+// Install downloads a build pack if it is not yet installed and returns the binary path for the compiler.
+func (bp *Buildpack) Install(ctx context.Context, fs afero.Fs) (path string, err error) {
+	ok, err := bp.IsUpToDate(fs)
+	if err != nil {
+		return "", fmt.Errorf("unable to determine if %s buildpack is up to date: %v", bp.Name, err)
+	}
+	if !ok {
+		fmt.Printf("latest %s buildpack not found, downloading now...\n", bp.Name)
+		dl := NewDownloader()
+		err := bp.Download(ctx, dl, fs)
+		if err != nil {
+			return "", fmt.Errorf("unable to install %s buildpack: %v", bp.Name, err)
+		}
+		fmt.Printf("latest %s buildpack download complete\n", bp.Name)
+	}
+	return bp.BinPath()
+}

--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -222,16 +222,6 @@ func executeGenerate(fs afero.Fs, p transformProject) error {
 
 func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
 	if p.Lang == project.WasmLangTinygo {
-		ok, err := buildpack.Tinygo.IsUpToDate(fs)
-		if err != nil {
-			return fmt.Errorf("unable to determine if tinygo buildpack is up to date: %v", err)
-		}
-		if !ok {
-			dl := buildpack.NewDownloader()
-			if err := buildpack.Tinygo.Download(ctx, dl, fs); err != nil {
-				return fmt.Errorf("unable to install tinygo buildpack: %v", err)
-			}
-		}
 		g, err := exec.LookPath("go")
 		if err != nil {
 			return fmt.Errorf("go is not available on $PATH, please download and install it: https://go.dev/doc/install")
@@ -249,6 +239,9 @@ func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
 		}
 		if err := runGoCli("mod", "tidy"); err != nil {
 			return fmt.Errorf("unable to run go mod tidy: %v", err)
+		}
+		if _, err := buildpack.Tinygo.Install(ctx, fs); err != nil {
+			return fmt.Errorf("unable to install tinygo buildpack: %v", err)
 		}
 		return nil
 	}

--- a/src/go/rpk/pkg/cli/transform/transform.go
+++ b/src/go/rpk/pkg/cli/transform/transform.go
@@ -15,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) error) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "transform",
 		Aliases: []string{"wasm", "transfrom"}, //nolint:misspell // auto correct a common misspelling
@@ -26,6 +26,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newDeleteCommand(fs, p),
 		newListCommand(fs, p),
 		newInitializeCommand(fs),
+		newBuildCommand(fs, execFn),
 	)
 	return cmd
 }


### PR DESCRIPTION
Introduce a command to build a WASI binary using the tinygo compiler (that we vendor as a "buildpack").

We use performance optimized defaults, but allow users to pass custom flags to tinygo via `--` syntax as documented in the help text.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
