### PR TITLE
ht-phase2: support blocking gcp object store

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py
+++ b/tests/rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py
@@ -1,4 +1,21 @@
 class cloudv2_object_store_blocked:
+    def __init__(self, rp, logger):
+        self.logger = logger
+        if rp._cloud_cluster.config.provider == "aws":
+            self._delegate = cloudv2_object_store_blocked_aws(rp, logger)
+        else:
+            self._delegate = cloudv2_object_store_blocked_gcp(rp, logger)
+
+    def __enter__(self):
+        """apply a blocking policy"""
+        self._delegate.__enter__()
+
+    def __exit__(self, type, value, traceback):
+        """remove block policy"""
+        self._delegate.__exit__(type, value, traceback)
+
+
+class cloudv2_object_store_blocked_aws:
     """Temporary block writes to a cloudv2 TS bucket"""
     def __init__(self, rp, logger):
         self.logger = logger
@@ -19,3 +36,24 @@ class cloudv2_object_store_blocked:
         """remove block policy"""
         self.logger.debug(f'Unblocking access to {self._bucket_name}')
         self._cloud_provider_client.unblock_bucket_from_vpc(self._bucket_name)
+
+
+class cloudv2_object_store_blocked_gcp:
+    def __init__(self, rp, logger):
+        self.logger = logger
+        self._cluster_id = rp._cloud_cluster.config.id
+        network_id = rp._cloud_cluster.current.network_id
+        self._cloud_provider_client = rp._cloud_cluster.provider_cli
+        self._bucket_name = f'redpanda-cloud-storage-{self._cluster_id}'
+
+    def __enter__(self):
+        """apply a blocking policy"""
+        self.logger.debug(f'Blocking access to {self._bucket_name}')
+        self._block_ctx = self._cloud_provider_client.block_bucket_access(
+            self._cluster_id, self._bucket_name)
+
+    def __exit__(self, type, value, traceback):
+        """remove block policy"""
+        self.logger.debug(f'Unblocking access to {self._bucket_name}')
+        self._cloud_provider_client.unblock_bucket_access(
+            self._cluster_id, self._bucket_name, self._block_ctx)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -23,7 +23,7 @@ setup(
         'grpcio==1.57.0', 'grpcio-tools==1.57', 'grpcio-status==1.57.0',
         'cachetools==5.3.1', 'google-api-core==2.11.1', 'google-auth==2.22.0',
         'googleapis-common-protos==1.60.0', 'google.cloud.compute==1.14.0',
-        'proto-plus==1.22.3', 'rsa==4.9',
+        'google-cloud-storage==2.11.0', 'proto-plus==1.22.3', 'rsa==4.9',
         'python-keycloak@git+https://github.com/redpanda-data/python-keycloak.git@10b822cb0320c54dbf5bf4fd00435afb1487415d',
         'z3-solver==4.12.2', 'hypothesis==6.82'
     ],


### PR DESCRIPTION
For HT phase 2 block object store test to support GCP as well as AWS

Requires the gcp ducktape service account to have editor permissions

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

- none