### PR TITLE
tests/redpanda: fixed assertion message accessing not existing field

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -939,7 +939,7 @@ class RedpandaServiceBase(Service):
     def metrics(self,
                 node,
                 metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS):
-        assert node in self._started, f"where node is {node.name}"
+        assert node in self._started, f"Node {node.account.hostname} is not started"
 
         metrics_endpoint = ("/metrics" if metrics_endpoint
                             == MetricsEndpoint.METRICS else "/public_metrics")
@@ -1686,7 +1686,7 @@ class RedpandaService(RedpandaServiceBase):
                 pass
 
     def set_extra_node_conf(self, node, conf):
-        assert node in self.nodes, f"where node is {node.name}"
+        assert node in self.nodes, f"Node {node.account.hostname} is not started"
         self._extra_node_conf[node] = conf
 
     def set_security_settings(self, settings):
@@ -2480,7 +2480,7 @@ class RedpandaService(RedpandaServiceBase):
         wait_until(is_awaited_state, timeout_sec=timeout_sec, backoff_sec=1)
 
     def monitor_log(self, node):
-        assert node in self.nodes, f"where node is {node.name}"
+        assert node in self.nodes, f"Node {node.account.hostname} is not started"
         return node.account.monitor_log(RedpandaService.STDOUT_STDERR_CAPTURE)
 
     def raise_on_crash(self,
@@ -3384,7 +3384,7 @@ class RedpandaService(RedpandaServiceBase):
         return int(node.account.ssh_output(shlex.join(cmd), timeout_sec=10))
 
     def broker_address(self, node, listener: str = "dnslistener"):
-        assert node in self.nodes, f"where node is {node.name}"
+        assert node in self.nodes, f"Node {node.account.hostname} is not started"
         assert node in self._started
         cfg = self._node_configs[node]
         if cfg['redpanda']['kafka_api']:
@@ -3399,7 +3399,7 @@ class RedpandaService(RedpandaServiceBase):
             return None
 
     def admin_endpoint(self, node):
-        assert node in self.nodes, f"where node is {node.name}"
+        assert node in self.nodes, f"Node {node.account.hostname} is not started"
         return f"{node.account.hostname}:9644"
 
     def admin_endpoints_list(self):


### PR DESCRIPTION
Previously an assertion message was accessing field `name` which doesn't exists.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none