### PR TITLE
c/members_backend: prioritize removing nodes when decomm isfinished

### DIFF
--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -139,6 +139,7 @@ private:
 
     ss::future<> reconcile_raft0_updates();
     ss::future<std::error_code> do_remove_node(model::node_id);
+    ss::future<> maybe_finish_decommissioning(update_meta&);
 
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<topic_table>& _topics;


### PR DESCRIPTION
When all reallocations are finished and allocator state for node being decommissioned is empty it is possible to remove node from the cluster. The removal is independent from other nodes being recommissioned.

Members backend processes one update at a time and it might happened that decommissioning operation was queued after the recommission one and couldn't have been finished before the recommissioning was finished.

Change the logic in `members_backend` to check if there are any decommission operation that may be finished before executing current node update reconfigurations. This way node decommission operation will be finished independently from other not related operations.

Fixes: #13637

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Faster node decommissioning