### PR TITLE
transform: hook up transform subsystem

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -144,6 +144,12 @@ configuration::configuration()
   , coproc_max_ingest_bytes(*this, "coproc_max_ingest_bytes")
   , coproc_max_batch_size(*this, "coproc_max_batch_size")
   , coproc_offset_flush_interval_ms(*this, "coproc_offset_flush_interval_ms")
+  , enable_data_transforms(
+      *this,
+      "enable_data_transforms",
+      "Enables WebAssembly powered Data Transforms directly in the broker",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      false)
   , topic_memory_per_partition(
       *this,
       "topic_memory_per_partition",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -67,6 +67,9 @@ struct configuration final : public config_store {
     deprecated_property coproc_max_batch_size;
     deprecated_property coproc_offset_flush_interval_ms;
 
+    // Data Transforms
+    property<bool> enable_data_transforms;
+
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;
     bounded_property<std::optional<int32_t>> topic_fds_per_partition;

--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -115,6 +115,13 @@ node_config::node_config() noexcept
       {},
       endpoint_tls_config::validate_many)
   , coproc_supervisor_server(*this, "coproc_supervisor_server")
+  , emergency_disable_data_transforms(
+      *this,
+      "emergency_disable_data_transforms",
+      "Override the cluster enablement setting and disable WebAssembly powered "
+      "data transforms. Only used as an emergency shutoff button.",
+      {.visibility = visibility::user},
+      false)
   , admin_api_doc_dir(
       *this,
       "admin_api_doc_dir",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -51,6 +51,9 @@ public:
     // Coproc/wasm
     deprecated_property coproc_supervisor_server;
 
+    // Data transforms
+    property<bool> emergency_disable_data_transforms;
+
     // HTTP server content dirs
     property<ss::sstring> admin_api_doc_dir;
     deprecated_property dashboard_dir;

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -83,6 +83,8 @@ std::string_view to_string_view(feature f) {
         return "enhanced_force_reconfiguration";
     case feature::broker_time_based_retention:
         return "broker_time_based_retention";
+    case feature::wasm_transforms:
+        return "wasm_transforms";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -66,6 +66,7 @@ enum class feature : std::uint64_t {
     cloud_storage_scrubbing = 1ULL << 32U,
     enhanced_force_reconfiguration = 1ULL << 33U,
     broker_time_based_retention = 1ULL << 34U,
+    wasm_transforms = 1ULL << 35U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -313,6 +314,12 @@ constexpr static std::array feature_schema{
     "broker_time_based_retention",
     feature::broker_time_based_retention,
     feature_spec::available_policy::new_clusters_only,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{11},
+    "wasm_transforms",
+    feature::wasm_transforms,
+    feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
 };
 

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -49,13 +49,15 @@ v_cc_library(
     Seastar::seastar
     v::cluster
     v::finjector
-    v::syschecks
     v::kafka
+    v::migrations
     v::pandaproxy_rest
     v::pandaproxy_schema_registry
-    v::migrations
     v::storage_resource_mgmt
+    v::syschecks
+    v::transform
     v::version 
+    v::wasm
   )
 
 add_subdirectory(tests)

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -25,6 +25,7 @@
 #include "rpc/connection_cache.h"
 #include "seastarx.h"
 #include "storage/node.h"
+#include "transform/fwd.h"
 #include "utils/request_auth.h"
 #include "utils/type_traits.h"
 
@@ -79,7 +80,8 @@ public:
       ss::sharded<storage::node>&,
       ss::sharded<memory_sampling>&,
       ss::sharded<cloud_storage::cache>&,
-      ss::sharded<resources::cpu_profiler>&);
+      ss::sharded<resources::cpu_profiler>&,
+      ss::sharded<transform::service>*);
 
     ss::future<> start();
     ss::future<> stop();
@@ -488,8 +490,8 @@ private:
       sampled_memory_profile_handler(std::unique_ptr<ss::http::request>);
 
     // Transform routes
-    ss::future<std::unique_ptr<ss::http::reply>> deploy_transform(
-      std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
+    ss::future<ss::json::json_return_type>
+      deploy_transform(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       list_transforms(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
@@ -549,6 +551,7 @@ private:
     ss::sharded<memory_sampling>& _memory_sampling_service;
     ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
     ss::sharded<resources::cpu_profiler>& _cpu_profiler;
+    ss::sharded<transform::service>* _transform_service;
 
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -894,7 +894,8 @@ void application::configure_admin_server() {
       std::ref(storage_node),
       std::ref(_memory_sampling),
       std::ref(shadow_index_cache),
-      std::ref(_cpu_profiler))
+      std::ref(_cpu_profiler),
+      &_transform_service)
       .get();
 }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -92,11 +92,16 @@
 #include "storage/compaction_controller.h"
 #include "storage/directories.h"
 #include "syschecks/syschecks.h"
+#include "transform/api.h"
+#include "transform/rpc/client.h"
+#include "transform/rpc/service.h"
 #include "utils/file_io.h"
 #include "utils/human.h"
 #include "utils/uuid.h"
 #include "version.h"
 #include "vlog.h"
+#include "wasm/api.h"
+#include "wasm/cache.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/memory.hh>
@@ -1060,6 +1065,52 @@ void application::wire_up_runtime_services(
           *_schema_reg_config,
           std::reference_wrapper(controller));
     }
+
+    if (wasm_data_transforms_enabled()) {
+        syschecks::systemd_message("Starting wasm runtime").get();
+        auto base_runtime = wasm::runtime::create_default(
+          _schema_registry.get());
+        construct_single_service(_wasm_runtime, std::move(base_runtime));
+
+        syschecks::systemd_message("Starting data transforms").get();
+        construct_service(
+          _transform_rpc_service,
+          ss::sharded_parameter([this] {
+              return transform::rpc::topic_metadata_cache::make_default(
+                &metadata_cache);
+          }),
+          ss::sharded_parameter([this] {
+              return transform::rpc::partition_manager::make_default(
+                &shard_table, &partition_manager);
+          }))
+          .get();
+        construct_service(
+          _transform_rpc_client,
+          node_id,
+          ss::sharded_parameter([this] {
+              return transform::rpc::partition_leader_cache::make_default(
+                &controller->get_partition_leaders());
+          }),
+          ss::sharded_parameter([this] {
+              return transform::rpc::topic_creator::make_default(
+                controller.get());
+          }),
+          &_connection_cache,
+          &_transform_rpc_service)
+          .get();
+
+        construct_service(
+          _transform_service,
+          _wasm_runtime.get(),
+          node_id,
+          &controller->get_plugin_frontend(),
+          &controller->get_feature_table(),
+          &raft_group_manager,
+          &partition_manager,
+          &_transform_rpc_client)
+          .get();
+    }
+
     construct_single_service(_monitor_unsafe_log_flag, std::ref(feature_table));
 
     configure_admin_server();
@@ -1735,6 +1786,11 @@ bool application::archival_storage_enabled() {
     return cfg.cloud_storage_enabled();
 }
 
+bool application::wasm_data_transforms_enabled() {
+    return config::shard_local_cfg().enable_data_transforms.value()
+           && !config::node().emergency_disable_data_transforms.value();
+}
+
 ss::future<>
 application::set_proxy_client_config(ss::sstring name, std::any val) {
     return _proxy->set_client_config(std::move(name), std::move(val));
@@ -2139,6 +2195,12 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
 
     start_kafka(node_id, app_signal);
     controller->set_ready().get();
+
+    if (wasm_data_transforms_enabled()) {
+        _wasm_runtime->start().get();
+        _transform_service.invoke_on_all(&transform::service::start).get();
+    }
+
     _admin.invoke_on_all([](admin_server& admin) { admin.set_ready(); }).get();
     _monitor_unsafe_log_flag->start().get();
 
@@ -2286,6 +2348,14 @@ void application::start_runtime_services(
               sched_groups.cluster_sg(),
               smp_service_groups.cluster_smp_sg(),
               std::ref(controller->get_ephemeral_credential_frontend())));
+
+          if (wasm_data_transforms_enabled()) {
+              runtime_services.push_back(
+                std::make_unique<transform::rpc::network_service>(
+                  sched_groups.cluster_sg(),
+                  smp_service_groups.cluster_smp_sg(),
+                  &_transform_rpc_service));
+          }
 
           runtime_services.push_back(
             std::make_unique<cluster::topic_recovery_status_rpc_handler>(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -52,7 +52,9 @@
 #include "ssx/metrics.h"
 #include "storage/api.h"
 #include "storage/fwd.h"
+#include "transform/fwd.h"
 #include "utils/stop_signal.h"
+#include "wasm/fwd.h"
 
 #include <seastar/core/app-template.hh>
 #include <seastar/core/metrics_registration.hh>
@@ -193,6 +195,8 @@ private:
 
     bool archival_storage_enabled();
 
+    bool wasm_data_transforms_enabled();
+
     /**
      * @brief Construct service boilerplate.
      *
@@ -269,6 +273,11 @@ private:
       _archival_upload_housekeeping;
     std::unique_ptr<monitor_unsafe_log_flag> _monitor_unsafe_log_flag;
     ss::sharded<archival::purger> _archival_purger;
+
+    std::unique_ptr<wasm::caching_runtime> _wasm_runtime;
+    ss::sharded<transform::service> _transform_service;
+    ss::sharded<transform::rpc::local_service> _transform_rpc_service;
+    ss::sharded<transform::rpc::client> _transform_rpc_client;
 
     ssx::metrics::metric_groups _metrics
       = ssx::metrics::metric_groups::make_internal();

--- a/src/v/resource_mgmt/io_priority.h
+++ b/src/v/resource_mgmt/io_priority.h
@@ -23,6 +23,7 @@ public:
     ss::io_priority_class raft_priority() { return _raft_priority; }
     ss::io_priority_class controller_priority() { return _controller_priority; }
     ss::io_priority_class kafka_read_priority() { return _kafka_read_priority; }
+    ss::io_priority_class wasm_read_priority() { return _wasm_read_priority; }
     ss::io_priority_class compaction_priority() { return _compaction_priority; }
     ss::io_priority_class raft_learner_recovery_priority() {
         return _raft_learner_recovery_priority;
@@ -46,6 +47,8 @@ private:
           ss::io_priority_class::register_one("controller", 1000))
       , _kafka_read_priority(
           ss::io_priority_class::register_one("kafka_read", 1000))
+      , _wasm_read_priority(
+          ss::io_priority_class::register_one("wasm_read", 500))
       , _compaction_priority(
           ss::io_priority_class::register_one("compaction", 200))
       , _raft_learner_recovery_priority(
@@ -63,6 +66,7 @@ private:
     ss::io_priority_class _raft_priority;
     ss::io_priority_class _controller_priority;
     ss::io_priority_class _kafka_read_priority;
+    ss::io_priority_class _wasm_read_priority;
     ss::io_priority_class _compaction_priority;
     ss::io_priority_class _raft_learner_recovery_priority;
     ss::io_priority_class _shadow_indexing_priority;
@@ -79,6 +83,10 @@ inline ss::io_priority_class controller_priority() {
 
 inline ss::io_priority_class kafka_read_priority() {
     return priority_manager::local().kafka_read_priority();
+}
+
+inline ss::io_priority_class wasm_read_priority() {
+    return priority_manager::local().wasm_read_priority();
 }
 
 inline ss::io_priority_class compaction_priority() {

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -1,12 +1,14 @@
 v_cc_library(
   NAME transform
   HDRS
+    api.h
     probe.h
     logger.h
     transform_processor.h
     transform_manager.h
     io.h
   SRCS
+    api.cc
     probe.cc
     logger.cc
     transform_processor.cc

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -16,6 +16,7 @@ v_cc_library(
   DEPS
     v::wasm
     v::model
+    v::transform_rpc
 )
 
 add_subdirectory(tests)

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -11,9 +11,21 @@
 
 #include "transform/api.h"
 
-#include <stdexcept>
+#include "cluster/errc.h"
+#include "cluster/plugin_frontend.h"
+#include "features/feature_table.h"
+#include "model/timeout_clock.h"
+#include "transform/logger.h"
+#include "transform/rpc/client.h"
+
+#include <seastar/coroutine/as_future.hh>
 
 namespace transform {
+
+namespace {
+constexpr auto wasm_binary_timeout = std::chrono::seconds(3);
+constexpr auto metadata_timeout = std::chrono::seconds(1);
+} // namespace
 
 service::service(
   wasm::runtime* runtime,
@@ -42,8 +54,59 @@ ss::future<cluster::errc> service::delete_transform(model::transform_name) {
 }
 
 ss::future<cluster::errc>
-service::deploy_transform(model::transform_metadata, iobuf) {
-    throw std::runtime_error("unimplemented");
+service::deploy_transform(model::transform_metadata meta, iobuf binary) {
+    if (!_feature_table->local().is_active(
+          features::feature::wasm_transforms)) {
+        co_return cluster::errc::feature_disabled;
+    }
+    auto _ = _gate.hold();
+
+    vlog(
+      tlog.info,
+      "deploying wasm binary (size={}) for transform {}",
+      binary.size_bytes(),
+      meta.name);
+    // TODO(rockwood): Validate that the wasm adheres to our ABI
+    auto result = co_await _rpc_client->local().store_wasm_binary(
+      std::move(binary), wasm_binary_timeout);
+    if (result.has_error()) {
+        vlog(
+          tlog.warn, "storing wasm binary for transform {} failed", meta.name);
+        co_return result.error();
+    }
+    auto [key, offset] = result.value();
+    meta.uuid = key;
+    meta.source_ptr = offset;
+    vlog(
+      tlog.debug,
+      "stored wasm binary for transform {} at offset {}",
+      meta.name,
+      offset);
+    cluster::errc ec = co_await _plugin_frontend->local().upsert_transform(
+      meta, model::timeout_clock::now() + metadata_timeout);
+    vlog(
+      tlog.debug,
+      "deploying transform {} result: {}",
+      meta.name,
+      cluster::error_category().message(int(ec)));
+    if (ec != cluster::errc::success) {
+        // TODO(rockwood): This is a best effort cleanup, we should also have
+        // some sort of GC process as well.
+        auto result = co_await ss::coroutine::as_future<cluster::errc>(
+          _rpc_client->local().delete_wasm_binary(key, wasm_binary_timeout));
+        if (result.failed()) {
+            vlog(
+              tlog.debug,
+              "cleaning up wasm binary failed: {}",
+              result.get_exception());
+        } else if (auto ec = result.get(); ec != cluster::errc::success) {
+            vlog(
+              tlog.debug,
+              "cleaning up wasm binary failed: {}",
+              cluster::error_category().message(int(ec)));
+        }
+    }
+    co_return ec;
 }
 
 } // namespace transform

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/api.h"
+
+#include <stdexcept>
+
+namespace transform {
+
+service::service(
+  wasm::runtime* runtime,
+  model::node_id self,
+  ss::sharded<cluster::plugin_frontend>* plugin_frontend,
+  ss::sharded<features::feature_table>* feature_table,
+  ss::sharded<raft::group_manager>* group_manager,
+  ss::sharded<cluster::partition_manager>* partition_manager,
+  ss::sharded<rpc::client>* rpc_client)
+  : _runtime(runtime)
+  , _self(self)
+  , _plugin_frontend(plugin_frontend)
+  , _feature_table(feature_table)
+  , _group_manager(group_manager)
+  , _partition_manager(partition_manager)
+  , _rpc_client(rpc_client) {}
+
+service::~service() = default;
+
+ss::future<> service::start() { throw std::runtime_error("unimplemented"); }
+
+ss::future<> service::stop() { throw std::runtime_error("unimplemented"); }
+
+ss::future<cluster::errc> service::delete_transform(model::transform_name) {
+    throw std::runtime_error("unimplemented");
+}
+
+ss::future<cluster::errc>
+service::deploy_transform(model::transform_metadata, iobuf) {
+    throw std::runtime_error("unimplemented");
+}
+
+} // namespace transform

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -87,8 +87,7 @@ public:
           storage::log_reader_config(
             /*start_offset=*/offset,
             /*max_offset=*/model::offset::max(),
-            // TODO: Make a new priority for WASM transforms
-            /*prio=*/kafka_read_priority(),
+            /*prio=*/wasm_read_priority(),
             /*as=*/*as));
         co_return std::move(translater).reader;
     }

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -62,6 +62,8 @@ public:
     ss::future<cluster::errc> delete_transform(model::transform_name);
 
 private:
+    ss::gate _gate;
+
     wasm::runtime* _runtime;
     model::node_id _self;
     ss::sharded<cluster::plugin_frontend>* _plugin_frontend;

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -20,6 +20,7 @@
 #include "transform/fwd.h"
 #include "wasm/fwd.h"
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
 
 namespace transform {
@@ -64,6 +65,13 @@ public:
 private:
     ss::future<> cleanup_wasm_binary(uuid_t);
 
+    ss::future<ss::optimized_optional<ss::shared_ptr<wasm::engine>>>
+      create_engine(model::transform_metadata);
+
+    ss::future<
+      ss::optimized_optional<ss::foreign_ptr<ss::shared_ptr<wasm::factory>>>>
+      get_factory(model::transform_metadata);
+
     ss::gate _gate;
 
     wasm::runtime* _runtime;
@@ -73,6 +81,7 @@ private:
     ss::sharded<raft::group_manager>* _group_manager;
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<rpc::client>* _rpc_client;
+    std::unique_ptr<manager<ss::lowres_clock>> _manager;
 };
 
 } // namespace transform

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "cluster/errc.h"
+#include "cluster/fwd.h"
+#include "features/fwd.h"
+#include "model/metadata.h"
+#include "model/transform.h"
+#include "raft/fwd.h"
+#include "seastarx.h"
+#include "transform/fwd.h"
+#include "wasm/fwd.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace transform {
+
+/**
+ * The transform service is responsible for intersecting the current state of
+ * plugins and topic partitions and ensures that the corresponding wasm
+ * transform is running for each leader partition (on the input topic).
+ *
+ * Instances on every shard.
+ */
+class service : public ss::peering_sharded_service<service> {
+public:
+    service(
+      wasm::runtime* runtime,
+      model::node_id self,
+      ss::sharded<cluster::plugin_frontend>* plugin_frontend,
+      ss::sharded<features::feature_table>* feature_table,
+      ss::sharded<raft::group_manager>* group_manager,
+      ss::sharded<cluster::partition_manager>* partition_manager,
+      ss::sharded<rpc::client>* rpc_client);
+    service(const service&) = delete;
+    service(service&&) = delete;
+    service& operator=(const service&) = delete;
+    service& operator=(service&&) = delete;
+    ~service();
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    /**
+     * Deploy a transform to the cluster.
+     */
+    ss::future<cluster::errc>
+      deploy_transform(model::transform_metadata, iobuf);
+
+    /**
+     * Delete a transform from the cluster.
+     */
+    ss::future<cluster::errc> delete_transform(model::transform_name);
+
+private:
+    wasm::runtime* _runtime;
+    model::node_id _self;
+    ss::sharded<cluster::plugin_frontend>* _plugin_frontend;
+    ss::sharded<features::feature_table>* _feature_table;
+    ss::sharded<raft::group_manager>* _group_manager;
+    ss::sharded<cluster::partition_manager>* _partition_manager;
+    ss::sharded<rpc::client>* _rpc_client;
+};
+
+} // namespace transform

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -62,6 +62,8 @@ public:
     ss::future<cluster::errc> delete_transform(model::transform_name);
 
 private:
+    ss::future<> cleanup_wasm_binary(uuid_t);
+
     ss::gate _gate;
 
     wasm::runtime* _runtime;

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -35,7 +35,7 @@ namespace transform {
 class service : public ss::peering_sharded_service<service> {
 public:
     service(
-      wasm::runtime* runtime,
+      wasm::caching_runtime* runtime,
       model::node_id self,
       ss::sharded<cluster::plugin_frontend>* plugin_frontend,
       ss::sharded<features::feature_table>* feature_table,
@@ -74,7 +74,7 @@ private:
 
     ss::gate _gate;
 
-    wasm::runtime* _runtime;
+    wasm::caching_runtime* _runtime;
     model::node_id _self;
     ss::sharded<cluster::plugin_frontend>* _plugin_frontend;
     ss::sharded<features::feature_table>* _feature_table;

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -22,6 +22,8 @@
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 namespace transform {
 
@@ -63,6 +65,9 @@ public:
     ss::future<cluster::errc> delete_transform(model::transform_name);
 
 private:
+    void register_notifications();
+    void unregister_notifications();
+
     ss::future<> cleanup_wasm_binary(uuid_t);
 
     ss::future<ss::optimized_optional<ss::shared_ptr<wasm::engine>>>
@@ -82,6 +87,8 @@ private:
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<rpc::client>* _rpc_client;
     std::unique_ptr<manager<ss::lowres_clock>> _manager;
+    std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>
+      _notification_cleanups;
 };
 
 } // namespace transform

--- a/src/v/transform/fwd.h
+++ b/src/v/transform/fwd.h
@@ -12,6 +12,8 @@
 #pragma once
 
 namespace transform {
+template<typename ClockType>
+class manager;
 class processor;
 class probe;
 namespace rpc {

--- a/src/v/transform/fwd.h
+++ b/src/v/transform/fwd.h
@@ -12,11 +12,13 @@
 #pragma once
 
 namespace transform {
+class service;
 template<typename ClockType>
 class manager;
 class processor;
 class probe;
 namespace rpc {
 class client;
-}
+class local_service;
+} // namespace rpc
 } // namespace transform

--- a/src/v/transform/fwd.h
+++ b/src/v/transform/fwd.h
@@ -14,4 +14,7 @@
 namespace transform {
 class processor;
 class probe;
+namespace rpc {
+class client;
+}
 } // namespace transform

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -227,8 +227,7 @@ ss::future<result<iobuf, cluster::errc>> local_service::load_wasm_binary(
             /*max_offset=*/model::next_offset(offset),
             /*min_bytes=*/0,
             /*max_bytes=*/1,
-            // TODO: a custom read priority
-            /*prio=*/kafka_read_priority(),
+            /*prio=*/wasm_read_priority(),
             /*type_filter=*/std::nullopt,
             /*time=*/std::nullopt,
             /*as=*/std::nullopt);

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -190,7 +190,7 @@ class processor_tracker : public processor_factory {
             id,
             std::move(ntp),
             std::move(meta),
-            std::make_unique<testing::fake_wasm_engine>(),
+            ss::make_shared<testing::fake_wasm_engine>(),
             [](auto, auto, auto) {},
             std::make_unique<testing::fake_source>(model::offset(1)),
             make_sink(),
@@ -225,6 +225,7 @@ public:
       model::transform_id id,
       model::ntp ntp,
       model::transform_metadata meta,
+      processor::error_callback,
       probe* probe) override {
         EXPECT_NE(probe, nullptr);
         co_return std::make_unique<tracked_processor>(

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -26,8 +26,8 @@ namespace {
 class ProcessorTestFixture : public ::testing::Test {
 public:
     void SetUp() override {
-        std::unique_ptr<wasm::engine> engine
-          = std::make_unique<testing::fake_wasm_engine>();
+        ss::shared_ptr<wasm::engine> engine
+          = ss::make_shared<testing::fake_wasm_engine>();
         auto src = std::make_unique<testing::fake_source>(_offset);
         _src = src.get();
         auto sink = std::make_unique<testing::fake_sink>();

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -353,8 +353,15 @@ template<typename ClockType>
 ss::future<> manager<ClockType>::create_processor(
   model::ntp ntp, model::transform_id id, model::transform_metadata meta) {
     auto p = _processors->get_or_create_probe(id, meta);
+    processor::error_callback cb = [this](
+                                     model::transform_id id,
+                                     model::ntp ntp,
+                                     model::transform_metadata meta) {
+        on_transform_error(id, std::move(ntp), std::move(meta));
+    };
     auto fut = co_await ss::coroutine::as_future(
-      _processor_factory->create_processor(id, ntp, meta, p.get()));
+      _processor_factory->create_processor(
+        id, ntp, meta, std::move(cb), p.get()));
     if (fut.failed()) {
         vlog(
           tlog.warn,

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -79,8 +79,8 @@ private:
     // the backoff policy for this processor for when we attempt to restart
     // the processor. If it's been enough time since our last restart of the
     // processor we will reset this.
-    rpc::backoff_policy _backoff
-      = rpc::make_exponential_backoff_policy<ClockType>(
+    ::rpc::backoff_policy _backoff
+      = ::rpc::make_exponential_backoff_policy<ClockType>(
         base_duration, max_duration);
 };
 

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -18,6 +18,7 @@
 #include "ssx/work_queue.h"
 #include "transform/fwd.h"
 #include "transform/io.h"
+#include "transform/transform_processor.h"
 #include "wasm/fwd.h"
 
 #include <seastar/core/lowres_clock.hh>
@@ -70,7 +71,11 @@ public:
 
     // Create a processor with the given metadata and input partition.
     virtual ss::future<std::unique_ptr<processor>> create_processor(
-      model::transform_id, model::ntp, model::transform_metadata, probe*)
+      model::transform_id,
+      model::ntp,
+      model::transform_metadata,
+      processor::error_callback,
+      probe*)
       = 0;
 };
 

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -29,7 +29,7 @@ processor::processor(
   model::transform_id id,
   model::ntp ntp,
   model::transform_metadata meta,
-  std::unique_ptr<wasm::engine> engine,
+  ss::shared_ptr<wasm::engine> engine,
   error_callback cb,
   std::unique_ptr<source> source,
   std::vector<std::unique_ptr<sink>> sinks,

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -41,7 +41,7 @@ public:
       model::transform_id,
       model::ntp,
       model::transform_metadata,
-      std::unique_ptr<wasm::engine>,
+      ss::shared_ptr<wasm::engine>,
       error_callback,
       std::unique_ptr<source>,
       std::vector<std::unique_ptr<sink>>,
@@ -64,7 +64,7 @@ private:
     model::transform_id _id;
     model::ntp _ntp;
     model::transform_metadata _meta;
-    std::unique_ptr<wasm::engine> _engine;
+    ss::shared_ptr<wasm::engine> _engine;
     std::unique_ptr<source> _source;
     std::vector<std::unique_ptr<sink>> _sinks;
     error_callback _error_callback;

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -59,6 +59,12 @@ public:
     ss::future<ss::shared_ptr<factory>>
     make_factory(model::transform_metadata, iobuf, ss::logger*) override;
 
+    /**
+     * If a factory exists in cached, return it without needing the binary.
+     */
+    ss::optimized_optional<ss::shared_ptr<factory>>
+    get_cached_factory(const model::transform_metadata&);
+
 private:
     friend class WasmCacheTest;
 

--- a/src/v/wasm/fwd.h
+++ b/src/v/wasm/fwd.h
@@ -16,5 +16,6 @@ class transform_probe;
 class engine;
 class factory;
 class runtime;
+class caching_runtime;
 class schema_registry;
 } // namespace wasm


### PR DESCRIPTION
This PR hooks up the transform subsystem into Redpanda

This introduces the service for the transform subsystem, which essentially wraps all the
dependencies on the rest of the system and injects them into the rest of the transform subsystem.
Additionally, the transform service is responsible for handling admin API commands, two of which
implemented in this PR, deploy + delete.

We also introduce configuration for enabling transforms + wasm, both a feature to protect during rolling upgrades AND a cluster configuration value to turn it on. There is also a node local configuration value to force disable transforms + wasm. In case of some incident where the wasm VM is bringing down the whole cluster, this is a useful safety knob to disable wasm (cluster configuration requires a quorum to be up to make changes at the moment).

Lastly, all of the parts of the transform + wasm subsystems are hooked up into application.cc

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
