### PR TITLE
Introduce validation for replication factor config

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -690,9 +690,8 @@ std::istream& operator>>(std::istream& i, replication_factor& cs) {
 replication_factor parsing_replication_factor(const ss::sstring& value) {
     auto raw_value = boost::lexical_cast<int32_t>(value);
     if (
-      raw_value <= 0
-      || raw_value
-           > std::numeric_limits<cluster::replication_factor::type>::max()) {
+      raw_value
+      > std::numeric_limits<cluster::replication_factor::type>::max()) {
         throw boost::bad_lexical_cast();
     }
 

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -229,7 +229,8 @@ create_topic_properties_update(
                 parse_and_set_topic_replication_factor(
                   update.custom_properties.replication_factor,
                   cfg.value,
-                  kafka::config_resource_operation::set);
+                  kafka::config_resource_operation::set,
+                  replication_factor_validator{});
                 continue;
             }
             if (

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -233,7 +233,10 @@ create_topic_properties_update(
             }
             if (cfg.name == topic_property_replication_factor) {
                 parse_and_set_topic_replication_factor(
-                  update.custom_properties.replication_factor, cfg.value, op);
+                  update.custom_properties.replication_factor,
+                  cfg.value,
+                  op,
+                  replication_factor_validator{});
                 continue;
             }
             if (cfg.name == topic_property_segment_ms) {

--- a/tests/rptest/tests/replication_factor_change_test.py
+++ b/tests/rptest/tests/replication_factor_change_test.py
@@ -38,7 +38,7 @@ class ReplicationFactorChangeTest(RedpandaTest):
 
     @cluster(num_nodes=4)
     def simple_test(self):
-        self.replication_factor = 4
+        self.replication_factor = 3
         self._rpk.alter_topic_config(self.topic_name, self.rf_property,
                                      self.replication_factor)
         self.check_rf(self.replication_factor)
@@ -51,7 +51,7 @@ class ReplicationFactorChangeTest(RedpandaTest):
                    backoff_sec=2,
                    err_msg="Can not wait end of reconfiguration")
 
-        self.replication_factor = 2
+        self.replication_factor = 1
         self._rpk.alter_topic_config(self.topic_name, self.rf_property,
                                      self.replication_factor)
         self.check_rf(self.replication_factor)
@@ -76,10 +76,20 @@ class ReplicationFactorChangeTest(RedpandaTest):
                 or "INVALID_CONFIG" in e.msg):
             self._rpk.alter_topic_config(self.topic_name, self.rf_property,
                                          new_rf)
+
         assert len(self.admin.list_reconfigurations()) == 0
         self.check_rf(self.replication_factor)
 
         new_rf = 10000
+        with expect_exception(
+                RpkException, lambda e: "INVALID_REPLICATION_FACTOR" in e.msg
+                or "INVALID_CONFIG" in e.msg):
+            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                         new_rf)
+        assert len(self.admin.list_reconfigurations()) == 0
+        self.check_rf(self.replication_factor)
+
+        new_rf = 4
         with expect_exception(
                 RpkException, lambda e: "INVALID_REPLICATION_FACTOR" in e.msg
                 or "INVALID_CONFIG" in e.msg):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR expands on some existing config validation machinery and adds
validators for replication factor config, rejecting any value which is not both
positive and odd.

The general idea was to do this in the least invasive way possible while
resolving the basic bug (config API accepts a replication factor that the
create API rejects. This PR does not address:

1. Auditing/aligning other configs with respect to existing validations on the create API
   -  NOTE: covered by #13443 
2. Unifying validation _mechanism_ between create and config APIs
3. Adding validation to the topic/config controller frontends

(1) straightforward to implement, building on this PR. (2) seems desirable but could require a fair bit of refactoring due to disparate data structures between APIs. (3) also desirable; perhaps should be included in this PR.

Fixes #13442 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fix a bug where the alter configs API would accept even-valued replication factors

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
