### PR TITLE
serde: Don't share an EOL iobuf

### DIFF
--- a/src/v/serde/rw/iobuf.h
+++ b/src/v/serde/rw/iobuf.h
@@ -25,7 +25,7 @@ inline void tag_invoke(
 
 inline void tag_invoke(tag_t<write_tag>, iobuf& out, iobuf t) {
     write<serde_size_t>(out, t.size_bytes());
-    out.append(t.share(0, t.size_bytes()));
+    out.append(std::move(t));
 }
 
 } // namespace serde


### PR DESCRIPTION
Just move it instead.

`share()`ing an iobuf is expensive as it will always cause allocations
for the `io_fragment`s and potentially also an extra allocation for the
underlying `ss::temporary_buffer` deleter control block if it hasn't
been shared before.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

