### PR TITLE
rptest: Ignore transient log error message

### DIFF
--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -44,6 +44,10 @@ CDT_CONFIGURATION = {
     "cloud_storage_segment_max_upload_interval_sec": 5
 }
 
+ALLOWED_LOG_LINES = [
+    'Ensure that your bucket exists and that the cloud_storage_bucket and cloud_storage_region cluster configs are correct.'
+]
+
 
 class CloudStorageCompactionTest(EndToEndTest):
     topic = "panda-topic"
@@ -162,7 +166,7 @@ class CloudStorageCompactionTest(EndToEndTest):
                    timeout_sec=30,
                    backoff_sec=5)
 
-    @cluster(num_nodes=9)
+    @cluster(num_nodes=9, log_allow_list=ALLOWED_LOG_LINES)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         docker_use_arbitrary=True))
     def test_read_from_replica(self, cloud_storage_type):


### PR DESCRIPTION
The log message `s3 - s3_client.cc:426 - The specified S3 bucket, panda-bucket-335a4708-61cc-11ee-9168-bd94df9c8361, could not be found. Ensure that your bucket exists and that the cloud_storage_bucket and cloud_storage_region cluster configs are correct.` sometimes causes the scale test to fail. It's not clear why this happens. The problem is not causing the test to actually fail because it is  transient. The upload is retried and the data is getting uploaded. We can expect things like this to happen on CDT from time to time. It's not an indication of a bug in Redpanda.

Fixes #13921

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none