### PR TITLE
cloud_storage/ducktape: Wait for chunk observer to stop

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -369,6 +369,9 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
 
         self._consume_baseline(timeout=180, max_msgs=read_count)
         observe_cache_dir.stop()
+        observe_cache_dir.join(timeout=10)
+        assert not observe_cache_dir.is_alive(
+        ), 'cache observer is unexpectedly alive'
 
         self._assert_not_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$')
         self._assert_in_cache(f'.*kafka/{self.topic}/.*_chunks/[0-9]+')


### PR DESCRIPTION
Tests which use chunk observer should wait for it to stop after the stop command is issued, to avoid the underlying set changing while it is being read from.

FIXES #13233 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
