### PR TITLE
rptest: Fix OMB workload add payload_file for non randomized payloads

### DIFF
--- a/tests/rptest/services/templates/omb_workload.yaml
+++ b/tests/rptest/services/templates/omb_workload.yaml
@@ -4,9 +4,13 @@ topics: {{topics}}
 partitionsPerTopic: {{partitions_per_topic}}
 {% if message_size is defined %}
 messageSize: {{message_size}}
+{% if use_randomized_payloads is defined %}
 useRandomizedPayloads: {{use_randomized_payloads}}
 randomBytesRatio: {{random_bytes_ratio}}
 randomizedPayloadPoolSize: {{randomized_payload_pool_size}}
+{% else %}
+payloadFile: {{payload_file}}
+{% endif %}
 {% else %}
 messageSize: 1024
 payloadFile: "payload/payload-1Kb.data"


### PR DESCRIPTION
In case workload dict not suppliyng use_randomized_payloads var, use
payload_file to load the sample payload data.

Fixes: #13702 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none