### PR TITLE
schema_registry: Split project_ids

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -352,8 +352,17 @@ post_subject_versions(server::request_t rq, server::reply_t rp) {
       unparsed.id.value_or(invalid_schema_id),
       is_deleted::no};
 
-    auto schema_id = co_await rq.service().writer().write_subject_version(
-      std::move(schema));
+    auto ids = co_await rq.service().schema_store().get_schema_version(schema);
+
+    schema_id schema_id{ids.id.value_or(invalid_schema_id)};
+    if (!ids.version.has_value()) {
+        schema.id = ids.id.value_or(invalid_schema_id);
+        schema.version = schema.version == invalid_schema_version
+                           ? ids.version.value_or(invalid_schema_version)
+                           : schema.version;
+        schema_id = co_await rq.service().writer().write_subject_version(
+          std::move(schema));
+    }
 
     auto json_rslt{
       json::rjson_serialize(post_subject_versions_response{.id{schema_id}})};

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -62,7 +62,7 @@ ss::future<> seq_writer::wait_for(model::offset offset) {
                   .consume(
                     consume_to_store{seq._store, seq}, model::no_timeout);
             } else {
-                vlog(plog.debug, "wait_for clean (offset  {})", offset);
+                vlog(plog.trace, "wait_for clean (offset  {})", offset);
                 return ss::make_ready_future<>();
             }
         });

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -35,12 +35,17 @@ public:
     ///\brief Construct a schema in the native format
     ss::future<valid_schema> make_valid_schema(canonical_schema schema);
 
+    struct has_schema_result {
+        std::optional<schema_id> id;
+        std::optional<schema_version> version;
+    };
+    ss::future<has_schema_result> get_schema_version(subject_schema schema);
+
     struct insert_result {
         schema_version version;
         schema_id id;
         bool inserted;
     };
-
     ss::future<insert_result> project_ids(subject_schema schema);
 
     ss::future<bool> upsert(


### PR DESCRIPTION
A common use of `POST /subjects/{subject}/versions` is to get the schema ID of an existing subject-version.

This case can be optimised by not taking the write_sem unless a new schema or version needs to be written to the topic.

Split out `get_schema_version` from `project_ids` to facilitate that.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Schema Registry: Don't hold the write semaphore if the schema posted to `POST /subjects/{subject}/versions` already exists.
