### PR TITLE
merge queue: embarking dev (4750d19) and #13974 together

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py
+++ b/tests/rptest/redpanda_cloud_tests/cloudv2_object_store_blocked.py
@@ -1,4 +1,21 @@
 class cloudv2_object_store_blocked:
+    def __init__(self, rp, logger):
+        self.logger = logger
+        if rp._cloud_cluster.config.provider == "aws":
+            self._delegate = cloudv2_object_store_blocked_aws(rp, logger)
+        else:
+            self._delegate = cloudv2_object_store_blocked_gcp(rp, logger)
+
+    def __enter__(self):
+        """apply a blocking policy"""
+        self._delegate.__enter__()
+
+    def __exit__(self, type, value, traceback):
+        """remove block policy"""
+        self._delegate.__exit__(type, value, traceback)
+
+
+class cloudv2_object_store_blocked_aws:
     """Temporary block writes to a cloudv2 TS bucket"""
     def __init__(self, rp, logger):
         self.logger = logger
@@ -19,3 +36,24 @@ class cloudv2_object_store_blocked:
         """remove block policy"""
         self.logger.debug(f'Unblocking access to {self._bucket_name}')
         self._cloud_provider_client.unblock_bucket_from_vpc(self._bucket_name)
+
+
+class cloudv2_object_store_blocked_gcp:
+    def __init__(self, rp, logger):
+        self.logger = logger
+        self._cluster_id = rp._cloud_cluster.config.id
+        network_id = rp._cloud_cluster.current.network_id
+        self._cloud_provider_client = rp._cloud_cluster.provider_cli
+        self._bucket_name = f'redpanda-cloud-storage-{self._cluster_id}'
+
+    def __enter__(self):
+        """apply a blocking policy"""
+        self.logger.debug(f'Blocking access to {self._bucket_name}')
+        self._block_ctx = self._cloud_provider_client.block_bucket_access(
+            self._cluster_id, self._bucket_name)
+
+    def __exit__(self, type, value, traceback):
+        """remove block policy"""
+        self.logger.debug(f'Unblocking access to {self._bucket_name}')
+        self._cloud_provider_client.unblock_bucket_access(
+            self._cluster_id, self._bucket_name, self._block_ctx)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -23,7 +23,7 @@ setup(
         'grpcio==1.57.0', 'grpcio-tools==1.57', 'grpcio-status==1.57.0',
         'cachetools==5.3.1', 'google-api-core==2.11.1', 'google-auth==2.22.0',
         'googleapis-common-protos==1.60.0', 'google.cloud.compute==1.14.0',
-        'proto-plus==1.22.3', 'rsa==4.9',
+        'google-cloud-storage==2.11.0', 'proto-plus==1.22.3', 'rsa==4.9',
         'python-keycloak@git+https://github.com/redpanda-data/python-keycloak.git@10b822cb0320c54dbf5bf4fd00435afb1487415d',
         'z3-solver==4.12.2', 'hypothesis==6.82'
     ],


### PR DESCRIPTION
**✨ Unexpected queue change: an external action moved the target branch head to 51967962127f28080be582a8e10224075d602706. The pull request [#13974](/redpanda-data/redpanda/pull/13974) has been re-embarked. ✨**

Branch **dev** (4750d19) and [#13974](/redpanda-data/redpanda/pull/13974) are embarked together for merge.

This pull request has been created by Mergify to speculatively check the mergeability of [#13974](/redpanda-data/redpanda/pull/13974).
You don't need to do anything. Mergify will close this pull request automatically when it is complete.


**Required conditions of queue** `dev` **for merge:**

- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=build-debug-clang-amd64`
  - [ ] `check-skipped=build-debug-clang-amd64`
  - [ ] `check-success=build-debug-clang-amd64`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=build-release-clang-amd64`
  - [ ] `check-skipped=build-release-clang-amd64`
  - [ ] `check-success=build-release-clang-amd64`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=ducktape-build-release-clang-amd64`
  - [ ] `check-skipped=ducktape-build-release-clang-amd64`
  - [ ] `check-success=ducktape-build-release-clang-amd64`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=ducktape-build-debug-clang-amd64`
  - [ ] `check-skipped=ducktape-build-debug-clang-amd64`
  - [ ] `check-success=ducktape-build-debug-clang-amd64`
- `#approved-reviews-by>=1` [🛡 GitHub branch protection]
  - [X] #13974
- `#changes-requested-reviews-by=0` [🛡 GitHub branch protection]
  - [X] #13974
- [X] `base=dev`
- `label=merge-queue`
  - [X] #13974

**Required conditions to stay in the queue:**

- `#approved-reviews-by>=1` [🛡 GitHub branch protection]
  - [X] #13974
- `#changes-requested-reviews-by=0` [🛡 GitHub branch protection]
  - [X] #13974
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=build-debug-clang-amd64`
  - [ ] `check-neutral=build-debug-clang-amd64`
  - [ ] `check-skipped=build-debug-clang-amd64`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=build-release-clang-amd64`
  - [ ] `check-neutral=build-release-clang-amd64`
  - [ ] `check-skipped=build-release-clang-amd64`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=ducktape-build-release-clang-amd64`
  - [ ] `check-neutral=ducktape-build-release-clang-amd64`
  - [ ] `check-skipped=ducktape-build-release-clang-amd64`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=ducktape-build-debug-clang-amd64`
  - [ ] `check-neutral=ducktape-build-debug-clang-amd64`
  - [ ] `check-skipped=ducktape-build-debug-clang-amd64`

**Visit the [Mergify Dashboard](https://dashboard.mergify.com/github/redpanda-data/repo/redpanda/queues/partitions/__default__?queues=dev&branch=dev) to check the state of the queue `dev`.**<!---
DO NOT EDIT
-*- Mergify Payload -*-
{"merge-queue-pr": true}
-*- Mergify Payload End -*-
-->

```yaml
---
previous_failed_batches: []
pull_requests:
  - number: 13974
...

```