### PR TITLE
r/heartbeats: do not use iobuf::share in cursor

### DIFF
--- a/src/v/raft/heartbeats.h
+++ b/src/v/raft/heartbeats.h
@@ -161,7 +161,8 @@ public:
         auto cnt = read_nested<uint32_t>(in, bytes_left_limit);
         auto last = read_nested<field_t>(in, bytes_left_limit);
         auto buffer = read_nested<iobuf>(in, bytes_left_limit);
-        c._data = encoder_t(initial, cnt, last, std::move(buffer));
+        // copy buffer content not share the buffer cross shards
+        c._data = encoder_t(initial, cnt, last, buffer.copy());
         c._cnt = read_nested<size_t>(in, bytes_left_limit);
     }
 
@@ -172,7 +173,8 @@ public:
         write(out, state._data.get_initial_value());
         write(out, state._data.get_row_count());
         write(out, state._data.get_last_value());
-        write(out, state._data.share());
+        // copy buffer content not share the buffer cross shards
+        write(out, state._data.copy());
         write(out, state._cnt);
     }
 


### PR DESCRIPTION
Since heartbeats reply/request is deserialized on the RPC connection core
which may differ from the core where it is processed it should copy
buffer while deserializing the request as the underlying buffer might
have been shared on the originating core.

Fixes: #13447

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixes segmentation fault that may happened when `heartbeat_reply_v2` was used on a different core than it was created. 