### PR TITLE
wasm: validate wasi logs

### DIFF
--- a/src/v/wasm/tests/wasi_logs_test.cc
+++ b/src/v/wasm/tests/wasi_logs_test.cc
@@ -9,10 +9,12 @@
  * by the Apache License, Version 2.0
  */
 
+#include "units.h"
 #include "wasm/wasi.h"
 
 #include <seastar/util/log.hh>
 
+#include <absl/strings/str_join.h>
 #include <absl/strings/str_split.h>
 #include <gtest/gtest.h>
 
@@ -86,6 +88,12 @@ INSTANTIATE_TEST_SUITE_P(
       .want = "INFO   [shard 0:main] LOGGER_NAME - XFORM_NAME - hello\n"
               "INFO   [shard 0:main] LOGGER_NAME - XFORM_NAME - world\n",
     },
+    test_param{
+      .input = std::string(8_KiB, 'a'),
+      .want = absl::StrCat(
+        "INFO   [shard 0:main] LOGGER_NAME - XFORM_NAME - ",
+        std::string(2_KiB, 'a'),
+        "\n")},
     test_param{
       .input = "The quic\b\b\b\b\b\bk brown "
                "fo\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007"

--- a/src/v/wasm/tests/wasi_logs_test.cc
+++ b/src/v/wasm/tests/wasi_logs_test.cc
@@ -85,4 +85,16 @@ INSTANTIATE_TEST_SUITE_P(
                "world\n",
       .want = "INFO   [shard 0:main] LOGGER_NAME - XFORM_NAME - hello\n"
               "INFO   [shard 0:main] LOGGER_NAME - XFORM_NAME - world\n",
-    }));
+    },
+    test_param{
+      .input = "The quic\b\b\b\b\b\bk brown "
+               "fo\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007\u0007"
+               "\u0007x... [Beeeep]\n",
+      .want = "INFO   [shard 0:main] LOGGER_NAME - XFORM_NAME - "
+              "The quic\\x08\\x08\\x08\\x08\\x08\\x08k brown "
+              "fo\\x07\\x07\\x07\\x07\\x07\\x07\\x07\\x07\\x07\\x07"
+              "\\x07x... [Beeeep]\n"},
+    test_param{
+      .input = "invalid utf8: \xF0\xA4\xAD\x7F\n",
+      .want = "INFO   [shard 0:main] LOGGER_NAME - XFORM_NAME - invalid utf8: "
+              "\\xf0\\xa4\\xad\\x7f\n"}));

--- a/src/v/wasm/wasi.cc
+++ b/src/v/wasm/wasi.cc
@@ -13,6 +13,7 @@
 
 #include "ffi.h"
 #include "seastarx.h"
+#include "units.h"
 #include "utils/utf8.h"
 #include "vassert.h"
 #include "vlog.h"
@@ -86,6 +87,10 @@ uint32_t log_writer::flush() {
     if (!is_valid_utf8(joined) || contains_control_character(joined))
       [[unlikely]] {
         joined = absl::CHexEscape(joined);
+    }
+    constexpr static size_t max_log_line = 2_KiB;
+    if (joined.size() > max_log_line) {
+        joined.resize(max_log_line);
     }
     _logger->log(level, "{} - {}", _name, joined);
     return amt;


### PR DESCRIPTION
Prevent control characters, invalid utf8 and long lines from being logged due to wasm.

Fixes: https://github.com/redpanda-data/core-internal/issues/807

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
