### PR TITLE
r/recovery_stm: check if node is a leader before sending request

### DIFF
--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -327,6 +327,9 @@ ss::future<> recovery_stm::send_install_snapshot_request() {
               (*meta)->expected_log_end_offset = _ptr->_last_snapshot_index;
           }
           vlog(_ctxlog.trace, "sending install_snapshot request: {}", req);
+          if (is_recovery_finished()) {
+              return ss::now();
+          }
           auto hb_guard = _ptr->suppress_heartbeats(_node_id);
           return _ptr->_client_protocol
             .install_snapshot(


### PR DESCRIPTION
Validation in `suppress_heartbeats_guard` checks if a node is a leader when heartbeat is suppressed. The assertion is triggered if node suppressing heartbeat is no longer a leader. Added a check immediately preceding heartbeat suppression in `recovery_stm`. Recovery STM works outside of the raft mutex and it may be the case that leadership was lost between the fiber scheduling points.

Fixes: #14066

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
