### PR TITLE
ht phase2: observe tests that check for firing alarms

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/observe_test.py
+++ b/tests/rptest/redpanda_cloud_tests/observe_test.py
@@ -1,0 +1,73 @@
+import requests
+import json
+from ducktape.tests.test import Test
+from types import SimpleNamespace
+
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import make_redpanda_service
+from rptest.tests.rpk_cloud_test import get_ci_env_var
+
+
+class HTObserveTest(Test):
+    """
+    Cloudv2 only - ensure no firing alarms for cloud cluster - should be ran after all other tests
+    this is acomplished by setting @cluster(num_nodes=0) which is good enough
+    """
+    def __init__(self, test_context):
+        super(HTObserveTest, self).__init__(test_context=test_context)
+        self.redpanda = make_redpanda_service(test_context, 3)
+        self._ctx = test_context
+        self._token = self.redpanda._cloud_cluster.config.grafana_token
+        self._endpoint = self.redpanda._cloud_cluster.config.grafana_alerts_url
+
+    def setUp(self):
+        self.redpanda.start()
+        self._clusterId = self.redpanda._cloud_cluster.config.id
+
+    def load_grafana_rules(self):
+        headers = {'Authorization': "Bearer {}".format(self._token)}
+        with requests.get(self._endpoint, headers=headers, stream=True) as r:
+            if r.status_code != requests.status_codes.codes.ok:
+                r.raise_for_status()
+            return json.load(r.raw, object_hook=lambda d: SimpleNamespace(**d))
+
+    def cluster_alerts(self, rule_groups):
+        alerts = []
+        for group in rule_groups:
+            for rule in group.rules:
+                if rule.state != 'firing' or len(rule.alerts) == 0:
+                    continue
+
+                if rule.health == 'error':
+                    continue
+
+                for alert in rule.alerts:
+                    if alert.state != 'Alerting':
+                        continue
+
+                    if hasattr(
+                            alert.labels, 'redpanda_agent'
+                    ) and alert.labels.redpanda_agent == self._clusterId:
+                        alerts.append(alert)
+
+                    if hasattr(
+                            alert.labels, 'redpanda_id'
+                    ) and alert.labels.redpanda_id == self._clusterId:
+                        alerts.append(alert)
+
+        return alerts
+
+    @cluster(num_nodes=0, check_allowed_error_logs=False)
+    def test_cloud_observe(self):
+        self.logger.debug("Here we go")
+
+        rule_groups = self.load_grafana_rules()
+
+        alerts = self.cluster_alerts(rule_groups.data.groups)
+
+        for alert in alerts:
+            self.logger.warn(
+                f'alert firing for cluster: {alert.labels.grafana_folder} / {alert.labels.alertname}'
+            )
+
+        assert len(alerts) == 0

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -272,6 +272,8 @@ class CloudClusterConfig:
     install_pack_url_template: str = ""
     install_pack_auth_type: str = ""
     install_pack_auth: str = ""
+    grafana_token: str = ""
+    grafana_alerts_url: str = ""
 
 
 @dataclass


### PR DESCRIPTION
requires grafana token and grafana rules url added to duck tape globals - will raise separate PR for vtools changes

will check for redpanda alerts as well as agent alerts

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

- none