### PR TITLE
wasm: minimal poll_oneoff for golang

### DIFF
--- a/src/v/wasm/ffi.h
+++ b/src/v/wasm/ffi.h
@@ -282,22 +282,6 @@ std::tuple<Type> extract_parameter(
     }
 }
 
-template<typename Type>
-constexpr size_t num_parameters() {
-    if constexpr (std::is_same_v<ffi::memory*, Type>) {
-        return 0;
-    } else if constexpr (
-      is_array<Type>::value || std::is_same_v<ss::sstring, Type>) {
-        // one for the pointer and one for the length
-        return 2;
-    } else if constexpr (std::is_pointer_v<Type> || std::is_integral_v<Type>) {
-        return 1;
-    } else if constexpr (reflection::is_rp_named_type<Type>) {
-        return num_parameters<typename Type::type>();
-    } else {
-        static_assert(utils::unsupported_type<Type>::value, "Unknown type");
-    }
-}
 } // namespace detail
 
 template<typename... Rest>
@@ -329,15 +313,4 @@ std::tuple<Type, Rest...> extract_parameters(
       std::move(head_type), extract_parameters<Rest...>(mem, params, idx));
 }
 
-template<typename... Rest>
-constexpr size_t parameter_count()
-requires(sizeof...(Rest) == 0)
-{
-    return 0;
-}
-
-template<typename Type, typename... Rest>
-constexpr size_t parameter_count() {
-    return detail::num_parameters<Type>() + parameter_count<Rest...>();
-}
 } // namespace wasm::ffi

--- a/src/v/wasm/ffi.h
+++ b/src/v/wasm/ffi.h
@@ -14,6 +14,7 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "reflection/type_traits.h"
+#include "utils/named_type.h"
 #include "utils/type_traits.h"
 #include "vassert.h"
 
@@ -26,11 +27,16 @@
 namespace wasm::ffi {
 
 /**
+ * A "raw" pointer into guest VM memory.
+ */
+using ptr = named_type<uint32_t, struct ptr_tag>;
+
+/**
  * An container for a sequence of T from the Wasm VM guest.
  *
  * This can be used in exposed functions, and the parameter translation will
- * convert this to two parameters on the guest side: a raw pointer and the size
- * of that pointer.
+ * convert this to two parameters on the guest side: a raw pointer and the
+ * size of that pointer.
  *
  * We'll bounds check the entire array during the parameter translation
  * transparently.
@@ -177,7 +183,7 @@ public:
      *
      * Throws if out of bounds.
      */
-    virtual void* translate_raw(size_t guest_ptr, size_t len) = 0;
+    virtual void* translate_raw(ptr guest_ptr, uint32_t len) = 0;
 
     /**
      * Convert a guest pointer into an array of items in host memory.
@@ -185,7 +191,7 @@ public:
      * Will throw if the memory is out of bounds of the guest memory.
      */
     template<typename T>
-    ffi::array<T> translate_array(size_t guest_ptr, size_t len) {
+    ffi::array<T> translate_array(ptr guest_ptr, uint32_t len) {
         void* ptr = translate_raw(guest_ptr, len * sizeof(T));
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
         return ffi::array<T>(reinterpret_cast<T*>(ptr), len);
@@ -222,7 +228,9 @@ void transform_type(std::vector<val_type>& types) {
     } else if constexpr (
       std::is_same_v<Type, int64_t> || std::is_same_v<Type, uint64_t>) {
         types.push_back(val_type::i64);
-    } else if constexpr (std::is_pointer_v<Type> || std::is_integral_v<Type>) {
+    } else if constexpr (
+      std::is_pointer_v<Type> || std::is_integral_v<Type>
+      || std::is_same_v<Type, ptr>) {
         types.push_back(val_type::i32);
     } else if constexpr (reflection::is_rp_named_type<Type>) {
         transform_type<typename Type::type>(types);
@@ -242,7 +250,7 @@ std::tuple<Type> extract_parameter(
     if constexpr (std::is_same_v<ffi::memory*, Type>) {
         return std::tuple(mem);
     } else if constexpr (detail::is_array<Type>::value) {
-        auto guest_ptr = static_cast<uint32_t>(raw_params[idx++]);
+        ptr guest_ptr{static_cast<uint32_t>(raw_params[idx++])};
         auto ptr_len = static_cast<uint32_t>(raw_params[idx++]);
         void* host_ptr = mem->translate_raw(
           guest_ptr, ptr_len * sizeof(typename Type::element_type));
@@ -251,7 +259,7 @@ std::tuple<Type> extract_parameter(
           reinterpret_cast<typename Type::element_type*>(host_ptr),
           ptr_len));
     } else if constexpr (std::is_same_v<ss::sstring, Type>) {
-        auto guest_ptr = static_cast<uint32_t>(raw_params[idx++]);
+        ptr guest_ptr{static_cast<uint32_t>(raw_params[idx++])};
         auto ptr_len = static_cast<uint32_t>(raw_params[idx++]);
         void* host_ptr = mem->translate_raw(guest_ptr, ptr_len);
         return std::make_tuple(ss::sstring(
@@ -266,7 +274,7 @@ std::tuple<Type> extract_parameter(
         return std::make_tuple(static_cast<Type>(nullptr));
     } else if constexpr (std::is_pointer_v<Type>) {
         // Assume this is an out val
-        auto guest_ptr = static_cast<uint32_t>(raw_params[idx++]);
+        ptr guest_ptr{static_cast<uint32_t>(raw_params[idx++])};
         uint32_t ptr_len = sizeof(typename std::remove_pointer_t<Type>);
         void* host_ptr = mem->translate_raw(guest_ptr, ptr_len);
         // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)

--- a/src/v/wasm/tests/ffi_helpers_test.cc
+++ b/src/v/wasm/tests/ffi_helpers_test.cc
@@ -124,7 +124,7 @@ TEST(FFIHelpers, ExtractParameters) {
     static uint64_t num = num_value;
     class test_memory : public memory {
         // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-        void* translate_raw(size_t guest_ptr, size_t len) final {
+        void* translate_raw(ptr guest_ptr, uint32_t len) final {
             switch (guest_ptr) {
             case array_offset: {
                 if (len != (array_len * sizeof(int32_t))) {

--- a/src/v/wasm/tests/ffi_helpers_test.cc
+++ b/src/v/wasm/tests/ffi_helpers_test.cc
@@ -114,17 +114,6 @@ TEST(FFIHelpers, ConvertSignature) {
         val_type::i32));
 }
 
-TEST(FFIHelpers, CountParameters) {
-    constexpr size_t count = ffi::parameter_count<
-      ffi::memory*,
-      ffi::array<int>,
-      model::ns,
-      int32_t,
-      int64_t,
-      uint64_t*>();
-    ASSERT_EQ(count, 7);
-}
-
 TEST(FFIHelpers, ExtractParameters) {
     constexpr size_t array_offset = 42;
     constexpr size_t array_len = 2;

--- a/src/v/wasm/wasi.cc
+++ b/src/v/wasm/wasi.cc
@@ -188,7 +188,7 @@ preview1_module::args_sizes_get(uint32_t* count_ptr, uint32_t* size_ptr) {
 }
 
 errno_t preview1_module::args_get(
-  ffi::memory* mem, uint32_t args_ptrs_offset, uint32_t args_buf_offset) {
+  ffi::memory* mem, ffi::ptr args_ptrs_offset, ffi::ptr args_buf_offset) {
     try {
         auto args_ptrs_buf = mem->translate_array<uint32_t>(
           args_ptrs_offset, _args.size());
@@ -211,7 +211,7 @@ preview1_module::environ_sizes_get(uint32_t* count_ptr, uint32_t* size_ptr) {
 }
 
 errno_t preview1_module::environ_get(
-  ffi::memory* mem, uint32_t environ_ptrs_offset, uint32_t environ_buf_offset) {
+  ffi::memory* mem, ffi::ptr environ_ptrs_offset, ffi::ptr environ_buf_offset) {
     try {
         auto environ_ptrs_buf = mem->translate_array<uint32_t>(
           environ_ptrs_offset, _environ.size());
@@ -288,7 +288,7 @@ errno_t preview1_module::fd_write(
         for (const iovec_t& vec : iovecs) {
             try {
                 ffi::array<char> data = mem->translate_array<char>(
-                  vec.buf, vec.buf_len);
+                  vec.buf_addr, vec.buf_len);
                 amt += logger->write(
                   std::string_view(data.data(), data.size()));
             } catch (const std::exception& ex) {
@@ -351,8 +351,8 @@ errno_t preview1_module::path_unlink_file(fd_t, ffi::array<uint8_t>) {
 }
 errno_t preview1_module::poll_oneoff(
   ffi::memory* memory,
-  int32_t in_addr,
-  int32_t out_addr,
+  ffi::ptr in_addr,
+  ffi::ptr out_addr,
   uint32_t nsubscriptions,
   uint32_t* retptr) {
     // This is a minimal implementation of poll_oneoff for golang, which

--- a/src/v/wasm/wasi.h
+++ b/src/v/wasm/wasi.h
@@ -225,7 +225,7 @@ struct event_t {
  */
 struct iovec_t {
     /** The (guest) address of the buffer to be written. */
-    uint32_t buf;
+    ffi::ptr buf_addr;
     /** The length of the buffer to be written. */
     uint32_t buf_len;
 };
@@ -280,8 +280,8 @@ public:
     errno_t clock_res_get(clock_id_t, timestamp_t*);
     errno_t clock_time_get(clock_id_t, timestamp_t, timestamp_t*);
     errno_t args_sizes_get(uint32_t*, uint32_t*);
-    errno_t args_get(ffi::memory*, uint32_t, uint32_t);
-    errno_t environ_get(ffi::memory*, uint32_t, uint32_t);
+    errno_t args_get(ffi::memory*, ffi::ptr, ffi::ptr);
+    errno_t environ_get(ffi::memory*, ffi::ptr, ffi::ptr);
     errno_t environ_sizes_get(uint32_t*, uint32_t*);
     errno_t fd_advise(fd_t, uint64_t, uint64_t, uint8_t);
     errno_t fd_allocate(fd_t, uint64_t, uint64_t);
@@ -324,7 +324,7 @@ public:
     errno_t path_rename(fd_t, ffi::array<uint8_t>, fd_t, ffi::array<uint8_t>);
     errno_t path_symlink(ffi::array<uint8_t>, fd_t, ffi::array<uint8_t>);
     errno_t path_unlink_file(fd_t, ffi::array<uint8_t>);
-    errno_t poll_oneoff(ffi::memory*, int32_t, int32_t, uint32_t, uint32_t*);
+    errno_t poll_oneoff(ffi::memory*, ffi::ptr, ffi::ptr, uint32_t, uint32_t*);
     errno_t random_get(ffi::array<uint8_t>);
     void proc_exit(int32_t exit_code);
     ss::future<errno_t> sched_yield();

--- a/src/v/wasm/wasi.h
+++ b/src/v/wasm/wasi.h
@@ -9,6 +9,23 @@
  * by the Apache License, Version 2.0
  */
 
+// These APIs are defined and documented in the wasi-libc project,
+// but Redpanda implements it's own version of the WASI standard,
+// so that it works with the model we want to expose and have full
+// control over all the details. Most APIs here are stubbed out as
+// unsupported.
+//
+// Supported functionality:
+// - Program args + environment variables
+// - Manual clock implementation (with millisecond resolution)
+// - Reading from "random" (it's actually deterministic)
+// - exitting the process (just forces a trap within the VM)
+// - yield (yields to the seastar scheduler)
+// - "sleeping" via poll_oneoff (needed for golang support)
+//
+// For the full spec in a C API see:
+// https://github.com/WebAssembly/wasi-libc/blob/main/libc-bottom-half/headers/public/wasi/api.h
+
 #pragma once
 
 #include "model/timestamp.h"
@@ -26,31 +43,183 @@
 
 namespace wasm::wasi {
 
+/**
+ * This is the function that the wasi standard expects to be exported to call
+ * into the user's main function.
+ */
 constexpr std::string_view preview_1_start_function_name = "_start";
 
+// Identifiers for errors.
 using errno_t = named_type<uint16_t, struct errc_tag>;
-// https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L110-L113C1
-constexpr errno_t ERRNO_SUCCESS = errno_t(0);
+constexpr errno_t ERRNO_SUCCESS{0};
+constexpr errno_t ERRNO_INVAL{16};
+constexpr errno_t ERRNO_NOSYS{52};
+constexpr errno_t ERRNO_BADF{8};
 
-// https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L250-L253C1
-constexpr errno_t ERRNO_INVAL = errno_t(16);
-
-// https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L370-L373
-constexpr errno_t ERRNO_NOSYS = errno_t(52);
-
-// https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L370-L373
-constexpr errno_t ERRNO_BADF = errno_t(8);
-
-// https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L70C1-L97
+// Identifiers for clocks.
 using clock_id_t = named_type<uint32_t, struct clock_id_tag>;
-constexpr clock_id_t REALTIME_CLOCK_ID = clock_id_t(0);
-constexpr clock_id_t MONOTONIC_CLOCK_ID = clock_id_t(1);
-constexpr clock_id_t PROCESS_CPUTIME_CLOCK_ID = clock_id_t(2);
-constexpr clock_id_t THREAD_CPUTIME_CLOCK_ID = clock_id_t(3);
+constexpr clock_id_t REALTIME_CLOCK_ID{0};
+constexpr clock_id_t MONOTONIC_CLOCK_ID{1};
+constexpr clock_id_t PROCESS_CPUTIME_CLOCK_ID{2};
+constexpr clock_id_t THREAD_CPUTIME_CLOCK_ID{3};
+
 // A timestamp in nanoseconds
 using timestamp_t = named_type<uint64_t, struct timestamp_tag>;
 // A file descriptor
 using fd_t = named_type<int32_t, struct fd_tag>;
+
+// Type of a subscription to an event or its occurrence.
+using event_type_t = named_type<uint8_t, struct eventtype_tag>;
+/**
+ * The time value of clock `subscription_clock::id` has
+ * reached timestamp `subscription_clock::timeout`.
+ */
+constexpr event_type_t CLOCK_EVENT_TYPE{0};
+/**
+ * File descriptor `subscription_fd_readwrite::file_descriptor` has data
+ * available for reading. This event always triggers for regular files.
+ */
+constexpr event_type_t FD_READ_EVENT_TYPE{1};
+/**
+ * File descriptor `subscription_fd_readwrite::file_descriptor` has capacity
+ * available for writing. This event always triggers for regular files.
+ */
+constexpr event_type_t FD_WRITE_EVENT_TYPE{2};
+
+// Arbitrary user data for subscriptions
+using user_data_t = named_type<int64_t, struct user_data_tag>;
+
+// Specify if a sleep time is relative or absolute
+using subclockflags_t = named_type<int16_t, struct subclockflags_tag>;
+/**
+ * If set, treat the timestamp provided in
+ * `subscription_clock::timeout` as an absolute timestamp of clock
+ * `subscription_clock::id`. If clear, treat the timestamp
+ * provided in `subscription_clock::timeout` relative to the
+ * current time value of clock `subscription_clock::id`.
+ */
+constexpr subclockflags_t RELATIVE_TIME_SUBCLOCK_FLAG{0};
+constexpr subclockflags_t ABSOLUTE_TIME_SUBCLOCK_FLAG{1};
+
+/**
+ * The contents of a `subscription` when type is `eventtype::clock`.
+ */
+struct subscription_clock_t {
+    /**
+     * The clock against which to compare the timestamp.
+     */
+    clock_id_t id;
+
+    /**
+     * The absolute or relative timestamp.
+     */
+    timestamp_t timeout;
+
+    /**
+     * The amount of time that the implementation may wait additionally
+     * to coalesce with other events.
+     */
+    timestamp_t precision;
+
+    /**
+     * Flags specifying whether the timeout is absolute or relative
+     */
+    subclockflags_t flags;
+};
+
+/**
+ * The contents of a `subscription` when type is type is
+ * `eventtype::fd_read` or `eventtype::fd_write`.
+ */
+struct subscription_fd_readwrite_t {
+    /**
+     * The file descriptor on which to wait for it to become ready for reading
+     * or writing.
+     */
+    fd_t file_descriptor;
+};
+
+/**
+ * The contents of a `subscription`.
+ */
+union subscription_union_options {
+    subscription_clock_t clock;
+    subscription_fd_readwrite_t fd_read;
+    subscription_fd_readwrite_t fd_write;
+};
+struct subscription_tagged_union {
+    event_type_t tag;
+    subscription_union_options u;
+};
+/**
+ * Subscription to an event.
+ */
+struct subscription_t {
+    /**
+     * User-provided value that is attached to the subscription in the
+     * implementation and returned through `event::userdata`.
+     */
+    user_data_t userdata;
+
+    /**
+     * The type of the event to which to subscribe, and its contents
+     */
+    subscription_tagged_union u;
+};
+
+/**
+ * Non-negative file size or length of a region within a file.
+ */
+using filesize_t = named_type<uint64_t, struct filesize_tag>;
+/**
+ * The state of the file descriptor subscribed to with
+ * `eventtype::fd_read` or `eventtype::fd_write`.
+ */
+using event_rw_flags_t = named_type<int16_t, struct eventrwflags_tag>;
+
+/**
+ * The contents of an `event` when type is `eventtype::fd_read` or
+ * `eventtype::fd_write`.
+ */
+struct event_fd_readwrite_t {
+    /**
+     * The number of bytes available for reading or writing.
+     */
+    filesize_t nbytes;
+
+    /**
+     * The state of the file descriptor.
+     */
+    event_rw_flags_t flags;
+};
+
+/**
+ * An event that occurred.
+ */
+struct event_t {
+    /**
+     * User-provided value that got attached to `subscription::userdata`.
+     */
+    user_data_t userdata;
+
+    /**
+     * If non-zero, an error that occurred while processing the subscription
+     * request.
+     */
+    errno_t error;
+
+    /**
+     * The type of event that occured
+     */
+    event_type_t type;
+
+    /**
+     * The contents of the event, if it is an `eventtype::fd_read` or
+     * `eventtype::fd_write`. `eventtype::clock` events ignore this field.
+     */
+    event_fd_readwrite_t fd_readwrite;
+};
+
 /**
  * A region of memory for scatter/gather writes.
  */
@@ -108,69 +277,38 @@ public:
 
     static constexpr std::string_view name = "wasi_snapshot_preview1";
 
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1446-L1452
     errno_t clock_res_get(clock_id_t, timestamp_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1453-L1469
     errno_t clock_time_get(clock_id_t, timestamp_t, timestamp_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1409-L1418
     errno_t args_sizes_get(uint32_t*, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1400-L1408
     errno_t args_get(ffi::memory*, uint32_t, uint32_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1419-L1427
     errno_t environ_get(ffi::memory*, uint32_t, uint32_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1428-L1437
     errno_t environ_sizes_get(uint32_t*, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1470-L1488
     errno_t fd_advise(fd_t, uint64_t, uint64_t, uint8_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1493-L1503
     errno_t fd_allocate(fd_t, uint64_t, uint64_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1504-L1510
     errno_t fd_close(fd_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1504-L1510
     errno_t fd_datasync(fd_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1518-L1527
     errno_t fd_fdstat_get(fd_t, void*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1528-L1538
     errno_t fd_fdstat_set_flags(fd_t, uint16_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1551-L1559
     errno_t fd_filestat_get(fd_t, void*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1560-L1570
     errno_t fd_filestat_set_size(fd_t, uint64_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1571-L1589
     errno_t fd_filestat_set_times(fd_t, timestamp_t, timestamp_t, uint16_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1590-L1611
     errno_t fd_pread(fd_t, ffi::array<iovec_t>, uint64_t, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1612-L1620
     errno_t fd_prestat_get(fd_t, void*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1621-L1631
     errno_t fd_prestat_dir_name(fd_t, uint8_t*, uint32_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1632-L1653
     errno_t fd_pwrite(fd_t, ffi::array<iovec_t>, uint64_t, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1654-L1671
     errno_t fd_read(fd_t, ffi::array<iovec_t>, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1672-L1697
     errno_t fd_readdir(fd_t, ffi::array<uint8_t>, uint64_t, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1698-L1714
     errno_t fd_renumber(fd_t, fd_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1715-L1732
     errno_t fd_seek(fd_t, int64_t, uint8_t, uint64_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1733-L1739
     errno_t fd_sync(fd_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1740-L1749
     errno_t fd_tell(fd_t, uint64_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1750-L1765
     errno_t fd_write(ffi::memory*, fd_t, ffi::array<iovec_t>, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1766-L1776
     errno_t path_create_directory(fd_t, ffi::array<uint8_t>);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1777-L1794
     errno_t path_filestat_get(fd_t, uint32_t, ffi::array<uint8_t>, void*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1795-L1821
     errno_t path_filestat_set_times(
       fd_t, uint32_t, ffi::array<uint8_t>, timestamp_t, timestamp_t, uint16_t);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1822-L1844
     errno_t
       path_link(fd_t, uint32_t, ffi::array<uint8_t>, fd_t, ffi::array<uint8_t>);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1845-L1884
     errno_t path_open(
       fd_t,
       uint32_t,
@@ -180,33 +318,20 @@ public:
       uint64_t,
       uint16_t,
       fd_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1885-L1903
     errno_t path_readlink(
       fd_t, ffi::array<uint8_t> path, ffi::array<uint8_t>, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1904-L1915
     errno_t path_remove_directory(fd_t, ffi::array<uint8_t>);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1916-L1934
     errno_t path_rename(fd_t, ffi::array<uint8_t>, fd_t, ffi::array<uint8_t>);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1935-L1949
     errno_t path_symlink(ffi::array<uint8_t>, fd_t, ffi::array<uint8_t>);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1950-L1961
     errno_t path_unlink_file(fd_t, ffi::array<uint8_t>);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1962-L1981
-    errno_t poll_oneoff(void*, void*, uint32_t, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L2000-L2014
+    errno_t poll_oneoff(ffi::memory*, int32_t, int32_t, uint32_t, uint32_t*);
     errno_t random_get(ffi::array<uint8_t>);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1982-L1992
     void proc_exit(int32_t exit_code);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L1993-L1999
     ss::future<errno_t> sched_yield();
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L2015-L2031
     errno_t sock_accept(fd_t, uint16_t, fd_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L2032-L2055
     errno_t
     sock_recv(fd_t, ffi::array<iovec_t>, uint16_t, uint32_t*, uint16_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L2056-L2078
     errno_t sock_send(fd_t, ffi::array<iovec_t>, uint16_t, uint32_t*);
-    // https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L2079-L2090
     errno_t sock_shutdown(fd_t, uint8_t);
 
 private:


### PR DESCRIPTION
Implement poll_oneoff for sleeping. This allows for "sleeping" which
upstream golang assumes is present for it to work. Only sleeping is
required, which we implement via a noop that does nothing, as the clock
is fixed for each record that is being processed.

Upstream golang uses this function for usleep here:
https://github.com/golang/go/blob/7e1713e93c626f7026d1de09258f03748c726e79/src/runtime/os_wasip1.go#L165-L181

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
