### PR TITLE
kerberos_test: Catch AuthenticationError and assert False

### DIFF
--- a/tests/rptest/services/kerberos.py
+++ b/tests/rptest/services/kerberos.py
@@ -6,6 +6,7 @@ from ducktape.cluster.remoteaccount import RemoteCommandError, RemoteAccount
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 from rptest.services.redpanda import RedpandaService
+from paramiko.ssh_exception import AuthenticationException
 
 KADM5_ACL_TMPL = """
 {kadmin_principal}@{realm} *
@@ -547,6 +548,8 @@ class ActiveDirectoryKdc:
                 self.logger.debug(
                     f"Running ssh command '{cmd}' exited with status {exit_status} and message: {stderr.readlines()}"
                 )
+        except AuthenticationException as e:
+            raise AuthenticationError(f"{e}")
         finally:
             stdin.close()
             stdout.close()

--- a/tests/rptest/tests/redpanda_kerberos_test.py
+++ b/tests/rptest/tests/redpanda_kerberos_test.py
@@ -368,8 +368,11 @@ class RedpandaKerberosExternalActiveDirectoryTest(RedpandaKerberosTestBase):
     @ok_to_fail  # Not all CI builders have access to an ADDS - let's find out which ones.
     @cluster(num_nodes=2)
     def test_metadata(self):
-        principal = f"client/localhost"
-        self.client.add_primary(primary=principal)
-        metadata = self.client.metadata(principal)
-        self.logger.info(f"metadata: {metadata}")
-        assert len(metadata['brokers']) == 1
+        try:
+            principal = f"client/localhost"
+            self.client.add_primary(primary=principal)
+            metadata = self.client.metadata(principal)
+            self.logger.info(f"metadata: {metadata}")
+            assert len(metadata['brokers']) == 1
+        except AuthenticationError:
+            assert False


### PR DESCRIPTION
Something amiss with the external AD server. Unhandled AuthenticationErrors are breaking CI.

This test is marked ok_to_fail already, so transforming the auth error into a failed assertion should unstick things pending investigation.

Mitigates #14053 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
