### PR TITLE
cloud_storage/remote_partition_fuzz_test: wrap with_timeout function

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -429,6 +429,11 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
                            pool.local().shutdown_connections();
                            return g.close();
                        });
-    ss::with_timeout(model::timeout_clock::now() + 60s, std::move(close_fut))
-      .get();
+
+    // NOTE: see issues/11271
+    BOOST_TEST_INFO("scan_unit_close should terminate in a finite amount of "
+                    "time at shutdown");
+    BOOST_REQUIRE_NO_THROW(
+      ss::with_timeout(model::timeout_clock::now() + 60s, std::move(close_fut))
+        .get());
 }


### PR DESCRIPTION
the function throws a non-descriptive seastar::timed_out_exception. mark this to distinguish from other seastar::timed_out_exceptions that might come from other sources

Related to #11271 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none