### PR TITLE
rptest: Add note to the test and mark it as ok_to_fail [ci-skip]

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -561,11 +561,19 @@ class HighThroughputTest(RedpandaTest):
                    timeout_sec=restart_timeout,
                    backoff_sec=1)
 
+    @ok_to_fail
     @cluster(num_nodes=2, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_disrupt_cloud_storage(self):
         """
         Make segments replicate to the cloud, then disrupt S3 connectivity
-        and restore it
+        and restore it.
+
+        Test designed with access to provider in mind and is
+        for BYOC clouds only.
+        Using it against FMC clouds will cause it to fail as
+        there is no access to S3 account that is used inside
+        cloudv2 API to create/update buckets and its
+        properties/policies
         """
         # create default topics
         self._create_default_topics()


### PR DESCRIPTION
## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none