### PR TITLE
ci-infra: set ducktape to always point to the tip of the 0.8.x

### DIFF
--- a/tests/setup.py
+++ b/tests/setup.py
@@ -13,8 +13,8 @@ setup(
     package_data={'': ['*.md']},
     include_package_data=True,
     install_requires=[
-        'ducktape@git+https://github.com/redpanda-data/ducktape.git@62e0285f6b3a2f22fd4a43b5fdbc13be8d4290d9',
-        'prometheus-client==0.9.0', 'pyyaml==6.0', 'kafka-python==2.0.2',
+        'ducktape@git+https://github.com/redpanda-data/ducktape.git@0.8.x',
+        'prometheus-client==0.9.0', 'pyyaml==6.0.1', 'kafka-python==2.0.2',
         'crc32c==2.2', 'confluent-kafka==2.0.2', 'zstandard==0.15.2',
         'xxhash==2.0.2', 'protobuf==4.21.8', 'fastavro==1.4.9',
         'psutil==5.9.0', 'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',


### PR DESCRIPTION
## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none