### PR TITLE
wasm: pool memory and limit VM max heap size

### DIFF
--- a/src/go/transform-sdk/internal/testdata/CMakeLists.txt
+++ b/src/go/transform-sdk/internal/testdata/CMakeLists.txt
@@ -28,4 +28,5 @@ add_wasm_transform(transform-panic)
 add_wasm_transform(setup-panic) 
 add_wasm_transform(wasi) 
 add_wasm_transform(schema-registry) 
+add_wasm_transform(dynamic) 
 

--- a/src/go/transform-sdk/internal/testdata/build_all.sh
+++ b/src/go/transform-sdk/internal/testdata/build_all.sh
@@ -7,7 +7,7 @@ PKGS=(
   transform-panic
   schema-registry
   wasi
-  poison-pill
+  dynamic
 )
 
 for PKG in "${PKGS[@]}"; do

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -144,12 +144,40 @@ configuration::configuration()
   , coproc_max_ingest_bytes(*this, "coproc_max_ingest_bytes")
   , coproc_max_batch_size(*this, "coproc_max_batch_size")
   , coproc_offset_flush_interval_ms(*this, "coproc_offset_flush_interval_ms")
-  , enable_data_transforms(
+  , data_transforms_enabled(
       *this,
-      "enable_data_transforms",
+      "data_transforms_enabled",
       "Enables WebAssembly powered Data Transforms directly in the broker",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
+  , data_transforms_per_core_memory_reservation(
+      *this,
+      "data_transforms_per_core_memory_reservation",
+      "The amount of memory to reserve per core for all WebAssembly Virtual "
+      "Machines. Memory is reserved on boot. The maximum number of functions "
+      "that can be deployed to a cluster is equal to "
+      "data_transforms_per_core_memory_reservation / "
+      "data_transforms_per_function_memory_limit",
+      {
+        .needs_restart = needs_restart::yes,
+        .example = std::to_string(25_MiB),
+        .visibility = visibility::tunable,
+      },
+      20_MiB)
+  , data_transforms_per_function_memory_limit(
+      *this,
+      "data_transforms_per_function_memory_limit",
+      "The amount of memory to give an instance of a WebAssembly Virtual "
+      "Machine. The maximum number of functions "
+      "that can be deployed to a cluster is equal to "
+      "data_transforms_per_core_memory_reservation / "
+      "data_transforms_per_function_memory_limit",
+      {
+        .needs_restart = needs_restart::yes,
+        .example = std::to_string(5_MiB),
+        .visibility = visibility::tunable,
+      },
+      2_MiB)
   , topic_memory_per_partition(
       *this,
       "topic_memory_per_partition",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -150,28 +150,28 @@ configuration::configuration()
       "Enables WebAssembly powered Data Transforms directly in the broker",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
-  , data_transforms_per_core_memory_reservation(
+  , wasm_per_core_memory_reservation(
       *this,
-      "data_transforms_per_core_memory_reservation",
+      "wasm_per_core_memory_reservation",
       "The amount of memory to reserve per core for all WebAssembly Virtual "
       "Machines. Memory is reserved on boot. The maximum number of functions "
       "that can be deployed to a cluster is equal to "
-      "data_transforms_per_core_memory_reservation / "
-      "data_transforms_per_function_memory_limit",
+      "wasm_per_core_memory_reservation / "
+      "wasm_per_function_memory_limit",
       {
         .needs_restart = needs_restart::yes,
         .example = std::to_string(25_MiB),
         .visibility = visibility::tunable,
       },
       20_MiB)
-  , data_transforms_per_function_memory_limit(
+  , wasm_per_function_memory_limit(
       *this,
-      "data_transforms_per_function_memory_limit",
+      "wasm_per_function_memory_limit",
       "The amount of memory to give an instance of a WebAssembly Virtual "
       "Machine. The maximum number of functions "
       "that can be deployed to a cluster is equal to "
-      "data_transforms_per_core_memory_reservation / "
-      "data_transforms_per_function_memory_limit",
+      "wasm_per_core_memory_reservation / "
+      "wasm_per_function_memory_limit",
       {
         .needs_restart = needs_restart::yes,
         .example = std::to_string(5_MiB),

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -163,7 +163,8 @@ configuration::configuration()
         .example = std::to_string(25_MiB),
         .visibility = visibility::tunable,
       },
-      20_MiB)
+      20_MiB,
+      {.min = 64_KiB, .max = 100_GiB})
   , wasm_per_function_memory_limit(
       *this,
       "wasm_per_function_memory_limit",
@@ -177,7 +178,9 @@ configuration::configuration()
         .example = std::to_string(5_MiB),
         .visibility = visibility::tunable,
       },
-      2_MiB)
+      2_MiB,
+      // WebAssembly uses 64KiB pages and has a 32bit address space
+      {.min = 64_KiB, .max = 4_GiB})
   , topic_memory_per_partition(
       *this,
       "topic_memory_per_partition",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -71,8 +71,8 @@ struct configuration final : public config_store {
     property<bool> data_transforms_enabled;
 
     // Wasm
-    property<size_t> wasm_per_core_memory_reservation;
-    property<size_t> wasm_per_function_memory_limit;
+    bounded_property<size_t> wasm_per_core_memory_reservation;
+    bounded_property<size_t> wasm_per_function_memory_limit;
 
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -68,7 +68,9 @@ struct configuration final : public config_store {
     deprecated_property coproc_offset_flush_interval_ms;
 
     // Data Transforms
-    property<bool> enable_data_transforms;
+    property<bool> data_transforms_enabled;
+    property<size_t> data_transforms_per_core_memory_reservation;
+    property<size_t> data_transforms_per_function_memory_limit;
 
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -69,8 +69,10 @@ struct configuration final : public config_store {
 
     // Data Transforms
     property<bool> data_transforms_enabled;
-    property<size_t> data_transforms_per_core_memory_reservation;
-    property<size_t> data_transforms_per_function_memory_limit;
+
+    // Wasm
+    property<size_t> wasm_per_core_memory_reservation;
+    property<size_t> wasm_per_function_memory_limit;
 
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1788,7 +1788,7 @@ bool application::archival_storage_enabled() {
 }
 
 bool application::wasm_data_transforms_enabled() {
-    return config::shard_local_cfg().enable_data_transforms.value()
+    return config::shard_local_cfg().data_transforms_enabled.value()
            && !config::node().emergency_disable_data_transforms.value();
 }
 
@@ -2198,10 +2198,13 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     controller->set_ready().get();
 
     if (wasm_data_transforms_enabled()) {
-        constexpr wasm::runtime::config config = {
+        const auto& cluster = config::shard_local_cfg();
+        wasm::runtime::config config = {
           .heap_memory = {
-            .per_core_pool_size_bytes = 20_MiB,
-            .per_engine_memory_limit = 2_MiB,
+            .per_core_pool_size_bytes = 
+              cluster.data_transforms_per_core_memory_reservation.value(),
+            .per_engine_memory_limit = 
+              cluster.data_transforms_per_function_memory_limit.value(),
           },
         };
         _wasm_runtime->start(config).get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2198,7 +2198,13 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     controller->set_ready().get();
 
     if (wasm_data_transforms_enabled()) {
-        _wasm_runtime->start().get();
+        constexpr wasm::runtime::config config = {
+          .heap_memory = {
+            .per_core_pool_size_bytes = 20_MiB,
+            .per_engine_memory_limit = 2_MiB,
+          },
+        };
+        _wasm_runtime->start(config).get();
         _transform_service.invoke_on_all(&transform::service::start).get();
     }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2201,10 +2201,8 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
         const auto& cluster = config::shard_local_cfg();
         wasm::runtime::config config = {
           .heap_memory = {
-            .per_core_pool_size_bytes = 
-              cluster.data_transforms_per_core_memory_reservation.value(),
-            .per_engine_memory_limit = 
-              cluster.data_transforms_per_function_memory_limit.value(),
+            .per_core_pool_size_bytes = cluster.wasm_per_core_memory_reservation.value(),
+            .per_engine_memory_limit = cluster.wasm_per_function_memory_limit.value(),
           },
         };
         _wasm_runtime->start(config).get();

--- a/src/v/wasm/CMakeLists.txt
+++ b/src/v/wasm/CMakeLists.txt
@@ -15,6 +15,7 @@ v_cc_library(
     wasi.cc
     wasmtime.cc
     cache.cc
+    allocator.cc
   DEPS
     wasmtime
     v::storage

--- a/src/v/wasm/allocator.cc
+++ b/src/v/wasm/allocator.cc
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "wasm/allocator.h"
+
+#include <seastar/core/align.hh>
+#include <seastar/core/aligned_buffer.hh>
+#include <seastar/core/print.hh>
+
+#include <stdexcept>
+#include <unistd.h>
+
+namespace wasm {
+
+heap_allocator::heap_allocator(config c) {
+    size_t page_size = ::getpagesize();
+    size_t alloc_size = ss::align_up(c.heap_memory_size, page_size);
+    for (size_t i = 0; i < c.num_heaps; ++i) {
+        auto buffer = ss::allocate_aligned_buffer<uint8_t>(
+          alloc_size, page_size);
+        _memory_pool.emplace_back(std::move(buffer), alloc_size);
+    }
+}
+
+std::optional<heap_memory> heap_allocator::allocate(request req) {
+    if (_memory_pool.empty()) {
+        return std::nullopt;
+    }
+    size_t size = _memory_pool.front().size;
+    if (size < req.minimum || size > req.maximum) {
+        return std::nullopt;
+    }
+    heap_memory front = std::move(_memory_pool.front());
+    _memory_pool.pop_front();
+    return front;
+}
+
+void heap_allocator::deallocate(heap_memory m) {
+    _memory_pool.push_back(std::move(m));
+}
+
+} // namespace wasm

--- a/src/v/wasm/allocator.h
+++ b/src/v/wasm/allocator.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/aligned_buffer.hh>
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/util/optimized_optional.hh>
+
+#include <type_traits>
+
+namespace wasm {
+
+/**
+ * An owned bit of heap memory, which is aligned to page size and it's size is a
+ * multiple of the page size.
+ */
+struct heap_memory {
+    // NOLINTNEXTLINE(*-avoid-c-arrays)
+    std::unique_ptr<uint8_t[], ss::free_deleter> data;
+    size_t size;
+};
+
+// The allocator for "heap" memory within a Wasm VM.
+//
+// This "heap" memory is known as LinearMemory in WebAssembly parlance and must
+// be a contiguous range of memory. Since these memories can grow beyond the
+// maximum amount of memory we recommend allocating at once in Redpanda (due to
+// fragmentation in long running processes), we allocate a pool at startup when
+// there are copious amounts of larger contiguous chunks.
+//
+// Additionally memory must be page-aligned and a multiple of page size to
+// enable performance optimizations within the Wasm VMs.
+//
+// Currently the allocation model requires a fixed sized heap at startup and
+// then those are handed out and reused as VM instances spin up and down.
+//
+// Future work may allow variable sized heaps for VMs, but then we must deal
+// with memory fragmentation and support spinning down VMs to defragment our
+// pool of memory.
+//
+// Instance on every core.
+class heap_allocator {
+public:
+    struct config {
+        // The size of a single allocated heap memory.
+        size_t heap_memory_size;
+        // The total number of heaps allocated per core.
+        size_t num_heaps;
+    };
+
+    explicit heap_allocator(config);
+
+    /**
+     * A request of heap memory based on the following bounds.
+     */
+    struct request {
+        size_t minimum;
+        size_t maximum;
+    };
+
+    /**
+     * Allocate heap memory by taking a memory instance from the pool.
+     */
+    std::optional<heap_memory> allocate(request);
+
+    /**
+     * Deallocate heap memory by returing a memory instance to the pool.
+     */
+    void deallocate(heap_memory);
+
+private:
+    // We expect this list to be small, so override the chunk to be smaller too.
+    static constexpr size_t items_per_chunk = 16;
+    ss::chunked_fifo<heap_memory, items_per_chunk> _memory_pool;
+};
+
+} // namespace wasm

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -85,7 +85,16 @@ public:
     runtime& operator=(const runtime&) = delete;
     runtime(runtime&&) = delete;
     runtime& operator=(runtime&&) = delete;
-    virtual ss::future<> start() = 0;
+
+    struct config {
+        struct heap_memory {
+            size_t per_core_pool_size_bytes;
+            size_t per_engine_memory_limit;
+        };
+        heap_memory heap_memory;
+    };
+
+    virtual ss::future<> start(config) = 0;
     virtual ss::future<> stop() = 0;
     /**
      * Create a factory for this transform and the corresponding source wasm

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -279,8 +279,8 @@ caching_runtime::caching_runtime(
 
 caching_runtime::~caching_runtime() = default;
 
-ss::future<> caching_runtime::start() {
-    co_await _underlying->start();
+ss::future<> caching_runtime::start(runtime::config c) {
+    co_await _underlying->start(c);
     co_await _engine_caches.start();
     _gc_timer.arm(_gc_interval);
 }

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -50,7 +50,7 @@ public:
     caching_runtime& operator=(caching_runtime&&) = delete;
     ~caching_runtime() override;
 
-    ss::future<> start() override;
+    ss::future<> start(runtime::config) override;
     ss::future<> stop() override;
 
     /**

--- a/src/v/wasm/tests/CMakeLists.txt
+++ b/src/v/wasm/tests/CMakeLists.txt
@@ -83,3 +83,16 @@ rp_test(
   ARGS "-- -c 4"
   LABELS wasm
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME wasm_allocator
+  SOURCES
+    wasm_allocator_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::wasm
+  ARGS "-- -c 1"
+  LABELS wasm
+)

--- a/src/v/wasm/tests/CMakeLists.txt
+++ b/src/v/wasm/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ rp_test(
     v::wasm_test_fixture
     Avro::avro
   BUILD_DEPENDENCIES
+    wasm_testdata_dynamic
     wasm_testdata_identity
     wasm_testdata_schema_registry
     wasm_testdata_setup_panic
@@ -34,6 +35,7 @@ rp_test(
     wasm_testdata_transform_panic
     wasm_testdata_wasi
   INPUT_FILES
+    "${TESTDATA_DIR}/dynamic.wasm"
     "${TESTDATA_DIR}/identity.wasm"
     "${TESTDATA_DIR}/schema-registry.wasm"
     "${TESTDATA_DIR}/setup-panic.wasm"

--- a/src/v/wasm/tests/wasm_allocator_test.cc
+++ b/src/v/wasm/tests/wasm_allocator_test.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "wasm/allocator.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <stdexcept>
+#include <unistd.h>
+
+namespace wasm {
+
+TEST(HeapAllocatorParamsTest, SizeIsAligned) {
+    size_t page_size = ::getpagesize();
+    heap_allocator allocator(heap_allocator::config{
+      .heap_memory_size = page_size + 3,
+      .num_heaps = 1,
+    });
+    auto mem = allocator.allocate(
+      {.minimum = 0, .maximum = std::numeric_limits<size_t>::max()});
+    ASSERT_TRUE(mem.has_value());
+    EXPECT_EQ(mem->size, page_size * 2);
+}
+
+TEST(HeapAllocatorTest, CanAllocateOne) {
+    size_t page_size = ::getpagesize();
+    heap_allocator allocator(heap_allocator::config{
+      .heap_memory_size = page_size,
+      .num_heaps = 1,
+    });
+    auto mem = allocator.allocate({.minimum = page_size, .maximum = page_size});
+    ASSERT_TRUE(mem.has_value());
+    EXPECT_EQ(mem->size, page_size);
+}
+
+TEST(HeapAllocatorTest, MustAllocateWithinBounds) {
+    size_t page_size = ::getpagesize();
+    heap_allocator allocator(heap_allocator::config{
+      .heap_memory_size = page_size,
+      .num_heaps = 1,
+    });
+    // minimum too large
+    auto mem = allocator.allocate(
+      {.minimum = page_size * 2, .maximum = page_size * 3});
+    EXPECT_FALSE(mem.has_value());
+    // maximum too small
+    mem = allocator.allocate(
+      {.minimum = page_size / 2, .maximum = page_size - 1});
+    EXPECT_FALSE(mem.has_value());
+}
+
+TEST(HeapAllocatorTest, Exhaustion) {
+    size_t page_size = ::getpagesize();
+    heap_allocator allocator(heap_allocator::config{
+      .heap_memory_size = page_size,
+      .num_heaps = 1,
+    });
+    auto mem = allocator.allocate({.minimum = page_size, .maximum = page_size});
+    EXPECT_TRUE(mem.has_value());
+    mem = allocator.allocate({.minimum = page_size, .maximum = page_size});
+    EXPECT_FALSE(mem.has_value());
+}
+
+TEST(HeapAllocatorTest, CanReturnMemoryToThePool) {
+    size_t page_size = ::getpagesize();
+    heap_allocator allocator(heap_allocator::config{
+      .heap_memory_size = page_size,
+      .num_heaps = 3,
+    });
+    heap_allocator::request req{.minimum = page_size, .maximum = page_size};
+    std::vector<heap_memory> allocated;
+    for (int i = 0; i < 3; ++i) {
+        auto mem = allocator.allocate(req);
+        ASSERT_TRUE(mem.has_value());
+        allocated.push_back(std::move(*mem));
+    }
+    auto mem = allocator.allocate(req);
+    EXPECT_FALSE(mem.has_value());
+    mem = std::move(allocated.back());
+    allocated.pop_back();
+    allocator.deallocate(std::move(*mem));
+    mem = allocator.allocate(req);
+    EXPECT_TRUE(mem.has_value());
+    mem = allocator.allocate(req);
+    EXPECT_FALSE(mem.has_value());
+}
+
+} // namespace wasm

--- a/src/v/wasm/tests/wasm_cache_test.cc
+++ b/src/v/wasm/tests/wasm_cache_test.cc
@@ -110,7 +110,7 @@ private:
 
 class fake_runtime : public runtime {
 public:
-    ss::future<> start() override { co_return; }
+    ss::future<> start(runtime::config) override { co_return; }
     ss::future<> stop() override { co_return; }
 
     ss::future<ss::shared_ptr<factory>>
@@ -138,7 +138,7 @@ public:
         // Effectively disable the gc interval
         _caching_runtime = std::make_unique<caching_runtime>(
           std::move(fr), /*gc_interval=*/std::chrono::hours(1));
-        _caching_runtime->start().get();
+        _caching_runtime->start({}).get();
     }
 
     void TearDown() override {

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -132,7 +132,13 @@ void WasmTestFixture::SetUp() {
     auto sr = std::make_unique<fake_schema_registry>();
     _sr = sr.get();
     _runtime = wasm::wasmtime::create_runtime(std::move(sr));
-    _runtime->start().get();
+    constexpr wasm::runtime::config wasm_runtime_config {
+        .heap_memory = {
+          .per_core_pool_size_bytes = 8_MiB,
+          .per_engine_memory_limit = 2_MiB,
+        },
+    };
+    _runtime->start(wasm_runtime_config).get();
     _meta = {
       .name = model::transform_name(ss::sstring("test_wasm_transform")),
       .input_topic = model::random_topic_namespace(),

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -132,10 +132,11 @@ void WasmTestFixture::SetUp() {
     auto sr = std::make_unique<fake_schema_registry>();
     _sr = sr.get();
     _runtime = wasm::wasmtime::create_runtime(std::move(sr));
+    // Support creating up to 4 instances in a test
     constexpr wasm::runtime::config wasm_runtime_config {
         .heap_memory = {
-          .per_core_pool_size_bytes = 8_MiB,
-          .per_engine_memory_limit = 2_MiB,
+          .per_core_pool_size_bytes = MAX_MEMORY * 4,
+          .per_engine_memory_limit = MAX_MEMORY,
         },
     };
     _runtime->start(wasm_runtime_config).get();

--- a/src/v/wasm/tests/wasm_fixture.h
+++ b/src/v/wasm/tests/wasm_fixture.h
@@ -14,6 +14,8 @@
 #include "model/record.h"
 #include "model/transform.h"
 #include "pandaproxy/schema_registry/types.h"
+#include "serde/rw/rw.h"
+#include "serde/rw/scalar.h"
 #include "test_utils/test.h"
 #include "wasm/api.h"
 #include "wasm/probe.h"
@@ -29,6 +31,7 @@ class fake_schema_registry;
 class WasmTestFixture : public ::testing::Test {
 public:
     static constexpr model::timestamp NOW = model::timestamp(1687201340524ULL);
+    static constexpr size_t MAX_MEMORY = 2_MiB;
 
     static void SetUpTestSuite();
 
@@ -39,6 +42,19 @@ public:
     model::record_batch make_tiny_batch();
     model::record_batch make_tiny_batch(iobuf record_value);
     model::record_batch transform(const model::record_batch&);
+    // For the "dynamic" wasm transform, issues a command record with the
+    // corresponding value
+    template<typename T>
+    void execute_command(std::string_view cmd, T&& value) {
+        iobuf k;
+        k.append(cmd.data(), cmd.size());
+        iobuf v;
+        serde::write(v, std::forward<T>(value));
+        storage::record_batch_builder b(
+          model::record_batch_type::raft_data, model::offset(1));
+        b.add_raw_kv(std::move(k), std::move(v));
+        transform(std::move(b).build());
+    }
 
     model::transform_metadata meta() const { return _meta; };
 

--- a/src/v/wasm/tests/wasm_transform_test.cc
+++ b/src/v/wasm/tests/wasm_transform_test.cc
@@ -24,6 +24,7 @@
 #include <avro/Specific.hh>
 #include <avro/Stream.hh>
 #include <avro/ValidSchema.hh>
+#include <gtest/gtest.h>
 
 TEST_F(WasmTestFixture, IdentityFunction) {
     load_wasm("identity.wasm");
@@ -100,4 +101,10 @@ TEST_F(WasmTestFixture, SchemaRegistry) {
     ASSERT_EQ(records.size(), 1);
     EXPECT_EQ(
       iobuf_to_bytes(records[0].value()), R"JSON({"a":4,"b":"foo"})JSON");
+}
+
+TEST_F(WasmTestFixture, MemoryIsLimited) {
+    load_wasm("dynamic.wasm");
+    EXPECT_NO_THROW(execute_command("allocate", 5_KiB));
+    EXPECT_THROW(execute_command("allocate", MAX_MEMORY), wasm::wasm_exception);
 }

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -15,6 +15,8 @@
 #include "ssx/thread_worker.h"
 #include "storage/parser_utils.h"
 #include "utils/type_traits.h"
+#include "vassert.h"
+#include "wasm/allocator.h"
 #include "wasm/api.h"
 #include "wasm/errc.h"
 #include "wasm/ffi.h"
@@ -24,6 +26,7 @@
 #include "wasm/transform_module.h"
 #include "wasm/wasi.h"
 
+#include <seastar/core/align.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/posix.hh>
 #include <seastar/core/sharded.hh>
@@ -34,10 +37,16 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+#include <wasmtime/config.h>
+#include <wasmtime/error.h>
+#include <wasmtime/memory.h>
+
+#include <cmath>
 #include <csignal>
 #include <memory>
 #include <pthread.h>
 #include <span>
+#include <unistd.h>
 #include <wasm.h>
 #include <wasmtime.h>
 
@@ -817,13 +826,87 @@ private:
 
 class wasmtime_runtime : public runtime {
 public:
-    wasmtime_runtime(
-      handle<wasm_engine_t, &wasm_engine_delete> h,
-      std::unique_ptr<schema_registry> sr)
-      : _engine(std::move(h))
-      , _sr(std::move(sr)) {}
+    explicit wasmtime_runtime(std::unique_ptr<schema_registry> sr)
+      : _sr(std::move(sr)) {
+        wasm_config_t* config = wasm_config_new();
 
-    ss::future<> start() override {
+        // Spend more time compiling so that we can have faster code.
+        wasmtime_config_cranelift_opt_level_set(
+          config, WASMTIME_OPT_LEVEL_SPEED);
+        // Fuel allows us to stop execution after some time.
+        wasmtime_config_consume_fuel_set(config, true);
+        // We want to enable memcopy and other efficent memcpy operators
+        wasmtime_config_wasm_bulk_memory_set(config, true);
+        // Our build disables this feature, so we don't need to turn it
+        // off, otherwise we'd want to turn this off (it's on by default).
+        // wasmtime_config_parallel_compilation_set(config, false);
+
+        // Let wasmtime do the stack switching so we can run async host
+        // functions and allow running out of fuel to pause the runtime.
+        //
+        // See the documentation for more information:
+        // https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#asynchronous-wasm
+        wasmtime_config_async_support_set(config, true);
+        // Set max stack size to generally be as big as a contiguous memory
+        // region we're willing to allocate in Redpanda.
+        //
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        wasmtime_config_async_stack_size_set(config, 128_KiB);
+        // The stack size needs to be less than the async stack size, and
+        // whatever is difference between the two is how much host functions can
+        // get, make sure to leave our own functions some room to execute.
+        //
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+        wasmtime_config_max_wasm_stack_set(config, 64_KiB);
+        // This disables static memory, see:
+        // https://docs.wasmtime.dev/contributing-architecture.html#linear-memory
+        wasmtime_config_static_memory_maximum_size_set(config, 0_KiB);
+        wasmtime_config_dynamic_memory_guard_size_set(config, 0_KiB);
+        wasmtime_config_dynamic_memory_reserved_for_growth_set(config, 0_KiB);
+        // Don't modify the unwind info as registering these symbols causes C++
+        // exceptions to grab a lock in libgcc and deadlock the Redpanda
+        // process.
+        wasmtime_config_native_unwind_info_set(config, false);
+
+        wasmtime_memory_creator_t memory_creator = {
+          .env = this,
+          .new_memory = &wasmtime_runtime::allocate_heap_memory,
+          .finalizer = nullptr,
+        };
+        wasmtime_config_host_memory_creator_set(config, &memory_creator);
+
+        _engine.reset(wasm_engine_new_with_config(config));
+    }
+
+    ss::future<> start(runtime::config c) override {
+        size_t page_size = ::getpagesize();
+        size_t aligned_pool_size = ss::align_down(
+          c.heap_memory.per_core_pool_size_bytes, page_size);
+        if (aligned_pool_size == 0) {
+            throw std::runtime_error(ss::format(
+              "aligned per core wasm memory pool size must be >0 "
+              "(page_size={}, pool_size={})",
+              page_size,
+              c.heap_memory.per_core_pool_size_bytes));
+        }
+        size_t aligned_instance_limit = ss::align_down(
+          c.heap_memory.per_engine_memory_limit, page_size);
+        if (aligned_instance_limit == 0) {
+            throw std::runtime_error(ss::format(
+              "aligned per wasm engine memory limit must be >0 (page_size={}, "
+              "limit={})",
+              page_size,
+              c.heap_memory.per_engine_memory_limit));
+        }
+        size_t num_heaps = aligned_pool_size / aligned_instance_limit;
+        if (num_heaps == 0) {
+            throw std::runtime_error("must allow at least one wasm heap");
+        }
+
+        co_await _heap_allocator.start(heap_allocator::config{
+          .heap_memory_size = aligned_instance_limit,
+          .num_heaps = num_heaps,
+        });
         co_await _alien_thread.start({.name = "wasm"});
         co_await ss::smp::invoke_on_all([] {
             // wasmtime needs some signals for it's handling, make sure we
@@ -837,7 +920,10 @@ public:
         });
     }
 
-    ss::future<> stop() override { return _alien_thread.stop(); }
+    ss::future<> stop() override {
+        co_await _alien_thread.stop();
+        co_await _heap_allocator.stop();
+    }
 
     ss::future<ss::shared_ptr<factory>> make_factory(
       model::transform_metadata meta, iobuf buf, ss::logger* logger) override {
@@ -878,54 +964,87 @@ public:
     }
 
 private:
+    // We don't have control over this API.
+    // NOLINTBEGIN(bugprone-easily-swappable-parameters)
+    static wasmtime_error_t* allocate_heap_memory(
+      void* env,
+      const wasm_memorytype_t* ty,
+      size_t minimum,
+      size_t maximum,
+      size_t reserved_size_in_bytes,
+      size_t guard_size_in_bytes,
+      wasmtime_linear_memory_t* memory_ret) {
+        // NOLINTEND(bugprone-easily-swappable-parameters)
+        vassert(
+          !wasmtime_memorytype_is64(ty),
+          "we only support 32bit addressable memory");
+        vassert(
+          reserved_size_in_bytes == 0,
+          "this value should be set to 0 according to the config");
+        vassert(
+          guard_size_in_bytes == 0,
+          "this value should be set to 0 according to the config");
+        auto* runtime = static_cast<wasmtime_runtime*>(env);
+        return runtime->allocate_heap_memory(minimum, maximum, memory_ret);
+    }
+
+    wasmtime_error_t* allocate_heap_memory(
+      size_t minimum, size_t maximum, wasmtime_linear_memory_t* memory_ret) {
+        auto memory = _heap_allocator.local().allocate(
+          {.minimum = minimum, .maximum = maximum});
+        if (!memory) {
+            auto msg = ss::format(
+              "unable to allocate memory with bounds [{}, {}]",
+              minimum,
+              maximum);
+            return wasmtime_error_new(msg.c_str());
+        }
+        struct linear_memory {
+            heap_memory underlying;
+            ss::noncopyable_function<void(heap_memory)> reclaimer;
+        };
+        memory_ret->env = new linear_memory{
+          .underlying = *std::move(memory),
+          .reclaimer =
+            [this](heap_memory mem) {
+                _heap_allocator.local().deallocate(std::move(mem));
+            },
+        };
+        memory_ret->finalizer = [](void* env) {
+            auto* mem = static_cast<linear_memory*>(env);
+            mem->reclaimer(std::move(mem->underlying));
+            // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+            delete mem;
+        };
+        memory_ret->get_memory =
+          // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+          [](void* env, size_t* byte_size, size_t* max_byte_size) {
+              auto* mem = static_cast<linear_memory*>(env);
+              *byte_size = mem->underlying.size;
+              *max_byte_size = mem->underlying.size;
+              return mem->underlying.data.get();
+          };
+        memory_ret->grow_memory =
+          [](void* env, size_t new_size) -> wasmtime_error_t* {
+            auto* mem = static_cast<linear_memory*>(env);
+            if (new_size == mem->underlying.size) {
+                return nullptr;
+            }
+            return wasmtime_error_new(
+              "linear memories are fixed size and ungrowable");
+        };
+        return nullptr;
+    }
+
     handle<wasm_engine_t, &wasm_engine_delete> _engine;
     std::unique_ptr<schema_registry> _sr;
     ssx::singleton_thread_worker _alien_thread;
+    ss::sharded<heap_allocator> _heap_allocator;
 };
 
 } // namespace
 
 std::unique_ptr<runtime> create_runtime(std::unique_ptr<schema_registry> sr) {
-    wasm_config_t* config = wasm_config_new();
-
-    // Spend more time compiling so that we can have faster code.
-    wasmtime_config_cranelift_opt_level_set(config, WASMTIME_OPT_LEVEL_SPEED);
-    // Fuel allows us to stop execution after some time.
-    wasmtime_config_consume_fuel_set(config, true);
-    // We want to enable memcopy and other efficent memcpy operators
-    wasmtime_config_wasm_bulk_memory_set(config, true);
-    // Our build disables this feature, so we don't need to turn it
-    // off, otherwise we'd want to turn this off (it's on by default).
-    // wasmtime_config_parallel_compilation_set(config, false);
-
-    // Let wasmtime do the stack switching so we can run async host functions
-    // and allow running out of fuel to pause the runtime.
-    //
-    // See the documentation for more information:
-    // https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#asynchronous-wasm
-    wasmtime_config_async_support_set(config, true);
-    // Set max stack size to generally be as big as a contiguous memory region
-    // we're willing to allocate in Redpanda.
-    //
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    wasmtime_config_async_stack_size_set(config, 128_KiB);
-    // The stack size needs to be less than the async stack size, and
-    // whatever is difference between the two is how much host functions can
-    // get, make sure to leave our own functions some room to execute.
-    //
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    wasmtime_config_max_wasm_stack_set(config, 64_KiB);
-    // This disables static memory, see:
-    // https://docs.wasmtime.dev/contributing-architecture.html#linear-memory
-    wasmtime_config_static_memory_maximum_size_set(config, 0_KiB);
-    wasmtime_config_dynamic_memory_guard_size_set(config, 0_KiB);
-    wasmtime_config_dynamic_memory_reserved_for_growth_set(config, 0_KiB);
-    // Don't modify the unwind info as registering these symbols causes C++
-    // exceptions to grab a lock in libgcc and deadlock the Redpanda process.
-    wasmtime_config_native_unwind_info_set(config, false);
-
-    handle<wasm_engine_t, &wasm_engine_delete> engine{
-      wasm_engine_new_with_config(config)};
-    return std::make_unique<wasmtime_runtime>(std::move(engine), std::move(sr));
+    return std::make_unique<wasmtime_runtime>(std::move(sr));
 }
 } // namespace wasm::wasmtime

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -556,9 +556,6 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             'kafka_mtls_principal_mapping_rules'
         }
 
-        # Don't enable coproc: it generates log errors if its companion service isn't running
-        exclude_settings.add('enable_coproc')
-
         # Don't enable schema id validation: the interdepedencies are too complex and are tested elsewhere.
         exclude_settings.add('enable_schema_id_validation')
 
@@ -608,10 +605,6 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 valid_value = [
                     'RULE:[1:$1]/L', 'RULE:[2:$1](Test.*)s/ABC///L', 'DEFAULT'
                 ]
-
-            if name == 'enable_coproc':
-                # Don't try enabling coproc, it has external dependencies
-                continue
 
             if name == 'admin_api_require_auth':
                 # Don't lock ourselves out of the admin API!


### PR DESCRIPTION
This PR hooks up a simple custom allocator with Wasmtime so that we use the seastar allocator (instead of mmap) to provide memory to wasm VMs.

There are two configuration knobs with buy in from product:
- `wasm_per_core_memory_reservation` the amount of memory to reserve in total per core
- `wasm_per_function_memory_limit` the amount of memory to allow per function to a single VM

The thinking here is that someday we can also allow per function memory limits and then have a more clever allocation scheme. 
See the commits for more details here - for now all functions in a cluster share the same memory limit.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
