### PR TITLE
[v23.2.x] cloud_storage/ducktape: Wait for chunk observer to stop

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -346,6 +346,9 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
 
         self._consume_baseline(timeout=180, max_msgs=read_count)
         observe_cache_dir.stop()
+        observe_cache_dir.join(timeout=10)
+        assert not observe_cache_dir.is_alive(
+        ), 'cache observer is unexpectedly alive'
 
         self._assert_not_in_cache(fr'.*kafka/{self.topic}/.*\.log\.[0-9]+$')
         self._assert_in_cache(f'.*kafka/{self.topic}/.*_chunks/[0-9]+')


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14032
Fixes: https://github.com/redpanda-data/redpanda/issues/14088,