### PR TITLE
default log_segment_ms_min to 10 min

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -98,9 +98,9 @@ configuration::configuration()
       "Lower bound on topic segment.ms: lower values will be clamped to this "
       "value",
       {.needs_restart = needs_restart::no,
-       .example = "60000",
+       .example = "600000",
        .visibility = visibility::tunable},
-      60s)
+      10min)
   , log_segment_ms_max(
       *this,
       "log_segment_ms_max",

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1416,6 +1416,9 @@ class EnableSegmentMs(Expression):
             # suggests.
             ClusterConfigInput("SetLowCompactionInterval_rp_conf",
                                {"log_compaction_interval_ms": "1000"}),
+            # Update lower clamp applied to segment.ms for testing
+            ClusterConfigInput("SetLogSegmentMsMin_rp_conf",
+                               {"log_segment_ms_min": "60000"}),
         ]
 
 

--- a/tests/rptest/tests/workload_upgrade_config_defaults.py
+++ b/tests/rptest/tests/workload_upgrade_config_defaults.py
@@ -1,0 +1,38 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.admin import Admin
+from rptest.services.workload_protocol import PWorkload
+
+PROP_NAME = 'log_segment_ms_min'
+PROP_NEW_VALUE = 9999999
+
+
+class SetLogSegmentMsMinConfig(PWorkload):
+    def __init__(self, ctx) -> None:
+        self.ctx = ctx
+        self.admin = Admin(self.ctx.redpanda)
+
+    def get_earliest_applicable_release(self):
+        # version before updating log_segment_ms_min from 60s to 10min
+        return (23, 2)
+
+    def begin(self):
+        # set log_segment_ms_min, to check later that this value did not update to something else
+
+        default_value = self.admin.get_cluster_config()[PROP_NAME]
+        assert default_value != PROP_NEW_VALUE, f"sanity check failed: we want to set a different value than the default for easier debugging {default_value=} {PROP_NEW_VALUE=}"
+
+        self.admin.patch_cluster_config(
+            upsert={PROP_NAME: str(PROP_NEW_VALUE)})
+
+    def on_cluster_upgraded(self, version: tuple[int, int, int]) -> int:
+        prop_val = self.admin.get_cluster_config()[PROP_NAME]
+        assert prop_val == PROP_NEW_VALUE, f"{PROP_NAME} did not maintain the value {PROP_NEW_VALUE} that was set before upgrading. {version=}"
+        return PWorkload.DONE

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -21,6 +21,7 @@ from rptest.tests.workload_producer_consumer import ProducerConsumerWorkload
 from rptest.tests.workload_dummy import DummyWorkload, MinimalWorkload
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.workload_license import LicenseWorkload
+from rptest.tests.workload_upgrade_config_defaults import SetLogSegmentMsMinConfig
 from rptest.utils.mode_checks import skip_debug_mode
 from ducktape.mark import matrix, ok_to_fail
 
@@ -165,6 +166,7 @@ class RedpandaUpgradeTest(PreallocNodesTest):
             DummyWorkload(self),
             MinimalWorkload(self),
             ProducerConsumerWorkload(self),
+            SetLogSegmentMsMinConfig(self),
             # NOTE: due to issue/13180 the next workload is temporarily disabled
             # LicenseWorkload(self),
         ]


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Set the default value for log_segment_ms_min to 10 minutes to reduce the chance of accidentally overloading the system with a low segment.ms value. Tests are updated to explicitly set log_segment_ms_min to 60 seconds.

Fixes #13468

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* default value for log_segment_ms_min is now 10 minutes. This means that if time-based rolling is active on a segment, the threshold will be silently clamped to at least 10 minutes