### PR TITLE
s/log: exposed `retention_offset` in `storage::log` api

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -210,7 +210,7 @@ ss::future<std::optional<ss::sstring>> disk_log_impl::close() {
 }
 
 std::optional<model::offset>
-disk_log_impl::size_based_gc_max_offset(gc_config cfg) {
+disk_log_impl::size_based_gc_max_offset(gc_config cfg) const {
     if (!cfg.max_bytes.has_value()) {
         return std::nullopt;
     }
@@ -242,7 +242,7 @@ disk_log_impl::size_based_gc_max_offset(gc_config cfg) {
 }
 
 std::optional<model::offset>
-disk_log_impl::time_based_gc_max_offset(gc_config cfg) {
+disk_log_impl::time_based_gc_max_offset(gc_config cfg) const {
     // The following compaction has a Kafka behavior compatibility bug. for
     // which we defer do nothing at the moment, possibly crashing the machine
     // and running out of disk. Kafka uses the same logic below as of
@@ -972,7 +972,8 @@ disk_log_impl::maybe_adjusted_retention_offset(gc_config cfg) {
     co_return retention_offset(cfg);
 }
 
-std::optional<model::offset> disk_log_impl::retention_offset(gc_config cfg) {
+std::optional<model::offset>
+disk_log_impl::retention_offset(gc_config cfg) const {
     if (deletion_exempt(config().ntp())) {
         vlog(
           gclog.trace,

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -142,6 +142,8 @@ public:
 
     size_t reclaimable_local_size_bytes() const override;
 
+    std::optional<model::offset> retention_offset(gc_config) const final;
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
@@ -197,8 +199,8 @@ private:
     // These methods search the log for the offset to evict at such that
     // the retention policy is satisfied. If no such offset is found
     // std::nullopt is returned.
-    std::optional<model::offset> size_based_gc_max_offset(gc_config);
-    std::optional<model::offset> time_based_gc_max_offset(gc_config);
+    std::optional<model::offset> size_based_gc_max_offset(gc_config) const;
+    std::optional<model::offset> time_based_gc_max_offset(gc_config) const;
 
     /// Conditionally adjust retention timestamp on any segment that appears
     /// to have invalid timestamps, to ensure retention can proceed.
@@ -220,8 +222,6 @@ private:
     gc_config override_retention_config(gc_config) const;
 
     bool is_cloud_retention_active() const;
-
-    std::optional<model::offset> retention_offset(gc_config);
 
     // returns retention_offset(cfg) but may also first apply adjustments to
     // future timestamps if this option is turned on in configuration.

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -24,6 +24,7 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/shared_ptr.hh>
 
+#include <optional>
 #include <utility>
 
 namespace storage {
@@ -148,6 +149,10 @@ public:
      * cases where this is not applicable, such as the log not being TS-enabled.
      */
     virtual size_t reclaimable_local_size_bytes() const = 0;
+    /**
+     * Returns new log start offset for given retention settings.
+     */
+    virtual std::optional<model::offset> retention_offset(gc_config) const = 0;
 
 private:
     ntp_config _config;


### PR DESCRIPTION
Exposed method allowing caller to calculate a new start offset of a log that would provide desired data retention. The API is going to be used by controller backend to establish initial learner offset.

Fixes: #13707

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none