### PR TITLE
merge queue: embarking dev (efe30fa) and #14072 together

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/observe_test.py
+++ b/tests/rptest/redpanda_cloud_tests/observe_test.py
@@ -1,0 +1,73 @@
+import requests
+import json
+from ducktape.tests.test import Test
+from types import SimpleNamespace
+
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import make_redpanda_service
+from rptest.tests.rpk_cloud_test import get_ci_env_var
+
+
+class HTObserveTest(Test):
+    """
+    Cloudv2 only - ensure no firing alarms for cloud cluster - should be ran after all other tests
+    this is acomplished by setting @cluster(num_nodes=0) which is good enough
+    """
+    def __init__(self, test_context):
+        super(HTObserveTest, self).__init__(test_context=test_context)
+        self.redpanda = make_redpanda_service(test_context, 3)
+        self._ctx = test_context
+        self._token = self.redpanda._cloud_cluster.config.grafana_token
+        self._endpoint = self.redpanda._cloud_cluster.config.grafana_alerts_url
+
+    def setUp(self):
+        self.redpanda.start()
+        self._clusterId = self.redpanda._cloud_cluster.config.id
+
+    def load_grafana_rules(self):
+        headers = {'Authorization': "Bearer {}".format(self._token)}
+        with requests.get(self._endpoint, headers=headers, stream=True) as r:
+            if r.status_code != requests.status_codes.codes.ok:
+                r.raise_for_status()
+            return json.load(r.raw, object_hook=lambda d: SimpleNamespace(**d))
+
+    def cluster_alerts(self, rule_groups):
+        alerts = []
+        for group in rule_groups:
+            for rule in group.rules:
+                if rule.state != 'firing' or len(rule.alerts) == 0:
+                    continue
+
+                if rule.health == 'error':
+                    continue
+
+                for alert in rule.alerts:
+                    if alert.state != 'Alerting':
+                        continue
+
+                    if hasattr(
+                            alert.labels, 'redpanda_agent'
+                    ) and alert.labels.redpanda_agent == self._clusterId:
+                        alerts.append(alert)
+
+                    if hasattr(
+                            alert.labels, 'redpanda_id'
+                    ) and alert.labels.redpanda_id == self._clusterId:
+                        alerts.append(alert)
+
+        return alerts
+
+    @cluster(num_nodes=0, check_allowed_error_logs=False)
+    def test_cloud_observe(self):
+        self.logger.debug("Here we go")
+
+        rule_groups = self.load_grafana_rules()
+
+        alerts = self.cluster_alerts(rule_groups.data.groups)
+
+        for alert in alerts:
+            self.logger.warn(
+                f'alert firing for cluster: {alert.labels.grafana_folder} / {alert.labels.alertname}'
+            )
+
+        assert len(alerts) == 0

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -272,6 +272,8 @@ class CloudClusterConfig:
     install_pack_url_template: str = ""
     install_pack_auth_type: str = ""
     install_pack_auth: str = ""
+    grafana_token: str = ""
+    grafana_alerts_url: str = ""
 
 
 @dataclass


### PR DESCRIPTION
**✨ Unexpected queue change: an external action moved the target branch head to d8b3e3a653704f43e141e87bf478ae504d4ea85d. The pull request [#14072](/redpanda-data/redpanda/pull/14072) has been re-embarked. ✨**

Branch **dev** (efe30fa) and [#14072](/redpanda-data/redpanda/pull/14072) are embarked together for merge.

This pull request has been created by Mergify to speculatively check the mergeability of [#14072](/redpanda-data/redpanda/pull/14072).
You don't need to do anything. Mergify will close this pull request automatically when it is complete.


**Required conditions of queue** `dev` **for merge:**

- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=build-debug-clang-amd64`
  - [ ] `check-skipped=build-debug-clang-amd64`
  - [ ] `check-success=build-debug-clang-amd64`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=build-release-clang-amd64`
  - [ ] `check-skipped=build-release-clang-amd64`
  - [ ] `check-success=build-release-clang-amd64`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=ducktape-build-release-clang-amd64`
  - [ ] `check-skipped=ducktape-build-release-clang-amd64`
  - [ ] `check-success=ducktape-build-release-clang-amd64`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=ducktape-build-debug-clang-amd64`
  - [ ] `check-skipped=ducktape-build-debug-clang-amd64`
  - [ ] `check-success=ducktape-build-debug-clang-amd64`
- `#approved-reviews-by>=1` [🛡 GitHub branch protection]
  - [X] #14072
- `#changes-requested-reviews-by=0` [🛡 GitHub branch protection]
  - [X] #14072
- [X] `base=dev`
- `label=merge-queue`
  - [X] #14072

**Required conditions to stay in the queue:**

- `#approved-reviews-by>=1` [🛡 GitHub branch protection]
  - [X] #14072
- `#changes-requested-reviews-by=0` [🛡 GitHub branch protection]
  - [X] #14072
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=build-debug-clang-amd64`
  - [ ] `check-neutral=build-debug-clang-amd64`
  - [ ] `check-skipped=build-debug-clang-amd64`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=build-release-clang-amd64`
  - [ ] `check-neutral=build-release-clang-amd64`
  - [ ] `check-skipped=build-release-clang-amd64`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=ducktape-build-release-clang-amd64`
  - [ ] `check-neutral=ducktape-build-release-clang-amd64`
  - [ ] `check-skipped=ducktape-build-release-clang-amd64`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=ducktape-build-debug-clang-amd64`
  - [ ] `check-neutral=ducktape-build-debug-clang-amd64`
  - [ ] `check-skipped=ducktape-build-debug-clang-amd64`

**Visit the [Mergify Dashboard](https://dashboard.mergify.com/github/redpanda-data/repo/redpanda/queues/partitions/__default__?queues=dev&branch=dev) to check the state of the queue `dev`.**<!---
DO NOT EDIT
-*- Mergify Payload -*-
{"merge-queue-pr": true}
-*- Mergify Payload End -*-
-->

```yaml
---
previous_failed_batches: []
pull_requests:
  - number: 14072
...

```