### PR TITLE
future-utils: Add ss::sleep_aborted to list of shutdown exceptions

### DIFF
--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -275,6 +275,7 @@ ignore_shutdown_exceptions(seastar::future<> fut) noexcept {
     } catch (const seastar::broken_semaphore&) {
     } catch (const seastar::broken_promise&) {
     } catch (const seastar::broken_condition_variable&) {
+    } catch (const seastar::sleep_aborted&) {
     }
 }
 
@@ -291,6 +292,8 @@ inline bool is_shutdown_exception(const std::exception_ptr& e) {
     } catch (const seastar::broken_promise&) {
         return true;
     } catch (const seastar::broken_condition_variable&) {
+        return true;
+    } catch (const seastar::sleep_aborted&) {
         return true;
     } catch (...) {
     }


### PR DESCRIPTION
This PR adds `ss::sleep_aborted` to the list of shutdown exceptions which should be explicitly ignored in some contexts. Specifically we've seen (very occasional) "exceptional future ignored" errors of this type during ducktape node shutdown.

Per seastar docs:

```
class seastar::sleep_aborted
    exception that is thrown when application is in process of been stopped
```

Fixes: #13272 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

- none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
