### PR TITLE
config: add example for audit events

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1359,7 +1359,11 @@ configuration::configuration()
       "[management, produce, consume, describe, heartbeat, authenticate]. "
       "Please refer to the documentation to know exactly which request(s) map "
       "to a particular audit event type.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      {
+        .needs_restart = needs_restart::no,
+        .example = R"(["management", "describe"])",
+        .visibility = visibility::user,
+      },
       {"management"},
       validate_audit_event_types)
   , cloud_storage_enabled(


### PR DESCRIPTION
This lets for cluster_config_test pick a valid value for this variable.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
