### PR TITLE
Fix for CI Failure (invalid timer interval) in `UsageTest.test_usage_metrics_collection`

### DIFF
--- a/tests/rptest/tests/usage_test.py
+++ b/tests/rptest/tests/usage_test.py
@@ -318,7 +318,9 @@ class UsageTest(RedpandaTest):
         fire_times = [delta_parse(x) for x in log_lines]
 
         # Ensure all deltas are 0 meaning there is no skew
-        return all([x == 0 for x in fire_times])
+        # Make an exception for 1 second delta to account for late timers
+        # in debug builds
+        return all([x == 0 or x == 1 for x in fire_times])
 
     @cluster(num_nodes=3)
     def test_usage_metrics_collection(self):
@@ -357,7 +359,8 @@ class UsageTest(RedpandaTest):
             iterations += 1
 
         # Additional validation to ensure there were no gaps and the timer fired exactly on time
-        assert self._validate_timer_interval()
+        assert self._validate_timer_interval(
+        ), "A timer skew of greater then 1s has been detected within a usage fiber"
 
     @cluster(num_nodes=4)
     def test_usage_collection_restart(self):


### PR DESCRIPTION
- The failing assertion checks that the time elapsed between two invocations of `usage_aggregator::rearm_window_timer` is exactly 1 usage_window_width_interval long.

- The test always fails detecting a 1 second skew, never a value greater then 1. It is also relatively infrequent and only occurring in debug builds. Options to resolve were to skip the test when running in debug builds or add an exception for small skews of 1 second.

- Fixes: #13520

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
