### PR TITLE
tests: added test validating if balancer can cooperate with space mgmnt

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -213,6 +213,16 @@ std::pair<uint64_t, uint64_t> partition_balancer_planner::get_node_bytes_info(
             }
         }
 
+        /**
+         * In the initial phase reported space may be incorrect as not all
+         * partition storage information are reported. Clamp down to actual
+         * disk free space + reclaimable size. This way we will never go beyond
+         * the actual free space but when all reported values are up to date
+         * the calculated free space should always be smaller then or equal to
+         * free space to reclaimable space.
+         */
+        total_free = std::min(
+          reclaimable_size + node_state.data_disk.free, total_free);
         // Clamp to total available target size.
         total_free = std::min(target_size, total_free);
         return std::make_pair(target_size, total_free);

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -20,6 +20,7 @@
 #include "model/namespace.h"
 #include "random/generators.h"
 #include "ssx/sformat.h"
+#include "vlog.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/coroutine/maybe_yield.hh>
@@ -187,6 +188,11 @@ private:
 std::pair<uint64_t, uint64_t> partition_balancer_planner::get_node_bytes_info(
   const node::local_state& node_state) {
     const auto& state = node_state.log_data_size;
+    vlog(
+      clusterlog.debug,
+      "getting node disk information from node: {}",
+      node_state);
+
     if (likely(state)) {
         // It is okay to account reclaimable space as free space even through
         // the space is not readily available. During the partition move if the
@@ -206,9 +212,7 @@ std::pair<uint64_t, uint64_t> partition_balancer_planner::get_node_bytes_info(
                 total_free = reclaimable_size - overage;
             }
         }
-        // Clamp the free space to be conservative and account for any error
-        // from space monitoring logic.
-        total_free = std::min(total_free, node_state.data_disk.free);
+
         // Clamp to total available target size.
         total_free = std::min(target_size, total_free);
         return std::make_pair(target_size, total_free);


### PR DESCRIPTION
The test executes a workload similar to the one in the full node test but it uses configuration that allows the new storage space manager to kick in. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug fixes: 
- Fixed a bug in which partition movement wouldn't take into account reclaimable space, preventing data movement