### PR TITLE
c/commands: introduced new update partition replicas command

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -97,6 +97,7 @@ static constexpr int8_t move_topic_replicas_cmd_type = 8;
 static constexpr int8_t revert_cancel_partition_move_cmd_type = 9;
 static constexpr int8_t topic_lifecycle_transition_cmd_type = 10;
 static constexpr int8_t force_partition_reconfiguration_type = 11;
+static constexpr int8_t update_partition_replicas_cmd_type = 12;
 
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
@@ -210,6 +211,16 @@ using force_partition_reconfiguration_cmd = controller_command<
   model::ntp,
   force_partition_reconfiguration_cmd_data,
   force_partition_reconfiguration_type,
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::serde_only>;
+
+/**
+ * new extendible version of move_partition_replicas command
+ */
+using update_partition_replicas_cmd = controller_command<
+  int8_t, // unused
+  update_partition_replicas_cmd_data,
+  update_topic_properties_cmd_type,
   model::record_batch_type::topic_management_cmd,
   serde_opts::serde_only>;
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1138,6 +1138,29 @@ std::ostream& operator<<(std::ostream& o, const nt_revision& ntr) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, reconfiguration_policy policy) {
+    switch (policy) {
+    case reconfiguration_policy::full_local_retention:
+        return o << "full_local_retention";
+    case reconfiguration_policy::target_initial_retention:
+        return o << "target_initial_retention";
+    case reconfiguration_policy::min_local_retention:
+        return o << "min_local_retention";
+    }
+    __builtin_unreachable();
+}
+
+std::ostream&
+operator<<(std::ostream& o, const update_partition_replicas_cmd_data& data) {
+    fmt::print(
+      o,
+      "{{ntp: {}, replicas: {} policy: {}}}",
+      data.ntp,
+      data.replicas,
+      data.policy);
+    return o;
+}
+
 } // namespace cluster
 
 namespace reflection {


### PR DESCRIPTION
Introduced new extensible command representing requested partition replicas update. The new command is serde serializable and has extensible data structure. Additionally the command contains a flag expressing partition reconfiguration policy. For now the flag can have one of the following values:

```
Moving partition with full local retention policy will deliver all
partition data available locally on the leader to newly joining
learners. If tiered storage is disabled for a partition the move will
alawys be executed with full local retention.

full_local_retention = 0,

With target initial retention parittion move policy controller
backend will calulate the learner start offset based on the configured
learner initial retention configuration (either a global cluster property
or topic override ) and partition max collectible offset. Max
collectible offset is advanced after all the previous offsets were
succesfully uploaded to the cloud.

target_initial_retention = 1,

The min local retention policy, before requesting partition
reconfiguration in the Raft layer will request log to be uploaded
to the Object Store up to the active segment boundry. After all data are
update the controller backend will request partition move setting
learner initial offset to the active segment start offset, allowing all
the data from not active segments to be skiped while recoverying learners.    

min_local_retention = 2
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none