### PR TITLE
archival: skip reuploads of identical size

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1441,7 +1441,7 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
         vlog(
           _rtclog.warn,
           "Upload skipped for range: {}-{} because these offsets lie inside "
-          "batches",
+          "batches or the reupload is not smaller than the current segment",
           upload.starting_offset,
           upload.final_offset);
         co_return scheduled_upload{


### PR DESCRIPTION
PR #9404 partially fixed the issue of compacted reupoads of the same size leading to gaps in the cloud log. However, the fix assumed the issue can only happen when one segment is selected for reupload. That's not the case. For example:

Node 1 segment layout: [0-3]
Node 2 segment layout: [0-2][3-3]


Node 1 does the initial upload of the offset range [0-3]. This is covered by just one segment. Then, Node 2 gains leadership. It decides to do a compacted re-upload for the [0-3] range. This is covered by two segments now. If the keys in the [0-3] range are unique, the reupload will have the same size, but our fix doesn't kick in since the reupload contains multiple segments.

PR #9404 was followed up by #9597 which added an additional defence layer for this in the manifest. While the issue doen't lead to gaps in the log, we still reupload a segment for no reason and replicate commands which fail to apply.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Bug Fixes
* Prevent compacted re-uploads for a given segment range from happening multiple times.

