### PR TITLE
security: Audit all admin server requests

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -89,6 +89,7 @@
 #include "rpc/errc.h"
 #include "rpc/rpc_utils.h"
 #include "security/acl.h"
+#include "security/audit/audit_log_manager.h"
 #include "security/credential_store.h"
 #include "security/scram_algorithm.h"
 #include "security/scram_authenticator.h"
@@ -244,7 +245,8 @@ admin_server::admin_server(
   ss::sharded<memory_sampling>& memory_sampling_service,
   ss::sharded<cloud_storage::cache>& cloud_storage_cache,
   ss::sharded<resources::cpu_profiler>& cpu_profiler,
-  ss::sharded<transform::service>* transform_service)
+  ss::sharded<transform::service>* transform_service,
+  ss::sharded<security::audit::audit_log_manager>& audit_mgr)
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
@@ -272,6 +274,7 @@ admin_server::admin_server(
   , _cloud_storage_cache(cloud_storage_cache)
   , _cpu_profiler(cpu_profiler)
   , _transform_service(transform_service)
+  , _audit_mgr(audit_mgr)
   , _default_blocked_reactor_notify(
       ss::engine().get_blocked_reactor_notify_ms()) {
     _server.set_content_streaming(true);

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -24,6 +24,7 @@
 #include "resource_mgmt/memory_sampling.h"
 #include "rpc/connection_cache.h"
 #include "seastarx.h"
+#include "security/fwd.h"
 #include "storage/node.h"
 #include "transform/fwd.h"
 #include "utils/request_auth.h"
@@ -81,7 +82,8 @@ public:
       ss::sharded<memory_sampling>&,
       ss::sharded<cloud_storage::cache>&,
       ss::sharded<resources::cpu_profiler>&,
-      ss::sharded<transform::service>*);
+      ss::sharded<transform::service>*,
+      ss::sharded<security::audit::audit_log_manager>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -552,6 +554,7 @@ private:
     ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
     ss::sharded<resources::cpu_profiler>& _cpu_profiler;
     ss::sharded<transform::service>* _transform_service;
+    ss::sharded<security::audit::audit_log_manager>& _audit_mgr;
 
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -926,7 +926,8 @@ void application::configure_admin_server() {
       std::ref(_memory_sampling),
       std::ref(shadow_index_cache),
       std::ref(_cpu_profiler),
-      &_transform_service)
+      &_transform_service,
+      std::ref(audit_mgr))
       .get();
 }
 

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -22,12 +22,14 @@ v_cc_library(
     krb5.cc
     krb5_configurator.cc
     gssapi_principal_mapper.cc
+    audit/schemas/utils.cc
   DEPS
     v::security_config
     v::config
     v::bytes
     v::utils
     v::rprandom
+    v::version
     absl::flat_hash_map
     absl::flat_hash_set
     cryptopp

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -78,6 +78,27 @@ public:
         return do_enqueue_audit_event(std::make_unique<T>(std::forward<T>(t)));
     }
 
+    /// Enqueue an event to be produced onto an audit log partition.  This will
+    /// always enqueue the event (if auditing is enabled).  This is used for
+    /// items like authentication events or application events.
+    ///
+    /// Returns: bool representing if the audit msg was successfully moved into
+    /// the queue or not. If unsuccessful this means the audit subsystem cannot
+    /// publish messages. Consumers of this API should react accordingly, i.e.
+    /// return an error to the client.
+    template<InheritsFromOCSFBase T>
+    bool enqueue_mandatory_audit_event(T&& t) {
+        if (!_audit_enabled()) {
+            return true;
+        }
+        if (_as.abort_requested()) {
+            /// Prevent auditing new messages when shutdown starts that way the
+            /// queue may be entirely flushed before shutdown
+            return false;
+        }
+        return do_enqueue_audit_event(std::make_unique<T>(std::forward<T>(t)));
+    }
+
     /// Returns the number of items pending to be written to auditing log
     ///
     /// Note does not include records already sent to client

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -65,8 +65,8 @@ public:
     /// the queue or not. If unsuccessful this means the audit subsystem cannot
     /// publish messages. Consumers of this API should react accordingly, i.e.
     /// return an error to the client.
-    template<InheritsFromOCSFBase T, typename... Args>
-    bool enqueue_audit_event(event_type type, Args&&... args) {
+    template<InheritsFromOCSFBase T>
+    bool enqueue_audit_event(event_type type, T&& t) {
         if (!_audit_enabled() || !is_audit_event_enabled(type)) {
             return true;
         }
@@ -75,8 +75,7 @@ public:
             /// queue may be entirely flushed before shutdown
             return false;
         }
-        return do_enqueue_audit_event(
-          std::make_unique<T>(std::forward<Args>(args)...));
+        return do_enqueue_audit_event(std::make_unique<T>(std::forward<T>(t)));
     }
 
     /// Returns the number of items pending to be written to auditing log

--- a/src/v/security/audit/schemas/iam.h
+++ b/src/v/security/audit/schemas/iam.h
@@ -59,6 +59,8 @@ public:
       used_mfa mfa,
       network_endpoint src_endpoint,
       severity_id severity_id,
+      status_id status_id,
+      std::optional<ss::sstring> status_detail,
       timestamp_t time,
       user user)
       : ocsf_base_event(
@@ -72,6 +74,8 @@ public:
       , _is_cleartext(is_cleartext)
       , _mfa(mfa)
       , _src_endpoint(std::move(src_endpoint))
+      , _status_id(status_id)
+      , _status_detail(std::move(status_detail))
       , _user(std::move(user)) {
         ss::visit(
           auth_protocol,
@@ -94,6 +98,8 @@ public:
           _is_cleartext,
           _mfa,
           _src_endpoint.addr.host(),
+          _status_id,
+          _status_detail,
           _user);
     }
 
@@ -105,6 +111,8 @@ private:
     used_cleartext _is_cleartext;
     used_mfa _mfa;
     network_endpoint _src_endpoint;
+    status_id _status_id;
+    std::optional<ss::sstring> _status_detail;
     user _user;
 
     size_t hash() const final { return std::hash<authentication>()(*this); }
@@ -129,6 +137,12 @@ private:
         ::json::rjson_serialize(w, bool(a._mfa));
         w.Key("src_endpoint");
         ::json::rjson_serialize(w, a._src_endpoint);
+        w.Key("status_id");
+        ::json::rjson_serialize(w, a._status_id);
+        if (a._status_detail.has_value()) {
+            w.Key("status_detail");
+            ::json::rjson_serialize(w, a._status_detail.value());
+        }
         w.Key("user");
         ::json::rjson_serialize(w, a._user);
         w.EndObject();

--- a/src/v/security/audit/schemas/schemas.h
+++ b/src/v/security/audit/schemas/schemas.h
@@ -66,6 +66,8 @@ public:
           *(static_cast<const Derived*>(this)));
     }
 
+    timestamp_t get_time() const { return _time; }
+
     ocsf_base_event(const ocsf_base_event&) = delete;
     ocsf_base_event& operator=(const ocsf_base_event&) = delete;
     ocsf_base_event(ocsf_base_event&&) = default;

--- a/src/v/security/audit/schemas/tests/CMakeLists.txt
+++ b/src/v/security/audit/schemas/tests/CMakeLists.txt
@@ -4,6 +4,6 @@ rp_test(
     SOURCES
       ocsf_schemas_test.cc
     DEFINITIONS BOOST_TEST_DYN_LINK
-    LIBRARIES Boost::unit_test_framework v::json v::version
+    LIBRARIES Boost::unit_test_framework v::json v::version v::security_audit
     LABELS audit
 )

--- a/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
+++ b/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
@@ -9,7 +9,15 @@
  * by the Apache License, Version 2.0
  */
 
+#include "json/json.h"
 #include "security/audit/schemas/types.h"
+#include "security/audit/schemas/utils.h"
+#include "security/types.h"
+#include "utils/request_auth.h"
+
+#include <seastar/net/socket_defs.hh>
+
+#include <optional>
 #define BOOST_TEST_MODULE security_audit
 
 #include "json/reader.h"
@@ -18,6 +26,8 @@
 #include "security/audit/schemas/application_activity.h"
 #include "security/audit/schemas/iam.h"
 #include "security/audit/schemas/schemas.h"
+
+#include <seastar/http/request.hh>
 
 #include <boost/test/unit_test.hpp>
 
@@ -642,4 +652,354 @@ BOOST_AUTO_TEST_CASE(validate_authn_hash) {
 
         BOOST_REQUIRE_NE(authn1.key(), authn2.key());
     }
+}
+
+BOOST_AUTO_TEST_CASE(make_api_activity_event_authorized) {
+    const ss::socket_address client_addr{ss::ipv4_addr("10.0.0.1", 12345)};
+    const ss::socket_address server_addr{ss::ipv4_addr("10.1.1.1", 23456)};
+    const ss::sstring url = "/v1/test?param=val";
+    const ss::sstring method = "GET";
+    const ss::sstring protocol_name = "https";
+    const ss::sstring host_name = "local";
+    const ss::sstring version = "1.1";
+    const ss::sstring user_agent = "Mozilla";
+    const ss::sstring username = "test";
+
+    auto req = ss::http::request::make(method, host_name, url);
+    req.parse_query_param();
+    req._client_address = client_addr;
+    req._server_address = server_addr;
+    req._version = version;
+    req._headers["User-Agent"] = user_agent;
+    req._headers["Authorization"] = "You shouldn't see this at all";
+    req.protocol_name = protocol_name;
+
+    request_auth_result auth_result{
+      security::credential_user{username},
+      security::credential_password{"password"},
+      "sasl",
+      request_auth_result::superuser::no};
+
+    auto api_activity = sa::make_api_activity_event(
+      req, auth_result, true, std::nullopt);
+
+    auth_result.pass();
+
+    const auto expected = fmt::format(
+      R"(
+{{
+ "category_uid": 6,
+  "class_uid": 6003,
+  "metadata": {metadata},
+  "severity_id": 1,
+  "time": {time},
+  "type_uid": 600302,
+  "activity_id": 2,
+  "actor": {{
+    "authorizations": [
+      {{
+        "decision": "authorized",
+        "policy": {{
+          "desc": "",
+          "name": "Admin httpd authorizer"
+        }}
+      }}
+    ],
+    "user": {{
+      "name": "{username}",
+      "type_id": 1
+    }}
+  }},
+  "api": {{
+    "operation": "{method}"
+  }},
+  "dst_endpoint": {{
+    "ip": "10.1.1.1",
+    "port": 23456
+  }},
+  "http_request": {{
+    "http_headers": [
+      {{
+        "name": "User-Agent",
+        "value": "{user_agent}"
+      }},
+      {{
+        "name": "Authorization",
+        "value": "******"
+      }},
+      {{
+        "name": "Host",
+        "value": "{host_name}"
+      }}
+    ],
+    "http_method": "{method}",
+    "url": {{
+      "hostname": "{host_name}",
+      "path": "{url}",
+      "port": 23456,
+      "scheme": "{protocol_name}",
+      "url_string": "{url_string}"
+    }},
+    "user_agent": "{user_agent}",
+    "version": "{version}"
+  }},
+  "src_endpoint": {{
+    "ip": "10.0.0.1",
+    "port": 12345
+  }},
+  "status_id": 1,
+  "unmapped": {{}}
+}}
+    )",
+      fmt::arg("metadata", metadata_ser),
+      fmt::arg("time", ss::to_sstring(api_activity.get_time())),
+      fmt::arg("username", username),
+      fmt::arg("method", method),
+      fmt::arg("user_agent", user_agent),
+      fmt::arg("host_name", host_name),
+      fmt::arg("url", url),
+      fmt::arg("protocol_name", protocol_name),
+      fmt::arg("url_string", protocol_name + "://" + host_name + url),
+      fmt::arg("version", version));
+
+    auto ser = sa::rjson_serialize(api_activity);
+
+    BOOST_REQUIRE_EQUAL(ser, ::json::minify(expected));
+}
+
+BOOST_AUTO_TEST_CASE(make_authentication_event_success) {
+    const ss::socket_address client_addr{ss::ipv4_addr("10.0.0.1", 12345)};
+    const ss::socket_address server_addr{ss::ipv4_addr("10.1.1.1", 23456)};
+    const ss::sstring url = "/v1/test?param=val";
+    const ss::sstring method = "GET";
+    const ss::sstring protocol_name = "https";
+    const ss::sstring host_name = "local";
+    const ss::sstring version = "1.1";
+    const ss::sstring user_agent = "Mozilla";
+    const ss::sstring username = "test";
+
+    auto req = ss::http::request::make(method, host_name, url);
+    req.parse_query_param();
+    req._client_address = client_addr;
+    req._server_address = server_addr;
+    req._version = version;
+    req._headers["User-Agent"] = user_agent;
+    req._headers["Authorization"] = "You shouldn't see this at all";
+    req.protocol_name = protocol_name;
+
+    request_auth_result auth_result{
+      security::credential_user{username},
+      security::credential_password{"password"},
+      "sasl",
+      request_auth_result::superuser::no};
+
+    auto authn = sa::make_authentication_event(req, auth_result);
+    auth_result.pass();
+
+    const auto expected = fmt::format(
+      R"(
+{{
+  "category_uid": 3,
+  "class_uid": 3002,
+  "metadata": {metadata},
+  "severity_id": 1,
+  "time": {time},
+  "type_uid": 300201,
+  "activity_id": 1,
+  "auth_protocol": "sasl",
+  "auth_protocol_id": 99,
+  "dst_endpoint": {{
+    "ip": "10.1.1.1",
+    "port": 23456
+  }},
+  "is_cleartext": false,
+  "mfa": false,
+  "src_endpoint": {{
+    "ip": "10.0.0.1",
+    "port": 12345
+  }},
+  "status_id": 1,
+  "user": {{
+    "name": "{username}",
+    "type_id": 1
+  }}
+}}
+    ))",
+      fmt::arg("metadata", metadata_ser),
+      fmt::arg("time", ss::to_sstring(authn.get_time())),
+      fmt::arg("username", username));
+
+    auto ser = sa::rjson_serialize(authn);
+    BOOST_REQUIRE_EQUAL(ser, ::json::minify(expected));
+}
+
+BOOST_AUTO_TEST_CASE(make_api_activity_event_authorized_authn_disabled) {
+    const ss::socket_address client_addr{ss::ipv4_addr("10.0.0.1", 12345)};
+    const ss::socket_address server_addr{ss::ipv4_addr("10.1.1.1", 23456)};
+    const ss::sstring url = "/v1/test?param=val";
+    const ss::sstring method = "GET";
+    const ss::sstring protocol_name = "https";
+    const ss::sstring host_name = "local";
+    const ss::sstring version = "1.1";
+    const ss::sstring user_agent = "Mozilla";
+    const ss::sstring username = "test";
+
+    auto req = ss::http::request::make(method, host_name, url);
+    req.parse_query_param();
+    req._client_address = client_addr;
+    req._server_address = server_addr;
+    req._version = version;
+    req._headers["User-Agent"] = user_agent;
+    req._headers["Authorization"] = "You shouldn't see this at all";
+    req.protocol_name = protocol_name;
+
+    request_auth_result auth_result{
+      request_auth_result::authenticated::yes,
+      request_auth_result::superuser::yes,
+      request_auth_result::auth_required::no};
+
+    auto api_activity = sa::make_api_activity_event(
+      req, auth_result, true, std::nullopt);
+
+    auth_result.pass();
+
+    const auto expected = fmt::format(
+      R"(
+{{
+  "category_uid": 6,
+  "class_uid": 6003,
+  "metadata": {metadata},
+  "severity_id": 1,
+  "time": {time},
+  "type_uid": 600302,
+  "activity_id": 2,
+  "actor": {{
+    "authorizations": [
+      {{
+        "decision": "authorized",
+        "policy": {{
+          "desc": "Auth Disabled",
+          "name": "Admin httpd authorizer"
+        }}
+      }}
+    ],
+    "user": {{
+      "name": "{{{{anonymous}}}}",
+      "type_id": 2
+    }}
+  }},
+  "api": {{
+    "operation": "{method}"
+  }},
+  "dst_endpoint": {{
+    "ip": "10.1.1.1",
+    "port": 23456
+  }},
+  "http_request": {{
+    "http_headers": [
+      {{
+        "name": "User-Agent",
+        "value": "{user_agent}"
+      }},
+      {{
+        "name": "Authorization",
+        "value": "******"
+      }},
+      {{
+        "name": "Host",
+        "value": "{host_name}"
+      }}
+    ],
+    "http_method": "{method}",
+    "url": {{
+      "hostname": "{host_name}",
+      "path": "{url}",
+      "port": 23456,
+      "scheme": "{protocol_name}",
+      "url_string": "{url_string}"
+    }},
+    "user_agent": "{user_agent}",
+    "version": "{version}"
+  }},
+  "src_endpoint": {{
+    "ip": "10.0.0.1",
+    "port": 12345
+  }},
+  "status_id": 1,
+  "unmapped": {{}}
+}}
+)",
+      fmt::arg("metadata", metadata_ser),
+      fmt::arg("time", ss::to_sstring(api_activity.get_time())),
+      fmt::arg("method", method),
+      fmt::arg("user_agent", user_agent),
+      fmt::arg("host_name", host_name),
+      fmt::arg("url", url),
+      fmt::arg("protocol_name", protocol_name),
+      fmt::arg("url_string", protocol_name + "://" + host_name + url),
+      fmt::arg("version", version));
+
+    auto ser = sa::rjson_serialize(api_activity);
+
+    BOOST_REQUIRE_EQUAL(ser, ::json::minify(expected));
+}
+
+BOOST_AUTO_TEST_CASE(make_authn_event_failure) {
+    const ss::socket_address client_addr{ss::ipv4_addr("10.0.0.1", 12345)};
+    const ss::socket_address server_addr{ss::ipv4_addr("10.1.1.1", 23456)};
+    const ss::sstring url = "/v1/test?param=val";
+    const ss::sstring method = "GET";
+    const ss::sstring protocol_name = "https";
+    const ss::sstring host_name = "local";
+    const ss::sstring version = "1.1";
+    const ss::sstring user_agent = "Mozilla";
+    const ss::sstring username = "test";
+
+    auto req = ss::http::request::make(method, host_name, url);
+    req.parse_query_param();
+    req._client_address = client_addr;
+    req._server_address = server_addr;
+    req._version = version;
+    req._headers["User-Agent"] = user_agent;
+    req._headers["Authorization"] = "You shouldn't see this at all";
+    req.protocol_name = protocol_name;
+
+    auto authn = sa::make_authentication_failure_event(
+      req, security::credential_user{username}, "FAILURE");
+
+    const auto expected = fmt::format(
+      R"(
+{{
+  "category_uid": 3,
+  "class_uid": 3002,
+  "metadata": {metadata},
+  "severity_id": 1,
+  "time": {time},
+  "type_uid": 300201,
+  "activity_id": 1,
+  "auth_protocol_id": 0,
+  "dst_endpoint": {{
+    "ip": "10.1.1.1",
+    "port": 23456
+  }},
+  "is_cleartext": false,
+  "mfa": false,
+  "src_endpoint": {{
+    "ip": "10.0.0.1",
+    "port": 12345
+  }},
+  "status_id": 2,
+  "status_detail": "FAILURE",
+  "user": {{
+    "name": "{username}",
+    "type_id": 0
+  }}
+}}
+)",
+      fmt::arg("metadata", metadata_ser),
+      fmt::arg("time", ss::to_sstring(authn.get_time())),
+      fmt::arg("username", username));
+
+    auto ser = sa::rjson_serialize(authn);
+    BOOST_REQUIRE_EQUAL(ser, ::json::minify(expected));
 }

--- a/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
+++ b/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
@@ -269,6 +269,8 @@ BOOST_AUTO_TEST_CASE(validate_authentication_sasl_scram) {
       sa::authentication::used_mfa ::yes,
       std::move(src_endpoint),
       sa::severity_id::informational,
+      sa::authentication::status_id::success,
+      std::nullopt,
       now,
       sa::user{default_user});
 
@@ -294,6 +296,7 @@ BOOST_AUTO_TEST_CASE(validate_authentication_sasl_scram) {
 "mfa": true,
 "src_endpoint": )"
       + client_kafka_endpoint_ser + R"(,
+"status_id": 1,
 "user": )"
       + default_user_ser + R"(
 }
@@ -317,6 +320,8 @@ BOOST_AUTO_TEST_CASE(validate_authentication_kerberos) {
       sa::authentication::used_mfa ::no,
       std::move(src_endpoint),
       sa::severity_id::informational,
+      sa::authentication::status_id::failure,
+      "Failure",
       now,
       sa::user{default_user});
 
@@ -341,6 +346,8 @@ BOOST_AUTO_TEST_CASE(validate_authentication_kerberos) {
 "mfa": false,
 "src_endpoint": )"
       + client_kafka_endpoint_ser + R"(,
+"status_id": 2,
+"status_detail": "Failure",
 "user": )"
       + default_user_ser + R"(
 }
@@ -579,6 +586,8 @@ BOOST_AUTO_TEST_CASE(validate_authn_hash) {
           sa::authentication::used_mfa::no,
           client_kafka_endpoint,
           sa::severity_id::informational,
+          sa::authentication::status_id::success,
+          std::nullopt,
           sa::timestamp_t{1},
           sa::user{default_user});
         auto authn2 = sa::authentication(
@@ -589,6 +598,8 @@ BOOST_AUTO_TEST_CASE(validate_authn_hash) {
           sa::authentication::used_mfa::no,
           client_kafka_endpoint,
           sa::severity_id::informational,
+          sa::authentication::status_id::success,
+          std::nullopt,
           sa::timestamp_t{2},
           sa::user{default_user});
 
@@ -612,6 +623,8 @@ BOOST_AUTO_TEST_CASE(validate_authn_hash) {
           sa::authentication::used_mfa::no,
           client_kafka_endpoint,
           sa::severity_id::informational,
+          sa::authentication::status_id::failure,
+          "Failure",
           sa::timestamp_t{1},
           sa::user{default_user});
         auto authn2 = sa::authentication(
@@ -622,6 +635,8 @@ BOOST_AUTO_TEST_CASE(validate_authn_hash) {
           sa::authentication::used_mfa::no,
           client_kafka_endpoint,
           sa::severity_id::informational,
+          sa::authentication::status_id::failure,
+          "Failure",
           sa::timestamp_t{2},
           sa::user{default_user});
 

--- a/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
+++ b/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
@@ -103,7 +103,6 @@ static const ss::sstring client_kafka_endpoint_ser{
 )"};
 
 static const sa::api_activity_unmapped unmapped {
-  .shard_id = ss::shard_id{1},
   .authorization_metadata = sa::authorization_metadata {
     .acl_authorization = {
       .host = "*",
@@ -122,7 +121,6 @@ static const sa::api_activity_unmapped unmapped {
 static const ss::sstring unmapped_ser{
   R"(
 {
-  "shard_id": 1,
   "authorization_metadata": {
     "acl_authorization": {
       "host": "*",

--- a/src/v/security/audit/schemas/types.h
+++ b/src/v/security/audit/schemas/types.h
@@ -210,12 +210,9 @@ struct authorization_metadata {
 };
 
 struct api_activity_unmapped {
-    ss::shard_id shard_id;
     std::optional<authorization_metadata> authorization_metadata;
 
-    auto equality_fields() const {
-        return std::tie(shard_id, authorization_metadata);
-    }
+    auto equality_fields() const { return std::tie(authorization_metadata); }
 };
 
 struct http_header {
@@ -393,8 +390,6 @@ rjson_serialize(Writer<StringBuffer>& w, const sa::authorization_metadata& m) {
 inline void
 rjson_serialize(Writer<StringBuffer>& w, const sa::api_activity_unmapped& u) {
     w.StartObject();
-    w.Key("shard_id");
-    ::json::rjson_serialize(w, u.shard_id);
     if (u.authorization_metadata) {
         w.Key("authorization_metadata");
         ::json::rjson_serialize(w, u.authorization_metadata.value());

--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "security/audit/schemas/utils.h"
+
+#include "security/audit/schemas/application_activity.h"
+#include "security/audit/schemas/types.h"
+#include "utils/request_auth.h"
+
+#include <boost/algorithm/string/predicate.hpp>
+
+namespace security::audit {
+
+namespace {
+
+api_activity::activity_id http_method_to_activity_id(std::string_view method) {
+    return string_switch<api_activity::activity_id>(method)
+      .match_all("POST", "post", api_activity::activity_id::create)
+      .match_all("GET", "get", api_activity::activity_id::read)
+      .match_all("PUT", "put", api_activity::activity_id::update)
+      .match_all("DELETE", "delete", api_activity::activity_id::delete_id)
+      .default_match(api_activity::activity_id::unknown);
+}
+
+uniform_resource_locator
+uri_from_ss_http_request(const ss::http::request& req) {
+    return {
+      .hostname = req.get_header("Host"),
+      .path = req._url,
+      .port = port_t{req.get_server_address().port()},
+      .scheme = req.get_protocol_name(),
+      .url_string = req.get_url()};
+}
+
+http_request from_ss_http_request(const ss::http::request& req) {
+    using ss_http_headers_t = decltype(req._headers);
+    using ss_http_headers_value_t = ss_http_headers_t::value_type;
+    const auto get_headers = [](const ss_http_headers_t& headers) {
+        const auto sanitize_header =
+          [](const ss_http_headers_value_t& kv) -> ss::sstring {
+            constexpr auto sensitive_headers = std::to_array<std::string_view>(
+              {"Authorization", "Cookie"});
+
+            if (
+              std::find_if(
+                sensitive_headers.begin(),
+                sensitive_headers.end(),
+                [&kv](std::string_view s) {
+                    return boost::iequals(s, kv.first);
+                })
+              != sensitive_headers.end()) {
+                return "******";
+            } else {
+                return kv.second;
+            }
+        };
+        std::vector<http_header> audit_headers;
+        std::transform(
+          headers.begin(),
+          headers.end(),
+          std::back_inserter(audit_headers),
+          [sanitize_header = std::move(sanitize_header)](const auto& kv) {
+              return http_header{
+                .name = kv.first, .value = sanitize_header(kv)};
+          });
+        return audit_headers;
+    };
+    return http_request{
+      .http_headers = get_headers(req._headers),
+      .http_method = req._method,
+      .url = uri_from_ss_http_request(req),
+      .user_agent = req.get_header("User-Agent"),
+      .version = req._version};
+}
+
+network_endpoint from_ss_endpoint(const ss::socket_address& sa) {
+    return network_endpoint{
+      .addr = net::unresolved_address(
+        fmt::format("{}", sa.addr()), sa.port(), sa.addr().in_family())};
+}
+
+/// TODO: Via ACLs metadata return correct response
+api_activity_unmapped unmapped_data() { return api_activity_unmapped{}; }
+
+user user_from_request_auth_result(const request_auth_result& r) {
+    auto& username = r.get_username();
+
+    return {
+      .name = username.empty() ? "{{anonymous}}" : username,
+      .type_id = r.is_authenticated()
+                   ? (r.is_superuser() ? user::type::admin : user::type::user)
+                   : user::type::unknown,
+    };
+}
+
+actor actor_from_request_auth_result(
+  const request_auth_result& r,
+  bool authorized,
+  const std::optional<std::string_view>& reason) {
+    auto u = user_from_request_auth_result(r);
+    std::vector<authorization_result> auths{
+      {.decision = authorized ? "authorized" : "denied",
+       .policy = policy{
+         .desc = ss::sstring{reason.value_or(
+           r.is_auth_required() ? "" : "Auth Disabled")},
+         .name = "Admin httpd authorizer"}}};
+
+    return {.authorizations = std::move(auths), .user = std::move(u)};
+}
+
+template<typename Clock>
+timestamp_t create_timestamp_t(std::chrono::time_point<Clock> time_point) {
+    return timestamp_t(std::chrono::duration_cast<std::chrono::milliseconds>(
+                         time_point.time_since_epoch())
+                         .count());
+}
+
+template<typename Clock>
+timestamp_t create_timestamp_t() {
+    return create_timestamp_t(Clock::now());
+}
+
+} // namespace
+
+api_activity make_api_activity_event(
+  ss::httpd::const_req req,
+  const request_auth_result& auth_result,
+  bool authorized,
+  const std::optional<std::string_view>& reason) {
+    auto act = actor_from_request_auth_result(auth_result, authorized, reason);
+    return {
+      http_method_to_activity_id(req._method),
+      std::move(act),
+      api{.operation = req._method},
+      from_ss_endpoint(req.get_server_address()),
+      from_ss_http_request(req),
+      {},
+      severity_id::informational,
+      from_ss_endpoint(req.get_client_address()),
+      authorized ? api_activity::status_id::success
+                 : api_activity::status_id::failure,
+      create_timestamp_t<std::chrono::system_clock>(),
+      unmapped_data()};
+}
+
+} // namespace security::audit

--- a/src/v/security/audit/schemas/utils.h
+++ b/src/v/security/audit/schemas/utils.h
@@ -12,7 +12,9 @@
 #pragma once
 #include "net/unresolved_address.h"
 #include "security/audit/schemas/application_activity.h"
+#include "security/audit/schemas/iam.h"
 #include "security/audit/schemas/types.h"
+#include "security/types.h"
 #include "utils/request_auth.h"
 #include "utils/string_switch.h"
 
@@ -26,5 +28,13 @@ api_activity make_api_activity_event(
   const request_auth_result& auth_result,
   bool authorized,
   const std::optional<std::string_view>& reason);
+
+authentication make_authentication_event(
+  ss::httpd::const_req req, const request_auth_result& r);
+
+authentication make_authentication_failure_event(
+  ss::httpd::const_req req,
+  const security::credential_user& r,
+  const ss::sstring& reason);
 
 } // namespace security::audit

--- a/src/v/security/audit/schemas/utils.h
+++ b/src/v/security/audit/schemas/utils.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "net/unresolved_address.h"
+#include "security/audit/schemas/application_activity.h"
+#include "security/audit/schemas/types.h"
+#include "utils/request_auth.h"
+#include "utils/string_switch.h"
+
+#include <seastar/http/handlers.hh>
+#include <seastar/http/request.hh>
+
+namespace security::audit {
+
+api_activity make_api_activity_event(
+  ss::httpd::const_req req,
+  const request_auth_result& auth_result,
+  bool authorized,
+  const std::optional<std::string_view>& reason);
+
+} // namespace security::audit

--- a/tests/rptest/tests/audit_log_tests.py
+++ b/tests/rptest/tests/audit_log_tests.py
@@ -1,0 +1,176 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import re
+import time
+import json
+from functools import partial, reduce
+from rptest.services.rpk_consumer import RpkConsumer
+from ducktape.utils.util import wait_until
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
+from rptest.clients.rpk import RpkTool
+from rptest.tests.cluster_config_test import wait_for_version_sync
+from rptest.utils.audit_schemas import validate_audit_schema
+from rptest.services.redpanda import LoggingConfig
+
+
+class AuditLogTests(RedpandaTest):
+    audit_log = "__audit_log"
+
+    def __init__(self, test_context):
+        self._extra_conf = {
+            'audit_enabled': True,
+            'audit_log_num_partitions': 8,
+            'audit_enabled_event_types': ['management'],
+        }
+        super(AuditLogTests,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf=self._extra_conf,
+                             log_config=LoggingConfig('info',
+                                                      logger_levels={
+                                                          'auditing':
+                                                          'trace',
+                                                          'admin_api_server':
+                                                          'trace'
+                                                      }))
+        self._ctx = test_context
+        self.admin = Admin(self.redpanda)
+        self.rpk = RpkTool(self.redpanda)
+
+    def _wait_for_audit_log(self, timeout_sec):
+        wait_until(lambda: self.audit_log in self.rpk.list_topics(),
+                   timeout_sec=timeout_sec,
+                   backoff_sec=2)
+
+    def _audit_log_total_number_records(self):
+        audit_partitions = self.rpk.describe_topic(self.audit_log)
+        partition_totals = [
+            partition.high_watermark for partition in audit_partitions
+        ]
+        assert len(partition_totals) == self._extra_conf[
+            'audit_log_num_partitions'], \
+                f"Expected: {self._extra_conf['audit_log_num_partitions']}, Result: {len(partition_totals)}"
+        return sum(partition_totals)
+
+    def _read_all_from_audit_log(self,
+                                 filter_fn,
+                                 stop_cond,
+                                 timeout_sec=30,
+                                 backoff_sec=1):
+        class MessageMapper():
+            def __init__(self, logger, filter_fn, stop_cond):
+                self.logger = logger
+                self.records = []
+                self.filter_fn = filter_fn
+                self.stop_cond = stop_cond
+                self.next_offset_ingest = 0
+
+            def ingest(self, records):
+                new_records = records[self.next_offset_ingest:]
+                self.next_offset_ingest = len(records)
+                new_records = [json.loads(msg['value']) for msg in new_records]
+                self.logger.info(f"Ingested: {len(new_records)} records")
+                self.records += [r for r in new_records if self.filter_fn(r)]
+
+            def is_finished(self):
+                return stop_cond(self.records)
+
+        mapper = MessageMapper(self.redpanda.logger, filter_fn, stop_cond)
+        n = self._audit_log_total_number_records()
+
+        consumer = RpkConsumer(self._ctx, self.redpanda, self.audit_log)
+        consumer.start()
+
+        def predicate():
+            mapper.ingest(consumer.messages)
+            return consumer.message_count >= n and mapper.is_finished()
+
+        wait_until(predicate, timeout_sec=timeout_sec, backoff_sec=backoff_sec)
+        consumer.stop()
+        consumer.free()
+        return mapper.records
+
+    @cluster(num_nodes=4)
+    def test_audit_log_functioning(self):
+        """
+        Ensures that the audit log can be produced to when the audit_enabled()
+        configuration option is set, and that the same actions do nothing
+        when the option is unset. Furthermore verifies that the internal duplicate
+        aggregation feature is working.
+        """
+        def is_api_match(matches, record):
+            self.logger.debug(f'{record}')
+            if record['class_uid'] == 6003:
+                regex = re.compile(
+                    "http:\/\/(?P<address>.*):(?P<port>\d+)\/v1\/(?P<handler>.*)"
+                )
+                match = regex.match(
+                        record['http_request']['url']['url_string'])
+                if match is None:
+                    raise RuntimeError(f'Record out of spec: {record}')
+                return match.group('handler') in matches
+            else:
+                return False
+
+        def number_of_records_matching(filter_by, n_expected):
+            filter_fn = partial(is_api_match, filter_by)
+
+            def aggregate_count(records):
+                # Duplicate records are combined with the 'count' field
+                def combine(acc, x):
+                    return acc + (1 if 'count' not in x else x['count'])
+
+                return reduce(combine, records, 0)
+
+            stop_cond = lambda records: aggregate_count(records) >= n_expected
+            records = self._read_all_from_audit_log(filter_fn, stop_cond)
+            assert aggregate_count(
+                records
+            ) == n_expected, f"Expected: {n_expected}, Actual: {aggregate_count(records)}"
+            return records
+
+        self._wait_for_audit_log(timeout_sec=10)
+
+        # The test override the default event type to 'heartbeat', therefore
+        # any actions on the admin server should not result in audit msgs
+        api_calls = {
+            'features/license': self.admin.get_license,
+            'cluster/health_overview': self.admin.get_cluster_health_overview
+        }
+        api_keys = api_calls.keys()
+        call_apis = lambda: [fn() for fn in api_calls.values()]
+        self.logger.debug("Starting 500 api calls with management enabled")
+        for _ in range(0, 500):
+            call_apis()
+        self.logger.debug("Finished 500 api calls with management enabled")
+
+        # Wait 1 second because asserting that 0 records of a type occur
+        # will not continuously loop for the records we are expected not to
+        # see. 1 second is long enough for the audit fibers to run and push
+        # data to the audit topic.
+        time.sleep(1)
+        records = number_of_records_matching(api_keys, 1000)
+        self.redpanda.logger.debug(f"records: {records}")
+
+        # Raises if validation fails on any records
+        [validate_audit_schema(record) for record in records]
+
+        # Remove management setting
+        patch_result = self.admin.patch_cluster_config(
+            upsert={'audit_enabled_event_types': ['heartbeat']})
+        wait_for_version_sync(self.admin, self.redpanda,
+                              patch_result['config_version'])
+
+        self.logger.debug("Started 500 api calls with management disabled")
+        for _ in range(0, 500):
+            call_apis()
+        self.logger.debug("Finished 500 api calls with management disabled")
+        _ = number_of_records_matching(api_keys, 1000)

--- a/tests/rptest/utils/audit_schemas.py
+++ b/tests/rptest/utils/audit_schemas.py
@@ -1,0 +1,400 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import jsonschema
+import jsonschema.exceptions
+
+PRODUCT_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'name': {
+            'type': 'string'
+        },
+        'vendor_name': {
+            'type': 'string'
+        },
+        'version': {
+            'type': 'string'
+        }
+    },
+    'required': ['name', 'vendor_name', 'version'],
+    'additionalProperties': False
+}
+
+OCSF_BASE_SCHEMA = {
+    'type':
+    'object',
+    'properties': {
+        'category_uid': {
+            'type': 'number',
+            'enum': [1, 2, 3, 4, 5, 6]
+        },
+        'class_uid': {
+            'type':
+            'number',
+            'enum': [
+                1001, 1002, 1003, 1004, 1005, 1006, 1007, 2001, 3001, 3002,
+                3003, 3004, 3005, 3006, 4001, 4002, 4003, 4004, 4005, 4006,
+                4007, 4008, 4009, 4010, 4011, 4012, 5001, 5002, 6001, 6002,
+                6003, 6004
+            ]
+        },
+        'count': {
+            'type': 'number'
+        },
+        'end_time': {
+            'type': 'number'
+        },
+        'metadata': {
+            'type': 'object',
+            'properties': {
+                'version': {
+                    'type': 'string'
+                },
+                'product': PRODUCT_SCHEMA
+            },
+            'required': ['product', 'version'],
+            'additionalProperties': False
+        },
+        'severity_id': {
+            'type': 'number',
+            'enum': [0, 1, 2, 3, 4, 5, 6, 99]
+        },
+        'start_time': {
+            'type': 'number'
+        },
+        'time': {
+            'type': 'number'
+        },
+        'type_uid': {
+            'type': 'number'
+        }
+    },
+    'required': [
+        'category_uid', 'class_uid', 'metadata', 'severity_id', 'time',
+        'type_uid'
+    ],
+    'additionalProperties':
+    False
+}
+
+ENDPOINT_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'intermediate_ips': {
+            'type': 'array'
+        },
+        'ip': {
+            'type': 'string'
+        },
+        'name': {
+            'type': 'string'
+        },
+        'port': {
+            'type': 'number'
+        },
+        'svc_name': {
+            'type': 'string'
+        },
+        'uid': {
+            'type': 'string'
+        }
+    },
+    'required': ['ip', 'port'],
+    'additionalProperties': False
+}
+
+AUTH_METADATA_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'acl_authorization': {
+            'type': 'object',
+            'properties': {
+                'host': {
+                    'type': 'string'
+                },
+                'op': {
+                    'type': 'string'
+                },
+                'permission_type': {
+                    'type': 'string'
+                },
+                'principal': {
+                    'type': 'string'
+                }
+            },
+            'required': ['host', 'op', 'permission_type', 'principal'],
+            'additionalProperties': False
+        },
+        'resource': {
+            'type': 'object',
+            'properties': {
+                'name': {
+                    'type': 'string'
+                },
+                'pattern': {
+                    'type': 'string'
+                },
+                'type': {
+                    'type': 'string'
+                }
+            },
+            'required': ['name', 'pattern', 'type'],
+            'additionalProperties': False
+        }
+    },
+    'required': ['acl_authorization', 'resource'],
+    'additionalProperties': False
+}
+
+API_ACTIVITY_SCHEMA = {
+    'type':
+    'object',
+    'properties': {
+        'activity_id': {
+            'type': 'number',
+            'enum': [0, 1, 2, 3, 4, 99]
+        },
+        'actor': {
+            'type': 'object',
+            'properties': {
+                'authorizations': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'properties': {
+                            'decision': {
+                                'type': 'string'
+                            },
+                            'policy': {
+                                'type': 'object',
+                                'properties': {
+                                    'desc': {
+                                        'type': 'string'
+                                    },
+                                    'name': {
+                                        'type': 'string'
+                                    }
+                                },
+                                'required': ['desc', 'name'],
+                                'additionalProperties': False
+                            },
+                        },
+                        'required': ['decision'],
+                        'additionalProperties': False
+                    }
+                },
+                'user': {
+                    'type': 'object',
+                    'properties': {
+                        'credential_uid': {
+                            'type': 'string'
+                        },
+                        'domain': {
+                            'type': 'string'
+                        },
+                        'name': {
+                            'type': 'string'
+                        },
+                        'type_id': {
+                            'type': 'number',
+                            'enum': [0, 1, 2, 3, 99]
+                        }
+                    },
+                    'required': ['name', 'type_id'],
+                    'additionalProperties': False
+                }
+            },
+            'required': ['authorizations', 'user'],
+            'additionalProperties': False
+        },
+        'api': {
+            'type': 'object',
+            'properties': {
+                'operation': {
+                    'type': 'string'
+                }
+            },
+            'required': ['operation'],
+            'additionalProperties': False
+        },
+        'dst_endpoint': ENDPOINT_SCHEMA,
+        'http_request': {
+            'type':
+            'object',
+            'properties': {
+                'http_headers': {
+                    'type': 'array',
+                    'items': {
+                        'type': 'object',
+                        'properties': {
+                            'name': {
+                                'type': 'string'
+                            },
+                            'value': {
+                                'type': 'string'
+                            }
+                        },
+                        'required': ['name', 'value'],
+                        'additionalProperties': False
+                    }
+                },
+                'http_method': {
+                    'type': 'string'
+                },
+                'url': {
+                    'type':
+                    'object',
+                    'properties': {
+                        'hostname': {
+                            'type': 'string'
+                        },
+                        'path': {
+                            'type': 'string'
+                        },
+                        'port': {
+                            'type': 'number'
+                        },
+                        'scheme': {
+                            'type': 'string'
+                        },
+                        'url_string': {
+                            'type': 'string'
+                        }
+                    },
+                    'required':
+                    ['hostname', 'path', 'port', 'scheme', 'url_string'],
+                    'additionalProperties':
+                    False
+                },
+                'user_agent': {
+                    'type': 'string'
+                },
+                'version': {
+                    'type': 'string'
+                }
+            },
+            'required':
+            ['http_headers', 'http_method', 'url', 'user_agent', 'version'],
+            'additionalProperties':
+            False
+        },
+        'resources': {
+            'type': 'object',
+            'properties': {
+                'name': {
+                    'type': 'string'
+                },
+                'type': {
+                    'type': 'string'
+                }
+            },
+            'required': ['name', 'type'],
+            'additionalProperties': False
+        },
+        'src_endpoint': ENDPOINT_SCHEMA,
+        'status_id': {
+            'type': 'number',
+            'enum': [0, 1, 2, 99]
+        },
+        'unmapped': {
+            'type': 'object',
+            'properties': {
+                'authorization_metadata': AUTH_METADATA_SCHEMA
+            },
+            'required': [],
+            'additionalProperties': False
+        }
+    },
+    'required': [
+        'activity_id', 'actor', 'api', 'dst_endpoint', 'src_endpoint',
+        'status_id', 'unmapped'
+    ],
+    'additionalProperties':
+    False
+}
+
+APPLICATION_ACTIVITY_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'activity_id': {
+            'type': 'number',
+            'enum': [0, 1, 2, 3, 4, 99]
+        },
+        'app': PRODUCT_SCHEMA
+    },
+    'required': ['activity_id', 'app'],
+    'additionalProperties': False
+}
+
+
+# A proper schema is an application based schema + the fields that exist
+# in the OCSF base schema.
+def _create_schema(schema):
+    return {
+        'type': 'object',
+        'properties': schema['properties'] | OCSF_BASE_SCHEMA['properties'],
+        'required': schema['required'] + OCSF_BASE_SCHEMA['required'],
+        'additionalProperties': False
+    }
+
+
+# All schemas outside of this list are nested within the supported structures
+# and are not expected to be observed as-is in the audit log
+VALID_AUDIT_SCHEMAS = [
+    _create_schema(schema)
+    for schema in [API_ACTIVITY_SCHEMA, APPLICATION_ACTIVITY_SCHEMA]
+]
+
+
+class AuditSchemeValidationException(Exception):
+    def __init__(self, excs):
+        failures = [str(exc) for exc in excs]
+        self.message = '\n'.join(failures)
+
+
+def validate_audit_contents(message):
+    """
+    This method verifies the validity of the contents of a message that
+    has already passed the schema check.
+    """
+    if 'count' not in message:
+        return 'start_time' not in message and 'end_time' not in message
+
+    if message['count'] <= 1:
+        return False
+    if 'start_time' not in message:
+        return False
+    if 'end_time' not in message:
+        return False
+    return True
+
+
+def validate_audit_schema(message):
+    """
+    Verify that a given message adheres to one of the supported audit log
+    record formats and if one of those checks pass, that the fields within
+    the records are themselves valid.
+    """
+    excs = []
+    for schema in VALID_AUDIT_SCHEMAS:
+        try:
+            jsonschema.validate(instance=message, schema=schema)
+            if not validate_audit_contents(message):
+                excs = [
+                    RuntimeError(
+                        f'Message {message} failed to pass content validation, check "count", "start_time" and "end_time keys/values"'
+                    )
+                ]
+                break
+            return
+        except Exception as e:
+            excs.append(e)
+    assert len(excs) > 0
+    raise AuditSchemeValidationException(excs)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -25,7 +25,7 @@ setup(
         'googleapis-common-protos==1.60.0', 'google.cloud.compute==1.14.0',
         'google-cloud-storage==2.11.0', 'proto-plus==1.22.3', 'rsa==4.9',
         'python-keycloak@git+https://github.com/redpanda-data/python-keycloak.git@10b822cb0320c54dbf5bf4fd00435afb1487415d',
-        'z3-solver==4.12.2', 'hypothesis==6.82'
+        'z3-solver==4.12.2', 'hypothesis==6.82', 'jsonschema==4.10.0'
     ],
     scripts=[],
 )


### PR DESCRIPTION
This PR adds the functionality to audit the admin server - enabled only when the proper configuration options are set. Th publish of an audit record occurs in the background that way the request handling path is not affected. The only way normal request processing will be modified is in the case the audit background queues are full. If so , the request is interrupted and a 500 response will be returned to the client.

Additional logic has been introduced to catch and handle authorization failures. Now upon observation of an authorization failure, redpanda will log the client IP and auth failure reason. If auditing is enabled this will also generate an audit log message, with all of the appropriate fields filled.

Ducktape tests have been written which test end to end functionality. Tests assert that expected records appear in the audit log only when the proper settings are enabled, and when disabled none of these records are generated. Furthermore the tests assert the records conform to the OCSF schema and that their contents are valid.  


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* Implements auditing capabilities for the admin server. To configure set `audit_enabled` to `True` and ensure one of the auditing enabled type in `audit_enabled_event_types` is set to `management`
