### PR TITLE
cloud_storage: Use zero copy for cache writes

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2516,7 +2516,7 @@ ss::future<> ntp_archiver::apply_spillover() {
         auto reservation = co_await _cache.reserve_space(len, 1);
         co_await _cache.put(
           tail.get_manifest_path()(),
-          str,
+          std::move(str),
           reservation,
           _conf->upload_io_priority);
 

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -1364,7 +1364,7 @@ async_manifest_view::hydrate_manifest(
         auto reservation = co_await _cache.local().reserve_space(len, 1);
         co_await _cache.local().put(
           manifest.get_manifest_path()(),
-          str,
+          std::move(str),
           reservation,
           priority_manager::local().shadow_indexing_priority());
         _ts_probe.on_spillover_manifest_hydration();

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -132,7 +132,7 @@ public:
     /// proceeding with put
     ss::future<> put(
       std::filesystem::path key,
-      ss::input_stream<char>& data,
+      ss::input_stream<char> data,
       space_reservation_guard& reservation,
       ss::io_priority_class io_priority
       = priority_manager::local().shadow_indexing_priority(),

--- a/src/v/cloud_storage/remote_file.cc
+++ b/src/v/cloud_storage/remote_file.cc
@@ -75,9 +75,7 @@ ss::future<uint64_t>
 remote_file::put_in_cache(uint64_t size_bytes, ss::input_stream<char> s) {
     try {
         auto reservation = co_await _cache.reserve_space(size_bytes, 1);
-        co_await _cache.put(_remote_path, s, reservation).finally([&s] {
-            return s.close();
-        });
+        co_await _cache.put(_remote_path, std::move(s), reservation);
     } catch (...) {
         auto put_exception = std::current_exception();
         vlog(

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -419,10 +419,7 @@ ss::future<uint64_t> remote_segment::put_segment_in_cache_and_create_index(
       remote_segment_sampling_step_bytes);
     auto fparse = parser->consume().finally(
       [parser] { return parser->close(); });
-    auto fput
-      = _cache.put(_path, sput, reservation).finally([sref = std::ref(sput)] {
-            return sref.get().close();
-        });
+    auto fput = _cache.put(_path, std::move(sput), reservation);
     auto [rparse, rput] = co_await ss::when_all(
       std::move(fparse), std::move(fput));
     bool index_prepared = true;
@@ -447,7 +444,9 @@ ss::future<uint64_t> remote_segment::put_segment_in_cache_and_create_index(
           storage::segment_index::estimate_size(size_bytes), 1);
         auto index_stream = make_iobuf_input_stream(tmpidx.to_iobuf());
         co_await _cache.put(
-          generate_index_path(_path), index_stream, index_reservation);
+          generate_index_path(_path),
+          std::move(index_stream),
+          index_reservation);
         _index = std::move(tmpidx);
     }
     co_return size_bytes;
@@ -458,9 +457,7 @@ ss::future<uint64_t> remote_segment::put_segment_in_cache(
   space_reservation_guard& reservation,
   ss::input_stream<char> s) {
     try {
-        co_await _cache.put(_path, s, reservation).finally([&s] {
-            return s.close();
-        });
+        co_await _cache.put(_path, std::move(s), reservation);
     } catch (...) {
         auto put_exception = std::current_exception();
         vlog(
@@ -478,8 +475,8 @@ ss::future<> remote_segment::put_chunk_in_cache(
   ss::input_stream<char> stream,
   chunk_start_offset_t chunk_start) {
     try {
-        co_await _cache.put(get_path_to_chunk(chunk_start), stream, reservation)
-          .finally([&stream] { return stream.close(); });
+        co_await _cache.put(
+          get_path_to_chunk(chunk_start), std::move(stream), reservation);
     } catch (...) {
         auto put_exception = std::current_exception();
         vlog(
@@ -548,9 +545,7 @@ ss::future<> remote_segment::do_hydrate_index() {
 
     auto reservation = co_await _cache.reserve_space(buf.size_bytes(), 1);
     auto str = make_iobuf_input_stream(std::move(buf));
-    co_await _cache.put(_index_path, str, reservation).finally([&str] {
-        return str.close();
-    });
+    co_await _cache.put(_index_path, std::move(str), reservation);
 }
 
 ss::future<> remote_segment::do_hydrate_txrange() {
@@ -587,8 +582,8 @@ ss::future<> remote_segment::do_hydrate_txrange() {
 
         auto [stream, size] = co_await manifest.serialize();
         auto reservation = co_await _cache.reserve_space(size, 1);
-        co_await _cache.put(manifest.get_manifest_path(), stream, reservation)
-          .finally([&s = stream]() mutable { return s.close(); });
+        co_await _cache.put(
+          manifest.get_manifest_path(), std::move(stream), reservation);
     }
 
     _tx_range = std::move(manifest).get_tx_range();

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -91,9 +91,11 @@ public:
             auto reservation = cache.local().reserve_space(123, 1).get();
             cache.local()
               .put(
-                path, stream.stream, reservation, ss::default_priority_class())
+                path,
+                std::move(stream.stream),
+                reservation,
+                ss::default_priority_class())
               .get();
-            stream.stream.close().get();
         }
         // upload to the cloud
         auto [in_stream, size_bytes] = spm.serialize().get();
@@ -134,9 +136,12 @@ public:
         auto stream = spm.serialize().get();
         auto reservation = cache.local().reserve_space(123, 1).get();
         cache.local()
-          .put(path, stream.stream, reservation, ss::default_priority_class())
+          .put(
+            path,
+            std::move(stream.stream),
+            reservation,
+            ss::default_priority_class())
           .get();
-        stream.stream.close().get();
     }
 
     void load_spillover_manifest_from_file(const ss::sstring& spill_path) {
@@ -214,9 +219,11 @@ public:
             auto reservation = cache.local().reserve_space(123, 1).get();
             cache.local()
               .put(
-                path, stream.stream, reservation, ss::default_priority_class())
+                path,
+                std::move(stream.stream),
+                reservation,
+                ss::default_priority_class())
               .get();
-            stream.stream.close().get();
         }
         // upload to the cloud
         auto [in_stream, size_bytes] = spm.serialize().get();

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -96,7 +96,7 @@ FIXTURE_TEST(is_cached_after_put_success, cache_test_fixture) {
     auto reservation
       = sharded_cache.local().reserve_space(buf.size_bytes(), 1).get();
     auto input = make_iobuf_input_stream(std::move(buf));
-    sharded_cache.local().put(KEY, input, reservation).get();
+    sharded_cache.local().put(KEY, std::move(input), reservation).get();
 
     auto is_cached = sharded_cache.local().is_cached(KEY).get();
 
@@ -293,7 +293,7 @@ FIXTURE_TEST(put_outside_cache_dir_throws, cache_test_fixture) {
     auto input = make_iobuf_input_stream(std::move(buf));
 
     BOOST_CHECK_EXCEPTION(
-      sharded_cache.local().put(key, input, reservation).get(),
+      sharded_cache.local().put(key, std::move(input), reservation).get(),
       std::invalid_argument,
       [](const std::invalid_argument& e) {
           return std::string(e.what()).find(

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -100,7 +100,7 @@ public:
               ? space_reservation_guard(sharded_cache.local(), 0, 0)
               : sharded_cache.local().reserve_space(buf.size_bytes(), 1).get();
         auto input = make_iobuf_input_stream(std::move(buf));
-        sharded_cache.local().put(key, input, reservation).get();
+        sharded_cache.local().put(key, std::move(input), reservation).get();
     }
 
     ss::future<> clean_up_at_start() {


### PR DESCRIPTION
Currently, when the segments or chunks are downloaded the data is copied from the input stream (S3 download) to the output stream (file cache). This introduced double buffering since both `input_stream` and `output_stream` have their own buffering. The bypass may help limit memory usage.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Use zero-copy when writing to the cloud-storage cache