### PR TITLE
rpk/transform/deploy: prompt if missing input/output topic

### DIFF
--- a/src/go/rpk/pkg/cli/transform/deploy.go
+++ b/src/go/rpk/pkg/cli/transform/deploy.go
@@ -67,6 +67,21 @@ The --env-var can be repeated to specify multiple variables.
 			err = validateProjectConfig(cfg, err)
 			out.MaybeDieErr(err)
 
+			if cfg.InputTopic == "" {
+				cfg.InputTopic, err = out.Prompt("Select an input topic:")
+				out.MaybeDie(err, "no input topic: %v", err)
+				if cfg.InputTopic == "" {
+					out.Die("missing input topic")
+				}
+			}
+			if cfg.OutputTopic == "" {
+				cfg.OutputTopic, err = out.Prompt("Select an output topic:")
+				out.MaybeDie(err, "no output topic: %v", err)
+				if cfg.OutputTopic == "" {
+					out.Die("missing output topic")
+				}
+			}
+
 			deployable := fmt.Sprintf("%s.wasm", cfg.Name)
 			if len(args) == 1 {
 				deployable = args[0]
@@ -197,12 +212,6 @@ func validateProjectConfig(cfg project.Config, fileConfigErr error) error {
 	}
 	if cfg.Name == "" {
 		return errors.New("missing name")
-	}
-	if cfg.InputTopic == "" {
-		return errors.New("missing input-topic")
-	}
-	if cfg.OutputTopic == "" {
-		return errors.New("missing output-topic")
 	}
 	return nil
 }


### PR DESCRIPTION
Without this prompt doing the following set of commands fails with an
error about missing topics:

```
rpk transform init
<follow prompts>
rpk transform build
rpk transform deploy
<error!>
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
