### PR TITLE
wasm: ensure that CPU usage is limited

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -89,14 +89,14 @@ fetch_dep(hdrhistogram
   REPO https://github.com/HdrHistogram/HdrHistogram_c
   TAG 0.11.5)
 
+list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --no-default-features)
+list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=async)
+
 # We need submodules for wasmtime to compile
 FetchContent_Declare(
   wasmtime
   GIT_REPOSITORY https://github.com/bytecodealliance/wasmtime
-  GIT_TAG b77b407b25c3c158be209b8df6d9054ac6e43203
-  # Remove the features we don't use.
-  PATCH_COMMAND
-    sed -i "s/default \\\\= \\\\['jitdump', 'wat', 'wasi', 'cache', 'parallel\\\\-compilation', 'async'\\\\]/default = ['async']/g" crates/c-api/Cargo.toml
+  GIT_TAG 81b14a50431104631023fb5723041667fd141efb
   GIT_PROGRESS TRUE
   USES_TERMINAL_DOWNLOAD TRUE
   OVERRIDE_FIND_PACKAGE

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -104,6 +104,13 @@ cat /tmp/license.md | sort | uniq
 | equivalent | Apache-2.0 OR MIT |
 | fallible-iterator | Apache-2.0 OR MIT |
 | form_urlencoded | Apache-2.0 OR MIT |
+| futures | Apache-2.0 OR MIT |
+| futures-channel | Apache-2.0 OR MIT |
+| futures-core | Apache-2.0 OR MIT |
+| futures-io | Apache-2.0 OR MIT |
+| futures-sink | Apache-2.0 OR MIT |
+| futures-task | Apache-2.0 OR MIT |
+| futures-util | Apache-2.0 OR MIT |
 | fxhash | Apache-2.0 OR MIT |
 | fxprof-processed-profile | Apache-2.0 OR MIT |
 | generic-array | MIT |
@@ -133,9 +140,10 @@ cat /tmp/license.md | sort | uniq
 | once_cell | Apache-2.0 OR MIT |
 | paste | Apache-2.0 OR MIT |
 | percent-encoding | Apache-2.0 OR MIT |
+| pin-project-lite | Apache-2.0 OR MIT |
+| pin-utils | Apache-2.0 OR MIT |
 | ppv-lite86 | Apache-2.0 OR MIT |
 | proc-macro2 | Apache-2.0 OR MIT |
-| psm | Apache-2.0 OR MIT |
 | pulldown-cmark | MIT |
 | quote | Apache-2.0 OR MIT |
 | rand | Apache-2.0 OR MIT |

--- a/src/go/transform-sdk/internal/testdata/dynamic/transform.go
+++ b/src/go/transform-sdk/internal/testdata/dynamic/transform.go
@@ -35,6 +35,9 @@ func identityTransform(e redpanda.WriteEvent) ([]redpanda.Record, error) {
 		return nil, errors.New("☠︎")
 	case "bomb":
 		panic("💥")
+	case "loop":
+		for {
+		}
 	case "allocate":
 		amt := binary.LittleEndian.Uint32(e.Record().Value)
 		allocated.Grow(int(amt))

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2243,6 +2243,9 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
             .per_core_pool_size_bytes = cluster.wasm_per_core_memory_reservation.value(),
             .per_engine_memory_limit = cluster.wasm_per_function_memory_limit.value(),
           },
+          .stack_memory = {
+            .debug_host_stack_usage = false,
+          },
         };
         _wasm_runtime->start(config).get();
         _transform_service.invoke_on_all(&transform::service::start).get();

--- a/src/v/wasm/allocator.cc
+++ b/src/v/wasm/allocator.cc
@@ -10,9 +10,15 @@
  */
 #include "wasm/allocator.h"
 
+#include "vassert.h"
+#include "vlog.h"
+#include "wasm/logger.h"
+
 #include <seastar/core/align.hh>
 #include <seastar/core/aligned_buffer.hh>
 #include <seastar/core/print.hh>
+
+#include <sys/mman.h>
 
 #include <stdexcept>
 #include <unistd.h>
@@ -44,6 +50,78 @@ std::optional<heap_memory> heap_allocator::allocate(request req) {
 
 void heap_allocator::deallocate(heap_memory m) {
     _memory_pool.push_back(std::move(m));
+}
+
+stack_memory::stack_memory(stack_bounds bounds, allocated_memory data)
+  : _bounds(bounds)
+  , _data(std::move(data)) {}
+
+stack_memory::~stack_memory() {
+    if (!_data) {
+        // This can happen if the memory was moved.
+        return;
+    }
+    int r = ::mprotect(
+      _data.get(), _bounds.bottom - _data.get(), PROT_READ | PROT_WRITE);
+    vassert(r == 0, "stack memory must be able to unprotect on destruction");
+}
+
+size_t stack_memory::size() const { return _bounds.top - _bounds.bottom; }
+
+stack_bounds stack_memory::bounds() const { return _bounds; }
+
+stack_allocator::stack_allocator(config c)
+  : _tracking_enabled(c.tracking_enabled)
+  , _page_size(::getpagesize()) {}
+
+stack_memory stack_allocator::allocate(size_t size) {
+    size = ss::align_up(size, _page_size);
+    stack_memory mem;
+    // Reuse a page
+    if (!_memory_pool.empty() && _memory_pool.front().size() == size) {
+        mem = std::move(_memory_pool.front());
+        _memory_pool.pop_front();
+    } else {
+        // Create a stack with a guard page and aligned to a page.
+        auto buffer = ss::allocate_aligned_buffer<uint8_t>(
+          size + _page_size, _page_size);
+        // Protect the guard page by making it read only.
+        ::mprotect(buffer.get(), _page_size, PROT_READ);
+        uint8_t* bottom = buffer.get() + _page_size;
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+        stack_bounds bounds{.top = bottom + size, .bottom = bottom};
+        mem = {bounds, std::move(buffer)};
+    }
+    if (_tracking_enabled) {
+        _live_stacks.emplace(mem.bounds());
+    }
+    return mem;
+}
+
+bool stack_allocator::tracking_enabled() const { return _tracking_enabled; }
+
+std::optional<stack_bounds>
+stack_allocator::stack_bounds_for_address(uint8_t* address) const {
+    auto it = _live_stacks.lower_bound({.top = address, .bottom = nullptr});
+    if (it == _live_stacks.end() || address < it->bottom) {
+        return std::nullopt;
+    }
+    return *it;
+}
+
+void stack_allocator::deallocate(stack_memory mem) {
+    if (_tracking_enabled) {
+        _live_stacks.erase(mem.bounds());
+    }
+    // Return this stack back to the pool so that it can be reused.
+    _memory_pool.push_back(std::move(mem));
+}
+
+std::ostream& operator<<(std::ostream& os, const stack_bounds& bounds) {
+    return os << ss::format(
+             "{{.top = {}, .bottom = {}}}",
+             static_cast<void*>(bounds.top),
+             static_cast<void*>(bounds.bottom));
 }
 
 } // namespace wasm

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -88,10 +88,21 @@ public:
 
     struct config {
         struct heap_memory {
+            // per core how many bytes to reserve
             size_t per_core_pool_size_bytes;
+            // per engine the max amount of memory
             size_t per_engine_memory_limit;
         };
         heap_memory heap_memory;
+        struct stack_memory {
+            // Enable debugging of host function's stack usage.
+            // These host functions are called on the VM stack, so we need to
+            // ensure that we aren't susceptible to guests that use most of the
+            // stack and then our host function overflowing the rest of the
+            // stack.
+            bool debug_host_stack_usage;
+        };
+        stack_memory stack_memory;
     };
 
     virtual ss::future<> start(config) = 0;

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -138,6 +138,18 @@ void WasmTestFixture::SetUp() {
           .per_core_pool_size_bytes = MAX_MEMORY * 4,
           .per_engine_memory_limit = MAX_MEMORY,
         },
+        .stack_memory = {
+#ifdef NDEBUG
+          // Only turn this on if ASAN is off.
+          // With ASAN on, we get issues because we haven't told
+          // ASAN that the stack has switched (as this happens within
+          // wasmtime and we don't have the ability to instrument rust 
+          // with ASAN checks).
+          .debug_host_stack_usage = true,
+#else
+          .debug_host_stack_usage = false,
+#endif
+        },
     };
     _runtime->start(wasm_runtime_config).get();
     _meta = {

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -14,6 +14,7 @@
 #include "model/transform.h"
 #include "ssx/thread_worker.h"
 #include "storage/parser_utils.h"
+#include "utils/human.h"
 #include "utils/type_traits.h"
 #include "vassert.h"
 #include "wasm/allocator.h"
@@ -34,9 +35,12 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/backtrace.hh>
+#include <seastar/util/bool_class.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/noncopyable_function.hh>
+#include <seastar/util/optimized_optional.hh>
 
+#include <alloca.h>
 #include <cmath>
 #include <csignal>
 #include <memory>
@@ -49,8 +53,18 @@
 namespace wasm::wasmtime {
 
 namespace {
-
-constexpr uint64_t wasmtime_fuel_amount = 1'000'000'000;
+// Our guidelines recommend allocating max 128KB at once. Since we also need to
+// allocate a guard page, allocate 128KB-4KB of usable stack space.
+constexpr size_t vm_stack_size = 124_KiB;
+// The WebAssembly code gets at half the stack space for it's own work.
+constexpr size_t max_vm_guest_stack_usage = 64_KiB;
+// We allow for half the stack for host functions,
+// plus a little wiggle room to not get too close
+// to the guard page.
+constexpr size_t max_host_function_stack_usage = vm_stack_size
+                                                 - max_vm_guest_stack_usage
+                                                 - 4_KiB;
+constexpr uint64_t fuel_amount = 1'000'000'000;
 
 template<typename T, auto fn>
 struct deleter {
@@ -347,7 +361,7 @@ private:
         uint64_t fuel = 0;
         wasmtime_context_fuel_remaining(ctx, &fuel);
         handle<wasmtime_error_t, wasmtime_error_delete> error(
-          wasmtime_context_add_fuel(ctx, wasmtime_fuel_amount - fuel));
+          wasmtime_context_add_fuel(ctx, fuel_amount - fuel));
         check_error(error.get());
     }
 
@@ -523,6 +537,17 @@ private:
     std::optional<ss::future<>> _pending_host_function;
 };
 
+// If strict stack checking is configured
+//
+// Strict stack checking ensures that our host functions don't use too much
+// stack, even if in our tests they leave plenty of extra stack space (not
+// all VM guest programs will be so nice).
+struct strict_stack_config {
+    ss::sharded<stack_allocator>* allocator;
+
+    bool enabled() const { return allocator != nullptr; }
+};
+
 template<auto value>
 struct host_function;
 
@@ -537,7 +562,10 @@ public:
      * Register a host function such that it can be invoked from the Wasmtime
      * VM.
      */
-    static void reg(wasmtime_linker_t* linker, std::string_view function_name) {
+    static void reg(
+      wasmtime_linker_t* linker,
+      std::string_view function_name,
+      const strict_stack_config& ssc) {
         std::vector<ffi::val_type> ffi_inputs;
         ffi::transform_types<ArgTypes...>(ffi_inputs);
         std::vector<ffi::val_type> ffi_outputs;
@@ -547,6 +575,37 @@ public:
         // Takes ownership of inputs and outputs
         handle<wasm_functype_t, wasm_functype_delete> functype{
           wasm_functype_new(&inputs, &outputs)};
+
+        if (ssc.enabled()) {
+            if constexpr (ss::is_future<ReturnType>::value) {
+                handle<wasmtime_error_t, wasmtime_error_delete> error(
+                  wasmtime_linker_define_async_func(
+                    linker,
+                    Module::name.data(),
+                    Module::name.size(),
+                    function_name.data(),
+                    function_name.size(),
+                    functype.get(),
+                    &invoke_async_host_fn_with_strict_stack_checking,
+                    /*data=*/ssc.allocator,
+                    /*finalizer=*/nullptr));
+                check_error(error.get());
+            } else {
+                handle<wasmtime_error_t, wasmtime_error_delete> error(
+                  wasmtime_linker_define_func(
+                    linker,
+                    Module::name.data(),
+                    Module::name.size(),
+                    function_name.data(),
+                    function_name.size(),
+                    functype.get(),
+                    &invoke_sync_host_fn_with_strict_stack_checking,
+                    /*data=*/ssc.allocator,
+                    /*finalizer=*/nullptr));
+                check_error(error.get());
+            }
+            return;
+        }
 
         if constexpr (ss::is_future<ReturnType>::value) {
             handle<wasmtime_error_t, wasmtime_error_delete> error(
@@ -760,12 +819,96 @@ private:
         mem->set_underlying_memory(&extern_item.of.memory);
         return nullptr;
     }
+
+    static wasm_trap_t* invoke_sync_host_fn_with_strict_stack_checking(
+      void* env,
+      wasmtime_caller_t* caller,
+      const wasmtime_val_t* args,
+      size_t nargs,
+      wasmtime_val_t* results,
+      size_t nresults) {
+        auto* allocator = static_cast<ss::sharded<stack_allocator>*>(env);
+        uint8_t dummy_stack_var = 0;
+        auto bounds = allocator->local().stack_bounds_for_address(
+          &dummy_stack_var);
+        if (!bounds) {
+            vlog(wasm_log.warn, "can't find vm stack!");
+            return invoke_sync_host_fn(
+              nullptr, caller, args, nargs, results, nresults);
+        }
+        // Ensure that we only use `max_host_function_stack_usage` by
+        // allocing enough to call the host function with only that much
+        // stack space left.
+        std::ptrdiff_t stack_left = (&dummy_stack_var) - bounds->bottom;
+        void* stack_ptr = ::alloca(stack_left - max_host_function_stack_usage);
+        // Prevent the alloca from being optimized away by logging the result.
+        vlog(
+          wasm_log.trace,
+          "alloca-ing {}, stack left: {}, alloca address: {}, stack bounds: {}",
+          human::bytes(stack_left - max_host_function_stack_usage),
+          human::bytes(stack_left),
+          stack_ptr,
+          bounds);
+        return invoke_sync_host_fn(
+          nullptr, caller, args, nargs, results, nresults);
+    }
+
+    static void invoke_async_host_fn_with_strict_stack_checking(
+      void* env,
+      wasmtime_caller_t* caller,
+      const wasmtime_val_t* args,
+      size_t nargs,
+      wasmtime_val_t* results,
+      size_t nresults,
+      wasm_trap_t** trap_ret,
+      wasmtime_async_continuation_t* continuation) {
+        auto* allocator = static_cast<ss::sharded<stack_allocator>*>(env);
+        uint8_t dummy_stack_var = 0;
+        auto bounds = allocator->local().stack_bounds_for_address(
+          &dummy_stack_var);
+        if (!bounds) {
+            vlog(wasm_log.warn, "can't find vm stack!");
+            invoke_async_host_fn(
+              nullptr,
+              caller,
+              args,
+              nargs,
+              results,
+              nresults,
+              trap_ret,
+              continuation);
+            return;
+        }
+        // Ensure that we only use `max_host_function_stack_usage` by
+        // allocing enough to call the host function with only that much
+        // stack space left.
+        std::ptrdiff_t stack_left = (&dummy_stack_var) - bounds->bottom;
+        void* stack_ptr = ::alloca(stack_left - max_host_function_stack_usage);
+        // Prevent the alloca from being optimized away by logging the result.
+        vlog(
+          wasm_log.trace,
+          "alloca-ing {}, stack left: {}, alloca address: {}, stack bounds: {}",
+          human::bytes(stack_left - max_host_function_stack_usage),
+          human::bytes(stack_left),
+          stack_ptr,
+          bounds);
+        invoke_async_host_fn(
+          nullptr,
+          caller,
+          args,
+          nargs,
+          results,
+          nresults,
+          trap_ret,
+          continuation);
+    }
 };
 
-void register_wasi_module(wasmtime_linker_t* linker) {
+void register_wasi_module(
+  wasmtime_linker_t* linker, const strict_stack_config& ssc) {
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define REG_HOST_FN(name)                                                      \
-    host_function<&wasi::preview1_module::name>::reg(linker, #name)
+    host_function<&wasi::preview1_module::name>::reg(linker, #name, ssc)
     REG_HOST_FN(args_get);
     REG_HOST_FN(args_sizes_get);
     REG_HOST_FN(environ_get);
@@ -813,19 +956,21 @@ void register_wasi_module(wasmtime_linker_t* linker) {
 #undef REG_HOST_FN
 }
 
-void register_transform_module(wasmtime_linker_t* linker) {
+void register_transform_module(
+  wasmtime_linker_t* linker, const strict_stack_config& ssc) {
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define REG_HOST_FN(name)                                                      \
-    host_function<&transform_module::name>::reg(linker, #name)
+    host_function<&transform_module::name>::reg(linker, #name, ssc)
     REG_HOST_FN(read_batch_header);
     REG_HOST_FN(read_record);
     REG_HOST_FN(write_record);
 #undef REG_HOST_FN
 }
-void register_sr_module(wasmtime_linker_t* linker) {
+void register_sr_module(
+  wasmtime_linker_t* linker, const strict_stack_config& ssc) {
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define REG_HOST_FN(name)                                                      \
-    host_function<&schema_registry_module::name>::reg(linker, #name)
+    host_function<&schema_registry_module::name>::reg(linker, #name, ssc)
     REG_HOST_FN(get_schema_definition);
     REG_HOST_FN(get_schema_definition_len);
     REG_HOST_FN(get_subject_schema);
@@ -889,15 +1034,11 @@ public:
         wasmtime_config_async_support_set(config, true);
         // Set max stack size to generally be as big as a contiguous memory
         // region we're willing to allocate in Redpanda.
-        //
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-        wasmtime_config_async_stack_size_set(config, 128_KiB);
+        wasmtime_config_async_stack_size_set(config, vm_stack_size);
         // The stack size needs to be less than the async stack size, and
         // whatever is difference between the two is how much host functions can
         // get, make sure to leave our own functions some room to execute.
-        //
-        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-        wasmtime_config_max_wasm_stack_set(config, 64_KiB);
+        wasmtime_config_max_wasm_stack_set(config, max_vm_guest_stack_usage);
         // This disables static memory, see:
         // https://docs.wasmtime.dev/contributing-architecture.html#linear-memory
         wasmtime_config_static_memory_maximum_size_set(config, 0_KiB);
@@ -955,7 +1096,7 @@ public:
           .num_heaps = num_heaps,
         });
         co_await _stack_allocator.start(stack_allocator::config{
-          .tracking_enabled = false,
+          .tracking_enabled = c.stack_memory.debug_host_stack_usage,
         });
         co_await _alien_thread.start({.name = "wasm"});
         co_await ss::smp::invoke_on_all([] {
@@ -979,33 +1120,44 @@ public:
     ss::future<ss::shared_ptr<factory>> make_factory(
       model::transform_metadata meta, iobuf buf, ss::logger* logger) override {
         auto preinitialized = ss::make_lw_shared<preinitialized_instance>();
-        co_await _alien_thread.submit([this, &meta, &buf, &preinitialized] {
-            vlog(wasm_log.debug, "compiling wasm module {}", meta.name);
-            // This can be a large contiguous allocation, however it happens
-            // on an alien thread so it bypasses the seastar allocator.
-            bytes b = iobuf_to_bytes(buf);
-            wasmtime_module_t* user_module_ptr = nullptr;
-            handle<wasmtime_error_t, wasmtime_error_delete> error{
-              wasmtime_module_new(
-                _engine.get(), b.data(), b.size(), &user_module_ptr)};
-            check_error(error.get());
-            handle<wasmtime_module_t, wasmtime_module_delete> user_module{
-              user_module_ptr};
-            wasm_log.info("Finished compiling wasm module {}", meta.name);
 
-            handle<wasmtime_linker_t, wasmtime_linker_delete> linker{
-              wasmtime_linker_new(_engine.get())};
+        // Enable strict stack checking only if tracking is enabled.
+        //
+        // (strict stack checking ensures our host functions don't use too much
+        // stack space, even when guests leave extra stack).
+        strict_stack_config ssc = {
+          .allocator = _stack_allocator.local().tracking_enabled()
+                         ? &_stack_allocator
+                         : nullptr,
+        };
+        co_await _alien_thread.submit(
+          [this, &meta, &buf, &preinitialized, &ssc] {
+              vlog(wasm_log.debug, "compiling wasm module {}", meta.name);
+              // This can be a large contiguous allocation, however it happens
+              // on an alien thread so it bypasses the seastar allocator.
+              bytes b = iobuf_to_bytes(buf);
+              wasmtime_module_t* user_module_ptr = nullptr;
+              handle<wasmtime_error_t, wasmtime_error_delete> error{
+                wasmtime_module_new(
+                  _engine.get(), b.data(), b.size(), &user_module_ptr)};
+              check_error(error.get());
+              handle<wasmtime_module_t, wasmtime_module_delete> user_module{
+                user_module_ptr};
+              wasm_log.info("Finished compiling wasm module {}", meta.name);
 
-            register_transform_module(linker.get());
-            register_sr_module(linker.get());
-            register_wasi_module(linker.get());
+              handle<wasmtime_linker_t, wasmtime_linker_delete> linker{
+                wasmtime_linker_new(_engine.get())};
 
-            wasmtime_instance_pre_t* preinitialized_ptr = nullptr;
-            error.reset(wasmtime_linker_instantiate_pre(
-              linker.get(), user_module.get(), &preinitialized_ptr));
-            preinitialized->underlying.reset(preinitialized_ptr);
-            check_error(error.get());
-        });
+              register_transform_module(linker.get(), ssc);
+              register_sr_module(linker.get(), ssc);
+              register_wasi_module(linker.get(), ssc);
+
+              wasmtime_instance_pre_t* preinitialized_ptr = nullptr;
+              error.reset(wasmtime_linker_instantiate_pre(
+                linker.get(), user_module.get(), &preinitialized_ptr));
+              preinitialized->underlying.reset(preinitialized_ptr);
+              check_error(error.get());
+          });
         co_return ss::make_shared<wasmtime_engine_factory>(
           _engine.get(),
           std::move(meta),

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -1048,6 +1048,11 @@ public:
         // exceptions to grab a lock in libgcc and deadlock the Redpanda
         // process.
         wasmtime_config_native_unwind_info_set(config, false);
+        // Memory data segments can be initialized using mmap tricks and copy on
+        // write memory support in the kernel. However this functionality isn't
+        // exposed in custom allocators, and we'd have to `mmap` to use this
+        // feature. Since we can't use it just disable it.
+        wasmtime_config_memory_init_cow_set(config, false);
 
         wasmtime_memory_creator_t memory_creator = {
           .env = this,


### PR DESCRIPTION
Add tests to ensure that user functions don't cause reactor stalls nor run forever.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
