### PR TITLE
tests: include compression at init topic creation

### DIFF
--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -86,6 +86,8 @@ sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule require
             args += ["--config", f"retention.ms={spec.retention_ms}"]
         if spec.max_message_bytes:
             args += ["--config", f"max.message.bytes={spec.max_message_bytes}"]
+        if spec.compression_type:
+            args += ["--config", f"compression.type={spec.compression_type}"]
         return self._run("kafka-topics.sh", args)
 
     def create_topic_partitions(self, topic, partitions):

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -85,7 +85,7 @@ class TopicSpec:
                  partition_count=1,
                  replication_factor=3,
                  cleanup_policy=CLEANUP_DELETE,
-                 compression_type=COMPRESSION_PRODUCER,
+                 compression_type=None,
                  message_timestamp_type=TIMESTAMP_CREATE_TIME,
                  segment_bytes=None,
                  retention_bytes=None,


### PR DESCRIPTION
Previously, the compression type was set but we did not create the topic with the compression config. Now compression is unset by default and, to support compatibility, KafkaCliTools includes the compression config when the compression type is given.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none