### PR TITLE
s3_client: Check if response contains error

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -34,6 +34,7 @@
 
 #include <boost/beast/core/error.hpp>
 #include <boost/beast/http/field.hpp>
+#include <boost/beast/http/status.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
 #include <gnutls/crypto.h>
@@ -41,6 +42,7 @@
 #include <bit>
 #include <exception>
 #include <utility>
+#include <variant>
 
 namespace cloud_storage_clients {
 
@@ -852,10 +854,22 @@ ss::future<> s3_client::do_delete_object(
       });
 }
 
-static auto iobuf_to_delete_objects_result(iobuf&& buf) {
+static std::variant<client::delete_objects_result, rest_error_response>
+iobuf_to_delete_objects_result(iobuf&& buf) {
     auto root = util::iobuf_to_ptree(std::move(buf), s3_log);
     auto result = client::delete_objects_result{};
     try {
+        if (root.count("Error.Code") > 0) {
+            // This is an error response. S3 can reply with 200 error code and
+            // error response in the body.
+            constexpr const char* empty = "";
+            auto code = root.get<ss::sstring>("Error.Code", empty);
+            auto msg = root.get<ss::sstring>("Error.Message", empty);
+            auto rid = root.get<ss::sstring>("Error.RequestId", empty);
+            auto res = root.get<ss::sstring>("Error.Resource", empty);
+            rest_error_response err(code, msg, rid, res);
+            return err;
+        }
         for (auto const& [tag, value] : root.get_child("DeleteResult")) {
             if (tag != "Error") {
                 continue;
@@ -920,8 +934,15 @@ auto s3_client::do_delete_objects(
                     return parse_rest_error_response<delete_objects_result>(
                       status, std::move(res));
                 }
-                return ss::make_ready_future<delete_objects_result>(
-                  iobuf_to_delete_objects_result(std::move(res)));
+                auto parse_result = iobuf_to_delete_objects_result(
+                  std::move(res));
+                if (std::holds_alternative<client::delete_objects_result>(
+                      parse_result)) {
+                    return ss::make_ready_future<delete_objects_result>(
+                      std::get<client::delete_objects_result>(parse_result));
+                }
+                return ss::make_exception_future<delete_objects_result>(
+                  std::get<rest_error_response>(parse_result));
             });
       });
 }


### PR DESCRIPTION
S3 can reply with error even if it's replying using status 200. Most of our parsing is done independent of status code (we're trying to check error fields every time). But in case of delete objects reply we're not trying to parse error fields if the status is 200. This commit fixes this and before any attempt at parsing the response is done we're checking if the 'Error.Code' field is present.

Fixes #14014
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none