### PR TITLE
ducktape/cloud_storage: Wait for at least two spillovers

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -273,7 +273,8 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
                     self.test_instance.topic, 0)
                 self.spillover_manifests = s3_snapshot.get_spillover_manifests(
                     NTP("kafka", self.test_instance.topic, 0))
-                if not self.spillover_manifests:
+                if not self.spillover_manifests or len(
+                        self.spillover_manifests) < 2:
                     return False
                 manifest_keys = set(self.manifest['segments'].keys())
                 spillover_keys = set()


### PR DESCRIPTION
When creating a manifest for reset we drop the first spillover and then use the rest of the spillovers to craft a new manifest. If only one spillover has been uploaded, then after dropping the first entry nothing is left to craft the manifest.

This change makes the test wait until more than one manifest is spilled over.

FIXES #13425 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
