### PR TITLE
ducktape/cloud_storage: Wait for topic info

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -591,6 +591,15 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         assert response[0].error_msg == '', f"Err msg: {response[0].error_msg}"
         assert new_lwm == response[0].new_start_offset, response[
             0].new_start_offset
+
+        def topic_info_populated():
+            return len(list(rpk.describe_topic(self.topic))) == 1
+
+        wait_until(topic_info_populated,
+                   timeout_sec=60,
+                   backoff_sec=1,
+                   err_msg=f"topic info not available for {self.topic}")
+
         topics_info = list(rpk.describe_topic(self.topic))
         assert len(topics_info) == 1
         assert topics_info[0].start_offset == new_lwm, topics_info
@@ -618,6 +627,11 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         wait_until(lambda: len(set(rpk.list_topics())) == 1,
                    timeout_sec=30,
                    backoff_sec=1)
+
+        wait_until(topic_info_populated,
+                   timeout_sec=60,
+                   backoff_sec=1,
+                   err_msg=f"topic info not available for {self.topic}")
         topics_info = list(rpk.describe_topic(self.topic))
         assert len(topics_info) == 1
         assert topics_info[0].start_offset == new_lwm, topics_info


### PR DESCRIPTION
The test asserts that rpk can describe topic, however there are test runs where the topic creation happens slightly after the topic info is requested.

This change wraps the describe operation in a wait loop so that the describe op is retried until it succeeds.

FIXES #11998 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
