### PR TITLE
[v23.2.x] ducktape/cloud_storage: Wait for at least two spillovers

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -269,7 +269,8 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
                     self.test_instance.topic, 0)
                 self.spillover_manifests = s3_snapshot.get_spillover_manifests(
                     NTP("kafka", self.test_instance.topic, 0))
-                if not self.spillover_manifests:
+                if not self.spillover_manifests or len(
+                        self.spillover_manifests) < 2:
                     return False
                 manifest_keys = set(self.manifest['segments'].keys())
                 spillover_keys = set()


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14183
Fixes: https://github.com/redpanda-data/redpanda/issues/14192,