### PR TITLE
cloud_storage: resume scrubbing from last scrubbed offset

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -539,6 +539,7 @@ ss::future<bool> ntp_archiver::sync_for_tests() {
 
 ss::future<std::error_code> ntp_archiver::process_anomalies(
   model::timestamp scrub_timestamp,
+  std::optional<model::offset> last_scrubbed_offset,
   cloud_storage::scrub_status status,
   cloud_storage::anomalies detected) {
     // If there's ongoing housekeeping job, let it finish first.
@@ -549,7 +550,12 @@ ss::future<std::error_code> ntp_archiver::process_anomalies(
     auto deadline = ss::lowres_clock::now() + sync_timeout;
 
     auto error = co_await _parent.archival_meta_stm()->process_anomalies(
-      scrub_timestamp, status, std::move(detected), deadline, _as);
+      scrub_timestamp,
+      last_scrubbed_offset,
+      status,
+      std::move(detected),
+      deadline,
+      _as);
     if (error != cluster::errc::success) {
         vlog(
           _rtclog.warn,

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -343,6 +343,7 @@ public:
 
     ss::future<std::error_code> process_anomalies(
       model::timestamp scrub_timestamp,
+      std::optional<model::offset> last_scrubbed_offset,
       cloud_storage::scrub_status status,
       cloud_storage::anomalies detected);
 

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -122,6 +122,7 @@ scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
 
     auto replicate_result = co_await _archiver.process_anomalies(
       model::timestamp::now(),
+      detect_result.last_scrubbed_offset,
       detect_result.status,
       std::move(detect_result.detected));
 

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -67,10 +67,14 @@ scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
           .remaining = quota};
     }
 
-    vlog(_logger.info, "Starting scrub with {} quota...", quota());
+    const auto scrub_from = _archiver.manifest().last_scrubbed_offset();
+    vlog(
+      _logger.info,
+      "Starting scrub with {} quota from offset {}",
+      quota(),
+      scrub_from);
 
     retry_chain_node anomaly_detection_rtc(5min, 100ms, &rtc_node);
-    const auto scrub_from = _archiver.manifest().last_scrubbed_offset();
     auto detect_result = co_await _detector.run(
       anomaly_detection_rtc, quota, scrub_from);
 
@@ -114,7 +118,9 @@ scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
 
     vlog(
       _logger.info,
-      "Scrub finished at {} with status {} and detected {} and used {} quota",
+      "Scrub which started at {} finished at {} with status {} and detected {} "
+      "and used {} quota",
+      scrub_from,
       detect_result.last_scrubbed_offset,
       detect_result.status,
       detect_result.detected,

--- a/src/v/cloud_storage/anomalies_detector.cc
+++ b/src/v/cloud_storage/anomalies_detector.cc
@@ -31,7 +31,9 @@ anomalies_detector::anomalies_detector(
   , _as(as) {}
 
 ss::future<anomalies_detector::result> anomalies_detector::run(
-  retry_chain_node& rtc_node, archival::run_quota_t quota) {
+  retry_chain_node& rtc_node,
+  archival::run_quota_t quota,
+  std::optional<model::offset> scrub_from) {
     _result = result{};
     _received_quota = quota;
 
@@ -88,8 +90,10 @@ ss::future<anomalies_detector::result> anomalies_detector::run(
         _result.detected.missing_partition_manifest = true;
     }
 
-    co_await check_manifest(manifest, rtc_node);
-    if (should_stop()) {
+    const auto stop_at_stm = co_await check_manifest(
+      manifest, scrub_from, rtc_node);
+    if (stop_at_stm == stop_detector::yes) {
+        _result.status = scrub_status::partial;
         co_return _result;
     }
 
@@ -98,15 +102,14 @@ ss::future<anomalies_detector::result> anomalies_detector::run(
         first_seg_previous_manifest = *manifest.begin();
     }
 
-    for (const auto& spill_manifest_path : spill_manifest_paths) {
+    for (size_t i = 0; i < spill_manifest_paths.size(); ++i) {
         if (should_stop()) {
             _result.status = scrub_status::partial;
             co_return _result;
         }
 
-        ++_result.ops;
         const auto spill = co_await download_spill_manifest(
-          spill_manifest_path, rtc_node);
+          spill_manifest_paths[i], rtc_node);
         if (spill) {
             // Check adjacent segments which have a manifest
             // boundary between them.
@@ -118,8 +121,10 @@ ss::future<anomalies_detector::result> anomalies_detector::run(
                   _result.detected.segment_metadata_anomalies);
             }
 
-            co_await check_manifest(*spill, rtc_node);
-            if (should_stop()) {
+            const auto stop_at_spill = co_await check_manifest(
+              *spill, scrub_from, rtc_node);
+            if (stop_at_spill == stop_detector::yes) {
+                _result.status = scrub_status::partial;
                 co_return _result;
             }
 
@@ -129,12 +134,17 @@ ss::future<anomalies_detector::result> anomalies_detector::run(
                 vlog(
                   _logger.warn,
                   "Empty spillover manifest at {}",
-                  spill_manifest_path);
+                  spill_manifest_paths[i]);
             }
         } else {
             _result.status = scrub_status::partial;
             first_seg_previous_manifest = std::nullopt;
         }
+    }
+
+    _result.last_scrubbed_offset = std::nullopt;
+    if (scrub_from) {
+        _result.status = scrub_status::partial;
     }
 
     co_return _result;
@@ -144,6 +154,8 @@ ss::future<std::optional<spillover_manifest>>
 anomalies_detector::download_spill_manifest(
   const ss::sstring& path, retry_chain_node& rtc_node) {
     vlog(_logger.debug, "Downloading spillover manifest {}", path);
+
+    ++_result.ops;
 
     spillover_manifest spill{_ntp, _initial_rev};
     auto manifest_get_result = co_await _remote.download_manifest(
@@ -161,16 +173,42 @@ anomalies_detector::download_spill_manifest(
     co_return spill;
 }
 
-ss::future<> anomalies_detector::check_manifest(
-  const partition_manifest& manifest, retry_chain_node& rtc_node) {
+ss::future<anomalies_detector::stop_detector>
+anomalies_detector::check_manifest(
+  const partition_manifest& manifest,
+  std::optional<model::offset> scrub_from,
+  retry_chain_node& rtc_node) {
     vlog(_logger.debug, "Checking manifest {}", manifest.get_manifest_path());
+    if (
+      scrub_from
+      && (manifest.get_start_offset() > *scrub_from || manifest.get_last_offset() == scrub_from)) {
+        vlog(
+          _logger.debug,
+          "Manifest with offset range [{}, {}] ({}) is above the scrub "
+          "starting offset ({}), so it has been scrubed already. "
+          "Skipping ...",
+          manifest.get_start_offset(),
+          manifest.get_last_offset(),
+          manifest.get_manifest_path(),
+          scrub_from);
 
+        co_return stop_detector::no;
+    }
+
+    auto seg_iter = manifest.begin();
     std::optional<segment_meta> previous_seg_meta;
-    for (auto seg_iter = manifest.begin(); seg_iter != manifest.end();
-         ++seg_iter) {
+    if (scrub_from && manifest.get_last_offset() > scrub_from) {
+        if (auto iter = manifest.segment_containing(*scrub_from);
+            iter != manifest.end()) {
+            previous_seg_meta = *iter;
+            seg_iter = std::move(++iter);
+        }
+    }
+
+    for (; seg_iter != manifest.end(); ++seg_iter) {
         if (should_stop()) {
             _result.status = scrub_status::partial;
-            co_return;
+            co_return stop_detector::yes;
         }
 
         const auto seg_meta = *seg_iter;
@@ -196,12 +234,16 @@ ss::future<> anomalies_detector::check_manifest(
           previous_seg_meta,
           _result.detected.segment_metadata_anomalies);
         previous_seg_meta = seg_meta;
+
+        _result.last_scrubbed_offset = seg_meta.committed_offset;
     }
 
     vlog(
       _logger.debug,
       "Finished checking manifest {}",
       manifest.get_manifest_path());
+
+    co_return stop_detector::no;
 }
 
 bool anomalies_detector::should_stop() const {
@@ -230,6 +272,7 @@ anomalies_detector::result::operator+=(anomalies_detector::result&& other) {
     }
 
     ops += other.ops;
+    last_scrubbed_offset = other.last_scrubbed_offset;
     detected += std::move(other.detected);
 
     return *this;

--- a/src/v/cloud_storage/anomalies_detector.cc
+++ b/src/v/cloud_storage/anomalies_detector.cc
@@ -252,7 +252,10 @@ bool anomalies_detector::should_stop() const {
     }
 
     if (archival::run_quota_t{_result.ops} > _received_quota) {
-        return true;
+        // Allow the scrubbing of one segment even if that means
+        // going above the quota in order to ensure some forward
+        // progress in all quota cases.
+        return _result.last_scrubbed_offset.has_value();
     }
 
     return false;

--- a/src/v/cloud_storage/anomalies_detector.h
+++ b/src/v/cloud_storage/anomalies_detector.h
@@ -46,20 +46,28 @@ public:
 
     struct result {
         scrub_status status{scrub_status::full};
+        std::optional<model::offset> last_scrubbed_offset;
         anomalies detected;
         int32_t ops{0};
 
         result& operator+=(result&&);
     };
 
-    ss::future<result> run(retry_chain_node&, archival::run_quota_t);
+    ss::future<result> run(
+      retry_chain_node&,
+      archival::run_quota_t,
+      std::optional<model::offset> = std::nullopt);
 
 private:
     ss::future<std::optional<spillover_manifest>> download_spill_manifest(
       const ss::sstring& path, retry_chain_node& rtc_node);
 
-    ss::future<> check_manifest(
-      const partition_manifest& manifest, retry_chain_node& rtc_node);
+    using stop_detector = ss::bool_class<struct stop_detector_tag>;
+
+    ss::future<stop_detector> check_manifest(
+      const partition_manifest& manifest,
+      std::optional<model::offset>,
+      retry_chain_node& rtc_node);
 
     bool should_stop() const;
 

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2656,7 +2656,10 @@ void partition_manifest::from_iobuf(iobuf in) {
 }
 
 void partition_manifest::process_anomalies(
-  model::timestamp scrub_timestamp, scrub_status status, anomalies detected) {
+  model::timestamp scrub_timestamp,
+  std::optional<model::offset> last_scrubbed_offset,
+  scrub_status status,
+  anomalies detected) {
     // Firstly, update the in memory list of anomalies.
     // If the entires log was scrubbed, overwrite the old anomalies,
     // otherwise append to them.
@@ -2711,6 +2714,7 @@ void partition_manifest::process_anomalies(
       });
 
     _last_partition_scrub = scrub_timestamp;
+    _last_scrubbed_offset = last_scrubbed_offset;
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2725,6 +2725,15 @@ void partition_manifest::process_anomalies(
 
     _last_partition_scrub = scrub_timestamp;
     _last_scrubbed_offset = last_scrubbed_offset;
+
+    vlog(
+      cst_log.debug,
+      "[{}] Anomalies processed: {{ detected: {}, last_partition_scrub: {}, "
+      "last_scrubbed_offset: {} }}",
+      _ntp,
+      _detected_anomalies,
+      _last_partition_scrub,
+      _last_scrubbed_offset);
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -154,6 +154,7 @@ public:
       uint64_t archive_size_bytes,
       const fragmented_vector<segment_t>& spillover,
       model::timestamp last_partition_scrub,
+      std::optional<model::offset> last_scrubbed_offset,
       anomalies detected_anomalies)
       : _ntp(std::move(ntp))
       , _rev(rev)
@@ -169,6 +170,7 @@ public:
       , _start_kafka_offset_override(start_kafka_offset)
       , _archive_size_bytes(archive_size_bytes)
       , _last_partition_scrub(last_partition_scrub)
+      , _last_scrubbed_offset(last_scrubbed_offset)
       , _detected_anomalies(std::move(detected_anomalies)) {
         for (auto nm : replaced) {
             auto key = parse_segment_name(nm.name);
@@ -456,6 +458,8 @@ public:
 
     model::timestamp last_partition_scrub() const;
 
+    std::optional<model::offset> last_scrubbed_offset() const;
+
     const anomalies& detected_anomalies() const;
 
     /// Removes all replaced segments from the manifest.
@@ -510,7 +514,8 @@ public:
           _start_kafka_offset_override,
           _archive_size_bytes,
           _spillover_manifests,
-          _last_partition_scrub);
+          _last_partition_scrub,
+          _last_scrubbed_offset);
     }
     auto serde_fields() const {
         // this list excludes _mem_tracker, which is not serialized
@@ -530,7 +535,8 @@ public:
           _start_kafka_offset_override,
           _archive_size_bytes,
           _spillover_manifests,
-          _last_partition_scrub);
+          _last_partition_scrub,
+          _last_scrubbed_offset);
     }
 
     /// Compare two manifests for equality. Don't compare the mem_tracker.
@@ -630,6 +636,12 @@ private:
     spillover_manifest_map _spillover_manifests;
     // Timestamps at which the last partition scrub completed
     model::timestamp _last_partition_scrub;
+    // Last offset proccessed in the most recent scrubber run.
+    // Null if the last scrub reached the end of the log.
+    // Note that this offset is not linear. The scrubber will process
+    // each manifest from newest to oldest and the data within each
+    // manifest is processed from oldest to newest.
+    std::optional<model::offset> _last_scrubbed_offset;
 
     // The starting offset for a Kafka batch in the segment that corresponds
     // with `_start_offset`. This value is computed from

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -550,6 +550,7 @@ public:
 
     void process_anomalies(
       model::timestamp scrub_timestamp,
+      std::optional<model::offset> last_scrubbed_offset,
       scrub_status status,
       anomalies detected);
 

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -266,17 +266,55 @@ public:
           _as);
     }
 
-    cloud_storage::anomalies_detector::result
-    run_detector(archival::run_quota_t quota) {
+    cloud_storage::anomalies_detector::result run_detector(
+      archival::run_quota_t quota,
+      std::optional<model::offset> start_from = std::nullopt) {
         BOOST_REQUIRE(_detector.has_value());
 
         retry_chain_node anomaly_detection_rtc(1min, 100ms, &_root_rtc);
-        auto res = _detector->run(anomaly_detection_rtc, quota).get();
+        auto res
+          = _detector->run(anomaly_detection_rtc, quota, start_from).get();
         vlog(
           test_logger.info,
-          "Anomalies detector run result: status={}, detected={}",
+          "Anomalies detector run result: status={}, detected={}, "
+          "last_scrubbed_offset={}",
           res.status,
-          res.detected);
+          res.detected,
+          res.last_scrubbed_offset);
+
+        return res;
+    }
+
+    std::vector<cloud_storage::anomalies_detector::result>
+    run_detector_until_log_end(archival::run_quota_t quota) {
+        BOOST_REQUIRE(_detector.has_value());
+        std::vector<cloud_storage::anomalies_detector::result> partial_results;
+
+        auto iters = 1;
+
+        auto res = run_detector(quota);
+        partial_results.push_back(res);
+
+        while (res.last_scrubbed_offset != std::nullopt) {
+            BOOST_REQUIRE_LE(iters, 100);
+
+            res = run_detector(quota, res.last_scrubbed_offset);
+            partial_results.push_back(res);
+
+            ++iters;
+        }
+
+        return partial_results;
+    }
+
+    cloud_storage::anomalies_detector::result flatten_partial_results(
+      std::vector<cloud_storage::anomalies_detector::result> partial_results) {
+        BOOST_REQUIRE(partial_results.size() > 0);
+        auto res = *partial_results.begin();
+
+        for (size_t i = 1; i < partial_results.size(); ++i) {
+            res += std::move(partial_results[i]);
+        }
 
         return res;
     }
@@ -489,6 +527,11 @@ FIXTURE_TEST(test_missing_segments, bucket_view_fixture) {
     BOOST_REQUIRE_EQUAL(missing_segs.size(), 2);
     BOOST_REQUIRE(missing_segs.contains(*stm_segment));
     BOOST_REQUIRE(missing_segs.contains(*spill_segment));
+
+    auto partial_results = run_detector_until_log_end(archival::run_quota_t{6});
+
+    BOOST_REQUIRE_EQUAL(
+      result.detected, flatten_partial_results(partial_results).detected);
 }
 
 FIXTURE_TEST(test_missing_spillover_manifest, bucket_view_fixture) {
@@ -511,6 +554,11 @@ FIXTURE_TEST(test_missing_spillover_manifest, bucket_view_fixture) {
       first_spill.get_revision_id(),
       *missing_spills.begin());
     BOOST_REQUIRE_EQUAL(first_spill.get_manifest_path(), expected_path);
+
+    auto partial_results = run_detector_until_log_end(archival::run_quota_t{6});
+
+    BOOST_REQUIRE_EQUAL(
+      result.detected, flatten_partial_results(partial_results).detected);
 }
 
 FIXTURE_TEST(test_missing_stm_manifest, bucket_view_fixture) {
@@ -524,6 +572,11 @@ FIXTURE_TEST(test_missing_stm_manifest, bucket_view_fixture) {
 
     BOOST_REQUIRE(result.detected.has_value());
     BOOST_REQUIRE_EQUAL(result.detected.missing_partition_manifest, true);
+
+    auto partial_results = run_detector_until_log_end(archival::run_quota_t{6});
+
+    BOOST_REQUIRE_EQUAL(
+      result.detected, flatten_partial_results(partial_results).detected);
 }
 
 FIXTURE_TEST(test_metadata_anomalies, bucket_view_fixture) {
@@ -695,6 +748,10 @@ FIXTURE_TEST(test_metadata_anomalies, bucket_view_fixture) {
       .previous = get_spillover_manifests().at(0).last_segment()});
 
     BOOST_REQUIRE(result.detected == expected);
+
+    auto partial_results = run_detector_until_log_end(archival::run_quota_t{6});
+    BOOST_REQUIRE_EQUAL(
+      result.detected, flatten_partial_results(partial_results).detected);
 }
 
 FIXTURE_TEST(test_filtering_of_segment_merge, bucket_view_fixture) {
@@ -789,6 +846,13 @@ FIXTURE_TEST(test_filtering_of_segment_merge, bucket_view_fixture) {
     BOOST_REQUIRE_EQUAL(result.detected.missing_segments.size(), 2);
     BOOST_REQUIRE_EQUAL(result.detected.segment_metadata_anomalies.size(), 1);
 
+    // Run the detection again but under very strict quota. A complete
+    // scrub will require multiple partial scrubs.
+    auto partial_results = run_detector_until_log_end(archival::run_quota_t{2});
+
+    BOOST_REQUIRE_EQUAL(
+      result.detected, flatten_partial_results(partial_results).detected);
+
     cloud_storage::segment_meta merged_seg{
       .is_compacted = false,
       .size_bytes = first_seg.size_bytes + last_seg.size_bytes,
@@ -804,13 +868,30 @@ FIXTURE_TEST(test_filtering_of_segment_merge, bucket_view_fixture) {
     BOOST_REQUIRE(get_stm_manifest_mut().safe_segment_meta_to_add(merged_seg));
     BOOST_REQUIRE(get_stm_manifest_mut().add(merged_seg));
 
+    auto manifest_clone = get_stm_manifest().clone();
+
     get_stm_manifest_mut().process_anomalies(
-      model::timestamp::now(), result.status, result.detected);
+      model::timestamp::now(),
+      result.last_scrubbed_offset,
+      result.status,
+      result.detected);
 
     const auto& filtered_anomalies = get_stm_manifest().detected_anomalies();
 
     BOOST_REQUIRE_EQUAL(filtered_anomalies.missing_segments.size(), 0);
     BOOST_REQUIRE(!filtered_anomalies.has_value());
+
+    for (const auto& result : partial_results) {
+        manifest_clone.process_anomalies(
+          model::timestamp::now(),
+          result.last_scrubbed_offset,
+          result.status,
+          result.detected);
+    }
+
+    const auto& filtered_from_partials = manifest_clone.detected_anomalies();
+
+    BOOST_REQUIRE_EQUAL(filtered_anomalies, filtered_from_partials);
 }
 
 BOOST_AUTO_TEST_CASE(test_offset_anomaly_detection) {

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -2623,7 +2623,8 @@ SEASTAR_THREAD_TEST_CASE(test_partition_manifest_unsafe_segment_add) {
 
 SEASTAR_THREAD_TEST_CASE(test_last_partition_scrub_json_serde) {
     /*
-     * Test that JSON ser/de works for last_partition_scrub
+     * Test that JSON ser/de works for last_partition_scrub and
+     * last_scrubbed_offset
      */
     constexpr std::string_view manifest_v3 = R"json({
     "version": 3,
@@ -2633,7 +2634,8 @@ SEASTAR_THREAD_TEST_CASE(test_last_partition_scrub_json_serde) {
     "revision": 0,
     "insync_offset": 0,
     "last_offset": 0,
-    "last_partition_scrub": 100
+    "last_partition_scrub": 100,
+    "last_scrubbed_offset": 10
 })json";
 
     partition_manifest manifest;
@@ -2641,6 +2643,8 @@ SEASTAR_THREAD_TEST_CASE(test_last_partition_scrub_json_serde) {
       .get();
 
     BOOST_REQUIRE_EQUAL(manifest.last_partition_scrub(), model::timestamp(100));
+    BOOST_REQUIRE_EQUAL(
+      manifest.last_scrubbed_offset().value(), model::offset(10));
 
     std::stringstream sstr;
     manifest.serialize_json(sstr);

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -197,6 +197,8 @@ struct archival_metadata_stm::snapshot
     fragmented_vector<segment> spillover_manifests;
     // Timestamp of last completed scrub
     model::timestamp last_partition_scrub;
+    // Offest at which the previous scrubbing stopped
+    std::optional<model::offset> last_scrubbed_offset;
     // Anomalies detected by the scrubber
     cloud_storage::anomalies detected_anomalies;
 };
@@ -952,6 +954,7 @@ ss::future<> archival_metadata_stm::apply_local_snapshot(
       snap.archive_size_bytes,
       snap.spillover_manifests,
       snap.last_partition_scrub,
+      snap.last_scrubbed_offset,
       snap.detected_anomalies);
 
     vlog(
@@ -991,6 +994,7 @@ ss::future<stm_snapshot> archival_metadata_stm::take_local_snapshot() {
       .start_kafka_offset = _manifest->get_start_kafka_offset_override(),
       .spillover_manifests = std::move(spillover),
       .last_partition_scrub = _manifest->last_partition_scrub(),
+      .last_scrubbed_offset = _manifest->last_scrubbed_offset(),
       .detected_anomalies = _manifest->detected_anomalies()});
 
     vlog(

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -77,6 +77,7 @@ public:
     command_batch_builder& replace_manifest(iobuf);
     command_batch_builder& process_anomalies(
       model::timestamp scrub_timestamp,
+      std::optional<model::offset> last_scrubbed_offset,
       cloud_storage::scrub_status status,
       cloud_storage::anomalies detected);
     /// Replicate the configuration batch
@@ -163,6 +164,7 @@ public:
 
     ss::future<std::error_code> process_anomalies(
       model::timestamp scrub_timestamp,
+      std::optional<model::offset> last_scrubbed_offset,
       cloud_storage::scrub_status status,
       cloud_storage::anomalies detected,
       ss::lowres_clock::time_point deadline,


### PR DESCRIPTION
For large partitions, one should not expect the scrubber to complete in one iteration
while respecting the allocated quota. This PR teaches the scrubber how to resume
from where the previous scrub stopped.

To this end we persist the last scrubbed offset in the manifest and feed it
into the anomalies detector, which will skip already scrubbed offsets. Conversely,
the anomalies detector reports the offset at which it stopped. Note that the
last scrubbed offset is not linear. We scrub manifest from newest to oldest, but
within a manifest we iterate from the beginning to the end (this is because the
columns in the cstore are encoded and reverse iteration is not possible).

Fixes #13884

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

