### PR TITLE
transform/list: implement list admin API

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_transform.go
+++ b/src/go/rpk/pkg/adminapi/api_transform.go
@@ -42,7 +42,6 @@ func (a *AdminAPI) DeleteWasmTransform(ctx context.Context, name string) error {
 type PartitionTransformStatus struct {
 	NodeID    int `json:"node_id"`
 	Partition int `json:"partition"`
-	Core      int `json:"core"`
 	// Status is an enum of: ["running", "inactive", "errored", "unknown"].
 	Status string `json:"status"`
 }

--- a/src/go/rpk/pkg/cli/transform/list.go
+++ b/src/go/rpk/pkg/cli/transform/list.go
@@ -145,9 +145,9 @@ func printDetailed(f config.OutFormatter, d []detailedTransformMetadata, w io.Wr
 		}
 		tw.Print(fmt.Sprintf("%s, %s → %s", m.Name, m.InputTopic, strings.Join(m.OutputTopics, ", ")))
 		// add an empty column to provide an indent
-		tw.Print("", "PARTITION", "NODE", "CORE", "STATUS")
+		tw.Print("", "PARTITION", "NODE", "STATUS")
 		for _, p := range m.Status {
-			tw.Print("", p.Partition, p.NodeID, p.Core, p.Status)
+			tw.Print("", p.Partition, p.NodeID, p.Status)
 		}
 	}
 }

--- a/src/go/rpk/pkg/cli/transform/list_test.go
+++ b/src/go/rpk/pkg/cli/transform/list_test.go
@@ -25,19 +25,16 @@ func setupTestData() []adminapi.TransformMetadata {
 				{
 					NodeID:    0,
 					Partition: 1,
-					Core:      0,
 					Status:    "running",
 				},
 				{
 					NodeID:    0,
 					Partition: 2,
-					Core:      1,
 					Status:    "running",
 				},
 				{
 					NodeID:    1,
 					Partition: 3,
-					Core:      4,
 					Status:    "inactive",
 				},
 			},
@@ -53,7 +50,6 @@ func setupTestData() []adminapi.TransformMetadata {
 				{
 					NodeID:    0,
 					Partition: 1,
-					Core:      0,
 					Status:    "errored",
 				},
 			},
@@ -107,14 +103,14 @@ func TestPrintDetailView(t *testing.T) {
 	cases := []testCase{
 		Text(`
 foo2bar, foo → bar
-      PARTITION  NODE  CORE  STATUS
-      1          0     0     running
-      2          0     1     running
-      3          1     4     inactive
+      PARTITION  NODE  STATUS
+      1          0     running
+      2          0     running
+      3          1     inactive
 
 scrubber, pii → cleaned, munged
-      PARTITION  NODE  CORE  STATUS
-      1          0     0     errored
+      PARTITION  NODE  STATUS
+      1          0     errored
 `),
 		JSON(t, d),
 		YAML(t, d),

--- a/src/v/model/CMakeLists.txt
+++ b/src/v/model/CMakeLists.txt
@@ -15,5 +15,7 @@ v_cc_library(
     v::rphashing
     v::reflection
     Seastar::seastar
+    absl::btree
+    absl::flat_hash_map
   )
 add_subdirectory(tests)

--- a/src/v/model/tests/CMakeLists.txt
+++ b/src/v/model/tests/CMakeLists.txt
@@ -37,3 +37,16 @@ rp_test(
   LABELS model
   ARGS "-- -c 1"
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME transform_models
+  SOURCES
+    transform_test.cc
+  LIBRARIES 
+    v::model_test_utils
+    v::gtest_main
+    v::model
+  LABELS model
+)

--- a/src/v/model/tests/transform_test.cc
+++ b/src/v/model/tests/transform_test.cc
@@ -15,8 +15,6 @@
 #include "random/generators.h"
 #include "test_utils/randoms.h"
 
-#include <seastar/core/smp.hh>
-
 #include <gtest/gtest.h>
 
 #include <initializer_list>
@@ -45,7 +43,6 @@ model::transform_report::processor make_processor_report(int id) {
         state::errored,
       }),
       .node = tests::random_named_int<model::node_id>(),
-      .core = random_generators::get_int<ss::shard_id>(0, 64),
     };
 }
 

--- a/src/v/model/tests/transform_test.cc
+++ b/src/v/model/tests/transform_test.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "model/fundamental.h"
+#include "model/tests/randoms.h"
+#include "model/transform.h"
+#include "random/generators.h"
+#include "test_utils/randoms.h"
+
+#include <seastar/core/smp.hh>
+
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+#include <utility>
+
+namespace model {
+
+namespace {
+model::transform_metadata make_transform_meta() {
+    return model::transform_metadata{
+      .name = tests::random_named_string<model::transform_name>(),
+      .input_topic = model::random_topic_namespace(),
+      .output_topics = {model::random_topic_namespace()},
+      .uuid = uuid_t::create(),
+      .source_ptr = model::random_offset()};
+}
+
+model::transform_report::processor make_processor_report(int id) {
+    using state = model::transform_report::processor::state;
+    return model::transform_report::processor{
+      .id = model::partition_id(id),
+      .status = random_generators::random_choice({
+        state::unknown,
+        state::inactive,
+        state::running,
+        state::errored,
+      }),
+      .node = tests::random_named_int<model::node_id>(),
+      .core = random_generators::get_int<ss::shard_id>(0, 64),
+    };
+}
+
+} // namespace
+
+TEST(TransformReportTest, AddProcessors) {
+    auto meta = make_transform_meta();
+    auto p_one = make_processor_report(1);
+    auto p_two = make_processor_report(2);
+    auto p_three = make_processor_report(3);
+    model::transform_report report(meta);
+    report.add(p_one);
+    report.add(p_two);
+    report.add(p_three);
+    model::transform_report expected(
+      meta,
+      {
+        {model::partition_id(1), p_one},
+        {model::partition_id(2), p_two},
+        {model::partition_id(3), p_three},
+      });
+    EXPECT_EQ(report, expected);
+}
+
+TEST(ClusterTransformReportTest, AddIndividualReports) {
+    using tid = model::transform_id;
+    using pid = model::partition_id;
+    auto meta_one = make_transform_meta();
+    auto meta_two = make_transform_meta();
+    auto p_one = make_processor_report(1);
+    auto p_two = make_processor_report(2);
+    auto p_three = make_processor_report(3);
+    model::cluster_transform_report actual;
+    for (const auto& p : {p_one, p_two, p_three}) {
+        actual.add(model::transform_id(1), meta_one, p);
+        actual.add(model::transform_id(2), meta_two, p);
+    }
+    model::cluster_transform_report expected;
+    expected.transforms.emplace(
+      tid(1),
+      model::transform_report(
+        meta_one,
+        {
+          {pid(1), p_one},
+          {pid(2), p_two},
+          {pid(3), p_three},
+        }));
+    expected.transforms.emplace(
+      tid(2),
+      model::transform_report(
+        meta_two,
+        {
+          {pid(1), p_one},
+          {pid(2), p_two},
+          {pid(3), p_three},
+        }));
+    EXPECT_EQ(actual, expected);
+}
+
+TEST(ClusterTransformReportTest, Merge) {
+    using tid = model::transform_id;
+    auto meta_one = make_transform_meta();
+    auto meta_two = make_transform_meta();
+    auto p_one = make_processor_report(1);
+    auto p_two = make_processor_report(2);
+    auto p_three = make_processor_report(3);
+
+    model::cluster_transform_report node_one;
+    node_one.add(tid(1), meta_one, p_one);
+    node_one.add(tid(2), meta_two, p_two);
+    node_one.add(tid(1), meta_one, p_three);
+    model::cluster_transform_report node_two;
+    node_two.add(tid(2), meta_two, p_one);
+    node_two.add(tid(1), meta_one, p_two);
+    node_two.add(tid(2), meta_two, p_three);
+
+    model::cluster_transform_report expected;
+    expected.add(tid(1), meta_one, p_one);
+    expected.add(tid(1), meta_one, p_two);
+    expected.add(tid(1), meta_one, p_three);
+    expected.add(tid(2), meta_two, p_one);
+    expected.add(tid(2), meta_two, p_two);
+    expected.add(tid(2), meta_two, p_three);
+
+    node_one.merge(node_two);
+
+    EXPECT_EQ(node_one, expected);
+}
+
+} // namespace model

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -70,11 +70,7 @@ void cluster_transform_report::add(
   transform_id id,
   const transform_metadata& meta,
   transform_report::processor processor) {
-    auto it = transforms.find(id);
-    if (it == transforms.end()) {
-        auto result = transforms.emplace(id, meta);
-        it = result.first;
-    }
+    auto [it, _] = transforms.try_emplace(id, meta);
     it->second.add(processor);
 }
 

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -39,4 +39,16 @@ operator<<(std::ostream& os, const transform_offsets_value& value) {
     return os;
 }
 
+std::ostream&
+operator<<(std::ostream& os, const transform_report::processor& p) {
+    fmt::print(
+      os,
+      "{{id: {}, status: {}, node: {}, core: {}}}",
+      p.id,
+      uint8_t(p.status),
+      p.node,
+      p.core);
+    return os;
+}
+
 } // namespace model

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -44,12 +44,7 @@ operator<<(std::ostream& os, const transform_offsets_value& value) {
 std::ostream&
 operator<<(std::ostream& os, const transform_report::processor& p) {
     fmt::print(
-      os,
-      "{{id: {}, status: {}, node: {}, core: {}}}",
-      p.id,
-      uint8_t(p.status),
-      p.node,
-      p.core);
+      os, "{{id: {}, status: {}, node: {}}}", p.id, uint8_t(p.status), p.node);
     return os;
 }
 

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -57,6 +57,11 @@ transform_report::transform_report(transform_metadata meta)
   : metadata(std::move(meta))
   , processors() {}
 
+transform_report::transform_report(
+  transform_metadata meta, absl::btree_map<model::partition_id, processor> map)
+  : metadata(std::move(meta))
+  , processors(std::move(map)){};
+
 void transform_report::add(processor processor) {
     processors.insert_or_assign(processor.id, processor);
 }

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -133,12 +133,11 @@ struct transform_report
         model::partition_id id;
         state status;
         model::node_id node;
-        ss::shard_id core;
         friend bool operator==(const processor&, const processor&) = default;
 
         friend std::ostream& operator<<(std::ostream&, const processor&);
 
-        auto serde_fields() { return std::tie(id, status, node, core); }
+        auto serde_fields() { return std::tie(id, status, node); }
     };
 
     transform_report() = default;

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -126,12 +126,6 @@ static const model::topic_namespace transform_offsets_nt(
 struct transform_report
   : serde::
       envelope<transform_report, serde::version<0>, serde::compat_version<0>> {
-    transform_report() = default;
-    explicit transform_report(transform_metadata meta);
-
-    // The overall metadata for a transform.
-    transform_metadata metadata;
-
     struct processor
       : serde::
           envelope<processor, serde::version<0>, serde::compat_version<0>> {
@@ -146,6 +140,14 @@ struct transform_report
 
         auto serde_fields() { return std::tie(id, status, node, core); }
     };
+
+    transform_report() = default;
+    explicit transform_report(transform_metadata meta);
+    transform_report(
+      transform_metadata meta, absl::btree_map<model::partition_id, processor>);
+
+    // The overall metadata for a transform.
+    transform_metadata metadata;
 
     // The state of each processor of a transform.
     //

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "seastarx.h"
@@ -19,6 +20,7 @@
 
 #include <seastar/core/sstring.hh>
 
+#include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_map.h>
 
 #include <cstdint>
@@ -113,5 +115,61 @@ struct transform_offsets_value
 static const model::topic transform_offsets_topic("transform_offsets");
 static const model::topic_namespace transform_offsets_nt(
   model::kafka_internal_namespace, transform_offsets_topic);
+
+/**
+ * A (possibly inconsistent) snapshot of a transform.
+ *
+ * We capture the metadata associated with the transform for as well as the
+ * state for each processor.
+ */
+struct transform_report
+  : serde::
+      envelope<transform_report, serde::version<0>, serde::compat_version<0>> {
+    // The overall metadata for a transform.
+    transform_metadata metadata;
+
+    struct processor
+      : serde::
+          envelope<processor, serde::version<0>, serde::compat_version<0>> {
+        enum class state : uint8_t { unknown, inactive, running, errored };
+        model::partition_id id;
+        state status;
+        model::node_id node;
+        ss::shard_id core;
+        friend bool operator==(const processor&, const processor&) = default;
+
+        friend std::ostream& operator<<(std::ostream&, const processor&);
+
+        auto serde_fields() { return std::tie(id, status, node, core); }
+    };
+
+    // The state of each processor of a transform.
+    //
+    // Currently, there should be a single processor for each partition on the
+    // input topic.
+    absl::btree_map<model::partition_id, processor> processors;
+
+    friend bool operator==(const transform_report&, const transform_report&)
+      = default;
+
+    auto serde_fields() { return std::tie(metadata, processors); }
+};
+
+/**
+ * A cluster wide view of all the currently running transforms.
+ */
+struct cluster_transform_report
+  : serde::envelope<
+      cluster_transform_report,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    absl::btree_map<model::transform_id, transform_report> transforms;
+
+    friend bool
+    operator==(const cluster_transform_report&, const cluster_transform_report&)
+      = default;
+
+    auto serde_fields() { return std::tie(transforms); }
+};
 
 } // namespace model

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -126,6 +126,7 @@ static const model::topic_namespace transform_offsets_nt(
 struct transform_report
   : serde::
       envelope<transform_report, serde::version<0>, serde::compat_version<0>> {
+    transform_report() = default;
     explicit transform_report(transform_metadata meta);
 
     // The overall metadata for a transform.

--- a/src/v/redpanda/admin/api-doc/transform.json
+++ b/src/v/redpanda/admin/api-doc/transform.json
@@ -130,10 +130,6 @@
           "type": "int",
           "description": "partition in the input topic"
         },
-        "core": {
-          "type": "int",
-          "description": "id of a core on a given node"
-        },
         "status": {
           "type": "string",
           "enum": [

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -65,6 +65,7 @@
 #include "model/namespace.h"
 #include "model/record.h"
 #include "model/timeout_clock.h"
+#include "model/transform.h"
 #include "net/dns.h"
 #include "pandaproxy/rest/api.h"
 #include "pandaproxy/schema_registry/api.h"
@@ -5795,12 +5796,63 @@ admin_server::delete_transform(std::unique_ptr<ss::http::request> req) {
     co_return ss::json::json_void();
 }
 
+namespace {
+ss::httpd::transform_json::partition_transform_status::
+  partition_transform_status_status
+  convert_transform_status(
+    model::transform_report::processor::state model_state) {
+    using model_status = model::transform_report::processor::state;
+    using json_status = ss::httpd::transform_json::partition_transform_status::
+      partition_transform_status_status;
+    switch (model_state) {
+    case model_status::inactive:
+        return json_status::inactive;
+    case model_status::running:
+        return json_status::running;
+    case model_status::errored:
+        return json_status::errored;
+    case model_status::unknown:
+        return json_status::unknown;
+    }
+    vlog(logger.error, "unknown transform status: {}", uint8_t(model_state));
+    return json_status::unknown;
+}
+} // namespace
+
 ss::future<ss::json::json_return_type>
 admin_server::list_transforms(std::unique_ptr<ss::http::request>) {
     if (!_transform_service->local_is_initialized()) {
         throw ss::httpd::bad_request_exception("data transforms not enabled");
     }
-    throw ss::httpd::server_error_exception("unimplemented");
+    auto report = co_await _transform_service->local().list_transforms();
+    ss::json::json_list<ss::httpd::transform_json::transform_metadata>
+      list_result;
+
+    co_return ss::json::json_return_type(
+      ss::json::stream_range_as_array(report.transforms, [](const auto& entry) {
+          const model::transform_report& t = entry.second;
+          ss::httpd::transform_json::transform_metadata meta;
+          meta.name = t.metadata.name();
+          meta.input_topic = t.metadata.input_topic.tp();
+          for (const auto& output_topic : t.metadata.output_topics) {
+              meta.output_topics.push(output_topic.tp());
+          }
+          for (const auto& [k, v] : t.metadata.environment) {
+              ss::httpd::transform_json::environment_variable var;
+              var.key = k;
+              var.value = v;
+              meta.environment.push(var);
+          }
+          for (const auto& [_, processor] : t.processors) {
+              ss::httpd::transform_json::partition_transform_status s;
+              s.partition = processor.id();
+              s.core = processor.core;
+              s.node_id = processor.node();
+              s.status = convert_transform_status(processor.status);
+              meta.status.push(s);
+          }
+          return meta;
+      }));
 }
 
 namespace {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -5846,7 +5846,6 @@ admin_server::list_transforms(std::unique_ptr<ss::http::request>) {
           for (const auto& [_, processor] : t.processors) {
               ss::httpd::transform_json::partition_transform_status s;
               s.partition = processor.id();
-              s.core = processor.core;
               s.node_id = processor.node();
               s.status = convert_transform_status(processor.status);
               meta.status.push(s);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1134,6 +1134,10 @@ void application::wire_up_runtime_services(
               return transform::rpc::topic_creator::make_default(
                 controller.get());
           }),
+          ss::sharded_parameter([this] {
+              return transform::rpc::cluster_members_cache::make_default(
+                &controller->get_members_table());
+          }),
           &_connection_cache,
           &_transform_rpc_service)
           .get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1114,6 +1114,9 @@ void application::wire_up_runtime_services(
           ss::sharded_parameter([this] {
               return transform::rpc::partition_manager::make_default(
                 &shard_table, &partition_manager);
+          }),
+          ss::sharded_parameter([this] {
+              return transform::service::create_reporter(&_transform_service);
           }))
           .get();
         construct_service(

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -225,6 +225,9 @@ public:
       : _service(service) {}
 
     ss::future<model::cluster_transform_report> compute_report() override {
+        // It's the RPC server is started before the transform subsystem boots
+        // up, so we need to check for initialization here.
+        // TODO(rockwood): Fix the bootup sequence so this doesn't happen.
         if (!_service->local_is_initialized()) {
             return ss::make_exception_future<model::cluster_transform_report>(
               std::make_exception_ptr(

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -243,6 +243,7 @@ ss::future<> service::start() {
       = std::make_unique<rpc_client_factory>(&_rpc_client->local());
 
     _manager = std::make_unique<manager<ss::lowres_clock>>(
+      _self,
       std::make_unique<registry_adapter>(
         &_plugin_frontend->local(), &_partition_manager->local()),
       std::make_unique<proc_factory>(

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -419,6 +419,15 @@ service::deploy_transform(model::transform_metadata meta, iobuf binary) {
     co_return ec;
 }
 
+ss::future<model::cluster_transform_report> service::list_transforms() {
+    if (!_feature_table->local().is_active(
+          features::feature::wasm_transforms)) {
+        co_return model::cluster_transform_report{};
+    }
+    auto _ = _gate.hold();
+    co_return co_await _rpc_client->local().generate_report();
+}
+
 ss::future<> service::cleanup_wasm_binary(uuid_t key) {
     // TODO(rockwood): This is a best effort cleanup, we should also have
     // some sort of GC process as well.

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -65,6 +65,11 @@ public:
     ss::future<cluster::errc> delete_transform(model::transform_name);
 
     /**
+     * List all transforms from the entire cluster.
+     */
+    ss::future<model::cluster_transform_report> list_transforms();
+
+    /**
      * Create a reporter of the transform subsystem.
      */
     static std::unique_ptr<rpc::reporter>

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -64,6 +64,12 @@ public:
      */
     ss::future<cluster::errc> delete_transform(model::transform_name);
 
+    /**
+     * Create a reporter of the transform subsystem.
+     */
+    static std::unique_ptr<rpc::reporter>
+    create_reporter(ss::sharded<service>*);
+
 private:
     void register_notifications();
     void unregister_notifications();
@@ -77,6 +83,7 @@ private:
       ss::optimized_optional<ss::foreign_ptr<ss::shared_ptr<wasm::factory>>>>
       get_factory(model::transform_metadata);
 
+    friend class wrapped_service_reporter;
     ss::future<model::cluster_transform_report> compute_node_local_report();
 
     ss::gate _gate;

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -77,6 +77,8 @@ private:
       ss::optimized_optional<ss::foreign_ptr<ss::shared_ptr<wasm::factory>>>>
       get_factory(model::transform_metadata);
 
+    ss::future<model::cluster_transform_report> compute_node_local_report();
+
     ss::gate _gate;
 
     wasm::caching_runtime* _runtime;

--- a/src/v/transform/fwd.h
+++ b/src/v/transform/fwd.h
@@ -20,5 +20,6 @@ class probe;
 namespace rpc {
 class client;
 class local_service;
+class reporter;
 } // namespace rpc
 } // namespace transform

--- a/src/v/transform/rpc/deps.cc
+++ b/src/v/transform/rpc/deps.cc
@@ -180,6 +180,21 @@ public:
 private:
     cluster::controller* _controller;
 };
+
+class cluster_members_cache_impl : public cluster_members_cache {
+public:
+    explicit cluster_members_cache_impl(
+      ss::sharded<cluster::members_table>* table)
+      : _table(table) {}
+
+    std::vector<model::node_id> all_cluster_members() override {
+        return _table->local().node_ids();
+    }
+
+private:
+    ss::sharded<cluster::members_table>* _table;
+};
+
 } // namespace
 
 std::unique_ptr<partition_leader_cache>
@@ -224,4 +239,10 @@ std::unique_ptr<topic_creator>
 topic_creator::make_default(cluster::controller* controller) {
     return std::make_unique<topic_creator_impl>(controller);
 }
+
+std::unique_ptr<cluster_members_cache>
+cluster_members_cache::make_default(ss::sharded<cluster::members_table>* m) {
+    return std::make_unique<cluster_members_cache_impl>(m);
+}
+
 } // namespace transform::rpc

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -16,6 +16,7 @@
 #include "model/fundamental.h"
 #include "model/ktp.h"
 #include "model/metadata.h"
+#include "model/transform.h"
 #include "transform/rpc/serde.h"
 
 #include <seastar/util/noncopyable_function.hh>
@@ -26,6 +27,21 @@
  */
 
 namespace transform::rpc {
+
+/**
+ * Able to report on the state of all transforms for this node.
+ */
+class reporter {
+public:
+    reporter() = default;
+    reporter(const reporter&) = delete;
+    reporter& operator=(const reporter&) = delete;
+    reporter(reporter&&) = delete;
+    reporter& operator=(reporter&&) = delete;
+    virtual ~reporter() = default;
+
+    virtual ss::future<model::cluster_transform_report> compute_report() = 0;
+};
 
 /**
  * A cache for which node owns a given partition leader.

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -44,6 +44,27 @@ public:
 };
 
 /**
+ * A cache for all the nodes that exist in the cluster.
+ */
+class cluster_members_cache {
+public:
+    cluster_members_cache() = default;
+    cluster_members_cache(const cluster_members_cache&) = delete;
+    cluster_members_cache& operator=(const cluster_members_cache&) = delete;
+    cluster_members_cache(cluster_members_cache&&) = delete;
+    cluster_members_cache& operator=(cluster_members_cache&&) = delete;
+    virtual ~cluster_members_cache() = default;
+
+    static std::unique_ptr<cluster_members_cache>
+    make_default(ss::sharded<cluster::members_table>*);
+
+    /**
+     * A list of all the nodes in the cluster, including the local node.
+     */
+    virtual std::vector<model::node_id> all_cluster_members() = 0;
+};
+
+/**
  * A cache for which node owns a given partition leader.
  */
 class partition_leader_cache {

--- a/src/v/transform/rpc/rpc.json
+++ b/src/v/transform/rpc/rpc.json
@@ -6,6 +6,11 @@
     ],
     "methods": [
         {
+            "name": "generate_report",
+            "input_type": "generate_report_request",
+            "output_type": "generate_report_reply"
+        },
+        {
             "name": "produce",
             "input_type": "produce_request",
             "output_type": "produce_reply"

--- a/src/v/transform/rpc/serde.h
+++ b/src/v/transform/rpc/serde.h
@@ -346,4 +346,31 @@ struct offset_fetch_response
     auto serde_fields() { return std::tie(errc, result); }
 };
 
+struct generate_report_request
+  : serde::envelope<
+      generate_report_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    generate_report_request() = default;
+
+    auto serde_fields() { return std::tie(); }
+};
+
+struct generate_report_reply
+  : serde::envelope<
+      generate_report_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    generate_report_reply() = default;
+    explicit generate_report_reply(model::cluster_transform_report r)
+      : report(std::move(r)) {}
+
+    auto serde_fields() { return std::tie(report); }
+
+    model::cluster_transform_report report;
+};
 } // namespace transform::rpc

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -449,4 +449,10 @@ ss::future<offset_commit_response> network_service::offset_commit(
     co_return co_await _service->local().offset_commit(req);
 }
 
+ss::future<generate_report_reply> network_service::generate_report(
+  generate_report_request&&, ::rpc::streaming_context&) {
+    auto report = co_await _service->local().compute_node_local_report();
+    co_return generate_report_reply(std::move(report));
+}
+
 } // namespace transform::rpc

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -110,6 +110,9 @@ public:
     ss::future<offset_fetch_response>
     offset_fetch(offset_fetch_request&&, ::rpc::streaming_context&) override;
 
+    ss::future<generate_report_reply> generate_report(
+      generate_report_request&&, ::rpc::streaming_context&) override;
+
 private:
     ss::sharded<local_service>* _service;
 };

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -31,7 +31,8 @@ class local_service {
 public:
     local_service(
       std::unique_ptr<topic_metadata_cache> metadata_cache,
-      std::unique_ptr<partition_manager> partition_manager);
+      std::unique_ptr<partition_manager> partition_manager,
+      std::unique_ptr<reporter>);
 
     ss::future<ss::chunked_fifo<transformed_topic_data_result>> produce(
       ss::chunked_fifo<transformed_topic_data> topic_data,
@@ -50,6 +51,8 @@ public:
     find_coordinator(find_coordinator_request&&);
     ss::future<offset_commit_response> offset_commit(offset_commit_request);
     ss::future<offset_fetch_response> offset_fetch(offset_fetch_request);
+
+    ss::future<model::cluster_transform_report> compute_node_local_report();
 
 private:
     ss::future<transformed_topic_data_result>
@@ -71,6 +74,7 @@ private:
       ss::lw_shared_ptr<cluster::partition>, offset_fetch_request);
     std::unique_ptr<topic_metadata_cache> _metadata_cache;
     std::unique_ptr<partition_manager> _partition_manager;
+    std::unique_ptr<reporter> _reporter;
 };
 
 /**

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -428,6 +428,14 @@ constexpr auto test_timeout = std::chrono::seconds(10);
 constexpr model::node_id self_node = model::node_id(1);
 constexpr model::node_id other_node = model::node_id(2);
 
+namespace {
+class fake_cluster_members_cache : public cluster_members_cache {
+    std::vector<model::node_id> all_cluster_members() override {
+        return {self_node, other_node};
+    }
+};
+} // namespace
+
 struct test_parameters {
     model::node_id leader_node;
     model::node_id non_leader_node;
@@ -524,6 +532,7 @@ public:
           std::move(fplc),
           std::make_unique<delegating_fake_topic_metadata_cache>(_local_ftmc),
           std::move(ftpc),
+          std::make_unique<fake_cluster_members_cache>(),
           &_conn_cache,
           &_local_services);
     }
@@ -601,6 +610,9 @@ public:
     record_batches leader_batches(const model::ntp& ntp) {
         return batches_for(leader_node(), ntp);
     }
+
+    fake_reporter* local_reporter() { return _local_fr; }
+    fake_reporter* remote_reporter() { return _remote_fr; }
 
     // local node state
     fake_topic_metadata_cache* local_metadata_cache() { return _local_ftmc; }

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -816,13 +816,11 @@ TEST_F(TransformRpcTest, CanAggregateReports) {
           .id = model::partition_id(0),
           .status = state::running,
           .node = self_node,
-          .core = 0,
         },
         model::transform_report::processor{
           .id = model::partition_id(2),
           .status = state::inactive,
           .node = self_node,
-          .core = 1,
         },
       });
     remote_reporter()->add_to_report(
@@ -832,7 +830,6 @@ TEST_F(TransformRpcTest, CanAggregateReports) {
         .id = model::partition_id(0),
         .status = state::running,
         .node = other_node,
-        .core = 2,
       }});
     remote_reporter()->add_to_report(
       model::transform_id(1),
@@ -841,7 +838,6 @@ TEST_F(TransformRpcTest, CanAggregateReports) {
         .id = model::partition_id(1),
         .status = state::errored,
         .node = other_node,
-        .core = 0,
       }});
     model::cluster_transform_report actual = client()->generate_report().get();
     model::cluster_transform_report expected = local_reporter()->report();

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -288,7 +288,7 @@ public:
         auto t = std::make_unique<processor_tracker>();
         _tracker = t.get();
         _manager = std::make_unique<manager<ss::manual_clock>>(
-          std::move(r), std::move(t));
+          /*self=*/model::node_id(0), std::move(r), std::move(t));
         _manager->start().get();
         // This allows us to wait for the seastar queue to be drained.
         //

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -99,19 +99,48 @@ const static model::ntp min_ntp = model::ntp(
 // complicated table of indexes.
 template<typename ClockType>
 class processor_table {
-    struct entry_t {
-        std::unique_ptr<transform::processor> processor;
-        ss::lw_shared_ptr<transform::probe> probe;
-        processor_backoff<ClockType> backoff;
+public:
+    class entry_t {
+    public:
+        entry_t(
+          std::unique_ptr<transform::processor> processor,
+          ss::lw_shared_ptr<transform::probe> probe)
+          : _processor(std::move(processor))
+          , _probe(std::move(probe)) {}
+
+        transform::processor* processor() const { return _processor.get(); }
+        ss::lw_shared_ptr<transform::probe> probe() const { return _probe; }
+
+        ClockType::duration next_backoff_duration() {
+            _is_errored = true;
+            return _backoff.next_backoff_duration();
+        }
+        void mark_start_attempt() {
+            _is_errored = false;
+            _backoff.mark_start_attempt();
+        }
+
+        model::transform_report::processor::state compute_state() const {
+            using state = model::transform_report::processor::state;
+            if (_processor->is_running()) {
+                return state::running;
+            }
+            return _is_errored ? state::errored : state::inactive;
+        }
+
+    private:
+        std::unique_ptr<transform::processor> _processor;
+        ss::lw_shared_ptr<transform::probe> _probe;
+        processor_backoff<ClockType> _backoff;
+        bool _is_errored = true;
     };
 
-public:
     entry_t&
     insert(std::unique_ptr<processor> processor, ss::lw_shared_ptr<probe> p) {
         auto id = processor->id();
         auto ntp = processor->ntp();
         auto [table_it, table_inserted] = _table.emplace(
-          std::make_pair(id, ntp), entry_t{std::move(processor), std::move(p)});
+          std::make_pair(id, ntp), entry_t(std::move(processor), std::move(p)));
         vassert(table_inserted, "invalid transform processor management");
         auto [index_it, index_inserted] = _ntp_index.emplace(
           std::make_pair(ntp, id));
@@ -123,7 +152,7 @@ public:
       model::transform_id id, const model::transform_metadata& meta) {
         auto it = _table.lower_bound(std::make_pair(id, min_ntp));
         if (it != _table.end() && it->first.first == id) {
-            return it->second.probe;
+            return it->second.probe();
         }
         auto probe = ss::make_lw_shared<transform::probe>();
         probe->setup_metrics(meta.name());
@@ -147,7 +176,7 @@ public:
           _table.begin(),
           _table.end(),
           // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
-          [](auto& e) { return e.second.processor->stop(); });
+          [](auto& e) { return e.second.processor()->stop(); });
         _table.clear();
         _ntp_index.clear();
     }
@@ -164,7 +193,7 @@ public:
             if (id != target_id) {
                 break;
             }
-            stop_futures.push_back(it->second.processor->stop());
+            stop_futures.push_back(it->second.processor()->stop());
             vassert(
               _ntp_index.erase(std::make_pair(ntp, id)) > 0,
               "inconsistent index");
@@ -188,7 +217,7 @@ public:
                 break;
             }
             auto node = _table.extract(std::make_pair(id, ntp));
-            stop_futures.push_back(node.mapped().processor->stop());
+            stop_futures.push_back(node.mapped().processor()->stop());
             // delay destroying the processor until after it's stopped.
             entries.push_back(std::move(node.mapped()));
             it = _ntp_index.erase(it);
@@ -206,8 +235,11 @@ private:
 
 template<typename ClockType>
 manager<ClockType>::manager(
-  std::unique_ptr<registry> r, std::unique_ptr<processor_factory> f)
-  : _queue([](const std::exception_ptr& ex) {
+  model::node_id self,
+  std::unique_ptr<registry> r,
+  std::unique_ptr<processor_factory> f)
+  : _self(self)
+  , _queue([](const std::exception_ptr& ex) {
       vlog(tlog.error, "unexpected transform manager error: {}", ex);
   })
   , _registry(std::move(r))
@@ -305,8 +337,8 @@ ss::future<> manager<ClockType>::handle_transform_error(
     if (!entry) {
         co_return;
     }
-    co_await entry->processor->stop();
-    auto delay = entry->backoff.next_backoff_duration();
+    co_await entry->processor()->stop();
+    auto delay = entry->next_backoff_duration();
     vlog(
       tlog.info,
       "transform {} errored on partition {}, delaying for {} then restarting",
@@ -324,7 +356,7 @@ manager<ClockType>::start_processor(model::ntp ntp, model::transform_id id) {
     auto* entry = _processors->get_or_null(id, ntp);
     // It's possible something else came along and kicked this processor and
     // that worked.
-    if (entry && entry->processor->is_running()) {
+    if (entry && entry->processor()->is_running()) {
         co_return;
     }
     auto transform = _registry->lookup_by_id(id);
@@ -342,8 +374,8 @@ manager<ClockType>::start_processor(model::ntp ntp, model::transform_id id) {
         co_return;
     }
     if (entry) {
-        entry->backoff.mark_start_attempt();
-        co_await entry->processor->start();
+        entry->mark_start_attempt();
+        co_await entry->processor()->start();
     } else {
         co_await create_processor(ntp, id, *std::move(transform));
     }
@@ -381,8 +413,8 @@ ss::future<> manager<ClockType>::create_processor(
         // we properly know that it's in flight.
         auto& entry = _processors->insert(std::move(fut).get(), std::move(p));
         vlog(tlog.info, "starting transform {} on {}", meta.name, ntp);
-        entry.backoff.mark_start_attempt();
-        co_await entry.processor->start();
+        entry.mark_start_attempt();
+        co_await entry.processor()->start();
     }
 }
 

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -448,7 +448,6 @@ model::cluster_transform_report manager<ClockType>::compute_report() const {
             .id = id,
             .status = entry.compute_state(),
             .node = _self,
-            .core = ss::this_shard_id(),
           });
     }
     return report;

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -104,7 +104,10 @@ class manager {
       "Only lowres or manual clocks are supported");
 
 public:
-    manager(std::unique_ptr<registry>, std::unique_ptr<processor_factory>);
+    manager(
+      model::node_id self,
+      std::unique_ptr<registry>,
+      std::unique_ptr<processor_factory>);
     manager(const manager&) = delete;
     manager& operator=(const manager&) = delete;
     manager(manager&&) = delete;
@@ -145,6 +148,7 @@ private:
     ss::future<> create_processor(
       model::ntp, model::transform_id, model::transform_metadata);
 
+    model::node_id _self;
     ssx::work_queue _queue;
     std::unique_ptr<registry> _registry;
     std::unique_ptr<processor_table<ClockType>> _processors;

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -125,6 +125,10 @@ public:
     void on_transform_error(
       model::transform_id, model::ntp, model::transform_metadata);
 
+    // Get the current state of all the transforms this manager is responsible
+    // for.
+    model::cluster_transform_report compute_report() const;
+
     // Exposed for testing, but drains all the pending operations.
     //
     // Any future here should resolve before calling `stop`.


### PR DESCRIPTION
Implement the transform list API for the Admin API.

This is consumed in RPK and the last bit needed to start writing ducktape tests (we need this to ensure all the processors have started).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
