### PR TITLE
storage: evict data from compactible topics under disk pressure

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -143,14 +143,6 @@ ss::future<> log_eviction_stm::monitor_log_eviction() {
     while (!_as.abort_requested()) {
         try {
             auto eviction_offset = co_await storage_eviction_event();
-            if (!_raft->log()->config().is_collectable()) {
-                vlog(
-                  _log.error,
-                  "Ignoring unexpected storage eviction event for a "
-                  "non-collectable NTP: {}",
-                  _raft->ntp());
-                continue;
-            }
             if (eviction_offset > _storage_eviction_offset) {
                 _storage_eviction_offset = eviction_offset;
                 _has_pending_truncation.signal();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -844,10 +844,6 @@ ss::future<std::optional<model::offset>> disk_log_impl::do_gc(gc_config cfg) {
 
     cfg = apply_overrides(cfg);
 
-    if (!config().is_collectable()) {
-        co_return std::nullopt;
-    }
-
     /*
      * _cloud_gc_offset is used to communicate the intent to collect
      * partition data in excess of normal retention settings (and for infinite
@@ -871,6 +867,10 @@ ss::future<std::optional<model::offset>> disk_log_impl::do_gc(gc_config cfg) {
           cfg);
 
         co_return co_await request_eviction_until_offset(offset);
+    }
+
+    if (!config().is_collectable()) {
+        co_return std::nullopt;
     }
 
     vlog(

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -7,46 +7,37 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 import random
-import requests
-from pickletools import long1
-from time import sleep, time, time_ns
-from collections import defaultdict
+from time import sleep, time
 
+import requests
 from ducktape.cluster.cluster import ClusterNode
-from ducktape.errors import TimeoutError
+from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 from kafka import KafkaProducer
 from kafka.errors import BrokerNotAvailableError, NotLeaderForPartitionError
-from rptest.clients.kafka_cli_tools import KafkaCliTools
+
 from rptest.clients.default import DefaultClient
-from rptest.clients.rpk import RpkTool
-from rptest.clients.offline_log_viewer import OfflineLogViewer
-from rptest.services.redpanda import SISettings
-from ducktape.mark import matrix
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import LoggingConfig, RedpandaService
-from rptest.services.storage import Topic
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import LoggingConfig, RedpandaService, SISettings
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.util import expect_exception, search_logs_with_timeout, produce_total_bytes
+from rptest.util import produce_total_bytes, search_logs_with_timeout
+from rptest.utils.expect_rate import ExpectRate, RateTarget
 from rptest.utils.full_disk import FullDiskHelper
 from rptest.utils.partition_metrics import PartitionMetrics
-from rptest.utils.si_utils import BucketView, quiesce_uploads
-from rptest.utils.expect_rate import ExpectRate, RateTarget
-from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
+from rptest.utils.si_utils import quiesce_uploads
 
 # reduce this?
 MAX_MSG: int = 600
 MAX_MSG_PER_SEC = 10
 FDT_LOG_ALLOW_LIST = [".*cluster - storage space alert: free space.*"]
 LOOP_ITERATIONS = 3
-
-import logging
-import sys
 
 
 # XXX This test really needs a raw protocol client (i.e. not librdkafka # based)
@@ -662,25 +653,23 @@ def min_local_start_offset(redpanda: RedpandaService, topic: str):
     min_offset = None
     for node in redpanda.nodes:
         for p in local_start_offsets(redpanda, node, topic):
-            if min_offset == None:
-                min_offset = p['start offset']
+            if min_offset is None:
+                min_offset = p['local_log_start_offset']
             else:
-                min_offset = max(min_offset, p['start offset'])
+                min_offset = max(min_offset, p['local_log_start_offset'])
     return min_offset
 
 
 def local_start_offsets(redpanda: RedpandaService, node: ClusterNode,
                         topic: str):
-    viewer = OfflineLogViewer(redpanda)
-    for shard_items in viewer.read_kvstore(node).values():
-        for item in shard_items:
-            k = item['key']
-            if (k['keyspace'] == 'storage'
-                    and k['data']['name'] == 'start offset'
-                    and k['data']['ntp']['namespace'] == 'kafka'
-                    and k['data']['ntp']['topic'] == topic):
+    admin = Admin(redpanda, default_node=node)
+    partitions = admin.get_partitions(topic)
 
-                yield {
-                    "partition": k['data']['ntp']['partition'],
-                    "start offset": item["value"]
-                }
+    for p in partitions:
+        status = admin.get_partition_cloud_storage_status(
+            topic, p["partition_id"])
+
+        yield {
+            "partition": p["partition_id"],
+            "local_log_start_offset": status["local_log_start_offset"]
+        }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Currently, under disk pressure, we evict local data that was uploaded to
the cloud storage only for topics with `cleanup.policy` equal to
`delete` or `delete,compact`.

Due to an oversight, data for topics with the policy set to `compact` is
never evicted. This commit ensures consistent eviction behavior for all
cleanup policies.

Since Redpanda doesn't run compaction for data that is present only in
the cloud storage, this change introduces a potential regression in
compaction quality. This choice is considered better than running out of
disk space.

If we decide to backport, this depends on #13856 and #13935.

Fixes #14015.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Evict local data that was uploaded to the cloud storage under disk pressure for topics with `cleanup.policy=compact`. Now all cleanup policies have consistent eviction behavior.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
