### PR TITLE
transform/rpc: fix wasm binary fetches

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -89,8 +89,9 @@ public:
      */
     ss::future<model::record_batch_reader> make_reader(
       storage::log_reader_config config,
-      std::optional<model::timeout_clock::time_point> deadline = std::nullopt) {
-        return _raft->make_reader(std::move(config), deadline);
+      std::optional<model::timeout_clock::time_point> debounce_deadline
+      = std::nullopt) {
+        return _raft->make_reader(std::move(config), debounce_deadline);
     }
 
     ss::future<result<model::offset, std::error_code>>

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -117,8 +117,9 @@ public:
 
     ss::future<storage::translating_reader> make_reader(
       storage::log_reader_config cfg,
-      std::optional<model::timeout_clock::time_point> deadline = std::nullopt) {
-        return _impl->make_reader(cfg, deadline);
+      std::optional<model::timeout_clock::time_point> debounce_deadline
+      = std::nullopt) {
+        return _impl->make_reader(cfg, debounce_deadline);
     }
 
     ss::future<std::optional<storage::timequery_result>>

--- a/src/v/transform/rpc/client.cc
+++ b/src/v/transform/rpc/client.cc
@@ -301,7 +301,7 @@ ss::future<bool> client::try_create_wasm_binary_ntp() {
     auto fut = co_await ss::coroutine::as_future<cluster::errc>(
       _topic_creator->create_topic(
         model::topic_namespace_view(model::wasm_binaries_internal_ntp),
-        1,
+        /*partition_count=*/1,
         topic_props));
     if (fut.failed()) {
         vlog(

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -231,9 +231,7 @@ ss::future<result<iobuf, cluster::errc>> local_service::load_wasm_binary(
             /*type_filter=*/std::nullopt,
             /*time=*/std::nullopt,
             /*as=*/std::nullopt);
-          model::timeout_clock::time_point deadline
-            = model::timeout_clock::now() + timeout;
-          return partition->make_reader(reader_config, deadline)
+          return partition->make_reader(reader_config)
             .then([this, timeout](storage::translating_reader rdr) {
                 return consume_wasm_binary_reader(
                   std::move(rdr.reader), timeout);


### PR DESCRIPTION
This fixes wasm binary fetching by not adding a debounce wait for new data to come along. This causes the request to timeout. The parameter `deadline` to `make_reader` is renamed to clarify semantics, then the bug is fixed (we should not pass a timeout to `make_reader`).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
