### PR TITLE
archival/purger: removed unused sort operation

### DIFF
--- a/src/v/archival/purger.cc
+++ b/src/v/archival/purger.cc
@@ -301,18 +301,13 @@ purger::global_position purger::get_global_position() {
     const auto& nodes = _members_table.local().nodes();
     auto self = config::node().node_id();
 
-    // members_table doesn't store nodes in sorted container, so
-    // we compose a sorted order first.
-    auto node_ids = _members_table.local().node_ids();
-    std::sort(node_ids.begin(), node_ids.end());
-
     uint32_t result = 0;
     uint32_t total = 0;
 
     // Iterate over node IDs earlier than ours, sum their core counts
-    for (auto i : node_ids) {
-        const auto cores = nodes.at(i).broker.properties().cores;
-        if (i < self) {
+    for (auto const& [id, node] : nodes) {
+        const auto cores = node.broker.properties().cores;
+        if (id < self) {
             result += cores;
         }
         total += cores;


### PR DESCRIPTION
sorting the node ids was probably done to achieve an early exit while iterating over all the nodes, but the loop using the id does a full scan so sorting does not influence the results

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none