### PR TITLE
rptest: use cloud variables in `CloudClusterUtils` init

### DIFF
--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -10,7 +10,21 @@ class FakePanda:
 
 
 class CloudClusterUtils:
-    def __init__(self, context, logger, infra_id, infra_secret, provider):
+    def __init__(self, context, logger, infra_id, infra_secret, provider,
+                 cloud_url_origin, oauth_url_origin, oauth_audience):
+        """
+        Initialize CloudClusterUtils.
+
+        :param logger: logging object
+        :param cluster_config: dict object loaded from
+               context.globals["cloud_cluster"]
+        :param infra_id: access key id
+        :param infra_secret: access key secret
+        :param provider: cloud provider, e.g. AWS
+        :param cloud_url_origin: just scheme and hostname
+        :param oauth_url_origin: just scheme and hostname
+        :param oauth_audience: audience for issued token
+        """
         # Create fake redpanda class with logger only
         self.fake_panda = FakePanda(context, logger)
         # Create rpk to use several functions that is isolated
@@ -19,11 +33,11 @@ class CloudClusterUtils:
         self.logger = logger
         self.provider = provider.lower()
         self.env = {
-            "RPK_CLOUD_SKIP_VERSION_CHECK": "True",
-            "RPK_CLOUD_URL": "https://cloud-api.ppd.cloud.redpanda.com",
-            "RPK_CLOUD_AUTH_URL": "https://preprod-cloudv2.us.auth0.com",
-            "RPK_CLOUD_AUTH_AUDIENCE": "cloudv2-preprod.redpanda.cloud",
-            "CLOUD_URL": "https://cloud-api.ppd.cloud.redpanda.com/api/v1",
+            'RPK_CLOUD_SKIP_VERSION_CHECK': 'True',
+            'RPK_CLOUD_URL': cloud_url_origin,
+            'RPK_CLOUD_AUTH_URL': oauth_url_origin,
+            'RPK_CLOUD_AUTH_AUDIENCE': oauth_audience,
+            'CLOUD_URL': f'{cloud_url_origin}/api/v1'
         }
         if self.provider == 'aws':
             self.env.update({

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -12,6 +12,7 @@ from ducktape.utils.util import wait_until
 from rptest.services.cloud_cluster_utils import CloudClusterUtils
 from rptest.services.provider_clients import make_provider_client
 from rptest.services.provider_clients.ec2_client import RTBS_LABEL
+from urllib.parse import urlparse
 
 rp_profiles_path = os.path.join(os.path.dirname(__file__),
                                 "rp_config_profiles")
@@ -410,9 +411,13 @@ class CloudCluster():
                                    f"for '{self.config.provider}'")
 
         # prepare rpk plugin
+        o = urlparse(self.config.oauth_url)
+        oauth_url_origin = f'{o.scheme}://{o.hostname}'
         self.utils = CloudClusterUtils(context, self._logger,
                                        self.provider_key, self.provider_secret,
-                                       self.config.provider)
+                                       self.config.provider,
+                                       self.config.api_url, oauth_url_origin,
+                                       self.config.oauth_audience)
         if self.config.type == CLOUD_TYPE_BYOC:
             # remove current plugin if any
             self.utils.rpk_plugin_uninstall('byoc', sudo=True)


### PR DESCRIPTION
Addresses https://github.com/redpanda-data/cloudv2/issues/9720

Replace hard-coded urls with values passed in from ducktape global config settings.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none