### PR TITLE
operator: add readiness check to Cluster statefulset

### DIFF
--- a/src/go/k8s/pkg/resources/certmanager/type_helpers.go
+++ b/src/go/k8s/pkg/resources/certmanager/type_helpers.go
@@ -602,8 +602,8 @@ func (cc *ClusterCertificates) Volumes() (
 		mountPoints.AdminAPI.NodeCertMountDir,
 		adminAPIClientCAVolName,
 		mountPoints.AdminAPI.ClientCAMountDir,
-		false,
-		false,
+		true,
+		true,
 	)
 	vols = append(vols, vol...)
 	mounts = append(mounts, mount...)
@@ -704,7 +704,6 @@ func secretVolumesForTLS(
 		clientCACertVolume.VolumeSource.Secret.Items = append(clientCACertVolume.VolumeSource.Secret.Items, caPath)
 	}
 
-	// Why do we need to mount the client certificate and key in RP? SEEMS NOT NEEDED.
 	if len(clientCertificates) > 0 && shouldIncludeClientCert {
 		clientCACertVolume.VolumeSource.Secret.Items = append(
 			clientCACertVolume.VolumeSource.Secret.Items,

--- a/src/go/k8s/pkg/resources/statefulset.go
+++ b/src/go/k8s/pkg/resources/statefulset.go
@@ -319,6 +319,20 @@ func (r *StatefulSetResource) obj(
 
 	tlsVolumes, tlsVolumeMounts := r.volumeProvider.Volumes()
 
+	rpkFlags := []string{}
+	u := fmt.Sprintf("%s://${POD_NAME}.%s:%d", r.pandaCluster.AdminAPIInternal().GetHTTPScheme(), r.serviceFQDN, r.pandaCluster.AdminAPIInternal().GetPort())
+	rpkFlags = append(rpkFlags, fmt.Sprintf("--api-urls %q", u))
+	if r.pandaCluster.AdminAPIInternal().GetTLS().Enabled {
+		rpkFlags = append(rpkFlags,
+			"--admin-api-tls-enabled",
+			fmt.Sprintf("--admin-api-tls-truststore %q", path.Join(resourcetypes.GetTLSMountPoints().AdminAPI.NodeCertMountDir, "ca.crt")))
+	}
+	if r.pandaCluster.AdminAPIInternal().GetTLS().RequireClientAuth {
+		rpkFlags = append(rpkFlags,
+			fmt.Sprintf("--admin-api-tls-cert %q", path.Join(resourcetypes.GetTLSMountPoints().AdminAPI.ClientCAMountDir, "tls.crt")),
+			fmt.Sprintf("--admin-api-tls-key %q", path.Join(resourcetypes.GetTLSMountPoints().AdminAPI.ClientCAMountDir, "tls.key")))
+	}
+
 	// We set statefulset replicas via status.currentReplicas in order to control it from the handleScaling function
 	replicas := r.pandaCluster.GetCurrentReplicas()
 
@@ -526,6 +540,13 @@ func (r *StatefulSetResource) obj(
 									ContainerPort: int32(r.pandaCluster.Spec.Configuration.RPCServer.Port),
 								},
 							}, r.getPorts()...),
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									Exec: &corev1.ExecAction{
+										Command: []string{"bash", "-xc", fmt.Sprintf("rpk cluster health %s| grep 'Healthy:.*true'", strings.Join(rpkFlags, " "))},
+									},
+								},
+							},
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:  pointer.Int64(userID),
 								RunAsGroup: pointer.Int64(groupID),


### PR DESCRIPTION
Add a readiness check to the old statefulset so it will be able to be tracked by the PodDisruptionBudget.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
