### PR TITLE
ducktape/transform: verify transform lifecycle

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -196,6 +196,24 @@ RUN /keycloak && rm /keycloak
 
 #################################
 
+FROM golang as tinygo
+
+COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/tinygo /
+RUN /tinygo && \
+    rm /tinygo
+ENV PATH="${PATH}:/usr/local/tinygo/bin"
+
+#################################
+
+FROM tinygo as wasi-transforms
+
+COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/tinygo-wasi-transforms /
+COPY --chown=0:0 --chmod=0755 src/go/transform-sdk /transform-sdk
+RUN /tinygo-wasi-transforms && \
+    rm -rf /transform-sdk
+
+#################################
+
 FROM librdkafka as final
 
 COPY --chown=0:0 --chmod=0755 tests/docker/ducktape-deps/teleport /
@@ -271,6 +289,7 @@ COPY --from=kcl /usr/local/bin/kcl /usr/local/bin/
 COPY --from=kgo-verifier /opt/kgo-verifier /opt/kgo-verifier
 COPY --from=byoc-mock /opt/redpanda-tests/go/byoc-mock/.rpk.managed-byoc /root/.local/bin/.rpk.managed-byoc
 COPY --from=keycloak /opt/keycloak/ /opt/keycloak/
+COPY --from=wasi-transforms /opt/transforms/ /opt/transforms/
 
 RUN ldconfig
 

--- a/tests/docker/Dockerfile.dockerignore
+++ b/tests/docker/Dockerfile.dockerignore
@@ -1,4 +1,5 @@
 **
+!src/go/transform-sdk
 !tests/java
 !tests/docker/ssh
 !tests/setup.py

--- a/tests/docker/ducktape-deps/tinygo
+++ b/tests/docker/ducktape-deps/tinygo
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+mkdir -p /usr/local/tinygo/
+if [ $(uname -m) = "aarch64" ]; then
+  export ARCHID="arm64"
+else
+  export ARCHID="amd64"
+fi
+curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 "https://github.com/redpanda-data/tinygo/releases/download/v0.30.0-rpk1/tinygo-linux-${ARCHID}.tar.gz" | tar -xz -C usr/local/tinygo/ --strip 1

--- a/tests/docker/ducktape-deps/tinygo-wasi-transforms
+++ b/tests/docker/ducktape-deps/tinygo-wasi-transforms
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+set -x
+
+mkdir -p /opt/transforms/tinygo/
+
+cd /transform-sdk/internal/testdata
+
+tinygo build -target wasi -opt=z \
+  -panic print -scheduler none \
+  -o "/opt/transforms/tinygo/identity.wasm" ./identity

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -110,6 +110,21 @@ class RpkGroup(typing.NamedTuple):
     partitions: list[RpkGroupPartition]
 
 
+class RpkWasmListProcessorResponse(typing.NamedTuple):
+    node_id: int
+    partition: int
+    # running | inactive | errored | unknown
+    status: str
+
+
+class RpkWasmListResponse(typing.NamedTuple):
+    name: str
+    input_topic: str
+    output_topics: list[str]
+    status: list[RpkWasmListProcessorResponse]
+    environment: dict[str, str]
+
+
 class RpkClusterInfoNode:
     def __init__(self, id, address):
         self.id = id
@@ -730,14 +745,6 @@ class RpkTool:
         out = self._run_group(cmd)
 
         return [l.split()[1] for l in out.splitlines()[1:]]
-
-    def wasm_deploy(self, script, name, description):
-        cmd = [
-            self._rpk_binary(), 'wasm', 'deploy', script, '--brokers',
-            self._redpanda.brokers(), '--name', name, '--description',
-            description
-        ]
-        return self._execute(cmd)
 
     def wasm_remove(self, name):
         cmd = ['wasm', 'remove', name, '--brokers', self._redpanda.brokers()]
@@ -1472,3 +1479,54 @@ class RpkTool:
             cmd += ["--permanent"]
 
         return self._run_registry(cmd)
+
+    def _run_wasm(self, rest):
+        cmd = [self._rpk_binary(), "transform"]
+        cmd += ["-X", "admin.hosts=" + self._redpanda.admin_endpoints()]
+        cmd += rest
+        return self._execute(cmd)
+
+    def deploy_wasm(self, name, input_topic, output_topic):
+        self._run_wasm([
+            "deploy",
+            "--name",
+            name,
+            "--input-topic",
+            input_topic,
+            "--output-topic",
+            output_topic,
+            "/opt/transforms/tinygo/identity.wasm",
+        ])
+
+    def delete_wasm(self, name):
+        self._run_wasm(["delete", name, "--no-confirm"])
+
+    def list_wasm(self):
+        out = self._run_wasm([
+            "list",
+            "--format",
+            "json",
+            "--detailed",
+        ])
+        loaded = json.loads(out)
+
+        def status_from_json(loaded):
+            return RpkWasmListProcessorResponse(
+                node_id=loaded["node_id"],
+                partition=loaded["partition"],
+                status=loaded["status"],
+            )
+
+        def transform_from_json(loaded):
+            return RpkWasmListResponse(
+                name=loaded["name"],
+                input_topic=loaded["input_topic"],
+                output_topics=loaded["output_topics"],
+                status=[status_from_json(s) for s in loaded["status"]],
+                environment={
+                    obj["key"]: obj["value"]
+                    for obj in loaded["environment"]
+                },
+            )
+
+        return [transform_from_json(o) for o in loaded]

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -1,0 +1,121 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.clients.rpk import RpkTool
+from rptest.services.cluster import cluster
+from ducktape.utils.util import wait_until
+
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.types import TopicSpec
+
+
+class WasmException(Exception):
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return repr(self.message)
+
+
+class DataTransformsTest(RedpandaTest):
+    """
+    Tests related to WebAssembly powered data transforms
+    """
+    topics = [TopicSpec(partition_count=9), TopicSpec(partition_count=9)]
+
+    def __init__(self, test_context):
+        super(DataTransformsTest,
+              self).__init__(test_context=test_context,
+                             extra_rp_conf={'data_transforms_enabled': True})
+        self._ctx = test_context
+        self._rpk = RpkTool(self.redpanda)
+
+    def _deploy_wasm(self, name: str):
+        """
+        Deploy a wasm transform and wait for all processors to be running.
+        """
+        [input_topic, output_topic] = self.topics
+
+        def do_deploy():
+            self._rpk.deploy_wasm(name, input_topic.name, output_topic.name)
+            return True
+
+        wait_until(
+            do_deploy,
+            timeout_sec=30,
+            backoff_sec=5,
+            err_msg=f"unable to deploy wasm transform {name}",
+            retry_on_exc=True,
+        )
+
+        def is_all_running():
+            transforms = self._rpk.list_wasm()
+            transform = next((x for x in transforms if x.name == name), None)
+            if not transform:
+                raise WasmException(f"missing transform {name} from report")
+            for partition_id in range(0, input_topic.partition_count):
+                processor = next(
+                    (p
+                     for p in transform.status if p.partition == partition_id),
+                    None)
+                if not processor:
+                    raise WasmException(
+                        f"missing processor {name}/{partition_id} from report")
+                if processor.status != "running":
+                    raise WasmException(
+                        f"processor {name}/{partition_id} is not running: {processor.status}"
+                    )
+            return True
+
+        wait_until(
+            is_all_running,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"wasm transform {name} did not reach steady state",
+            retry_on_exc=True,
+        )
+
+    def _delete_wasm(self, name: str):
+        """
+        Delete a wasm transform and wait for all processors to stop.
+        """
+        def do_deploy():
+            self._rpk.delete_wasm(name)
+            return True
+
+        wait_until(
+            do_deploy,
+            timeout_sec=30,
+            backoff_sec=5,
+            err_msg=f"unable to delete wasm transform {name}",
+            retry_on_exc=True,
+        )
+
+        def transform_is_gone():
+            transforms = self._rpk.list_wasm()
+            transform = next((x for x in transforms if x.name == name), None)
+            if transform:
+                raise WasmException(f"transform {name} still in report")
+            return True
+
+        wait_until(
+            transform_is_gone,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=f"wasm transform {name} was not fully shutdown",
+            retry_on_exc=True,
+        )
+
+    @cluster(num_nodes=3)
+    def test_lifecycle(self):
+        """
+        Test that a Wasm binary can be deployed, reach steady state and then be deleted.
+        """
+        self._deploy_wasm("identity-xform")
+        self._delete_wasm("identity-xform")


### PR DESCRIPTION
Writing my first ducktape test - this adds most of the boilerplate to inject a Wasm binary into the docker image we build,
adding the commands to `RpkTool` then a minimal example of the system working by verifying all the lifecycle commands work
as intended.

I've tried to write these tests with lots of error context and to be robust, but as I noted this is my first pass at a ducktape
test, so please let me know if I'm doing anything abormal.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
