### PR TITLE
rpk/transform/list: handle empty list responses

### DIFF
--- a/src/go/rpk/pkg/cli/transform/list.go
+++ b/src/go/rpk/pkg/cli/transform/list.go
@@ -86,6 +86,7 @@ func makeEnvMap(env []adminapi.EnvironmentVariable) map[string]string {
 }
 
 func summarizedView(metadata []adminapi.TransformMetadata) (resp []summarizedTransformMetadata) {
+	resp = make([]summarizedTransformMetadata, 0, len(metadata))
 	for _, meta := range metadata {
 		total := len(meta.Status)
 		running := 0
@@ -119,6 +120,7 @@ func printSummary(f config.OutFormatter, s []summarizedTransformMetadata, w io.W
 }
 
 func detailView(metadata []adminapi.TransformMetadata) (resp []detailedTransformMetadata) {
+	resp = make([]detailedTransformMetadata, 0, len(metadata))
 	for _, meta := range metadata {
 		resp = append(resp, detailedTransformMetadata{
 			Name:         meta.Name,

--- a/src/go/rpk/pkg/cli/transform/list_test.go
+++ b/src/go/rpk/pkg/cli/transform/list_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"gopkg.in/yaml.v3"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -81,6 +82,13 @@ func YAML(t *testing.T, o any) testCase {
 func Text(s string) testCase {
 	s = strings.TrimSpace(s)
 	return testCase{Kind: "text", Output: s + "\n"}
+}
+
+func TestHandleEmptyInput(t *testing.T) {
+	s := summarizedView([]adminapi.TransformMetadata{})
+	assert.NotNil(t, s)
+	d := detailView([]adminapi.TransformMetadata{})
+	assert.NotNil(t, d)
 }
 
 func TestPrintSummaryView(t *testing.T) {


### PR DESCRIPTION
This ensures that the JSON/YAML outputs for list don't return `null`,
but `[]`.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
