### PR TITLE
cluster/kv: track kv limit using bytes

### DIFF
--- a/src/v/cluster/tests/distributed_kv_stm_tests.cc
+++ b/src/v/cluster/tests/distributed_kv_stm_tests.cc
@@ -10,11 +10,12 @@
 #include "cluster/distributed_kv_stm.h"
 #include "raft/tests/raft_group_fixture.h"
 #include "raft/tests/simple_raft_fixture.h"
+#include "serde/envelope.h"
 
 static ss::logger logger{"kv_stm-test"};
 
-using test_key = ss::sstring;
-using test_value = kafka::offset;
+using test_key = int;
+using test_value = int;
 using stm_t = cluster::distributed_kv_stm<test_key, test_value>;
 
 struct stm_test_fixture : simple_raft_fixture {
@@ -41,31 +42,31 @@ FIXTURE_TEST(test_stm_basic, stm_test_fixture) {
     wait_for_confirmed_leader();
 
     // simple query, should initialize state.
-    auto result = stm.coordinator("test").get0();
+    auto result = stm.coordinator(0).get0();
     BOOST_REQUIRE(result);
     BOOST_REQUIRE_EQUAL(result.value(), 0);
 
     // same query, should return the same result.
-    auto result2 = stm.coordinator("test").get0();
+    auto result2 = stm.coordinator(0).get0();
     BOOST_REQUIRE(result2);
     BOOST_REQUIRE_EQUAL(result.value(), result2.value());
 
     absl::flat_hash_map<test_key, test_value> kvs;
-    kvs["test"] = kafka::offset{99};
-    kvs["test1"] = kafka::offset{100};
+    kvs[0] = 99;
+    kvs[1] = 100;
 
     auto result3 = stm.put(kvs).get0();
     BOOST_REQUIRE_EQUAL(result3, cluster::errc::success);
 
-    BOOST_REQUIRE_EQUAL(stm.get("test").get0().value(), kafka::offset{99});
-    BOOST_REQUIRE_EQUAL(stm.get("test1").get0().value(), kafka::offset{100});
+    BOOST_REQUIRE_EQUAL(stm.get(0).get0().value(), test_value{99});
+    BOOST_REQUIRE_EQUAL(stm.get(1).get0().value(), test_value{100});
 
     // delete key
-    BOOST_REQUIRE(stm.remove("test").get0() == cluster::errc::success);
+    BOOST_REQUIRE(stm.remove(0).get0() == cluster::errc::success);
     // mapping should be gone.
-    BOOST_REQUIRE(!stm.get("test").get0().value());
+    BOOST_REQUIRE(!stm.get(0).get0().value());
     // other mapping should be retained.
-    BOOST_REQUIRE_EQUAL(stm.get("test1").get0().value(), kafka::offset{100});
+    BOOST_REQUIRE_EQUAL(stm.get(1).get0().value(), test_value{100});
 }
 
 FIXTURE_TEST(test_batched_put, stm_test_fixture) {
@@ -75,20 +76,19 @@ FIXTURE_TEST(test_batched_put, stm_test_fixture) {
     wait_for_confirmed_leader();
 
     for (int i = 0; i < 30; i++) {
-        auto result = stm.coordinator(fmt::format("test-{}", i)).get0();
+        auto result = stm.coordinator(i).get0();
         BOOST_REQUIRE(result);
         BOOST_REQUIRE_EQUAL(result.value(), model::partition_id{0});
     }
 
     absl::flat_hash_map<test_key, test_value> kvs;
     for (int i = 0; i < 30; i++) {
-        kvs[fmt::format("test-{}", i)] = kafka::offset{i};
+        kvs[i] = test_value{i};
     }
     stm.put(std::move(kvs)).get();
 
     for (int i = 0; i < 30; i++) {
-        BOOST_REQUIRE_EQUAL(
-          stm.get(fmt::format("test-{}", i)).get0().value(), kafka::offset{i});
+        BOOST_REQUIRE_EQUAL(stm.get(i).get0().value(), test_value{i});
     }
 }
 
@@ -98,13 +98,13 @@ FIXTURE_TEST(test_stm_repartitioning, stm_test_fixture) {
     stm.start().get0();
     wait_for_confirmed_leader();
 
-    auto result = stm.coordinator("test").get0();
+    auto result = stm.coordinator(0).get0();
     BOOST_REQUIRE(result);
     BOOST_REQUIRE_EQUAL(result.value(), 0);
 
     // load up some keys, should all hash to 0 partition.
     for (int i = 0; i < 99; i++) {
-        auto result = stm.coordinator(fmt::format("test-{}", i)).get0();
+        auto result = stm.coordinator(i).get0();
         BOOST_REQUIRE(result);
         BOOST_REQUIRE_EQUAL(result.value(), model::partition_id{0});
     }
@@ -117,7 +117,7 @@ FIXTURE_TEST(test_stm_repartitioning, stm_test_fixture) {
     // load up more keys that hash to all partitions
     bool partition_1 = false, partition_2 = false;
     for (int i = 100; partition_1 && partition_2; i++) {
-        auto result = stm.coordinator(fmt::format("test-{}", i)).get0();
+        auto result = stm.coordinator(i).get0();
         BOOST_REQUIRE(result);
         BOOST_REQUIRE_GE(result.value(), 0);
         BOOST_REQUIRE_LE(result.value(), 2);
@@ -127,7 +127,7 @@ FIXTURE_TEST(test_stm_repartitioning, stm_test_fixture) {
 
     // ensure the original set of keys are still with partition 0;
     for (int i = 0; i < 99; i++) {
-        auto result = stm.coordinator(fmt::format("test-{}", i)).get0();
+        auto result = stm.coordinator(i).get0();
         BOOST_REQUIRE(result);
         BOOST_REQUIRE_EQUAL(result.value(), model::partition_id{0});
     }
@@ -145,15 +145,14 @@ FIXTURE_TEST(test_stm_snapshots, stm_test_fixture) {
 
     // load some data into the stm
     for (int i = 0; i < 99; i++) {
-        auto result = stm.coordinator(fmt::format("test-{}", i)).get0();
+        auto result = stm.coordinator(i).get0();
         BOOST_REQUIRE(result);
     }
 
     for (int i = 0; i < 99; i++) {
-        auto key = fmt::format("test-{}", i);
         for (int j = 0; j < 10; j++) {
             absl::flat_hash_map<test_key, test_value> kvs;
-            kvs[key] = kafka::offset{j};
+            kvs[i] = test_value{j};
             auto result = stm.put(kvs).get0();
             BOOST_REQUIRE(result == cluster::errc::success);
         }
@@ -171,9 +170,8 @@ FIXTURE_TEST(test_stm_snapshots, stm_test_fixture) {
     BOOST_REQUIRE_EQUAL(_raft->start_offset(), model::next_offset(offset));
     auto& new_stm = *_stm;
     for (int i = 0; i < 99; i++) {
-        auto key = fmt::format("test-{}", i);
-        auto result = new_stm.get(key).get0();
+        auto result = new_stm.get(i).get0();
         BOOST_REQUIRE(result);
-        BOOST_REQUIRE_EQUAL(result.value().value(), kafka::offset{9});
+        BOOST_REQUIRE_EQUAL(result.value().value(), test_value{9});
     }
 }

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -24,7 +24,7 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <cstdint>
-#include <utility>
+#include <type_traits>
 
 namespace model {
 /**


### PR DESCRIPTION
Instead of reasoning about the amount of memory that the offset tracker
for wasm could use as number of keys constant, we instead compute the
max number of keys from the number of entries that we're OK with
storing.

Instead of a blanket 10K keys we can keep in the distributed_kv_stm, we
now default to 1MB worth of data can be stored. To keep the
implementation fast and simple, we assert that the memory usage for
each object is fixed at compile time.

In our specific case, for offset metadata we now can store ~40k
transform offsets instead of 10k.

If we ever need key value pairs with dynamic memory usage, we can
evolve the implementation.

The nice thing about this change is that we know can easily account 
for about how much memory offset tracking can use in the system.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
