### PR TITLE
ci: Add util to test structure to clean cloudv2 after testrun

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -1,0 +1,53 @@
+import json
+import logging
+import os
+import sys
+from rptest.services.provider_clients.rpcloud_client import RpCloudApiClient
+from rptest.services.redpanda_cloud import CloudClusterConfig
+
+log = logging.getLogger()
+gconfig_path = './'
+
+
+def load_globals(path):
+    _gconfig = {}
+    _gpath = os.path.join(path, "globals.json")
+    try:
+        with open(_gpath, "r") as gf:
+            _gconfig = json.load(gf)
+    except Exception as e:
+        log.error(f"# ERROR: globals.json not found; {e}")
+    return _gconfig
+
+
+class CloudCleanup():
+    def __init__(self, ducktape_globals, log):
+        self.log = log
+        # Serialize params
+        self.config = CloudClusterConfig(**ducktape_globals['cloud_cluster'])
+        # Init the REST client
+        self.cloudv2 = RpCloudApiClient(self.config, log)
+
+    def clean_namespaces(self):
+        self.log.info("# Cleaning namespaces")
+        # TODO: Clean namespaces
+        return
+
+
+# Main script
+def cleanup_entrypoint():
+    # Try to load cluster config
+    gconfig = load_globals(gconfig_path)
+    if "cloud_cluster" not in gconfig:
+        log.warn("# WARNING: Cloud cluster configuration not present, exiting")
+        sys.exit(1)
+    # Init the cleaner class
+    cleaner = CloudCleanup(gconfig, log)
+
+    # Namespaces
+    cleaner.clean_namespaces()
+
+
+if __name__ == "__main__":
+    cleanup_entrypoint()
+    sys.exit(0)

--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -25,9 +25,15 @@ def setupLogger(level):
 
 class CloudCleanup():
     _ns_pattern = "rp-ducktape-ns-"
+    # At this point all is disabled except namespaces
+    delete_clusters = False
+    delete_peerings = False
+    delete_networks = False
+    delete_namespaces = True
 
     def __init__(self, log_level=logging.INFO):
         self.log = setupLogger(log_level)
+        self.log.info("# CloudV2 resourse cleanup util")
         # Load config
         ducktape_globals = self.load_globals(gconfig_path)
 
@@ -51,22 +57,64 @@ class CloudCleanup():
             self.log.error(f"# ERROR: globals.json not found; {e}")
         return _gconfig
 
+    def _delete_peerings(self, pool, queue):
+        if not self.delete_peerings:
+            self.log.info(f"# {len(queue)} network peerings could be deleted")
+        else:
+            self.log.info(f"# Deleting {len(queue)} network peerings")
+            for r in pool.map(self.cloudv2.delete_resource, queue):
+                # TODO: Check on real peering network delete request
+                if not r:
+                    self.log.warning(f"# Network peering '{r['name']}' "
+                                     "not deleted")
+
+    def _delete_clusters(self, pool, queue):
+        if not self.delete_clusters:
+            self.log.info(f"# {len(queue)} clusters could be deleted")
+        else:
+            self.log.info(f"# Deleting {len(queue)} clusters")
+            for r in pool.map(self.cloudv2.delete_resource, queue):
+                if r['state'] != 'deleted':
+                    self.log.warning(f"# Cluster '{r['name']}' not deleted")
+
+    def _delete_networks(self, pool, queue):
+        if not self.delete_networks:
+            self.log.info(f"# {len(queue)} networks could be deleted")
+        else:
+            self.log.info(f"# Deleting {len(queue)} networks")
+            for r in pool.map(self.cloudv2.delete_resource, queue):
+                if r['state'] != 'deleted':
+                    self.log.warning(f"# Network '{r['name']}' not deleted")
+
+    def _delete_namespaces(self, pool, queue):
+        if not self.delete_namespaces:
+            self.log.info(f"# {len(queue)} namespaces could be deleted")
+        else:
+            self.log.info(f"# Deleting {len(queue)} namespaces")
+            for r in pool.map(self.cloudv2.delete_resource, queue):
+                if not r['deleted']:
+                    self.log.warning(f"# Namespace '{r['name']}' not deleted")
+
     def clean_namespaces(self):
         """
             Function lists non-deleted namespaces and hierachically deletes
             clusters, networks and network-peerings if any
         """
-        self.log.info("# Cleaning namespaces")
+        self.log.info("# Listing namespaces")
         # Items to delete
-        _queue = []
+        cl_queue = []
+        net_queue = []
+        npr_queue = []
+        ns_queue = []
 
         # Get namespaces
         ns_list = self.cloudv2.list_namespaces()
         # filter out
         self.log.info(f" {len(ns_list)} total namespaces found. "
                       f"Filtering with '{self._ns_pattern}*'")
-        ns_list = [n for n in ns_list
-                   if n['name'].startswith(self._ns_pattern)]
+        ns_list = [
+            n for n in ns_list if n['name'].startswith(self._ns_pattern)
+        ]
         # Check which ones are empty
         # The areas that are checked is clusters, networks and network-peerings
         self.log.info(f" {len(ns_list)} namespaces to process")
@@ -84,23 +132,42 @@ class CloudCleanup():
                                  f"not empty: {counts[0]} clusters,"
                                  f" {counts[1]} networks,"
                                  f" {counts[2]} peering connections")
-                # TODO: Cleanup clusters
-                # TODO: Cleanup networks
                 # TODO: Cleanup network peerings
-                pass
+                if counts[2]:
+                    for peernet in peerings:
+                        npr_queue += [
+                            self.cloudv2.network_peering_endpoint(
+                                id=peernet['net_id'], peering_id=peernet['id'])
+                        ]
+                # TODO: Cleanup clusters
+                if counts[0]:
+                    for cluster in clusters:
+                        # TODO: Check creation date
+                        # Add cluster to queue
+                        cl_queue += [
+                            self.cloudv2.cluster_endpoint(cluster['id'])
+                        ]
+                # TODO: Cleanup networks
+                if counts[1]:
+                    for net in networks:
+                        net_queue += [self.cloudv2.network_endpoint(net['id'])]
             else:
                 # Add delete handle to the list
-                _queue += [self.cloudv2.namespace_endpoint(uuid=ns['id'])]
-                # ##### debug
-                # if len(_queue) > 10:
-                #    break
-                # ##### debug
-        # Use ThreadPool to delete them
-        self.log.info(f"# Deleting {len(_queue)} namespaces")
+                ns_queue += [self.cloudv2.namespace_endpoint(uuid=ns['id'])]
+                # #### debug purposes while in draft mode
+                if len(ns_queue) > 10:
+                    break
+                # #### debug
+        # Use ThreadPool
         pool = ThreadPoolExecutor(max_workers=5)
-        for r in pool.map(self.cloudv2.delete_resource, _queue):
-            if not r['deleted']:
-                self.log.warning(f"# Namespace '{r['name']}' not deleted")
+        # Delete network peerings
+        self._delete_peerings(pool, npr_queue)
+        # Delete clusters
+        self._delete_clusters(pool, cl_queue)
+        # Delete orphaned networks
+        self._delete_networks(pool, net_queue)
+        # Delete namespaces
+        self._delete_namespaces(pool, ns_queue)
         # Cleanup thread resources
         pool.shutdown()
 

--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -2,47 +2,115 @@ import json
 import logging
 import os
 import sys
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from rptest.services.provider_clients.rpcloud_client import RpCloudApiClient
 from rptest.services.redpanda_cloud import CloudClusterConfig
 
-log = logging.getLogger()
 gconfig_path = './'
 
 
-def load_globals(path):
-    _gconfig = {}
-    _gpath = os.path.join(path, "globals.json")
-    try:
-        with open(_gpath, "r") as gf:
-            _gconfig = json.load(gf)
-    except Exception as e:
-        log.error(f"# ERROR: globals.json not found; {e}")
-    return _gconfig
+def setupLogger(level):
+    root = logging.getLogger()
+    root.setLevel(level)
+    # Console
+    cli = logging.StreamHandler(sys.stdout)
+    cli.setLevel(logging.DEBUG)
+    formatter = logging.Formatter('%(message)s')
+    cli.setFormatter(formatter)
+    root.addHandler(cli)
+
+    return root
 
 
 class CloudCleanup():
-    def __init__(self, ducktape_globals, log):
-        self.log = log
-        # Serialize params
+    _ns_pattern = "rp-ducktape-ns-"
+
+    def __init__(self, log_level=logging.INFO):
+        self.log = setupLogger(log_level)
+        # Load config
+        ducktape_globals = self.load_globals(gconfig_path)
+
+        # Serialize it to class
+        if "cloud_cluster" not in ducktape_globals:
+            self.log.warn("# WARNING: Cloud cluster configuration "
+                          "not present, exiting")
+            sys.exit(1)
         self.config = CloudClusterConfig(**ducktape_globals['cloud_cluster'])
+
         # Init the REST client
-        self.cloudv2 = RpCloudApiClient(self.config, log)
+        self.cloudv2 = RpCloudApiClient(self.config, self.log)
+
+    def load_globals(self, path):
+        _gconfig = {}
+        _gpath = os.path.join(path, "globals.json")
+        try:
+            with open(_gpath, "r") as gf:
+                _gconfig = json.load(gf)
+        except Exception as e:
+            self.log.error(f"# ERROR: globals.json not found; {e}")
+        return _gconfig
 
     def clean_namespaces(self):
+        """
+            Function lists non-deleted namespaces and hierachically deletes
+            clusters, networks and network-peerings if any
+        """
         self.log.info("# Cleaning namespaces")
-        # TODO: Clean namespaces
+        # Items to delete
+        _queue = []
+
+        # Get namespaces
+        ns_list = self.cloudv2.list_namespaces()
+        # filter out
+        self.log.info(f" {len(ns_list)} total namespaces found. "
+                      f"Filtering with '{self._ns_pattern}*'")
+        ns_list = [n for n in ns_list
+                   if n['name'].startswith(self._ns_pattern)]
+        # Check which ones are empty
+        # The areas that are checked is clusters, networks and network-peerings
+        self.log.info(f" {len(ns_list)} namespaces to process")
+        for ns in ns_list:
+            clusters = self.cloudv2.list_clusters(ns_uuid=ns['id'])
+            networks = self.cloudv2.list_networks(ns_uuid=ns['id'])
+            # check if any peerings exists
+            peerings = []
+            for net in networks:
+                peerings += self.cloudv2.list_network_peerings(
+                    net['id'], ns_uuid=ns['id'])
+            counts = [len(clusters), len(networks), len(peerings)]
+            if any(counts):
+                self.log.warning(f"# WARNING: Namespace '{ns['name']}' "
+                                 f"not empty: {counts[0]} clusters,"
+                                 f" {counts[1]} networks,"
+                                 f" {counts[2]} peering connections")
+                # TODO: Cleanup clusters
+                # TODO: Cleanup networks
+                # TODO: Cleanup network peerings
+                pass
+            else:
+                # Add delete handle to the list
+                _queue += [self.cloudv2.namespace_endpoint(uuid=ns['id'])]
+                # ##### debug
+                # if len(_queue) > 10:
+                #    break
+                # ##### debug
+        # Use ThreadPool to delete them
+        self.log.info(f"# Deleting {len(_queue)} namespaces")
+        pool = ThreadPoolExecutor(max_workers=5)
+        for r in pool.map(self.cloudv2.delete_resource, _queue):
+            if not r['deleted']:
+                self.log.warning(f"# Namespace '{r['name']}' not deleted")
+        # Cleanup thread resources
+        pool.shutdown()
+
         return
 
 
 # Main script
 def cleanup_entrypoint():
-    # Try to load cluster config
-    gconfig = load_globals(gconfig_path)
-    if "cloud_cluster" not in gconfig:
-        log.warn("# WARNING: Cloud cluster configuration not present, exiting")
-        sys.exit(1)
     # Init the cleaner class
-    cleaner = CloudCleanup(gconfig, log)
+    cleaner = CloudCleanup()
 
     # Namespaces
     cleaner.clean_namespaces()

--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -6,7 +6,8 @@ import sys
 from datetime import datetime, timedelta
 from concurrent.futures import ThreadPoolExecutor
 from rptest.services.provider_clients.rpcloud_client import RpCloudApiClient
-from rptest.services.redpanda_cloud import CloudClusterConfig
+from rptest.services.redpanda_cloud import CloudClusterConfig, ns_name_date_fmt, \
+    ns_name_prefix
 
 gconfig_path = './'
 
@@ -25,17 +26,16 @@ def setupLogger(level):
 
 
 class CloudCleanup():
-    _ns_pattern = "rp-ducktape-ns-"
+    _ns_pattern = f"{ns_name_prefix}"
     # At this point all is disabled except namespaces
     delete_clusters = False
     delete_peerings = False
     delete_networks = False
     delete_namespaces = True
 
-    ns_regex = re.compile("^(?P<prefix>rp-ducktape-ns-)"
+    ns_regex = re.compile("^(?P<prefix>" + f"{ns_name_prefix}" + ")"
                           "(?P<date>\d{4}-\d{2}-\d{2}-\d{6}-)?"
                           "(?P<id>[a-zA-Z0-9]{8})$")
-    ns_date_fmt = "%Y-%m-%d-%H%M%S"
 
     def __init__(self, log_level=logging.INFO):
         self.log = setupLogger(log_level)
@@ -115,16 +115,31 @@ class CloudCleanup():
 
         # Get namespaces
         ns_list = self.cloudv2.list_namespaces()
-        # filter out
-        self.log.info(f" {len(ns_list)} total namespaces found. "
+        self.log.info(f"  {len(ns_list)} total namespaces found. "
                       f"Filtering with '{self._ns_pattern}*'")
+        # filter namespaces according to 'ns_name_prefix'
         ns_list = [
             n for n in ns_list if n['name'].startswith(self._ns_pattern)
         ]
-        # Check which ones are empty
-        # The areas that are checked is clusters, networks and network-peerings
-        self.log.info(f" {len(ns_list)} namespaces to process")
+        # Processing namespaces
+        self.log.info(
+            f"# Searching for resources in {len(ns_list)} namespaces")
+        # Fugure out which time was 36h back
+        back_36h = datetime.now() - timedelta(hours=36)
         for ns in ns_list:
+            # Filter out according to dates in name
+            # Detect date
+            ns_match = self.ns_regex.match(ns['name'])
+            date = ns_match['date']
+            if date is not None:
+                # Parse date into datetime object
+                ns_creation_date = datetime.strptime(date, ns_name_date_fmt)
+                if ns_creation_date > back_36h:
+                    self.log.info(f"  skipped '{ns['name']}', "
+                                  "36h delay not passed")
+                    continue
+            # Check which ones are empty
+            # The areas that are checked is clusters, networks and network-peerings
             clusters = self.cloudv2.list_clusters(ns_uuid=ns['id'])
             networks = self.cloudv2.list_networks(ns_uuid=ns['id'])
             # check if any peerings exists
@@ -132,60 +147,54 @@ class CloudCleanup():
             for net in networks:
                 peerings += self.cloudv2.list_network_peerings(
                     net['id'], ns_uuid=ns['id'])
+            # Calculate existing resources for this namespace
             counts = [len(clusters), len(networks), len(peerings)]
             if any(counts):
+                # Announce counts
                 self.log.warning(f"# WARNING: Namespace '{ns['name']}' "
                                  f"not empty: {counts[0]} clusters,"
                                  f" {counts[1]} networks,"
                                  f" {counts[2]} peering connections")
-                # TODO: Cleanup network peerings
+                # TODO: Prepare needed data for peerings
                 if counts[2]:
                     for peernet in peerings:
+                        # Add peerings delete handle to own list
                         npr_queue += [
                             self.cloudv2.network_peering_endpoint(
                                 id=peernet['net_id'], peering_id=peernet['id'])
                         ]
-                # TODO: Cleanup clusters
+                # TODO: Prepare needed data for clusters
                 if counts[0]:
                     for cluster in clusters:
                         # TODO: Check creation date
-                        # Add cluster to queue
+                        # Add cluster delete handle to own list
                         cl_queue += [
                             self.cloudv2.cluster_endpoint(cluster['id'])
                         ]
-                # TODO: Cleanup networks
+                # TODO: Prepare needed data for networks
                 if counts[1]:
                     for net in networks:
+                        # Add network delete handle to own list
                         net_queue += [self.cloudv2.network_endpoint(net['id'])]
-            else:
-                # Detect date
-                ns_match = self.ns_regex.match(ns['name'])
-                date = ns_match['date']
-                if date is not None:
-                    # Fugure out which time was 36h back
-                    back_36h = datetime.now() - timedelta(hours=36)
-                    ns_creation_date = datetime.strptime(
-                        date, self.ns_date_fmt)
-                    if ns_creation_date > back_36h:
-                        self.log.info(f"# Skipped '{ns['name']}', "
-                                      "36h delay not passed")
-                        continue
-                # Add delete handle to the list
-                ns_queue += [self.cloudv2.namespace_endpoint(uuid=ns['id'])]
-                # #### debug purposes while in draft mode
-                if len(ns_queue) > 10:
-                    break
-                # #### debug
+            # Add ns delete handle to the list
+            ns_queue += [self.cloudv2.namespace_endpoint(uuid=ns['id'])]
         # Use ThreadPool
+        # Deletion can be done only in this order:
+        # Peerings - > clusters -> networks -> namespaces
         pool = ThreadPoolExecutor(max_workers=5)
+
         # Delete network peerings
         self._delete_peerings(pool, npr_queue)
+
         # Delete clusters
         self._delete_clusters(pool, cl_queue)
+
         # Delete orphaned networks
         self._delete_networks(pool, net_queue)
+
         # Delete namespaces
         self._delete_namespaces(pool, ns_queue)
+
         # Cleanup thread resources
         pool.shutdown()
 

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -1,0 +1,92 @@
+import requests
+
+
+class RpCloudApiClient(object):
+    def __init__(self, config, log):
+        self._config = config
+        self._token = None
+        self._logger = log
+        self.lasterror = None
+
+    def _handle_error(self, response):
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as e:
+            self.lasterror = f'{e} {response.text}'
+            self._logger.error(self.lasterror)
+            raise e
+        return response
+
+    def _get_token(self):
+        """
+        Returns access token to be used in subsequent api calls to cloud api.
+
+        To save on repeated token generation, this function will cache it in a local variable.
+        Assumes the token has an expiration that will last throughout the usage of this cluster.
+
+        :return: access token as a string
+        """
+
+        if self._token is None:
+            headers = {'Content-Type': "application/x-www-form-urlencoded"}
+            data = {
+                'grant_type': 'client_credentials',
+                'client_id': f'{self._config.oauth_client_id}',
+                'client_secret': f'{self._config.oauth_client_secret}',
+                'audience': f'{self._config.oauth_audience}'
+            }
+            resp = requests.post(f'{self._config.oauth_url}',
+                                 headers=headers,
+                                 data=data)
+            _r = self._handle_error(resp)
+            if _r is None:
+                return _r
+            j = resp.json()
+            self._token = j['access_token']
+        return self._token
+
+    def _http_get(self,
+                  endpoint='',
+                  base_url=None,
+                  override_headers=None,
+                  text_response=False,
+                  **kwargs):
+        headers = override_headers
+        if headers is None:
+            token = self._get_token()
+            headers = {
+                'Authorization': f'Bearer {token}',
+                'Accept': 'application/json'
+            }
+        _base = base_url if base_url else self._config.api_url
+        resp = requests.get(f'{_base}{endpoint}', headers=headers, **kwargs)
+        _r = self._handle_error(resp)
+        if text_response:
+            return _r if _r is None else _r.text
+        return _r if _r is None else _r.json()
+
+    def _http_post(self, base_url=None, endpoint='', **kwargs):
+        token = self._get_token()
+        headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/json'
+        }
+        if base_url is None:
+            base_url = self._config.api_url
+        resp = requests.post(f'{base_url}{endpoint}',
+                             headers=headers,
+                             **kwargs)
+        _r = self._handle_error(resp)
+        return _r if _r is None else _r.json()
+
+    def _http_delete(self, endpoint='', **kwargs):
+        token = self._get_token()
+        headers = {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/json'
+        }
+        resp = requests.delete(f'{self._config.api_url}{endpoint}',
+                               headers=headers,
+                               **kwargs)
+        _r = self._handle_error(resp)
+        return _r if _r is None else _r.json()

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -153,10 +153,8 @@ class RpCloudApiClient(object):
         return _ret
 
     def list_network_peerings(self, network_id, ns_uuid=None):
-        _ret = self._http_get(
-            self.network_peering_endpoint(id=network_id),
-            params=self._prepare_params(ns_uuid=ns_uuid)
-        )
+        _ret = self._http_get(self.network_peering_endpoint(id=network_id),
+                              params=self._prepare_params(ns_uuid=ns_uuid))
         return _ret
 
     def get_network(self, network_id):

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -12,6 +12,7 @@ from ducktape.utils.util import wait_until
 from rptest.services.cloud_cluster_utils import CloudClusterUtils
 from rptest.services.provider_clients import make_provider_client
 from rptest.services.provider_clients.ec2_client import RTBS_LABEL
+from rptest.services.provider_clients.rpcloud_client import RpCloudApiClient
 from urllib.parse import urlparse
 
 rp_profiles_path = os.path.join(os.path.dirname(__file__),
@@ -153,97 +154,6 @@ AdvertisedTierConfigs = {
     ),
 }
 # yapf: enable
-
-
-class RpCloudApiClient(object):
-    def __init__(self, config, log):
-        self._config = config
-        self._token = None
-        self._logger = log
-        self.lasterror = None
-
-    def _handle_error(self, response):
-        try:
-            response.raise_for_status()
-        except requests.HTTPError as e:
-            self.lasterror = f'{e} {response.text}'
-            self._logger.error(self.lasterror)
-            raise e
-        return response
-
-    def _get_token(self):
-        """
-        Returns access token to be used in subsequent api calls to cloud api.
-
-        To save on repeated token generation, this function will cache it in a local variable.
-        Assumes the token has an expiration that will last throughout the usage of this cluster.
-
-        :return: access token as a string
-        """
-
-        if self._token is None:
-            headers = {'Content-Type': "application/x-www-form-urlencoded"}
-            data = {
-                'grant_type': 'client_credentials',
-                'client_id': f'{self._config.oauth_client_id}',
-                'client_secret': f'{self._config.oauth_client_secret}',
-                'audience': f'{self._config.oauth_audience}'
-            }
-            resp = requests.post(f'{self._config.oauth_url}',
-                                 headers=headers,
-                                 data=data)
-            _r = self._handle_error(resp)
-            if _r is None:
-                return _r
-            j = resp.json()
-            self._token = j['access_token']
-        return self._token
-
-    def _http_get(self,
-                  endpoint='',
-                  base_url=None,
-                  override_headers=None,
-                  text_response=False,
-                  **kwargs):
-        headers = override_headers
-        if headers is None:
-            token = self._get_token()
-            headers = {
-                'Authorization': f'Bearer {token}',
-                'Accept': 'application/json'
-            }
-        _base = base_url if base_url else self._config.api_url
-        resp = requests.get(f'{_base}{endpoint}', headers=headers, **kwargs)
-        _r = self._handle_error(resp)
-        if text_response:
-            return _r if _r is None else _r.text
-        return _r if _r is None else _r.json()
-
-    def _http_post(self, base_url=None, endpoint='', **kwargs):
-        token = self._get_token()
-        headers = {
-            'Authorization': f'Bearer {token}',
-            'Accept': 'application/json'
-        }
-        if base_url is None:
-            base_url = self._config.api_url
-        resp = requests.post(f'{base_url}{endpoint}',
-                             headers=headers,
-                             **kwargs)
-        _r = self._handle_error(resp)
-        return _r if _r is None else _r.json()
-
-    def _http_delete(self, endpoint='', **kwargs):
-        token = self._get_token()
-        headers = {
-            'Authorization': f'Bearer {token}',
-            'Accept': 'application/json'
-        }
-        resp = requests.delete(f'{self._config.api_url}{endpoint}',
-                               headers=headers,
-                               **kwargs)
-        _r = self._handle_error(resp)
-        return _r if _r is None else _r.json()
 
 
 @dataclass(kw_only=True)

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -6,6 +6,7 @@ import requests
 import uuid
 import yaml
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import Enum
 from typing import Optional
 from ducktape.utils.util import wait_until
@@ -19,6 +20,8 @@ rp_profiles_path = os.path.join(os.path.dirname(__file__),
                                 "rp_config_profiles")
 tiers_config_filename = os.path.join(rp_profiles_path,
                                      "redpanda.cloud-tiers-config.yml")
+ns_name_prefix = "rp-ducktape-ns-"
+ns_name_date_fmt = "%Y-%m-%d-%H%M%S-"
 
 
 def load_tier_profiles():
@@ -399,9 +402,15 @@ class CloudCluster():
         else:
             return False if username not in _users else True
 
+    def _format_namespace_name(self):
+        # format namespace name as 'rp-ducktape-ns-YYYY-MM-DD-HHMMSS-3b36f516'
+        _date = datetime.now().strftime(ns_name_date_fmt)
+        # For easier regex parsing, date format has second dash inside
+        return f'{ns_name_prefix}{_date}{self._unique_id}'
+
     def _create_namespace(self):
-        # format namespace name as 'rp-ducktape-ns-3b36f516
-        name = f'rp-ducktape-ns-{self._unique_id}'
+        # fetch namespace name
+        name = self._format_namespace_name()
         self._logger.debug(f'creating namespace name {name}')
         body = {'name': name}
         r = self.cloudv2._http_post(endpoint='/api/v1/namespaces', json=body)


### PR DESCRIPTION
  To minimize code duplication, util is using the same RpCloudApiClient
  class that is used in redpanda_cloud class. Also, to isolate it from
  ducktape runtime, its placed in tests folder to utilize rptest as an
  external module and prevent any CI-related modifications.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
