### PR TITLE
cloud_roles: redact fields from request string representation

### DIFF
--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -180,4 +180,6 @@ time_source::time_source(Fn&& fn, int)
 
 ss::sstring uri_encode(const ss::sstring& input, bool encode_slash);
 
+ss::sstring redact_headers_from_string(const std::string_view original);
+
 } // namespace cloud_roles

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -39,16 +39,15 @@
 #include <limits>
 #include <stdexcept>
 
-namespace {
-using field_type = std::variant<boost::beast::http::field, std::string>;
-
-const std::unordered_set<field_type> redacted_fields{
-  boost::beast::http::field::authorization,
-  "x-amz-content-sha256",
-  "x-amz-security-token"};
-} // namespace
-
 namespace http {
+
+const std::unordered_set<std::variant<boost::beast::http::field, std::string>>
+redacted_fields() {
+    return {
+      boost::beast::http::field::authorization,
+      "x-amz-content-sha256",
+      "x-amz-security-token"};
+}
 
 // client implementation //
 static constexpr ss::lowres_clock::duration default_max_idle_time = 1s;
@@ -627,7 +626,7 @@ ss::input_stream<char> client::response_stream::as_input_stream() {
 
 client::request_header redacted_header(client::request_header original) {
     auto h{std::move(original)};
-    for (const auto& field : redacted_fields) {
+    for (const auto& field : redacted_fields()) {
         std::visit(
           [&h](const auto& f) {
               if (h.find(f) != h.end()) {

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -268,6 +268,9 @@ auto with_client(client&& cl, Func func) {
       });
 }
 
+const std::unordered_set<std::variant<boost::beast::http::field, std::string>>
+redacted_fields();
+
 } // namespace http
 
 template<>


### PR DESCRIPTION
Do not print values of sensitive headers when printing the string representation of an http request.

FIXES https://github.com/redpanda-data/core-internal/issues/839

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

* none
