### PR TITLE
tests/scale: import missing `ok_to_fail` decorator

### DIFF
--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -25,6 +25,7 @@ from rptest.services.redpanda import (RESTART_LOG_ALLOW_LIST,
                                       AdvertisedTierConfig, CloudTierName,
                                       MetricsEndpoint, SISettings)
 from rptest.tests.prealloc_nodes import PreallocNodesTest
+from ducktape.mark import ok_to_fail
 
 kiB = 1024
 MiB = kiB * kiB


### PR DESCRIPTION
fixes the error:
Failed to import rptest.scale_tests.high_throughput_test,
which may indicate a broken test that cannot be loaded:
NameError: name 'ok_to_fail' is not defined

ref https://github.com/redpanda-data/devprod/issues/878

## Release Notes

* none
