### PR TITLE
rpk: accept property aliases for cluster config set

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_config.go
+++ b/src/go/rpk/pkg/adminapi/api_config.go
@@ -81,6 +81,7 @@ type ConfigPropertyMetadata struct {
 	Example      string              `json:"example,omitempty"`     // A non-default value for use in docs or tests
 	EnumValues   []string            `json:"enum_values,omitempty"` // Permitted values, or empty list.
 	Items        ConfigPropertyItems `json:"items,omitempty"`       // If this is an array, the contained value type
+	Aliases      []string            `json:"aliases,omitempty"`     // Aliases for this property
 }
 
 type ConfigSchema map[string]ConfigPropertyMetadata

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1425,12 +1425,10 @@ class ClusterConfigAliasTest(RedpandaTest, ClusterConfigHelpersMixin):
                                      prop_set.test_values[1])
 
         # The rpk CLI should also accept aliased names
-        # NOTE due to https://github.com/redpanda-data/redpanda/issues/13389
-        # this is not possible at the moment: rpk rejects the aliased_name
-        # self.rpk.cluster_config_set(prop_set.aliased_name,
-        #                             prop_set.test_values[2])
-        # self._check_value_everywhere(prop_set.primary_name,
-        #                              prop_set.test_values[2])
+        self.rpk.cluster_config_set(prop_set.aliased_name,
+                                    prop_set.test_values[2])
+        self._check_value_everywhere(prop_set.primary_name,
+                                     prop_set.test_values[2])
 
     @cluster(num_nodes=3)
     @matrix(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

while setting a config, this pr extends the check of the key on the aliases for properties, and adds a test for it

Fixes #13389 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* `rpk cluster config set` can use the property alias 