### PR TITLE
operator: move kubebuilder comments back

### DIFF
--- a/src/go/k8s/config/crd/kustomization.yaml
+++ b/src/go/k8s/config/crd/kustomization.yaml
@@ -4,29 +4,31 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-#+kubebuilder:scaffold:crdkustomizeresource
 resources:
 - bases/redpanda.vectorized.io_clusters.yaml
 - bases/redpanda.vectorized.io_consoles.yaml
 - bases/cluster.redpanda.com_redpandas.yaml
 - bases/cluster.redpanda.com_topics.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
 - bases/toolkit.fluxcd.io/helm-controller.yaml
 - bases/toolkit.fluxcd.io/source-controller.yaml
 
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
+- path: patches/webhook_in_clusters.yaml
+- path: patches/webhook_in_redpanda_consoles.yaml
+- path: patches/webhook_in_cluster.redpanda.com_topics.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-patches:
-- path: patches/webhook_in_clusters.yaml
-- path: patches/webhook_in_redpanda_consoles.yaml
-- path: patches/webhook_in_cluster.redpanda.com_topics.yaml
 - path: patches/cainjection_in_clusters.yaml
 - path: patches/cainjection_in_redpanda_consoles.yaml
 - path: patches/cainjection_in_cluster.redpanda.com_topics.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# patches CRD to re-add removed fields from beta CRDs
 - path: patches/re-add-checksum-field_in_source.toolkit.fluxcd.io.yaml
   target:
     kind: CustomResourceDefinition
@@ -39,9 +41,6 @@ patches:
   target:
     kind: CustomResourceDefinition
     name: ocirepositories.source.toolkit.fluxcd.io
-
-
-# patches CRD to re-add removed fields from beta CRDs
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:


### PR DESCRIPTION
`kustomize edit fix` moved yaml around, breaking the in-line comments needed for kubebuilder.

This just moves those comments back where they belong

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
