### PR TITLE
storage: offset key map housekeeping

### DIFF
--- a/src/v/hashing/secure.h
+++ b/src/v/hashing/secure.h
@@ -107,6 +107,7 @@ class hash {
     static_assert(DigestSize > 0, "digest cannot be zero length");
 
 public:
+    static constexpr auto digest_size = DigestSize;
     using digest_type = std::array<char, DigestSize>;
 
     // silence clang-tidy about _handle being uninitialized

--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -38,6 +38,7 @@ v_cc_library(
     file_sanitizer_types.cc
     api.cc
     node.cc
+    key_offset_map.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -18,7 +18,7 @@ simple_key_offset_map::simple_key_offset_map(size_t max_keys)
       _memory_tracker))
   , _max_keys(max_keys) {}
 
-bool simple_key_offset_map::put(compaction_key key, model::offset o) {
+bool simple_key_offset_map::put(const compaction_key& key, model::offset o) {
     if (_map.size() >= _max_keys) {
         return false;
     }

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "storage/key_offset_map.h"
+
+namespace storage {
+
+simple_key_offset_map::simple_key_offset_map(size_t max_keys)
+  : _memory_tracker(ss::make_shared<util::mem_tracker>("simple_key_offset_map"))
+  , _map(util::mem_tracked::map<absl::btree_map, compaction_key, model::offset>(
+      _memory_tracker))
+  , _max_keys(max_keys) {}
+
+bool simple_key_offset_map::put(compaction_key key, model::offset o) {
+    if (_map.size() >= _max_keys) {
+        return false;
+    }
+    _map[key] = std::max(o, _map[key]);
+    _max_offset = std::max(_max_offset, o);
+    return true;
+}
+
+std::optional<model::offset>
+simple_key_offset_map::get(const compaction_key& key) const {
+    auto iter = _map.find(key);
+    if (iter == _map.end()) {
+        return std::nullopt;
+    }
+    return iter->second;
+}
+
+model::offset simple_key_offset_map::max_offset() const { return _max_offset; }
+
+} // namespace storage

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -18,22 +18,25 @@ simple_key_offset_map::simple_key_offset_map(size_t max_keys)
       _memory_tracker))
   , _max_keys(max_keys) {}
 
-bool simple_key_offset_map::put(const compaction_key& key, model::offset o) {
+seastar::future<bool>
+simple_key_offset_map::put(const compaction_key& key, model::offset o) {
     if (_map.size() >= _max_keys) {
-        return false;
+        return seastar::make_ready_future<bool>(false);
     }
     _map[key] = std::max(o, _map[key]);
     _max_offset = std::max(_max_offset, o);
-    return true;
+    return seastar::make_ready_future<bool>(true);
 }
 
-std::optional<model::offset>
+seastar::future<std::optional<model::offset>>
 simple_key_offset_map::get(const compaction_key& key) const {
     auto iter = _map.find(key);
     if (iter == _map.end()) {
-        return std::nullopt;
+        return seastar::make_ready_future<std::optional<model::offset>>(
+          std::nullopt);
     }
-    return iter->second;
+    return seastar::make_ready_future<std::optional<model::offset>>(
+      iter->second);
 }
 
 model::offset simple_key_offset_map::max_offset() const { return _max_offset; }

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -10,7 +10,8 @@
 
 #include "storage/compacted_index.h"
 #include "utils/tracking_allocator.h"
-#include "vlog.h"
+
+#include <seastar/core/future.hh>
 
 #include <absl/container/btree_map.h>
 
@@ -33,12 +34,13 @@ public:
      * the new mapping with override the existing mapping provided that \p
      * offset is larger than the existing offset associated with the key.
      */
-    virtual bool put(const compaction_key& key, model::offset offset) = 0;
+    virtual seastar::future<bool>
+    put(const compaction_key& key, model::offset offset) = 0;
 
     /**
      * Return the offset for the given \p key.
      */
-    virtual std::optional<model::offset>
+    virtual seastar::future<std::optional<model::offset>>
     get(const compaction_key& key) const = 0;
 
     /**
@@ -60,9 +62,11 @@ public:
      */
     explicit simple_key_offset_map(size_t max_keys = default_key_limit);
 
-    bool put(const compaction_key& key, model::offset offset) override;
+    seastar::future<bool>
+    put(const compaction_key& key, model::offset offset) override;
 
-    std::optional<model::offset> get(const compaction_key& key) const override;
+    seastar::future<std::optional<model::offset>>
+    get(const compaction_key& key) const override;
 
     model::offset max_offset() const override;
 

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -33,7 +33,7 @@ public:
      * the new mapping with override the existing mapping provided that \p
      * offset is larger than the existing offset associated with the key.
      */
-    virtual bool put(compaction_key key, model::offset offset) = 0;
+    virtual bool put(const compaction_key& key, model::offset offset) = 0;
 
     /**
      * Return the offset for the given \p key.
@@ -60,7 +60,7 @@ public:
      */
     explicit simple_key_offset_map(size_t max_keys = default_key_limit);
 
-    bool put(compaction_key key, model::offset offset) override;
+    bool put(const compaction_key& key, model::offset offset) override;
 
     std::optional<model::offset> get(const compaction_key& key) const override;
 

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -16,50 +16,55 @@
 
 namespace storage {
 
-// Map containing the latest offsets of each key.
+/**
+ * Map containing the latest offsets of each key.
+ */
 class key_offset_map {
 public:
-    // Returns true if the put was successful.
-    virtual bool put(compaction_key key, model::offset o) = 0;
+    key_offset_map() = default;
+    key_offset_map(const key_offset_map&) = delete;
+    key_offset_map& operator=(const key_offset_map&) = delete;
+    key_offset_map(key_offset_map&&) noexcept = default;
+    key_offset_map& operator=(key_offset_map&&) noexcept = default;
+    virtual ~key_offset_map() = default;
 
-    // Returns the latest offset for the given key put into the map.
+    /**
+     * Associate \p offset with the given \p key. If \p key already exists then
+     * the new mapping with override the existing mapping provided that \p
+     * offset is larger than the existing offset associated with the key.
+     */
+    virtual bool put(compaction_key key, model::offset offset) = 0;
+
+    /**
+     * Return the offset for the given \p key.
+     */
     virtual std::optional<model::offset>
     get(const compaction_key& key) const = 0;
 
-    // Returns the highest offset indexed by this map.
+    /**
+     * Return the highest inserted offset.
+     */
     virtual model::offset max_offset() const = 0;
 };
 
-class simple_key_offset_map : public key_offset_map {
+/**
+ * A key_offset_map that stores the entire key.
+ */
+class simple_key_offset_map final : public key_offset_map {
 public:
     static constexpr size_t default_key_limit = 1000;
 
-    simple_key_offset_map(size_t max_keys = default_key_limit)
-      : _memory_tracker(
-        ss::make_shared<util::mem_tracker>("simple_key_offset_map"))
-      , _map(util::mem_tracked::
-               map<absl::btree_map, compaction_key, model::offset>(
-                 _memory_tracker))
-      , _max_keys(max_keys) {}
+    /**
+     * Construct a new simple_key_offset_map with \p max_key maximum number of
+     * keys.
+     */
+    explicit simple_key_offset_map(size_t max_keys = default_key_limit);
 
-    bool put(compaction_key key, model::offset o) override {
-        if (_map.size() >= _max_keys) {
-            return false;
-        }
-        _map[key] = std::max(o, _map[key]);
-        _max_offset = std::max(_max_offset, o);
-        return true;
-    }
+    bool put(compaction_key key, model::offset offset) override;
 
-    std::optional<model::offset> get(const compaction_key& key) const override {
-        auto iter = _map.find(key);
-        if (iter == _map.end()) {
-            return std::nullopt;
-        }
-        return iter->second;
-    }
+    std::optional<model::offset> get(const compaction_key& key) const override;
 
-    model::offset max_offset() const override { return _max_offset; }
+    model::offset max_offset() const override;
 
 private:
     ss::shared_ptr<util::mem_tracker> _memory_tracker;


### PR DESCRIPTION
storage: offset key map housekeeping

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
