### PR TITLE
Compaction lossy hash

### DIFF
--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -115,7 +115,6 @@ hash_key_offset_map::put(const compaction_key& key, model::offset offset) {
     };
 
     // handle a non-normalized probe position
-    // returns true if key is inserted
     auto handle_entry = [&](size_t index) {
         ++probe_count_;
         index = index % entries_.size();

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -46,4 +46,6 @@ simple_key_offset_map::get(const compaction_key& key) const {
 
 model::offset simple_key_offset_map::max_offset() const { return _max_offset; }
 
+size_t simple_key_offset_map::size() const { return _map.size(); }
+
 } // namespace storage

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -49,4 +49,209 @@ model::offset simple_key_offset_map::max_offset() const { return _max_offset; }
 size_t simple_key_offset_map::size() const { return _map.size(); }
 size_t simple_key_offset_map::capacity() const { return _max_keys; }
 
+seastar::future<std::optional<model::offset>>
+hash_key_offset_map::get(const compaction_key& key) const {
+    const auto hash = hash_key(key);
+
+    // handle a non-normalized probe position
+    // (true, value) -> stop and return value
+    // (false, _)    -> keep probing
+    auto handle_entry =
+      [&](size_t index) -> std::pair<bool, std::optional<model::offset>> {
+        ++probe_count_;
+        index = index % entries_.size();
+        auto& entry = entries_[index];
+        if (entry.empty()) {
+            return std::make_pair(true, std::nullopt);
+        } else if (entry.digest == hash) {
+            return std::make_pair(true, entry.offset);
+        }
+        return std::make_pair(false, std::nullopt);
+    };
+
+    ++search_count_;
+
+    // probe using the hash
+    probe probe(hash);
+    auto index = probe.next();
+    while (index.has_value()) {
+        const auto [stop, value] = handle_entry(index.value());
+        if (stop) {
+            return seastar::make_ready_future<std::optional<model::offset>>(
+              value);
+        }
+        const auto next_index = probe.next();
+        if (next_index.has_value()) {
+            index = next_index;
+        } else {
+            break;
+        }
+    }
+
+    // fall back to linear probe
+    const auto linear_base = index.value_or(0);
+    for (size_t probe = 0; probe < entries_.size(); ++probe) {
+        const auto [stop, value] = handle_entry(linear_base + probe);
+        if (stop) {
+            return seastar::make_ready_future<std::optional<model::offset>>(
+              value);
+        }
+    }
+
+    return seastar::make_ready_future<std::optional<model::offset>>(
+      std::nullopt);
+}
+
+seastar::future<bool>
+hash_key_offset_map::put(const compaction_key& key, model::offset offset) {
+    const auto hash = hash_key(key);
+
+    const auto full = size_ >= capacity_;
+
+    enum class handle {
+        inserted,
+        not_inserted,
+        not_inserted_full,
+    };
+
+    // handle a non-normalized probe position
+    // returns true if key is inserted
+    auto handle_entry = [&](size_t index) {
+        ++probe_count_;
+        index = index % entries_.size();
+        auto& entry = entries_[index];
+        if (entry.empty()) {
+            if (full) {
+                return handle::not_inserted_full;
+            }
+            entry.digest = hash;
+            entry.offset = offset;
+            ++size_;
+            max_offset_ = std::max(max_offset_, offset);
+            return handle::inserted;
+        } else if (entry.digest == hash) {
+            if (offset > entry.offset) {
+                entry.offset = offset;
+                max_offset_ = std::max(max_offset_, offset);
+            }
+            return handle::inserted;
+        }
+        return handle::not_inserted;
+    };
+
+    ++search_count_;
+
+    // probe using the hash
+    probe probe(hash);
+    auto index = probe.next();
+    while (index.has_value()) {
+        const auto res = handle_entry(index.value());
+        if (res == handle::inserted) {
+            return seastar::make_ready_future<bool>(true);
+        }
+        if (res == handle::not_inserted_full) {
+            return seastar::make_ready_future<bool>(false);
+        }
+        const auto next_index = probe.next();
+        if (next_index.has_value()) {
+            index = next_index;
+        } else {
+            break;
+        }
+    }
+
+    // fall back to linear probe
+    const auto linear_base = index.value_or(0);
+    for (size_t probe = 0; probe < entries_.size(); ++probe) {
+        const auto res = handle_entry(linear_base + probe);
+        if (res == handle::inserted) {
+            return seastar::make_ready_future<bool>(true);
+        }
+        if (res == handle::not_inserted_full) {
+            return seastar::make_ready_future<bool>(false);
+        }
+    }
+
+    return seastar::make_ready_future<bool>(false);
+}
+
+model::offset hash_key_offset_map::max_offset() const { return max_offset_; }
+
+size_t hash_key_offset_map::size() const { return size_; }
+size_t hash_key_offset_map::capacity() const { return capacity_; }
+
+seastar::future<> hash_key_offset_map::reset(size_t size) {
+    co_await fragmented_vector_clear_async(entries_);
+    while (entries_.memory_size() < size) {
+        for (size_t i = 0; i < entries_.elements_per_fragment(); ++i) {
+            entries_.push_back(entry{});
+        }
+        if (seastar::need_preempt()) {
+            co_await seastar::maybe_yield();
+        }
+    }
+    size_ = 0;
+    max_offset_ = model::offset{};
+    if (entries_.size() > 0) {
+        capacity_ = std::max(
+          size_t(1),
+          static_cast<size_t>(
+            static_cast<double>(entries_.size()) * max_load_factor));
+    } else {
+        capacity_ = 0;
+    }
+    search_count_ = 0;
+    probe_count_ = 0;
+}
+
+seastar::future<> hash_key_offset_map::initialize() {
+    co_await fragmented_vector_fill_async(entries_, entry{});
+    size_ = 0;
+    max_offset_ = model::offset{};
+    search_count_ = 0;
+    probe_count_ = 0;
+}
+
+double hash_key_offset_map::hit_rate() const {
+    if (probe_count_ == 0) {
+        return 1.0;
+    }
+    return static_cast<double>(search_count_)
+           / static_cast<double>(probe_count_);
+}
+
+bool hash_key_offset_map::entry::empty() const {
+    return digest == hash_type::digest_type{};
+}
+
+hash_key_offset_map::probe::probe(const hash_type::digest_type& hash)
+  : iter(hash.data())
+  , end(iter + hash_type::digest_size) {}
+
+std::optional<hash_key_offset_map::probe::index_type>
+hash_key_offset_map::probe::next() {
+    if ((iter + sizeof(index_type)) > end) {
+        return std::nullopt;
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+    index_type index;
+    std::memcpy(&index, iter, sizeof(index_type));
+
+    iter += sizeof(index_type);
+
+    return index;
+}
+
+hash_key_offset_map::hash_type::digest_type
+hash_key_offset_map::hash_key(const compaction_key& key) const {
+    try {
+        hasher_.update(key);
+        return hasher_.reset();
+    } catch (...) {
+        hasher_.reset();
+        throw;
+    }
+}
+
 } // namespace storage

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -47,5 +47,6 @@ simple_key_offset_map::get(const compaction_key& key) const {
 model::offset simple_key_offset_map::max_offset() const { return _max_offset; }
 
 size_t simple_key_offset_map::size() const { return _map.size(); }
+size_t simple_key_offset_map::capacity() const { return _max_keys; }
 
 } // namespace storage

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -52,6 +52,11 @@ public:
      * Return the number of keys in the map.
      */
     virtual size_t size() const = 0;
+
+    /**
+     * Returns the number of entries the map has space allocated for.
+     */
+    virtual size_t capacity() const = 0;
 };
 
 /**
@@ -76,6 +81,7 @@ public:
     model::offset max_offset() const override;
 
     size_t size() const override;
+    size_t capacity() const override;
 
 private:
     ss::shared_ptr<util::mem_tracker> _memory_tracker;

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -47,6 +47,11 @@ public:
      * Return the highest inserted offset.
      */
     virtual model::offset max_offset() const = 0;
+
+    /**
+     * Return the number of keys in the map.
+     */
+    virtual size_t size() const = 0;
 };
 
 /**
@@ -69,6 +74,8 @@ public:
     get(const compaction_key& key) const override;
 
     model::offset max_offset() const override;
+
+    size_t size() const override;
 
 private:
     ss::shared_ptr<util::mem_tracker> _memory_tracker;

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -8,7 +8,9 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "hashing/secure.h"
 #include "storage/compacted_index.h"
+#include "utils/fragmented_vector.h"
 #include "utils/tracking_allocator.h"
 
 #include <seastar/core/future.hh>
@@ -89,6 +91,99 @@ private:
       _map;
     model::offset _max_offset;
     size_t _max_keys;
+};
+
+/**
+ * A key_offset_map in which the key space is mapped to sha256(key).
+ *
+ * This container does not auto-grow on insert, and a default initialized
+ * instance has zero capacity. To add capacity call `reset(size_bytes)`. This is
+ * futurized to avoid reactor stalls when allocating a large amount of memory
+ * for the container.
+ *
+ * For large containers call `co_await reset(0)` to clean up before the
+ * destructor is run.
+ */
+class hash_key_offset_map : public key_offset_map {
+    static constexpr double max_load_factor = 0.95;
+
+public:
+    seastar::future<std::optional<model::offset>>
+    get(const compaction_key& key) const override;
+
+    seastar::future<bool>
+    put(const compaction_key& key, model::offset offset) override;
+
+    model::offset max_offset() const override;
+
+    size_t size() const override;
+    size_t capacity() const override;
+
+    /**
+     * Reset the map to have capacity \p size bytes. A call to reset() will
+     * destroy all existing data in the map and reset the size to zero.
+     *
+     * A call to `reset(0)` is useful when destroying a large instance of this
+     * container which may otherwise incur reactor stalls when freed as part of
+     * the destructor cleanup.
+     */
+    seastar::future<> reset(size_t size);
+
+    /**
+     * Initialize prepares the container for use in a new context by resetting
+     * every element to an initial state. This call does not change the size of
+     * the container.
+     */
+    seastar::future<> initialize();
+
+    /**
+     * The ratio of hash table searches (e.g. one get or put) to the number of
+     * underlying accesses made into the hash table.
+     */
+    double hit_rate() const;
+
+private:
+    using hash_type = hash_sha256;
+
+    /**
+     * hash table entry.
+     */
+    struct entry {
+        hash_type::digest_type digest{};
+        model::offset offset;
+        bool empty() const;
+    };
+
+    /**
+     * Uses successive chunks of sizeof(index_type) bytes taken from hash(key)
+     * as probes into the hash table. When `next()` returns null then the caller
+     * should switch to linear probing.
+     */
+    struct probe {
+        using index_type = uint32_t;
+        static_assert(sizeof(index_type) <= hash_type::digest_size);
+
+        explicit probe(const hash_type::digest_type&);
+
+        std::optional<index_type> next();
+
+        hash_type::digest_type::const_pointer iter;
+        hash_type::digest_type::const_pointer end;
+    };
+
+    /**
+     * hash the compaction key. this helper will catch exceptions and reset the
+     * hashing object which is reused to avoid reinitialization of gnutls state.
+     */
+    hash_type::digest_type hash_key(const compaction_key&) const;
+
+    mutable hash_type hasher_;
+    large_fragment_vector<entry> entries_;
+    size_t size_{0};
+    model::offset max_offset_;
+    size_t capacity_{0};
+    mutable size_t search_count_{0};
+    mutable size_t probe_count_{0};
 };
 
 } // namespace storage

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -121,3 +121,15 @@ rp_test(
   LABELS storage
 )
 
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME key_offset_map
+  SOURCES
+    key_offset_map_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::storage
+  ARGS "-- -c 1"
+  LABELS storage
+)

--- a/src/v/storage/tests/key_offset_map_test.cc
+++ b/src/v/storage/tests/key_offset_map_test.cc
@@ -1,0 +1,253 @@
+#include "storage/key_offset_map.h"
+#include "units.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+storage::compaction_key k(std::string_view key) {
+    return storage::compaction_key(
+      bytes(reinterpret_cast<const uint8_t*>(key.data()), key.size()));
+}
+
+model::offset o(int o) { return model::offset(o); }
+} // namespace
+
+template<typename T>
+class KeyOffsetMapTest : public ::testing::Test {
+public:
+    T map;
+};
+
+/*
+ * helper to default-initialize the map in the typed test suite. since
+ * allocations are futurized we don't want to bake it into constructor.
+ */
+class default_sized_hash_key_offset_map : public storage::hash_key_offset_map {
+public:
+    default_sized_hash_key_offset_map() { reset(1_MiB).get(); }
+};
+
+using test_types = ::testing::
+  Types<storage::simple_key_offset_map, default_sized_hash_key_offset_map>;
+
+TYPED_TEST_SUITE(KeyOffsetMapTest, test_types);
+
+TYPED_TEST(KeyOffsetMapTest, Empty) {
+    auto& map = this->map;
+    EXPECT_EQ(map.size(), 0);
+    EXPECT_EQ(map.max_offset(), model::offset{});
+    EXPECT_EQ(map.get(k("key")).get(), std::nullopt);
+}
+
+TYPED_TEST(KeyOffsetMapTest, Put) {
+    auto& map = this->map;
+    EXPECT_EQ(map.put(k("key"), o(9)).get(), true);
+    EXPECT_EQ(map.size(), 1);
+    EXPECT_EQ(map.max_offset(), o(9));
+    EXPECT_EQ(map.get(k("key")).get(), o(9));
+}
+
+TYPED_TEST(KeyOffsetMapTest, PutGet) {
+    auto& map = this->map;
+
+    // new key
+    EXPECT_EQ(map.put(k("key0"), o(9)).get(), true);
+    EXPECT_EQ(map.get(k("key0")).get(), o(9));
+
+    // new key
+    EXPECT_EQ(map.put(k("key1"), o(9)).get(), true);
+    EXPECT_EQ(map.get(k("key1")).get(), o(9));
+
+    // new key
+    EXPECT_EQ(map.put(k("key2"), o(99)).get(), true);
+    EXPECT_EQ(map.get(k("key2")).get(), o(99));
+
+    // overwrite
+    EXPECT_EQ(map.put(k("key0"), o(10)).get(), true);
+    EXPECT_EQ(map.get(k("key0")).get(), o(10));
+
+    EXPECT_EQ(map.size(), 3);
+}
+
+TYPED_TEST(KeyOffsetMapTest, PutKeepsLargestOffset) {
+    auto& map = this->map;
+
+    // put(9) - first entry
+    EXPECT_EQ(map.put(k("key"), o(9)).get(), true);
+    EXPECT_EQ(map.get(k("key")).get(), o(9));
+
+    // put(8) - no change
+    EXPECT_EQ(map.put(k("key"), o(8)).get(), true);
+    EXPECT_EQ(map.get(k("key")).get(), o(9));
+
+    // put(10) - overwrites with 10
+    EXPECT_EQ(map.put(k("key"), o(10)).get(), true);
+    EXPECT_EQ(map.get(k("key")).get(), o(10));
+
+    EXPECT_EQ(map.size(), 1);
+}
+
+TYPED_TEST(KeyOffsetMapTest, MaxOffset) {
+    auto& map = this->map;
+
+    // put(9)
+    EXPECT_EQ(map.put(k("key0"), o(9)).get(), true);
+    EXPECT_EQ(map.max_offset(), o(9));
+
+    // put(9) - no change
+    EXPECT_EQ(map.put(k("key1"), o(9)).get(), true);
+    EXPECT_EQ(map.max_offset(), o(9));
+
+    // put(8) - no change
+    EXPECT_EQ(map.put(k("key2"), o(8)).get(), true);
+    EXPECT_EQ(map.max_offset(), o(9));
+
+    // put(10) - new max
+    EXPECT_EQ(map.put(k("key3"), o(10)).get(), true);
+    EXPECT_EQ(map.max_offset(), o(10));
+
+    EXPECT_EQ(map.size(), 4);
+}
+
+TYPED_TEST(KeyOffsetMapTest, ManyEntries) {
+    static constexpr auto test_size = 1000;
+
+    auto& map = this->map;
+    std::unordered_map<std::string, int> truth;
+
+    for (int i = 0; i < test_size; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        EXPECT_TRUE(map.put(ck, model::offset(i)).get()) << fmt::format(
+          "Inserting key {} offset {} size {} capacity {}",
+          key,
+          i,
+          map.size(),
+          map.capacity());
+        EXPECT_TRUE(truth.emplace(key, i).second);
+    }
+
+    EXPECT_EQ(map.size(), truth.size())
+      << fmt::format("map size {} capacity {}", map.size(), map.capacity());
+
+    for (const auto& [key, val] : truth) {
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        const auto maybe_val = map.get(ck).get();
+        ASSERT_TRUE(maybe_val.has_value());
+        EXPECT_EQ(maybe_val.value(), model::offset(val));
+    }
+}
+
+TYPED_TEST(KeyOffsetMapTest, UpdateSucceedsWhenFull) {
+    auto& map = this->map;
+
+    // insert until full
+    int count = 0;
+    while (true) {
+        const auto key = fmt::format("key-{}", count);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        if (!map.put(ck, model::offset(count)).get()) {
+            break;
+        }
+        ++count;
+    }
+    ASSERT_GT(count, 0);
+    ASSERT_EQ(map.size(), map.capacity());
+
+    // none of the values should be equal to `count`
+    for (int i = 0; i < count; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        const auto val = map.get(ck).get();
+        ASSERT_TRUE(val.has_value());
+        ASSERT_NE(val.value(), model::offset(count));
+    }
+
+    // when at capacity, we can still update existing keys
+    // here we make all the values equal to `count`.
+    for (int i = 0; i < count; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        ASSERT_TRUE(map.put(ck, model::offset(count)).get());
+    }
+
+    // all of the values should be equal to `count`
+    for (int i = 0; i < count; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        const auto val = map.get(ck).get();
+        ASSERT_TRUE(val.has_value());
+        ASSERT_EQ(val.value(), model::offset(count));
+    }
+}
+
+TEST(HashKeyOffsetMapTest, HitRate) {
+    storage::hash_key_offset_map map;
+    map.reset(20_MiB).get();
+
+    int i = 0;
+    while (true) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        if (!map.put(ck, model::offset(i)).get()) {
+            break;
+        }
+        ++i;
+    }
+
+    EXPECT_LE(map.hit_rate(), 0.3) << fmt::format("Inserted {}", i);
+}
+
+TEST(HashKeyOffsetMapTest, Initialize) {
+    storage::hash_key_offset_map map;
+    map.reset(1_MiB).get();
+
+    // fill it up with keys with offset 100
+    for (int i = 0;; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        if (!map.put(ck, model::offset(100)).get()) {
+            break;
+        }
+    }
+    EXPECT_GT(map.size(), 0);
+    const auto orig_size = map.size();
+
+    // we'll try to overwrite with 99
+    for (int i = 0; i < orig_size; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        ASSERT_TRUE(map.put(ck, model::offset(99)).get());
+    }
+
+    // but it won't work cause they are still in the map
+    for (int i = 0; i < orig_size; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        const auto val = map.get(ck).get();
+        ASSERT_TRUE(val.has_value());
+        ASSERT_EQ(val.value(), model::offset(100));
+    }
+    EXPECT_EQ(map.size(), orig_size);
+
+    // but now we'll initialize it
+    map.initialize().get();
+    EXPECT_EQ(map.size(), 0);
+
+    // now try to write the 99 offsets
+    for (int i = 0; i < orig_size; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        EXPECT_TRUE(map.put(ck, model::offset(99)).get());
+    }
+    EXPECT_EQ(map.size(), orig_size);
+
+    // and we'll see the offset = 99 entries
+    for (int i = 0; i < orig_size; ++i) {
+        const auto key = fmt::format("key-{}", i);
+        storage::compaction_key ck(bytes(key.begin(), key.end()));
+        const auto val = map.get(ck).get();
+        ASSERT_TRUE(val.has_value());
+        ASSERT_EQ(val.value(), model::offset(99));
+    }
+}

--- a/src/v/storage/tests/key_offset_map_test.cc
+++ b/src/v/storage/tests/key_offset_map_test.cc
@@ -1,3 +1,13 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
 #include "storage/key_offset_map.h"
 #include "units.h"
 

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -12,6 +12,10 @@
 
 #include "vassert.h"
 
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/util/later.hh>
+
 #include <cstddef>
 #include <iterator>
 #include <stdexcept>
@@ -327,6 +331,10 @@ private:
 private:
     fragmented_vector(const fragmented_vector&) noexcept = default;
 
+    template<typename TT, size_t SS>
+    friend seastar::future<>
+    fragmented_vector_fill_async(fragmented_vector<TT, SS>&, const TT&);
+
     size_t _size{0};
     size_t _capacity{0};
     std::vector<std::vector<T>> _frags;
@@ -344,3 +352,34 @@ using large_fragment_vector = fragmented_vector<T, 32 * 1024>;
  */
 template<typename T>
 using small_fragment_vector = fragmented_vector<T, 1024>;
+
+/**
+ * A futurized version of std::fill optimized for fragmented vector. It is
+ * futurized to allow for large vectors to be filled without incurring reactor
+ * stalls. It is optimized by circumventing the indexing indirection incurred by
+ * using the fragmented vector interface directly.
+ */
+template<typename T, size_t S>
+inline seastar::future<>
+fragmented_vector_fill_async(fragmented_vector<T, S>& vec, const T& value) {
+    auto remaining = vec._size;
+    for (auto& frag : vec._frags) {
+        const auto n = std::min(frag.size(), remaining);
+        if (n == 0) {
+            break;
+        }
+        std::fill_n(frag.begin(), n, value);
+        remaining -= n;
+        if (seastar::need_preempt()) {
+            co_await seastar::yield();
+        }
+    }
+    vassert(
+      remaining == 0,
+      "fragmented vector inconsistency filling remaining {} size {} cap {} "
+      "nfrags {}",
+      remaining,
+      vec._size,
+      vec._capacity,
+      vec._frags.size());
+}

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ rp_test(
     uuid_test.cc
     vint_test.cc
     waiter_queue_test.cc
+    fragmented_vector_async_test.cc
   LIBRARIES v::seastar_testing_main v::utils v::bytes v::version absl::flat_hash_set
   ARGS "-- -c 1"
   LABELS utils

--- a/src/v/utils/tests/fragmented_vector_async_test.cc
+++ b/src/v/utils/tests/fragmented_vector_async_test.cc
@@ -33,3 +33,26 @@ SEASTAR_THREAD_TEST_CASE(fragmented_vector_fill_async_test) {
         BOOST_REQUIRE(e == 0);
     }
 }
+
+SEASTAR_THREAD_TEST_CASE(fragmented_vector_clear_async_test) {
+    fragmented_vector<int> v;
+    fragmented_vector_clear_async(v).get();
+    BOOST_REQUIRE(v.size() == 0);
+
+    // one element
+    v.push_back(0);
+    BOOST_REQUIRE(v.size() == 1);
+    fragmented_vector_clear_async(v).get();
+    BOOST_REQUIRE(v.size() == 0);
+
+    // many fragments
+    for (int i = 0; i < 5; ++i) {
+        for (int j = 0; j < v.elements_per_fragment(); ++j) {
+            v.push_back(j);
+        }
+    }
+    BOOST_REQUIRE(v.size() == (5 * v.elements_per_fragment()));
+
+    fragmented_vector_clear_async(v).get();
+    BOOST_REQUIRE(v.size() == 0);
+}

--- a/src/v/utils/tests/fragmented_vector_async_test.cc
+++ b/src/v/utils/tests/fragmented_vector_async_test.cc
@@ -1,0 +1,35 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "seastarx.h"
+#include "utils/fragmented_vector.h"
+
+#include <seastar/testing/thread_test_case.hh>
+
+SEASTAR_THREAD_TEST_CASE(fragmented_vector_fill_async_test) {
+    fragmented_vector<int> v;
+    fragmented_vector_fill_async(v, 0).get();
+    BOOST_REQUIRE(v.size() == 0);
+
+    // fill with non-zero
+    for (int i = 1; i <= 10; ++i) {
+        v.push_back(i);
+    }
+    BOOST_REQUIRE(v.size() == 10);
+    for (const auto& e : v) {
+        BOOST_REQUIRE(e > 0);
+    }
+
+    // fill with zero
+    fragmented_vector_fill_async(v, 0).get();
+    BOOST_REQUIRE(v.size() == 10);
+    for (const auto& e : v) {
+        BOOST_REQUIRE(e == 0);
+    }
+}

--- a/tools/format-cc
+++ b/tools/format-cc
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+root_dir=$(git -C ${script_dir} rev-parse --show-toplevel)
+
+pushd ${root_dir}
+git ls-files --full-name "*.cc" "*.java" "*.h" "*.proto" | xargs -n1 clang-format -i -style=file -fallback-style=none
+popd


### PR DESCRIPTION
Introduces a new offset key map implementation that maps compaction key space into sha256(key) space.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

