### PR TITLE
config: support configuration constraints

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     rjson_serialization.cc
     validators.cc
     throughput_control_group.cc
+    constraints.cc
   DEPS
     v::json
     v::model

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -128,6 +128,10 @@ public:
     virtual std::optional<std::string_view> units_name() const = 0;
     virtual bool is_nullable() const = 0;
     virtual bool is_array() const = 0;
+    virtual bool is_signed() const = 0;
+    virtual bool is_unsigned() const = 0;
+    virtual bool is_bool() const = 0;
+    virtual bool is_milliseconds() const = 0;
     virtual std::optional<std::string_view> example() const = 0;
     virtual std::vector<ss::sstring> enum_values() const { return {}; };
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2775,7 +2775,17 @@ configuration::configuration()
       "are allowed.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {"BASIC"},
-      validate_http_authn_mechanisms) {}
+      validate_http_authn_mechanisms)
+  , constraints(
+      *this,
+      "constraints",
+      "A sequence of constraints for cluster-level configs",
+      {.needs_restart = needs_restart::no,
+       .example
+       = R"([{'name': 'default_topic_replications','type': 'restrict','min': 3, 'max': 9}])",
+       .visibility = visibility::user},
+      {},
+      validate_constraints) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -14,6 +14,7 @@
 #include "config/broker_endpoint.h"
 #include "config/client_group_byte_rate_quota.h"
 #include "config/config_store.h"
+#include "config/constraints.h"
 #include "config/convert.h"
 #include "config/data_directory_path.h"
 #include "config/endpoint_tls_config.h"
@@ -527,6 +528,9 @@ struct configuration final : public config_store {
 
     // HTTP Authentication
     property<std::vector<ss::sstring>> http_authentication;
+
+    // Constraints
+    one_or_many_map_property<constraint_t> constraints;
 
     configuration();
 

--- a/src/v/config/constraints.cc
+++ b/src/v/config/constraints.cc
@@ -12,8 +12,17 @@
 #include "cluster/types.h"
 #include "config/base_property.h"
 #include "config/configuration.h"
+#include "kafka/server/handlers/topics/types.h"
+#include "model/fundamental.h"
+#include "vlog.h"
+
+#include <seastar/util/log.hh>
+
+#include <limits>
 
 namespace config {
+inline ss::logger constraints_log{"constraints"};
+
 std::string_view to_string_view(constraint_type type) {
     switch (type) {
     case constraint_type::restrikt:
@@ -44,6 +53,479 @@ std::ostream& operator<<(std::ostream& os, const constraint_t& constraint) {
       [&os](const auto range) { os << range; });
 
     return os;
+}
+
+namespace {
+bool is_retention_property(const std::string_view& topic_property) {
+    return topic_property == kafka::topic_property_retention_duration
+           || topic_property == kafka::topic_property_retention_local_target_ms
+           || topic_property == kafka::topic_property_retention_bytes
+           || topic_property
+                == kafka::topic_property_retention_local_target_bytes;
+}
+
+template<typename T>
+bool is_infinite(
+  const tristate<T>& tri, const std::string_view& topic_property) {
+    return tri.is_disabled() && is_retention_property(topic_property);
+}
+
+template<typename T>
+bool is_turned_off(
+  const tristate<T>& tri, const std::string_view& topic_property) {
+    return tri.is_disabled() && !is_retention_property(topic_property);
+}
+
+template<typename T, typename RangeMinT>
+bool valid_min(
+  const tristate<T>& topic_val,
+  const std::optional<RangeMinT>& min,
+  const std::string_view& topic_property) {
+    if (min) {
+        // Disabled state could mean infinite which is always greater than the
+        // minimum or it could mean turned-off which is never within a range.
+        if (is_infinite(topic_val, topic_property)) {
+            return true;
+        } else if (is_turned_off(topic_val, topic_property)) {
+            return false;
+        }
+
+        // An undefined topic value implicity breaks the minimum because
+        // "nothing" is not within any range. Not to be confused with disabled
+        // state.
+        if (!topic_val.has_optional_value()) {
+            return false;
+        }
+
+        return topic_val.value() >= static_cast<T>(*min);
+    }
+
+    // Topic value is valid if minimum is undefined because there is no bound to
+    // compare
+    return true;
+}
+
+template<typename T, typename RangeMaxT>
+bool valid_max(
+  const tristate<T>& topic_val, const std::optional<RangeMaxT> max) {
+    if (max) {
+        // Disabled state could mean infinite which is always greater than the
+        // maximum or it could mean turned-off which is never within a range.
+        if (topic_val.is_disabled()) {
+            return false;
+        }
+
+        // An undefined topic value implicity breaks the maximum because
+        // "nothing" is not within any range. Not to be confused with disabled
+        // state.
+        if (!topic_val.has_optional_value()) {
+            return false;
+        }
+
+        return topic_val.value() <= static_cast<T>(*max);
+    }
+
+    // Topic value is valid if maximum is undefined because there is no bound to
+    // compare
+    return true;
+}
+
+template<typename T, typename RangeT>
+bool within_range(
+  const tristate<T>& topic_val,
+  const range_values<RangeT>& range,
+  const model::topic& topic,
+  const std::string_view& topic_property) {
+    if (!(valid_min(topic_val, range.min, topic_property)
+          && valid_max(topic_val, range.max))) {
+        vlog(
+          constraints_log.error,
+          "Constraints failure[value out-of-range]: topic property {}.{}, "
+          "value {}",
+          topic(),
+          topic_property,
+          topic_val);
+        return false;
+    }
+
+    // Otherwise, the topic value is valid
+    return true;
+}
+
+template<typename T>
+bool matches_cluster_property_value(
+  const tristate<T>& topic_val,
+  const std::optional<T>& cluster_val,
+  const constraint_enabled_t& enabled,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::string_view& cluster_property) {
+    if (enabled == constraint_enabled_t::no) {
+        // A constraint that is turned off (i.e., no) means that the broker
+        // should not compare the topic property to the cluster one. This
+        // implies the the topic property automatically satisfies the
+        // constraint.
+        return true;
+    }
+
+    // A constraint with "enabled" flag means that the topic property must match
+    // the cluster one. A disabled/undefined topic value or cluster value could
+    // not match the other, this implies that the constraint is not satisfied.
+    if (!topic_val.has_optional_value() || !cluster_val) {
+        return false;
+    }
+
+    if (topic_val.value() != *cluster_val) {
+        vlog(
+          constraints_log.error,
+          "Constraints failure[does not match the cluster property {}]: "
+          "topic property {}.{}, value {}",
+          cluster_property,
+          topic(),
+          topic_property,
+          topic_val);
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Returns true if the topic-level value satisfies the constraint.
+ * \param topic_val: the topic value
+ * \param constraint: the constraint to evaluate
+ * \param property_name: name of the cluster-level property
+ * \param cluster_opt: the value from the cluster-level property
+ */
+template<typename T>
+bool validate_value(
+  const tristate<T>& topic_val,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    return ss::visit(
+      constraint.flags,
+      [&topic_val,
+       &topic,
+       &topic_property,
+       &cluster_opt,
+       cluster_property{constraint.name}](const constraint_enabled_t enabled) {
+          return matches_cluster_property_value(
+            topic_val,
+            cluster_opt,
+            enabled,
+            topic,
+            topic_property,
+            cluster_property);
+      },
+      [&topic_val, &topic, &topic_property](const auto range) {
+          return within_range(topic_val, range, topic, topic_property);
+      });
+}
+
+template<typename T, typename RangeT>
+void range_clamp(
+  tristate<T>& topic_val,
+  const range_values<RangeT>& range,
+  const model::topic& topic,
+  const std::string_view& topic_property) {
+    if (!valid_min(topic_val, range.min, topic_property)) {
+        vlog(
+          constraints_log.warn,
+          "Overwriting topic property to constraint min: topic property {}.{}, "
+          "min {}",
+          topic(),
+          topic_property,
+          range.min);
+        // NOTE: valid_min checks if the minimum opt is defined, so it is OK to
+        // de-reference it here.
+        topic_val = tristate<T>{static_cast<T>(*range.min)};
+    }
+
+    if (!valid_max(topic_val, range.max)) {
+        vlog(
+          constraints_log.warn,
+          "Overwriting topic property to constraint max: topic property {}.{}, "
+          "max {}",
+          topic(),
+          topic_property,
+          range.max);
+        // NOTE: valid_max checks if the maximum opt is defined, so it is OK to
+        // de-reference it here.
+        topic_val = tristate<T>{static_cast<T>(*range.max)};
+    }
+}
+
+template<typename T>
+void cluster_property_clamp(
+  tristate<T>& topic_val,
+  const std::optional<T>& cluster_val,
+  const constraint_enabled_t& enabled,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::string_view& cluster_property) {
+    if (enabled == constraint_enabled_t::no) {
+        // Since the constraint is turned off, there is no need to clamp
+        return;
+    }
+
+    // A constraint with "enabled" flag means that the topic property gets the
+    // cluster value, but an undefined cluster value cannot be assigned so
+    // ignore.
+    if (!cluster_val) {
+        return;
+    }
+
+    vlog(
+      constraints_log.warn,
+      "Overwriting topic property to the cluster property {}: topic property "
+      "{}.{}, "
+      "value {}",
+      cluster_property,
+      topic(),
+      topic_property,
+      topic_val);
+    topic_val = tristate<T>{cluster_val};
+}
+
+/**
+ * Assigns the constraint range or cluster-level value to the topic-level value
+ * \param topic_val: the topic value
+ * \param constraint: the constraint to evaluate
+ * \param property_name: name of the cluster-level property
+ * \param cluster_opt: the value from the cluster-level property
+ */
+template<typename T>
+void clamp_value(
+  tristate<T>& topic_val,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    ss::visit(
+      constraint.flags,
+      [&topic_val,
+       &topic,
+       &topic_property,
+       &cluster_opt,
+       cluster_property{constraint.name}](const constraint_enabled_t enabled) {
+          cluster_property_clamp(
+            topic_val,
+            cluster_opt,
+            enabled,
+            topic,
+            topic_property,
+            cluster_property);
+      },
+      [&topic_val, &topic, &topic_property](const auto range) {
+          range_clamp(topic_val, range, topic, topic_property);
+      });
+}
+
+template<typename T>
+bool do_apply_constraint_tristate(
+  tristate<T>& topic_val,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    if (constraint.type == config::constraint_type::restrikt) {
+        return validate_value(
+          topic_val, constraint, topic, topic_property, cluster_opt);
+    } else if (constraint.type == config::constraint_type::clamp) {
+        clamp_value(topic_val, constraint, topic, topic_property, cluster_opt);
+        return true;
+    }
+    vlog(constraints_log.error, "Unknown constraint type");
+    return false;
+}
+
+template<typename T>
+bool do_apply_constraint_optional(
+  std::optional<T>& topic_val,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    auto tri = tristate<T>{topic_val};
+    auto ret = do_apply_constraint_tristate(
+      tri, constraint, topic, topic_property, cluster_opt);
+    // The tristate is not in disabled state since it was assigned an optional
+    // earlier.
+    topic_val = tri.get_optional();
+    return ret;
+}
+
+template<typename T>
+bool do_apply_constraint(
+  T& topic_val,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    auto tri = tristate<T>{topic_val};
+    auto ret = do_apply_constraint_tristate(
+      tri, constraint, topic, topic_property, cluster_opt);
+    // The tristate is not in disabled state since it was assigned an optional
+    // earlier.
+    topic_val = tri.value();
+    return ret;
+}
+} // namespace
+
+bool apply_constraint(
+  cluster::topic_configuration& topic_cfg, const constraint_t& constraint) {
+    if (
+      constraint.name
+      == config::shard_local_cfg().default_topic_partitions.name()) {
+        return do_apply_constraint(
+          topic_cfg.partition_count,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_partition_count);
+    }
+
+    if (
+      constraint.name
+      == config::shard_local_cfg().default_topic_replication.name()) {
+        return do_apply_constraint(
+          topic_cfg.replication_factor,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_replication_factor);
+    }
+
+    if (
+      constraint.name
+      == config::shard_local_cfg().log_compression_type.name()) {
+        return do_apply_constraint_optional<model::compression>(
+          topic_cfg.properties.compression,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_compression,
+          config::shard_local_cfg().log_compression_type());
+    }
+
+    if (
+      constraint.name == config::shard_local_cfg().log_cleanup_policy.name()) {
+        return do_apply_constraint_optional<model::cleanup_policy_bitflags>(
+          topic_cfg.properties.cleanup_policy_bitflags,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_cleanup_policy,
+          config::shard_local_cfg().log_cleanup_policy());
+    }
+
+    if (
+      constraint.name
+      == config::shard_local_cfg().log_message_timestamp_type.name()) {
+        return do_apply_constraint_optional<model::timestamp_type>(
+          topic_cfg.properties.timestamp_type,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_timestamp_type,
+          config::shard_local_cfg().log_message_timestamp_type());
+    }
+
+    if (constraint.name == config::shard_local_cfg().log_segment_size.name()) {
+        return do_apply_constraint_optional(
+          topic_cfg.properties.segment_size,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_segment_size);
+    }
+
+    if (constraint.name == config::shard_local_cfg().retention_bytes.name()) {
+        return do_apply_constraint_tristate(
+          topic_cfg.properties.retention_bytes,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_retention_bytes);
+    }
+
+    if (constraint.name == config::shard_local_cfg().log_retention_ms.name()) {
+        return do_apply_constraint_tristate(
+          topic_cfg.properties.retention_duration,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_retention_duration);
+    }
+
+    if (
+      constraint.name
+      == config::shard_local_cfg().kafka_batch_max_bytes.name()) {
+        return do_apply_constraint_optional(
+          topic_cfg.properties.batch_max_bytes,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_max_message_bytes);
+    }
+
+    if (
+      constraint.name
+      == config::shard_local_cfg().retention_local_target_ms_default.name()) {
+        return do_apply_constraint_tristate(
+          topic_cfg.properties.retention_local_target_bytes,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_retention_local_target_bytes);
+    }
+
+    if (
+      constraint.name
+      == config::shard_local_cfg().retention_local_target_ms_default.name()) {
+        return do_apply_constraint_tristate(
+          topic_cfg.properties.retention_local_target_ms,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_retention_local_target_ms);
+    }
+
+    if (constraint.name == config::shard_local_cfg().log_segment_ms.name()) {
+        return do_apply_constraint_tristate(
+          topic_cfg.properties.segment_ms,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_segment_ms);
+    }
+
+    auto is_cloud_storage_config = [](const ss::sstring& name) {
+        return name
+                 == config::shard_local_cfg()
+                      .cloud_storage_enable_remote_read.name()
+               || name
+                    == config::shard_local_cfg()
+                         .cloud_storage_enable_remote_write.name();
+    };
+    if (
+      is_cloud_storage_config(constraint.name)
+      && topic_cfg.properties.shadow_indexing) {
+        auto fetch_enabled = model::is_fetch_enabled(
+          *topic_cfg.properties.shadow_indexing);
+        auto archival_enabled = model::is_archival_enabled(
+          *topic_cfg.properties.shadow_indexing);
+        auto ret
+          = do_apply_constraint<bool>(
+              fetch_enabled,
+              constraint,
+              topic_cfg.tp_ns.tp,
+              kafka::topic_property_remote_read,
+              config::shard_local_cfg().cloud_storage_enable_remote_read())
+            || do_apply_constraint<bool>(
+              archival_enabled,
+              constraint,
+              topic_cfg.tp_ns.tp,
+              kafka::topic_property_remote_write,
+              config::shard_local_cfg().cloud_storage_enable_remote_write());
+        topic_cfg.properties.shadow_indexing
+          = model::get_shadow_indexing_mode_impl(
+            archival_enabled, fetch_enabled);
+        return ret;
+    }
+
+    vlog(constraints_log.error, "Unknown constraint {}", constraint);
+    return false;
 }
 } // namespace config
 

--- a/src/v/config/constraints.cc
+++ b/src/v/config/constraints.cc
@@ -1,0 +1,190 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/constraints.h"
+
+#include "cluster/types.h"
+#include "config/base_property.h"
+#include "config/configuration.h"
+
+namespace config {
+std::string_view to_string_view(constraint_type type) {
+    switch (type) {
+    case constraint_type::restrikt:
+        return "restrict";
+    case constraint_type::clamp:
+        return "clamp";
+    }
+}
+
+template<>
+std::optional<constraint_type>
+from_string_view<constraint_type>(std::string_view sv) {
+    return string_switch<std::optional<constraint_type>>(sv)
+      .match("restrict", constraint_type::restrikt)
+      .match("clamp", constraint_type::clamp);
+}
+
+std::ostream& operator<<(std::ostream& os, const constraint_t& constraint) {
+    os << ssx::sformat(
+      "name: {} type: {}",
+      constraint.name,
+      config::to_string_view(constraint.type));
+    ss::visit(
+      constraint.flags,
+      [&os](const config::constraint_enabled_t enabled) {
+          os << ssx::sformat(" enabled: {}", enabled);
+      },
+      [&os](const auto range) { os << range; });
+
+    return os;
+}
+} // namespace config
+
+namespace YAML {
+
+template<typename T>
+void encode_range(Node& node, config::range_values<T>& range) {
+    if (range.min) {
+        node["min"] = *range.min;
+    }
+    if (range.max) {
+        node["max"] = *range.max;
+    }
+}
+
+Node convert<config::constraint_t>::encode(const type& rhs) {
+    Node node;
+    node["name"] = rhs.name;
+    node["type"] = ss::sstring(config::to_string_view(rhs.type));
+
+    ss::visit(
+      rhs.flags,
+      [&node](config::constraint_enabled_t enabled) {
+          node["enabled"] = enabled == config::constraint_enabled_t::yes;
+      },
+      [&node](auto range) { encode_range(node, range); });
+
+    return node;
+}
+
+template<typename T>
+config::range_values<T> decode_range(const Node& node) {
+    config::range_values<T> range;
+    if (node["min"] && !node["min"].IsNull()) {
+        range.min = node["min"].as<T>();
+    }
+
+    if (node["max"] && !node["max"].IsNull()) {
+        range.max = node["max"].as<T>();
+    }
+    return range;
+}
+
+template<typename T>
+bool maybe_decode_range(const Node& node, config::constraint_t& constraint) {
+    auto range = decode_range<T>(node);
+    if (!range.min && !range.max) {
+        return false;
+    }
+
+    constraint.flags = range;
+    return true;
+}
+
+// Used to run a condition based on the type of the property.
+template<typename SignedFunc, typename UnsignedFunc, typename ElseFunc>
+auto ternary_property_op(
+  const config::base_property& property,
+  SignedFunc&& signed_condition,
+  UnsignedFunc&& unsigned_condition,
+  ElseFunc&& else_condition) {
+    if (property.is_signed() || property.is_milliseconds()) {
+        return signed_condition();
+    } else if (property.is_unsigned() && !property.is_bool()) {
+        return unsigned_condition();
+    } else {
+        return else_condition();
+    }
+}
+
+bool convert<config::constraint_t>::decode(const Node& node, type& rhs) {
+    for (const auto& s : {"name", "type"}) {
+        if (!node[s]) {
+            return false;
+        }
+    }
+
+    rhs.name = node["name"].as<ss::sstring>();
+
+    auto type_opt = config::from_string_view<config::constraint_type>(
+      node["type"].as<ss::sstring>());
+    if (type_opt) {
+        rhs.type = *type_opt;
+    } else {
+        return false;
+    }
+
+    // Here, we decode constraint flags based on the property type
+    return ternary_property_op(
+      config::shard_local_cfg().get(rhs.name),
+      [&node, &rhs] { return maybe_decode_range<int64_t>(node, rhs); },
+      [&node, &rhs] { return maybe_decode_range<uint64_t>(node, rhs); },
+      [&node, &rhs] {
+          // For "enabled" contraints
+          if (node["enabled"] && !node["enabled"].IsNull()) {
+              rhs.flags = config::constraint_enabled_t(
+                node["enabled"].as<bool>());
+              return true;
+          }
+
+          return false;
+      });
+}
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_enabled_t& ep) {
+    w.Bool(bool(ep));
+}
+
+template<typename T>
+void rjson_serialize_range(
+  json::Writer<json::StringBuffer>& w, config::range_values<T>& range) {
+    if (range.min) {
+        w.Key("min");
+        rjson_serialize(w, range.min);
+    }
+    if (range.max) {
+        w.Key("max");
+        rjson_serialize(w, range.max);
+    }
+}
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_t& constraint) {
+    w.StartObject();
+    w.Key("name");
+    w.String(constraint.name);
+    w.Key("type");
+    w.String(ss::sstring(config::to_string_view(constraint.type)));
+    ss::visit(
+      constraint.flags,
+      [&w](config::constraint_enabled_t enabled) {
+          w.Key("enabled");
+          rjson_serialize(w, enabled);
+      },
+      [&w](auto range) { rjson_serialize_range(w, range); });
+    w.EndObject();
+}
+
+} // namespace json

--- a/src/v/config/constraints.h
+++ b/src/v/config/constraints.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/convert.h"
+#include "config/from_string_view.h"
+#include "config/property.h"
+#include "json/json.h"
+#include "ssx/sformat.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <yaml-cpp/node/node.h>
+
+#include <optional>
+#include <string>
+
+namespace cluster {
+struct topic_configuration;
+} // namespace cluster
+
+namespace config {
+enum class constraint_type {
+    restrikt = 0,
+    clamp = 1,
+};
+
+std::string_view to_string_view(constraint_type type);
+
+template<>
+std::optional<constraint_type>
+from_string_view<constraint_type>(std::string_view sv);
+
+using constraint_enabled_t = ss::bool_class<struct constraint_enabled_tag>;
+
+template<typename T>
+struct range_values {
+    std::optional<T> min;
+    std::optional<T> max;
+
+    range_values() = default;
+    range_values(std::optional<T> min_opt, std::optional<T> max_opt)
+      : min{std::move(min_opt)}
+      , max{std::move(max_opt)} {}
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const range_values<T>& range) {
+        os << ssx::sformat(" min: {}, max: {}", range.min, range.max);
+        return os;
+    }
+
+    friend bool operator==(const range_values&, const range_values&) = default;
+    friend bool operator!=(const range_values&, const range_values&) = default;
+};
+
+// Captures the flags that constraints could hold
+struct constraint_t {
+    using key_type = ss::sstring;
+
+    ss::sstring name;
+    constraint_type type;
+
+    std::variant<
+      range_values<int64_t>,
+      range_values<uint64_t>,
+      constraint_enabled_t>
+      flags;
+
+    static ss::sstring key_name() { return "name"; }
+
+    const ss::sstring& key() const { return name; }
+
+    friend bool operator==(const constraint_t&, const constraint_t&) = default;
+
+    friend std::ostream& operator<<(std::ostream& os, const constraint_t& args);
+};
+
+namespace detail {
+
+template<>
+consteval std::string_view property_type_name<constraint_t>() {
+    return "config::constraint_t";
+}
+
+} // namespace detail
+} // namespace config
+
+namespace YAML {
+template<>
+struct convert<config::constraint_t> {
+    using type = config::constraint_t;
+    static Node encode(const type& rhs);
+    static bool decode(const Node& node, type& rhs);
+};
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_enabled_t& ep);
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_t& ep);
+
+} // namespace json

--- a/src/v/config/constraints.h
+++ b/src/v/config/constraints.h
@@ -84,6 +84,13 @@ struct constraint_t {
     friend std::ostream& operator<<(std::ostream& os, const constraint_t& args);
 };
 
+/**
+ * Apply a constraint to the topic configuration. Returns true
+ * if application is successful, false otherwise. Clamp constraints will change
+ * configuration values.
+ */
+bool apply_constraint(cluster::topic_configuration&, const constraint_t&);
+
 namespace detail {
 
 template<>

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -125,6 +125,14 @@ public:
 
     bool is_array() const override;
 
+    bool is_signed() const override;
+
+    bool is_unsigned() const override;
+
+    bool is_bool() const override;
+
+    bool is_milliseconds() const override;
+
     bool is_overriden() const { return is_required() || _value != _default; }
 
     bool is_default() const override { return _value == _default; }
@@ -702,6 +710,35 @@ bool property<T>::is_array() const {
     return detail::is_array<T>();
 }
 
+template<typename T>
+bool property<T>::is_signed() const {
+    return std::is_signed_v<T>;
+}
+
+template<typename T>
+bool property<T>::is_unsigned() const {
+    if constexpr (reflection::is_std_optional<T>) {
+        return std::is_unsigned_v<typename T::value_type>;
+    } else {
+        return std::is_unsigned_v<T>;
+    }
+}
+
+template<typename T>
+bool property<T>::is_bool() const {
+    return std::is_same_v<T, bool>;
+}
+
+template<typename T>
+bool property<T>::is_milliseconds() const {
+    if constexpr (reflection::is_std_optional<T>) {
+        return std::
+          is_same_v<typename T::value_type, std::chrono::milliseconds>;
+    } else {
+        return std::is_same_v<T, std::chrono::milliseconds>;
+    }
+}
+
 /*
  * Same as property<std::vector<T>> but will also decode a single T. This can be
  * useful for dealing with backwards compatibility or creating easier yaml
@@ -908,5 +945,4 @@ private:
         }
     }
 };
-
 }; // namespace config

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -19,3 +19,14 @@ rp_test(
   LIBRARIES v::seastar_testing_main v::config
   LABELS config
 )
+
+set(gtest_srcs
+    config_constraints_gtests.cc
+    validator_gtests.cc)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_configuration
+  SOURCES ${gtest_srcs}
+  LIBRARIES v::gtest_main v::config v::kafka)

--- a/src/v/config/tests/config_constraints_gtests.cc
+++ b/src/v/config/tests/config_constraints_gtests.cc
@@ -1,0 +1,176 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/types.h"
+#include "config/bounded_property.h"
+#include "config/configuration.h"
+#include "config/property.h"
+#include "config/tests/constraint_utils.h"
+#include "kafka/server/handlers/topics/topic_utils.h"
+#include "model/fundamental.h"
+#include "test_utils/test.h"
+
+#include <seastar/util/log.hh>
+
+namespace {
+struct test_config : public config::config_store {
+    config::bounded_property<int16_t> default_topic_replication;
+    config::property<model::cleanup_policy_bitflags> log_cleanup_policy;
+    config::retention_duration_property log_retention_ms;
+    config::one_or_many_map_property<config::constraint_t> restrict_constraints;
+    config::one_or_many_map_property<config::constraint_t> clamp_constraints;
+
+    test_config()
+      : default_topic_replication(
+        *this, "default_topic_replications", "An integral property", {}, 1, {})
+      , log_cleanup_policy(
+          *this,
+          "log_cleanup_policy",
+          "An enum property",
+          {},
+          model::cleanup_policy_bitflags::deletion)
+      , log_retention_ms(*this, "log_retention_ms", "A ms property", {}, 1h)
+      , restrict_constraints(
+          *this,
+          "restrict_constraints",
+          "A sequence of constraints for testing configs with restrict "
+          "constraint "
+          "type",
+          {},
+          make_constraints(config::constraint_type::restrikt))
+      , clamp_constraints(
+          *this,
+          "clamp_constraints",
+          "A sequence of constraints for testing configs with clamp constraint "
+          "type",
+          {},
+          make_constraints(config::constraint_type::clamp)) {}
+};
+
+bool do_apply(
+  const config::constraint_t::key_type key,
+  cluster::topic_configuration& topic_cfg,
+  const std::unordered_map<
+    config::constraint_t::key_type,
+    config::constraint_t>& constraints) {
+    return config::apply_constraint(topic_cfg, constraints.at(key));
+}
+
+TEST(ConfigConstraintsTest, ConstraintValidation) {
+    auto cfg = test_config{};
+    const auto& constraints = cfg.restrict_constraints();
+    cluster::topic_configuration topic_cfg;
+
+    auto name = ss::sstring{"log_cleanup_policy"};
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::deletion;
+    EXPECT_TRUE(do_apply(name, topic_cfg, constraints));
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    EXPECT_FALSE(do_apply(name, topic_cfg, constraints));
+
+    name = ss::sstring{"default_topic_replications"};
+    topic_cfg.replication_factor = LIMIT_MIN;
+    EXPECT_TRUE(do_apply(name, topic_cfg, constraints));
+    topic_cfg.replication_factor = LIMIT_MAX;
+    EXPECT_TRUE(do_apply(name, topic_cfg, constraints));
+    topic_cfg.replication_factor = LIMIT_MIN - 1;
+    EXPECT_FALSE(do_apply(name, topic_cfg, constraints));
+    topic_cfg.replication_factor = LIMIT_MAX + 1;
+    EXPECT_FALSE(do_apply(name, topic_cfg, constraints));
+
+    name = ss::sstring{"log_retention_ms"};
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{LIMIT_MIN_MS};
+    EXPECT_TRUE(do_apply(name, topic_cfg, constraints));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{LIMIT_MAX_MS};
+    EXPECT_TRUE(do_apply(name, topic_cfg, constraints));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{LIMIT_MIN_MS - 1ms};
+    EXPECT_FALSE(do_apply(name, topic_cfg, constraints));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{LIMIT_MAX_MS + 1ms};
+    EXPECT_FALSE(do_apply(name, topic_cfg, constraints));
+    // Disabled state (infinite retention) with a [min,max] range is not valid
+    // because infinity > max
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{};
+    EXPECT_FALSE(do_apply(name, topic_cfg, constraints));
+}
+
+TEST(ConfigConstraintsTest, ConstraintClamping) {
+    auto cfg = test_config{};
+    const auto& constraints = cfg.clamp_constraints();
+    cluster::topic_configuration topic_cfg;
+
+    // Check enum clamp constraint
+    auto name = ss::sstring{"log_cleanup_policy"};
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::deletion;
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.cleanup_policy_bitflags, cfg.log_cleanup_policy());
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.cleanup_policy_bitflags, cfg.log_cleanup_policy());
+
+    // Check integral clamp constraint
+    name = ss::sstring{"default_topic_replications"};
+    topic_cfg.replication_factor = LIMIT_MIN;
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MIN);
+    topic_cfg.replication_factor = LIMIT_MAX;
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MAX);
+    topic_cfg.replication_factor = LIMIT_MIN - 1;
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MIN);
+    topic_cfg.replication_factor = LIMIT_MAX + 1;
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MAX);
+
+    // Check ms clamp constraint
+    name = ss::sstring{"log_retention_ms"};
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{LIMIT_MIN_MS};
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>{LIMIT_MIN_MS});
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{LIMIT_MAX_MS};
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>{LIMIT_MAX_MS});
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{LIMIT_MIN_MS - 1ms};
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>{LIMIT_MIN_MS});
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{LIMIT_MAX_MS + 1ms};
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>{LIMIT_MAX_MS});
+    // Disabled state (infinite retention) with a [min,max] range, value should
+    // become max because infinity > max
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{};
+    do_apply(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>{LIMIT_MAX_MS});
+}
+} // namespace

--- a/src/v/config/tests/constraint_utils.h
+++ b/src/v/config/tests/constraint_utils.h
@@ -1,0 +1,50 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/constraints.h"
+
+#include <chrono>
+#include <optional>
+#include <unordered_map>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr static int16_t LIMIT_MIN = 3;
+constexpr static int16_t LIMIT_MAX = 10;
+constexpr static std::chrono::milliseconds LIMIT_MIN_MS = 1s;
+constexpr static std::chrono::milliseconds LIMIT_MAX_MS = 5s;
+
+std::unordered_map<config::constraint_t::key_type, config::constraint_t>
+make_constraints(config::constraint_type type) {
+    auto integral_constraint_t = config::constraint_t{
+      .name = "default_topic_replications",
+      .type = type,
+      .flags = config::range_values<int64_t>(LIMIT_MIN, LIMIT_MAX)};
+    auto enum_constraint_t = config::constraint_t{
+      .name = "log_cleanup_policy",
+      .type = type,
+      .flags = config::constraint_enabled_t::yes};
+    auto ms_constraint_t = config::constraint_t{
+      .name = "log_retention_ms",
+      .type = type,
+      .flags = config::range_values<int64_t>(
+        LIMIT_MIN_MS.count(), LIMIT_MAX_MS.count())};
+
+    std::unordered_map<config::constraint_t::key_type, config::constraint_t>
+      res;
+    res.reserve(3);
+    res[integral_constraint_t.name] = std::move(integral_constraint_t);
+    res[enum_constraint_t.name] = std::move(enum_constraint_t);
+    res[ms_constraint_t.name] = std::move(ms_constraint_t);
+    return res;
+}
+
+} // namespace

--- a/src/v/config/tests/validator_gtests.cc
+++ b/src/v/config/tests/validator_gtests.cc
@@ -1,0 +1,28 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/tests/constraint_utils.h"
+#include "config/validators.h"
+#include "test_utils/test.h"
+
+TEST(ConfigConstraintsTest, InvaldConstraintConfig) {
+    auto valid_constraints = make_constraints(
+      config::constraint_type::restrikt);
+    auto invalid_integral_constraints = std::
+      unordered_map<config::constraint_t::key_type, config::constraint_t>{
+        {"invalid-integral",
+         config::constraint_t{
+           .name = "invalid-integral",
+           .type = config::constraint_type::restrikt,
+           .flags = config::range_values<int64_t>(LIMIT_MAX, LIMIT_MIN)}}};
+
+    EXPECT_FALSE(config::validate_constraints(valid_constraints).has_value());
+    EXPECT_TRUE(
+      config::validate_constraints(invalid_integral_constraints).has_value());
+}

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "config/client_group_byte_rate_quota.h"
+#include "config/constraints.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -47,4 +48,6 @@ validate_non_empty_string_opt(const std::optional<ss::sstring>&);
 std::optional<ss::sstring>
 validate_audit_event_types(const std::vector<ss::sstring>& vs);
 
+std::optional<ss::sstring> validate_constraints(
+  const std::unordered_map<ss::sstring, config::constraint_t>&);
 }; // namespace config

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -20,7 +20,7 @@ set(handlers_srcs
   server/handlers/alter_partition_reassignments.cc
   server/handlers/list_partition_reassignments.cc
   server/handlers/handler_interface.cc
-  server/handlers/topics/types.cc
+  server/handlers/topics/config_map.cc
   server/handlers/topics/topic_utils.cc
   server/handlers/delete_records.cc
   server/handlers/describe_producers.cc

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -15,6 +15,7 @@
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/timeout.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/quota_manager.h"

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -502,7 +502,7 @@ static void report_broker_config(
     add_broker_config_if_requested(
       resource,
       result,
-      "num.partitions",
+      topic_property_partition_count,
       config::shard_local_cfg().default_topic_partitions,
       include_synonyms,
       maybe_make_documentation(

--- a/src/v/kafka/server/handlers/topics/config_map.cc
+++ b/src/v/kafka/server/handlers/topics/config_map.cc
@@ -1,4 +1,4 @@
-// Copyright 2020 Redpanda Data, Inc.
+// Copyright 2023 Redpanda Data, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "kafka/server/handlers/topics/types.h"
+#include "kafka/server/handlers/topics/config_map.h"
 
 #include "cluster/types.h"
 #include "config/configuration.h"
@@ -105,16 +105,7 @@ get_shadow_indexing_mode(const config_map_t& config) {
           = config::shard_local_cfg().cloud_storage_enable_remote_read();
     }
 
-    model::shadow_indexing_mode mode = model::shadow_indexing_mode::disabled;
-    if (*arch_enabled) {
-        mode = model::shadow_indexing_mode::archival;
-    }
-    if (*si_enabled) {
-        mode = mode == model::shadow_indexing_mode::archival
-                 ? model::shadow_indexing_mode::full
-                 : model::shadow_indexing_mode::fetch;
-    }
-    return mode;
+    return model::get_shadow_indexing_mode_impl(*arch_enabled, *si_enabled);
 }
 
 // Special case for options where Kafka allows -1

--- a/src/v/kafka/server/handlers/topics/config_map.h
+++ b/src/v/kafka/server/handlers/topics/config_map.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/types.h"
+#include "kafka/protocol/schemata/create_topics_request.h"
+#include "kafka/protocol/schemata/create_topics_response.h"
+#include "kafka/server/handlers/topics/types.h"
+
+#include <boost/lexical_cast.hpp>
+
+namespace kafka {
+
+inline creatable_topic_result
+from_cluster_topic_result(const cluster::topic_result& err) {
+    return {.name = err.tp_ns.tp, .error_code = map_topic_error_code(err.ec)};
+}
+
+config_map_t config_map(const std::vector<createable_topic_config>& config);
+config_map_t config_map(const std::vector<creatable_topic_configs>& config);
+
+cluster::custom_assignable_topic_configuration
+to_cluster_type(const creatable_topic& t);
+
+config_map_t from_cluster_type(const cluster::topic_properties&);
+} // namespace kafka

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -12,7 +12,8 @@
 #pragma once
 #include "cluster/fwd.h"
 #include "cluster/types.h"
-#include "kafka/server/handlers/topics/types.h"
+#include "config/constraints.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/validators.h"
 #include "model/timeout_clock.h"
 #include "seastarx.h"

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -189,5 +189,4 @@ ss::future<> wait_for_topics(
   std::vector<cluster::topic_result>,
   cluster::controller_api&,
   model::timeout_clock::time_point);
-
 } // namespace kafka

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Redpanda Data, Inc.
+ * Copyright 2023 Redpanda Data, Inc.
  *
  * Use of this software is governed by the Business Source License
  * included in the file licenses/BSL.md
@@ -10,17 +10,12 @@
  */
 
 #pragma once
-#include "cluster/types.h"
-#include "kafka/protocol/schemata/create_topics_request.h"
-#include "kafka/protocol/schemata/create_topics_response.h"
 #include "kafka/server/errors.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "utils/absl_sstring_hash.h"
 
 #include <absl/container/flat_hash_map.h>
-#include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <array>
 
@@ -63,6 +58,8 @@ static constexpr std::string_view topic_property_retention_local_target_ms
   = "retention.local.target.ms";
 static constexpr std::string_view topic_property_replication_factor
   = "replication.factor";
+static constexpr std::string_view topic_property_partition_count
+  = "num.partitions";
 static constexpr std::string_view topic_property_remote_delete
   = "redpanda.remote.delete";
 static constexpr std::string_view topic_property_segment_ms = "segment.ms";
@@ -134,17 +131,4 @@ struct topic_op_result {
     error_code ec;
     std::optional<ss::sstring> err_msg;
 };
-
-inline creatable_topic_result
-from_cluster_topic_result(const cluster::topic_result& err) {
-    return {.name = err.tp_ns.tp, .error_code = map_topic_error_code(err.ec)};
-}
-
-config_map_t config_map(const std::vector<createable_topic_config>& config);
-config_map_t config_map(const std::vector<creatable_topic_configs>& config);
-
-cluster::custom_assignable_topic_configuration
-to_cluster_type(const creatable_topic& t);
-
-config_map_t from_cluster_type(const cluster::topic_properties&);
 } // namespace kafka

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "kafka/protocol/schemata/create_topics_request.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/types.h"
 
 namespace kafka {

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/metadata.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "redpanda/tests/fixture.h"
 #include "resource_mgmt/io_priority.h"

--- a/src/v/kafka/server/tests/types_conversion_tests.cc
+++ b/src/v/kafka/server/tests/types_conversion_tests.cc
@@ -9,8 +9,8 @@
 
 #include "cluster/types.h"
 #include "kafka/protocol/schemata/create_topics_request.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
-#include "kafka/server/handlers/topics/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -424,6 +424,20 @@ std::ostream& operator<<(std::ostream&, const shadow_indexing_mode&);
 
 using client_address_t = named_type<ss::sstring, struct client_address_tag>;
 
+inline shadow_indexing_mode
+get_shadow_indexing_mode_impl(bool arch_enabled, bool si_enabled) {
+    model::shadow_indexing_mode mode = model::shadow_indexing_mode::disabled;
+    if (arch_enabled) {
+        mode = model::shadow_indexing_mode::archival;
+    }
+    if (si_enabled) {
+        mode = mode == model::shadow_indexing_mode::archival
+                 ? model::shadow_indexing_mode::full
+                 : model::shadow_indexing_mode::fetch;
+    }
+
+    return mode;
+}
 } // namespace model
 
 namespace kafka {


### PR DESCRIPTION
https://github.com/redpanda-data/redpanda/pull/13942 is stale, use this one instead.

Enable users to set configuration constraints for cluster-level properties. This patch adds support for constraints for a sub-set of cluster-level configs. Specifically, those that are settable via the Kafka CreateTopics API or reported by the DescribeConfigs API. 

Fixes: https://github.com/redpanda-data/redpanda/issues/13571
Fixes: https://github.com/redpanda-data/redpanda/issues/14052

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none