### PR TITLE
ducktape/cloud_storage: Ignore accessdenied errors

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1489,7 +1489,11 @@ class TopicRecoveryTest(RedpandaTest):
                                        self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
-    @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
+    @cluster(
+        num_nodes=4,
+        log_allow_list=TRANSIENT_ERRORS + [
+            r'unexpected REST API error "" detected, code: AccessDenied, .* resource: /recovery_state/kafka/.*'
+        ])
     @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_admin_api_recovery(self, cloud_storage_type):
         topics = [


### PR DESCRIPTION
When running the topic recovery test, occassionally we see accessdenied errors when the following sequence is seen:

1. Node A issues delete request for key recovery_state/.../A
2. Node B PUTs key recovery_state/.../B

Node B gets access-denied. This seems to be a quirk of MinIO, they have multiple issues documenting PUT failure because of locking, eg

https://github.com/minio/minio/issues/12914

Since AWS guarantees that parallel DELETE and PUT for different keys under the same root path are possible, we should ignore the error for MinIO based environments.

FIXES #8388 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
