### PR TITLE
Implemented handling of fast partition movements in cluster controller 

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -220,7 +220,7 @@ using force_partition_reconfiguration_cmd = controller_command<
 using update_partition_replicas_cmd = controller_command<
   int8_t, // unused
   update_partition_replicas_cmd_data,
-  update_topic_properties_cmd_type,
+  update_partition_replicas_cmd_type,
   model::record_batch_type::topic_management_cmd,
   serde_opts::serde_only>;
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -355,6 +355,14 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
             std::ref(_tp_frontend),
             std::ref(_storage),
             std::ref(_feature_table),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .initial_retention_local_target_bytes_default.bind();
+            }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .initial_retention_local_target_ms_default.bind();
+            }),
             std::ref(_as));
       })
       .then(

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -36,6 +36,7 @@
 #include <seastar/core/loop.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/util/variant_utils.hh>
 
 #include <absl/container/node_hash_map.h>
 
@@ -174,21 +175,26 @@ controller_api::get_reconciliation_state(model::ntp ntp) {
     const auto shards = boost::irange<ss::shard_id>(0, ss::smp::count);
     for (auto shard : shards) {
         auto local_deltas = co_await get_remote_core_deltas(ntp, shard);
+        for (auto& m : local_deltas) {
+            auto assignment = ss::visit(
+              m.delta.get_data(),
+              [](delta_reconfiguration_data& data) {
+                  return std::move(data.target_assignment);
+              },
+              [](delta_finish_update_data& data) {
+                  return std::move(data.target_assignment);
+              },
+              [](auto&) { return partition_assignment{}; });
 
-        std::transform(
-          local_deltas.begin(),
-          local_deltas.end(),
-          std::back_inserter(ops),
-          [shard](controller_backend::delta_metadata& m) {
-              return backend_operation{
-                .source_shard = shard,
-                .p_as = std::move(m.delta.new_assignment()),
-                .type = m.delta.type(),
-                .current_retry = m.retries,
-                .last_operation_result = m.last_error,
-                .revision_of_operation = m.delta.revision(),
-              };
-          });
+            ops.push_back(backend_operation{
+              .source_shard = shard,
+              .p_as = std::move(assignment),
+              .type = m.delta.type(),
+              .current_retry = m.retries,
+              .last_operation_result = m.last_error,
+              .revision_of_operation = m.delta.revision(),
+            });
+        }
     }
 
     // having any deltas is sufficient to state that reconciliation is still

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -336,6 +336,7 @@ controller_api::get_partitions_reconfiguration_state(
         state.current_assignment = std::move(p_as->replicas);
         state.previous_assignment = progress_it->second.get_previous_replicas();
         state.state = progress_it->second.get_state();
+        state.policy = progress_it->second.get_reconfiguration_policy();
         states.emplace(ntp, std::move(state));
 
         auto [tp_it, _] = partitions_filter.namespaces.try_emplace(

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -186,7 +186,7 @@ controller_api::get_reconciliation_state(model::ntp ntp) {
                 .type = m.delta.type(),
                 .current_retry = m.retries,
                 .last_operation_result = m.last_error,
-                .revision_of_operation = model::revision_id(m.delta.offset()),
+                .revision_of_operation = m.delta.revision(),
               };
           });
     }

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -182,11 +182,11 @@ controller_api::get_reconciliation_state(model::ntp ntp) {
           [shard](controller_backend::delta_metadata& m) {
               return backend_operation{
                 .source_shard = shard,
-                .p_as = std::move(m.delta.new_assignment),
-                .type = m.delta.type,
+                .p_as = std::move(m.delta.new_assignment()),
+                .type = m.delta.type(),
                 .current_retry = m.retries,
                 .last_operation_result = m.last_error,
-                .revision_of_operation = model::revision_id(m.delta.offset),
+                .revision_of_operation = model::revision_id(m.delta.offset()),
               };
           });
     }

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -489,7 +489,8 @@ ss::future<std::error_code> do_update_replica_set(
     // only vnodes to update raft replica set
     if (likely(command_based_members_update)) {
         auto nodes = create_vnode_set(replicas, replica_revisions);
-        co_return co_await p->update_replica_set(std::move(nodes), rev);
+        co_return co_await p->update_replica_set(
+          std::move(nodes), rev, std::nullopt);
     }
 
     auto brokers = create_brokers_set(replicas, replica_revisions, members);

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -302,16 +302,16 @@ private:
       partition_operation_type,
       model::ntp,
       const partition_assignment& requested_assignment,
-      const std::vector<model::broker_shard>& previous_replica_set,
+      const replicas_t& previous_replica_set,
       const replicas_revision_map&,
       model::revision_id);
 
     ss::future<std::error_code> execute_reconfiguration(
       partition_operation_type,
       const model::ntp&,
-      const std::vector<model::broker_shard>&,
+      const replicas_t&,
       const replicas_revision_map&,
-      const std::vector<model::broker_shard>&,
+      const replicas_t&,
       model::revision_id);
 
     ss::future<> finish_partition_update(
@@ -341,37 +341,34 @@ private:
     ss::future<std::error_code> reset_partition(
       model::ntp,
       const partition_assignment& target_assignment,
-      const std::vector<model::broker_shard>& prev_replicas,
+      const replicas_t& prev_replicas,
       const replicas_revision_map&,
       model::revision_id cmd_revision);
     template<typename Func>
     ss::future<std::error_code> apply_configuration_change_on_leader(
-      const model::ntp&,
-      const std::vector<model::broker_shard>&,
-      model::revision_id,
-      Func&& f);
+      const model::ntp&, const replicas_t&, model::revision_id, Func&& f);
     ss::future<std::error_code> update_partition_replica_set(
       const model::ntp&,
-      const std::vector<model::broker_shard>&,
+      const replicas_t&,
       const replicas_revision_map&,
       model::revision_id);
     ss::future<std::error_code> cancel_replica_set_update(
       const model::ntp&,
-      const std::vector<model::broker_shard>&,
+      const replicas_t&,
       const replicas_revision_map&,
-      const std::vector<model::broker_shard>&,
+      const replicas_t&,
       model::revision_id);
 
     ss::future<std::error_code> force_abort_replica_set_update(
       const model::ntp&,
-      const std::vector<model::broker_shard>&,
+      const replicas_t&,
       const replicas_revision_map&,
-      const std::vector<model::broker_shard>&,
+      const replicas_t&,
       model::revision_id);
 
     ss::future<std::error_code> force_replica_set_update(
       const model::ntp&,
-      const std::vector<model::broker_shard>& /*new replicas*/,
+      const replicas_t& /*new replicas*/,
       const replicas_revision_map&,
       model::revision_id);
 
@@ -399,7 +396,7 @@ private:
       std::optional<model::node_id> current_leader,
       uint64_t current_retry,
       partition_operation_type operation_type,
-      const std::vector<model::broker_shard>& requested_replicas);
+      const replicas_t& requested_replicas);
 
     void housekeeping();
     void setup_metrics();

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -299,7 +299,7 @@ private:
     ss::future<std::error_code> execute_partition_op(const delta_metadata&);
     ss::future<std::error_code> process_partition_reconfiguration(
       uint64_t current_retry,
-      topic_table_delta::op_type,
+      partition_operation_type,
       model::ntp,
       const partition_assignment& requested_assignment,
       const std::vector<model::broker_shard>& previous_replica_set,
@@ -307,7 +307,7 @@ private:
       model::revision_id);
 
     ss::future<std::error_code> execute_reconfiguration(
-      topic_table_delta::op_type,
+      partition_operation_type,
       const model::ntp&,
       const std::vector<model::broker_shard>&,
       const replicas_revision_map&,
@@ -398,7 +398,7 @@ private:
     bool can_finish_update(
       std::optional<model::node_id> current_leader,
       uint64_t current_retry,
-      topic_table_delta::op_type operation_type,
+      partition_operation_type operation_type,
       const std::vector<model::broker_shard>& requested_replicas);
 
     void housekeeping();

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -301,24 +301,19 @@ private:
       uint64_t current_retry,
       partition_operation_type,
       model::ntp,
-      const partition_assignment& requested_assignment,
-      const replicas_t& previous_replica_set,
-      const replicas_revision_map&,
+      const delta_reconfiguration_data&,
       model::revision_id);
 
     ss::future<std::error_code> execute_reconfiguration(
       partition_operation_type,
       const model::ntp&,
-      const replicas_t&,
-      const replicas_revision_map&,
-      const replicas_t&,
+      const delta_reconfiguration_data&,
       model::revision_id);
 
     ss::future<> finish_partition_update(
       model::ntp, const partition_assignment&, model::revision_id);
 
-    ss::future<>
-      process_partition_properties_update(model::ntp, partition_assignment);
+    ss::future<> process_partition_properties_update(model::ntp);
 
     ss::future<std::error_code> create_partition(
       model::ntp,

--- a/src/v/cluster/controller_log_limiter.h
+++ b/src/v/cluster/controller_log_limiter.h
@@ -20,6 +20,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <optional>
+#include <type_traits>
 
 namespace cluster {
 
@@ -79,8 +80,9 @@ public:
           std::is_same_v<Cmd, create_partition_cmd>) {
             return _topic_operations_limiter.try_throttle();
         } else if constexpr (
-          std::is_same_v<Cmd, move_partition_replicas_cmd> || //
-          std::is_same_v<Cmd, cancel_moving_partition_replicas_cmd>) {
+          std::is_same_v<Cmd, move_partition_replicas_cmd> ||          //
+          std::is_same_v<Cmd, cancel_moving_partition_replicas_cmd> || //
+          std::is_same_v<Cmd, update_partition_replicas_cmd>) {
             return _move_operations_limiter.try_throttle();
         } else if constexpr (
           std::is_same_v<Cmd, create_user_cmd> || //

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -142,7 +142,7 @@ struct topics_t
 
     struct update_t
       : public serde::
-          envelope<update_t, serde::version<0>, serde::compat_version<0>> {
+          envelope<update_t, serde::version<1>, serde::compat_version<0>> {
         /// NOTE: In the event of cancellation this remains the original target.
         std::vector<model::broker_shard> target_assignment;
         reconfiguration_state state;
@@ -150,12 +150,14 @@ struct topics_t
         model::revision_id revision;
         /// Revision of the last command in this update (cancellation etc.)
         model::revision_id last_cmd_revision;
+        /// Reconfiguration policy used with this update
+        reconfiguration_policy policy;
 
         friend bool operator==(const update_t&, const update_t&) = default;
 
         auto serde_fields() {
             return std::tie(
-              target_assignment, state, revision, last_cmd_revision);
+              target_assignment, state, revision, last_cmd_revision, policy);
         }
     };
 

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -36,7 +36,7 @@ class topic_table;
 class plugin_frontend;
 class plugin_table;
 class plugin_backend;
-struct topic_table_delta;
+class topic_table_delta;
 class topic_table_partition_generator;
 class cloud_storage_size_reducer;
 class members_manager;

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -30,6 +30,7 @@ class tx_gateway_frontend;
 class partition_leaders_table;
 class partition_allocator;
 class partition_manager;
+class partition;
 class shard_table;
 class topics_frontend;
 class topic_table;

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -17,6 +17,7 @@
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/topic_table.h"
 #include "cluster/topics_frontend.h"
+#include "cluster/types.h"
 #include "model/namespace.h"
 #include "model/transform.h"
 #include "seastarx.h"
@@ -101,7 +102,10 @@ ss::future<bool> health_manager::ensure_partition_replication(model::ntp ntp) {
     const auto& replicas = allocation.value().replicas();
 
     auto err = co_await _topics_frontend.local().move_partition_replicas(
-      ntp, replicas, model::timeout_clock::now() + set_replicas_timeout);
+      ntp,
+      replicas,
+      reconfiguration_policy::full_local_retention,
+      model::timeout_clock::now() + set_replicas_timeout);
     if (err) {
         vlog(
           clusterlog.warn,

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -619,6 +619,7 @@ ss::future<> members_backend::reconcile_reallocation_state(
           = co_await _topics_frontend.local().move_partition_replicas(
             ntp,
             meta.new_replica_set,
+            reconfiguration_policy::full_local_retention,
             model::timeout_clock::now() + _retry_timeout);
         if (error) {
             vlog(

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -277,7 +277,7 @@ metadata_cache::get_default_initial_retention_local_target_bytes() const {
     return config::shard_local_cfg()
       .initial_retention_local_target_bytes_default();
 }
-std::chrono::milliseconds
+std::optional<std::chrono::milliseconds>
 metadata_cache::get_default_initial_retention_local_target_ms() const {
     return config::shard_local_cfg()
       .initial_retention_local_target_ms_default();

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -180,7 +180,7 @@ public:
     std::chrono::milliseconds get_default_retention_local_target_ms() const;
     std::optional<size_t>
     get_default_initial_retention_local_target_bytes() const;
-    std::chrono::milliseconds
+    std::optional<std::chrono::milliseconds>
     get_default_initial_retention_local_target_ms() const;
     model::shadow_indexing_mode get_default_shadow_indexing_mode() const;
     uint32_t get_default_batch_max_bytes() const;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -239,8 +239,11 @@ public:
           std::move(brokers), new_revision_id);
     }
     ss::future<std::error_code> update_replica_set(
-      std::vector<raft::vnode> nodes, model::revision_id new_revision_id) {
-        return _raft->replace_configuration(std::move(nodes), new_revision_id);
+      std::vector<raft::vnode> nodes,
+      model::revision_id new_revision_id,
+      std::optional<model::offset> learner_start_offset) {
+        return _raft->replace_configuration(
+          std::move(nodes), new_revision_id, learner_start_offset);
     }
 
     ss::future<std::error_code> force_update_replica_set(

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -472,7 +472,7 @@ ss::future<> partition_balancer_backend::do_tick() {
           auto f = _topics_frontend.move_partition_replicas(
             reassignment.ntp,
             reassignment.allocated.replicas(),
-            reconfiguration_policy::full_local_retention,
+            reassignment.reconfiguration_policy,
             model::timeout_clock::now() + add_move_cmd_timeout,
             _cur_term->id);
           return f.then([reassignment = std::move(reassignment)](auto errc) {

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -19,6 +19,7 @@
 #include "cluster/partition_balancer_state.h"
 #include "cluster/topic_table.h"
 #include "cluster/topics_frontend.h"
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/property.h"
 #include "random/generators.h"
@@ -471,6 +472,7 @@ ss::future<> partition_balancer_backend::do_tick() {
           auto f = _topics_frontend.move_partition_replicas(
             reassignment.ntp,
             reassignment.allocated.replicas(),
+            reconfiguration_policy::full_local_retention,
             model::timeout_clock::now() + add_move_cmd_timeout,
             _cur_term->id);
           return f.then([reassignment = std::move(reassignment)](auto errc) {

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -14,6 +14,7 @@
 #include "cluster/partition_balancer_types.h"
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/topic_table.h"
+#include "cluster/types.h"
 #include "model/metadata.h"
 
 #include <absl/container/flat_hash_map.h>
@@ -25,6 +26,7 @@ namespace cluster {
 struct ntp_reassignment {
     model::ntp ntp;
     allocated_partition allocated;
+    reconfiguration_policy reconfiguration_policy;
 };
 
 struct planner_config {

--- a/src/v/cluster/tests/controller_backend_test.cc
+++ b/src/v/cluster/tests/controller_backend_test.cc
@@ -66,7 +66,7 @@ meta_t update_with_current = make_delta(
   {make_bs(9, 0), make_bs(10, 0)});
 
 meta_t finish_update_with_current = make_delta(
-  7, op_t::update_finished, {make_bs(0, 0), make_bs(10, 0)});
+  7, op_t::finish_update, {make_bs(0, 0), make_bs(10, 0)});
 
 meta_t update_without_current = make_delta(
   8,
@@ -75,19 +75,19 @@ meta_t update_without_current = make_delta(
   {make_bs(9, 0), make_bs(10, 0)});
 
 meta_t finish_update_without_current = make_delta(
-  9, op_t::update_finished, {make_bs(1, 0), make_bs(10, 0)});
+  9, op_t::finish_update, {make_bs(1, 0), make_bs(10, 0)});
 
 meta_t update_without_current_2 = make_delta(
   10, op_t::update, {make_bs(10, 0)}, {make_bs(9, 0)});
 
 meta_t finish_update_without_current_2 = make_delta(
-  11, op_t::update_finished, {make_bs(10, 0)});
+  11, op_t::finish_update, {make_bs(10, 0)});
 
 meta_t update_with_current_2 = make_delta(
   12, op_t::update, {make_bs(0, 0)}, {make_bs(1, 0)});
 
 meta_t finish_update_with_current_2 = make_delta(
-  13, op_t::update_finished, {make_bs(0, 0)});
+  13, op_t::finish_update, {make_bs(0, 0)});
 
 meta_t final_delete = make_delta(
   100, op_t::remove, {make_bs(0, 0), make_bs(2, 1), make_bs(1, 0)});

--- a/src/v/cluster/tests/controller_backend_test.cc
+++ b/src/v/cluster/tests/controller_backend_test.cc
@@ -41,7 +41,7 @@ meta_t make_delta(
     return meta_t(cluster::topic_table::delta(
       test_ntp,
       make_assignment(std::move(replicas)),
-      model::offset(o),
+      model::revision_id(o),
       type,
       previous.empty() ? std::nullopt : std::make_optional(previous)));
 };
@@ -100,7 +100,7 @@ SEASTAR_THREAD_TEST_CASE(test_simple_bootstrap) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
     BOOST_REQUIRE_EQUAL(
-      deltas.back().delta.offset(), add_current.delta.offset());
+      deltas.back().delta.revision(), add_current.delta.revision());
 
     // add topic on different node, should not include this
     deltas_t d_2{add_different};
@@ -120,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(test_simple_bootstrap) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
     BOOST_REQUIRE_EQUAL(
-      deltas.back().delta.offset(), recreate_current.delta.offset());
+      deltas.back().delta.revision(), recreate_current.delta.revision());
 
     // recreate topic on different node
     deltas_t d_5{add_current, delete_current, recreate_different};
@@ -144,13 +144,13 @@ SEASTAR_THREAD_TEST_CASE(update_including_current_node) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 3);
     BOOST_REQUIRE_EQUAL(
-      deltas.begin()->delta.offset(), recreate_current.delta.offset());
+      deltas.begin()->delta.revision(), recreate_current.delta.revision());
     BOOST_REQUIRE_EQUAL(
-      std::next(deltas.begin())->delta.offset(),
-      update_with_current.delta.offset());
+      std::next(deltas.begin())->delta.revision(),
+      update_with_current.delta.revision());
     BOOST_REQUIRE_EQUAL(
-      std::next(deltas.begin(), 2)->delta.offset(),
-      finish_update_with_current.delta.offset());
+      std::next(deltas.begin(), 2)->delta.revision(),
+      finish_update_with_current.delta.revision());
 }
 
 SEASTAR_THREAD_TEST_CASE(update_excluding_current_node) {
@@ -200,10 +200,10 @@ SEASTAR_THREAD_TEST_CASE(move_back_to_current_node) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 2);
     BOOST_REQUIRE_EQUAL(
-      deltas.begin()->delta.offset(), update_with_current_2.delta.offset());
+      deltas.begin()->delta.revision(), update_with_current_2.delta.revision());
     BOOST_REQUIRE_EQUAL(
-      std::next(deltas.begin())->delta.offset(),
-      finish_update_with_current_2.delta.offset());
+      std::next(deltas.begin())->delta.revision(),
+      finish_update_with_current_2.delta.revision());
 }
 
 SEASTAR_THREAD_TEST_CASE(move_back_to_current_node_not_finished) {
@@ -223,5 +223,5 @@ SEASTAR_THREAD_TEST_CASE(move_back_to_current_node_not_finished) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
     BOOST_REQUIRE_EQUAL(
-      deltas.begin()->delta.offset(), update_with_current_2.delta.offset());
+      deltas.begin()->delta.revision(), update_with_current_2.delta.revision());
 }

--- a/src/v/cluster/tests/controller_backend_test.cc
+++ b/src/v/cluster/tests/controller_backend_test.cc
@@ -28,14 +28,14 @@ make_assignment(std::vector<model::broker_shard> replicas) {
       raft::group_id(1), model::partition_id(1), std::move(replicas)};
 }
 
-using op_t = cluster::topic_table::delta::op_type;
+using op_t = cluster::partition_operation_type;
 using delta_t = cluster::topic_table::delta;
 using meta_t = cluster::controller_backend::delta_metadata;
 using deltas_t = std::deque<meta_t>;
 
 meta_t make_delta(
   int64_t o,
-  cluster::topic_table::delta::op_type type,
+  op_t type,
   std::vector<model::broker_shard> replicas,
   std::vector<model::broker_shard> previous = {}) {
     return meta_t(cluster::topic_table::delta(
@@ -53,7 +53,7 @@ meta_t add_different = make_delta(
   2, op_t::add, {make_bs(3, 0), make_bs(2, 1), make_bs(1, 0)});
 
 meta_t delete_current = make_delta(
-  3, op_t::del, {make_bs(0, 0), make_bs(2, 1), make_bs(1, 0)});
+  3, op_t::remove, {make_bs(0, 0), make_bs(2, 1), make_bs(1, 0)});
 
 meta_t recreate_different = make_delta(4, op_t::add, {make_bs(3, 0)});
 
@@ -90,7 +90,7 @@ meta_t finish_update_with_current_2 = make_delta(
   13, op_t::update_finished, {make_bs(0, 0)});
 
 meta_t final_delete = make_delta(
-  100, op_t::del, {make_bs(0, 0), make_bs(2, 1), make_bs(1, 0)});
+  100, op_t::remove, {make_bs(0, 0), make_bs(2, 1), make_bs(1, 0)});
 
 SEASTAR_THREAD_TEST_CASE(test_simple_bootstrap) {
     // add topic on current node

--- a/src/v/cluster/tests/controller_backend_test.cc
+++ b/src/v/cluster/tests/controller_backend_test.cc
@@ -99,7 +99,8 @@ SEASTAR_THREAD_TEST_CASE(test_simple_bootstrap) {
       current_node, std::move(d_1));
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
-    BOOST_REQUIRE_EQUAL(deltas.back().delta.offset, add_current.delta.offset);
+    BOOST_REQUIRE_EQUAL(
+      deltas.back().delta.offset(), add_current.delta.offset());
 
     // add topic on different node, should not include this
     deltas_t d_2{add_different};
@@ -119,7 +120,7 @@ SEASTAR_THREAD_TEST_CASE(test_simple_bootstrap) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
     BOOST_REQUIRE_EQUAL(
-      deltas.back().delta.offset, recreate_current.delta.offset);
+      deltas.back().delta.offset(), recreate_current.delta.offset());
 
     // recreate topic on different node
     deltas_t d_5{add_current, delete_current, recreate_different};
@@ -143,13 +144,13 @@ SEASTAR_THREAD_TEST_CASE(update_including_current_node) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 3);
     BOOST_REQUIRE_EQUAL(
-      deltas.begin()->delta.offset, recreate_current.delta.offset);
+      deltas.begin()->delta.offset(), recreate_current.delta.offset());
     BOOST_REQUIRE_EQUAL(
-      std::next(deltas.begin())->delta.offset,
-      update_with_current.delta.offset);
+      std::next(deltas.begin())->delta.offset(),
+      update_with_current.delta.offset());
     BOOST_REQUIRE_EQUAL(
-      std::next(deltas.begin(), 2)->delta.offset,
-      finish_update_with_current.delta.offset);
+      std::next(deltas.begin(), 2)->delta.offset(),
+      finish_update_with_current.delta.offset());
 }
 
 SEASTAR_THREAD_TEST_CASE(update_excluding_current_node) {
@@ -199,10 +200,10 @@ SEASTAR_THREAD_TEST_CASE(move_back_to_current_node) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 2);
     BOOST_REQUIRE_EQUAL(
-      deltas.begin()->delta.offset, update_with_current_2.delta.offset);
+      deltas.begin()->delta.offset(), update_with_current_2.delta.offset());
     BOOST_REQUIRE_EQUAL(
-      std::next(deltas.begin())->delta.offset,
-      finish_update_with_current_2.delta.offset);
+      std::next(deltas.begin())->delta.offset(),
+      finish_update_with_current_2.delta.offset());
 }
 
 SEASTAR_THREAD_TEST_CASE(move_back_to_current_node_not_finished) {
@@ -222,5 +223,5 @@ SEASTAR_THREAD_TEST_CASE(move_back_to_current_node_not_finished) {
 
     BOOST_REQUIRE_EQUAL(deltas.size(), 1);
     BOOST_REQUIRE_EQUAL(
-      deltas.begin()->delta.offset, update_with_current_2.delta.offset);
+      deltas.begin()->delta.offset(), update_with_current_2.delta.offset());
 }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1391,7 +1391,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cluster::backend_operation data{
           .source_shard = random_generators::get_int<unsigned>(1000),
           .p_as = random_partition_assignments().front(),
-          .type = cluster::topic_table_delta::op_type::del,
+          .type = cluster::partition_operation_type::remove,
         };
         roundtrip_test(data);
     }
@@ -1401,7 +1401,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
             backend_operations.push_back(cluster::backend_operation{
               .source_shard = random_generators::get_int<unsigned>(1000),
               .p_as = random_partition_assignments().front(),
-              .type = cluster::topic_table_delta::op_type::del,
+              .type = cluster::partition_operation_type::remove,
             });
         }
 
@@ -1421,7 +1421,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
                 backend_operations.push_back(cluster::backend_operation{
                   .source_shard = random_generators::get_int<unsigned>(1000),
                   .p_as = random_partition_assignments().front(),
-                  .type = cluster::topic_table_delta::op_type::del,
+                  .type = cluster::partition_operation_type::remove,
                 });
             }
             results.emplace_back(

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -30,11 +30,11 @@ inline void validate_delta(
   int removed_partitions) {
     size_t additions = std::count_if(
       d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
-          return d.type == cluster::topic_table::delta::op_type::add;
+          return d.type == cluster::partition_operation_type::add;
       });
     size_t deletions = std::count_if(
       d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
-          return d.type == cluster::topic_table::delta::op_type::del;
+          return d.type == cluster::partition_operation_type::remove;
       });
     BOOST_REQUIRE_EQUAL(additions, new_partitions);
     BOOST_REQUIRE_EQUAL(deletions, removed_partitions);

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -30,11 +30,11 @@ inline void validate_delta(
   int removed_partitions) {
     size_t additions = std::count_if(
       d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
-          return d.type == cluster::partition_operation_type::add;
+          return d.type() == cluster::partition_operation_type::add;
       });
     size_t deletions = std::count_if(
       d.begin(), d.end(), [](const cluster::topic_table::delta& d) {
-          return d.type == cluster::partition_operation_type::remove;
+          return d.type() == cluster::partition_operation_type::remove;
       });
     BOOST_REQUIRE_EQUAL(additions, new_partitions);
     BOOST_REQUIRE_EQUAL(deletions, removed_partitions);

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -267,7 +267,7 @@ topic_table::apply(move_partition_replicas_cmd cmd, model::offset o) {
 
 static replicas_revision_map update_replicas_revisions(
   replicas_revision_map revisions,
-  const std::vector<model::broker_shard>& new_assignment,
+  const replicas_t& new_assignment,
   model::revision_id update_revision) {
     // remove replicas not present in the new assignment
     for (auto it = revisions.begin(); it != revisions.end();) {
@@ -788,7 +788,7 @@ topic_table::fill_snapshot(controller_snapshot& controller_snap) const {
           updates;
 
         for (const auto& p_as : md_item.get_assignments()) {
-            std::vector<model::broker_shard> replicas;
+            replicas_t replicas;
             model::ntp ntp(ns_tp.ns, ns_tp.tp, p_as.id);
             if (auto upd_it = _updates_in_progress.find(ntp);
                 upd_it != _updates_in_progress.end()) {
@@ -1414,7 +1414,7 @@ topic_table::get_initial_revision(const model::ntp& ntp) const {
     return get_initial_revision(model::topic_namespace_view(ntp));
 }
 
-std::optional<std::vector<model::broker_shard>>
+std::optional<replicas_t>
 topic_table::get_previous_replica_set(const model::ntp& ntp) const {
     if (auto it = _updates_in_progress.find(ntp);
         it != _updates_in_progress.end()) {
@@ -1422,7 +1422,7 @@ topic_table::get_previous_replica_set(const model::ntp& ntp) const {
     }
     return std::nullopt;
 }
-std::optional<std::vector<model::broker_shard>>
+std::optional<replicas_t>
 topic_table::get_target_replica_set(const model::ntp& ntp) const {
     if (auto it = _updates_in_progress.find(ntp);
         it != _updates_in_progress.end()) {
@@ -1504,7 +1504,7 @@ std::vector<model::ntp> topic_table::all_updates_in_progress() const {
 
 void topic_table::change_partition_replicas(
   model::ntp ntp,
-  const std::vector<model::broker_shard>& new_assignment,
+  const replicas_t& new_assignment,
   topic_metadata_item& metadata,
   partition_assignment& current_assignment,
   model::offset o,

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -344,7 +344,7 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
       std::move(cmd.key),
       std::move(delta_assignment),
       o,
-      partition_operation_type::update_finished);
+      partition_operation_type::finish_update);
 
     notify_waiters();
 
@@ -427,7 +427,7 @@ topic_table::apply(cancel_moving_partition_replicas_cmd cmd, model::offset o) {
         current_assignment_it->id,
         in_progress_it->second.get_previous_replicas()},
       o,
-      cmd.value.force ? partition_operation_type::force_abort_update
+      cmd.value.force ? partition_operation_type::force_cancel_update
                       : partition_operation_type::cancel_update,
       std::move(replicas),
       // this replica revisions map reflects the state right before the update
@@ -505,7 +505,7 @@ topic_table::apply(revert_cancel_partition_move_cmd cmd, model::offset o) {
       ntp,
       std::move(delta_assignment),
       o,
-      partition_operation_type::update_finished);
+      partition_operation_type::finish_update);
 
     notify_waiters();
 
@@ -1077,7 +1077,7 @@ public:
                     break;
                 case reconfiguration_state::force_cancelled:
                     add_cancel_delta(
-                      partition_operation_type::force_abort_update);
+                      partition_operation_type::force_cancel_update);
                     break;
                 }
             }

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -116,8 +116,8 @@ public:
     class in_progress_update {
     public:
         explicit in_progress_update(
-          std::vector<model::broker_shard> previous_replicas,
-          std::vector<model::broker_shard> target_replicas,
+          replicas_t previous_replicas,
+          replicas_t target_replicas,
           reconfiguration_state state,
           model::revision_id update_revision,
           topic_table_probe& probe)
@@ -159,10 +159,10 @@ public:
             _last_cmd_revision = rev;
         }
 
-        const std::vector<model::broker_shard>& get_previous_replicas() const {
+        const replicas_t& get_previous_replicas() const {
             return _previous_replicas;
         }
-        const std::vector<model::broker_shard>& get_target_replicas() const {
+        const replicas_t& get_target_replicas() const {
             return _target_replicas;
         }
 
@@ -175,8 +175,8 @@ public:
         }
 
     private:
-        std::vector<model::broker_shard> _previous_replicas;
-        std::vector<model::broker_shard> _target_replicas;
+        replicas_t _previous_replicas;
+        replicas_t _target_replicas;
         reconfiguration_state _state;
         model::revision_id _update_revision;
         model::revision_id _last_cmd_revision;
@@ -440,15 +440,13 @@ public:
      * reconfigured. For reconfiguration from [1,2,3] to [2,3,4] this method
      * will return [1,2,3].
      */
-    std::optional<std::vector<model::broker_shard>>
-    get_previous_replica_set(const model::ntp&) const;
+    std::optional<replicas_t> get_previous_replica_set(const model::ntp&) const;
     /**
      * returns target replica set of partition if partition is currently being
      * reconfigured. For reconfiguration from [1,2,3] to [2,3,4] this method
      * will return [2,3,4].
      */
-    std::optional<std::vector<model::broker_shard>>
-    get_target_replica_set(const model::ntp&) const;
+    std::optional<replicas_t> get_target_replica_set(const model::ntp&) const;
 
     /**
      * Lists all NTPs that replicas are being move to a node
@@ -519,7 +517,7 @@ private:
 
     void change_partition_replicas(
       model::ntp ntp,
-      const std::vector<model::broker_shard>& new_assignment,
+      const replicas_t& new_assignment,
       topic_metadata_item& metadata,
       partition_assignment& current_assignment,
       model::offset o,

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -72,7 +72,8 @@ public:
       cancel_moving_partition_replicas_cmd,
       move_topic_replicas_cmd,
       revert_cancel_partition_move_cmd,
-      force_partition_reconfiguration_cmd>();
+      force_partition_reconfiguration_cmd,
+      update_partition_replicas_cmd>();
 
     bool is_batch_applicable(const model::record_batch& batch) const {
         return batch.header().type
@@ -103,6 +104,8 @@ private:
       apply(revert_cancel_partition_move_cmd, model::offset);
     ss::future<std::error_code>
       apply(force_partition_reconfiguration_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(update_partition_replicas_cmd, model::offset);
 
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -81,6 +81,7 @@ public:
     ss::future<std::error_code> move_partition_replicas(
       model::ntp,
       std::vector<model::broker_shard>,
+      reconfiguration_policy,
       model::timeout_clock::time_point,
       std::optional<model::term_id> = std::nullopt);
 
@@ -98,6 +99,7 @@ public:
     ss::future<std::error_code> move_partition_replicas(
       model::ntp,
       std::vector<model::node_id>,
+      reconfiguration_policy,
       model::timeout_clock::time_point,
       std::optional<model::term_id> = std::nullopt);
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -273,7 +273,7 @@ topic_table_delta::topic_table_delta(
   model::ntp ntp,
   cluster::partition_assignment new_assignment,
   model::offset o,
-  op_type tp,
+  partition_operation_type tp,
   std::optional<std::vector<model::broker_shard>> previous,
   std::optional<replicas_revision_map> replica_revisions)
   : ntp(std::move(ntp))
@@ -446,30 +446,29 @@ std::ostream& operator<<(std::ostream& o, const partition_assignment& p_as) {
     return o;
 }
 
-std::ostream&
-operator<<(std::ostream& o, const topic_table_delta::op_type& tp) {
+std::ostream& operator<<(std::ostream& o, const partition_operation_type& tp) {
     switch (tp) {
-    case topic_table_delta::op_type::add:
+    case partition_operation_type::add:
         return o << "addition";
-    case topic_table_delta::op_type::del:
+    case partition_operation_type::remove:
         return o << "deletion";
-    case topic_table_delta::op_type::reset:
+    case partition_operation_type::reset:
         return o << "reset";
-    case topic_table_delta::op_type::update:
+    case partition_operation_type::update:
         return o << "update";
-    case topic_table_delta::op_type::force_update:
+    case partition_operation_type::force_update:
         return o << "force_update";
-    case topic_table_delta::op_type::update_finished:
+    case partition_operation_type::update_finished:
         return o << "update_finished";
-    case topic_table_delta::op_type::update_properties:
+    case partition_operation_type::update_properties:
         return o << "update_properties";
-    case topic_table_delta::op_type::add_non_replicable:
+    case partition_operation_type::add_non_replicable:
         return o << "add_non_replicable_addition";
-    case topic_table_delta::op_type::del_non_replicable:
+    case partition_operation_type::del_non_replicable:
         return o << "del_non_replicable_deletion";
-    case topic_table_delta::op_type::cancel_update:
+    case partition_operation_type::cancel_update:
         return o << "cancel_update";
-    case topic_table_delta::op_type::force_abort_update:
+    case partition_operation_type::force_abort_update:
         return o << "force_abort_update";
     }
     __builtin_unreachable();

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -272,13 +272,13 @@ storage::ntp_config topic_configuration::make_ntp_config(
 topic_table_delta::topic_table_delta(
   model::ntp ntp,
   cluster::partition_assignment new_assignment,
-  model::offset o,
+  model::revision_id revision,
   partition_operation_type tp,
   std::optional<std::vector<model::broker_shard>> previous,
   std::optional<replicas_revision_map> replica_revisions)
   : _ntp(std::move(ntp))
   , _new_assignment(std::move(new_assignment))
-  , _offset(o)
+  , _revision(revision)
   , _type(tp)
   , _previous_replica_set(std::move(previous))
   , _replica_revisions(std::move(replica_revisions)) {}
@@ -479,11 +479,11 @@ std::ostream& operator<<(std::ostream& o, const partition_operation_type& tp) {
 std::ostream& operator<<(std::ostream& o, const topic_table_delta& d) {
     fmt::print(
       o,
-      "{{type: {}, ntp: {}, offset: {}, new_assignment: {}, "
+      "{{type: {}, ntp: {}, revision: {}, new_assignment: {}, "
       "previous_replica_set: {}, replica_revisions: {}}}",
       d._type,
       d._ntp,
-      d._offset,
+      d._revision,
       d._new_assignment,
       d._previous_replica_set,
       d._replica_revisions);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -271,31 +271,169 @@ storage::ntp_config topic_configuration::make_ntp_config(
 
 topic_table_delta::topic_table_delta(
   model::ntp ntp,
-  cluster::partition_assignment new_assignment,
   model::revision_id revision,
   partition_operation_type tp,
-  std::optional<replicas_t> previous,
-  std::optional<replicas_revision_map> replica_revisions)
+  data_t data)
   : _ntp(std::move(ntp))
-  , _new_assignment(std::move(new_assignment))
   , _revision(revision)
   , _type(tp)
-  , _previous_replica_set(std::move(previous))
-  , _replica_revisions(std::move(replica_revisions)) {}
+  , _data(std::move(data)) {}
+
+topic_table_delta topic_table_delta::create_add_partition_delta(
+  model::ntp ntp,
+  model::revision_id rev,
+  partition_assignment assignment,
+  replicas_revision_map replica_revisions) {
+    return topic_table_delta(
+      std::move(ntp),
+      rev,
+      partition_operation_type::add,
+      delta_add_partition_data{
+        .target_assignment = std::move(assignment),
+        .replica_revisions = std::move(replica_revisions),
+      });
+}
+
+topic_table_delta topic_table_delta::create_remove_partition_delta(
+  model::ntp ntp, model::revision_id rev) {
+    return topic_table_delta(
+      std::move(ntp),
+      rev,
+      partition_operation_type::remove,
+      delta_remove_partition_data{});
+}
+
+topic_table_delta topic_table_delta::create_update_delta(
+  model::ntp ntp,
+  model::revision_id rev,
+  is_forced forced,
+  partition_assignment target_assignment,
+  replicas_t previous_replicas,
+  replicas_revision_map replica_revisions) {
+    return topic_table_delta(
+      std::move(ntp),
+      rev,
+      forced ? partition_operation_type::force_update
+             : partition_operation_type::update,
+      delta_reconfiguration_data{
+        .target_assignment = std::move(target_assignment),
+        .previous_replica_set = std::move(previous_replicas),
+        .replica_revisions = std::move(replica_revisions),
+      });
+}
+
+topic_table_delta topic_table_delta::create_finish_update_delta(
+  model::ntp ntp,
+  model::revision_id rev,
+  partition_assignment target_assignment) {
+    return topic_table_delta(
+      std::move(ntp),
+      rev,
+      partition_operation_type::finish_update,
+      delta_finish_update_data{
+        .target_assignment = std::move(target_assignment)});
+}
+
+topic_table_delta topic_table_delta::create_cancel_update_delta(
+  model::ntp ntp,
+  model::revision_id rev,
+  is_forced forced,
+  partition_assignment target_assignment,
+  replicas_t previous_replicas,
+  replicas_revision_map replica_revisions) {
+    return topic_table_delta(
+      std::move(ntp),
+      rev,
+      forced ? partition_operation_type::force_cancel_update
+             : partition_operation_type::cancel_update,
+      delta_reconfiguration_data{
+        .target_assignment = std::move(target_assignment),
+        .previous_replica_set = std::move(previous_replicas),
+        .replica_revisions = std::move(replica_revisions),
+      });
+}
+
+topic_table_delta topic_table_delta::create_update_properties_delta(
+  model::ntp ntp, model::revision_id rev) {
+    return topic_table_delta(
+      std::move(ntp),
+      rev,
+      partition_operation_type::update_properties,
+      delta_update_properties_data{});
+}
+
+topic_table_delta topic_table_delta::create_reset_delta(
+  model::ntp ntp,
+  model::revision_id rev,
+  partition_assignment target_assignment,
+  replicas_t previous_replicas,
+  replicas_revision_map replica_revisions) {
+    return topic_table_delta(
+      std::move(ntp),
+      rev,
+      partition_operation_type::reset,
+      delta_reconfiguration_data{
+        .target_assignment = std::move(target_assignment),
+        .previous_replica_set = std::move(previous_replicas),
+        .replica_revisions = std::move(replica_revisions),
+      });
+}
+
+namespace {
+model::revision_id do_get_replica_revision(
+  model::node_id replica, const replicas_revision_map& replica_revisions) {
+    auto it = replica_revisions.find(replica);
+
+    vassert(
+      it != replica_revisions.end(),
+      "replica {} must exists in {}",
+      replica,
+      replica_revisions);
+    return it->second;
+}
+} // namespace
 
 model::revision_id
-topic_table_delta::get_replica_revision(model::node_id replica) const {
-    vassert(
-      _replica_revisions,
-      "ntp {}: replica_revisions map must be present",
-      _ntp);
-    auto rev_it = _replica_revisions->find(replica);
-    vassert(
-      rev_it != _replica_revisions->end(),
-      "ntp {}: node {} must be present in the replica_revisions map",
-      _ntp,
-      replica);
-    return rev_it->second;
+delta_reconfiguration_data::get_replica_revision(model::node_id replica) const {
+    return do_get_replica_revision(replica, replica_revisions);
+}
+
+model::revision_id
+delta_add_partition_data::get_replica_revision(model::node_id replica) const {
+    return do_get_replica_revision(replica, replica_revisions);
+}
+
+std::ostream&
+operator<<(std::ostream& o, const delta_reconfiguration_data& data) {
+    fmt::print(
+      o,
+      "{{target_assignment: {}, previous_replicas: {} replica_revisions: {}}}",
+      data.target_assignment,
+      data.previous_replica_set,
+      data.replica_revisions);
+    return o;
+}
+std::ostream&
+operator<<(std::ostream& o, const delta_add_partition_data& data) {
+    fmt::print(
+      o,
+      "{{target_assignment: {}, replica_revisions: {}}}",
+      data.target_assignment,
+      data.replica_revisions);
+    return o;
+}
+std::ostream&
+operator<<(std::ostream& o, const delta_finish_update_data& data) {
+    fmt::print(o, "{{target_assignment: {}}}", data.target_assignment);
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const delta_update_properties_data&) {
+    fmt::print(o, "delta_update_properties_data: {{}}");
+    return o;
+}
+std::ostream& operator<<(std::ostream& o, const delta_remove_partition_data&) {
+    fmt::print(o, "delta_remove_partition_data: {{}}");
+    return o;
 }
 
 ntp_reconciliation_state::ntp_reconciliation_state(
@@ -479,14 +617,11 @@ std::ostream& operator<<(std::ostream& o, const partition_operation_type& tp) {
 std::ostream& operator<<(std::ostream& o, const topic_table_delta& d) {
     fmt::print(
       o,
-      "{{type: {}, ntp: {}, revision: {}, new_assignment: {}, "
-      "previous_replica_set: {}, replica_revisions: {}}}",
-      d._type,
+      "{{ntp: {}, type: {}, revision: {}, data: {}}}",
       d._ntp,
+      d._type,
       d._revision,
-      d._new_assignment,
-      d._previous_replica_set,
-      d._replica_revisions);
+      d._data);
 
     return o;
 }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -458,7 +458,7 @@ std::ostream& operator<<(std::ostream& o, const partition_operation_type& tp) {
         return o << "update";
     case partition_operation_type::force_update:
         return o << "force_update";
-    case partition_operation_type::update_finished:
+    case partition_operation_type::finish_update:
         return o << "update_finished";
     case partition_operation_type::update_properties:
         return o << "update_properties";
@@ -468,7 +468,7 @@ std::ostream& operator<<(std::ostream& o, const partition_operation_type& tp) {
         return o << "del_non_replicable_deletion";
     case partition_operation_type::cancel_update:
         return o << "cancel_update";
-    case partition_operation_type::force_abort_update:
+    case partition_operation_type::force_cancel_update:
         return o << "force_abort_update";
     }
     __builtin_unreachable();

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -276,22 +276,24 @@ topic_table_delta::topic_table_delta(
   partition_operation_type tp,
   std::optional<std::vector<model::broker_shard>> previous,
   std::optional<replicas_revision_map> replica_revisions)
-  : ntp(std::move(ntp))
-  , new_assignment(std::move(new_assignment))
-  , offset(o)
-  , type(tp)
-  , previous_replica_set(std::move(previous))
-  , replica_revisions(std::move(replica_revisions)) {}
+  : _ntp(std::move(ntp))
+  , _new_assignment(std::move(new_assignment))
+  , _offset(o)
+  , _type(tp)
+  , _previous_replica_set(std::move(previous))
+  , _replica_revisions(std::move(replica_revisions)) {}
 
 model::revision_id
 topic_table_delta::get_replica_revision(model::node_id replica) const {
     vassert(
-      replica_revisions, "ntp {}: replica_revisions map must be present", ntp);
-    auto rev_it = replica_revisions->find(replica);
+      _replica_revisions,
+      "ntp {}: replica_revisions map must be present",
+      _ntp);
+    auto rev_it = _replica_revisions->find(replica);
     vassert(
-      rev_it != replica_revisions->end(),
+      rev_it != _replica_revisions->end(),
       "ntp {}: node {} must be present in the replica_revisions map",
-      ntp,
+      _ntp,
       replica);
     return rev_it->second;
 }
@@ -479,12 +481,12 @@ std::ostream& operator<<(std::ostream& o, const topic_table_delta& d) {
       o,
       "{{type: {}, ntp: {}, offset: {}, new_assignment: {}, "
       "previous_replica_set: {}, replica_revisions: {}}}",
-      d.type,
-      d.ntp,
-      d.offset,
-      d.new_assignment,
-      d.previous_replica_set,
-      d.replica_revisions);
+      d._type,
+      d._ntp,
+      d._offset,
+      d._new_assignment,
+      d._previous_replica_set,
+      d._replica_revisions);
 
     return o;
 }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -309,7 +309,8 @@ topic_table_delta topic_table_delta::create_update_delta(
   is_forced forced,
   partition_assignment target_assignment,
   replicas_t previous_replicas,
-  replicas_revision_map replica_revisions) {
+  replicas_revision_map replica_revisions,
+  reconfiguration_policy policy) {
     return topic_table_delta(
       std::move(ntp),
       rev,
@@ -319,6 +320,7 @@ topic_table_delta topic_table_delta::create_update_delta(
         .target_assignment = std::move(target_assignment),
         .previous_replica_set = std::move(previous_replicas),
         .replica_revisions = std::move(replica_revisions),
+        .policy = policy,
       });
 }
 
@@ -350,6 +352,10 @@ topic_table_delta topic_table_delta::create_cancel_update_delta(
         .target_assignment = std::move(target_assignment),
         .previous_replica_set = std::move(previous_replicas),
         .replica_revisions = std::move(replica_revisions),
+        /**
+         * Default policy for reconfigurations that are cancelled
+         */
+        .policy = reconfiguration_policy::full_local_retention,
       });
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -274,7 +274,7 @@ topic_table_delta::topic_table_delta(
   cluster::partition_assignment new_assignment,
   model::revision_id revision,
   partition_operation_type tp,
-  std::optional<std::vector<model::broker_shard>> previous,
+  std::optional<replicas_t> previous,
   std::optional<replicas_revision_map> replica_revisions)
   : _ntp(std::move(ntp))
   , _new_assignment(std::move(new_assignment))
@@ -2004,8 +2004,7 @@ cluster::partition_assignment
 adl<cluster::partition_assignment>::from(iobuf_parser& parser) {
     auto group = reflection::adl<raft::group_id>{}.from(parser);
     auto id = reflection::adl<model::partition_id>{}.from(parser);
-    auto replicas = reflection::adl<std::vector<model::broker_shard>>{}.from(
-      parser);
+    auto replicas = reflection::adl<cluster::replicas_t>{}.from(parser);
 
     return {group, id, std::move(replicas)};
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -4138,6 +4138,8 @@ struct partition_reconfiguration_state {
     std::vector<replica_bytes> already_transferred_bytes;
     // current size of partition
     size_t current_partition_size{0};
+    // policy used to execute an update
+    reconfiguration_policy policy;
 };
 
 struct node_decommission_progress {

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2330,7 +2330,7 @@ public:
     topic_table_delta(
       model::ntp,
       cluster::partition_assignment,
-      model::offset,
+      model::revision_id,
       partition_operation_type,
       std::optional<std::vector<model::broker_shard>> previous = std::nullopt,
       std::optional<replicas_revision_map> = std::nullopt);
@@ -2351,7 +2351,7 @@ public:
     const cluster::partition_assignment& new_assignment() const {
         return _new_assignment;
     }
-    model::offset offset() const { return _offset; }
+    model::revision_id revision() const { return _revision; }
 
     partition_operation_type type() const { return _type; }
 
@@ -2373,7 +2373,7 @@ public:
 private:
     model::ntp _ntp;
     cluster::partition_assignment _new_assignment;
-    model::offset _offset;
+    model::revision_id _revision;
     partition_operation_type _type;
     std::optional<std::vector<model::broker_shard>> _previous_replica_set;
     std::optional<replicas_revision_map> _replica_revisions;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2304,6 +2304,36 @@ private:
     ss::sstring _msg;
 };
 
+enum class reconfiguration_policy {
+    /**
+     * Moving partition with full local retention policy will deliver all
+     * partition data available locally on the leader to newly joining learners.
+     * If tiered storage is disabled for a partition the move will always be
+     * executed with full local retention.
+     */
+    full_local_retention = 0,
+    /**
+     * With target initial retention partition move policy controller backend
+     * will calculate the learner start offset based on the configured learner
+     * initial retention configuration (either a global cluster property or
+     * topic override ) and partition max collectible offset. Max collectible
+     * offset is advanced after all the previous offsets were successfully
+     * uploaded to the cloud.
+     */
+    target_initial_retention = 1,
+    /*
+     * The min local retention policy, before requesting partition
+     * reconfiguration in the Raft layer will request log to be uploaded to the
+     * Object Store up to the active segment boundary. After all data are update
+     * the controller backend will request partition move setting learner
+     * initial offset to the active segment start offset, allowing all the data
+     * from not active segments to be skiped while recovering learners.
+     *
+     * (NOTE: not yet implemented)
+     */
+    min_local_retention = 2
+};
+
 /**
  * Replicas revision map is used to track revision of brokers in a replica
  * set. When a node is added into replica set its gets the revision assigned
@@ -4296,34 +4326,6 @@ struct remove_plugin_response
       = default;
 
     auto serde_fields() { return std::tie(uuid, ec); }
-};
-
-enum class reconfiguration_policy {
-    /**
-     * Moving partition with full local retention policy will deliver all
-     * partition data available locally on the leader to newly joining learners.
-     * If tiered storage is disabled for a partition the move will alawys be
-     * executed with full local retention.
-     */
-    full_local_retention = 0,
-    /**
-     * With target initial retention parittion move policy controller backend
-     * will calulate the learner start offset based on the configured learner
-     * initial retention configuration (either a global cluster property or
-     * topic override ) and partition max collectible offset. Max collectible
-     * offset is advanced after all the previous offsets were succesfully
-     * uploaded to the cloud.
-     */
-    target_initial_retention = 1,
-    /*
-     * The min local retention policy, before requesting partition
-     * reconfiguration in the Raft layer will request log to be uploaded to the
-     * Object Store up to the active segment boundry. After all data are update
-     * the controller backend will request partition move setting learner
-     * initial offset to the active segment start offset, allowing all the data
-     * from not active segments to be skiped while recoverying learners.
-     */
-    min_local_retention = 2
 };
 
 std::ostream& operator<<(std::ostream&, reconfiguration_policy);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2375,6 +2375,7 @@ struct delta_reconfiguration_data {
     partition_assignment target_assignment;
     replicas_t previous_replica_set;
     replicas_revision_map replica_revisions;
+    reconfiguration_policy policy;
 
     model::revision_id get_replica_revision(model::node_id) const;
     friend std::ostream&
@@ -2469,7 +2470,8 @@ public:
       is_forced,
       partition_assignment,
       replicas_t,
-      replicas_revision_map);
+      replicas_revision_map,
+      reconfiguration_policy);
 
     static topic_table_delta create_finish_update_delta(
       model::ntp, model::revision_id, partition_assignment);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2312,15 +2312,15 @@ using replicas_revision_map
 
 enum class partition_operation_type {
     add,
-    del,
+    remove,
     update,
     force_update,
-    update_finished,
+    finish_update,
     update_properties,
     add_non_replicable,
     del_non_replicable,
     cancel_update,
-    force_abort_update,
+    force_cancel_update,
     reset,
 };
 std::ostream& operator<<(std::ostream&, const partition_operation_type&);
@@ -2349,7 +2349,7 @@ struct topic_table_delta {
         return type == partition_operation_type::update
                || type == partition_operation_type::force_update
                || type == partition_operation_type::cancel_update
-               || type == partition_operation_type::force_abort_update;
+               || type == partition_operation_type::force_cancel_update;
     }
 
     /// Preconditions: delta is of type that has replica_revisions and the node

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -4335,6 +4335,8 @@ struct update_partition_replicas_cmd_data
       update_partition_replicas_cmd_data,
       serde::version<0>,
       serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
     model::ntp ntp;
     replicas_t replicas;
     reconfiguration_policy policy;
@@ -4344,7 +4346,7 @@ struct update_partition_replicas_cmd_data
       const update_partition_replicas_cmd_data&)
       = default;
 
-    auto serde_fields() { std::tie(ntp, replicas, policy); }
+    auto serde_fields() { return std::tie(ntp, replicas, policy); }
 
     friend std::ostream&
     operator<<(std::ostream&, const update_partition_replicas_cmd_data&);

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -517,15 +517,15 @@ struct instance_generator<cluster::backend_operation> {
           .source_shard = random_generators::get_int<unsigned>(),
           .p_as = instance_generator<cluster::partition_assignment>::random(),
           .type = random_generators::random_choice(
-            {cluster::topic_table_delta::op_type::add,
-             cluster::topic_table_delta::op_type::add_non_replicable,
-             cluster::topic_table_delta::op_type::del_non_replicable,
-             cluster::topic_table_delta::op_type::cancel_update,
-             cluster::topic_table_delta::op_type::force_abort_update,
-             cluster::topic_table_delta::op_type::update,
-             cluster::topic_table_delta::op_type::update_finished,
-             cluster::topic_table_delta::op_type::update_properties,
-             cluster::topic_table_delta::op_type::del}),
+            {cluster::partition_operation_type::add,
+             cluster::partition_operation_type::add_non_replicable,
+             cluster::partition_operation_type::del_non_replicable,
+             cluster::partition_operation_type::cancel_update,
+             cluster::partition_operation_type::force_cancel_update,
+             cluster::partition_operation_type::update,
+             cluster::partition_operation_type::finish_update,
+             cluster::partition_operation_type::update_properties,
+             cluster::partition_operation_type::remove}),
         };
     }
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2023,18 +2023,20 @@ configuration::configuration()
       *this,
       "initial_retention_local_target_bytes_default",
       "Initial local retention size target for partitions of topics with cloud "
-      "storage "
-      "write enabled",
+      "storage write enabled. If no initial local target retention is "
+      "configured all locally retained data will be delivered to learner when "
+      "joining partition replica set",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt)
   , initial_retention_local_target_ms_default(
       *this,
       "initial_retention_local_target_ms_default",
       "Initial local retention time target for partitions of topics with cloud "
-      "storage "
-      "write enabled",
+      "storage write enabled. If no initial local target retention is "
+      "configured all locally retained data will be delivered to learner when "
+      "joining partition replica set",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      24h)
+      std::nullopt)
   , cloud_storage_cache_size(
       *this,
       "cloud_storage_cache_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -378,7 +378,7 @@ struct configuration final : public config_store {
     bounded_property<uint16_t> space_management_max_segment_concurrency;
     property<std::optional<size_t>>
       initial_retention_local_target_bytes_default;
-    property<std::chrono::milliseconds>
+    property<std::optional<std::chrono::milliseconds>>
       initial_retention_local_target_ms_default;
 
     // Archival cache

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -89,6 +89,8 @@ std::string_view to_string_view(feature f) {
         return "raft_config_serde";
     case feature::idempotency_v2:
         return "idempotency_v2";
+    case feature::fast_partition_reconfiguration:
+        return "fast_partition_reconfiguration";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -69,6 +69,7 @@ enum class feature : std::uint64_t {
     wasm_transforms = 1ULL << 35U,
     raft_config_serde = 1ULL << 36U,
     idempotency_v2 = 1ULL << 37U,
+    fast_partition_reconfiguration = 1ULL << 38U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -334,6 +335,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{11},
     "idempotency_v2",
     feature::idempotency_v2,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{11},
+    "fast_partition_reconfiguration",
+    feature::fast_partition_reconfiguration,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always}};
 

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -486,7 +486,7 @@ void group_manager::handle_topic_delta(
     std::vector<model::topic_partition> tps;
     for (const auto& delta : deltas) {
         if (
-          delta.type == cluster::topic_table_delta::op_type::del
+          delta.type == cluster::partition_operation_type::remove
           && delta.ntp.ns == model::kafka_namespace) {
             tps.emplace_back(delta.ntp.tp);
         }

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -486,9 +486,9 @@ void group_manager::handle_topic_delta(
     std::vector<model::topic_partition> tps;
     for (const auto& delta : deltas) {
         if (
-          delta.type == cluster::partition_operation_type::remove
-          && delta.ntp.ns == model::kafka_namespace) {
-            tps.emplace_back(delta.ntp.tp);
+          delta.type() == cluster::partition_operation_type::remove
+          && delta.ntp().ns == model::kafka_namespace) {
+            tps.emplace_back(delta.ntp().tp);
         }
     }
 

--- a/src/v/kafka/server/handlers/alter_partition_reassignments.cc
+++ b/src/v/kafka/server/handlers/alter_partition_reassignments.cc
@@ -242,6 +242,7 @@ ss::future<std::error_code> handle_partition(
         return octx.rctx.topics_frontend().move_partition_replicas(
           ntp,
           std::move(*partition.replicas),
+          cluster::reconfiguration_policy::full_local_retention,
           model::timeout_clock::now() + octx.request.data.timeout_ms);
 
     } else {

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -981,9 +981,8 @@ ss::future<response_ptr> describe_configs_handler::handle(
               resource,
               result,
               topic_property_initial_retention_local_target_ms,
-              std::make_optional(
-                ctx.metadata_cache()
-                  .get_default_initial_retention_local_target_ms()),
+              ctx.metadata_cache()
+                .get_default_initial_retention_local_target_ms(),
               topic_property_initial_retention_local_target_ms,
               topic_config->properties.initial_retention_local_target_ms,
               request.data.include_synonyms,

--- a/src/v/redpanda/admin/api-doc/broker.json
+++ b/src/v/redpanda/admin/api-doc/broker.json
@@ -400,6 +400,10 @@
                 "partition_size": {
                     "type": "long",
                     "description": "current size of partition"
+                },
+                "reconfiguration_policy": {
+                    "type": "string",
+                    "description": "Policy used to reconfigure partition replica set"
                 }
             }
         },

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -570,6 +570,10 @@
                         "type": "partition_reconciliation_status"
                     },
                     "description": "list of reconciliation statuses per node"
+                },
+                "reconfiguration_policy": {
+                    "type": "string",
+                    "description": "Reconfiguration policy used to perform this update"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3177,6 +3177,7 @@ admin_server::set_partition_replicas_handler(
                  .move_partition_replicas(
                    ntp,
                    replicas,
+                   cluster::reconfiguration_policy::full_local_retention,
                    model::timeout_clock::now()
                      + 10s); // NOLINT(cppcoreguidelines-avoid-magic-numbers)
 

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -2576,6 +2576,7 @@ admin_server::get_decommission_progress_handler(
         if (already_moved == 0 && left_to_move == 0) {
             status.bytes_left_to_move = p.current_partition_size;
         }
+        status.reconfiguration_policy = ssx::sformat("{}", p.policy);
         ret.partitions.push(status);
     }
 
@@ -2980,7 +2981,7 @@ admin_server::get_reconfigurations_handler(std::unique_ptr<ss::http::request>) {
           if (already_moved == 0 && left_to_move == 0) {
               r.bytes_left_to_move = s.current_partition_size;
           }
-
+          r.reconfiguration_policy = ssx::sformat("{}", s.policy);
           auto it = reconciliations->ntp_backend_operations.find(s.ntp);
           if (it != reconciliations->ntp_backend_operations.end()) {
               for (auto& node_ops : it->second) {

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -208,15 +208,19 @@ class DescribeTopicsTest(RedpandaTest):
                 config_type="LONG",
                 value="-1",
                 doc_string=
-                "Initial local retention size target for partitions of topics with cloud storage write enabled"
-            ),
+                "Initial local retention size target for partitions of topics with cloud "
+                "storage write enabled. If no initial local target retention is "
+                "configured all locally retained data will be delivered to learner when "
+                "joining partition replica set"),
             "initial.retention.local.target.ms":
             ConfigProperty(
                 config_type="LONG",
-                value="86400000",
+                value="-1",
                 doc_string=
-                "Initial local retention time target for partitions of topics with cloud storage write enabled"
-            ),
+                "Initial local retention time target for partitions of topics with cloud "
+                "storage write enabled. If no initial local target retention is "
+                "configured all locally retained data will be delivered to learner when "
+                "joining partition replica set"),
         }
 
         tp_spec = TopicSpec()


### PR DESCRIPTION
Added support for past partition movement leveraging data stored in object store to speed up and make partition replica set reconfigurations more cost effective. 

Partition reconfigurations are expressed with a new `topic_table` command which contains information about the reconfiguration policy. Reconfiguration requester can control policy which is going to be use to reconfigure partition. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features

- Implemented fast partition reconfiguration to speed up cluster node opeations