### PR TITLE
cloud_roles: replace boost::string_view with std::string_view

### DIFF
--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -376,13 +376,16 @@ ss::sstring signature_v4::sha256_hexdigest(std::string_view payload) {
 }
 
 ss::sstring redact_headers_from_string(const std::string_view original) {
-    std::set<boost::core::string_view> redacted{};
+    std::set<std::string_view> redacted{};
     const auto redacted_fields = http::redacted_fields();
     for (const auto& rf : redacted_fields) {
         redacted.insert(ss::visit(
           rf,
-          [](const boost::beast::http::field& f) { return to_string(f); },
-          [](const std::string& s) { return boost::core::string_view{s}; }));
+          [](const boost::beast::http::field& f) {
+              const auto view = to_string(f);
+              return std::string_view{view.data(), view.size()};
+          },
+          [](const std::string& s) { return std::string_view{s}; }));
     }
 
     const auto lines = absl::StrSplit(original, "\n");


### PR DESCRIPTION
The boost::core::string_view returned by boost::beast helpers seems to break OSS build.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
