### PR TITLE
transform: add processor metrics

### DIFF
--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -43,8 +43,7 @@ operator<<(std::ostream& os, const transform_offsets_value& value) {
 
 std::ostream&
 operator<<(std::ostream& os, const transform_report::processor& p) {
-    fmt::print(
-      os, "{{id: {}, status: {}, node: {}}}", p.id, uint8_t(p.status), p.node);
+    fmt::print(os, "{{id: {}, status: {}, node: {}}}", p.id, p.status, p.node);
     return os;
 }
 
@@ -77,4 +76,22 @@ void cluster_transform_report::merge(const cluster_transform_report& other) {
     }
 }
 
+std::ostream&
+operator<<(std::ostream& os, transform_report::processor::state s) {
+    return os << processor_state_to_string(s);
+}
+std::string_view
+processor_state_to_string(transform_report::processor::state state) {
+    switch (state) {
+    case transform_report::processor::state::inactive:
+        return "inactive";
+    case transform_report::processor::state::running:
+        return "running";
+    case transform_report::processor::state::errored:
+        return "errored";
+    case transform_report::processor::state::unknown:
+        break;
+    }
+    return "unknown";
+}
 } // namespace model

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -163,6 +163,12 @@ struct transform_report
     void add(processor);
 };
 
+std::string_view
+processor_state_to_string(transform_report::processor::state state);
+
+std::ostream&
+operator<<(std::ostream& os, transform_report::processor::state s);
+
 /**
  * A cluster wide view of all the currently running transforms.
  */

--- a/src/v/transform/probe.cc
+++ b/src/v/transform/probe.cc
@@ -42,6 +42,14 @@ void probe::setup_metrics(ss::sstring transform_name, probe_gauges gauges) {
                         "from a transform"),
         labels)
         .aggregate({sm::shard_label}));
+    metric_defs.emplace_back(
+      sm::make_counter(
+        "processor_failures",
+        [this] { return _failures; },
+        sm::description(
+          "A counter for each time that a processor encounters a failure"),
+        labels)
+        .aggregate({sm::shard_label}));
 
     auto state_label = sm::label("state");
     using state = model::transform_report::processor::state;
@@ -63,4 +71,5 @@ void probe::setup_metrics(ss::sstring transform_name, probe_gauges gauges) {
 }
 void probe::increment_write_bytes(uint64_t bytes) { _write_bytes += bytes; }
 void probe::increment_read_bytes(uint64_t bytes) { _read_bytes += bytes; }
+void probe::increment_failure() { ++_failures; }
 } // namespace transform

--- a/src/v/transform/probe.cc
+++ b/src/v/transform/probe.cc
@@ -17,7 +17,7 @@
 
 namespace transform {
 
-void probe::setup_metrics(ss::sstring transform_name) {
+void probe::setup_metrics(ss::sstring transform_name, probe_gauges gauges) {
     wasm::transform_probe::setup_metrics(transform_name);
     namespace sm = ss::metrics;
 
@@ -25,24 +25,41 @@ void probe::setup_metrics(ss::sstring transform_name) {
     const std::vector<sm::label_instance> labels = {
       name_label(std::move(transform_name)),
     };
+    std::vector<sm::metric_definition> metric_defs;
+    metric_defs.emplace_back(
+      sm::make_counter(
+        "processor_read_bytes",
+        [this] { return _read_bytes; },
+        sm::description(
+          "A counter for all the bytes that has been input to a transform"),
+        labels)
+        .aggregate({sm::shard_label}));
+    metric_defs.emplace_back(
+      sm::make_counter(
+        "processor_write_bytes",
+        [this] { return _write_bytes; },
+        sm::description("A counter for all the bytes that has been output "
+                        "from a transform"),
+        labels)
+        .aggregate({sm::shard_label}));
+
+    auto state_label = sm::label("state");
+    using state = model::transform_report::processor::state;
+    for (const auto& s : {state::running, state::inactive, state::errored}) {
+        std::vector<sm::label_instance> state_labels = labels;
+        state_labels.push_back(
+          state_label(model::processor_state_to_string(s)));
+        metric_defs.emplace_back(
+          sm::make_gauge(
+            "processor_state",
+            [s, cb = gauges.num_processors] { return cb(s); },
+            sm::description(
+              "The count of transform processors in a certain state"),
+            state_labels)
+            .aggregate({sm::shard_label}));
+    }
     _public_metrics.add_group(
-      prometheus_sanitize::metrics_name("transform"),
-      {
-        sm::make_counter(
-          "processor_read_bytes",
-          [this] { return _read_bytes; },
-          sm::description(
-            "A counter for all the bytes that has been input to a transform"),
-          labels)
-          .aggregate({ss::metrics::shard_label}),
-        sm::make_counter(
-          "processor_write_bytes",
-          [this] { return _write_bytes; },
-          sm::description("A counter for all the bytes that has been output "
-                          "from a transform"),
-          labels)
-          .aggregate({ss::metrics::shard_label}),
-      });
+      prometheus_sanitize::metrics_name("transform"), metric_defs);
 }
 void probe::increment_write_bytes(uint64_t bytes) { _write_bytes += bytes; }
 void probe::increment_read_bytes(uint64_t bytes) { _read_bytes += bytes; }

--- a/src/v/transform/probe.h
+++ b/src/v/transform/probe.h
@@ -27,10 +27,12 @@ public:
 
     void increment_read_bytes(uint64_t bytes);
     void increment_write_bytes(uint64_t bytes);
+    void increment_failure();
 
 private:
     uint64_t _read_bytes = 0;
     uint64_t _write_bytes = 0;
+    uint64_t _failures = 0;
 };
 
 } // namespace transform

--- a/src/v/transform/probe.h
+++ b/src/v/transform/probe.h
@@ -10,16 +10,20 @@
  */
 #pragma once
 
+#include "model/transform.h"
 #include "wasm/probe.h"
 
-#include <functional>
-
 namespace transform {
+
+struct probe_gauges {
+    std::function<int64_t(model::transform_report::processor::state)>
+      num_processors;
+};
 
 /** A per transform probe. */
 class probe : public wasm::transform_probe {
 public:
-    void setup_metrics(ss::sstring transform_name);
+    void setup_metrics(ss::sstring transform_name, probe_gauges);
 
     void increment_read_bytes(uint64_t bytes);
     void increment_write_bytes(uint64_t bytes);

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -32,10 +32,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/log.hh>
 
-#include <boost/multi_index/composite_key.hpp>
-#include <boost/multi_index/hashed_index.hpp>
-#include <boost/multi_index/mem_fun.hpp>
-#include <boost/multi_index_container.hpp>
+#include <absl/algorithm/container.h>
 
 #include <algorithm>
 #include <chrono>
@@ -157,7 +154,16 @@ public:
             return it->second.probe();
         }
         auto probe = ss::make_lw_shared<transform::probe>();
-        probe->setup_metrics(meta.name());
+        probe->setup_metrics(
+          meta.name(),
+          {
+            .num_processors =
+              [this](auto state) {
+                  return absl::c_count_if(_table, [state](const auto& entry) {
+                      return entry.second.compute_state() == state;
+                  });
+              },
+          });
         return probe;
     }
 

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -132,7 +132,7 @@ public:
         std::unique_ptr<transform::processor> _processor;
         ss::lw_shared_ptr<transform::probe> _probe;
         processor_backoff<ClockType> _backoff;
-        bool _is_errored = true;
+        bool _is_errored = false;
     };
 
     auto range() const { return std::make_pair(_table.begin(), _table.end()); }

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -106,7 +106,9 @@ public:
           , _probe(std::move(probe)) {}
 
         transform::processor* processor() const { return _processor.get(); }
-        ss::lw_shared_ptr<transform::probe> probe() const { return _probe; }
+        const ss::lw_shared_ptr<transform::probe>& probe() const {
+            return _probe;
+        }
 
         ClockType::duration next_backoff_duration() {
             _is_errored = true;
@@ -345,6 +347,7 @@ ss::future<> manager<ClockType>::handle_transform_error(
     if (!entry) {
         co_return;
     }
+    entry->probe()->increment_failure();
     co_await entry->processor()->stop();
     auto delay = entry->next_backoff_duration();
     vlog(


### PR DESCRIPTION
Add metrics for transform::processor state and when processors run into failures.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
