### PR TITLE
storage: implement sliding window compaction

### DIFF
--- a/src/v/kafka/server/tests/produce_consume_utils.cc
+++ b/src/v/kafka/server/tests/produce_consume_utils.cc
@@ -22,6 +22,11 @@ namespace tests {
 
 static ss::logger test_log("produce_consume_logger");
 
+std::ostream& operator<<(std::ostream& o, const kv_t& kv) {
+    o << ssx::sformat("{{k=\"{}\", v=\"{}\"}}", kv.key, kv.val);
+    return o;
+}
+
 // Produces the given records per partition to the given topic.
 // NOTE: inputs must remain valid for the duration of the call.
 ss::future<kafka_produce_transport::pid_to_offset_map_t>

--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -21,6 +21,8 @@ struct kv_t {
     ss::sstring key;
     ss::sstring val;
 
+    friend std::ostream& operator<<(std::ostream& o, const kv_t& kv);
+
     kv_t(ss::sstring k, ss::sstring v)
       : key(std::move(k))
       , val(std::move(v)) {}

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -16,10 +16,12 @@
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "reflection/adl.h"
+#include "storage/chunk_cache.h"
 #include "storage/compacted_offset_list.h"
 #include "storage/compaction_reducers.h"
 #include "storage/disk_log_appender.h"
 #include "storage/fwd.h"
+#include "storage/key_offset_map.h"
 #include "storage/kvstore.h"
 #include "storage/log_manager.h"
 #include "storage/logger.h"
@@ -27,6 +29,7 @@
 #include "storage/offset_to_filepos.h"
 #include "storage/readers_cache.h"
 #include "storage/segment.h"
+#include "storage/segment_deduplication_utils.h"
 #include "storage/segment_set.h"
 #include "storage/segment_utils.h"
 #include "storage/types.h"
@@ -507,6 +510,140 @@ segment_set disk_log_impl::find_sliding_range(
         }
     }
     return segs;
+}
+
+ss::future<> disk_log_impl::sliding_window_compact(
+  const compaction_config& cfg, std::optional<model::offset> new_start_offset) {
+    vlog(gclog.info, "[{}] running sliding window compaction", config().ntp());
+    auto segs = find_sliding_range(cfg, new_start_offset);
+    if (segs.empty()) {
+        vlog(gclog.info, "[{}] no more segments to compact", config().ntp());
+        co_return;
+    }
+    for (auto& seg : segs) {
+        auto result = co_await storage::internal::self_compact_segment(
+          seg,
+          _stm_manager,
+          cfg,
+          *_probe,
+          *_readers_cache,
+          _manager.resources(),
+          storage::internal::should_apply_delta_time_offset(_feature_table));
+
+        vlog(
+          gclog.debug,
+          "[{}] segment {} self compaction result: {}",
+          config().ntp(),
+          seg->reader().filename(),
+          result);
+    }
+
+    simple_key_offset_map map(cfg.key_offset_map_max_keys);
+    model::offset idx_start_offset;
+    try {
+        idx_start_offset = co_await build_offset_map(cfg, segs, map);
+    } catch (...) {
+        vlog(
+          gclog.warn,
+          "[{}] failed to build offset map. Stopping compaction: {}",
+          config().ntp(),
+          std::current_exception());
+        co_return;
+    }
+
+    auto segment_modify_lock = co_await _segment_rewrite_lock.get_units();
+    for (auto& seg : segs) {
+        if (seg->offsets().base_offset > map.max_offset()) {
+            break;
+        }
+        // TODO: implement a segment replacement strategy such that each term
+        // tries to write only one segment (or more if the term had a large
+        // amount of data), rather than replacing N segments with N segments.
+        auto tmpname = seg->reader().path().to_staging();
+        auto appender = co_await internal::make_segment_appender(
+          tmpname,
+          segment_appender::write_behind_memory
+            / internal::chunks().chunk_size(),
+          std::nullopt,
+          cfg.iopc,
+          resources(),
+          cfg.sanitizer_config);
+
+        auto cmp_idx_tmpname = seg->path().to_compaction_staging();
+        auto cmp_idx_name = seg->path().to_compacted_index();
+        auto compacted_idx_writer = make_file_backed_compacted_index(
+          cmp_idx_tmpname, cfg.iopc, true, resources(), cfg.sanitizer_config);
+
+        vlog(
+          gclog.trace,
+          "Deduplicating data from segment {} to {}",
+          seg->path(),
+          tmpname);
+        auto initial_generation_id = seg->get_generation_id();
+        std::exception_ptr eptr;
+        index_state new_idx;
+        try {
+            new_idx = co_await deduplicate_segment(
+              cfg,
+              map,
+              seg,
+              *appender,
+              compacted_idx_writer,
+              *_probe,
+              storage::internal::should_apply_delta_time_offset(
+                _feature_table));
+
+        } catch (...) {
+            eptr = std::current_exception();
+        }
+        // We must close the segment apender
+        co_await compacted_idx_writer.close();
+        co_await appender->close();
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        }
+
+        vlog(
+          gclog.trace,
+          "Proceeding to replace segment {} with {}",
+          tmpname,
+          seg->path(),
+          tmpname);
+
+        auto rdr_holder = co_await _readers_cache->evict_segment_readers(seg);
+        auto write_lock = seg->write_lock();
+        if (initial_generation_id != seg->get_generation_id()) {
+            throw std::runtime_error(fmt::format(
+              "Aborting compaction of segment: {}, segment was mutated "
+              "while compacting",
+              seg->path()));
+        }
+        if (seg->is_closed()) {
+            throw segment_closed_exception();
+        }
+
+        // Clear our indexes before swapping the data files (note, the new
+        // compaction index was opened with the truncate option above).
+        co_await seg->index().drop_all_data();
+
+        // Rename the data file.
+        co_await internal::do_swap_data_file_handles(
+          tmpname, seg, cfg, *_probe);
+
+        // Persist the state of our indexes in their new names.
+        seg->index().swap_index_state(std::move(new_idx));
+        seg->force_set_commit_offset_from_index();
+        seg->release_batch_cache_index();
+        co_await seg->index().flush();
+        co_await ss::rename_file(
+          cmp_idx_tmpname.string(), cmp_idx_name.string());
+
+        seg->mark_as_finished_windowed_compaction();
+        _probe->segment_compacted();
+        seg->advance_generation();
+    }
+    _last_compaction_window_start_offset = idx_start_offset;
+    co_return;
 }
 
 std::optional<std::pair<segment_set::iterator, segment_set::iterator>>

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -365,7 +365,7 @@ disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
     co_return _start_offset;
 }
 
-ss::future<> disk_log_impl::do_compact(
+ss::future<> disk_log_impl::adjacent_merge_compact(
   compaction_config cfg, std::optional<model::offset> new_start_offset) {
     vlog(
       gclog.trace,
@@ -878,7 +878,7 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
      * there is a need to run it separately.
      */
     if (config().is_compacted() && !_segs.empty()) {
-        co_await do_compact(cfg.compact, new_start_offset);
+        co_await adjacent_merge_compact(cfg.compact, new_start_offset);
     }
 
     _probe->set_compaction_ratio(_compaction_ratio.get());

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -158,6 +158,9 @@ public:
 
     storage_resources& resources();
 
+    ss::future<> adjacent_merge_compact(
+      compaction_config, std::optional<model::offset> = std::nullopt);
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
@@ -175,8 +178,6 @@ private:
     // Returns if the update actually took place.
     ss::future<bool> update_start_offset(model::offset o);
 
-    ss::future<> do_compact(
-      compaction_config, std::optional<model::offset> = std::nullopt);
     ss::future<compaction_result> compact_adjacent_segments(
       std::pair<segment_set::iterator, segment_set::iterator>,
       storage::compaction_config cfg);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -161,6 +161,10 @@ public:
     ss::future<> adjacent_merge_compact(
       compaction_config, std::optional<model::offset> = std::nullopt);
 
+    ss::future<> sliding_window_compact(
+      const compaction_config& cfg,
+      std::optional<model::offset> new_start_offset = std::nullopt);
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -143,3 +143,13 @@ rp_test(
   LABELS storage
   ARGS "-- -c 1"
 )
+
+rp_test(
+  FIXTURE_TEST
+  GTEST
+  BINARY_NAME gtest_storage_e2e
+  SOURCES compaction_e2e_test.cc
+  LIBRARIES  v::application v::features v::gtest_main v::kafka_test_utils
+  LABELS storage
+  ARGS "-- -c 1"
+)

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -1,0 +1,299 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "model/namespace.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/async.h"
+#include "test_utils/scoped_config.h"
+#include "test_utils/test.h"
+#include "utils/directory_walker.h"
+#include "vlog.h"
+
+#include <seastar/core/io_priority_class.hh>
+
+#include <absl/container/btree_map.h>
+
+namespace {
+ss::logger cmp_testlog("cmp_testlog");
+} // anonymous namespace
+
+class storage_manual_mixin {
+public:
+    storage_manual_mixin() {
+        cfg.get("log_segment_size_min")
+          .set_value(std::make_optional<uint64_t>(1));
+        cfg.get("log_disable_housekeeping_for_tests").set_value(true);
+    }
+
+private:
+    scoped_config cfg;
+};
+
+struct work_dir_summary {
+    explicit work_dir_summary(ss::sstring path)
+      : dir_path(std::move(path)) {}
+
+    ss::sstring dir_path;
+    std::vector<ss::sstring> staging_files;
+    std::unordered_map<ss::sstring, size_t> index_files;
+    std::unordered_map<ss::sstring, size_t> segment_files;
+    std::unordered_map<ss::sstring, size_t> compacted_index_files;
+
+    ss::future<> add(const ss::directory_entry& de) {
+        auto filename = de.name;
+        if (
+          filename.ends_with(".staging")
+          || filename.ends_with(".log.compaction.compaction_index")
+          || filename.ends_with(".log.compaction.base_index")) {
+            staging_files.emplace_back(filename);
+            co_return;
+        }
+        auto sz = co_await ss::file_size(
+          ssx::sformat("{}/{}", dir_path, filename));
+        // Ignore empty segments (likely the active segment)..
+        if (filename.ends_with(".log") && sz > 0) {
+            segment_files.emplace(filename, sz);
+            co_return;
+        }
+        if (filename.ends_with(".compaction_index")) {
+            compacted_index_files.emplace(filename, sz);
+            co_return;
+        }
+        if (filename.ends_with(".base_index")) {
+            index_files.emplace(filename, sz);
+            co_return;
+        }
+    }
+
+    // Ensures that we have exactly the number of files we expect.
+    // NOTE: expected to be run after compaction; if run before compaction, may
+    // be flaky if segments/indexes aren't flushed.
+    void check_clean(size_t expected_segs) {
+        EXPECT_TRUE(staging_files.empty()) << staging_files;
+        EXPECT_EQ(index_files.size(), expected_segs) << index_files;
+        EXPECT_EQ(compacted_index_files.size(), expected_segs)
+          << compacted_index_files;
+        EXPECT_EQ(segment_files.size(), expected_segs) << segment_files;
+    }
+};
+
+class CompactionFixtureTest
+  : public storage_manual_mixin
+  , public redpanda_thread_fixture
+  , public seastar_test {
+public:
+    ss::future<> SetUpAsync() override {
+        cluster::topic_properties props;
+        props.cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::compaction;
+        co_await add_topic({model::kafka_namespace, topic_name}, 1, props);
+        co_await wait_for_leader(ntp);
+
+        partition = app.partition_manager.local().get(ntp).get();
+        log = partition->log();
+    }
+
+    ss::future<work_dir_summary> dir_summary() {
+        auto dir_path = log->config().work_directory();
+        directory_walker walker;
+        work_dir_summary summary(dir_path);
+        co_await walker.walk(
+          dir_path, [&summary](const ss::directory_entry& de) {
+              return summary.add(de);
+          });
+        co_return summary;
+    }
+
+    ss::future<> generate_data(
+      size_t num_segments, size_t cardinality, size_t records_per_segment) {
+        tests::kafka_produce_transport producer(co_await make_kafka_client());
+        co_await producer.start();
+
+        // Generate some segments.
+        size_t val_count = 0;
+        absl::btree_map<ss::sstring, ss::sstring> latest_kv;
+        for (size_t i = 0; i < num_segments; i++) {
+            for (int r = 0; r < records_per_segment; r++) {
+                auto kvs = tests::kv_t::sequence(
+                  val_count % cardinality, 1, val_count);
+                for (const auto& [k, v] : kvs) {
+                    latest_kv[k] = v;
+                }
+                co_await producer.produce_to_partition(
+                  topic_name, model::partition_id(0), std::move(kvs));
+                val_count++;
+            }
+            co_await log->flush();
+            co_await log->force_roll(ss::default_priority_class());
+        }
+    }
+    ss::future<std::vector<tests::kv_t>>
+    check_records(size_t cardinality, size_t max_duplicates) {
+        tests::kafka_consume_transport consumer(co_await make_kafka_client());
+        co_await consumer.start();
+        auto consumed_kvs = co_await consumer.consume_from_partition(
+          topic_name, model::partition_id(0), model::offset(0));
+        EXPECT_GE(consumed_kvs.size(), cardinality);
+        auto num_duplicates = consumed_kvs.size() - cardinality;
+        EXPECT_LE(num_duplicates, max_duplicates);
+        co_return consumed_kvs;
+    }
+
+protected:
+    const model::topic topic_name{"compaction_e2e_test_topic"};
+    const model::ntp ntp{model::kafka_namespace, topic_name, 0};
+    cluster::partition* partition;
+    ss::shared_ptr<storage::log> log;
+};
+
+class CompactionFixtureParamTest
+  : public CompactionFixtureTest
+  , public ::testing::WithParamInterface<size_t> {};
+
+// Test where the entire key space fits in the offset map, and compaction
+// finishes in one pass.
+TEST_P(CompactionFixtureParamTest, TestDedupeOnePass) {
+    auto duplicates_per_key = GetParam();
+    auto num_segments = 10;
+    auto total_records = 100;
+    auto cardinality = total_records / duplicates_per_key;
+    size_t records_per_segment = total_records / num_segments;
+    generate_data(num_segments, cardinality, records_per_segment).get();
+
+    // Sanity check we created the right number of segments.
+    // NOTE: ignore the active segment.
+    auto segment_count_before = log->segment_count() - 1;
+    ASSERT_EQ(segment_count_before, num_segments);
+
+    // Compact, allowing the map to grow as large as we need.
+    ss::abort_source never_abort;
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    storage::compaction_config cfg(
+      disk_log.segments().back()->offsets().base_offset,
+      ss::default_priority_class(),
+      never_abort,
+      std::nullopt,
+      cardinality);
+    disk_log.sliding_window_compact(cfg).get();
+
+    // Another sanity check after compaction.
+    auto segment_count_after = log->segment_count() - 1;
+    ASSERT_EQ(num_segments, segment_count_after);
+    auto summary_after = dir_summary().get();
+    ASSERT_NO_FATAL_FAILURE(summary_after.check_clean(num_segments));
+
+    // The number of duplicates can't exceed the number of segments - 1: the
+    // latest closed segment should have no duplicates, and at worst, each
+    // preceding segment will have 1 duplicate (the last record).
+    auto consumed_kvs = check_records(cardinality, num_segments - 1).get();
+    ASSERT_NO_FATAL_FAILURE();
+
+    // Compacting again won't attempt again since the segments are marked as
+    // compacted.
+    auto segments_compacted = disk_log.get_probe().get_segments_compacted();
+    disk_log.sliding_window_compact(cfg).get();
+    auto segments_compacted_again
+      = disk_log.get_probe().get_segments_compacted();
+    ASSERT_EQ(segments_compacted, segments_compacted_again);
+
+    // Consume again after restarting and ensure our assertions about
+    // duplicates are still valid.
+    restart(should_wipe::no);
+    wait_for_leader(ntp).get();
+    auto restart_summary = dir_summary().get();
+
+    tests::kafka_consume_transport second_consumer(make_kafka_client().get());
+    second_consumer.start().get();
+    auto consumed_kvs_restarted = second_consumer
+                                    .consume_from_partition(
+                                      topic_name,
+                                      model::partition_id(0),
+                                      model::offset(0))
+                                    .get();
+    ASSERT_EQ(consumed_kvs, consumed_kvs_restarted);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  DuplicatesPerKey, CompactionFixtureParamTest, ::testing::Values(1, 10, 100));
+
+// Test where the key space doesn't fit in the offset map, forcing multiple
+// compactions.
+TEST_F(CompactionFixtureTest, TestDedupeMultiPass) {
+    constexpr auto duplicates_per_key = 10;
+    constexpr auto num_segments = 25;
+    constexpr auto total_records = 100;
+    constexpr auto cardinality = total_records / duplicates_per_key; // 10
+    size_t records_per_segment = total_records / num_segments;       // 4
+    generate_data(num_segments, cardinality, records_per_segment).get();
+
+    // Compact, but with a map size that requires us to compact multiple times
+    // to compact everything.
+    ss::abort_source never_abort;
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    storage::compaction_config cfg(
+      disk_log.segments().back()->offsets().base_offset,
+      ss::default_priority_class(),
+      never_abort,
+      std::nullopt,
+      cardinality - 1);
+    disk_log.sliding_window_compact(cfg).get();
+    auto segments_compacted = disk_log.get_probe().get_segments_compacted();
+
+    // Another attempt to compact will actually rewrite segments.
+    disk_log.sliding_window_compact(cfg).get();
+    auto segments_compacted_2 = disk_log.get_probe().get_segments_compacted();
+    ASSERT_LT(segments_compacted, segments_compacted_2);
+
+    // But the above compaction should deduplicate any remaining keys.
+    // Subsequent compactions will be no-ops.
+    disk_log.sliding_window_compact(cfg).get();
+    auto segments_compacted_3 = disk_log.get_probe().get_segments_compacted();
+    ASSERT_EQ(segments_compacted_2, segments_compacted_3);
+
+    ASSERT_NO_FATAL_FAILURE(check_records(cardinality, num_segments - 1).get());
+}
+
+TEST_F(CompactionFixtureTest, TestRecompactWithNewData) {
+    constexpr auto duplicates_per_key = 10;
+    constexpr auto num_segments = 10;
+    constexpr auto total_records = 100;
+    constexpr auto cardinality = total_records / duplicates_per_key; // 10
+    size_t records_per_segment = total_records / num_segments;       // 10
+    generate_data(num_segments, cardinality, records_per_segment).get();
+
+    // Compact everything in one go.
+    ss::abort_source never_abort;
+    auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
+    storage::compaction_config cfg(
+      disk_log.segments().back()->offsets().base_offset,
+      ss::default_priority_class(),
+      never_abort,
+      std::nullopt,
+      cardinality);
+    disk_log.sliding_window_compact(cfg).get();
+    auto segments_compacted = disk_log.get_probe().get_segments_compacted();
+
+    // Subsequent compaction doesn't do anything.
+    disk_log.sliding_window_compact(cfg).get();
+    auto segments_compacted_2 = disk_log.get_probe().get_segments_compacted();
+    ASSERT_EQ(segments_compacted, segments_compacted_2);
+
+    // But once we add more data, we become eligible for compaction again.
+    generate_data(1, cardinality, records_per_segment).get();
+    storage::compaction_config new_cfg(
+      disk_log.segments().back()->offsets().base_offset,
+      ss::default_priority_class(),
+      never_abort,
+      std::nullopt,
+      cardinality);
+    disk_log.sliding_window_compact(new_cfg).get();
+    auto segments_compacted_3 = disk_log.get_probe().get_segments_compacted();
+    ASSERT_LT(segments_compacted, segments_compacted_3);
+}

--- a/src/v/storage/tests/utils/disk_log_builder.cc
+++ b/src/v/storage/tests/utils/disk_log_builder.cc
@@ -151,7 +151,7 @@ disk_log_builder::apply_retention(gc_config cfg) {
 
 ss::future<> disk_log_builder::apply_compaction(
   compaction_config cfg, std::optional<model::offset> new_start_offset) {
-    return get_disk_log_impl().do_compact(cfg, new_start_offset);
+    return get_disk_log_impl().adjacent_merge_compact(cfg, new_start_offset);
 }
 
 ss::future<bool>


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This commit introduces sliding window compaction as a method to be used in `disk_log_impl`. The high level algorithm is as follows:
- collect the compactible set of segments (i.e. don't compact the active segment, don't compact segments that have done sliding window compaction)
- self compact all collected segments
- build an offset map over the collected segments
- deduplicate each segment, rewriting it and swapping it with the old segment

There is a key difference in approach approach compared to the existing merge-self-compact implementation: it doesn't reduce the number of segments. For that reason, this commit doesn't enable this behavior by default. A later PR will introduce reducing the number of segments, and enable the new implementation by default.

Fixes #14364

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
