### PR TITLE
storage: enable sliding window compaction by default

### DIFF
--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -75,6 +75,8 @@ public:
       const cloud_storage::partition_manifest& manifest,
       ss::lowres_clock::duration segment_lock_duration);
 
+    static bool eligible_for_compacted_reupload(const storage::segment&);
+
 private:
     /// Check if the upload have to be forced due to timeout
     ///

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1104,7 +1104,8 @@ remote_segment_path ntp_archiver::segment_path_for_candidate(
     auto front = candidate.sources.front();
     cloud_storage::partition_manifest::value val{
       .is_compacted = front->is_compacted_segment()
-                      && front->finished_self_compaction(),
+                      && archival_policy::eligible_for_compacted_reupload(
+                        *front),
       .size_bytes = candidate.content_length,
       .base_offset = candidate.starting_offset,
       .committed_offset = candidate.final_offset,
@@ -1567,7 +1568,8 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
     auto upl_fut = aggregate_upload_results(std::move(all_uploads));
 
     auto is_compacted = first_source->is_compacted_segment()
-                        && first_source->finished_self_compaction();
+                        && archival_policy::eligible_for_compacted_reupload(
+                          *first_source);
     co_return scheduled_upload{
       .result = std::move(upl_fut),
       .inclusive_last_offset = offset,
@@ -2843,7 +2845,7 @@ ss::future<bool> ntp_archiver::do_upload_local(
     auto [upload, locks] = std::move(upload_locks);
 
     for (const auto& s : upload.sources) {
-        if (s->finished_self_compaction()) {
+        if (archival_policy::eligible_for_compacted_reupload(*s)) {
             vlog(
               _rtclog.warn,
               "Upload {} requested contains compacted segments.",

--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -11,6 +11,7 @@
 #include "segment_reupload.h"
 
 #include "cloud_storage/partition_manifest.h"
+#include "config/configuration.h"
 #include "logger.h"
 #include "storage/disk_log_impl.h"
 #include "storage/fs_utils.h"
@@ -300,7 +301,8 @@ segment_collector::lookup_result segment_collector::find_next_segment(
     }
 
     const auto& segment = *it;
-    auto segment_is_compacted = segment->finished_self_compaction();
+    auto segment_is_compacted
+      = archival_policy::eligible_for_compacted_reupload(*segment);
     auto compacted_segment_expected
       = mode == segment_collector_mode::collect_compacted;
     if (segment_is_compacted == compacted_segment_expected) {

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -909,7 +909,7 @@ FIXTURE_TEST(
       ->housekeeping(storage::housekeeping_config(
         model::timestamp::now(),
         std::nullopt,
-        model::offset::max(),
+        model::offset{999},
         ss::default_priority_class(),
         as))
       .get0();

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -1121,6 +1121,84 @@ SEASTAR_THREAD_TEST_CASE(test_do_not_reupload_prefix_truncated) {
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
 }
 
+SEASTAR_THREAD_TEST_CASE(test_bump_start_when_not_aligned) {
+    auto ntp = model::ntp{"test_ns", "test_tpc", 0};
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    auto o = std::make_unique<ntp_config::default_overrides>();
+    o->cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    b | start(ntp_config{ntp, {data_path}, std::move(o)});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    b | storage::add_segment(0) | storage::add_random_batch(0, 1000)
+      | storage::add_segment(1000) | storage::add_random_batch(1000, 1000)
+      | storage::add_segment(2000) | storage::add_random_batch(2000, 1000);
+
+    // Set up our manifest to look as if our local data is a compacted version
+    // of what's in the cloud.
+    auto seg_size = b.get_segment(0).size_bytes();
+    cloud_storage::partition_manifest m(ntp, model::initial_revision_id{1});
+    m.add(
+      segment_name("0-499-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = seg_size,
+        .base_offset = model::offset(0),
+        .committed_offset = model::offset(499),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+    m.add(
+      segment_name("500-999-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = seg_size,
+        .base_offset = model::offset(500),
+        .committed_offset = model::offset(999),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+    m.add(
+      segment_name("1000-1999-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = seg_size,
+        .base_offset = model::offset(1000),
+        .committed_offset = model::offset(1999),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+    m.add(
+      segment_name("2000-2999-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = seg_size,
+        .base_offset = model::offset(2000),
+        .committed_offset = model::offset(2999),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+
+    // Mark our local segments compacted, making them eligible for reupload.
+    for (int i = 0; i < 3; i++) {
+        b.get_segment(i).mark_as_compacted_segment();
+        b.get_segment(i).mark_as_finished_self_compaction();
+        b.get_segment(i).mark_as_finished_windowed_compaction();
+    }
+
+    // Try collecting from the middle of a local segment that hapens to align
+    // with our manifest. The containing segment should be included, and the
+    // start offset of the upload candidate should be aligned with our
+    // manifest.
+    archival::segment_collector collector{
+      model::offset{500}, m, b.get_disk_log_impl(), seg_size * 10};
+    collector.collect_segments();
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive()(), 500);
+    BOOST_REQUIRE_EQUAL(collector.segments().size(), 3);
+    BOOST_REQUIRE_EQUAL(collector.segments()[0]->offsets().base_offset(), 0);
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
+}
+
 SEASTAR_THREAD_TEST_CASE(test_adjacent_segment_collection) {
     auto ntp = model::ntp{"test_ns", "test_tpc", 0};
     temporary_dir tmp_dir("concat_segment_read");

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -736,7 +736,7 @@ configuration::configuration()
       "log_compaction_use_sliding_window",
       "Use sliding window compaction.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
-      false)
+      true)
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -731,6 +731,12 @@ configuration::configuration()
       "to simplify testing and shouldn't be set in production.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       false)
+  , log_compaction_use_sliding_window(
+      *this,
+      "log_compaction_use_sliding_window",
+      "Use sliding window compaction.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , retention_bytes(
       *this,
       "retention_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -160,6 +160,7 @@ struct configuration final : public config_store {
     retention_duration_property log_retention_ms;
     property<std::chrono::milliseconds> log_compaction_interval_ms;
     property<bool> log_disable_housekeeping_for_tests;
+    property<bool> log_compaction_use_sliding_window;
     // same as retention.size in kafka - TODO: size not implemented
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -616,7 +616,7 @@ ss::future<> disk_log_impl::sliding_window_compact(
           tmpname);
 
         auto rdr_holder = co_await _readers_cache->evict_segment_readers(seg);
-        auto write_lock = seg->write_lock();
+        auto write_lock = co_await seg->write_lock();
         if (initial_generation_id != seg->get_generation_id()) {
             throw std::runtime_error(fmt::format(
               "Aborting compaction of segment: {}, segment was mutated "

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1020,7 +1020,11 @@ ss::future<> disk_log_impl::housekeeping(housekeeping_config cfg) {
      * there is a need to run it separately.
      */
     if (config().is_compacted() && !_segs.empty()) {
-        co_await adjacent_merge_compact(cfg.compact, new_start_offset);
+        if (config::shard_local_cfg().log_compaction_use_sliding_window()) {
+            co_await sliding_window_compact(cfg.compact, new_start_offset);
+        } else {
+            co_await adjacent_merge_compact(cfg.compact, new_start_offset);
+        }
     }
 
     _probe->set_compaction_ratio(_compaction_ratio.get());

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -268,6 +268,7 @@ private:
         ss::abort_source::subscription subscription;
     };
     bool _closed{false};
+    ss::abort_source _compaction_as;
     ss::gate _compaction_housekeeping_gate;
     log_manager& _manager;
     float _segment_size_jitter;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -161,7 +161,7 @@ public:
     ss::future<> adjacent_merge_compact(
       compaction_config, std::optional<model::offset> = std::nullopt);
 
-    ss::future<> sliding_window_compact(
+    ss::future<bool> sliding_window_compact(
       const compaction_config& cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);
 

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -663,6 +663,7 @@ std::ostream& operator<<(std::ostream& o, const segment& h) {
     o << "{offset_tracker:" << h._tracker
       << ", compacted_segment=" << h.is_compacted_segment()
       << ", finished_self_compaction=" << h.finished_self_compaction()
+      << ", finished_windowed_compaction=" << h.finished_windowed_compaction()
       << ", generation=" << h.get_generation_id() << ", reader=";
     if (h._reader) {
         o << *h._reader;

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -102,8 +102,15 @@ ss::future<model::offset> build_offset_map(
         if (cfg.asrc) {
             cfg.asrc->check();
         }
+        const auto& seg = iter->get();
+        auto read_lock = co_await seg->read_lock();
+        if (seg->is_closed()) {
+            // Stop early if the segment e.g. has been prefix truncated. We'll
+            // make do with the offset map we have so far.
+            break;
+        }
         auto seg_fully_indexed = co_await build_offset_map_for_segment(
-          cfg, *(iter->get()), m);
+          cfg, *seg, m);
         if (!seg_fully_indexed) {
             // The offset map is full. Note that we may have only partially
             // indexed a segment, but it's safe to use this index. If no new
@@ -111,7 +118,7 @@ ss::future<model::offset> build_offset_map(
             // from this segment for completeness.
             break;
         }
-        min_segment_fully_indexed = iter->get()->offsets().base_offset;
+        min_segment_fully_indexed = seg->offsets().base_offset;
         if (iter == segs.begin()) {
             break;
         }

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -99,6 +99,9 @@ ss::future<model::offset> build_offset_map(
     // Build the key offset map by iterating on older and older data.
     auto iter = std::prev(segs.end());
     while (true) {
+        if (cfg.asrc) {
+            cfg.asrc->check();
+        }
         auto seg_fully_indexed = co_await build_offset_map_for_segment(
           cfg, *(iter->get()), m);
         if (!seg_fully_indexed) {

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -260,7 +260,7 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             cloud_storage_idle_timeout_ms=100,
             cloud_storage_segment_size_target=4 * self.log_segment_size,
             cloud_storage_segment_size_min=2 * self.log_segment_size,
-            retention_local_target_bytes_default=10 * self.log_segment_size,
+            retention_local_target_bytes_default=2 * self.log_segment_size,
             cloud_storage_enable_segment_merging=True,
             cloud_storage_cache_chunk_size=self.chunk_size)
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This commit enables sliding window compaction by default, including a few tweaks and fixes to make that possible:
- Fixed a segment locking issue (missing co_await).
- Runs adjacent segment merging if no segments are window compacted, ensuring a reduction in the number of segments (expected by many tests).
- Passes an abort source to compaction, allowing partition movement and deletion to abort compaction.
- Adds a cluster config to control whether sliding window compaction is used.
- Updates archival policy to look for window compacted segments instead of self compacted segments.
- Updates existing unit tests to account for this change (we're no longer always going to compact down to 2 segments, instead, we're just going to merge adjacent segments when we perform sliding window compaction).

Fixes https://github.com/redpanda-data/redpanda/issues/14367

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Redpanda will do a more thorough job in compacting records. Topics configured with the `compact` or `compact,delete` cleanup policies will take less space, particularly when the cardinality of the topic is low.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
