### PR TITLE
wasm: add store limits

### DIFF
--- a/src/v/wasm/allocator.cc
+++ b/src/v/wasm/allocator.cc
@@ -27,11 +27,11 @@ namespace wasm {
 
 heap_allocator::heap_allocator(config c) {
     size_t page_size = ::getpagesize();
-    size_t alloc_size = ss::align_up(c.heap_memory_size, page_size);
+    _max_size = ss::align_up(c.heap_memory_size, page_size);
     for (size_t i = 0; i < c.num_heaps; ++i) {
         auto buffer = ss::allocate_aligned_buffer<uint8_t>(
-          alloc_size, page_size);
-        _memory_pool.emplace_back(std::move(buffer), alloc_size);
+          _max_size, page_size);
+        _memory_pool.emplace_back(std::move(buffer), _max_size);
     }
 }
 
@@ -51,6 +51,8 @@ std::optional<heap_memory> heap_allocator::allocate(request req) {
 void heap_allocator::deallocate(heap_memory m) {
     _memory_pool.push_back(std::move(m));
 }
+
+size_t heap_allocator::max_size() const { return _max_size; }
 
 stack_memory::stack_memory(stack_bounds bounds, allocated_memory data)
   : _bounds(bounds)
@@ -123,5 +125,4 @@ std::ostream& operator<<(std::ostream& os, const stack_bounds& bounds) {
              fmt::ptr(bounds.top),
              fmt::ptr(bounds.bottom));
 }
-
 } // namespace wasm

--- a/src/v/wasm/allocator.h
+++ b/src/v/wasm/allocator.h
@@ -80,7 +80,13 @@ public:
      */
     void deallocate(heap_memory);
 
+    /**
+     * The maximum size of a heap_memory that can be allocated.
+     */
+    size_t max_size() const;
+
 private:
+    size_t _max_size;
     // We expect this list to be small, so override the chunk to be smaller too.
     static constexpr size_t items_per_chunk = 16;
     ss::chunked_fifo<heap_memory, items_per_chunk> _memory_pool;


### PR DESCRIPTION
Add limits to an underlying store. The primary goal of this is to not have tables grow beyond our recommended allocation size, memory is already limited, but now we plug that value into a store for better error messages and not needing to ask for a new memory before OOM'ing a VM.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
