### PR TITLE
.github: use latest golangci-lint; rpk: remove dead linters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.52.2
+        version: latest
         args: --timeout 5m
         working-directory: src/go/rpk/
 

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -46,6 +46,6 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: latest
           args: --timeout 5m
           working-directory: src/go/transform-sdk/

--- a/src/go/rpk/.golangci.yml
+++ b/src/go/rpk/.golangci.yml
@@ -13,15 +13,12 @@ linters:
   disable-all: true
   enable:
   # Enabled by default linters:
-    - deadcode
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
   # Disabled by default
     - asciicheck
     - bidichk

--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -258,7 +258,7 @@ func CreateNode(
 	if err != nil {
 		return nil, err
 	}
-	kPort, err := nat.NewPort( //nolint:revive // var-naming diff here is intended kPort = kafkaPort.
+	kPort, err := nat.NewPort(
 		"tcp",
 		strconv.Itoa(int(externalKafkaPort)),
 	)


### PR DESCRIPTION
PR #14275 is failing because it uses `min` and `max`, which were added in go1.21. Our builds use go1.21, but the currently installed golangci-lint is old and does not recognize min / max.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none