### PR TITLE
rptest: Updates to traffic heavy cloud tests

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -656,7 +656,7 @@ class HighThroughputTest(PreallocNodesTest):
                    timeout_sec=600,
                    backoff_sec=20)
 
-    @ignore
+    @ok_to_fail
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_and_add(self):
         """
@@ -796,6 +796,7 @@ class HighThroughputTest(PreallocNodesTest):
                 consumer.stop()
                 consumer.wait(timeout_sec=600)
 
+    @ok_to_fail
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_consume(self):
         # create default topics
@@ -904,7 +905,7 @@ class HighThroughputTest(PreallocNodesTest):
     # The testcase occasionally fails on various parts:
     # - toing on `_consume_from_offset(self.topic, 1, p_id, "newest", 30)`
     # - failing to ensure all manifests are in the cloud in `stop_and_scrub_object_storage`
-    @ignore
+    @ok_to_fail
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_consume_miss_cache(self):
         # create default topics

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -675,7 +675,7 @@ class HighThroughputTest(PreallocNodesTest):
                    timeout_sec=600,
                    backoff_sec=20)
 
-    @ok_to_fail
+    @ignore
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_and_add(self):
         """
@@ -817,6 +817,7 @@ class HighThroughputTest(PreallocNodesTest):
                 consumer.stop()
                 consumer.wait(timeout_sec=600)
 
+    @ignore
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_consume(self):
         # create default topics
@@ -926,7 +927,7 @@ class HighThroughputTest(PreallocNodesTest):
     # The testcase occasionally fails on various parts:
     # - toing on `_consume_from_offset(self.topic, 1, p_id, "newest", 30)`
     # - failing to ensure all manifests are in the cloud in `stop_and_scrub_object_storage`
-    @ok_to_fail
+    @ignore
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_consume_miss_cache(self):
         # create default topics


### PR DESCRIPTION
CloudV2 Tiers have enforced minimal segment size of 16MB. Due to this traffic heavy tests needs to be updated, so they run in a reasonable timeframe along with other tests (less than ~30min). 

This PR updated several parameters along with some timeout tweaks:
- Reducing cloud segments per partition from 1,000 to 100 in the segment upload stress test.
- Increasing the initial segment size from 4KiB to 16MiB.
- Decreasing the failed consumers from 10,000 to 5,000.
- Increasing message size from 128KiB to 256KiB.
- Increase Failed consumer step from 10 to 50. Which results in 100 steps total (5000/50)

Test that fills up the cache still takes a significant time to run, though and there is almost no workarounds here rather than force RP to process huge amounts of data and do cache-misses in the process

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
