### PR TITLE
cloud_storage: perform a full internal scrub at the end of TS tests

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -187,7 +187,9 @@ static std::unique_ptr<scrubber> maybe_make_scrubber(
           remote,
           feature_table,
           config::shard_local_cfg().cloud_storage_enable_scrubbing.bind(),
-          config::shard_local_cfg().cloud_storage_scrubbing_interval_ms.bind(),
+          config::shard_local_cfg()
+            .cloud_storage_partial_scrub_interval_ms.bind(),
+          config::shard_local_cfg().cloud_storage_full_scrub_interval_ms.bind(),
           config::shard_local_cfg()
             .cloud_storage_scrubbing_interval_jitter_ms.bind());
         result->set_enabled(am_leader);

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -594,6 +594,8 @@ ss::future<std::error_code> ntp_archiver::reset_scrubbing_metadata() {
           _rtclog.warn,
           "Failed to replicate reset scrubbing metadata command: {}",
           error.message());
+    } else if (_scrubber) {
+        _scrubber->reset_scheduler();
     }
 
     co_return error;

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -347,6 +347,8 @@ public:
       cloud_storage::scrub_status status,
       cloud_storage::anomalies detected);
 
+    ss::future<std::error_code> reset_scrubbing_metadata();
+
 private:
     // Labels for contexts in which manifest uploads occur. Used for logging.
     static constexpr const char* housekeeping_ctx_label = "housekeeping";

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "archival/archival_policy.h"
 #include "archival/probe.h"
+#include "archival/scrubber.h"
 #include "archival/types.h"
 #include "cloud_storage/cache_service.h"
 #include "cloud_storage/fwd.h"
@@ -649,7 +650,7 @@ private:
     std::unique_ptr<housekeeping_job> _local_segment_merger;
 
     // NTP level scrubbing job
-    std::unique_ptr<housekeeping_job> _scrubber;
+    std::unique_ptr<scrubber> _scrubber;
 
     // The archival metadata stm has its own clean/dirty mechanism, but it
     // is expensive to persistently mark it clean after each segment upload,

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -20,7 +20,8 @@ scrubber::scrubber(
   cloud_storage::remote& remote,
   features::feature_table& feature_table,
   config::binding<bool> config_enabled,
-  config::binding<std::chrono::milliseconds> interval,
+  config::binding<std::chrono::milliseconds> partial_interval,
+  config::binding<std::chrono::milliseconds> full_interval,
   config::binding<std::chrono::milliseconds> jitter)
   : _root_rtc(_as)
   , _logger(archival_log, _root_rtc, archiver.get_ntp().path())
@@ -30,8 +31,20 @@ scrubber::scrubber(
   , _feature_table(feature_table)
   , _detector{_archiver.get_bucket_name(), _archiver.get_ntp(), _archiver.get_revision_id(), _remote, _logger, _as}
   , _scheduler(
-      [this] { return _archiver.manifest().last_partition_scrub(); },
-      std::move(interval),
+      [this] {
+          const auto at = _archiver.manifest().last_partition_scrub();
+          const auto offset = _archiver.manifest().last_scrubbed_offset();
+          cloud_storage::scrub_status status;
+          if (!offset && at != model::timestamp::missing()) {
+              status = cloud_storage::scrub_status::full;
+          } else {
+              status = cloud_storage::scrub_status::partial;
+          }
+
+          return std::make_tuple(at, status);
+      },
+      std::move(partial_interval),
+      std::move(full_interval),
       std::move(jitter)) {
     ssx::spawn_with_gate(_gate, [this] { return await_feature_enabled(); });
 }

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -211,4 +211,6 @@ std::pair<bool, std::optional<ss::sstring>> scrubber::should_skip() const {
     return {false, std::nullopt};
 }
 
+void scrubber::reset_scheduler() { _scheduler.pick_next_scrub_time(); }
+
 } // namespace archival

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -159,7 +159,7 @@ void scrubber::release() {
 }
 
 ss::future<> scrubber::stop() {
-    vlog(archival_log.info, "Stopping scrubber ({})...", _gate.get_count());
+    vlog(_logger.info, "Stopping scrubber ({})...", _gate.get_count());
     _as.request_abort();
     return _gate.close();
 }

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -69,7 +69,8 @@ public:
 
     std::pair<bool, std::optional<ss::sstring>> should_skip() const;
 
-    model::timestamp next_scrub_at() const;
+    // Reset the scheduler and pick a new time-point for the next scrub
+    void reset_scheduler();
 
 private:
     ss::abort_source _as;

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -44,7 +44,8 @@ public:
       cloud_storage::remote& remote,
       features::feature_table& feature_table,
       config::binding<bool> config_enabled,
-      config::binding<std::chrono::milliseconds> interval,
+      config::binding<std::chrono::milliseconds> partial_interval,
+      config::binding<std::chrono::milliseconds> full_interval,
       config::binding<std::chrono::milliseconds> jitter);
 
     ss::future<> await_feature_enabled();

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -863,6 +863,12 @@ const anomalies& partition_manifest::detected_anomalies() const {
     return _detected_anomalies;
 }
 
+void partition_manifest::reset_scrubbing_metadata() {
+    _detected_anomalies = {};
+    _last_partition_scrub = model::timestamp::missing();
+    _last_scrubbed_offset = std::nullopt;
+}
+
 std::optional<size_t> partition_manifest::move_aligned_offset_range(
   const segment_meta& replacing_segment) {
     size_t total_replaced_size = 0;

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -2774,6 +2774,10 @@ void partition_manifest::process_anomalies(
     _last_partition_scrub = scrub_timestamp;
     _last_scrubbed_offset = last_scrubbed_offset;
 
+    if (!_last_scrubbed_offset) {
+        _detected_anomalies.last_complete_scrub = scrub_timestamp;
+    }
+
     vlog(
       cst_log.debug,
       "[{}] Anomalies processed: {{ detected: {}, last_partition_scrub: {}, "

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -465,6 +465,8 @@ public:
 
     const anomalies& detected_anomalies() const;
 
+    void reset_scrubbing_metadata();
+
     /// Removes all replaced segments from the manifest.
     /// Method 'replaced_segments' will return empty value
     /// after the call.

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -23,6 +23,19 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+namespace cloud_storage {
+
+bool operator==(const anomalies& lhs, const anomalies& rhs) {
+    return lhs.missing_partition_manifest == rhs.missing_partition_manifest
+           && lhs.missing_spillover_manifests == rhs.missing_spillover_manifests
+           && lhs.missing_segments == rhs.missing_segments
+           && lhs.segment_metadata_anomalies == rhs.segment_metadata_anomalies;
+
+    // anomalies::last_complete_scrub is intentionally omitted
+}
+
+} // namespace cloud_storage
+
 namespace {
 
 ss::logger test_logger{"anomaly_detection_test"};

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -264,6 +264,9 @@ anomalies& anomalies::operator+=(anomalies&& other) {
       std::make_move_iterator(other.segment_metadata_anomalies.begin()),
       std::make_move_iterator(other.segment_metadata_anomalies.end()));
 
+    last_complete_scrub = std::max(
+      last_complete_scrub, other.last_complete_scrub);
+
     return *this;
 }
 

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -391,20 +391,24 @@ struct anomalies
     absl::node_hash_set<segment_meta> missing_segments;
     // Segments that have metadata anomalies (e.g. gaps or overlaps)
     segment_meta_anomalies segment_metadata_anomalies;
+    // Optional timestamp indicating the last time point at which
+    // the scrub of the full log completed.
+    std::optional<model::timestamp> last_complete_scrub;
 
     auto serde_fields() {
         return std::tie(
           missing_partition_manifest,
           missing_spillover_manifests,
           missing_segments,
-          segment_metadata_anomalies);
+          segment_metadata_anomalies,
+          last_complete_scrub);
     }
 
     bool has_value() const;
 
     anomalies& operator+=(anomalies&&);
 
-    bool operator==(anomalies const&) const = default;
+    friend bool operator==(const anomalies& lhs, const anomalies& rhs);
 };
 
 std::ostream& operator<<(std::ostream& o, const anomalies& a);

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -82,6 +82,7 @@ public:
       std::optional<model::offset> last_scrubbed_offset,
       cloud_storage::scrub_status status,
       cloud_storage::anomalies detected);
+    command_batch_builder& reset_scrubbing_metadata();
     /// Replicate the configuration batch
     ss::future<std::error_code> replicate();
 
@@ -281,6 +282,7 @@ private:
     struct spillover_cmd;
     struct replace_manifest_cmd;
     struct process_anomalies_cmd;
+    struct reset_scrubbing_metadata;
     struct snapshot;
 
     friend segment segment_from_meta(const cloud_storage::segment_meta& meta);
@@ -307,6 +309,7 @@ private:
     void apply_spillover(const spillover_cmd& so);
     void apply_replace_manifest(iobuf);
     void apply_process_anomalies(iobuf);
+    void apply_reset_scrubbing_metadata();
 
 private:
     prefix_logger _logger;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1637,10 +1637,16 @@ configuration::configuration()
       "the integrity of data and metadata uploaded to cloud storage",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
-  , cloud_storage_scrubbing_interval_ms(
+  , cloud_storage_partial_scrub_interval_ms(
       *this,
-      "cloud_storage_scrubbing_interval_ms",
-      "Time interval between scrubs of the same partition",
+      "cloud_storage_partial_scrub_interval_ms",
+      "Time interval between two partial scrubs of the same partition",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1h)
+  , cloud_storage_full_scrub_interval_ms(
+      *this,
+      "cloud_storage_full_scrub_interval_ms",
+      "Time interval between a final scrub and thte next scrub",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1h)
   , cloud_storage_scrubbing_interval_jitter_ms(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -318,7 +318,8 @@ struct configuration final : public config_store {
     property<int32_t> cloud_storage_background_jobs_quota;
     property<bool> cloud_storage_enable_segment_merging;
     property<bool> cloud_storage_enable_scrubbing;
-    property<std::chrono::milliseconds> cloud_storage_scrubbing_interval_ms;
+    property<std::chrono::milliseconds> cloud_storage_partial_scrub_interval_ms;
+    property<std::chrono::milliseconds> cloud_storage_full_scrub_interval_ms;
     property<std::chrono::milliseconds>
       cloud_storage_scrubbing_interval_jitter_ms;
     property<bool> cloud_storage_disable_upload_loop_for_tests;

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -561,6 +561,10 @@
           "type": "array",
           "items": {"type": "metadata_anomaly"},
           "nullable": true
+        },
+        "last_complete_scrub_at": {
+          "type": "long",
+          "nullable": true
         }
       }
     }

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -261,6 +261,37 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/v1/cloud_storage/reset_scrubbing_metadata/{namespace}/{topic}/{partition}",
+      "operations": [
+        {
+          "method": "POST",
+          "summary": "Reset scrubbing related metadata and anomalies for given partition",
+          "operationId": "reset_scrubbing_metadata",
+          "nickname": "reset_scrubbing_metadata",
+          "parameters": [
+            {
+              "name": "namespace",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "topic",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "partition",
+              "in": "path",
+              "required": true,
+              "type": "integer"
+            }
+          ]
+        }
+      ]
     }
   ],
   "models": {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -5401,6 +5401,10 @@ map_anomalies_to_json(
     json.partition = ntp.tp.partition();
     json.revision_id = initial_rev();
 
+    if (detected.last_complete_scrub) {
+        json.last_complete_scrub_at = detected.last_complete_scrub->value();
+    }
+
     if (detected.missing_partition_manifest) {
         json.missing_partition_manifest = true;
     }

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -5744,6 +5744,50 @@ admin_server::unsafe_reset_metadata_from_cloud(
     co_return reply;
 }
 
+ss::future<ss::json::json_return_type>
+admin_server::reset_scrubbing_metadata(std::unique_ptr<ss::http::request> req) {
+    const model::ntp ntp = parse_ntp_from_request(
+      req->param, model::kafka_namespace);
+
+    if (need_redirect_to_leader(ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, ntp);
+    }
+
+    const auto shard = _shard_table.local().shard_for(ntp);
+    if (!shard) {
+        throw ss::httpd::not_found_exception(fmt::format(
+          "{} could not be found on the node. Perhaps it has been moved "
+          "during the redirect.",
+          ntp));
+    }
+
+    auto status = co_await _partition_manager.invoke_on(
+      *shard, [&ntp, shard](const auto& pm) {
+          const auto& partitions = pm.partitions();
+          auto partition_iter = partitions.find(ntp);
+
+          if (partition_iter == partitions.end()) {
+              throw ss::httpd::not_found_exception(
+                fmt::format("{} could not be found on shard {}.", ntp, *shard));
+          }
+
+          auto archiver = partition_iter->second->archiver();
+          if (!archiver) {
+              throw ss::httpd::not_found_exception(
+                fmt::format("{} has no archiver on shard {}.", ntp, *shard));
+          }
+
+          return archiver.value().get().reset_scrubbing_metadata();
+      });
+
+    if (status != cluster::errc::success) {
+        throw ss::httpd::server_error_exception{
+          "Failed to replicate or apply scrubber metadata reset command"};
+    }
+
+    co_return ss::json::json_return_type(ss::json::json_void());
+}
+
 void admin_server::register_shadow_indexing_routes() {
     register_route<superuser>(
       ss::httpd::shadow_indexing_json::sync_local_state,
@@ -5807,6 +5851,10 @@ void admin_server::register_shadow_indexing_routes() {
     register_route<superuser>(
       ss::httpd::shadow_indexing_json::unsafe_reset_metadata_from_cloud,
       std::move(unsafe_reset_metadata_from_cloud_handler));
+
+    register_route<user>(
+      ss::httpd::shadow_indexing_json::reset_scrubbing_metadata,
+      [this](auto req) { return reset_scrubbing_metadata(std::move(req)); });
 }
 
 constexpr std::string_view to_string_view(service_kind kind) {

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -508,6 +508,8 @@ private:
       std::unique_ptr<ss::http::reply> rep);
     ss::future<ss::json::json_return_type>
       get_cloud_storage_anomalies(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      reset_scrubbing_metadata(std::unique_ptr<ss::http::request>);
 
     /// Self test routes
     ss::future<ss::json::json_return_type>

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1118,3 +1118,13 @@ class Admin:
         return self._request(
             "GET",
             f"cloud_storage/anomalies/{namespace}/{topic}/{partition}").json()
+
+    def reset_scrubbing_metadata(self,
+                                 namespace: str,
+                                 topic: str,
+                                 partition: int,
+                                 node: Optional[ClusterNode] = None):
+        return self._request(
+            "POST",
+            f"cloud_storage/reset_scrubbing_metadata/{namespace}/{topic}/{partition}",
+            node=node)

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -156,6 +156,7 @@ def cluster(log_allow_list=None,
 
                 if self.redpanda.si_settings is not None:
                     try:
+                        self.redpanda.maybe_do_internal_scrub()
                         self.redpanda.stop_and_scrub_object_storage()
                     except:
                         self.redpanda.cloud_storage_diagnostics()

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -62,7 +62,8 @@ class CloudStorageScrubberTest(RedpandaTest):
             test_context=test_context,
             extra_rp_conf={
                 "cloud_storage_enable_scrubbing": True,
-                "cloud_storage_scrubbing_interval_ms": 1000,
+                "cloud_storage_partial_scrub_interval_ms": 1000,
+                "cloud_storage_full_scrub_interval_ms": 1000,
                 "cloud_storage_scrubbing_interval_jitter_ms": 100,
                 # Small quota forces partial scrubs
                 "cloud_storage_background_jobs_quota": 30,

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -367,5 +367,7 @@ class CloudStorageScrubberTest(RedpandaTest):
         # This test deletes segments, spillover manifests
         # and fudges the manifest. rp-storage-tool also picks
         # up on some of these things.
-        self.redpanda.si_settings.set_expected_damage(
-            {"missing_segments", "metadata_offset_gaps"})
+        self.redpanda.si_settings.set_expected_damage({
+            "missing_segments", "metadata_offset_gaps",
+            "missing_spillover_manifests"
+        })

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -118,6 +118,8 @@ class CloudStorageScrubberTest(RedpandaTest):
                                                           topic=self.topic,
                                                           partition=pid)
 
+            anomalies.pop("last_complete_scrub_at", None)
+
             ntpr = NTPR(ns=anomalies["ns"],
                         topic=anomalies["topic"],
                         partition=anomalies["partition"],


### PR DESCRIPTION
This patch set has the goal of performing an internal (as opposed to external via rp-storage-tool) scrub
for each partition at the end of each tiered storage tests. This change is made in the final commit, but
there are a number of prerequisites:
1. Split the `cloud_storage_scrubbing_interval_ms` config into two separate configs: `cloud_storage_{partia|full}_scrub_interval_ms`. The partial interval is applied for scrubs
which continue the work of a previous scrub. The full interval is applied after a scrub which
has reached the end of the log. In production, I expect these values to always be the same,
but they're very useful for testing as it allows us to pause scrubbing after the end of the log was reached.
2. An endpoint for resetting scrubbing metadata is also added to clear any existing anomalies
before the final scrub: `v1/cloud_storage/reset_scrubbing_metadata/{namespace}/{topic}/{partition}`
3. Include the time point at which a partition's scrubber reaches the end of the log. This allows tests
to figure out when to stop waiting.

Fixes #13886 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

