### PR TITLE
fix topic_manifest.json deserialization for disabled tristate 

### DIFF
--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -24,6 +24,7 @@
 
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
+#include <fmt/ranges.h>
 
 #include <chrono>
 #include <limits>
@@ -365,4 +366,37 @@ SEASTAR_THREAD_TEST_CASE(test_negative_property_manifest) {
     // The usigned types that were passed in negative values shouldn't be set.
     BOOST_REQUIRE(tp_props.retention_bytes.is_disabled());
     BOOST_REQUIRE(!tp_props.segment_size.has_value());
+}
+
+SEASTAR_THREAD_TEST_CASE(test_retention_ms_bytes_manifest) {
+    // see issues/14325
+
+    // check that serialization/deserialization of disabled tristate for
+    // retention_bytes and retention_duration works as expected
+
+    auto test_cfg = cfg;
+    test_cfg.properties.retention_bytes = tristate<size_t>{disable_tristate};
+    test_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>{disable_tristate};
+    auto m = topic_manifest{test_cfg, model::initial_revision_id{0}};
+
+    auto serialized = m.serialize().get().stream;
+    auto buf = iobuf{};
+    auto os = make_iobuf_ref_output_stream(buf);
+    ss::copy(serialized, os).get();
+
+    auto reconstructed = topic_manifest{};
+    reconstructed.update(make_iobuf_input_stream(std::move(buf))).get();
+
+    BOOST_REQUIRE(reconstructed.get_topic_config());
+    auto reconstructed_props
+      = reconstructed.get_topic_config().value().properties;
+    BOOST_CHECK_MESSAGE(
+      test_cfg.properties == reconstructed_props,
+      fmt::format(
+        "test_cfg: {} reconstructed_cfg: {}",
+        reflection::to_tuple(test_cfg.properties),
+        reflection::to_tuple(reconstructed_props)));
+
+    BOOST_CHECK(test_cfg == reconstructed.get_topic_config());
 }

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -204,12 +204,8 @@ SEASTAR_THREAD_TEST_CASE(min_config_update_all_fields_correct) {
     BOOST_REQUIRE(!topic_config.properties.compaction_strategy);
     BOOST_REQUIRE(!topic_config.properties.timestamp_type);
     BOOST_REQUIRE(!topic_config.properties.segment_size);
-    BOOST_REQUIRE(
-      !topic_config.properties.retention_bytes.is_disabled()
-      && !topic_config.properties.retention_bytes.has_optional_value());
-    BOOST_REQUIRE(
-      !topic_config.properties.retention_duration.is_disabled()
-      && !topic_config.properties.retention_duration.has_optional_value());
+    BOOST_REQUIRE(topic_config.properties.retention_bytes.is_empty());
+    BOOST_REQUIRE(topic_config.properties.retention_duration.is_empty());
 }
 
 SEASTAR_THREAD_TEST_CASE(full_config_update_all_fields_correct) {

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -204,8 +204,8 @@ SEASTAR_THREAD_TEST_CASE(min_config_update_all_fields_correct) {
     BOOST_REQUIRE(!topic_config.properties.compaction_strategy);
     BOOST_REQUIRE(!topic_config.properties.timestamp_type);
     BOOST_REQUIRE(!topic_config.properties.segment_size);
-    BOOST_REQUIRE(topic_config.properties.retention_bytes.is_empty());
-    BOOST_REQUIRE(topic_config.properties.retention_duration.is_empty());
+    BOOST_REQUIRE(topic_config.properties.retention_bytes.is_disabled());
+    BOOST_REQUIRE(topic_config.properties.retention_duration.is_disabled());
 }
 
 SEASTAR_THREAD_TEST_CASE(full_config_update_all_fields_correct) {

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -118,7 +118,8 @@ struct topic_manifest_handler
                 // Just leave them empty.
                 _properties.segment_size = std::nullopt;
             } else if (_key == "retention_bytes") {
-                _properties.retention_bytes = tristate<size_t>{};
+                _properties.retention_bytes = tristate<size_t>{
+                  disable_tristate};
             } else if (_key == "retention_duration") {
                 _properties.retention_duration
                   = tristate<std::chrono::milliseconds>(

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -173,6 +173,13 @@ struct topic_manifest_handler
 
     bool Null() {
         if (_state == state::expect_value) {
+            if (_key == "retention_bytes") {
+                _properties.retention_bytes = tristate<size_t>{std::nullopt};
+            } else if (_key == "retention_duration") {
+                _properties.retention_duration
+                  = tristate<std::chrono::milliseconds>{std::nullopt};
+            }
+
             _state = state::expect_key;
             return true;
         }
@@ -198,7 +205,10 @@ struct topic_manifest_handler
     std::optional<model::initial_revision_id> _revision_id{};
 
     // optional fields
-    manifest_topic_configuration::topic_properties _properties;
+    manifest_topic_configuration::topic_properties _properties{
+      .retention_bytes = tristate<size_t>(disable_tristate),
+      .retention_duration = tristate<std::chrono::milliseconds>(
+        disable_tristate)};
     std::optional<ss::sstring> compaction_strategy_sv;
     std::optional<ss::sstring> timestamp_type_sv;
     std::optional<ss::sstring> compression_sv;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1931,13 +1931,6 @@ struct topic_configuration
         }
     }
 
-    static void maybe_adjust_retention_policies(
-      std::optional<model::shadow_indexing_mode>,
-      tristate<std::size_t>&,
-      tristate<std::chrono::milliseconds>&,
-      tristate<std::size_t>&,
-      tristate<std::chrono::milliseconds>&);
-
     friend std::ostream& operator<<(std::ostream&, const topic_configuration&);
 
     friend bool

--- a/tests/rptest/tests/retention_policy_test.py
+++ b/tests/rptest/tests/retention_policy_test.py
@@ -23,7 +23,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (produce_until_segments, produce_total_bytes,
                          wait_for_local_storage_truncate, segments_count,
                          expect_exception)
-from rptest.utils.si_utils import BucketView
+from rptest.utils.si_utils import BucketView, quiesce_uploads
 
 
 def bytes_for_segments(want_segments, segment_size):
@@ -641,6 +641,58 @@ class ShadowIndexingCloudRetentionTest(RedpandaTest):
                    timeout_sec=10,
                    backoff_sec=2,
                    err_msg=f"Too many bytes in the cloud")
+
+    @cluster(num_nodes=1)
+    def test_topic_recovery_retention_settings(self):
+        """
+        Test that topic recovery handles retention.ms/bytes correctly
+        see issues/14325
+        """
+
+        topic_name = 'topic-with-retention'
+        # pre step: set cluster default values different from -1
+        self.rpk.cluster_config_set("log_retention_ms", "12345678")
+        self.rpk.cluster_config_set("retention_bytes", "12345678")
+        # create a remote topic with infinite retention and
+        self.rpk.create_topic(topic=topic_name,
+                              partitions=1,
+                              replicas=1,
+                              config={
+                                  'redpanda.remote.delete': 'false',
+                                  'redpanda.remote.read': 'true',
+                                  'redpanda.remote.write': 'true',
+                                  'retention.ms': -1,
+                                  'retention.bytes': -1,
+                              })
+
+        # check that the source of the retention configuration is DYNAMIC
+        pre_cfg = self.rpk.describe_topic_configs(topic_name)
+        assert pre_cfg['retention.bytes'] == (
+            '-1', 'DYNAMIC_TOPIC_CONFIG'
+        ) and pre_cfg['retention.ms'] == (
+            '-1', 'DYNAMIC_TOPIC_CONFIG'
+        ), f"{topic_name} expected DYNAMIC_TOPIC_CONFIG for retention.bytes and retention.ms, got {pre_cfg}"
+
+        # produce data and wait for uploads, to ensure that the topic manifest is uploaded
+        produce_total_bytes(self.redpanda, topic_name, bytes_to_produce=200)
+        quiesce_uploads(self.redpanda,
+                        topic_names=[topic_name],
+                        timeout_sec=60)
+
+        # delete topic and recreated it with redpanda.remote.recovery
+        self.rpk.delete_topic(topic_name)
+
+        self.rpk.create_topic(topic=topic_name,
+                              partitions=1,
+                              replicas=1,
+                              config={
+                                  'redpanda.remote.recovery': 'true',
+                              })
+        # check that recovered cfg matches
+        post_cfg = self.rpk.describe_topic_configs(topic_name)
+        assert pre_cfg['retention.bytes'] == post_cfg[
+            'retention.bytes'] and pre_cfg['retention.ms'] == post_cfg[
+                'retention.ms'], f"recreated topic {topic_name} cfg do not match {pre_cfg=} {post_cfg=}"
 
 
 class BogusTimestampTest(RedpandaTest):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

fix for topic_manifest deserialization for disabled tristate (retention_bytes and retention_duration).

the serialization format is described here: https://github.com/redpanda-data/redpanda/blob/7ef7a17be289ebbf513b3bf5d6c09c9e79bdd6ee/src/v/cloud_storage/topic_manifest.cc#L424-L445

| tristate key |  json  |
| ------------- | ------------- |
| `disabled`  | nothing in the json  |
| `nullopt`   | `"key": null`  |
| some value   | `"key": value`  |

to deserialize this, the starting value has to be disabled (the default constructor for topic_properties would [set it to nullopt](https://github.com/redpanda-data/redpanda/blob/512a595d0983c9f31f4d03000fab9768ac19a6d5/src/v/cloud_storage/types.h#L132-L141) )

and the Null deserialization handler has to be used.

the ducktape test reproduces the original ticket

Fixes #14325 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* topic remote recovery via redpanda.remote.recovery handle correctly disabled retention 