### PR TITLE
transform/probe: precompute processor state counts

### DIFF
--- a/src/v/transform/probe.h
+++ b/src/v/transform/probe.h
@@ -13,26 +13,33 @@
 #include "model/transform.h"
 #include "wasm/probe.h"
 
+#include <absl/container/flat_hash_map.h>
+
 namespace transform {
 
-struct probe_gauges {
-    std::function<int64_t(model::transform_report::processor::state)>
-      num_processors;
+struct processor_state_change {
+    using state = model::transform_report::processor::state;
+
+    std::optional<state> from;
+    std::optional<state> to;
 };
 
 /** A per transform probe. */
 class probe : public wasm::transform_probe {
 public:
-    void setup_metrics(ss::sstring transform_name, probe_gauges);
+    void setup_metrics(ss::sstring);
 
     void increment_read_bytes(uint64_t bytes);
     void increment_write_bytes(uint64_t bytes);
     void increment_failure();
+    void state_change(processor_state_change);
 
 private:
     uint64_t _read_bytes = 0;
     uint64_t _write_bytes = 0;
     uint64_t _failures = 0;
+    absl::flat_hash_map<model::transform_report::processor::state, uint64_t>
+      _processor_state;
 };
 
 } // namespace transform

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -46,7 +46,10 @@ public:
       std::unique_ptr<source>,
       std::vector<std::unique_ptr<sink>>,
       probe*);
-
+    processor(const processor&) = delete;
+    processor(processor&&) = delete;
+    processor& operator=(const processor&) = delete;
+    processor& operator=(processor&&) = delete;
     virtual ~processor() = default;
     virtual ss::future<> start();
     virtual ss::future<> stop();


### PR DESCRIPTION
A followup to https://github.com/redpanda-data/redpanda/pull/14327 to prevent number of processors from becoming a stat performance issue.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
