### PR TITLE
storage: utilities to implement sliding window compaction

### DIFF
--- a/src/v/storage/CMakeLists.txt
+++ b/src/v/storage/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   NAME storage
   SRCS
     segment_reader.cc
+    segment_deduplication_utils.cc
     log_manager.cc
     disk_log_impl.cc
     disk_log_appender.cc

--- a/src/v/storage/compacted_index_reader.h
+++ b/src/v/storage/compacted_index_reader.h
@@ -17,6 +17,7 @@
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/file.hh>
+#include <seastar/core/loop.hh>
 
 #include <memory>
 namespace storage {
@@ -66,6 +67,22 @@ public:
               std::move(consumer), [this, timeout](Consumer& consumer) {
                   return do_consume(consumer, timeout);
               });
+        }
+
+        template<typename Func>
+        ss::future<>
+        for_each_async(Func f, model::timeout_clock::time_point timeout) {
+            while (true) {
+                while (likely(!is_slice_empty())) {
+                    if (co_await f(pop_batch()) == ss::stop_iteration::yes) {
+                        co_return;
+                    }
+                }
+                if (is_end_of_stream()) {
+                    co_return;
+                }
+                co_await do_load_slice(timeout);
+            }
         }
 
     private:
@@ -127,6 +144,12 @@ public:
     requires CompactedIndexEntryConsumer<Consumer>
     auto consume(Consumer consumer, model::timeout_clock::time_point timeout) {
         return _impl->consume(std::move(consumer), timeout);
+    }
+
+    template<typename Func>
+    ss::future<>
+    for_each_async(Func f, model::timeout_clock::time_point timeout) {
+        return _impl->for_each_async(std::move(f), timeout);
     }
 
     friend std::ostream&

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -119,7 +119,7 @@ compacted_offset_list_reducer::operator()(compacted_index::entry&& e) {
 }
 
 std::optional<model::record_batch>
-copy_data_segment_reducer::filter(model::record_batch&& batch) {
+copy_data_segment_reducer::filter(model::record_batch batch) {
     // do not compact raft configuration and archival metadata as they shift
     // offset translation
     if (!is_compactible(batch)) {

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -158,14 +158,14 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
     }
 
     // 1. compute which records to keep
-    const auto base = batch.base_offset();
     std::vector<int32_t> offset_deltas;
     offset_deltas.reserve(batch.record_count());
-    batch.for_each_record([this, base, &offset_deltas](const model::record& r) {
-        if (should_keep(base, r.offset_delta())) {
-            offset_deltas.push_back(r.offset_delta());
-        }
-    });
+    batch.for_each_record(
+      [this, &batch, &offset_deltas](const model::record& r) {
+          if (_should_keep_fn(batch, r)) {
+              offset_deltas.push_back(r.offset_delta());
+          }
+      });
 
     // 2. no record to keep
     if (offset_deltas.empty()) {

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -117,7 +117,7 @@ private:
 
 class copy_data_segment_reducer : public compaction_reducer {
 public:
-    using filter_t = ss::noncopyable_function<bool(
+    using filter_t = ss::noncopyable_function<ss::future<bool>(
       const model::record_batch&, const model::record&)>;
     copy_data_segment_reducer(
       filter_t f,
@@ -136,7 +136,10 @@ private:
     ss::future<ss::stop_iteration>
       do_compaction(model::compression, model::record_batch);
 
-    std::optional<model::record_batch> filter(model::record_batch);
+    ss::future<> maybe_keep_offset(
+      const model::record_batch&, const model::record&, std::vector<int32_t>&);
+
+    ss::future<std::optional<model::record_batch>> filter(model::record_batch);
 
     filter_t _should_keep_fn;
 

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -136,7 +136,7 @@ private:
         const auto o = base + model::offset(delta);
         return _list.contains(o);
     }
-    std::optional<model::record_batch> filter(model::record_batch&&);
+    std::optional<model::record_batch> filter(model::record_batch);
 
     compacted_offset_list _list;
     segment_appender* _appender;

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -123,8 +123,10 @@ public:
       filter_t f,
       segment_appender* a,
       bool internal_topic,
-      offset_delta_time apply_offset)
+      offset_delta_time apply_offset,
+      model::offset segment_last_offset = model::offset{})
       : _should_keep_fn(std::move(f))
+      , _segment_last_offset(segment_last_offset)
       , _appender(a)
       , _idx(index_state::make_empty_index(apply_offset))
       , _internal_topic(internal_topic) {}
@@ -143,6 +145,8 @@ private:
 
     filter_t _should_keep_fn;
 
+    // Offset to keep in case the index is empty as of getting to this offset.
+    model::offset _segment_last_offset;
     segment_appender* _appender;
     index_state _idx;
     size_t _acc{0};

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -124,10 +124,12 @@ public:
       segment_appender* a,
       bool internal_topic,
       offset_delta_time apply_offset,
-      model::offset segment_last_offset = model::offset{})
+      model::offset segment_last_offset = model::offset{},
+      compacted_index_writer* cidx = nullptr)
       : _should_keep_fn(std::move(f))
       , _segment_last_offset(segment_last_offset)
       , _appender(a)
+      , _compacted_idx(cidx)
       , _idx(index_state::make_empty_index(apply_offset))
       , _internal_topic(internal_topic) {}
 
@@ -148,6 +150,11 @@ private:
     // Offset to keep in case the index is empty as of getting to this offset.
     model::offset _segment_last_offset;
     segment_appender* _appender;
+
+    // Compacted index writer for the newly written segment. May not be
+    // supplied if the compacted index isn't expected to change, e.g. when
+    // rewriting a single segment filtering with its own compacted index.
+    compacted_index_writer* _compacted_idx;
     index_state _idx;
     size_t _acc{0};
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -462,6 +462,53 @@ ss::future<> disk_log_impl::do_compact(
     }
 }
 
+segment_set disk_log_impl::find_sliding_range(
+  const compaction_config& cfg, std::optional<model::offset> new_start_offset) {
+    // Collect all segments that have stable data.
+    segment_set::underlying_t buf;
+    for (const auto& seg : _segs) {
+        if (
+          new_start_offset
+          && seg->offsets().base_offset < new_start_offset.value()) {
+            // Skip over segments that are being truncated.
+            continue;
+        }
+        if (seg->has_appender() || !seg->has_compactible_offsets(cfg)) {
+            // Stop once we get to an unstable segment.
+            break;
+        }
+        buf.emplace_back(seg);
+    }
+    segment_set segs(std::move(buf));
+    if (segs.empty()) {
+        return segs;
+    }
+
+    // If a previous sliding window compaction ran, and there are no new
+    // segments, segments at the start of that window and above have been
+    // fully deduplicated and don't need to be compacted further.
+    //
+    // If there are new segments that have not been compacted, we can't make
+    // this claim, and compact everything again.
+    if (
+      segs.back()->finished_windowed_compaction()
+      && _last_compaction_window_start_offset.has_value()) {
+        while (!segs.empty()) {
+            if (
+              segs.back()->offsets().base_offset
+              >= _last_compaction_window_start_offset.value()) {
+                // A previous compaction deduplicated the keys above this
+                // offset. As such, segments above this point would not benefit
+                // from being included in the compaction window.
+                segs.pop_back();
+            } else {
+                break;
+            }
+        }
+    }
+    return segs;
+}
+
 std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
 disk_log_impl::find_compaction_range(const compaction_config& cfg) {
     /*

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -16,6 +16,8 @@
 #include "model/timeout_clock.h"
 #include "model/timestamp.h"
 #include "reflection/adl.h"
+#include "storage/compacted_offset_list.h"
+#include "storage/compaction_reducers.h"
 #include "storage/disk_log_appender.h"
 #include "storage/fwd.h"
 #include "storage/kvstore.h"
@@ -43,6 +45,7 @@
 #include <seastar/core/shared_ptr.hh>
 
 #include <fmt/format.h>
+#include <roaring/roaring.hh>
 
 #include <exception>
 #include <iterator>

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -168,6 +168,13 @@ private:
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_compaction_range(const compaction_config&);
+
+    // Collects an iterable list of segments over which to perform sliding
+    // window compaction.
+    segment_set find_sliding_range(
+      const compaction_config& cfg,
+      std::optional<model::offset> new_start_offset = std::nullopt);
+
     ss::future<std::optional<model::offset>> do_gc(gc_config);
 
     ss::future<> remove_empty_segments();
@@ -291,6 +298,7 @@ private:
     mutex _segments_rolling_lock;
 
     std::optional<model::offset> _cloud_gc_offset;
+    std::optional<model::offset> _last_compaction_window_start_offset;
     size_t _reclaimable_local_size_bytes{0};
 };
 

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -144,6 +144,20 @@ public:
 
     std::optional<model::offset> retention_offset(gc_config) const final;
 
+    // Collects an iterable list of segments over which to perform sliding
+    // window compaction.
+    segment_set find_sliding_range(
+      const compaction_config& cfg,
+      std::optional<model::offset> new_start_offset = std::nullopt);
+
+    void set_last_compaction_window_start_offset(model::offset o) {
+        _last_compaction_window_start_offset = o;
+    }
+
+    readers_cache& readers() { return *_readers_cache; }
+
+    storage_resources& resources();
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests
@@ -168,12 +182,6 @@ private:
       storage::compaction_config cfg);
     std::optional<std::pair<segment_set::iterator, segment_set::iterator>>
     find_compaction_range(const compaction_config&);
-
-    // Collects an iterable list of segments over which to perform sliding
-    // window compaction.
-    segment_set find_sliding_range(
-      const compaction_config& cfg,
-      std::optional<model::offset> new_start_offset = std::nullopt);
 
     ss::future<std::optional<model::offset>> do_gc(gc_config);
 
@@ -216,8 +224,6 @@ private:
 
     gc_config apply_overrides(gc_config) const;
     gc_config apply_base_overrides(gc_config) const;
-
-    storage_resources& resources();
 
     void wrote_stm_bytes(size_t);
 

--- a/src/v/storage/fwd.h
+++ b/src/v/storage/fwd.h
@@ -14,19 +14,23 @@
 namespace storage {
 
 class api;
-class node_api;
+class compacted_index_writer;
+class compaction_controller;
+class key_offset_map;
 class kvstore;
+class node_api;
+class ntp_config;
 class log;
 class log_manager;
-class ntp_config;
+class probe;
+class offset_translator_state;
+class readers_cache;
 class segment;
 class segment_appender;
 class simple_snapshot_manager;
 class snapshot_manager;
 class storage_resources;
-class readers_cache;
-class compaction_controller;
-class offset_translator_state;
+struct compaction_config;
 struct log_reader_config;
 struct timequery_config;
 

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -12,11 +12,11 @@
 
 namespace storage {
 
-simple_key_offset_map::simple_key_offset_map(size_t max_keys)
+simple_key_offset_map::simple_key_offset_map(std::optional<size_t> max_keys)
   : _memory_tracker(ss::make_shared<util::mem_tracker>("simple_key_offset_map"))
   , _map(util::mem_tracked::map<absl::btree_map, compaction_key, model::offset>(
       _memory_tracker))
-  , _max_keys(max_keys) {}
+  , _max_keys(max_keys ? *max_keys : default_key_limit) {}
 
 seastar::future<bool>
 simple_key_offset_map::put(const compaction_key& key, model::offset o) {

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -72,7 +72,8 @@ public:
      * Construct a new simple_key_offset_map with \p max_key maximum number of
      * keys.
      */
-    explicit simple_key_offset_map(size_t max_keys = default_key_limit);
+    explicit simple_key_offset_map(
+      std::optional<size_t> max_keys = std::nullopt);
 
     seastar::future<bool>
     put(const compaction_key& key, model::offset offset) override;

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -68,6 +68,7 @@ public:
         finished_self_compaction = 1U << 1U,
         mark_tombstone = 1U << 2U,
         closed = 1U << 3U,
+        finished_windowed_compaction = 1U << 4U,
     };
 
 public:
@@ -119,6 +120,8 @@ public:
     bool is_compacted_segment() const;
     void mark_as_finished_self_compaction();
     bool finished_self_compaction() const;
+    void mark_as_finished_windowed_compaction();
+    bool finished_windowed_compaction() const;
     /// \brief used for compaction, to reset the tracker from index
     void force_set_commit_offset_from_index();
     // low level api's are discouraged and might be deprecated
@@ -376,6 +379,13 @@ inline void segment::mark_as_finished_self_compaction() {
 inline bool segment::finished_self_compaction() const {
     return (_flags & bitflags::finished_self_compaction)
            == bitflags::finished_self_compaction;
+}
+inline void segment::mark_as_finished_windowed_compaction() {
+    _flags |= bitflags::finished_windowed_compaction;
+}
+inline bool segment::finished_windowed_compaction() const {
+    return (_flags & bitflags::finished_windowed_compaction)
+           == bitflags::finished_windowed_compaction;
 }
 inline std::optional<std::reference_wrapper<batch_cache_index>>
 segment::cache() {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -1,0 +1,153 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "storage/segment_deduplication_utils.h"
+
+#include "storage/compacted_index_writer.h"
+#include "storage/compaction_reducers.h"
+#include "storage/index_state.h"
+#include "storage/key_offset_map.h"
+#include "storage/probe.h"
+#include "storage/segment.h"
+#include "storage/segment_set.h"
+#include "storage/segment_utils.h"
+#include "storage/types.h"
+
+#include <exception>
+
+namespace storage {
+
+namespace {
+ss::future<ss::stop_iteration> put_entry(
+  key_offset_map& map,
+  const compacted_index::entry& idx_entry,
+  bool& fully_indexed) {
+    auto offset = idx_entry.offset + model::offset_delta(idx_entry.delta);
+    bool success = co_await map.put(idx_entry.key, offset);
+    if (success) {
+        co_return ss::stop_iteration::no;
+    }
+    fully_indexed = false;
+    co_return ss::stop_iteration::yes;
+}
+
+ss::future<bool> should_keep(
+  const key_offset_map& map,
+  const model::record_batch& b,
+  const model::record& r) {
+    const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
+    auto key_view = compaction_key{iobuf_to_bytes(r.key())};
+    auto key = enhance_key(
+      b.header().type, b.header().attrs.is_control(), key_view);
+    auto latest_offset_indexed = co_await map.get(key);
+    // If the map hasn't indexed the given key, we should keep the
+    // key.
+    if (!latest_offset_indexed.has_value()) {
+        co_return true;
+    }
+    // We should only keep the record if its offset is equal or higher than
+    // that indexed.
+    co_return o >= latest_offset_indexed.value();
+}
+} // anonymous namespace
+
+ss::future<bool> build_offset_map_for_segment(
+  const compaction_config& cfg, const segment& seg, key_offset_map& m) {
+    auto compaction_idx_path = seg.path().to_compacted_index();
+    auto compaction_idx_file = co_await internal::make_reader_handle(
+      compaction_idx_path, cfg.sanitizer_config);
+    std::exception_ptr eptr;
+    auto rdr = make_file_backed_compacted_reader(
+      compaction_idx_path, compaction_idx_file, cfg.iopc, 64_KiB);
+    try {
+        co_await rdr.verify_integrity();
+    } catch (...) {
+        // TODO: rebuild?
+        eptr = std::current_exception();
+    }
+    if (eptr) {
+        co_await rdr.close();
+        vlog(
+          gclog.error,
+          "Error building offset map for segment {}: {}",
+          seg.path(),
+          eptr);
+        std::rethrow_exception(eptr);
+    }
+    bool fully_indexed = true;
+    co_await rdr.for_each_async(
+      [&m, &fully_indexed](const compacted_index::entry& idx_entry) {
+          return put_entry(m, idx_entry, fully_indexed);
+      },
+      model::no_timeout);
+    co_return fully_indexed;
+}
+
+ss::future<model::offset> build_offset_map(
+  const compaction_config& cfg, const segment_set& segs, key_offset_map& m) {
+    if (segs.empty()) {
+        throw std::runtime_error("No segments to build offset map");
+    }
+
+    std::optional<model::offset> min_segment_fully_indexed;
+    // Build the key offset map by iterating on older and older data.
+    auto iter = std::prev(segs.end());
+    while (true) {
+        auto seg_fully_indexed = co_await build_offset_map_for_segment(
+          cfg, *(iter->get()), m);
+        if (!seg_fully_indexed) {
+            // The offset map is full. Note that we may have only partially
+            // indexed a segment, but it's safe to use this index. If no new
+            // segments come in, the next time we compact, we need to start
+            // from this segment for completeness.
+            break;
+        }
+        min_segment_fully_indexed = iter->get()->offsets().base_offset;
+        if (iter == segs.begin()) {
+            break;
+        }
+        iter--;
+    }
+    if (!min_segment_fully_indexed.has_value()) {
+        // If we broke out without setting an offset, we failed to index even a
+        // single segment, likely because it had too many keys.
+        throw std::runtime_error(
+          fmt::format("Couldn't index {}", iter->get()->path()));
+    }
+    co_return min_segment_fully_indexed.value();
+}
+
+ss::future<index_state> deduplicate_segment(
+  const compaction_config& cfg,
+  const key_offset_map& map,
+  ss::lw_shared_ptr<storage::segment> seg,
+  segment_appender& appender,
+  compacted_index_writer& cmp_idx_writer,
+  probe& probe,
+  offset_delta_time should_offset_delta_times) {
+    auto read_holder = co_await seg->read_lock();
+    auto rdr = internal::create_segment_full_reader(
+      seg, cfg, probe, std::move(read_holder));
+    auto copy_reducer = internal::copy_data_segment_reducer(
+      [&map](const model::record_batch& b, const model::record& r) {
+          return should_keep(map, b, r);
+      },
+      &appender,
+      seg->path().is_internal_topic(),
+      should_offset_delta_times,
+      seg->offsets().committed_offset,
+      &cmp_idx_writer);
+
+    auto new_idx = co_await rdr.consume(
+      std::move(copy_reducer), model::no_timeout);
+    new_idx.broker_timestamp = seg->index().broker_timestamp();
+    co_return new_idx;
+}
+
+} // namespace storage

--- a/src/v/storage/segment_deduplication_utils.h
+++ b/src/v/storage/segment_deduplication_utils.h
@@ -1,0 +1,51 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "model/fundamental.h"
+#include "seastarx.h"
+#include "storage/fwd.h"
+#include "storage/index_state.h"
+#include "storage/segment_set.h"
+
+namespace storage {
+using segment_list_t = fragmented_vector<segment_set::type>;
+
+// Adds the keys from the given compacted index reader to the map. Returns
+// true if the entire reader was successfully indexed, false if the index was
+// full before reaching the end of the segment.
+ss::future<bool> build_offset_map_for_segment(
+  const compaction_config& cfg, const segment& seg, key_offset_map& m);
+
+// Builds a map from key to latest offset from the last segment to the
+// earliest segment in 'segs'.
+//
+// Returns the start offset of the earliest segment that was fully indexed.
+// The resulting map may contain offsets below this point (i.e. the
+// preceding segment may have been partially indexed), but to fully
+// deduplicate the log, subsequent compactions should start below this
+// offset.
+//
+// Returns nullopt if there was a problem building the map or if the map
+// couldn't build a single segment.
+ss::future<model::offset> build_offset_map(
+  const compaction_config& cfg, const segment_set& segs, key_offset_map& m);
+
+// Rewrites 'seg' according to the parameters in 'cfg' to 'appender' and
+// 'cmp_idx_writer', deduplicating with latest offsets per key from 'map'.
+ss::future<index_state> deduplicate_segment(
+  const compaction_config& cfg,
+  const key_offset_map& map,
+  ss::lw_shared_ptr<storage::segment> seg,
+  segment_appender& appender,
+  compacted_index_writer& cmp_idx_writer,
+  storage::probe& probe,
+  offset_delta_time should_offset_delta_times);
+
+} // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -419,18 +419,22 @@ ss::future<storage::index_state> do_copy_segment_data(
       seg->reader().filename(),
       tmpname);
 
-    auto copy_reducer = [&] {
-        return copy_data_segment_reducer(
-          std::move(compacted_offsets),
-          appender.get(),
-          seg->path().is_internal_topic(),
-          apply_offset);
+    auto should_keep = [compacted_list = std::move(compacted_offsets)](
+                         const model::record_batch& b, const model::record& r) {
+        const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
+        return compacted_list.contains(o);
     };
+
+    auto copy_reducer = copy_data_segment_reducer(
+      std::move(should_keep),
+      appender.get(),
+      seg->path().is_internal_topic(),
+      apply_offset);
 
     // create the segment, get the in-memory index for the new segment
     auto new_index = co_await create_segment_full_reader(
                        seg, cfg, pb, std::move(rw_lock_holder))
-                       .consume(copy_reducer(), model::no_timeout)
+                       .consume(std::move(copy_reducer), model::no_timeout)
                        .finally([&] {
                            return appender->close().handle_exception(
                              [](std::exception_ptr e) {

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -422,7 +422,7 @@ ss::future<storage::index_state> do_copy_segment_data(
     auto should_keep = [compacted_list = std::move(compacted_offsets)](
                          const model::record_batch& b, const model::record& r) {
         const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
-        return compacted_list.contains(o);
+        return ss::make_ready_future<bool>(compacted_list.contains(o));
     };
 
     auto copy_reducer = copy_data_segment_reducer(

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -133,3 +133,13 @@ rp_test(
   ARGS "-- -c 1"
   LABELS storage
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_storage
+  SOURCES segment_deduplication_test.cc
+  LIBRARIES  v::storage v::storage_test_utils v::gtest_main
+  LABELS storage
+  ARGS "-- -c 1"
+)

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -1,0 +1,158 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "gmock/gmock.h"
+#include "random/generators.h"
+#include "storage/disk_log_impl.h"
+#include "storage/key_offset_map.h"
+#include "storage/segment_deduplication_utils.h"
+#include "storage/segment_utils.h"
+#include "storage/tests/disk_log_builder_fixture.h"
+#include "storage/tests/utils/disk_log_builder.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/util/defer.hh>
+
+#include <stdexcept>
+
+using namespace storage;
+
+namespace {
+ss::abort_source never_abort;
+} // anonymous namespace
+
+// Builds a segment layout:
+// [0    9][10   19][20    29]...
+void build_segments(storage::disk_log_builder& b, int num_segs) {
+    b | start();
+    auto& disk_log = b.get_disk_log_impl();
+    auto records_per_seg = 10;
+    for (int i = 0; i < num_segs; i++) {
+        auto offset = i * records_per_seg;
+        b | add_segment(offset)
+          | add_random_batch(
+            offset, records_per_seg, maybe_compress_batches::yes);
+    }
+    for (auto& seg : disk_log.segments()) {
+        seg->mark_as_finished_windowed_compaction();
+        if (seg->has_appender()) {
+            seg->appender().close().get();
+            seg->release_appender();
+        }
+    }
+}
+
+TEST(FindSlidingRangeTest, TestCollectSegments) {
+    storage::disk_log_builder b;
+    build_segments(b, 3);
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& disk_log = b.get_disk_log_impl();
+    for (int start = 0; start < 30; start += 5) {
+        for (int end = start; end < 30; end += 5) {
+            compaction_config cfg(
+              model::offset{end}, ss::default_priority_class(), never_abort);
+            auto segs = disk_log.find_sliding_range(cfg, model::offset{start});
+            if (end - start < 10) {
+                // If the compactible range isn't a full segment, we can't
+                // compact anything. We only care about full segments.
+                ASSERT_EQ(segs.size(), 0);
+                continue;
+            }
+            // We can't compact partial segments so we round the end down to
+            // the nearest segment boundary.
+            ASSERT_EQ((end - (end % 10) - start) / 10, segs.size())
+              << ssx::sformat("{} to {}: {}", start, end, segs.size());
+        }
+    }
+}
+
+TEST(FindSlidingRangeTest, TestCollectExcludesPrevious) {
+    storage::disk_log_builder b;
+    build_segments(b, 3);
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& disk_log = b.get_disk_log_impl();
+    compaction_config cfg(
+      model::offset{30}, ss::default_priority_class(), never_abort);
+    auto segs = disk_log.find_sliding_range(cfg);
+    ASSERT_EQ(3, segs.size());
+    ASSERT_EQ(segs.front()->offsets().base_offset(), 0);
+
+    // Let's pretend the previous compaction indexed offsets [20, 30).
+    // Subsequent compaction should ignore that last segment.
+    disk_log.set_last_compaction_window_start_offset(model::offset(20));
+    segs = disk_log.find_sliding_range(cfg);
+    ASSERT_EQ(2, segs.size());
+    ASSERT_EQ(segs.front()->offsets().base_offset(), 0);
+
+    disk_log.set_last_compaction_window_start_offset(model::offset(10));
+    segs = disk_log.find_sliding_range(cfg);
+    ASSERT_EQ(1, segs.size());
+    ASSERT_EQ(segs.front()->offsets().base_offset(), 0);
+}
+
+TEST(BuildOffsetMap, TestBuildSimpleMap) {
+    storage::disk_log_builder b;
+    build_segments(b, 3);
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& disk_log = b.get_disk_log_impl();
+    auto& segs = disk_log.segments();
+    compaction_config cfg(
+      model::offset{30}, ss::default_priority_class(), never_abort);
+    probe pb;
+
+    // Self-compact each segment so we're left with compaction indices. This is
+    // a requirement to build the offset map.
+    for (auto& seg : segs) {
+        storage::internal::self_compact_segment(
+          seg,
+          disk_log.stm_manager(),
+          cfg,
+          pb,
+          disk_log.readers(),
+          disk_log.resources(),
+          offset_delta_time::yes)
+          .get();
+    }
+
+    // Build a map, configuring it to hold too little data for even a single
+    // segment.
+    simple_key_offset_map too_small_map(5);
+    ASSERT_THAT(
+      [&] { build_offset_map(cfg, segs, too_small_map).get(); },
+      testing::ThrowsMessage<std::runtime_error>(
+        testing::HasSubstr("Couldn't index")));
+
+    // Now configure a map to index some segments.
+    simple_key_offset_map partial_map(15);
+    auto partial_o = build_offset_map(cfg, segs, partial_map).get();
+    ASSERT_GT(partial_o(), 0);
+
+    // Now make it large enough to index all segments.
+    simple_key_offset_map all_segs_map(100);
+    auto all_segs_o = build_offset_map(cfg, segs, all_segs_map).get();
+    ASSERT_EQ(all_segs_o(), 0);
+}
+
+TEST(BuildOffsetMap, TestBuildMapWithError) {
+    storage::disk_log_builder b;
+    build_segments(b, 3);
+    auto cleanup = ss::defer([&] { b.stop().get(); });
+    auto& segs = b.get_disk_log_impl().segments();
+    compaction_config cfg(
+      model::offset{30}, ss::default_priority_class(), never_abort);
+
+    // Proceed to window compaction without building any compacted indexes.
+    // This should indicate a failure to build the map.
+    simple_key_offset_map missing_index_map(100);
+    ASSERT_THAT(
+      [&] { build_offset_map(cfg, segs, missing_index_map).get(); },
+      testing::ThrowsMessage<std::runtime_error>(
+        testing::HasSubstr("compaction_index size is too small")));
+}

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -383,10 +383,12 @@ struct compaction_config {
       model::offset max_collect_offset,
       ss::io_priority_class p,
       ss::abort_source& as,
-      std::optional<ntp_sanitizer_config> san_cfg = std::nullopt)
+      std::optional<ntp_sanitizer_config> san_cfg = std::nullopt,
+      std::optional<size_t> max_keys = std::nullopt)
       : max_collectible_offset(max_collect_offset)
       , iopc(p)
       , sanitizer_config(std::move(san_cfg))
+      , key_offset_map_max_keys(max_keys)
       , asrc(&as) {}
 
     // Cannot delete or compact past this offset (i.e. for unresolved txn
@@ -396,6 +398,10 @@ struct compaction_config {
     ss::io_priority_class iopc;
     // use proxy fileops with assertions and/or failure injection
     std::optional<ntp_sanitizer_config> sanitizer_config;
+
+    // Limit the number of keys stored by a compaction's key-offset map.
+    std::optional<size_t> key_offset_map_max_keys;
+
     // abort source for compaction task
     ss::abort_source* asrc;
 


### PR DESCRIPTION
Adds utility methods that will be used in sliding window comapction. There are a few pieces to this:

- Selecting the "sliding range", the range of segments that are eligible for compaction in a given round of compaction. Only "traditionally" compactible segments (i.e. stable, can't be active) are viable, and segments that have had their keys deduplicated in a previous been sliding window compaction no longer need deduplication unless new non-compacted data shows up.
- Building the offset map, a mapping of keys to the latest offset seen for that key, with keys from multiple segments. Within the sliding range, we look at the newest segment and add all keys to the map, iterating on older and older segments. We keep track of the earliest segment that has been fully indexed, and in the next round of compaction, that is the new upper bound of the sliding range.
- Deduplicating the keys with the offset map. In this implementation, one segment is rewritten and replaced at a time, similar to self compaction.

This PR introduces the mechanisms to perform the above steps, but doesn't orchestrate them into a method to be used by compaction. This will come in a follow-up PR.

Fixes #14363

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
