### PR TITLE
c/partition_allocator: make `_highest_group` updates monotonic

### DIFF
--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -24,8 +24,6 @@ void allocation_state::rollback(
             remove_allocation(bs, domain);
             remove_final_count(bs, domain);
         }
-        // rollback for each assignment as the groups are distinct
-        _highest_group = raft::group_id(_highest_group() - 1);
     }
 }
 

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -133,7 +133,6 @@ public:
     ss::future<> apply_snapshot(const controller_snapshot&);
 
 private:
-    // reverts not only allocations but group_ids as well
     class intermediate_allocation {
     public:
         intermediate_allocation(

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -212,7 +212,7 @@ FIXTURE_TEST(partial_assignment, partition_allocator_fixture) {
 
     BOOST_REQUIRE_EQUAL(3, max_capacity());
     BOOST_REQUIRE_EQUAL(
-      allocator.state().last_group_id()(), max_partitions_in_cluster - 1);
+      allocator.state().last_group_id()(), max_partitions_in_cluster);
 }
 FIXTURE_TEST(max_deallocation, partition_allocator_fixture) {
     register_node(0, 3);


### PR DESCRIPTION
Previously, in case of failed allocation of partitions for new topics, we tried to revert `_highest_group` value as well. When a large number of topics were allocated in a single request concurrently (e.g. when MirrorMaker creates required topics on the destination cluster) and some of these requests bump into partition allocation limits, this could lead to duplicate group_ids.

As there is no reason to try to reuse group_ids, simply remove the code moving `_highest_group` backwards.

Fixes https://github.com/redpanda-data/redpanda/issues/12610

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes


### Bug Fixes

* Fix a bug that could lead to crashes with `double registration of group` assertion after trying to create a lot of topics in a single CreateTopics request when some of these topics could not be allocated (e.g. due to bumping into partition count limits).