### PR TITLE
transform/rpc: add retries to client

### DIFF
--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -85,21 +85,28 @@ private:
     ss::future<model::cluster_transform_report>
       generate_remote_report(model::node_id);
 
+    ss::future<cluster::errc> do_produce_once(produce_request);
     ss::future<produce_reply> do_local_produce(produce_request);
     ss::future<produce_reply>
       do_remote_produce(model::node_id, produce_request);
 
+    ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
+    do_store_wasm_binary_once(iobuf, model::timeout_clock::duration timeout);
     ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
     do_local_store_wasm_binary(iobuf, model::timeout_clock::duration timeout);
     ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
     do_remote_store_wasm_binary(
       model::node_id, iobuf, model::timeout_clock::duration timeout);
 
+    ss::future<cluster::errc> do_delete_wasm_binary_once(
+      uuid_t key, model::timeout_clock::duration timeout);
     ss::future<cluster::errc> do_local_delete_wasm_binary(
       uuid_t key, model::timeout_clock::duration timeout);
     ss::future<cluster::errc> do_remote_delete_wasm_binary(
       model::node_id, uuid_t key, model::timeout_clock::duration timeout);
 
+    ss::future<result<iobuf, cluster::errc>> do_load_wasm_binary_once(
+      model::offset, model::timeout_clock::duration timeout);
     ss::future<result<iobuf, cluster::errc>> do_local_load_wasm_binary(
       model::offset, model::timeout_clock::duration timeout);
     ss::future<result<iobuf, cluster::errc>> do_remote_load_wasm_binary(

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -82,7 +82,7 @@ public:
 private:
     ss::future<model::cluster_transform_report>
       generate_one_report(model::node_id);
-    ss::future<model::cluster_transform_report>
+    ss::future<result<model::cluster_transform_report, cluster::errc>>
       generate_remote_report(model::node_id);
 
     ss::future<cluster::errc> do_produce_once(produce_request);

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -66,10 +66,10 @@ public:
     ss::future<result<iobuf, cluster::errc>>
     load_wasm_binary(model::offset, model::timeout_clock::duration timeout);
 
-    ss::future<result<model::partition_id>>
+    ss::future<result<model::partition_id, cluster::errc>>
       find_coordinator(model::transform_offsets_key);
 
-    ss::future<result<model::transform_offsets_value>>
+    ss::future<result<model::transform_offsets_value, cluster::errc>>
       offset_fetch(model::transform_offsets_key);
 
     ss::future<cluster::errc> offset_commit(
@@ -116,11 +116,11 @@ private:
     ss::future<bool> try_create_wasm_binary_ntp();
     ss::future<> try_create_transform_offsets_topic();
 
-    ss::future<result<model::partition_id>>
+    ss::future<result<model::partition_id, cluster::errc>>
       find_coordinator_once(model::transform_offsets_key);
     ss::future<cluster::errc> offset_commit_once(
       model::transform_offsets_key, model::transform_offsets_value);
-    ss::future<result<model::transform_offsets_value>>
+    ss::future<result<model::transform_offsets_value, cluster::errc>>
       offset_fetch_once(model::transform_offsets_key);
 
     ss::future<find_coordinator_response>

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -28,6 +28,7 @@
 #include <absl/container/flat_hash_map.h>
 
 #include <memory>
+#include <type_traits>
 
 namespace transform::rpc {
 
@@ -137,6 +138,9 @@ private:
     ss::future<offset_fetch_response>
       do_remote_offset_fetch(model::node_id, offset_fetch_request);
 
+    template<typename Func>
+    std::invoke_result_t<Func> retry(Func&&);
+
     model::node_id _self;
     std::unique_ptr<cluster_members_cache> _cluster_members;
     // need partition_leaders_table to know which node owns the partitions
@@ -145,6 +149,7 @@ private:
     std::unique_ptr<topic_creator> _topic_creator;
     ss::sharded<::rpc::connection_cache>* _connections;
     ss::sharded<local_service>* _local_service;
+    ss::abort_source _as;
 };
 
 } // namespace transform::rpc

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -181,23 +181,15 @@ public:
         ss::future<cluster::errc>(kafka::partition_proxy*)>)
       = 0;
 
-    virtual ss::future<find_coordinator_response> invoke_on_shard(
-      ss::shard_id,
-      ss::noncopyable_function<
-        ss::future<find_coordinator_response>(cluster::partition_manager&)>)
+    virtual ss::future<find_coordinator_response>
+    invoke_on_shard(ss::shard_id, const model::ntp&, find_coordinator_request)
       = 0;
 
-    virtual ss::future<offset_commit_response> invoke_on_shard(
-      ss::shard_id,
-      ss::noncopyable_function<
-        ss::future<offset_commit_response>(cluster::partition_manager&)>)
-      = 0;
+    virtual ss::future<offset_commit_response>
+    invoke_on_shard(ss::shard_id, const model::ntp&, offset_commit_request) = 0;
 
-    virtual ss::future<offset_fetch_response> invoke_on_shard(
-      ss::shard_id,
-      ss::noncopyable_function<
-        ss::future<offset_fetch_response>(cluster::partition_manager&)>)
-      = 0;
+    virtual ss::future<offset_fetch_response>
+    invoke_on_shard(ss::shard_id, const model::ntp&, offset_fetch_request) = 0;
 };
 
 }; // namespace transform::rpc

--- a/src/v/transform/rpc/serde.cc
+++ b/src/v/transform/rpc/serde.cc
@@ -16,6 +16,8 @@
 
 #include <seastar/core/chunked_fifo.hh>
 
+#include <fmt/format.h>
+
 namespace transform::rpc {
 transformed_topic_data::transformed_topic_data(
   model::topic_partition tp, model::record_batch b)
@@ -73,4 +75,99 @@ operator<<(std::ostream& os, const find_coordinator_response& resp) {
       resp.ec);
     return os;
 }
+
+std::ostream& operator<<(std::ostream& os, const generate_report_request&) {
+    fmt::print(os, "{{ }}");
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const generate_report_reply& reply) {
+    fmt::print(os, "{{ transforms: {} }}", reply.report.transforms.size());
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const offset_fetch_request& resp) {
+    fmt::print(
+      os, "{{ key: {}, coordinator: {} }}", resp.key, resp.coordinator);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const offset_fetch_response& resp) {
+    fmt::print(os, "{{ errc: {}, result: {} }}", resp.errc, resp.result);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const load_wasm_binary_request& req) {
+    fmt::print(os, "{{ offset: {}, timeout: {} }}", req.offset, req.timeout);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const load_wasm_binary_reply& reply) {
+    fmt::print(
+      os, "{{ data_size: {}, errc: {} }}", reply.data.size_bytes(), reply.ec);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const delete_wasm_binary_reply& reply) {
+    fmt::print(os, "{{ errc: {} }}", reply.ec);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const delete_wasm_binary_request& req) {
+    fmt::print(os, "{{ key: {}, timeout: {} }}", req.key, req.timeout);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const store_wasm_binary_reply& reply) {
+    fmt::print(os, "{{ errc: {}, stored: {} }}", reply.ec, reply.stored);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const stored_wasm_binary_metadata& meta) {
+    fmt::print(os, "{{ key: {}, offset: {} }}", meta.key, meta.offset);
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const store_wasm_binary_request& req) {
+    fmt::print(
+      os,
+      "{{ data_size: {}, timeout: {} }}",
+      req.data.size_bytes(),
+      req.timeout);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const produce_request& req) {
+    fmt::print(
+      os,
+      "{{ topic_data: {}, timeout: {} }}",
+      fmt::join(req.topic_data, ", "),
+      req.timeout);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const produce_reply& reply) {
+    fmt::print(os, "{{ results: {} }}", fmt::join(reply.results, ", "));
+    return os;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const transformed_topic_data_result& result) {
+    fmt::print(os, "{{ errc: {}, tp: {} }}", result.err, result.tp);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const transformed_topic_data& data) {
+    fmt::print(
+      os, "{{ tp: {}, batches_size: {} }}", data.tp, data.batches.size());
+    return os;
+}
+
 } // namespace transform::rpc

--- a/src/v/transform/rpc/serde.h
+++ b/src/v/transform/rpc/serde.h
@@ -40,6 +40,8 @@ struct transformed_topic_data
     ss::chunked_fifo<model::record_batch> batches;
 
     transformed_topic_data share();
+    friend std::ostream&
+    operator<<(std::ostream&, const transformed_topic_data&);
 
     auto serde_fields() { return std::tie(tp, batches); }
 };
@@ -59,6 +61,7 @@ struct produce_request
     auto serde_fields() { return std::tie(topic_data, timeout); }
 
     produce_request share();
+    friend std::ostream& operator<<(std::ostream&, const produce_request&);
 
     ss::chunked_fifo<transformed_topic_data> topic_data;
     model::timeout_clock::duration timeout{};
@@ -78,6 +81,8 @@ struct transformed_topic_data_result
     cluster::errc err{cluster::errc::success};
 
     auto serde_fields() { return std::tie(tp, err); }
+    friend std::ostream&
+    operator<<(std::ostream&, const transformed_topic_data_result&);
 };
 
 struct produce_reply
@@ -90,6 +95,8 @@ struct produce_reply
       : results(std::move(r)) {}
 
     auto serde_fields() { return std::tie(results); }
+
+    friend std::ostream& operator<<(std::ostream&, const produce_reply&);
 
     ss::chunked_fifo<transformed_topic_data_result> results;
 };
@@ -109,6 +116,9 @@ struct store_wasm_binary_request
 
     auto serde_fields() { return std::tie(data, timeout); }
 
+    friend std::ostream&
+    operator<<(std::ostream&, const store_wasm_binary_request&);
+
     iobuf data;
     model::timeout_clock::duration timeout{};
 };
@@ -126,6 +136,9 @@ struct stored_wasm_binary_metadata
       , offset(o){};
 
     auto serde_fields() { return std::tie(key, offset); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const stored_wasm_binary_metadata&);
 
     uuid_t key{};
     model::offset offset;
@@ -146,6 +159,9 @@ struct store_wasm_binary_reply
 
     auto serde_fields() { return std::tie(ec, stored); }
 
+    friend std::ostream&
+    operator<<(std::ostream&, const store_wasm_binary_reply&);
+
     cluster::errc ec = cluster::errc::success;
     stored_wasm_binary_metadata stored;
 };
@@ -165,6 +181,9 @@ struct delete_wasm_binary_request
 
     auto serde_fields() { return std::tie(key, timeout); }
 
+    friend std::ostream&
+    operator<<(std::ostream&, const delete_wasm_binary_request&);
+
     uuid_t key{};
     model::timeout_clock::duration timeout{};
 };
@@ -181,6 +200,9 @@ struct delete_wasm_binary_reply
       : ec(e) {}
 
     auto serde_fields() { return std::tie(ec); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const delete_wasm_binary_reply&);
 
     cluster::errc ec = cluster::errc::success;
 };
@@ -200,6 +222,9 @@ struct load_wasm_binary_request
 
     auto serde_fields() { return std::tie(offset, timeout); }
 
+    friend std::ostream&
+    operator<<(std::ostream&, const load_wasm_binary_request&);
+
     model::offset offset;
     model::timeout_clock::duration timeout{};
 };
@@ -217,6 +242,9 @@ struct load_wasm_binary_reply
       , data(std::move(b)) {}
 
     auto serde_fields() { return std::tie(ec, data); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const load_wasm_binary_reply&);
 
     cluster::errc ec = cluster::errc::success;
     iobuf data;
@@ -255,7 +283,7 @@ struct find_coordinator_response
       coordinators;
 
     friend std::ostream&
-    operator<<(std::ostream&, const find_coordinator_request&);
+    operator<<(std::ostream&, const find_coordinator_response&);
 
     auto serde_fields() { return std::tie(ec, coordinators); }
 };
@@ -324,6 +352,8 @@ struct offset_fetch_request
     model::partition_id coordinator;
 
     auto serde_fields() { return std::tie(key, coordinator); }
+
+    friend std::ostream& operator<<(std::ostream&, const offset_fetch_request&);
 };
 
 struct offset_fetch_response
@@ -344,6 +374,9 @@ struct offset_fetch_response
     std::optional<model::transform_offsets_value> result;
 
     auto serde_fields() { return std::tie(errc, result); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const offset_fetch_response&);
 };
 
 struct generate_report_request
@@ -356,6 +389,9 @@ struct generate_report_request
     generate_report_request() = default;
 
     auto serde_fields() { return std::tie(); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const generate_report_request&);
 };
 
 struct generate_report_reply
@@ -370,6 +406,9 @@ struct generate_report_reply
       : report(std::move(r)) {}
 
     auto serde_fields() { return std::tie(report); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const generate_report_reply&);
 
     model::cluster_transform_report report;
 };

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -48,7 +48,7 @@ public:
     load_wasm_binary(model::offset, model::timeout_clock::duration timeout);
 
     ss::future<find_coordinator_response>
-    find_coordinator(find_coordinator_request&&);
+      find_coordinator(find_coordinator_request);
     ss::future<offset_commit_response> offset_commit(offset_commit_request);
     ss::future<offset_fetch_response> offset_fetch(offset_fetch_request);
 
@@ -66,12 +66,6 @@ private:
     ss::future<result<iobuf, cluster::errc>> consume_wasm_binary_reader(
       model::record_batch_reader, model::timeout_clock::duration);
 
-    ss::future<find_coordinator_response> do_find_coordinator(
-      ss::lw_shared_ptr<cluster::partition>, find_coordinator_request&&);
-    ss::future<offset_commit_response> do_local_offset_commit(
-      ss::lw_shared_ptr<cluster::partition>, offset_commit_request);
-    ss::future<offset_fetch_response> do_local_offset_fetch(
-      ss::lw_shared_ptr<cluster::partition>, offset_fetch_request);
     std::unique_ptr<topic_metadata_cache> _metadata_cache;
     std::unique_ptr<partition_manager> _partition_manager;
     std::unique_ptr<reporter> _reporter;

--- a/src/v/transform/rpc/tests/CMakeLists.txt
+++ b/src/v/transform/rpc/tests/CMakeLists.txt
@@ -9,7 +9,6 @@ rp_test(
     v::gtest_main
     v::transform_rpc
     v::model_test_utils
-    v::application
   ARGS "-- -c 1"
   LABELS transform_rpc
 )

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -36,6 +36,7 @@
 #include "transform/rpc/client.h"
 #include "transform/rpc/deps.h"
 #include "transform/rpc/logger.h"
+#include "transform/rpc/serde.h"
 #include "transform/rpc/service.h"
 #include "transform/tests/cluster_fixture.h"
 
@@ -303,23 +304,23 @@ public:
     }
 
     ss::future<find_coordinator_response> invoke_on_shard(
-      ss::shard_id,
-      ss::noncopyable_function<ss::future<find_coordinator_response>(
-        cluster::partition_manager&)>) override final {
+      ss::shard_id shard_id,
+      const model::ntp& ntp,
+      find_coordinator_request req) final {
         return ss::make_exception_future<find_coordinator_response>({});
     }
 
     ss::future<offset_commit_response> invoke_on_shard(
-      ss::shard_id,
-      ss::noncopyable_function<ss::future<offset_commit_response>(
-        cluster::partition_manager&)>) override final {
+      ss::shard_id shard_id,
+      const model::ntp& ntp,
+      offset_commit_request req) final {
         return ss::make_exception_future<offset_commit_response>({});
     }
 
     ss::future<offset_fetch_response> invoke_on_shard(
-      ss::shard_id,
-      ss::noncopyable_function<ss::future<offset_fetch_response>(
-        cluster::partition_manager&)>) override final {
+      ss::shard_id shard_id,
+      const model::ntp& ntp,
+      offset_fetch_request req) final {
         return ss::make_exception_future<offset_fetch_response>({});
     }
 


### PR DESCRIPTION
Make transform RPCs more robust via retries.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
