### PR TITLE
cluster/health_manager: add transform offset topic

### DIFF
--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -18,6 +18,7 @@
 #include "cluster/topic_table.h"
 #include "cluster/topics_frontend.h"
 #include "model/namespace.h"
+#include "model/transform.h"
 #include "seastarx.h"
 #include "vlog.h"
 
@@ -187,6 +188,10 @@ ss::future<> health_manager::do_tick() {
         if (ok) {
             ok = co_await ensure_topic_replication(
               model::topic_namespace_view(model::wasm_binaries_internal_ntp));
+        }
+
+        if (ok) {
+            ok = co_await ensure_topic_replication(model::transform_offsets_nt);
         }
     }
 


### PR DESCRIPTION
To ensure that the replication is correctly set if a cluster ever goes
from 1 -> 3+ nodes

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
