### PR TITLE
rptest: ok_to_fail test_ts_resource_utilization

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -823,11 +823,14 @@ class HighThroughputTest(RedpandaTest):
             producer.wait(timeout_sec=600)
             self.free_preallocated_nodes()
 
-    # The test is ignored because it can hardly achieve 1 GiB/s
-    # in the regular CDT environment, the test is designed for 3*is4gen.4xlarge
-    @ignore
+    @ok_to_fail
     @cluster(num_nodes=10, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_ts_resource_utilization(self):
+        """
+        In the AWS EC2 CDT testing env, this test is designed for
+        at least three is4gen.4xlarge or it will not achieve the
+        desired throughput to drive resource utilization.
+        """
         self._create_topic_spec()
         self.stage_tiered_storage_consuming()
 


### PR DESCRIPTION
Related to issue https://github.com/redpanda-data/cloudv2/issues/9613

First, have this test run on the scheduled buildkite jobs so we can determine which instance type is best to use. A follow-up PR will remove the `@ok_to_fail`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none