### PR TITLE
[v23.2.x] c/partition_allocator: make `_highest_group` updates monotonic

### DIFF
--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -24,8 +24,6 @@ void allocation_state::rollback(
             remove_allocation(bs, domain);
             remove_final_count(bs, domain);
         }
-        // rollback for each assignment as the groups are distinct
-        _highest_group = raft::group_id(_highest_group() - 1);
     }
 }
 

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -133,7 +133,6 @@ public:
     ss::future<> apply_snapshot(const controller_snapshot&);
 
 private:
-    // reverts not only allocations but group_ids as well
     class intermediate_allocation {
     public:
         intermediate_allocation(

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -212,7 +212,7 @@ FIXTURE_TEST(partial_assignment, partition_allocator_fixture) {
 
     BOOST_REQUIRE_EQUAL(3, max_capacity());
     BOOST_REQUIRE_EQUAL(
-      allocator.state().last_group_id()(), max_partitions_in_cluster - 1);
+      allocator.state().last_group_id()(), max_partitions_in_cluster);
 }
 FIXTURE_TEST(max_deallocation, partition_allocator_fixture) {
     register_node(0, 3);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14375
Fixes: https://github.com/redpanda-data/redpanda/issues/14390,