### PR TITLE
cloud_storage: Fix offset for leader epoch request for read-replica

### DIFF
--- a/tests/rptest/tests/offset_for_leader_epoch_read_replica_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_read_replica_test.py
@@ -1,0 +1,172 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.cluster import cluster
+from ducktape.mark import parametrize
+from ducktape.utils.util import wait_until
+
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.clients.kcl import KCL
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, SISettings, MetricsEndpoint, make_redpanda_service
+from rptest.tests.end_to_end import EndToEndTest
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+import time
+import random
+
+
+class OffsetForLeaderEpochReadReplicaTest(EndToEndTest):
+    # Size of the segment in the local storage
+    segment_size = 0x2000
+    # Generate at least 100 terms
+    num_terms = 20
+
+    def __init__(self, test_context):
+        self.extra_rp_conf = {
+            'enable_leader_balancer': False,
+            "log_compaction_interval_ms": 1000
+        }
+        super(OffsetForLeaderEpochReadReplicaTest, self).__init__(
+            test_context=test_context,
+            si_settings=SISettings(
+                test_context,
+                cloud_storage_max_connections=5,
+                log_segment_size=OffsetForLeaderEpochReadReplicaTest.
+                segment_size,
+                cloud_storage_enable_remote_write=True,
+                cloud_storage_enable_remote_read=True,
+                cloud_storage_readreplica_manifest_sync_timeout_ms=500,
+                cloud_storage_segment_max_upload_interval_sec=5,
+                fast_uploads=True),
+            extra_rp_conf=self.extra_rp_conf)
+
+        self.rr_settings = SISettings(
+            test_context,
+            bypass_bucket_creation=True,
+            cloud_storage_enable_remote_write=False,
+            cloud_storage_max_connections=5,
+            cloud_storage_readreplica_manifest_sync_timeout_ms=100,
+            cloud_storage_segment_max_upload_interval_sec=5,
+            cloud_storage_housekeeping_interval_ms=10)
+
+        self.topic_name = "panda-topic"
+        self.second_cluster = None
+        self.epoch_offsets = {}
+
+    def start_second_cluster(self) -> None:
+        self.second_cluster = make_redpanda_service(
+            self.test_context, num_brokers=3, si_settings=self.rr_settings)
+        self.second_cluster.start(start_si=False)
+
+    def create_source_topic(self):
+        self.rpk_client().create_topic(self.topic_name,
+                                       partitions=1,
+                                       replicas=3)
+
+    def create_read_replica_topic(self) -> None:
+        rpk_dst_cluster = RpkTool(self.second_cluster)
+        bucket_name = self.si_settings.cloud_storage_bucket
+
+        conf = {
+            'redpanda.remote.readreplica': bucket_name,
+        }
+
+        rpk_dst_cluster.create_topic(self.topic_name, config=conf)
+
+        def has_leader():
+            partitions = list(
+                rpk_dst_cluster.describe_topic(self.topic_name, tolerant=True))
+            for part in partitions:
+                if part.leader == -1:
+                    return False
+            return True
+
+        wait_until(has_leader,
+                   timeout_sec=60,
+                   backoff_sec=10,
+                   err_msg="Failed to create a read-replica, no leadership")
+
+    def produce(self, topic, msg_count):
+        msg_size = 64
+        for _ in range(0, self.num_terms):
+            KgoVerifierProducer.oneshot(context=self.test_context,
+                                        redpanda=self.redpanda,
+                                        topic=topic,
+                                        msg_size=msg_size,
+                                        msg_count=100,
+                                        use_transactions=False,
+                                        debug_logs=True)
+            self.transfer_leadership()
+            time.sleep(1)
+
+    def transfer_leadership(self):
+        res = list(self.rpk_client().describe_topic(self.topic_name))
+        self.epoch_offsets[res[0].leader_epoch] = res[0].high_watermark
+        self.logger.info(
+            f"leadership transfer, epoch {res[0]}, high watermark {res[0]}")
+
+        admin = Admin(self.redpanda)
+        leader = admin.get_partition_leader(namespace='kafka',
+                                            topic=self.topic_name,
+                                            partition=0)
+
+        broker_ids = [x['node_id'] for x in admin.get_brokers()]
+        transfer_to = random.choice([n for n in broker_ids if n != leader])
+        admin.transfer_leadership_to(namespace="kafka",
+                                     topic=self.topic_name,
+                                     partition=0,
+                                     target_id=transfer_to,
+                                     leader_id=leader)
+
+        admin.await_stable_leader(self.topic_name,
+                                  partition=0,
+                                  namespace='kafka',
+                                  timeout_s=20,
+                                  backoff_s=2,
+                                  check=lambda node_id: node_id == transfer_to)
+
+    def query_offset_for_leader_epoch(self, query_rrr):
+        self.logger.info(
+            f"query offset for leader epoch started, RRR={query_rrr}")
+
+        kcl = KCL(self.second_cluster) if query_rrr else KCL(self.redpanda)
+
+        for epoch, offset in self.epoch_offsets.items():
+
+            def check():
+                self.logger.info(
+                    f"querying epoch {epoch} end offsets, expected to get {offset}"
+                )
+                epoch_end_offset = kcl.offset_for_leader_epoch(
+                    topics=self.topic_name,
+                    leader_epoch=epoch)[0].epoch_end_offset
+                if epoch_end_offset < 0:
+                    # NOT_LEADER_FOR_PARTITION error, retry
+                    return False
+                self.logger.info(
+                    f"epoch {epoch} end_offset: {epoch_end_offset}, expected offset: {offset}"
+                )
+                assert epoch_end_offset == offset, f"{epoch_end_offset} vs {offset}"
+                return True
+
+            wait_until(check,
+                       timeout_sec=30,
+                       backoff_sec=10,
+                       err_msg=f"Failed query epoch/offset {epoch}/{offset}")
+
+    @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_offset_for_leader_epoch(self):
+        self.start_redpanda(num_nodes=3)
+        self.create_source_topic()
+        self.produce(self.topic_name, 1000)
+        self.query_offset_for_leader_epoch(False)
+        self.start_second_cluster()
+        self.create_read_replica_topic()
+        self.query_offset_for_leader_epoch(True)


### PR DESCRIPTION
Read-replica uses local Raft group as a source of information for `OffsetForLeaderEpoch` request. This PR fixes this problem and adds a reproducer in form of ducktape test.

Fixes #14402 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Fix OffsetForLeaderEpoch for read-replicas