### PR TITLE
transform/processor: streamline transforms

### DIFF
--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -25,6 +25,20 @@
 
 namespace transform {
 
+namespace {
+
+/**
+ * A specific exception to throw on processor::stop so that we're not accidently
+ * swallowing unexpected exceptions.
+ */
+class processor_shutdown_exception : public std::exception {
+    const char* what() const noexcept override {
+        return "processor shutting down";
+    }
+};
+
+} // namespace
+
 processor::processor(
   model::transform_id id,
   model::ntp ntp,
@@ -42,6 +56,8 @@ processor::processor(
   , _sinks(std::move(sinks))
   , _error_callback(std::move(cb))
   , _probe(p)
+  , _consumer_transform_pipe(1)
+  , _transform_producer_pipe(1)
   , _task(ss::now())
   , _logger(tlog, ss::format("{}/{}", _meta.name(), _ntp.tp.partition())) {
     vassert(
@@ -57,33 +73,33 @@ ss::future<> processor::start() {
         vlog(_logger.warn, "error starting processor engine: {}", ex);
         _error_callback(_id, _ntp, _meta);
     }
-    _task = run_transform_loop();
+    _task = when_all_shutdown(
+      run_consumer_loop(), run_transform_loop(), run_producer_loop());
 }
 
 ss::future<> processor::stop() {
-    _as.request_abort();
+    auto ex = std::make_exception_ptr(processor_shutdown_exception());
+    _as.request_abort_ex(ex);
+    _consumer_transform_pipe.abort(ex);
+    _transform_producer_pipe.abort(ex);
     co_await std::exchange(_task, ss::now());
     co_await _engine->stop();
 }
 
-ss::future<> processor::run_transform_loop() {
+ss::future<> processor::poll_sleep() {
+    constexpr auto fallback_poll_interval = std::chrono::seconds(1);
+    simple_time_jitter<ss::lowres_clock> jitter(fallback_poll_interval);
     try {
-        co_await do_run_transform_loop();
-    } catch (const ss::abort_requested_exception&) {
-        // do nothing, we wanted to stop.
-    } catch (...) {
-        vlog(
-          _logger.warn,
-          "error running processor: {}",
-          std::current_exception());
-        _error_callback(_id, _ntp, _meta);
+        co_await ss::sleep_abortable<ss::lowres_clock>(
+          jitter.next_duration(), _as);
+    } catch (const ss::sleep_aborted&) {
+        // do nothing, the caller will handle exiting properly.
     }
 }
-ss::future<> processor::do_run_transform_loop() {
+
+ss::future<> processor::run_consumer_loop() {
     auto offset = co_await _source->load_latest_offset();
     vlog(_logger.trace, "starting at offset {}", offset);
-    // TODO(rockwood): Optimize this loop, we should not wait for the transform
-    // or for writing before attempting to read more data.
     while (!_as.abort_requested()) {
         auto reader = co_await _source->read_batch(offset, &_as);
         auto batches = co_await model::consume_reader_to_memory(
@@ -93,28 +109,50 @@ ss::future<> processor::do_run_transform_loop() {
               _logger.trace,
               "received no results, sleeping before polling at offset {}",
               offset);
-            constexpr auto fallback_poll_interval = std::chrono::seconds(1);
-            simple_time_jitter<ss::lowres_clock> jitter(fallback_poll_interval);
-            try {
-                co_await ss::sleep_abortable<ss::lowres_clock>(
-                  jitter.next_duration(), _as);
-            } catch (const ss::sleep_aborted&) {
-                // do nothing, the next iteration of the loop will exit
-            }
+            co_await poll_sleep();
             continue;
         }
         offset = model::next_offset(batches.back().last_offset());
-        vlog(_logger.trace, "consumed upto offset {}", offset);
-        ss::chunked_fifo<model::record_batch> transformed_batches;
-        transformed_batches.reserve(batches.size());
+        vlog(_logger.trace, "consumed up to offset {}", offset);
         for (auto& batch : batches) {
             _probe->increment_read_bytes(batch.size_bytes());
-            auto transformed = co_await _engine->transform(
-              std::move(batch), _probe);
-            _probe->increment_write_bytes(transformed.size_bytes());
-            transformed_batches.push_back(std::move(transformed));
+            co_await _consumer_transform_pipe.push_eventually(std::move(batch));
         }
-        co_await _sinks[0]->write(std::move(transformed_batches));
+    }
+}
+
+ss::future<> processor::run_transform_loop() {
+    while (!_as.abort_requested()) {
+        auto batch = co_await _consumer_transform_pipe.pop_eventually();
+        batch = co_await _engine->transform(std::move(batch), _probe);
+        co_await _transform_producer_pipe.push_eventually(std::move(batch));
+    }
+}
+
+ss::future<> processor::run_producer_loop() {
+    while (!_as.abort_requested()) {
+        auto batch = co_await _transform_producer_pipe.pop_eventually();
+        _probe->increment_write_bytes(batch.size_bytes());
+        ss::chunked_fifo<model::record_batch> batches;
+        batches.push_back(std::move(batch));
+        co_await _sinks[0]->write(std::move(batches));
+    }
+}
+
+template<typename... T>
+ss::future<> processor::when_all_shutdown(T&&... futs) {
+    return ss::when_all_succeed(handle_run_loop(std::forward<T>(futs))...)
+      .discard_result();
+}
+
+ss::future<> processor::handle_run_loop(ss::future<> fut) {
+    try {
+        co_await std::move(fut);
+    } catch (const processor_shutdown_exception&) {
+        // Do nothing, this is an expected error on shutdown
+    } catch (const std::exception& ex) {
+        vlog(_logger.warn, "error running transform: {}", ex);
+        _error_callback(_id, _ntp, _meta);
     }
 }
 


### PR DESCRIPTION
This makes a number of performance improvements to the transform processor.

We attempt to pipeline operations as much as possible, so one step doesn't stop other parts from making progress. 
This is done by splitting the processor into multiple fibers, one for reading, one for writing and one for transforming.

Additionally, we try not to keep intermidiate buffers of batches unless there is natural backpressure from the system
(for example because writes are slow or the transform is running slow).

This is a prerequisite to overall transform subsystem memory caps, mostly by ensuring this "inflight" data all transform
processors is accounted for (next PR).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
