### PR TITLE
c/tx_gt_frontend: do not retry when not leader for `tx` topic partition

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -348,7 +348,7 @@ ss::future<> tx_gateway_frontend::stop() {
 }
 
 ss::future<std::optional<model::ntp>>
-tx_gateway_frontend::get_ntp(kafka::transactional_id id) {
+tx_gateway_frontend::ntp_for_tx_id(kafka::transactional_id id) {
     if (!_feature_table.local().is_active(
           features::feature::transaction_partitioning)) {
         co_return model::legacy_tm_ntp;
@@ -1436,7 +1436,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::do_init_tm_tx(
 
 ss::future<add_paritions_tx_reply> tx_gateway_frontend::add_partition_to_tx(
   add_paritions_tx_request request, model::timeout_clock::duration timeout) {
-    auto tx_ntp_opt = co_await get_ntp(request.transactional_id);
+    auto tx_ntp_opt = co_await ntp_for_tx_id(request.transactional_id);
     if (!tx_ntp_opt) {
         co_return make_add_partitions_error_response(
           request, tx_errc::coordinator_not_available);
@@ -1658,7 +1658,7 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
 
 ss::future<add_offsets_tx_reply> tx_gateway_frontend::add_offsets_to_tx(
   add_offsets_tx_request request, model::timeout_clock::duration timeout) {
-    auto tx_ntp_opt = co_await get_ntp(request.transactional_id);
+    auto tx_ntp_opt = co_await ntp_for_tx_id(request.transactional_id);
     if (!tx_ntp_opt) {
         co_return add_offsets_tx_reply{
           .error_code = tx_errc::coordinator_not_available};
@@ -1766,7 +1766,7 @@ ss::future<add_offsets_tx_reply> tx_gateway_frontend::do_add_offsets_to_tx(
 
 ss::future<end_tx_reply> tx_gateway_frontend::end_txn(
   end_tx_request request, model::timeout_clock::duration timeout) {
-    auto tx_ntp_opt = co_await get_ntp(request.transactional_id);
+    auto tx_ntp_opt = co_await ntp_for_tx_id(request.transactional_id);
     if (!tx_ntp_opt) {
         co_return end_tx_reply{
           .error_code = tx_errc::coordinator_not_available};

--- a/src/v/cluster/tx_gateway_frontend.h
+++ b/src/v/cluster/tx_gateway_frontend.h
@@ -43,7 +43,8 @@ public:
       ss::sharded<cluster::tm_stm_cache_manager>&,
       config::binding<uint64_t> max_transactions_per_coordinator);
 
-    ss::future<std::optional<model::ntp>> get_ntp(kafka::transactional_id);
+    ss::future<std::optional<model::ntp>>
+      ntp_for_tx_id(kafka::transactional_id);
     ss::future<bool> hosts(model::partition_id, kafka::transactional_id);
     ss::future<fetch_tx_reply> fetch_tx_locally(
       kafka::transactional_id, model::term_id, model::partition_id);

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -3792,7 +3792,7 @@ admin_server::delete_partition_handler(std::unique_ptr<ss::http::request> req) {
         throw co_await redirect_to_leader(*req, *r.ntp);
     }
 
-    auto tx_ntp = co_await tx_frontend.local().get_ntp(tid);
+    auto tx_ntp = co_await tx_frontend.local().ntp_for_tx_id(tid);
     if (!tx_ntp) {
         throw ss::httpd::bad_request_exception("Coordinator not available");
     }


### PR DESCRIPTION
Changed the logic in `init_tm_tx` not to retry when current node is not leader for partition hosting particular transactional id. Previously when current node wasn't a leader for partition host the transactional id the logic retired finding `tx_id` hosting `ntp` in the same way as it would be missing in metadata cache.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- Do not retry waiting for `tx_id` hosting partition when current node is not leader
