### PR TITLE
tests: fix s3 GCP endpoint in SISettings

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -419,7 +419,7 @@ class SISettings:
             self.cloud_storage_api_endpoint = cloud_storage_api_endpoint
             if test_context.globals.get(self.GLOBAL_CLOUD_PROVIDER,
                                         'aws') == 'gcp':
-                self.cloud_storage_api_endpoint = 'storage.googleapis.com'
+                self.cloud_storage_api_endpoint = 'https://storage.googleapis.com'
             self.cloud_storage_api_endpoint_port = cloud_storage_api_endpoint_port
         elif self.cloud_storage_type == CloudStorageType.ABS:
             self.cloud_storage_azure_shared_key = self.ABS_AZURITE_KEY


### PR DESCRIPTION
running tests on gcp returns an error

```
JSONDecodeError('Expecting value: line 1 column 1 (char 0)')
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 184, in _do_run
    data = self.run_test()
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 269, in run_test
    return self.test_context.function(self.test)
  File "/usr/local/lib/python3.10/dist-packages/ducktape/mark/_mark.py", line 481, in wrapper
    return functools.partial(f, *args, **kwargs)(*w_args, **w_kwargs)
  File "/home/ubuntu/redpanda/tests/rptest/services/cluster.py", line 159, in wrapped
    self.redpanda.stop_and_scrub_object_storage()
  File "/home/ubuntu/redpanda/tests/rptest/services/redpanda.py", line 3830, in stop_and_scrub_object_storage
    report = self._get_object_storage_report(timeout=scrub_timeout)
  File "/home/ubuntu/redpanda/tests/rptest/services/redpanda.py", line 3738, in _get_object_storage_report
    report = json.loads(output)
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

The underlying issue is from the `rp_storage_tool` execution:
`{ kind: Reset(StreamId(1), PROTOCOL_ERROR, Remote) }`

ref
redpanda-data/devprod#882

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [X] v23.1.x
- [X] v22.3.x

## Release Notes

* none
