### PR TITLE
transform: remove copartitioning requirement

### DIFF
--- a/src/v/cluster/plugin_frontend.cc
+++ b/src/v/cluster/plugin_frontend.cc
@@ -505,18 +505,6 @@ errc plugin_frontend::validator::validate_mutation(const transform_cmd& cmd) {
                     out_name.tp);
                   return errc::transform_invalid_create;
               }
-              if (
-                output_config.partition_count < input_config.partition_count) {
-                  // copartitioning is required
-                  vlog(
-                    clusterlog.info,
-                    "attempted to deploy transform {} without copartitioning "
-                    "{} < {}",
-                    cmd.value.name,
-                    output_config.partition_count,
-                    input_config.partition_count);
-                  return errc::transform_invalid_create;
-              }
               if (would_cause_cycle(cmd.value.input_topic, out_name)) {
                   vlog(
                     clusterlog.info,

--- a/src/v/cluster/tests/plugin_frontend_validation_test.cc
+++ b/src/v/cluster/tests/plugin_frontend_validation_test.cc
@@ -294,25 +294,6 @@ TEST_F(PluginValidationTest, MultipleOutputs) {
       errc::transform_invalid_create);
 }
 
-TEST_F(PluginValidationTest, Copartitioned) {
-    EXPECT_EQ(create_topic("foo", {.partition_count = 2}), errc::success);
-    EXPECT_EQ(create_topic("bar", {.partition_count = 4}), errc::success);
-    EXPECT_EQ(
-      upsert_transform({
-        .name = "missing-output-partitions",
-        .src = "bar",
-        .sinks = {"foo"},
-      }),
-      errc::transform_invalid_create);
-    EXPECT_EQ(
-      upsert_transform({
-        .name = "ok-to-have-extra-output-partitions",
-        .src = "foo",
-        .sinks = {"bar"},
-      }),
-      errc::success);
-}
-
 TEST_F(PluginValidationTest, RemoveMustExist) {
     EXPECT_EQ(delete_transform("bar2foo"), errc::transform_does_not_exist);
 }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1173,6 +1173,7 @@ void application::wire_up_runtime_services(
           &controller->get_plugin_frontend(),
           &controller->get_feature_table(),
           &raft_group_manager,
+          &controller->get_topics_state(),
           &partition_manager,
           &_transform_rpc_client)
           .get();

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -42,6 +42,7 @@ public:
       ss::sharded<cluster::plugin_frontend>* plugin_frontend,
       ss::sharded<features::feature_table>* feature_table,
       ss::sharded<raft::group_manager>* group_manager,
+      ss::sharded<cluster::topic_table>* topic_table,
       ss::sharded<cluster::partition_manager>* partition_manager,
       ss::sharded<rpc::client>* rpc_client);
     service(const service&) = delete;
@@ -98,6 +99,7 @@ private:
     ss::sharded<cluster::plugin_frontend>* _plugin_frontend;
     ss::sharded<features::feature_table>* _feature_table;
     ss::sharded<raft::group_manager>* _group_manager;
+    ss::sharded<cluster::topic_table>* _topic_table;
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<rpc::client>* _rpc_client;
     std::unique_ptr<manager<ss::lowres_clock>> _manager;


### PR DESCRIPTION
Remove copartitioning requirement from transforms, we do this by round robin style assigning input partitions to output partitions.
This will support filter use cases that want to take a 100 partition topic and write to a 1 partition output topic (assuming the filter removes 99% of data).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
