### PR TITLE
ci: Handle errors on cloud namespaces cleanup

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -176,6 +176,9 @@ class CloudCleanup():
                     for net in networks:
                         # Add network delete handle to own list
                         net_queue += [self.cloudv2.network_endpoint(net['id'])]
+                # At this point, we should not add namespace to cleaning
+                # if it has any resources. Just leave it to the next run
+                continue
             # Add ns delete handle to the list
             ns_queue += [self.cloudv2.namespace_endpoint(uuid=ns['id'])]
         # Use ThreadPool

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -167,6 +167,9 @@ class RpCloudApiClient(object):
         return _r
 
     def delete_resource(self, resource_handle):
-        _r = self._http_delete(endpoint=resource_handle)
-        self._logger.debug(f"...delete requested for '{resource_handle}'")
+        try:
+            _r = self._http_delete(endpoint=resource_handle)
+            self._logger.debug(f"...delete requested for '{resource_handle}'")
+        except Exception as e:
+            self.log.warning(f"# Warning deletion failed: {e}")
         return _r


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none