### PR TITLE
cloud_storage: give each housekeeping job its own RTC root node

### DIFF
--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -148,7 +148,7 @@ std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
 }
 
 ss::future<housekeeping_job::run_result>
-adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
+adjacent_segment_merger::run(run_quota_t quota) {
     ss::gate::holder h(_gate);
     run_result result{
       .status = run_status::skipped,
@@ -227,7 +227,7 @@ adjacent_segment_merger::run(retry_chain_node& rtc, run_quota_t quota) {
               src->size_bytes());
         }
         auto uploaded = co_await _archiver.upload(
-          std::move(*archiver_units), std::move(*upl), std::ref(rtc));
+          std::move(*archiver_units), std::move(*upl), std::ref(_root_rtc));
         if (uploaded) {
             _last = next;
             result.status = run_status::ok;

--- a/src/v/archival/adjacent_segment_merger.h
+++ b/src/v/archival/adjacent_segment_merger.h
@@ -25,10 +25,7 @@ namespace archival {
 class adjacent_segment_merger : public housekeeping_job {
 public:
     explicit adjacent_segment_merger(
-      ntp_archiver& parent,
-      retry_chain_logger& ctxlog,
-      bool,
-      config::binding<bool>);
+      ntp_archiver& parent, bool, config::binding<bool>);
 
     ss::future<run_result>
     run(retry_chain_node& rtc, run_quota_t quota) override;
@@ -43,6 +40,8 @@ public:
 
     void acquire() override;
     void release() override;
+
+    retry_chain_node& get_root_retry_chain_node() override;
 
     ss::sstring name() const override;
 
@@ -65,10 +64,11 @@ private:
 
     model::offset _last;
     ntp_archiver& _archiver;
-    retry_chain_logger& _ctxlog;
     config::binding<std::optional<size_t>> _target_segment_size;
     config::binding<std::optional<size_t>> _min_segment_size;
     ss::abort_source _as;
+    retry_chain_node _root_rtc;
+    retry_chain_logger _ctxlog;
     ss::gate _gate;
     ss::gate::holder _holder;
 };

--- a/src/v/archival/adjacent_segment_merger.h
+++ b/src/v/archival/adjacent_segment_merger.h
@@ -27,8 +27,7 @@ public:
     explicit adjacent_segment_merger(
       ntp_archiver& parent, bool, config::binding<bool>);
 
-    ss::future<run_result>
-    run(retry_chain_node& rtc, run_quota_t quota) override;
+    ss::future<run_result> run(run_quota_t quota) override;
 
     void interrupt() override;
 

--- a/src/v/archival/purger.cc
+++ b/src/v/archival/purger.cc
@@ -42,7 +42,8 @@ purger::purger(
   cluster::topic_table& tt,
   ss::sharded<cluster::topics_frontend>& tf,
   ss::sharded<cluster::members_table>& mt)
-  : _api(r)
+  : _root_rtc(_as)
+  , _api(r)
   , _topic_table(tt)
   , _topics_frontend(tf)
   , _members_table(mt) {}
@@ -562,6 +563,8 @@ void purger::set_enabled(bool e) { _enabled = e; }
 void purger::acquire() { _holder = ss::gate::holder(_gate); }
 
 void purger::release() { _holder.release(); }
+
+retry_chain_node& purger::get_root_retry_chain_node() { return _root_rtc; }
 
 ss::sstring purger::name() const { return "purger"; }
 

--- a/src/v/archival/purger.cc
+++ b/src/v/archival/purger.cc
@@ -319,8 +319,7 @@ purger::global_position purger::get_global_position() {
     return global_position{.self = result, .total = total};
 }
 
-ss::future<housekeeping_job::run_result>
-purger::run(retry_chain_node& parent_rtc, run_quota_t quota) {
+ss::future<housekeeping_job::run_result> purger::run(run_quota_t quota) {
     auto gate_holder = _gate.hold();
 
     run_result result{
@@ -409,11 +408,12 @@ purger::run(retry_chain_node& parent_rtc, run_quota_t quota) {
             // Persist a record that we have started purging: this is useful for
             // anything reading from the bucket that wants to distinguish
             // corruption from in-progress deletion.
+            retry_chain_node pre_purge_marker_rtc(5s, 1s, &_root_rtc);
             auto marker_r = co_await write_remote_lifecycle_marker(
               nt_revision,
               bucket,
               cloud_storage::lifecycle_status::purging,
-              parent_rtc);
+              pre_purge_marker_rtc);
             if (marker_r != cloud_storage::upload_result::success) {
                 vlog(
                   archival_log.warn,
@@ -435,7 +435,7 @@ purger::run(retry_chain_node& parent_rtc, run_quota_t quota) {
                 }
 
                 auto purge_r = co_await purge_partition(
-                  marker, bucket, ntp, marker.initial_revision_id, parent_rtc);
+                  marker, bucket, ntp, marker.initial_revision_id, _root_rtc);
 
                 result.consumed += run_quota_t(purge_r.ops);
                 result.remaining
@@ -470,7 +470,7 @@ purger::run(retry_chain_node& parent_rtc, run_quota_t quota) {
               archival_log.debug,
               "Erasing topic manifest {}",
               topic_manifest_path);
-            retry_chain_node topic_manifest_rtc(5s, 1s, &parent_rtc);
+            retry_chain_node topic_manifest_rtc(5s, 1s, &_root_rtc);
             auto manifest_delete_result = co_await _api.delete_object(
               bucket,
               cloud_storage_clients::object_key(topic_manifest_path),
@@ -489,11 +489,12 @@ purger::run(retry_chain_node& parent_rtc, run_quota_t quota) {
             // unambiguously understand that this topic is gone due to an
             // intentional deletion, and that any stray objects belonging to
             // this topic may be purged.
+            retry_chain_node post_purge_marker_rtc(5s, 1s, &_root_rtc);
             marker_r = co_await write_remote_lifecycle_marker(
               nt_revision,
               bucket,
               cloud_storage::lifecycle_status::purged,
-              parent_rtc);
+              post_purge_marker_rtc);
             if (marker_r != cloud_storage::upload_result::success) {
                 vlog(
                   archival_log.warn,

--- a/src/v/archival/purger.h
+++ b/src/v/archival/purger.h
@@ -35,8 +35,7 @@ public:
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::members_table>&);
 
-    ss::future<run_result>
-    run(retry_chain_node& rtc, run_quota_t quota) override;
+    ss::future<run_result> run(run_quota_t quota) override;
 
     void interrupt() override;
 

--- a/src/v/archival/purger.h
+++ b/src/v/archival/purger.h
@@ -49,6 +49,8 @@ public:
     void acquire() override;
     void release() override;
 
+    retry_chain_node& get_root_retry_chain_node() override;
+
     ss::sstring name() const override;
 
 private:
@@ -117,6 +119,7 @@ private:
     global_position get_global_position();
 
     ss::abort_source _as;
+    retry_chain_node _root_rtc;
     ss::gate _gate;
 
     // A gate holder we keep on behalf of the housekeeping service, when

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -55,8 +55,7 @@ ss::future<> scrubber::await_feature_enabled() {
     _scheduler.pick_next_scrub_time();
 }
 
-ss::future<scrubber::run_result>
-scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
+ss::future<scrubber::run_result> scrubber::run(run_quota_t quota) {
     ss::gate::holder holder{_gate};
 
     if (auto [skip, reason] = should_skip(); skip) {
@@ -74,7 +73,7 @@ scrubber::run(retry_chain_node& rtc_node, run_quota_t quota) {
       quota(),
       scrub_from);
 
-    retry_chain_node anomaly_detection_rtc(5min, 100ms, &rtc_node);
+    retry_chain_node anomaly_detection_rtc(5min, 100ms, &_root_rtc);
     auto detect_result = co_await _detector.run(
       anomaly_detection_rtc, quota, scrub_from);
 

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -42,7 +42,6 @@ public:
     scrubber(
       ntp_archiver& archiver,
       cloud_storage::remote& remote,
-      retry_chain_logger& logger,
       features::feature_table& feature_table,
       config::binding<bool> config_enabled,
       config::binding<std::chrono::milliseconds> interval,
@@ -64,6 +63,8 @@ public:
     void acquire() override;
     void release() override;
 
+    retry_chain_node& get_root_retry_chain_node() override;
+
     ss::sstring name() const override;
 
     std::pair<bool, std::optional<ss::sstring>> should_skip() const;
@@ -72,6 +73,8 @@ public:
 
 private:
     ss::abort_source _as;
+    retry_chain_node _root_rtc;
+    retry_chain_logger _logger;
     ss::gate _gate;
 
     // A gate holder we keep on behalf of the housekeeping service, when
@@ -87,7 +90,6 @@ private:
 
     ntp_archiver& _archiver;
     cloud_storage::remote& _remote;
-    retry_chain_logger& _logger;
 
     features::feature_table& _feature_table;
 

--- a/src/v/archival/scrubber.h
+++ b/src/v/archival/scrubber.h
@@ -49,8 +49,7 @@ public:
 
     ss::future<> await_feature_enabled();
 
-    ss::future<run_result>
-    run(retry_chain_node& rtc, run_quota_t quota) override;
+    ss::future<run_result> run(run_quota_t quota) override;
 
     void interrupt() override;
 

--- a/src/v/archival/tests/upload_housekeeping_service_test.cc
+++ b/src/v/archival/tests/upload_housekeeping_service_test.cc
@@ -130,7 +130,7 @@ void wait_for_job_execution(
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_stop) {
     retry_chain_node rtc(abort_never);
-    archival::housekeeping_workflow wf(rtc, mock_quota);
+    archival::housekeeping_workflow wf(mock_quota);
     mock_job job1(10s);
     mock_job job2(10s);
     wf.register_job(job1);
@@ -151,7 +151,7 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_stop) {
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_pause) {
     retry_chain_node rtc(abort_never);
-    archival::housekeeping_workflow wf(rtc, mock_quota);
+    archival::housekeeping_workflow wf(mock_quota);
     mock_job job1(10ms);
     mock_job job2(10ms);
     wf.register_job(job1);
@@ -178,7 +178,7 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_pause) {
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_drain) {
     retry_chain_node rtc(abort_never);
-    archival::housekeeping_workflow wf(rtc, mock_quota);
+    archival::housekeeping_workflow wf(mock_quota);
     mock_job job1(10ms);
     mock_job job2(10ms);
     mock_job job3(10ms);
@@ -209,7 +209,7 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_drain) {
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_interrupt) {
     retry_chain_node rtc(abort_never);
-    archival::housekeeping_workflow wf(rtc, mock_quota);
+    archival::housekeeping_workflow wf(mock_quota);
     mock_job job1(10s);
     mock_job job2(10ms);
     wf.register_job(job1);
@@ -228,7 +228,7 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_interrupt) {
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_no_jobs) {
     retry_chain_node rtc(abort_never);
-    archival::housekeeping_workflow wf(rtc, mock_quota);
+    archival::housekeeping_workflow wf(mock_quota);
     {
         mock_job job1(10s);
         mock_job job2(10ms);
@@ -253,7 +253,7 @@ SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_no_jobs) {
 
 SEASTAR_THREAD_TEST_CASE(test_housekeeping_workflow_job_throws) {
     retry_chain_node rtc(abort_never);
-    archival::housekeeping_workflow wf(rtc, mock_quota);
+    archival::housekeeping_workflow wf(mock_quota);
     {
         mock_job job1; // This job will throw
         mock_job job2(10s);

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -162,6 +162,9 @@ public:
     virtual ss::future<run_result>
     run(retry_chain_node& rtc, run_quota_t quota) = 0;
 
+    /// Returns the the root retry chain node of the job.
+    virtual retry_chain_node& get_root_retry_chain_node() = 0;
+
     virtual ss::sstring name() const = 0;
 
 private:

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -152,15 +152,13 @@ public:
 
     /// Start the job. The job can be paused (not immediately).
     ///
-    /// \param rtc is a retry chain node of the housekeeping service
     /// \param quota is number of actions job can execute during current run
     ///        the job is not forced to use its entire quota. It's also possible
     ///        to use more resuorces than the job was given.
     /// \return a future that will become available when the job is completed.
     ///         The result of the future contains stats for the current run (
     ///         number of uploaded segments/manifests, etc).
-    virtual ss::future<run_result>
-    run(retry_chain_node& rtc, run_quota_t quota) = 0;
+    virtual ss::future<run_result> run(run_quota_t quota) = 0;
 
     /// Returns the the root retry chain node of the job.
     virtual retry_chain_node& get_root_retry_chain_node() = 0;

--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -62,9 +62,7 @@ upload_housekeeping_service::upload_housekeeping_service(
       config::shard_local_cfg().cloud_storage_idle_threshold_rps.bind())
   , _raw_quota(
       config::shard_local_cfg().cloud_storage_background_jobs_quota.bind())
-  , _rtc(_as)
-  , _ctxlog(archival_log, _rtc)
-  , _workflow(_rtc, run_quota_t{_raw_quota()}, sg, _probe)
+  , _workflow(run_quota_t{_raw_quota()}, sg, _probe)
   , _api_utilization(
       std::make_unique<sliding_window_t>(0.0, _idle_timeout(), ma_resolution))
   , _api_slow_downs(
@@ -171,7 +169,7 @@ ss::future<> upload_housekeeping_service::bg_idle_loop() {
           slow_downs_rate >= max_slow_downs_rate
           && _workflow.state() == housekeeping_state::active) {
             vlog(
-              _ctxlog.info,
+              archival_log.info,
               "Too many cloud storage requests are being throttled ({}% >= "
               "{}%). Pausing housekeeping workflow to get some headroom",
               slow_downs_rate,
@@ -187,11 +185,11 @@ void upload_housekeeping_service::rearm_idle_timer() {
 }
 
 void upload_housekeeping_service::idle_timer_callback() {
-    vlog(_ctxlog.debug, "Cloud storage is idle");
+    vlog(archival_log.debug, "Cloud storage is idle");
     if (
       _workflow.state() == housekeeping_state::idle
       || _workflow.state() == housekeeping_state::pause) {
-        vlog(_ctxlog.debug, "Activating upload housekeeping");
+        vlog(archival_log.debug, "Activating upload housekeeping");
         _workflow.resume(false);
     }
 
@@ -199,10 +197,11 @@ void upload_housekeeping_service::idle_timer_callback() {
 }
 
 void upload_housekeeping_service::epoch_timer_callback() {
-    vlog(_ctxlog.debug, "Cloud storage housekeeping epoch");
+    vlog(archival_log.debug, "Cloud storage housekeeping epoch");
     if (_workflow.state() != housekeeping_state::draining) {
         vlog(
-          _ctxlog.debug, "Housekeeping epoch timeout, draining the job queue");
+          archival_log.debug,
+          "Housekeeping epoch timeout, draining the job queue");
         _workflow.resume(true);
     }
 }
@@ -210,7 +209,7 @@ void upload_housekeeping_service::epoch_timer_callback() {
 void upload_housekeeping_service::register_jobs(
   std::vector<std::reference_wrapper<housekeeping_job>> jobs) {
     for (auto ref : jobs) {
-        vlog(_ctxlog.debug, "Registering job: {}", ref.get().name());
+        vlog(archival_log.debug, "Registering job: {}", ref.get().name());
         _filter.add_source_to_ignore(ref.get().get_root_retry_chain_node());
         _workflow.register_job(ref.get());
     }
@@ -219,19 +218,17 @@ void upload_housekeeping_service::register_jobs(
 void upload_housekeeping_service::deregister_jobs(
   std::vector<std::reference_wrapper<housekeeping_job>> jobs) {
     for (auto ref : jobs) {
-        vlog(_ctxlog.debug, "Deregistering job: {}", ref.get().name());
+        vlog(archival_log.debug, "Deregistering job: {}", ref.get().name());
         _workflow.deregister_job(ref.get());
         _filter.remove_source_to_ignore(ref.get().get_root_retry_chain_node());
     }
 }
 
 housekeeping_workflow::housekeeping_workflow(
-  retry_chain_node& parent,
   run_quota_t quota,
   ss::scheduling_group sg,
   std::optional<std::reference_wrapper<upload_housekeeping_probe>> probe)
-  : _parent(parent)
-  , _sg(sg)
+  : _sg(sg)
   , _probe(probe)
   , _quota(quota) {}
 

--- a/src/v/archival/upload_housekeeping_service.h
+++ b/src/v/archival/upload_housekeeping_service.h
@@ -61,7 +61,6 @@ public:
       = std::optional<std::reference_wrapper<upload_housekeeping_probe>>;
 
     explicit housekeeping_workflow(
-      retry_chain_node& parent,
       run_quota_t quota,
       ss::scheduling_group sg = ss::default_scheduling_group(),
       probe_opt_t probe = std::nullopt);
@@ -111,7 +110,6 @@ private:
     ss::gate _gate;
     ss::gate _exec_gate;
     ss::abort_source _as;
-    retry_chain_node& _parent;
     ss::scheduling_group _sg;
     probe_opt_t _probe;
     housekeeping_state _state{housekeeping_state::idle};
@@ -243,8 +241,6 @@ private:
     /// Quota to be shared between jobs in one interation of the housekeeping
     /// loop
     config::binding<int32_t> _raw_quota;
-    retry_chain_node _rtc;
-    retry_chain_logger _ctxlog;
     cloud_storage::remote::event_filter _filter;
     upload_housekeeping_probe _probe;
     housekeeping_workflow _workflow;

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -459,11 +459,18 @@ void remote::notify_external_subscribers(
         if (flt._events_to_ignore.contains(event.type)) {
             continue;
         }
-        if (
-          flt._source_to_ignore.has_value()
-          && flt._source_to_ignore->get().same_root(caller)) {
+
+        auto iter = std::find_if(
+          flt._sources_to_ignore.begin(),
+          flt._sources_to_ignore.end(),
+          [&caller](const auto& source) {
+              return source.get().same_root(caller);
+          });
+
+        if (iter != flt._sources_to_ignore.end()) {
             continue;
         }
+
         // Invariant: the filter._promise is always initialized
         // by the 'subscribe' method.
         vassert(

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -424,28 +424,42 @@ public:
     /// events from all sybsystems except one.
     /// The filter is a RAII object. It works until the object
     /// exists. If the filter is destroyed before the notification
-    /// will be received the receiver of the event will se broken
+    /// will be received the receiver of the event will see broken
     /// promise error.
     class event_filter {
         friend class remote;
 
     public:
-        /// Event filter that subscribes to events from all sources.
-        /// The event type wildcard can also be specified.
+        event_filter() = default;
+
         explicit event_filter(
-          std::unordered_set<api_activity_type> ignored_events = {})
+          std::unordered_set<api_activity_type> ignored_events)
           : _events_to_ignore(std::move(ignored_events)) {}
-        /// Event filter that subscribes to events from all sources
-        /// except one. The event type wildcard can also be specified.
-        /// The filter will ignore all events triggered by callers which
-        /// are using the same retry_chain_node. This is useful when the
-        /// client of the 'remote' needs to subscribe to all events except
-        /// own.
-        explicit event_filter(
-          retry_chain_node& ignored_src,
-          std::unordered_set<api_activity_type> ignored_events = {})
-          : _source_to_ignore(std::ref(ignored_src))
-          , _events_to_ignore(std::move(ignored_events)) {}
+
+        void
+        add_source_to_ignore(std::reference_wrapper<retry_chain_node> source) {
+            _sources_to_ignore.push_back(source);
+        }
+
+        void remove_source_to_ignore(
+          std::reference_wrapper<retry_chain_node> source) {
+            auto at = std::find_if(
+              _sources_to_ignore.begin(),
+              _sources_to_ignore.end(),
+              [&source](const auto& src) {
+                  return source.get().same_root(src.get());
+              });
+
+            if (at == _sources_to_ignore.end()) {
+                return;
+            }
+
+            if (std::distance(at, _sources_to_ignore.end()) > 1) {
+                std::iter_swap(at, _sources_to_ignore.end() - 1);
+            }
+
+            _sources_to_ignore.pop_back();
+        }
 
         void cancel() {
             if (_promise.has_value()) {
@@ -455,8 +469,8 @@ public:
         }
 
     private:
-        std::optional<std::reference_wrapper<retry_chain_node>>
-          _source_to_ignore;
+        fragmented_vector<std::reference_wrapper<retry_chain_node>>
+          _sources_to_ignore;
         std::unordered_set<api_activity_type> _events_to_ignore;
         std::optional<ss::promise<api_activity_notification>> _promise;
         intrusive_list_hook _hook;

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -911,7 +911,9 @@ FIXTURE_TEST(test_filter_by_source, remote_fixture) { // NOLINT
       .url = "/" + manifest_url, .body = ss::sstring(manifest_payload)}});
     auto conf = get_configuration();
     retry_chain_node root_rtc(never_abort, 100ms, 20ms);
-    remote::event_filter flt(root_rtc);
+    remote::event_filter flt;
+    flt.add_source_to_ignore(root_rtc);
+
     auto subscription = remote.local().subscribe(flt);
     partition_manifest actual(manifest_ntp, manifest_revision);
 
@@ -951,6 +953,22 @@ FIXTURE_TEST(test_filter_by_source, remote_fixture) { // NOLINT
               json_manifest_format_path,
               actual,
               other_rtc)
+            .get();
+    BOOST_REQUIRE(res == download_result::success);
+    BOOST_REQUIRE(subscription.available());
+    BOOST_REQUIRE(
+      subscription.get().type == api_activity_type::manifest_download);
+
+    // Remove the rtc node from the filter and re-subscribe. This time we should
+    // receive the notification.
+    flt.remove_source_to_ignore(root_rtc);
+    subscription = remote.local().subscribe(flt);
+    res = remote.local()
+            .download_manifest(
+              cloud_storage_clients::bucket_name("bucket"),
+              json_manifest_format_path,
+              actual,
+              child_rtc)
             .get();
     BOOST_REQUIRE(res == download_result::success);
     BOOST_REQUIRE(subscription.available());


### PR DESCRIPTION
Previously, each housekeeping job would receive a retry chain node from the housekeeping
service (call it `rtc_1`). `rtc_1` was hooked up to an abort source which only aborted when
Redpanda stops.

When removing a partition, one needs to `stop()` it first. This involves
triggering the abort sources of all jobs added by the archiver and waiting for them to exit.
Since these jobs are using `rtc_1` they are not aware of the local abort source being triggered
and blissfully continue retrying their requests. This is especially bad if the job doesn't have abort
checks sprinkled throughout and/or we are exponentially backing off.

The solution is to allow each job to create its own retry chain node. Note that we still respect
the `upload_housekeeping_service` abort source by subscribing to it while any job is running
and propagating the abort if needed.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

Fixes https://github.com/redpanda-data/redpanda/issues/14065

## Release Notes

### Bug Fixes
* Fix a shut-down and topic deletion bug which caused the operation to be delayed by the cloud storage
background jobs.
