### PR TITLE
transform/manager: don't move during erase

### DIFF
--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -228,7 +228,7 @@ public:
         ss::chunked_fifo<entry_t> entries;
         ss::chunked_fifo<ss::future<>> stop_futures;
         while (it != _ntp_index.end()) {
-            auto [ntp, id] = std::move(*it);
+            auto [ntp, id] = *it;
             if (ntp != target_ntp) {
                 break;
             }


### PR DESCRIPTION
Since we can break out of the loop, it's possible that we move an entry
out of the btree_set secondary index and then that breaks the container,
causing assertion errors later on with the invalid index.

I wrote a unit test that caught this issue, then had to dump the index
multiple times to find what was going on.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
