### PR TITLE
rpk: add `rpk redpanda mode recovery`.

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/redpanda/mode.go
@@ -32,7 +32,7 @@ func NewModeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			// We complete "dev" and "prod", but if the user is typing
 			// the full word, we switch to completing that.
 			var complete []string
-			for _, s := range []string{config.ModeDev, config.ModeProd} {
+			for _, s := range []string{config.ModeDev, config.ModeProd, config.ModeRecovery} {
 				if strings.HasPrefix(s, toComplete) {
 					complete = append(complete, s)
 				}
@@ -50,7 +50,7 @@ func NewModeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Run: func(_ *cobra.Command, args []string) {
 			err := executeMode(fs, p, args[0])
 			out.MaybeDieErr(err)
-			fmt.Printf("Successfully set mode to %q.", args[0])
+			fmt.Printf("Successfully set mode to %q.\n", args[0])
 		},
 	}
 	return cmd

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -185,8 +185,9 @@ func (p *Params) LoadVirtualProfile(fs afero.Fs) (*RpkProfile, error) {
 ///////////
 
 const (
-	ModeDev  = "dev"
-	ModeProd = "prod"
+	ModeDev      = "dev"
+	ModeProd     = "prod"
+	ModeRecovery = "recovery"
 )
 
 func (c *Config) SetMode(fs afero.Fs, mode string) error {
@@ -196,6 +197,8 @@ func (c *Config) SetMode(fs afero.Fs, mode string) error {
 		yRedpanda.setDevMode()
 	case strings.HasPrefix("production", mode):
 		yRedpanda.setProdMode()
+	case strings.HasPrefix("recovery", mode):
+		yRedpanda.setRecoveryMode()
 	default:
 		return fmt.Errorf("unknown mode %q", mode)
 	}
@@ -204,6 +207,7 @@ func (c *Config) SetMode(fs afero.Fs, mode string) error {
 
 func (y *RedpandaYaml) setDevMode() {
 	y.Redpanda.DeveloperMode = true
+	y.Redpanda.RecoveryModeEnabled = false
 	// Defaults to setting all tuners to false
 	y.Rpk = RpkNodeConfig{
 		KafkaAPI:             y.Rpk.KafkaAPI,
@@ -221,6 +225,7 @@ func (y *RedpandaYaml) setDevMode() {
 
 func (y *RedpandaYaml) setProdMode() {
 	y.Redpanda.DeveloperMode = false
+	y.Redpanda.RecoveryModeEnabled = false
 	y.Rpk.Overprovisioned = false
 	y.Rpk.Tuners.TuneNetwork = true
 	y.Rpk.Tuners.TuneDiskScheduler = true
@@ -233,4 +238,8 @@ func (y *RedpandaYaml) setProdMode() {
 	y.Rpk.Tuners.TuneSwappiness = true
 	y.Rpk.Tuners.TuneDiskWriteCache = true
 	y.Rpk.Tuners.TuneBallastFile = true
+}
+
+func (y *RedpandaYaml) setRecoveryMode() {
+	y.Redpanda.RecoveryModeEnabled = true
 }

--- a/src/go/rpk/pkg/config/redpanda_yaml.go
+++ b/src/go/rpk/pkg/config/redpanda_yaml.go
@@ -64,6 +64,7 @@ type (
 		AdvertisedRPCAPI           *SocketAddress            `yaml:"advertised_rpc_api,omitempty" json:"advertised_rpc_api,omitempty"`
 		AdvertisedKafkaAPI         []NamedSocketAddress      `yaml:"advertised_kafka_api,omitempty" json:"advertised_kafka_api,omitempty"`
 		DeveloperMode              bool                      `yaml:"developer_mode,omitempty" json:"developer_mode"`
+		RecoveryModeEnabled        bool                      `yaml:"recovery_mode_enabled,omitempty" json:"recovery_mode_enabled,omitempty"`
 		CrashLoopLimit             *int                      `yaml:"crash_loop_limit,omitempty" json:"crash_loop_limit"`
 		Other                      map[string]interface{}    `yaml:",inline"`
 	}

--- a/src/go/rpk/pkg/config/weak.go
+++ b/src/go/rpk/pkg/config/weak.go
@@ -342,6 +342,7 @@ func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 		AdvertisedRPCAPI           *SocketAddress            `yaml:"advertised_rpc_api"`
 		AdvertisedKafkaAPI         namedSocketAddresses      `yaml:"advertised_kafka_api"`
 		DeveloperMode              weakBool                  `yaml:"developer_mode"`
+		RecoveryModeEnabled        weakBool                  `yaml:"recovery_mode_enabled"`
 		CrashLoopLimit             *weakInt                  `yaml:"crash_loop_limit"`
 		Other                      map[string]interface{}    `yaml:",inline"`
 	}
@@ -397,6 +398,7 @@ func (rpc *RedpandaNodeConfig) UnmarshalYAML(n *yaml.Node) error {
 	rpc.AdvertisedRPCAPI = internal.AdvertisedRPCAPI
 	rpc.AdvertisedKafkaAPI = internal.AdvertisedKafkaAPI
 	rpc.DeveloperMode = bool(internal.DeveloperMode)
+	rpc.RecoveryModeEnabled = bool(internal.RecoveryModeEnabled)
 	rpc.CrashLoopLimit = (*int)(internal.CrashLoopLimit)
 	rpc.Other = internal.Other
 	return nil


### PR DESCRIPTION
It enables `redpanda.recovery_mode_enable` in the node redpanda.yaml.

We also turn off this knob in Dev and Prod mode.

Solves the first bullet point of #14394 

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Features

* `rpk redpanda mode recovery` lets you set redpanda in recovery mode.


