### PR TITLE
r/tests: hold gate open during exchange

### DIFF
--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -97,7 +97,7 @@ ss::future<iobuf> channel::exchange(msg_type type, iobuf request) {
     _messages.push_back(std::move(m));
     _new_messages.broadcast();
 
-    return f;
+    co_return co_await std::move(f);
 }
 bool channel::is_valid() const { return _node && _node->raft() != nullptr; }
 


### PR DESCRIPTION
If we don't hold the gate open while the exchange is going on, we can
call `set_exception` twice on the resp_data promise, which erronously
reports a dropped exception to seastar.

Fixes: #13299

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
