### PR TITLE
rptest: Make OMB startup timeout configurable

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -168,7 +168,9 @@ def traffic_generator(context, redpanda, tier_cfg, *args, **kwargs):
 def omb_runner(context, redpanda, driver, workload, omb_config):
     bench = OpenMessagingBenchmark(context, redpanda, driver,
                                    (workload, omb_config))
-    bench.start()
+    # No need to set 'clean' flag as OMB service always cleans node on start
+    # On nodes with lower perf start takes longer than 60 sec
+    bench.start(timeout_sec=120)
     try:
         benchmark_time_min = bench.benchmark_time() + 1
         bench.wait(timeout_sec=benchmark_time_min * 60)

--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -51,7 +51,7 @@ class OpenMessagingBenchmarkWorkers(Service):
             assert len(nodes) > 0
             self.nodes = nodes
 
-    def start_node(self, node):
+    def start_node(self, node, timeout_sec=60, **kwargs):
         self.logger.info("Starting Open Messaging Benchmark worker node on %s",
                          node.account.hostname)
 
@@ -71,7 +71,7 @@ class OpenMessagingBenchmarkWorkers(Service):
             node.account.ssh(start_cmd)
             monitor.wait_until(
                 "Javalin has started",
-                timeout_sec=60,
+                timeout_sec=timeout_sec,
                 backoff_sec=4,
                 err_msg=
                 "Open Messaging Benchmark worker service didn't finish startup"
@@ -219,7 +219,7 @@ class OpenMessagingBenchmark(Service):
             nodes=self.worker_nodes)
         self.workers.start()
 
-    def start_node(self, node):
+    def start_node(self, node, timeout_sec=60, **kwargs):
         idx = self.idx(node)
         self.logger.info("Open Messaging Benchmark: benchmark node - %d on %s",
                          idx, node.account.hostname)
@@ -270,7 +270,7 @@ class OpenMessagingBenchmark(Service):
             node.account.ssh(start_cmd)
             monitor.wait_until(
                 "Starting warm-up traffic",
-                timeout_sec=60,
+                timeout_sec=timeout_sec,
                 backoff_sec=4,
                 err_msg="Open Messaging Benchmark service didn't start")
 


### PR DESCRIPTION
During a test run of CloudV2 tests there is a series of tests that run OMB on the same cluster. If two tests are creating topics with specific parameters fast one after another OMB node startup takes longer than default 60 sec

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none