### PR TITLE
cmake: upgrade wasmtime

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -91,12 +91,13 @@ fetch_dep(hdrhistogram
 
 list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --no-default-features)
 list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=async)
+list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=addr2line)
 
 # We need submodules for wasmtime to compile
 FetchContent_Declare(
   wasmtime
   GIT_REPOSITORY https://github.com/bytecodealliance/wasmtime
-  GIT_TAG 81b14a50431104631023fb5723041667fd141efb
+  GIT_TAG 282edac149c0883a7d064132f93ce0a20a50d0d7
   GIT_PROGRESS TRUE
   USES_TERMINAL_DOWNLOAD TRUE
   OVERRIDE_FIND_PACKAGE

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -375,10 +375,8 @@ public:
 
 private:
     void reset_fuel(wasmtime_context_t* ctx) {
-        uint64_t fuel = 0;
-        wasmtime_context_fuel_remaining(ctx, &fuel);
         handle<wasmtime_error_t, wasmtime_error_delete> error(
-          wasmtime_context_add_fuel(ctx, fuel_amount - fuel));
+          wasmtime_context_set_fuel(ctx, fuel_amount));
         check_error(error.get());
     }
 


### PR DESCRIPTION
Upgrade wasmtime to the latest version (has a breaking change related to fuel APIs)

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
