### PR TITLE
cmake: enable implicit fallthrough warning

### DIFF
--- a/cmake/v_library.cmake
+++ b/cmake/v_library.cmake
@@ -2,7 +2,7 @@ include(CMakeParseArguments)
 
 set(V_CXX_STANDARD 20)
 set(V_DEFAULT_LINKOPTS)
-set(V_DEFAULT_COPTS -Wall -Wextra -Werror -Wno-missing-field-initializers)
+set(V_DEFAULT_COPTS -Wall -Wextra -Werror -Wno-missing-field-initializers -Wimplicit-fallthrough)
 set(V_COMMON_INCLUDE_DIRS
   "${PROJECT_SOURCE_DIR}/src/v")
 # v_cc_library()

--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -460,6 +460,7 @@ void housekeeping_workflow::maybe_update_probe(
     switch (res.status) {
     case housekeeping_job::run_status::ok:
         is_ok = 1;
+        [[fallthrough]];
     case housekeeping_job::run_status::failed:
         probe.housekeeping_jobs(is_ok);
         probe.housekeeping_jobs_failed(1 - is_ok);

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -956,6 +956,7 @@ ss::future<response_ptr> describe_configs_handler::handle(
                   &describe_as_string<
                     pandaproxy::schema_registry::subject_name_strategy>,
                   validation_hide_default_override);
+                [[fallthrough]];
             }
             case pandaproxy::schema_registry::schema_id_validation_mode::none: {
                 break;


### PR DESCRIPTION
I believe this to be a good practice. And I've seen plenty of cases
where reviewers ask for explicit attribute anyway. Handing this job to
the compiler from now on.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
