### PR TITLE
Fixed reading raft configuration when `serde` serialized

### DIFF
--- a/src/v/raft/configuration_bootstrap_state.cc
+++ b/src/v/raft/configuration_bootstrap_state.cc
@@ -9,8 +9,10 @@
 
 #include "raft/configuration_bootstrap_state.h"
 
+#include "bytes/iobuf_parser.h"
 #include "likely.h"
 #include "model/record.h"
+#include "raft/consensus_utils.h"
 #include "raft/types.h"
 #include "reflection/adl.h"
 
@@ -34,10 +36,9 @@ void configuration_bootstrap_state::process_configuration(
 
     process_offsets(b.base_offset(), last_offset);
     b.for_each_record([this, o = b.base_offset()](model::record rec) {
+        iobuf_parser parser(rec.release_value());
         _configurations.emplace_back(
-          o,
-          reflection::from_iobuf<raft::group_configuration>(
-            rec.release_value()));
+          o, details::deserialize_configuration(parser));
     });
 }
 void configuration_bootstrap_state::process_data_offsets(

--- a/src/v/raft/tests/simple_record_fixture.h
+++ b/src/v/raft/tests/simple_record_fixture.h
@@ -15,7 +15,10 @@
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/tests/randoms.h"
+#include "raft/consensus_utils.h"
+#include "raft/group_configuration.h"
 #include "raft/types.h"
+#include "random/generators.h"
 #include "storage/record_batch_builder.h"
 // testing
 #include "test_utils/randoms.h"
@@ -32,9 +35,11 @@ struct simple_record_fixture {
         }
         return model::make_memory_record_batch_reader(std::move(batches));
     }
-    model::record_batch_reader configs(std::size_t n) {
-        return reader_gen(n, [this] { return config_batch(); });
+    model::record_batch_reader
+    configs(std::size_t n, raft::group_configuration::version_t version) {
+        return reader_gen(n, [this, version] { return config_batch(version); });
     }
+
     model::record_batch_reader datas(std::size_t n) {
         return reader_gen(n, [this] { return data_batch(); });
     }
@@ -45,31 +50,49 @@ struct simple_record_fixture {
         ++_base_offset;
         return std::move(bldr).build();
     }
-    model::record_batch config_batch() {
-        storage::record_batch_builder bldr(
-          model::record_batch_type::raft_configuration, _base_offset);
-        bldr.add_raw_kv(rand_iobuf(), reflection::to_iobuf(rand_config()));
-        ++_base_offset;
-        return std::move(bldr).build();
+    model::record_batch
+    config_batch(raft::group_configuration::version_t version) {
+        auto batches = details::serialize_configuration_as_batches(
+          rand_config(version));
+        return std::move(batches.front());
     }
+
     iobuf rand_iobuf() const {
         iobuf b;
         auto data = random_generators::gen_alphanum_string(100);
         b.append(data.data(), data.size());
         return b;
     }
-    raft::group_configuration rand_config() const {
+    raft::group_configuration
+    rand_config(raft::group_configuration::version_t version) const {
         std::vector<model::broker> nodes;
-        std::vector<model::broker> learners;
+        std::vector<raft::vnode> voters;
+        std::vector<raft::vnode> learners;
 
         for (auto i = 0; i < active_nodes; ++i) {
-            nodes.push_back(model::random_broker(i, i));
-            learners.push_back(model::random_broker(
-              active_nodes + 1, active_nodes * active_nodes));
+            nodes.push_back(model::random_broker(0, 1000));
         }
-        return raft::group_configuration(
-          std::move(nodes), model::revision_id{});
+
+        if (version < raft::group_configuration::v_5) {
+            return raft::group_configuration(
+              std::move(nodes), model::revision_id{});
+        } else {
+            std::vector<raft::vnode> voters;
+
+            for (auto i = 0; i < active_nodes; ++i) {
+                voters.emplace_back(
+                  tests::random_named_int<model::node_id>(),
+                  tests::random_named_int<model::revision_id>());
+            }
+
+            raft::group_configuration cfg(
+              voters, tests::random_named_int<model::revision_id>());
+
+            cfg.set_version(version);
+            return cfg;
+        }
     }
+
     model::offset _base_offset{0};
     model::ntp _ntp{
       ss::sstring("simple_record_fixture_test_")


### PR DESCRIPTION
When Raft starts it may have to recover some of the stored
configurations from the log. Fixed deserializing configurations when
their version is greater than 6 and `serde` is being used to serialize the configuration object. 

Fixes: #14442

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none