### PR TITLE
[v23.2.x] build(deps): bump github.com/onsi/gomega from 1.28.1 to 1.29.0 in /src/go/k8s

### DIFF
--- a/src/go/k8s/go.mod
+++ b/src/go/k8s/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/moby/moby v24.0.6+incompatible
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/onsi/ginkgo/v2 v2.13.0
-	github.com/onsi/gomega v1.28.1
+	github.com/onsi/gomega v1.29.0
 	github.com/prometheus/client_golang v1.17.0
 	github.com/prometheus/common v0.45.0
 	github.com/redpanda-data/console/backend v0.0.0-20230222172326-354751cc7524

--- a/src/go/k8s/go.sum
+++ b/src/go/k8s/go.sum
@@ -1043,8 +1043,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9yPro=
-github.com/onsi/gomega v1.28.1 h1:MijcGUbfYuznzK/5R4CPNoUP/9Xvuo20sXfEm6XxoTA=
-github.com/onsi/gomega v1.28.1/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/onsi/gomega v1.29.0 h1:KIA/t2t5UBzoirT4H9tsML45GEbo3ouUnBHsCfD2tVg=
+github.com/onsi/gomega v1.29.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
 github.com/opencontainers/go-digest v1.0.1-0.20230815154656-802ce17c4f59 h1:CxG/9ofVc6JEX3s9ORGnWClpUpeR7DurWZTdyWk6f9Y=
 github.com/opencontainers/go-digest v1.0.1-0.20230815154656-802ce17c4f59/go.mod h1:RqnyioA3pIEZMkSbOIcrw32YSgETfn/VrLuEikEdPNU=
 github.com/opencontainers/go-digest/blake3 v0.0.0-20230815154656-802ce17c4f59 h1:PHIYPK2sf+Wfnsy6Sj8oHjLmPpbybrYBjxzSZckHjDQ=


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14453
