### PR TITLE
APIs for disabling topics/partitions and listing them

### DIFF
--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -98,6 +98,7 @@ static constexpr int8_t revert_cancel_partition_move_cmd_type = 9;
 static constexpr int8_t topic_lifecycle_transition_cmd_type = 10;
 static constexpr int8_t force_partition_reconfiguration_type = 11;
 static constexpr int8_t update_partition_replicas_cmd_type = 12;
+static constexpr int8_t set_topic_partitions_disabled_cmd_type = 13;
 
 static constexpr int8_t create_user_cmd_type = 5;
 static constexpr int8_t delete_user_cmd_type = 6;
@@ -211,6 +212,13 @@ using force_partition_reconfiguration_cmd = controller_command<
   model::ntp,
   force_partition_reconfiguration_cmd_data,
   force_partition_reconfiguration_type,
+  model::record_batch_type::topic_management_cmd,
+  serde_opts::serde_only>;
+
+using set_topic_partitions_disabled_cmd = controller_command<
+  int8_t, // unused
+  set_topic_partitions_disabled_cmd_data,
+  set_topic_partitions_disabled_cmd_type,
   model::record_batch_type::topic_management_cmd,
   serde_opts::serde_only>;
 

--- a/src/v/cluster/controller_log_limiter.h
+++ b/src/v/cluster/controller_log_limiter.h
@@ -77,7 +77,8 @@ public:
           std::is_same_v<Cmd, create_topic_cmd> ||            //
           std::is_same_v<Cmd, delete_topic_cmd> ||            //
           std::is_same_v<Cmd, update_topic_properties_cmd> || //
-          std::is_same_v<Cmd, create_partition_cmd>) {
+          std::is_same_v<Cmd, create_partition_cmd> ||        //
+          std::is_same_v<Cmd, set_topic_partitions_disabled_cmd>) {
             return _topic_operations_limiter.try_throttle();
         } else if constexpr (
           std::is_same_v<Cmd, move_partition_replicas_cmd> ||          //

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -113,7 +113,7 @@ struct config_t
 
 struct topics_t
   : public serde::
-      envelope<topics_t, serde::version<0>, serde::compat_version<0>> {
+      envelope<topics_t, serde::version<1>, serde::compat_version<0>> {
     // NOTE: layout here is a bit different than in the topic table because it
     // allows more compact storage and more convenient generation of controller
     // backend deltas when applying the snapshot.
@@ -183,6 +183,13 @@ struct topics_t
       nt_revision_hash,
       nt_revision_eq>
       lifecycle_markers;
+
+    absl::node_hash_map<
+      model::topic_namespace,
+      topic_disabled_partitions_set,
+      model::topic_namespace_hash,
+      model::topic_namespace_eq>
+      disabled_partitions;
 
     friend bool operator==(const topics_t&, const topics_t&) = default;
 

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -469,6 +469,11 @@ ss::future<std::error_code> topic_updates_dispatcher::apply(
     co_return ec;
 }
 
+ss::future<std::error_code> topic_updates_dispatcher::apply(
+  set_topic_partitions_disabled_cmd cmd, model::offset base_offset) {
+    co_return co_await dispatch_updates_to_cores(cmd, base_offset);
+}
+
 topic_updates_dispatcher::in_progress_map
 topic_updates_dispatcher::collect_in_progress(
   const model::topic_namespace& tp_ns,

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -73,7 +73,8 @@ public:
       move_topic_replicas_cmd,
       revert_cancel_partition_move_cmd,
       force_partition_reconfiguration_cmd,
-      update_partition_replicas_cmd>();
+      update_partition_replicas_cmd,
+      set_topic_partitions_disabled_cmd>();
 
     bool is_batch_applicable(const model::record_batch& batch) const {
         return batch.header().type
@@ -106,6 +107,8 @@ private:
       apply(force_partition_reconfiguration_cmd, model::offset);
     ss::future<std::error_code>
       apply(update_partition_replicas_cmd, model::offset);
+    ss::future<std::error_code>
+      apply(set_topic_partitions_disabled_cmd, model::offset);
 
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -138,6 +138,17 @@ public:
       std::vector<create_partitions_configuration>,
       model::timeout_clock::time_point);
 
+    /// if partition_id is nullopt, the disabled flag is applied to all
+    /// partitions of the topic.
+    ///
+    /// The method is idempotent, i.e. if the disabled flag already has the
+    /// desired value, the call is ignored.
+    ss::future<std::error_code> set_topic_partitions_disabled(
+      model::topic_namespace_view,
+      std::optional<model::partition_id>,
+      bool disabled,
+      model::timeout_clock::time_point);
+
     ss::future<bool> validate_shard(model::node_id node, uint32_t shard) const;
 
     ss::future<result<std::vector<move_cancellation_result>>>

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1064,6 +1064,17 @@ operator<<(std::ostream& o, const force_partition_reconfiguration_cmd_data& r) {
     return o;
 }
 
+std::ostream&
+operator<<(std::ostream& o, const set_topic_partitions_disabled_cmd_data& r) {
+    fmt::print(
+      o,
+      "{{topic: {}, partition_id: {}, disabled: {}}}",
+      r.ns_tp,
+      r.partition_id,
+      r.disabled);
+    return o;
+}
+
 std::ostream& operator<<(
   std::ostream& o, const feature_update_license_update_cmd_data& fulu) {
     fmt::print(o, "{{redpanda_license {}}}", fulu.redpanda_license);

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -4377,6 +4377,41 @@ struct update_partition_replicas_cmd_data
     operator<<(std::ostream&, const update_partition_replicas_cmd_data&);
 };
 
+struct topic_disabled_partitions_set
+  : serde::envelope<
+      topic_disabled_partitions_set,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    // std::nullopt means that the topic is fully disabled.
+    // This is different from the partitions set containing all partition ids,
+    // as it will also affect partitions created later with create_partitions
+    // request.
+    std::optional<absl::node_hash_set<model::partition_id>> partitions;
+
+    topic_disabled_partitions_set() noexcept
+      : partitions(absl::node_hash_set<model::partition_id>{}) {}
+
+    friend bool operator==(
+      const topic_disabled_partitions_set&,
+      const topic_disabled_partitions_set&)
+      = default;
+
+    auto serde_fields() { return std::tie(partitions); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const topic_disabled_partitions_set&);
+
+    bool is_disabled(model::partition_id id) const {
+        return !partitions || partitions->contains(id);
+    }
+    bool is_topic_disabled() const { return !partitions.has_value(); }
+    bool is_empty() const { return partitions && partitions->empty(); }
+
+    void add(model::partition_id id);
+    void remove(model::partition_id id, const assignments_set& all_partitions);
+    void set_topic_disabled() { partitions = std::nullopt; }
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2891,6 +2891,27 @@ struct move_topic_replicas_data
     operator<<(std::ostream&, const move_topic_replicas_data&);
 };
 
+struct set_topic_partitions_disabled_cmd_data
+  : serde::envelope<
+      set_topic_partitions_disabled_cmd_data,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    model::topic_namespace ns_tp;
+    // if nullopt, applies to all partitions of the topic.
+    std::optional<model::partition_id> partition_id;
+    bool disabled = false;
+
+    auto serde_fields() { return std::tie(ns_tp, partition_id, disabled); }
+
+    friend bool operator==(
+      const set_topic_partitions_disabled_cmd_data&,
+      const set_topic_partitions_disabled_cmd_data&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const set_topic_partitions_disabled_cmd_data&);
+};
+
 struct feature_update_license_update_cmd_data
   : serde::envelope<
       feature_update_license_update_cmd_data,

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -91,6 +91,8 @@ std::string_view to_string_view(feature f) {
         return "idempotency_v2";
     case feature::fast_partition_reconfiguration:
         return "fast_partition_reconfiguration";
+    case feature::disabling_partitions:
+        return "disabling_partitions";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -70,6 +70,7 @@ enum class feature : std::uint64_t {
     raft_config_serde = 1ULL << 36U,
     idempotency_v2 = 1ULL << 37U,
     fast_partition_reconfiguration = 1ULL << 38U,
+    disabling_partitions = 1ULL << 39U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -342,7 +343,14 @@ constexpr static std::array feature_schema{
     "fast_partition_reconfiguration",
     feature::fast_partition_reconfiguration,
     feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always}};
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{11},
+    "disabling_partitions",
+    feature::disabling_partitions,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+};
 
 std::string_view to_string_view(feature);
 std::string_view to_string_view(feature_state::state);

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -66,6 +66,68 @@
                     "parameters": []
                 }
             ]
+        },
+        {
+            "path": "/v1/cluster/partitions/{namespace}/{topic}",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Disable/enable all partitions of a topic",
+                    "nickname": "post_cluster_partitions_topic",
+                    "type": "void",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "path": "/v1/cluster/partitions/{namespace}/{topic}/{partition}",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Disable/enable a single partition",
+                    "nickname": "post_cluster_partitions_topic_partition",
+                    "type": "void",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "long"
+                        }
+                    ]
+                }
+            ]
         }
     ],
     "models": {

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -92,6 +92,38 @@
                             "type": "string"
                         }
                     ]
+                },
+                {
+                    "method": "GET",
+                    "summary": "Get cluster-level metadata for all partitions in a topic",
+                    "nickname": "get_cluster_partitions_topic",
+                    "type": "array",
+                    "items": {
+                        "type": "cluster_partition"
+                    },
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "disabled",
+                            "in": "query",
+                            "required": false,
+                            "type": "boolean"
+                        }
+                    ]
                 }
             ]
         },
@@ -242,6 +274,52 @@
             "properties": {
                 "cluster_uuid": {
                     "type": "string"
+                }
+            }
+        },
+        "replica_assignment": {
+            "id": "replica_assignment",
+            "description": "Replica assignment",
+            "properties": {
+                "node_id": {
+                    "type": "long",
+                    "description": "node id"
+                },
+                "core": {
+                    "type": "long",
+                    "description": "core"
+                }
+            }
+        },
+        "cluster_partition": {
+            "id": "cluster_partition",
+            "description": "high-level partition info known to all cluster nodes",
+            "properties": {
+                "ns": {
+                    "type": "string",
+                    "description": "namespace"
+                },
+                "topic": {
+                    "type": "string",
+                    "description": "topic"
+                },
+                "partition_id": {
+                    "type": "long",
+                    "description": "partition"
+                },
+                "leader_id": {
+                    "type": "long",
+                    "description": "leader node id"
+                },
+                "replicas": {
+                    "type": "array",
+                    "items": {
+                        "type": "replica_assignment"
+                    },
+                    "description": "replica assignments"
+                },
+                "disabled": {
+                    "type": "boolean"
                 }
             }
         }

--- a/src/v/redpanda/admin/api-doc/cluster.json
+++ b/src/v/redpanda/admin/api-doc/cluster.json
@@ -68,6 +68,37 @@
             ]
         },
         {
+            "path": "/v1/cluster/partitions",
+            "operations": [
+                {
+                    "method": "GET",
+                    "summary": "Get cluster-level metadata for all partitions in the cluster",
+                    "nickname": "get_cluster_partitions",
+                    "type": "array",
+                    "items": {
+                        "type": "cluster_partition"
+                    },
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "disabled",
+                            "in": "query",
+                            "required": false,
+                            "type": "boolean"
+                        },
+                        {
+                            "name": "with_internal",
+                            "in": "query",
+                            "required": false,
+                            "type": "boolean"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "/v1/cluster/partitions/{namespace}/{topic}",
             "operations": [
                 {

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -455,6 +455,9 @@
                         "type": "assignment"
                     },
                     "description": "Replica assignments"
+                },
+                "disabled": {
+                    "type": "boolean"
                 }
             }
         },

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -5016,6 +5016,131 @@ admin_server::post_cluster_partitions_topic_partition_handler(
     co_return ss::json::json_void();
 }
 
+namespace {
+
+struct cluster_partition_info {
+    ss::lw_shared_ptr<model::topic_namespace> ns_tp;
+    model::partition_id id;
+    std::vector<model::broker_shard> replicas;
+    bool disabled = false;
+
+    ss::httpd::cluster_json::cluster_partition to_json() const {
+        ss::httpd::cluster_json::cluster_partition ret;
+        ret.ns = ns_tp->ns();
+        ret.topic = ns_tp->tp();
+        ret.partition_id = id();
+        for (auto& r : replicas) {
+            ss::httpd::cluster_json::replica_assignment a;
+            a.node_id = r.node_id;
+            a.core = r.shard;
+            ret.replicas.push(a);
+        }
+        ret.disabled = disabled;
+        return ret;
+    }
+};
+
+fragmented_vector<cluster_partition_info> topic2cluster_partitions(
+  model::topic_namespace ns_tp,
+  const cluster::assignments_set& assignments,
+  const cluster::topic_disabled_partitions_set* disabled_set,
+  std::optional<bool> disabled_filter) {
+    fragmented_vector<cluster_partition_info> ret;
+
+    if (disabled_filter) {
+        // fast exits
+        if (
+          disabled_filter.value()
+          && (!disabled_set || disabled_set->is_empty())) {
+            return ret;
+        }
+
+        if (
+          !disabled_filter.value() && disabled_set
+          && disabled_set->is_topic_disabled()) {
+            return ret;
+        }
+    }
+
+    auto shared_ns_tp = ss::make_lw_shared<model::topic_namespace>(
+      std::move(ns_tp));
+
+    if (
+      disabled_filter && disabled_filter.value() && disabled_set
+      && disabled_set->partitions) {
+        // special handling for disabled=true filter, as we hope that iterating
+        // over the disabled set is more optimal.
+        for (const auto& id : *disabled_set->partitions) {
+            auto as_it = assignments.find(id);
+            vassert(
+              as_it != assignments.end(),
+              "topic: {}, partition {} must be present",
+              *shared_ns_tp,
+              id);
+
+            ret.push_back(cluster_partition_info{
+              .ns_tp = shared_ns_tp,
+              .id = id,
+              .replicas = as_it->replicas,
+              .disabled = true,
+            });
+        }
+    } else {
+        for (const auto& p_as : assignments) {
+            bool disabled = disabled_set && disabled_set->is_disabled(p_as.id);
+
+            if (disabled_filter && *disabled_filter != disabled) {
+                continue;
+            }
+
+            ret.push_back(cluster_partition_info{
+              .ns_tp = shared_ns_tp,
+              .id = p_as.id,
+              .replicas = p_as.replicas,
+              .disabled = disabled,
+            });
+        }
+    }
+
+    std::sort(ret.begin(), ret.end(), [](const auto& l, const auto& r) {
+        return l.id < r.id;
+    });
+
+    return ret;
+}
+
+} // namespace
+
+ss::future<ss::json::json_return_type>
+admin_server::get_cluster_partitions_topic_handler(
+  std::unique_ptr<ss::http::request> req) {
+    auto ns_tp = model::topic_namespace{
+      model::ns{req->param["namespace"]}, model::topic{req->param["topic"]}};
+
+    std::optional<bool> disabled_filter;
+    if (req->query_parameters.contains("disabled")) {
+        disabled_filter = get_boolean_query_param(*req, "disabled");
+    }
+
+    const auto& topics_state = _controller->get_topics_state().local();
+
+    auto topic_it = topics_state.topics_map().find(ns_tp);
+    if (topic_it == topics_state.topics_map().end()) {
+        throw ss::httpd::not_found_exception(
+          fmt::format("topic {} not found", ns_tp));
+    }
+
+    auto partitions = topic2cluster_partitions(
+      ns_tp,
+      topic_it->second.get_assignments(),
+      topics_state.get_topic_disabled_set(ns_tp),
+      disabled_filter);
+
+    co_return ss::json::json_return_type(ss::json::stream_range_as_array(
+      lw_shared_container{std::move(partitions)},
+      [](const auto& p) { return p.to_json(); }));
+}
+
 void admin_server::register_cluster_routes() {
     register_route<publik>(
       ss::httpd::cluster_json::get_cluster_health_overview,
@@ -5109,6 +5234,15 @@ void admin_server::register_cluster_partitions_routes() {
       [this](std::unique_ptr<ss::http::request> req) {
           return post_cluster_partitions_topic_partition_handler(
             std::move(req));
+      });
+
+    // The following GET routes provide APIs for getting high-level partition
+    // info known to all cluster nodes.
+
+    register_route<user>(
+      ss::httpd::cluster_json::get_cluster_partitions_topic,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return get_cluster_partitions_topic_handler(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -489,6 +489,8 @@ private:
     ss::future<ss::json::json_return_type>
       post_cluster_partitions_topic_partition_handler(
         std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      get_cluster_partitions_topic_handler(std::unique_ptr<ss::http::request>);
 
     /// Shadow indexing routes
     ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -391,6 +391,7 @@ private:
     void register_usage_routes();
     void register_self_test_routes();
     void register_cluster_routes();
+    void register_cluster_partitions_routes();
     void register_shadow_indexing_routes();
     void register_wasm_transform_routes();
 
@@ -480,6 +481,13 @@ private:
       get_partition_balancer_status_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       cancel_all_partitions_reconfigs_handler(
+        std::unique_ptr<ss::http::request>);
+
+    /// Cluster partition routes
+    ss::future<ss::json::json_return_type>
+      post_cluster_partitions_topic_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      post_cluster_partitions_topic_partition_handler(
         std::unique_ptr<ss::http::request>);
 
     /// Shadow indexing routes

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -490,6 +490,8 @@ private:
       post_cluster_partitions_topic_partition_handler(
         std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
+      get_cluster_partitions_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
       get_cluster_partitions_topic_handler(std::unique_ptr<ss::http::request>);
 
     /// Shadow indexing routes

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -614,6 +614,10 @@ class Admin:
 
         return self._request('get', path, node=node).json()
 
+    def get_partition(self, ns: str, topic: str, id: int, node=None):
+        return self._request("GET", f"partitions/{ns}/{topic}/{id}",
+                             node=node).json()
+
     def get_transactions(self, topic, partition, namespace, node=None):
         """
         Get transaction for current partition
@@ -1128,3 +1132,31 @@ class Admin:
             "POST",
             f"cloud_storage/reset_scrubbing_metadata/{namespace}/{topic}/{partition}",
             node=node)
+
+    def get_cluster_partitions(self,
+                               ns: str | None = None,
+                               topic: str | None = None,
+                               disabled: bool | None = None,
+                               node=None):
+        if topic is not None:
+            assert ns is not None
+            req = f"cluster/partitions/{ns}/{topic}"
+        else:
+            assert ns is None
+            req = f"cluster/partitions"
+
+        if disabled is not None:
+            req += f"?disabled={disabled}"
+
+        return self._request("GET", req, node=node).json()
+
+    def set_partitions_disabled(self,
+                                ns: str | None = None,
+                                topic: str | None = None,
+                                partition: int | None = None,
+                                value: bool = True):
+        if partition is not None:
+            req = f"cluster/partitions/{ns}/{topic}/{partition}"
+        else:
+            req = f"cluster/partitions/{ns}/{topic}"
+        return self._request("POST", req, json={"disabled": value})


### PR DESCRIPTION
Add admin APIs for setting the disabled flag and storing it in the topic table.

Also add APIs for viewing the cluster-wide list of partitions/list of partitions of a single topic with filtering by the `disabled` flag.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
* Added admin APIs for viewing the cluster-wide list of partitions/list of partitions of a single topic.