### PR TITLE
[v23.1.x] c/partition_allocator: make `_highest_group` updates monotonic

### DIFF
--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -21,8 +21,6 @@ void allocation_state::rollback(
     verify_shard();
     for (auto& as : v) {
         rollback(as.replicas, domain);
-        // rollback for each assignment as the groups are distinct
-        _highest_group = raft::group_id(_highest_group() - 1);
     }
 }
 

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -184,7 +184,7 @@ FIXTURE_TEST(partial_assignment, partition_allocator_fixture) {
 
     BOOST_REQUIRE_EQUAL(3, max_capacity());
     BOOST_REQUIRE_EQUAL(
-      allocator.state().last_group_id()(), max_partitions_in_cluster - 1);
+      allocator.state().last_group_id()(), max_partitions_in_cluster);
 }
 FIXTURE_TEST(max_deallocation, partition_allocator_fixture) {
     register_node(0, 3);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14375 