### PR TITLE
resource_mgmt: memory group shares with data transforms

### DIFF
--- a/src/v/cloud_storage/materialized_resources.cc
+++ b/src/v/cloud_storage/materialized_resources.cc
@@ -163,7 +163,7 @@ materialized_resources::materialized_resources()
   , _storage_read_readahead_count(
       config::shard_local_cfg().storage_read_readahead_count.bind())
   , _mem_units(
-      memory_groups::tiered_storage_max_memory(),
+      memory_groups().tiered_storage_max_memory(),
       "cst_materialized_resources_memory")
   , _hydration_units(max_parallel_hydrations(), "cst_hydrations")
   , _manifest_meta_size(
@@ -344,10 +344,10 @@ size_t materialized_resources::max_memory_utilization() const {
         auto max_mem = projected_remote_segment_reader_memory_usage()
                        * max_readers.value();
         return std::min(
-          memory_groups::tiered_storage_max_memory(),
+          memory_groups().tiered_storage_max_memory(),
           static_cast<size_t>(max_mem));
     }
-    return memory_groups::tiered_storage_max_memory();
+    return memory_groups().tiered_storage_max_memory();
 }
 
 size_t materialized_resources::max_parallel_hydrations() const {

--- a/src/v/raft/recovery_memory_quota.cc
+++ b/src/v/raft/recovery_memory_quota.cc
@@ -22,8 +22,8 @@ namespace raft {
 recovery_memory_quota::recovery_memory_quota(
   recovery_memory_quota::config_provider_fn config_provider)
   : _cfg(config_provider())
-  , _current_max_recovery_mem(
-      _cfg.max_recovery_memory().value_or(memory_groups::recovery_max_memory()))
+  , _current_max_recovery_mem(_cfg.max_recovery_memory().value_or(
+      memory_groups().recovery_max_memory()))
   , _memory(_current_max_recovery_mem, "raft/recovery-quota") {
     _cfg.max_recovery_memory.watch([this] { on_max_memory_changed(); });
 }
@@ -35,12 +35,12 @@ ss::future<ssx::semaphore_units> recovery_memory_quota::acquire_read_memory() {
 }
 
 void recovery_memory_quota::on_max_memory_changed() {
-    int64_t new_size = _cfg.max_recovery_memory().value_or(
-      memory_groups::recovery_max_memory());
+    int64_t new_size = int64_t(_cfg.max_recovery_memory().value_or(
+      memory_groups().recovery_max_memory()));
 
     vlog(raftlog.info, "max recovery memory changed to {} bytes", new_size);
 
-    int64_t diff = new_size - static_cast<int64_t>(_current_max_recovery_mem);
+    auto diff = new_size - static_cast<int64_t>(_current_max_recovery_mem);
     if (diff < 0) {
         _memory.consume(-diff);
     } else if (diff > 0) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1104,7 +1104,7 @@ void application::wire_up_runtime_services(
           smp_service_groups.proxy_smp_sg(),
           // TODO: Improve memory budget for services
           // https://github.com/redpanda-data/redpanda/issues/1392
-          memory_groups::kafka_total_memory(),
+          memory_groups().kafka_total_memory(),
           *_proxy_client_config,
           *_proxy_config,
           controller.get());
@@ -1116,7 +1116,7 @@ void application::wire_up_runtime_services(
           smp_service_groups.proxy_smp_sg(),
           // TODO: Improve memory budget for services
           // https://github.com/redpanda-data/redpanda/issues/1392
-          memory_groups::kafka_total_memory(),
+          memory_groups().kafka_total_memory(),
           *_schema_reg_client_config,
           *_schema_reg_config,
           std::reference_wrapper(controller));
@@ -1717,8 +1717,8 @@ void application::wire_up_redpanda_services(
       .invoke_on_all([this](net::server_configuration& c) {
           return ss::async([this, &c] {
               c.conn_quotas = std::ref(_kafka_conn_quotas);
-              c.max_service_memory_per_core
-                = memory_groups::kafka_total_memory();
+              c.max_service_memory_per_core = int64_t(
+                memory_groups().kafka_total_memory());
               c.listen_backlog
                 = config::shard_local_cfg().rpc_server_listen_backlog;
               if (config::shard_local_cfg().kafka_rpc_server_tcp_recv_buf()) {
@@ -1956,7 +1956,8 @@ void application::wire_up_bootstrap_services() {
               // shard assignment deterministic.
               c.load_balancing_algo
                 = ss::server_socket::load_balancing_algorithm::port;
-              c.max_service_memory_per_core = memory_groups::rpc_total_memory();
+              c.max_service_memory_per_core = int64_t(
+                memory_groups().rpc_total_memory());
               c.disable_metrics = net::metrics_disabled(
                 config::shard_local_cfg().disable_metrics());
               c.disable_public_metrics = net::public_metrics_disabled(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -428,7 +428,10 @@ void application::initialize(
   std::optional<YAML::Node> schema_reg_client_cfg,
   std::optional<YAML::Node> audit_log_client_cfg,
   std::optional<scheduling_groups> groups) {
-    ss::smp::invoke_on_all(&initialize_memory_groups).get();
+    ss::smp::invoke_on_all([] {
+        // initialize memory groups now that our configuration is loaded
+        memory_groups();
+    }).get();
     construct_service(
       _memory_sampling, std::ref(_log), ss::sharded_parameter([]() {
           return config::shard_local_cfg().sampled_memory_profile.bind();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -84,6 +84,7 @@
 #include "raft/service.h"
 #include "redpanda/admin_server.h"
 #include "resource_mgmt/io_priority.h"
+#include "resource_mgmt/memory_groups.h"
 #include "resource_mgmt/memory_sampling.h"
 #include "rpc/rpc_utils.h"
 #include "security/audit/audit_log_manager.h"
@@ -427,6 +428,7 @@ void application::initialize(
   std::optional<YAML::Node> schema_reg_client_cfg,
   std::optional<YAML::Node> audit_log_client_cfg,
   std::optional<scheduling_groups> groups) {
+    ss::smp::invoke_on_all(&initialize_memory_groups).get();
     construct_service(
       _memory_sampling, std::ref(_log), ss::sharded_parameter([]() {
           return config::shard_local_cfg().sampled_memory_profile.bind();

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -131,7 +131,8 @@ public:
         app.wire_up_and_start(*app_signal, true);
 
         net::server_configuration scfg("fixture_config");
-        scfg.max_service_memory_per_core = memory_groups::rpc_total_memory();
+        scfg.max_service_memory_per_core = int64_t(
+          memory_groups().rpc_total_memory());
         scfg.disable_metrics = net::metrics_disabled::yes;
         scfg.disable_public_metrics = net::public_metrics_disabled::yes;
         configs.start(scfg).get();

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
   NAME resource_mgmt
   SRCS
+    memory_groups.cc
     available_memory.cc
     memory_sampling.cc
     cpu_profiler.cc

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "resource_mgmt/memory_groups.h"
+
+#include "config/configuration.h"
+#include "config/node_config.h"
+#include "seastarx.h"
+
+#include <seastar/core/memory.hh>
+
+size_t memory_groups::kafka_total_memory() {
+    // 30%
+    return total_memory() * .30; // NOLINT
+}
+
+size_t memory_groups::rpc_total_memory() {
+    // 20%
+    return total_memory() * .20; // NOLINT
+}
+
+size_t memory_groups::chunk_cache_min_memory() {
+    return total_memory() * .10; // NOLINT
+}
+
+size_t memory_groups::chunk_cache_max_memory() {
+    return total_memory() * .30; // NOLINT
+}
+
+size_t memory_groups::recovery_max_memory() {
+    return total_memory() * .10; // NOLINT
+}
+
+size_t memory_groups::tiered_storage_max_memory() {
+    return total_memory() * .10; // NOLINT
+}
+
+size_t memory_groups::total_memory() {
+    size_t total = ss::memory::stats().total_memory();
+    if (
+      config::shard_local_cfg().data_transforms_enabled.value()
+      && !config::node().emergency_disable_data_transforms.value()) {
+        size_t wasm_memory_reservation
+          = config::shard_local_cfg().wasm_per_core_memory_reservation.value();
+        total -= wasm_memory_reservation;
+    }
+    return total;
+}

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -31,12 +31,20 @@ struct memory_shares {
     constexpr static size_t tiered_storage = 1;
     constexpr static size_t data_transforms = 1;
 
-    constexpr static size_t total_shares() {
-        return kafka + rpc + recovery + tiered_storage + data_transforms;
+    static size_t total_shares(bool with_wasm) {
+        size_t total = kafka + rpc + recovery + tiered_storage;
+        if (with_wasm) {
+            total += data_transforms;
+        }
+        return total;
     }
 };
 
 } // namespace
+
+memory_groups::memory_groups(size_t total_system_memory, bool wasm_enabled)
+  : _total_system_memory(total_system_memory)
+  , _wasm_enabled(wasm_enabled) {}
 
 size_t memory_groups::chunk_cache_min_memory() {
     return total_memory() * .10; // NOLINT
@@ -63,22 +71,31 @@ size_t memory_groups::tiered_storage_max_memory() {
 }
 
 size_t memory_groups::data_transforms_max_memory() {
+    if (!_wasm_enabled) {
+        return 0;
+    }
     return subsystem_memory<memory_shares::data_transforms>();
 }
 
 template<size_t shares>
 size_t memory_groups::subsystem_memory() {
     size_t remaining = total_memory() - chunk_cache_max_memory();
-    size_t per_share_amount = remaining / memory_shares::total_shares();
+    size_t per_share_amount = remaining
+                              / memory_shares::total_shares(_wasm_enabled);
     return per_share_amount * shares;
 }
 
 size_t memory_groups::total_memory() {
+    size_t total = _total_system_memory;
+    return total;
+}
+
+class memory_groups memory_groups() {
     size_t total = ss::memory::stats().total_memory();
     if (wasm_enabled()) {
         size_t wasm_memory_reservation
           = config::shard_local_cfg().wasm_per_core_memory_reservation.value();
         total -= wasm_memory_reservation;
     }
-    return total;
+    return {total, wasm_enabled()};
 }

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -17,6 +17,13 @@
 
 #include <seastar/core/memory.hh>
 
+namespace {
+bool wasm_enabled() {
+    return config::shard_local_cfg().data_transforms_enabled.value()
+           && !config::node().emergency_disable_data_transforms.value();
+}
+} // namespace
+
 size_t memory_groups::kafka_total_memory() {
     // 30%
     return total_memory() * .30; // NOLINT
@@ -45,9 +52,7 @@ size_t memory_groups::tiered_storage_max_memory() {
 
 size_t memory_groups::total_memory() {
     size_t total = ss::memory::stats().total_memory();
-    if (
-      config::shard_local_cfg().data_transforms_enabled.value()
-      && !config::node().emergency_disable_data_transforms.value()) {
+    if (wasm_enabled()) {
         size_t wasm_memory_reservation
           = config::shard_local_cfg().wasm_per_core_memory_reservation.value();
         total -= wasm_memory_reservation;

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -42,35 +42,36 @@ struct memory_shares {
 
 } // namespace
 
-memory_groups::memory_groups(size_t total_system_memory, bool wasm_enabled)
+system_memory_groups::system_memory_groups(
+  size_t total_system_memory, bool wasm_enabled)
   : _total_system_memory(total_system_memory)
   , _wasm_enabled(wasm_enabled) {}
 
-size_t memory_groups::chunk_cache_min_memory() {
+size_t system_memory_groups::chunk_cache_min_memory() {
     return total_memory() * .10; // NOLINT
 }
 
-size_t memory_groups::chunk_cache_max_memory() {
+size_t system_memory_groups::chunk_cache_max_memory() {
     return total_memory() * .30; // NOLINT
 }
 
-size_t memory_groups::kafka_total_memory() {
+size_t system_memory_groups::kafka_total_memory() {
     return subsystem_memory<memory_shares::kafka>();
 }
 
-size_t memory_groups::rpc_total_memory() {
+size_t system_memory_groups::rpc_total_memory() {
     return subsystem_memory<memory_shares::rpc>();
 }
 
-size_t memory_groups::recovery_max_memory() {
+size_t system_memory_groups::recovery_max_memory() {
     return subsystem_memory<memory_shares::recovery>();
 }
 
-size_t memory_groups::tiered_storage_max_memory() {
+size_t system_memory_groups::tiered_storage_max_memory() {
     return subsystem_memory<memory_shares::tiered_storage>();
 }
 
-size_t memory_groups::data_transforms_max_memory() {
+size_t system_memory_groups::data_transforms_max_memory() {
     if (!_wasm_enabled) {
         return 0;
     }
@@ -78,19 +79,16 @@ size_t memory_groups::data_transforms_max_memory() {
 }
 
 template<size_t shares>
-size_t memory_groups::subsystem_memory() {
+size_t system_memory_groups::subsystem_memory() {
     size_t remaining = total_memory() - chunk_cache_max_memory();
     size_t per_share_amount = remaining
                               / memory_shares::total_shares(_wasm_enabled);
     return per_share_amount * shares;
 }
 
-size_t memory_groups::total_memory() {
-    size_t total = _total_system_memory;
-    return total;
-}
+size_t system_memory_groups::total_memory() { return _total_system_memory; }
 
-class memory_groups memory_groups() {
+system_memory_groups memory_groups() {
     size_t total = ss::memory::stats().total_memory();
     if (wasm_enabled()) {
         size_t wasm_memory_reservation

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -25,8 +25,6 @@ public:
      * The target allocation size for the chunk cache. This is a soft target,
      * and may be expanded as needed by segment appenders, or reclaimed from by
      * seastar under memory pressure.
-     *
-     * add upper bound of 30 pct of memory as a hard outstanding limit.
      */
     static size_t chunk_cache_min_memory();
 
@@ -42,9 +40,18 @@ public:
     /// Max memory that both cloud storage uploads and read-path could use
     static size_t tiered_storage_max_memory();
 
+    /// Max memory that data transform subsystem should use.
+    static size_t data_transforms_max_memory();
+
 private:
     /**
      * Total memory for a core after the user's Wasm reservation.
      */
     static size_t total_memory();
+    /**
+     * The amount of memory we reserve for the rest of the system to use, after
+     * we take the minimum amount required for the batch cache.
+     */
+    template<size_t shares>
+    static size_t subsystem_memory();
 };

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -17,9 +17,8 @@
  * Centralized unit for memory management.
  *
  * Works via a share system. First we subtract the amount of memory the user
- * decides to use for their WebAssembly functions, then we carve out 30% for the
- * batch cache. The remaining subsystems are distributed memory via a share
- * system.
+ * decides to use for their WebAssembly functions. The remaining subsystems
+ * are distributed memory via a share system.
  */
 class system_memory_groups {
 public:
@@ -58,8 +57,8 @@ private:
      */
     size_t total_memory() const;
     /**
-     * The amount of memory we reserve for the rest of the system to use, after
-     * we take the minimum amount required for the batch cache.
+     * The fraction of memory for this subsystem based on the number of shares
+     * allotted to it.
      */
     template<size_t shares>
     size_t subsystem_memory() const;

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -16,42 +16,52 @@
 // centralized unit for memory management
 class memory_groups {
 public:
-    static size_t kafka_total_memory();
+    memory_groups(size_t total_system_memory, bool wasm_enabled);
+
+    size_t kafka_total_memory();
 
     /// \brief includes raft & all services
-    static size_t rpc_total_memory();
+    size_t rpc_total_memory();
 
     /**
      * The target allocation size for the chunk cache. This is a soft target,
      * and may be expanded as needed by segment appenders, or reclaimed from by
      * seastar under memory pressure.
      */
-    static size_t chunk_cache_min_memory();
+    size_t chunk_cache_min_memory();
 
     /**
      * Upper bound on the amount of outstanding memory for inflight write
      * requests. Requests above this limit will wait for an existing chunk to be
      * returned to the cache.
      */
-    static size_t chunk_cache_max_memory();
+    size_t chunk_cache_max_memory();
 
-    static size_t recovery_max_memory();
+    size_t recovery_max_memory();
 
     /// Max memory that both cloud storage uploads and read-path could use
-    static size_t tiered_storage_max_memory();
+    size_t tiered_storage_max_memory();
 
     /// Max memory that data transform subsystem should use.
-    static size_t data_transforms_max_memory();
+    size_t data_transforms_max_memory();
 
 private:
     /**
      * Total memory for a core after the user's Wasm reservation.
      */
-    static size_t total_memory();
+    size_t total_memory();
     /**
      * The amount of memory we reserve for the rest of the system to use, after
      * we take the minimum amount required for the batch cache.
      */
     template<size_t shares>
-    static size_t subsystem_memory();
+    size_t subsystem_memory();
+
+    size_t _total_system_memory;
+    bool _wasm_enabled;
 };
+
+/**
+ * Compute the memory groups based on the system configuration.
+ */
+memory_groups memory_groups();

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -14,9 +14,9 @@
 #include <cstddef>
 
 // centralized unit for memory management
-class memory_groups {
+class system_memory_groups {
 public:
-    memory_groups(size_t total_system_memory, bool wasm_enabled);
+    system_memory_groups(size_t total_system_memory, bool wasm_enabled);
 
     size_t kafka_total_memory();
 
@@ -64,4 +64,4 @@ private:
 /**
  * Compute the memory groups based on the system configuration.
  */
-memory_groups memory_groups();
+system_memory_groups memory_groups();

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -11,25 +11,15 @@
 
 #pragma once
 
-#include "config/configuration.h"
-#include "config/node_config.h"
-#include "seastarx.h"
-
-#include <seastar/core/memory.hh>
+#include <cstddef>
 
 // centralized unit for memory management
 class memory_groups {
 public:
-    static size_t kafka_total_memory() {
-        // 30%
-        return total_memory() * .30; // NOLINT
-    }
+    static size_t kafka_total_memory();
 
     /// \brief includes raft & all services
-    static size_t rpc_total_memory() {
-        // 20%
-        return total_memory() * .20; // NOLINT
-    }
+    static size_t rpc_total_memory();
 
     /**
      * The target allocation size for the chunk cache. This is a soft target,
@@ -38,42 +28,23 @@ public:
      *
      * add upper bound of 30 pct of memory as a hard outstanding limit.
      */
-    static size_t chunk_cache_min_memory() {
-        return total_memory() * .10; // NOLINT
-    }
+    static size_t chunk_cache_min_memory();
 
     /**
      * Upper bound on the amount of outstanding memory for inflight write
      * requests. Requests above this limit will wait for an existing chunk to be
      * returned to the cache.
      */
-    static size_t chunk_cache_max_memory() {
-        return total_memory() * .30; // NOLINT
-    }
+    static size_t chunk_cache_max_memory();
 
-    static size_t recovery_max_memory() {
-        return total_memory() * .10; // NOLINT
-    }
+    static size_t recovery_max_memory();
 
     /// Max memory that both cloud storage uploads and read-path could use
-    static size_t tiered_storage_max_memory() {
-        return total_memory() * .10; // NOLINT
-    }
+    static size_t tiered_storage_max_memory();
 
 private:
     /**
      * Total memory for a core after the user's Wasm reservation.
      */
-    static size_t total_memory() {
-        size_t total = ss::memory::stats().total_memory();
-        if (
-          config::shard_local_cfg().data_transforms_enabled.value()
-          && !config::node().emergency_disable_data_transforms.value()) {
-            size_t wasm_memory_reservation
-              = config::shard_local_cfg()
-                  .wasm_per_core_memory_reservation.value();
-            total -= wasm_memory_reservation;
-        }
-        return total;
-    }
+    static size_t total_memory();
 };

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -11,20 +11,24 @@
 
 #pragma once
 
+#include "config/configuration.h"
+#include "config/node_config.h"
 #include "seastarx.h"
 
 #include <seastar/core/memory.hh>
 
 // centralized unit for memory management
-struct memory_groups {
+class memory_groups {
+public:
     static size_t kafka_total_memory() {
         // 30%
-        return ss::memory::stats().total_memory() * .30;
+        return total_memory() * .30; // NOLINT
     }
+
     /// \brief includes raft & all services
     static size_t rpc_total_memory() {
         // 20%
-        return ss::memory::stats().total_memory() * .20;
+        return total_memory() * .20; // NOLINT
     }
 
     /**
@@ -35,7 +39,7 @@ struct memory_groups {
      * add upper bound of 30 pct of memory as a hard outstanding limit.
      */
     static size_t chunk_cache_min_memory() {
-        return ss::memory::stats().total_memory() * .10; // NOLINT
+        return total_memory() * .10; // NOLINT
     }
 
     /**
@@ -44,15 +48,32 @@ struct memory_groups {
      * returned to the cache.
      */
     static size_t chunk_cache_max_memory() {
-        return ss::memory::stats().total_memory() * .30; // NOLINT
+        return total_memory() * .30; // NOLINT
     }
 
     static size_t recovery_max_memory() {
-        return ss::memory::stats().total_memory() * .10;
+        return total_memory() * .10; // NOLINT
     }
 
     /// Max memory that both cloud storage uploads and read-path could use
     static size_t tiered_storage_max_memory() {
-        return ss::memory::stats().total_memory() * .10;
+        return total_memory() * .10; // NOLINT
+    }
+
+private:
+    /**
+     * Total memory for a core after the user's Wasm reservation.
+     */
+    static size_t total_memory() {
+        size_t total = ss::memory::stats().total_memory();
+        if (
+          config::shard_local_cfg().data_transforms_enabled.value()
+          && !config::node().emergency_disable_data_transforms.value()) {
+            size_t wasm_memory_reservation
+              = config::shard_local_cfg()
+                  .wasm_per_core_memory_reservation.value();
+            total -= wasm_memory_reservation;
+        }
+        return total;
     }
 };

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -13,55 +13,71 @@
 
 #include <cstddef>
 
-// centralized unit for memory management
+/**
+ * Centralized unit for memory management.
+ *
+ * Works via a share system. First we subtract the amount of memory the user
+ * decides to use for their WebAssembly functions, then we carve out 30% for the
+ * batch cache. The remaining subsystems are distributed memory via a share
+ * system.
+ */
 class system_memory_groups {
 public:
     system_memory_groups(size_t total_system_memory, bool wasm_enabled);
 
-    size_t kafka_total_memory();
+    size_t kafka_total_memory() const;
 
     /// \brief includes raft & all services
-    size_t rpc_total_memory();
+    size_t rpc_total_memory() const;
 
     /**
      * The target allocation size for the chunk cache. This is a soft target,
      * and may be expanded as needed by segment appenders, or reclaimed from by
      * seastar under memory pressure.
      */
-    size_t chunk_cache_min_memory();
+    size_t chunk_cache_min_memory() const;
 
     /**
      * Upper bound on the amount of outstanding memory for inflight write
      * requests. Requests above this limit will wait for an existing chunk to be
      * returned to the cache.
      */
-    size_t chunk_cache_max_memory();
+    size_t chunk_cache_max_memory() const;
 
-    size_t recovery_max_memory();
+    size_t recovery_max_memory() const;
 
     /// Max memory that both cloud storage uploads and read-path could use
-    size_t tiered_storage_max_memory();
+    size_t tiered_storage_max_memory() const;
 
     /// Max memory that data transform subsystem should use.
-    size_t data_transforms_max_memory();
+    size_t data_transforms_max_memory() const;
 
 private:
     /**
      * Total memory for a core after the user's Wasm reservation.
      */
-    size_t total_memory();
+    size_t total_memory() const;
     /**
      * The amount of memory we reserve for the rest of the system to use, after
      * we take the minimum amount required for the batch cache.
      */
     template<size_t shares>
-    size_t subsystem_memory();
+    size_t subsystem_memory() const;
 
     size_t _total_system_memory;
     bool _wasm_enabled;
 };
 
 /**
- * Compute the memory groups based on the system configuration.
+ * Initialize the memory groups for **this core**.
+ *
+ * Initializing memory groups reads from cluster configuration values that can
+ * change, but require a restart to take effect, so we read and lock in the
+ * configuration values when initializing memory groups.
  */
-system_memory_groups memory_groups();
+void initialize_memory_groups();
+
+/**
+ * Grab the shard local, initialized on startup, system memory groups.
+ */
+system_memory_groups& memory_groups();

--- a/src/v/resource_mgmt/memory_groups.h
+++ b/src/v/resource_mgmt/memory_groups.h
@@ -69,15 +69,6 @@ private:
 };
 
 /**
- * Initialize the memory groups for **this core**.
- *
- * Initializing memory groups reads from cluster configuration values that can
- * change, but require a restart to take effect, so we read and lock in the
- * configuration values when initializing memory groups.
- */
-void initialize_memory_groups();
-
-/**
- * Grab the shard local, initialized on startup, system memory groups.
+ * Grab the shard local, lazily initialized, system memory groups.
  */
 system_memory_groups& memory_groups();

--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -30,3 +30,13 @@ rp_test(
   LIBRARIES v::seastar_testing_main v::storage_resource_mgmt v::config
   LABELS resource_mgmt
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_resource_mgmt
+  SOURCES
+    memory_groups_test.cc
+  LIBRARIES v::resource_mgmt v::gtest_main
+  LABELS resource_mgmt
+)

--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -37,6 +37,6 @@ rp_test(
   BINARY_NAME gtest_resource_mgmt
   SOURCES
     memory_groups_test.cc
-  LIBRARIES v::resource_mgmt v::gtest_main
+  LIBRARIES v::resource_mgmt v::gtest_main v::utils
   LABELS resource_mgmt
 )

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "resource_mgmt/memory_groups.h"
+#include "units.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+TEST(MemoryGroups, HasCompatibility) {
+    class memory_groups groups(2_GiB, /*wasm_enabled=*/false);
+    EXPECT_THAT(groups.chunk_cache_max_memory(), 2_GiB * .3);
+    EXPECT_THAT(groups.chunk_cache_min_memory(), 2_GiB * .1);
+    EXPECT_THAT(groups.tiered_storage_max_memory(), 2_GiB * .1);
+    EXPECT_THAT(groups.recovery_max_memory(), 2_GiB * .1);
+    // These round differently than the original calculation.
+    EXPECT_THAT(groups.kafka_total_memory(), (2_GiB * .3) - 2);
+    EXPECT_THAT(groups.rpc_total_memory(), (2_GiB * .2) - 1);
+    EXPECT_THAT(groups.data_transforms_max_memory(), 0);
+}
+
+// It's not really useful to know the exact byte values for each of these
+// numbers so we just make sure we're within a MB
+MATCHER_P(IsApprox, n, "") {
+    *result_listener << "is within 1MiB of " << n;
+    size_t low = n - 1_MiB;
+    size_t high = n + 1_MiB;
+    return arg >= low && arg <= high;
+}
+
+TEST(MemoryGroups, DividesSharesWithWasm) {
+    constexpr size_t user_wasm_reservation = 20_MiB;
+    class memory_groups groups(
+      2_GiB - user_wasm_reservation, /*wasm_enabled=*/true);
+    EXPECT_THAT(groups.chunk_cache_min_memory(), IsApprox(202_MiB));
+    EXPECT_THAT(groups.chunk_cache_max_memory(), IsApprox(609_MiB));
+    EXPECT_THAT(groups.tiered_storage_max_memory(), IsApprox(177_MiB));
+    EXPECT_THAT(groups.recovery_max_memory(), IsApprox(177_MiB));
+    EXPECT_THAT(groups.kafka_total_memory(), IsApprox(532_MiB));
+    EXPECT_THAT(groups.rpc_total_memory(), IsApprox(354_MiB));
+    EXPECT_THAT(groups.data_transforms_max_memory(), IsApprox(177_MiB));
+    EXPECT_LT(
+      groups.data_transforms_max_memory() + groups.chunk_cache_max_memory()
+        + groups.kafka_total_memory() + groups.recovery_max_memory()
+        + groups.rpc_total_memory() + groups.tiered_storage_max_memory(),
+      2_GiB - user_wasm_reservation);
+}

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -11,17 +11,18 @@
 
 #include "resource_mgmt/memory_groups.h"
 #include "units.h"
+#include "utils/human.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 TEST(MemoryGroups, HasCompatibility) {
     class system_memory_groups groups(2_GiB, /*wasm_enabled=*/false);
-    EXPECT_THAT(groups.chunk_cache_max_memory(), 2_GiB * .3);
     EXPECT_THAT(groups.chunk_cache_min_memory(), 2_GiB * .1);
     EXPECT_THAT(groups.tiered_storage_max_memory(), 2_GiB * .1);
     EXPECT_THAT(groups.recovery_max_memory(), 2_GiB * .1);
     // These round differently than the original calculation.
+    EXPECT_THAT(groups.chunk_cache_max_memory(), (2_GiB * .3) - 2);
     EXPECT_THAT(groups.kafka_total_memory(), (2_GiB * .3) - 2);
     EXPECT_THAT(groups.rpc_total_memory(), (2_GiB * .2) - 1);
     EXPECT_THAT(groups.data_transforms_max_memory(), 0);
@@ -30,7 +31,8 @@ TEST(MemoryGroups, HasCompatibility) {
 // It's not really useful to know the exact byte values for each of these
 // numbers so we just make sure we're within a MB
 MATCHER_P(IsApprox, n, "") {
-    *result_listener << "is within 1MiB of " << n;
+    *result_listener << "expected " << human::bytes(arg)
+                     << " to be within 1MiB of " << human::bytes(n);
     size_t low = n - 1_MiB;
     size_t high = n + 1_MiB;
     return arg >= low && arg <= high;
@@ -40,13 +42,13 @@ TEST(MemoryGroups, DividesSharesWithWasm) {
     constexpr size_t user_wasm_reservation = 20_MiB;
     class system_memory_groups groups(
       2_GiB - user_wasm_reservation, /*wasm_enabled=*/true);
-    EXPECT_THAT(groups.chunk_cache_min_memory(), IsApprox(202_MiB));
-    EXPECT_THAT(groups.chunk_cache_max_memory(), IsApprox(609_MiB));
-    EXPECT_THAT(groups.tiered_storage_max_memory(), IsApprox(177_MiB));
-    EXPECT_THAT(groups.recovery_max_memory(), IsApprox(177_MiB));
-    EXPECT_THAT(groups.kafka_total_memory(), IsApprox(532_MiB));
-    EXPECT_THAT(groups.rpc_total_memory(), IsApprox(354_MiB));
-    EXPECT_THAT(groups.data_transforms_max_memory(), IsApprox(177_MiB));
+    EXPECT_THAT(groups.chunk_cache_min_memory(), IsApprox(184_MiB));
+    EXPECT_THAT(groups.chunk_cache_max_memory(), IsApprox(553_MiB));
+    EXPECT_THAT(groups.tiered_storage_max_memory(), IsApprox(184_MiB));
+    EXPECT_THAT(groups.recovery_max_memory(), IsApprox(184_MiB));
+    EXPECT_THAT(groups.kafka_total_memory(), IsApprox(553_MiB));
+    EXPECT_THAT(groups.rpc_total_memory(), IsApprox(368_MiB));
+    EXPECT_THAT(groups.data_transforms_max_memory(), IsApprox(184_MiB));
     EXPECT_LT(
       groups.data_transforms_max_memory() + groups.chunk_cache_max_memory()
         + groups.kafka_total_memory() + groups.recovery_max_memory()

--- a/src/v/resource_mgmt/tests/memory_groups_test.cc
+++ b/src/v/resource_mgmt/tests/memory_groups_test.cc
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 
 TEST(MemoryGroups, HasCompatibility) {
-    class memory_groups groups(2_GiB, /*wasm_enabled=*/false);
+    class system_memory_groups groups(2_GiB, /*wasm_enabled=*/false);
     EXPECT_THAT(groups.chunk_cache_max_memory(), 2_GiB * .3);
     EXPECT_THAT(groups.chunk_cache_min_memory(), 2_GiB * .1);
     EXPECT_THAT(groups.tiered_storage_max_memory(), 2_GiB * .1);
@@ -38,7 +38,7 @@ MATCHER_P(IsApprox, n, "") {
 
 TEST(MemoryGroups, DividesSharesWithWasm) {
     constexpr size_t user_wasm_reservation = 20_MiB;
-    class memory_groups groups(
+    class system_memory_groups groups(
       2_GiB - user_wasm_reservation, /*wasm_enabled=*/true);
     EXPECT_THAT(groups.chunk_cache_min_memory(), IsApprox(202_MiB));
     EXPECT_THAT(groups.chunk_cache_max_memory(), IsApprox(609_MiB));

--- a/src/v/storage/chunk_cache.h
+++ b/src/v/storage/chunk_cache.h
@@ -31,8 +31,8 @@ public:
     static constexpr const alignment alignment{4_KiB};
 
     chunk_cache() noexcept
-      : _size_target(memory_groups::chunk_cache_min_memory())
-      , _size_limit(memory_groups::chunk_cache_max_memory())
+      : _size_target(memory_groups().chunk_cache_min_memory())
+      , _size_limit(memory_groups().chunk_cache_max_memory())
       , _chunk_size(config::shard_local_cfg().append_chunk_size()) {}
 
     chunk_cache(chunk_cache&&) = delete;
@@ -42,7 +42,7 @@ public:
     ~chunk_cache() noexcept = default;
 
     ss::future<> start() {
-        const auto num_chunks = memory_groups::chunk_cache_min_memory()
+        const auto num_chunks = memory_groups().chunk_cache_min_memory()
                                 / _chunk_size;
         return ss::do_for_each(
           boost::counting_iterator<size_t>(0),


### PR DESCRIPTION
Expand out memory group reservation system for data transforms.

Data transforms is the first item here that is fully optional (well isn't TS optional too and we're still carving out 10% for it?) and has a decent impact on memory usage in Redpanda.

In order to support more use cases and subsystems switch a "share" model where the memory is divided up between the different subsystems that ask for memory. With data transforms off, this is a no-op. However when wasm enabled we split the remaining system memory between the rest of the subsystems according to the shares they ask for.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
