### PR TITLE
rptest: use productName instead of productId for cloud api

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -288,7 +288,7 @@ class LiveClusterParams:
     network_id: str = None
     network_cidr: str = None
     install_pack_ver: str = None
-    product_id: str = None
+    product_name: str = None
     region: str = None
     region_id: str = None
     peer_vpc_id: str = None
@@ -584,8 +584,8 @@ class CloudCluster():
                 return r['id']
         return None
 
-    def _get_product_id(self, config_profile_name):
-        """Get the product id for the first matching config
+    def _get_product_name(self, config_profile_name):
+        """Get the product name for the first matching config
         profile name using filter parameters.
         Uses self.current as a source of params
             provider: cloud provider filter, e.g. 'AWS'
@@ -608,8 +608,8 @@ class CloudCluster():
             endpoint='/api/v1/clusters-resources/products', params=params)
         for p in products:
             if p['redpandaConfigProfileName'] == config_profile_name:
-                return p['id']
-        self._logger.warning("CloudV2 API returned empty 'product_id' list "
+                return p['name']
+        self._logger.warning("CloudV2 API returned empty 'product_name' list "
                              f"for request: '{params}'")
         return None
 
@@ -618,8 +618,8 @@ class CloudCluster():
         return {
             "cluster": {
                 "name": self.current.name,
-                "productId": self.current.product_id,
                 "spec": {
+                    "productName": self.current.product_name,
                     "clusterType": self.config.type,
                     "connectors": {
                         "enabled": True
@@ -775,7 +775,7 @@ class CloudCluster():
             # Populate self.current from cluster info
             self._update_live_cluster_info()
             # Fill in additional info based on collected from cluster
-            self.current.product_id = self._get_product_id(
+            self.current.product_name = self._get_product_name(
                 self.config.config_profile_name)
         else:
             # In order not to have long list of arguments in each internal
@@ -796,9 +796,9 @@ class CloudCluster():
             self.current.zones = self.provider_cli.get_single_zone(
                 self.current.region)
             # Call CloudV2 API to determine Product ID
-            self.current.product_id = self._get_product_id(
+            self.current.product_name = self._get_product_name(
                 self.config.config_profile_name)
-            if self.current.product_id is None:
+            if self.current.product_name is None:
                 raise RuntimeError("ProductID failed to be determined for "
                                    f"'{self.config.provider}', "
                                    f"'{self.config.type}', "


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/cloudv2/issues/10044

verified fix by running test:
```console
ducktape --debug --globals=/home/ubuntu/redpanda/tests/globals.json --cluster=ducktape.cluster.json.JsonCluster --cluster-file=/home/ubuntu/redpanda/tests/cluster.json --test-runner-timeout=3600000 tests/rptest/tests/rpk_topic_test.py::RpkToolTest.test_consume_from_partition
```

which showed cluster being created with `productName`:
```
...
[INFO  - 2023-10-27 06:35:37,640 - redpanda_cloud - create - lineno:809]: creating cluster name rp-ducktape-cluster-069a9cd4
[DEBUG - 2023-10-27 06:35:37,641 - redpanda_cloud - create - lineno:812]: body: {"cluster": {"name": "rp-ducktape-cluster-069a9cd4", "spec": {"productName": "tier-1-aws-sbdg", "clusterType": "BYOC", "connectors": {"enabled": true}, "installPackVersion": "23.2.20231027021636", "isMultiAz": false, "networkId": "", "provider": "AWS", "region": "us-west-2", "zones": "usw2-az2"}}, "connectionType": "public", "namespaceUuid": "523361fc-2db8-41a1-b895-5f535ea11893", "network": {"displayName": "public-network-rp-ducktape-cluster-069a9cd4", "spec": {"cidr": "10.1.0.0/16", "deploymentType": "BYOC", "installPackVersion": "23.2.20231027021636", "provider": "AWS", "regionId": "cfgkn8nj54gc23umqu70"}}}
[INFO  - 2023-10-27 06:36:02,226 - redpanda_cloud - _wait_for_cluster_id - lineno:748]: Cluster ID is 'cktlkhjdi3elqvvc2is0'
...
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none