### PR TITLE
[v23.2.x] tests: do not reserve disk space in full_node_test

### DIFF
--- a/tests/rptest/tests/partition_balancer_test.py
+++ b/tests/rptest/tests/partition_balancer_test.py
@@ -658,9 +658,8 @@ class PartitionBalancerTest(PartitionBalancerService):
                 "health_monitor_max_metadata_age": 3000,
                 "log_segment_size": 104857600,  # 100 MiB
                 "retention_local_target_capacity_percent": 100.0,
-                # add disk reservation to buffer
-                "disk_reservation_percent": 10.0,
-                "retention_local_trim_interval": 3000
+                "retention_local_trim_interval": 3000,
+                "disk_reservation_percent": 0.0
             },
             environment={"__REDPANDA_TEST_DISK_SIZE": disk_size})
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14460
Fixes: https://github.com/redpanda-data/redpanda/issues/14475,