### PR TITLE
tests: added tiered storage to node pool migration test

### DIFF
--- a/src/v/kafka/protocol/kafka_batch_adapter.h
+++ b/src/v/kafka/protocol/kafka_batch_adapter.h
@@ -100,7 +100,8 @@ struct produce_request_record_data {
         // NOTE: this stream is intentially devoid of user data.
         fmt::print(
           os,
-          "batch {} v2_format {} valid_crc {}",
+          "batch {{records: {}, size: {}}} v2_format {} valid_crc {}",
+          data.adapter.batch ? data.adapter.batch->header().record_count : -1,
           data.adapter.batch ? data.adapter.batch->size_bytes() : -1,
           data.adapter.v2_format,
           data.adapter.valid_crc);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -236,7 +236,7 @@ class Admin:
         When the timeout is exhaust it throws TimeoutException
         """
         if hosts == None:
-            hosts = [n.account.hostname for n in self.redpanda.nodes]
+            hosts = [n.account.hostname for n in self.redpanda.started_nodes()]
         hosts = list(hosts)
 
         def get_stable_configuration():

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3271,7 +3271,7 @@ class RedpandaService(RedpandaServiceBase):
         """
         :return: the ClusterNode that is currently controller leader, or None if no leader exists
         """
-        for node in self.nodes:
+        for node in self.started_nodes():
             try:
                 r = requests.request(
                     "get",
@@ -3285,7 +3285,7 @@ class RedpandaService(RedpandaServiceBase):
             else:
                 resp_leader_id = r.json()['leader_id']
                 if resp_leader_id != -1:
-                    return self.get_node(resp_leader_id)
+                    return self.get_node_by_id(resp_leader_id)
 
         return None
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3995,7 +3995,7 @@ class RedpandaService(RedpandaServiceBase):
                     namespace="kafka",
                     topic=p.topic,
                     partition=p.index,
-                    node=self.get_node(leader_id))
+                    node=self.get_node_by_id(leader_id))
             except HTTPError as he:
                 if he.response.status_code == 404:
                     # Old redpanda, doesn't have this endpoint.  We can't


### PR DESCRIPTION
Extended node pool migration test with tiered storage and different cleanup policies.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none