### PR TITLE
storage: only evict if remote read is enabled

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -953,7 +953,7 @@ gc_config disk_log_impl::override_retention_config(gc_config cfg) const {
 
 bool disk_log_impl::is_cloud_retention_active() const {
     return config::shard_local_cfg().cloud_storage_enabled()
-           && (config().is_archival_enabled());
+           && (config().is_remote_fetch_enabled());
 }
 
 /*

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -560,11 +560,13 @@ class LogStorageMaxSizeSI(RedpandaTest):
         """
         # start redpanda with specific config like segment size
         si_settings = SISettings(test_context=self.test_context,
-                                 log_segment_size=log_segment_size)
+                                 log_segment_size=log_segment_size,
+                                 fast_uploads=True)
         extra_rp_conf = {
             'compacted_log_segment_size': log_segment_size,
             'disk_reservation_percent': 0,
             'retention_local_target_capacity_percent': 100,
+            'retention_local_trim_interval': 1000,  # every second
         }
         self.redpanda.set_extra_rp_conf(extra_rp_conf)
         self.redpanda.set_si_settings(si_settings)
@@ -657,7 +659,7 @@ class LogStorageMaxSizeSI(RedpandaTest):
         # The informal guarantee that this correctly tests the behavior we're interesting in
         # is given by the fact that the `cleanup.policy=delete` hits the same invariants within
         # the same timeout.
-        timeout_sec = 120
+        timeout_sec = 30
 
         if cleanup_policy == TopicSpec.CLEANUP_COMPACT:
             # For `cleanup.policy=compat` we don't expect any removal. Wait for timeout.


### PR DESCRIPTION
Fixes #14479

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fix a bug where space management would evict local data for topics that didn't have `cloud_storage_enable_remote_read` enabled. This resulted in clients not being able to consume data.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
