### PR TITLE
rpk: support decoding schema registry encoded messages in `rpk topic consume`

### DIFF
--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -25,11 +25,15 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/serde"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/franz-go/pkg/kadm"
 	"github.com/twmb/franz-go/pkg/kerr"
 	"github.com/twmb/franz-go/pkg/kgo"
+	"github.com/twmb/franz-go/pkg/sr"
+	"go.uber.org/zap"
 )
 
 type consumer struct {
@@ -52,12 +56,17 @@ type consumer struct {
 
 	resetOffset kgo.Offset // defaults to NoResetOffset, can be start or end
 
+	useSchemaRegistry []string // schema registry options
+	decodeKey         bool
+	decodeVal         bool
+
 	// If an end offset is specified, we immediately look up where we will
 	// end and quit rpk when we hit the end.
 	partEnds   map[string]map[int32]int64
 	partStarts map[string]map[int32]int64
 
-	cl *kgo.Client
+	cl   *kgo.Client
+	srCl *sr.Client
 }
 
 func newConsumeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
@@ -108,10 +117,17 @@ func newConsumeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			c.cl, err = kafka.NewFranzClient(fs, p, opts...)
 			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
 
+			if len(c.useSchemaRegistry) > 0 {
+				err = c.formatSchemaRegistryFlag()
+				out.MaybeDie(err, "unable to parse --use-schema-registry flag: %v", err)
+				c.srCl, err = schemaregistry.NewClient(fs, p)
+				out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
+			}
+
 			doneConsume := make(chan struct{})
 			go func() {
 				defer close(doneConsume)
-				c.consume()
+				c.consume(cmd.Context())
 				c.cl.LeaveGroup()
 			}()
 
@@ -152,22 +168,26 @@ func newConsumeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 	cmd.Flags().StringVar(&c.rack, "rack", "", "Rack to use for consuming, which opts into follower fetching")
 
+	cmd.Flags().StringSliceVar(&c.useSchemaRegistry, "use-schema-registry", []string{}, "If present, rpk will decode the key and the value with the schema registry. Also accepts use-schema-registry=key or use-schema-registry=value")
 	// Deprecated.
 	cmd.Flags().BoolVar(new(bool), "commit", false, "")
 	cmd.Flags().MarkDeprecated("commit", "Group consuming always commits")
 
+	cmd.Flags().Lookup("use-schema-registry").NoOptDefVal = "key,value"
+
 	return cmd
 }
 
-func (c *consumer) consume() {
+func (c *consumer) consume(ctx context.Context) {
 	var (
 		buf   []byte
 		n     int
 		marks []*kgo.Record
 		done  bool
 	)
+	serdeCache := make(map[int]*serde.Serde)
 	for !done {
-		fs := c.cl.PollFetches(context.Background())
+		fs := c.cl.PollFetches(ctx)
 		if fs.IsClientClosed() {
 			return
 		}
@@ -183,19 +203,41 @@ func (c *consumer) consume() {
 			if done {
 				return
 			}
-
 			pend, hasEnd := c.getPartitionEnd(p.Topic, p.Partition)
 			if hasEnd && pend < 0 {
 				return // reached end, still draining client
 			}
 
 			for _, r := range p.Records {
+				var toStdErr bool
+				if r.Key != nil && c.decodeKey {
+					decKey, err := handleDecode(ctx, c.srCl, r.Key, serdeCache)
+					if err != nil {
+						zap.L().Sugar().Warnf("unable to decode record key %v with schema registry: %v\n", r.Key, err)
+						toStdErr = true
+					} else {
+						r.Key = decKey
+					}
+				}
+				if r.Value != nil && c.decodeVal {
+					decVal, err := handleDecode(ctx, c.srCl, r.Value, serdeCache)
+					if err != nil {
+						zap.L().Sugar().Warnf("unable to decode record value %v with schema registry: %v\n", r.Value, err)
+						toStdErr = true
+					} else {
+						r.Value = decVal
+					}
+				}
 				if !r.Attrs.IsControl() || c.printControl {
 					if c.f == nil {
-						c.writeRecordJSON(r)
+						c.writeRecordJSON(r, toStdErr)
 					} else {
 						buf = c.f.AppendPartitionRecord(buf[:0], &p.FetchPartition, r)
-						os.Stdout.Write(buf)
+						if toStdErr {
+							os.Stderr.Write(buf)
+						} else {
+							os.Stdout.Write(buf)
+						}
 					}
 				}
 
@@ -221,7 +263,7 @@ func (c *consumer) consume() {
 	}
 }
 
-func (c *consumer) writeRecordJSON(r *kgo.Record) {
+func (c *consumer) writeRecordJSON(r *kgo.Record, toStdErr bool) {
 	type Header struct {
 		Key   string `json:"key"`
 		Value string `json:"value"`
@@ -269,8 +311,13 @@ func (c *consumer) writeRecordJSON(r *kgo.Record) {
 	} else {
 		out, _ = json.Marshal(m)
 	}
-	os.Stdout.Write(out)
-	os.Stdout.Write(newline)
+	if toStdErr {
+		os.Stderr.Write(out)
+		os.Stderr.Write(newline)
+	} else {
+		os.Stdout.Write(out)
+		os.Stdout.Write(newline)
+	}
 }
 
 var newline = []byte("\n")
@@ -761,6 +808,48 @@ func (c *consumer) intoOptions(topics []string) ([]kgo.Opt, error) {
 	}
 
 	return opts, nil
+}
+
+func (c *consumer) formatSchemaRegistryFlag() error {
+	if len(c.useSchemaRegistry) == 0 {
+		// We don't expect to hit this, but better be safe.
+		return errors.New("schema registry flag is empty")
+	}
+	for _, f := range c.useSchemaRegistry {
+		switch {
+		case strings.HasPrefix("value", f):
+			c.decodeVal = true
+		case strings.HasPrefix("key", f):
+			c.decodeKey = true
+		default:
+			return fmt.Errorf("unsupported decode type %q", f)
+		}
+	}
+	return nil
+}
+
+func handleDecode(ctx context.Context, cl *sr.Client, record []byte, serdeCache map[int]*serde.Serde) ([]byte, error) {
+	var serdeHeader sr.ConfluentHeader
+	id, toDecode, err := serdeHeader.DecodeID(record)
+	if err != nil {
+		return nil, errors.New("unable to decode the ID")
+	}
+	var rpkSerde *serde.Serde
+	if cachedSerde, ok := serdeCache[id]; ok {
+		rpkSerde = cachedSerde
+	} else {
+		schema, err := cl.SchemaByID(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get schema with index %v from the schema registry: %v", id, err)
+		}
+		rpkSerde, err = serde.NewSerde(ctx, cl, &schema, id, "")
+		if err != nil {
+			return nil, err
+		}
+		serdeCache[id] = rpkSerde
+	}
+
+	return rpkSerde.DecodeRecord(toDecode)
 }
 
 const helpConsume = `Consume records from topics.

--- a/src/go/rpk/pkg/serde/proto.go
+++ b/src/go/rpk/pkg/serde/proto.go
@@ -11,9 +11,11 @@ package serde
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/bufbuild/protocompile"
+	"github.com/bufbuild/protocompile/linker"
 	"github.com/twmb/franz-go/pkg/sr"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
@@ -21,56 +23,32 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
+// inMemFileName is an arbitrary name given to the in-memory proto file
+// generated while compiling the schema.
+const inMemFileName = "tmp.proto"
+
 // newAvroEncoder will generate a serializer function using the specified
 // schema. It utilizes the message type identified by protoFQN. If the schema
 // includes references, it retrieves them using the supplied client. The
 // generated function returns the record encoded in the protobuf wire format.
-func newProtoEncoder(ctx context.Context, cl *sr.Client, schema *sr.Schema, protoFQN string, schemaID int) (serdeFunc, error) {
-	if protoFQN == "" {
-		return nil, fmt.Errorf("please provide the protobuf message name")
-	}
-	// Compile the Schema Registry proto. //
-	const inMemFileName = "tmp.proto"
-	accessorMap := make(map[string]string)
-	// This is the original schema.
-	accessorMap[inMemFileName] = schema.Schema
-
-	// And we add the rest of schemas if we have references.
-	if len(schema.References) > 0 {
-		err := mapReferences(ctx, cl, schema, accessorMap)
-		if err != nil {
-			return nil, fmt.Errorf("unable to map references: %v", err)
-		}
-	}
-
-	compiler := protocompile.Compiler{
-		Resolver: &protocompile.SourceResolver{
-			Accessor: protocompile.SourceAccessorFromMap(accessorMap),
-		},
-		SourceInfoMode: protocompile.SourceInfoStandard,
-	}
-	compiled, err := compiler.Compile(ctx, inMemFileName)
-	if err != nil {
-		return nil, fmt.Errorf("unable to compile the given schema: %v", err)
-	}
-
+func newProtoEncoder(compiledFiles linker.Files, protoFQN string, schemaID int) (serdeFunc, error) {
 	// Create proto message with runtime information. //
-	d := compiled.FindFileByPath(inMemFileName).FindDescriptorByName(protoreflect.FullName(protoFQN))
-	if d == nil {
+	descriptor := compiledFiles.FindFileByPath(inMemFileName).FindDescriptorByName(protoreflect.FullName(protoFQN))
+	if descriptor == nil {
 		return nil, fmt.Errorf("unable to find message with name %q", protoFQN)
 	}
-	msgDescriptor, ok := d.(protoreflect.MessageDescriptor)
+	msgDescriptor, ok := descriptor.(protoreflect.MessageDescriptor)
 	if !ok {
 		return nil, fmt.Errorf("unable to process message with name %q", protoFQN)
 	}
 	message := dynamicpb.NewMessage(msgDescriptor)
 
 	o := protojson.UnmarshalOptions{
-		Resolver: compiled.AsResolver(),
+		Resolver: compiledFiles.AsResolver(),
 	}
 	return func(record []byte) ([]byte, error) {
 		// Unmarshal the record into the proto message. //
-		err = o.Unmarshal(record, message)
+		err := o.Unmarshal(record, message)
 		if err != nil {
 			return nil, fmt.Errorf("unable to decode the record into the given schema: %v", err)
 		}
@@ -85,6 +63,42 @@ func newProtoEncoder(ctx context.Context, cl *sr.Client, schema *sr.Schema, prot
 		var serdeHeader sr.ConfluentHeader
 		h, _ := serdeHeader.AppendEncode(nil, schemaID, messageIndex(msgDescriptor))
 		return append(h, binary...), nil
+	}, nil
+}
+
+// newProtoDecoder will generate a deserializar function that decodes a record
+// with the given schema. The generated function expects the record to contain
+// the index of the message (schema ID should already be stripped away) in the
+// first bytes of the record.
+func newProtoDecoder(compiledFiles linker.Files) (serdeFunc, error) {
+	descriptors := compiledFiles.FindFileByPath(inMemFileName).Messages()
+
+	return func(record []byte) ([]byte, error) {
+		var serdeHeader sr.ConfluentHeader
+		protoIndex, toDecode, err := serdeHeader.DecodeIndex(record, 0)
+		if err != nil {
+			return nil, errors.New("unable to decode index from the protobuf record")
+		}
+		if len(protoIndex) == 0 {
+			return nil, errors.New("encoded message does not contain the protobuf index")
+		}
+		msgDescriptor := messageDescriptorFromIndex(descriptors, protoIndex)
+
+		message := dynamicpb.NewMessage(msgDescriptor)
+		err = proto.Unmarshal(toDecode, message)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshall protobuf encoded record into the message with index %v: %v", protoIndex, err)
+		}
+
+		// Unmarshal the record into the proto message. //
+		o := protojson.MarshalOptions{
+			Resolver: compiledFiles.AsResolver(),
+		}
+		jsonBytes, err := o.Marshal(message)
+		if err != nil {
+			return nil, fmt.Errorf("unable to marshal protobuf message as JSON: %v", err)
+		}
+		return jsonBytes, nil
 	}, nil
 }
 
@@ -122,4 +136,41 @@ func mapReferences(ctx context.Context, cl *sr.Client, schema *sr.Schema, refMap
 		}
 	}
 	return nil
+}
+
+// messageDescriptorFromIndex recursively finds the inner message descriptor
+// based on the protoIndex. Initial protoIndex must be a non-empty slice.
+func messageDescriptorFromIndex(msgs protoreflect.MessageDescriptors, protoIndex []int) protoreflect.MessageDescriptor {
+	descriptor := msgs.Get(protoIndex[0])
+	if len(protoIndex) > 1 {
+		descriptor = messageDescriptorFromIndex(descriptor.Messages(), protoIndex[1:])
+	}
+	return descriptor
+}
+
+func compileSchema(ctx context.Context, cl *sr.Client, schema *sr.Schema) (linker.Files, error) {
+	// Compile the Schema Registry proto. //
+	accessorMap := make(map[string]string)
+	// This is the original schema.
+	accessorMap[inMemFileName] = schema.Schema
+
+	// And we add the rest of schemas if we have references.
+	if len(schema.References) > 0 {
+		err := mapReferences(ctx, cl, schema, accessorMap)
+		if err != nil {
+			return nil, fmt.Errorf("unable to map references: %v", err)
+		}
+	}
+
+	compiler := protocompile.Compiler{
+		Resolver: &protocompile.SourceResolver{
+			Accessor: protocompile.SourceAccessorFromMap(accessorMap),
+		},
+		SourceInfoMode: protocompile.SourceInfoStandard,
+	}
+	compiled, err := compiler.Compile(ctx, inMemFileName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to compile the given schema: %v", err)
+	}
+	return compiled, nil
 }

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -398,7 +398,11 @@ class RpkTool:
                 headers=[],
                 partition=None,
                 timeout=None,
-                compression_type=TopicSpec.COMPRESSION_NONE):
+                compression_type=TopicSpec.COMPRESSION_NONE,
+                schema_id=None,
+                schema_key_id=None,
+                proto_msg=None,
+                proto_key_msg=None):
 
         if timeout is None:
             # For produce, we use a lower timeout than the general
@@ -410,15 +414,31 @@ class RpkTool:
             'produce', '--key', key, '-z', f'{compression_type}',
             '--delivery-timeout', f'{timeout}s', '-f', '%v', topic
         ]
+        use_schema_registry = False
         if headers:
             cmd += ['-H ' + h for h in headers]
         if partition is not None:
             cmd += ['-p', str(partition)]
+        if schema_id is not None:
+            cmd += ["--schema-id", f'{schema_id}']
+            use_schema_registry = True
+        if schema_key_id is not None:
+            cmd += ["--schema-key-id", f'{schema_key_id}']
+            use_schema_registry = True
+        if proto_msg is not None:
+            cmd += ["--proto-msg-type", proto_msg]
+            use_schema_registry = True
+        if proto_key_msg is not None:
+            cmd += ["--proto-key-msg-type", proto_key_msg]
+            use_schema_registry = True
 
         # Run remote process with a slightly higher timeout than the
         # rpk delivery timeout, so that we get a clean-ish rpk timeout
         # message rather than sigkilling the remote process.
-        out = self._run_topic(cmd, stdin=msg, timeout=timeout + 0.5)
+        out = self._run_topic(cmd,
+                              stdin=msg,
+                              timeout=timeout + 0.5,
+                              use_schema_registry=use_schema_registry)
 
         m = re.search(r"at offset (\d+)", out)
         assert m, f"Reported offset not found in: {out}"
@@ -567,7 +587,8 @@ class RpkTool:
                 fetch_max_bytes=None,
                 quiet=False,
                 format=None,
-                timeout=None):
+                timeout=None,
+                use_schema_registry=None):
         cmd = ["consume", topic]
         if group is not None:
             cmd += ["-g", group]
@@ -583,10 +604,15 @@ class RpkTool:
             cmd += ["-p", f"{partition}"]
         if quiet:
             cmd += ["-f", "_\\n"]
+        if use_schema_registry is not None:
+            cmd += ["--use-schema-registry=" + use_schema_registry]
         elif format is not None:
             cmd += ["-f", format]
 
-        return self._run_topic(cmd, timeout=timeout)
+        return self._run_topic(cmd,
+                               timeout=timeout,
+                               use_schema_registry=use_schema_registry
+                               is not None)
 
     def group_seek_to(self, group, to):
         cmd = ["seek", group, "--to", to]
@@ -807,8 +833,14 @@ class RpkTool:
         output = self._execute(cmd)
         return json.loads(output) if output_format == 'json' else output
 
-    def _run_topic(self, cmd, stdin=None, timeout=None):
+    def _run_topic(self,
+                   cmd,
+                   stdin=None,
+                   timeout=None,
+                   use_schema_registry=False):
         cmd = [self._rpk_binary(), "topic"] + self._kafka_conn_settings() + cmd
+        if use_schema_registry:
+            cmd = cmd + self._schema_registry_conn_settings()
         return self._execute(cmd, stdin=stdin, timeout=timeout)
 
     def _run_group(self, cmd, stdin=None, timeout=None):


### PR DESCRIPTION
This PR introduces a new flag to `rpk topic consume`: `--use-schema-registry`. This flag allows the user to inform rpk that they want to decode the message using the schema registry.

**Usages:**
- `--use-schema-registry`: decodes key and value.
-  `--use-schema-registry=key`: decodes only the key.
- `--use-schema-registry=value`: decodes only the value.

If rpk fails to decode a message, it will print it to stderr and log the error.

**Example:**
```
# No decoding, it will show the raw bytes:
$ rpk topic consume test -o 96:end                       
{
  "topic": "test",
  "value": "\u0000\u0000\u0000\u0000\u0006\u0000\u0012\u0007vasquez\n\u0006Rogger",
  "timestamp": 1698207671816,
  "partition": 0,
  "offset": 96
}

# Decoding the value
$ rpk topic consume test -o 96:end --use-schema-registry                      
{
  "topic": "test",
  "value": "{\"name\":\"Rogger\", \"lastname\":\"vasquez\"}",
  "timestamp": 1698207671816,
  "partition": 0,
  "offset": 96
}
```

**Details:**
Each encoded message will have the serde header, this header has information about the Schema ID, Schema Message Index (for proto) and rpk uses this to retrieve the schema and parse the message accordingly
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Features

* You can decode now schema registry encoded messages (AVRO or Protobuf) using `rpk topic consume --use-schema-registry`

