### PR TITLE
rptest: ignore HighThroughputTest.test_ts_resource_utilization for now

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -853,7 +853,7 @@ class HighThroughputTest(PreallocNodesTest):
             producer.wait(timeout_sec=600)
             self.free_preallocated_nodes()
 
-    @ok_to_fail
+    @ignore
     @cluster(num_nodes=10, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_ts_resource_utilization(self):
         """


### PR DESCRIPTION
Following on PR #14389, need to ignore the test for now since it is causing ducktape [timeouts](https://buildkite.com/redpanda/vtools/builds/10272#018b7211-03c7-4645-9bf0-98ee93fbba4f/8783-8893):
```
...
[INFO:2023-10-27 17:54:49,317]: RunnerClient: rptest.redpanda_cloud_tests.high_throughput_test.HighThroughputTest.test_ts_resource_utilization: Running...
[ERROR:2023-10-27 20:54:49,516]: Exception receiving message: <class 'ducktape.errors.TimeoutError'>: runner client unresponsive, active_tests:
 [TestKey(test_id='rptest.redpanda_cloud_tests.high_throughput_test.HighThroughputTest.test_ts_resource_utilization', test_index=1)]
...
```

Related issue: https://github.com/redpanda-data/cloudv2/issues/9613

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
