### PR TITLE
storage: evict data from compactible topics under disk pressure

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -143,14 +143,6 @@ ss::future<> log_eviction_stm::monitor_log_eviction() {
     while (!_as.abort_requested()) {
         try {
             auto eviction_offset = co_await storage_eviction_event();
-            if (!_raft->log()->config().is_collectable()) {
-                vlog(
-                  _log.error,
-                  "Ignoring unexpected storage eviction event for a "
-                  "non-collectable NTP: {}",
-                  _raft->ntp());
-                continue;
-            }
             if (eviction_offset > _storage_eviction_offset) {
                 _storage_eviction_offset = eviction_offset;
                 _has_pending_truncation.signal();

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -7,46 +7,37 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 import random
-import requests
-from pickletools import long1
-from time import sleep, time, time_ns
-from collections import defaultdict
+from time import sleep, time
 
+import requests
 from ducktape.cluster.cluster import ClusterNode
-from ducktape.errors import TimeoutError
+from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 from kafka import KafkaProducer
 from kafka.errors import BrokerNotAvailableError, NotLeaderForPartitionError
-from rptest.clients.kafka_cli_tools import KafkaCliTools
+
 from rptest.clients.default import DefaultClient
-from rptest.clients.rpk import RpkTool
-from rptest.clients.offline_log_viewer import OfflineLogViewer
-from rptest.services.redpanda import SISettings
-from ducktape.mark import matrix
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import LoggingConfig, RedpandaService
-from rptest.services.storage import Topic
+from rptest.services.kgo_verifier_services import KgoVerifierProducer
+from rptest.services.redpanda import LoggingConfig, RedpandaService, SISettings
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.tests.redpanda_test import RedpandaTest
-from rptest.util import expect_exception, search_logs_with_timeout, produce_total_bytes
+from rptest.util import produce_total_bytes, search_logs_with_timeout
+from rptest.utils.expect_rate import ExpectRate, RateTarget
 from rptest.utils.full_disk import FullDiskHelper
 from rptest.utils.partition_metrics import PartitionMetrics
-from rptest.utils.si_utils import BucketView, quiesce_uploads
-from rptest.utils.expect_rate import ExpectRate, RateTarget
-from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer
+from rptest.utils.si_utils import quiesce_uploads
 
 # reduce this?
 MAX_MSG: int = 600
 MAX_MSG_PER_SEC = 10
 FDT_LOG_ALLOW_LIST = [".*cluster - storage space alert: free space.*"]
 LOOP_ITERATIONS = 3
-
-import logging
-import sys
 
 
 # XXX This test really needs a raw protocol client (i.e. not librdkafka # based)
@@ -560,11 +551,13 @@ class LogStorageMaxSizeSI(RedpandaTest):
         """
         # start redpanda with specific config like segment size
         si_settings = SISettings(test_context=self.test_context,
-                                 log_segment_size=log_segment_size)
+                                 log_segment_size=log_segment_size,
+                                 fast_uploads=True)
         extra_rp_conf = {
             'compacted_log_segment_size': log_segment_size,
             'disk_reservation_percent': 0,
             'retention_local_target_capacity_percent': 100,
+            'retention_local_trim_interval': 1000,  # every second
         }
         self.redpanda.set_extra_rp_conf(extra_rp_conf)
         self.redpanda.set_si_settings(si_settings)
@@ -651,64 +644,34 @@ class LogStorageMaxSizeSI(RedpandaTest):
                 )
             return below
 
-        # In the case of the `cleanup.policy=compact` We want to assert a "safety property,"
-        # which means proving that nothing bad happens. The best mechanism we have for doing
-        # this here is to run the system for some time and periodically check the invariant(s).
-        # The informal guarantee that this correctly tests the behavior we're interesting in
-        # is given by the fact that the `cleanup.policy=delete` hits the same invariants within
-        # the same timeout.
-        timeout_sec = 120
-
-        if cleanup_policy == TopicSpec.CLEANUP_COMPACT:
-            # For `cleanup.policy=compat` we don't expect any removal. Wait for timeout.
-            with expect_exception(TimeoutError, bool):
-                wait_until(target_size_reached,
-                           timeout_sec=timeout_sec,
-                           backoff_sec=5)
-            assert max_local_start_offset(
-                self.redpanda, topic_name
-            ) == 0, "not expecting local offsets to advance when `cleanup.policy=compact`"
-        else:
-            # give it plenty of time. on debug it is hella slow
-            wait_until(target_size_reached,
-                       timeout_sec=timeout_sec,
-                       backoff_sec=5)
-            assert min_local_start_offset(
-                self.redpanda, topic_name
-            ) > 0, "expecting disk storage to be reduced by advancing local offsets (local log prefix trim)"
-
-
-def max_local_start_offset(redpanda: RedpandaService, topic: str):
-    max_offset = 0
-    for node in redpanda.nodes:
-        for p in local_start_offsets(redpanda, node, topic):
-            max_offset = max(max_offset, p['start offset'])
-    return max_offset
+        # give it plenty of time. on debug it is hella slow
+        wait_until(target_size_reached, timeout_sec=30, backoff_sec=5)
+        assert min_local_start_offset(
+            self.redpanda, topic_name
+        ) > 0, "expecting disk storage to be reduced by advancing local offsets (local log prefix trim)"
 
 
 def min_local_start_offset(redpanda: RedpandaService, topic: str):
     min_offset = None
     for node in redpanda.nodes:
         for p in local_start_offsets(redpanda, node, topic):
-            if min_offset == None:
-                min_offset = p['start offset']
+            if min_offset is None:
+                min_offset = p['local_log_start_offset']
             else:
-                min_offset = max(min_offset, p['start offset'])
+                min_offset = max(min_offset, p['local_log_start_offset'])
     return min_offset
 
 
 def local_start_offsets(redpanda: RedpandaService, node: ClusterNode,
                         topic: str):
-    viewer = OfflineLogViewer(redpanda)
-    for shard_items in viewer.read_kvstore(node).values():
-        for item in shard_items:
-            k = item['key']
-            if (k['keyspace'] == 'storage'
-                    and k['data']['name'] == 'start offset'
-                    and k['data']['ntp']['namespace'] == 'kafka'
-                    and k['data']['ntp']['topic'] == topic):
+    admin = Admin(redpanda, default_node=node)
+    partitions = admin.get_partitions(topic)
 
-                yield {
-                    "partition": k['data']['ntp']['partition'],
-                    "start offset": item["value"]
-                }
+    for p in partitions:
+        status = admin.get_partition_cloud_storage_status(
+            topic, p["partition_id"])
+
+        yield {
+            "partition": p["partition_id"],
+            "local_log_start_offset": status["local_log_start_offset"]
+        }


### PR DESCRIPTION
This is a resubmit of #14212 with an additional change which excludes __consumer_offsets and __schemas from being evicted. The rationale is captured in the code doc of the `deletion_exempt` function.

---

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Currently, under disk pressure, we evict local data that was uploaded to
the cloud storage only for topics with `cleanup.policy` equal to
`delete` or `delete,compact`.

Due to an oversight, data for topics with the policy set to `compact` is
never evicted. This commit ensures consistent eviction behavior for all
cleanup policies.

Since Redpanda doesn't run compaction for data that is present only in
the cloud storage, this change introduces a potential regression in
compaction quality. This choice is considered better than running out of
disk space.

If we decide to backport, this depends on #13856 and #13935.

Fixes #14015.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Evict local data that was uploaded to the cloud storage under disk pressure for topics with `cleanup.policy=compact`. Now all cleanup policies have consistent eviction behavior.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
