### PR TITLE
Control consistency checks in the upload loop and STM independently

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -932,121 +932,163 @@ bool partition_manifest::add(
     return add(m);
 }
 
-bool partition_manifest::safe_segment_meta_to_add(const segment_meta& m) {
-    if (_segments.empty()) {
-        // The empty manifest can be started from any offset. If we deleted all
-        // segments due to retention we should start from last uploaded offset.
-        // The reuploads are not possible if the manifest is empty.
-        const bool is_safe = _last_offset == model::offset{0}
-                             || model::next_offset(_last_offset)
-                                  == m.base_offset;
-
-        if (!is_safe) {
-            vlog(
-              cst_log.error,
-              "[{}] New segment does not line up with last offset of empty "
-              "log: "
-              "last_offset: {}, new_segment: {}",
-              _ntp,
-              _last_offset,
-              m);
-        }
-
-        return is_safe;
-    }
-
-    auto format_seg_meta_anomalies = [](const segment_meta_anomalies& smas) {
-        if (smas.empty()) {
-            return ss::sstring{};
-        }
-
-        std::vector<anomaly_type> types;
-        for (const auto& a : smas) {
-            types.push_back(a.type);
-        }
-
-        return ssx::sformat(
-          "{{anomaly_types: {}, new_segment: {}, previous_segment: {}}}",
-          types,
-          smas.begin()->at,
-          smas.begin()->previous);
+size_t partition_manifest::safe_segment_meta_to_add(
+  std::vector<segment_meta> meta_list) const {
+    struct manifest_substitute {
+        model::offset last_offset;
+        std::optional<segment_meta> last_segment;
+        size_t num_accepted{0};
     };
 
-    auto it = _segments.find(m.base_offset);
-    if (it == _segments.end()) {
-        // Segment added to tip of the log
-        const auto last_seg = last_segment();
-        vassert(last_seg.has_value(), "Empty manifest");
+    manifest_substitute subst{
+      .last_offset = _last_offset,
+      .last_segment = last_segment(),
+    };
 
-        segment_meta_anomalies anomalies;
-        scrub_segment_meta(m, last_seg, anomalies);
-        if (!anomalies.empty()) {
-            vlog(
-              cst_log.error,
-              "[{}] New segment does not line up with previous segment: {}",
-              _ntp,
-              format_seg_meta_anomalies(anomalies));
-            return false;
-        }
-        return true;
-    } else {
-        // Segment reupload case:
-        // The segment should be aligned with existing segments in the manifest
-        // but there should be at least one segment covered by 'm'.
-        if (it != _segments.begin()) {
-            // Firstly, check that the replacement lines up with the segment
-            // preceeding it if one exists.
-            const auto prev_segment_it = _segments.prev(it);
-            segment_meta_anomalies anomalies;
-            scrub_segment_meta(m, *prev_segment_it, anomalies);
-            if (!anomalies.empty()) {
+    for (const auto& m : meta_list) {
+        if (_segments.empty() && !subst.last_segment.has_value()) {
+            // The empty manifest can be started from any offset. If we deleted
+            // all segments due to retention we should start from last uploaded
+            // offset. The reuploads are not possible if the manifest is empty.
+            const bool is_safe = subst.last_offset == model::offset{0}
+                                 || model::next_offset(_last_offset)
+                                      == m.base_offset;
+
+            if (!is_safe) {
                 vlog(
                   cst_log.error,
-                  "[{}] New replacement segment does not line up with "
-                  "previous "
-                  "segment: {}",
+                  "[{}] New segment does not line up with last offset of empty "
+                  "log: "
+                  "last_offset: {}, new_segment: {}",
                   _ntp,
-                  format_seg_meta_anomalies(anomalies));
-                return false;
+                  subst.last_offset,
+                  m);
+                break;
+            }
+            subst.last_offset = m.committed_offset;
+            subst.last_segment = m;
+            subst.num_accepted++;
+        } else {
+            // We have segments to check
+            auto format_seg_meta_anomalies =
+              [](const segment_meta_anomalies& smas) {
+                  if (smas.empty()) {
+                      return ss::sstring{};
+                  }
+
+                  std::vector<anomaly_type> types;
+                  for (const auto& a : smas) {
+                      types.push_back(a.type);
+                  }
+
+                  return ssx::sformat(
+                    "{{anomaly_types: {}, new_segment: {}, previous_segment: "
+                    "{}}}",
+                    types,
+                    smas.begin()->at,
+                    smas.begin()->previous);
+              };
+
+            auto it = _segments.find(m.base_offset);
+            if (it == _segments.end()) {
+                // Segment added to tip of the log
+                const auto last_seg = subst.last_segment;
+                vassert(
+                  last_seg.has_value(),
+                  "Empty manifest, base_offset: {}",
+                  m.base_offset);
+
+                segment_meta_anomalies anomalies;
+                scrub_segment_meta(m, last_seg, anomalies);
+                if (!anomalies.empty()) {
+                    vlog(
+                      cst_log.error,
+                      "[{}] New segment does not line up with previous "
+                      "segment: {}",
+                      _ntp,
+                      format_seg_meta_anomalies(anomalies));
+                    break;
+                }
+                // Only update if we extending the log
+                subst.last_offset = m.committed_offset;
+                subst.last_segment = m;
+                subst.num_accepted++;
+                continue;
+            } else {
+                // Segment reupload case:
+                // The segment should be aligned with existing segments in the
+                // manifest but there should be at least one segment covered by
+                // 'm'.
+                if (it != _segments.begin()) {
+                    // Firstly, check that the replacement lines up with the
+                    // segment preceeding it if one exists.
+                    const auto prev_segment_it = _segments.prev(it);
+                    segment_meta_anomalies anomalies;
+                    scrub_segment_meta(m, *prev_segment_it, anomalies);
+                    if (!anomalies.empty()) {
+                        vlog(
+                          cst_log.error,
+                          "[{}] New replacement segment does not line up with "
+                          "previous "
+                          "segment: {}",
+                          _ntp,
+                          format_seg_meta_anomalies(anomalies));
+                        break;
+                    }
+                }
+
+                if (it->committed_offset == m.committed_offset) {
+                    // 'm' is a reupload of an individual segment, the segment
+                    // should have different size
+                    if (it->size_bytes == m.size_bytes) {
+                        vlog(
+                          cst_log.error,
+                          "[{}] New replacement segment has the same size as "
+                          "replaced "
+                          "segment: new_segment: {}, replaced_segment: {}",
+                          _ntp,
+                          m,
+                          *it);
+                        break;
+                    }
+                    subst.num_accepted++;
+                    continue;
+                }
+
+                // 'm' is a reupload which merges multiple segments. The
+                // committed offset of 'm' should match an existing segment.
+                // Otherwise, the re-upload changes segment boundaries and is
+                // *not valid*.
+                ++it;
+                bool boundary_found = false;
+                while (it != _segments.end()) {
+                    if (it->committed_offset == m.committed_offset) {
+                        boundary_found = true;
+                        break;
+                    }
+                    ++it;
+                }
+
+                if (!boundary_found) {
+                    vlog(
+                      cst_log.error,
+                      "[{}] New replacement segment does not match the "
+                      "committed "
+                      "offset of "
+                      "any previous segment: new_segment: {}",
+                      _ntp,
+                      m);
+                    break;
+                }
+                subst.num_accepted++;
             }
         }
-
-        if (it->committed_offset == m.committed_offset) {
-            // 'm' is a reupload of an individual segment, the segment should
-            // have different size
-            if (it->size_bytes == m.size_bytes) {
-                vlog(
-                  cst_log.error,
-                  "[{}] New replacement segment has the same size as replaced "
-                  "segment: new_segment: {}, replaced_segment: {}",
-                  _ntp,
-                  m,
-                  *it);
-                return false;
-            }
-
-            return true;
-        }
-
-        // 'm' is a reupload which merges multiple segments. The committed
-        // offset of 'm' should match an existing segment. Otherwise, the
-        // re-upload changes segment boundaries and is *not valid*.
-        ++it;
-        while (it != _segments.end()) {
-            if (it->committed_offset == m.committed_offset) {
-                return true;
-            }
-            ++it;
-        }
-
-        vlog(
-          cst_log.error,
-          "[{}] New replacement segment does not match the committed offset of "
-          "any previous segment: new_segment: {}",
-          _ntp,
-          m);
-        return false;
     }
+    return subst.num_accepted;
+}
+
+bool partition_manifest::safe_segment_meta_to_add(const segment_meta& m) const {
+    return safe_segment_meta_to_add(std::vector<segment_meta>{m}) == 1;
 }
 
 partition_manifest

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -337,7 +337,10 @@ public:
     bool add(const segment_name& name, const segment_meta& meta);
 
     /// Return 'true' if the segment meta can be added safely
-    bool safe_segment_meta_to_add(const segment_meta& meta);
+    bool safe_segment_meta_to_add(const segment_meta& meta) const;
+    /// Return number of segments (counting from the beginning of the list) that
+    /// can be added safely.
+    size_t safe_segment_meta_to_add(std::vector<segment_meta> list) const;
 
     /// \brief Truncate the manifest (remove entries from the manifest)
     ///

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -1044,7 +1044,7 @@ void archival_metadata_stm::apply_add_segment(const segment& segment) {
     auto meta = segment.meta;
     bool disable_safe_add
       = config::shard_local_cfg()
-          .cloud_storage_disable_upload_consistency_checks.value();
+          .cloud_storage_disable_metadata_consistency_checks.value();
     if (!disable_safe_add && !_manifest->safe_segment_meta_to_add(meta)) {
         auto last = _manifest->last_segment();
         vlog(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1811,6 +1811,14 @@ configuration::configuration()
       "violations. Normally, this options should be disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , cloud_storage_disable_metadata_consistency_checks(
+      *this,
+      "cloud_storage_disable_metadata_consistency_checks",
+      "Disable all metadata consistency checks. This will allow redpanda to "
+      "replay logs with inconsistent tiered-storage metadata. Normally, this "
+      "option should be disabled.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -343,6 +343,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       cloud_storage_topic_purge_grace_period_ms;
     property<bool> cloud_storage_disable_upload_consistency_checks;
+    property<bool> cloud_storage_disable_metadata_consistency_checks;
 
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;


### PR DESCRIPTION
Currently, both STM and upload loop are checking segments for consistency violations. This may create problems when we're replaying the log generated by old redpanda version. In order to be able to enable checks only for new segments we need two different configuration options. 

This PR also unifies all consistency checks by introducing plural version of the `safe_segment_meta_to_add` method. This method accepts list of segments and performs consistency checks on them. Method returns number of segments that passed the check. The caller of the method then can remove segments that didn't pass the check by truncating the list of segments.

Fixes #14504
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Improved Tiered-Storage metadata consistency