### PR TITLE
ducktape: Infer rp-storage-tool backend from URL

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3712,6 +3712,8 @@ class RedpandaService(RedpandaServiceBase):
                 vars[
                     "AZURE_STORAGE_ACCOUNT_NAME"] = self.si_settings.cloud_storage_azure_storage_account
 
+        if self.si_settings.endpoint_url and self.si_settings.endpoint_url == 'https://storage.googleapis.com':
+            backend = "gcp"
         # Pick an arbitrary node to run the scrub from
         node = self.nodes[0]
 


### PR DESCRIPTION
FIXES #14480 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
