### PR TITLE
rptest:ht observe test fix response decode from grafana

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/observe_test.py
+++ b/tests/rptest/redpanda_cloud_tests/observe_test.py
@@ -2,6 +2,7 @@ import requests
 import json
 from ducktape.tests.test import Test
 from types import SimpleNamespace
+from io import BytesIO
 
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import make_redpanda_service
@@ -29,7 +30,8 @@ class HTObserveTest(Test):
         with requests.get(self._endpoint, headers=headers, stream=True) as r:
             if r.status_code != requests.status_codes.codes.ok:
                 r.raise_for_status()
-            return json.load(r.raw, object_hook=lambda d: SimpleNamespace(**d))
+            return json.load(BytesIO(r.content),
+                             object_hook=lambda d: SimpleNamespace(**d))
 
     def cluster_alerts(self, rule_groups):
         alerts = []


### PR DESCRIPTION
should be using a Requests response decoder that handles compression

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

- none
