### PR TITLE
wasm: ensure CPU usage is limited

### DIFF
--- a/src/go/transform-sdk/internal/testdata/dynamic/transform.go
+++ b/src/go/transform-sdk/internal/testdata/dynamic/transform.go
@@ -35,6 +35,9 @@ func identityTransform(e redpanda.WriteEvent) ([]redpanda.Record, error) {
 		return nil, errors.New("☠︎")
 	case "bomb":
 		panic("💥")
+	case "loop":
+		for {
+		}
 	case "allocate":
 		amt := binary.LittleEndian.Uint32(e.Record().Value)
 		allocated.Grow(int(amt))


### PR DESCRIPTION
This PR adds support for forcing Wasmtime to yield control periodically so that we don't hit reactor stalls running expensive transforms (or bugs with infinite loops in the user's transform).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
