### PR TITLE
ci: Cleanup BYOC agent after test runs

### DIFF
--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -83,7 +83,7 @@ class CloudClusterUtils:
 
     def rpk_cloud_login(self, client_id, client_secret):
         # perform cloud login
-        self.logger.info("Loggin in to cloud cluster")
+        self.logger.debug(f"...[{client_id}] Loggin in to cloud cluster")
         cmd = self._get_rpk_cloud_cmd()
         cmd += [
             "login", "--save", f"--client-id={client_id}",
@@ -132,7 +132,7 @@ class CloudClusterUtils:
         return False
 
     def rpk_cloud_agent_delete(self, cluster_id):
-        self.logger.info("Destroying cluster agent")
+        self.logger.debug(f"...[{cluster_id}] destroying cluster agent")
         cmd = self._get_rpk_cloud_cmd()
         cmd += [
             "byoc", self.provider, "destroy", f"--redpanda-id={cluster_id}"

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -161,6 +161,15 @@ class RpCloudApiClient(object):
         _network = self._http_get(self.network_endpoint(id=network_id))
         return _network
 
+    def get_resource(self, resource_handle):
+        try:
+            _r = self._http_get(endpoint=resource_handle)
+            self._logger.debug(
+                f"...resource requested with '{resource_handle}'")
+        except Exception as e:
+            self.log.warning(f"# Warning failed to get resource: {e}")
+        return _r
+
     def delete_namespace(self, uuid):
         _r = self._http_delete(endpoint=self.namespace_endpoint(uuid=uuid))
         # Check status
@@ -172,4 +181,5 @@ class RpCloudApiClient(object):
             self._logger.debug(f"...delete requested for '{resource_handle}'")
         except Exception as e:
             self.log.warning(f"# Warning deletion failed: {e}")
+            return False
         return _r


### PR DESCRIPTION
After BYOC test runs and native CloudV2 daily cleanups. Agents left untouched, which consumes resources.
It needs to be handled

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none