### PR TITLE
transform: switch over to kafka::offset

### DIFF
--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -66,9 +66,9 @@ public:
     source& operator=(source&&) = delete;
     virtual ~source() = default;
 
-    virtual ss::future<model::offset> load_latest_offset() = 0;
+    virtual ss::future<kafka::offset> load_latest_offset() = 0;
     virtual ss::future<model::record_batch_reader>
-    read_batch(model::offset, ss::abort_source*) = 0;
+    read_batch(kafka::offset, ss::abort_source*) = 0;
 
     using factory = detail::factory<source>;
 };

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -50,19 +50,19 @@ class fake_source : public source {
     static constexpr size_t max_queue_size = 64;
 
 public:
-    explicit fake_source(model::offset initial_offset)
+    explicit fake_source(kafka::offset initial_offset)
       : _batches(max_queue_size)
       , _latest_offset(initial_offset) {}
 
-    ss::future<model::offset> load_latest_offset() override;
+    ss::future<kafka::offset> load_latest_offset() override;
     ss::future<model::record_batch_reader>
-    read_batch(model::offset offset, ss::abort_source* as) override;
+    read_batch(kafka::offset offset, ss::abort_source* as) override;
 
     ss::future<> push_batch(model::record_batch batch);
 
 private:
     ss::queue<model::record_batch> _batches;
-    model::offset _latest_offset;
+    kafka::offset _latest_offset;
 };
 
 class fake_sink : public sink {

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -192,7 +192,7 @@ class processor_tracker : public processor_factory {
             std::move(meta),
             ss::make_shared<testing::fake_wasm_engine>(),
             [](auto, auto, auto) {},
-            std::make_unique<testing::fake_source>(model::offset(1)),
+            std::make_unique<testing::fake_source>(kafka::offset(1)),
             make_sink(),
             p)
           , _track_fn(std::move(cb)) {

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -52,7 +52,9 @@ public:
 
     model::record_batch make_tiny_batch() {
         return model::test::make_random_batch(model::test::record_batch_spec{
-          .offset = _offset++, .allow_compression = false, .count = 1});
+          .offset = kafka::offset_cast(_offset++),
+          .allow_compression = false,
+          .count = 1});
     }
     void push_batch(model::record_batch batch) {
         _src->push_batch(std::move(batch)).get();
@@ -61,9 +63,9 @@ public:
     uint64_t error_count() const { return _error_count; }
 
 private:
-    static constexpr model::offset start_offset = model::offset(9);
+    static constexpr kafka::offset start_offset = kafka::offset(9);
 
-    model::offset _offset = start_offset;
+    kafka::offset _offset = start_offset;
     std::unique_ptr<transform::processor> _p;
     testing::fake_source* _src;
     std::vector<testing::fake_sink*> _sinks;


### PR DESCRIPTION
The transform subsystem only uses kafka::partition_proxy and above for
the data path, so use kafka::offset internally for that type - it's safe
to cast to that type.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
