### PR TITLE
transform/rpc/client: fix loading missing offsets

### DIFF
--- a/src/v/transform/rpc/client.cc
+++ b/src/v/transform/rpc/client.cc
@@ -631,12 +631,12 @@ ss::future<offset_commit_response> client::do_remote_offset_commit(
     co_return response.value();
 }
 
-ss::future<result<model::transform_offsets_value, cluster::errc>>
+ss::future<result<std::optional<model::transform_offsets_value>, cluster::errc>>
 client::offset_fetch(model::transform_offsets_key key) {
     return retry([key, this] { return offset_fetch_once(key); });
 }
 
-ss::future<result<model::transform_offsets_value, cluster::errc>>
+ss::future<result<std::optional<model::transform_offsets_value>, cluster::errc>>
 client::offset_fetch_once(model::transform_offsets_key key) {
     auto coordinator = co_await find_coordinator(key);
     if (!coordinator) {
@@ -657,7 +657,7 @@ client::offset_fetch_once(model::transform_offsets_key key) {
     vlog(log.trace, "offset_fetch_once_response(node={}): {}", *leader, resp);
 
     if (resp.errc == cluster::errc::success) {
-        co_return *resp.result;
+        co_return resp.result;
     }
     co_return resp.errc;
 }

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -70,7 +70,8 @@ public:
     ss::future<result<model::partition_id, cluster::errc>>
       find_coordinator(model::transform_offsets_key);
 
-    ss::future<result<model::transform_offsets_value, cluster::errc>>
+    ss::future<
+      result<std::optional<model::transform_offsets_value>, cluster::errc>>
       offset_fetch(model::transform_offsets_key);
 
     ss::future<cluster::errc> offset_commit(
@@ -121,7 +122,8 @@ private:
       find_coordinator_once(model::transform_offsets_key);
     ss::future<cluster::errc> offset_commit_once(
       model::transform_offsets_key, model::transform_offsets_value);
-    ss::future<result<model::transform_offsets_value, cluster::errc>>
+    ss::future<
+      result<std::optional<model::transform_offsets_value>, cluster::errc>>
       offset_fetch_once(model::transform_offsets_key);
 
     ss::future<find_coordinator_response>


### PR DESCRIPTION
If an offset isn't stored, then we'll get a success, but a nullopt.
Ensure we're bubbling that up correctly.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
