### PR TITLE
transform: track processor progress

### DIFF
--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -41,6 +41,13 @@ inline offset next_offset(offset p) {
     return p + offset{1};
 }
 
+inline constexpr offset prev_offset(offset o) {
+    if (o <= offset{0}) {
+        return offset{};
+    }
+    return o - offset{1};
+}
+
 } // namespace kafka
 
 namespace cloud_storage_clients {

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -16,6 +16,7 @@
 #include "cluster/plugin_frontend.h"
 #include "cluster/types.h"
 #include "features/feature_table.h"
+#include "kafka/server/partition_proxy.h"
 #include "kafka/server/replicated_partition.h"
 #include "model/fundamental.h"
 #include "model/timeout_clock.h"
@@ -35,6 +36,8 @@
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/util/optimized_optional.hh>
+
+#include <memory>
 
 namespace transform {
 
@@ -59,19 +62,6 @@ public:
 
 private:
     model::ntp _ntp;
-    rpc::client* _client;
-};
-
-class rpc_client_factory final : public sink::factory {
-public:
-    explicit rpc_client_factory(rpc::client* c)
-      : _client(c) {}
-
-    std::optional<std::unique_ptr<sink>> create(model::ntp ntp) override {
-        return std::make_unique<rpc_client_sink>(ntp, _client);
-    };
-
-private:
     rpc::client* _client;
 };
 
@@ -102,24 +92,6 @@ public:
 
 private:
     kafka::partition_proxy _partition;
-};
-
-class partition_source_factory final : public source::factory {
-public:
-    explicit partition_source_factory(cluster::partition_manager* manager)
-      : _manager(manager) {}
-
-    std::optional<std::unique_ptr<source>> create(model::ntp ntp) final {
-        auto p = _manager->get(ntp);
-        if (!p) {
-            return std::nullopt;
-        }
-        return std::make_unique<partition_source>(kafka::partition_proxy(
-          std::make_unique<kafka::replicated_partition>(p)));
-    };
-
-private:
-    cluster::partition_manager* _manager;
 };
 
 class registry_adapter : public registry {
@@ -210,11 +182,11 @@ class proc_factory : public processor_factory {
 public:
     proc_factory(
       wasm_engine_factory factory,
-      std::unique_ptr<source::factory> source_factory,
-      std::unique_ptr<sink::factory> sink_factory)
+      cluster::partition_manager* partition_manager,
+      rpc::client* client)
       : _wasm_engine_factory(std::move(factory))
-      , _source_factory(std::move(source_factory))
-      , _sink_factory(std::move(sink_factory)) {}
+      , _partition_manager(partition_manager)
+      , _client(client) {}
 
     ss::future<std::unique_ptr<processor>> create_processor(
       model::transform_id id,
@@ -226,37 +198,41 @@ public:
         if (!engine) {
             throw std::runtime_error("unable to create wasm engine");
         }
-        auto src = _source_factory->create(ntp);
-        if (!src) {
+        auto partition = kafka::make_partition_proxy(ntp, *_partition_manager);
+        if (!partition) {
             throw std::runtime_error("unable to create transform source");
         }
+        auto src = std::make_unique<partition_source>(*std::move(partition));
         vassert(
           meta.output_topics.size() == 1,
           "only a single output topic is supported");
         const auto& output_topic = meta.output_topics[0];
         std::vector<std::unique_ptr<sink>> sinks;
-        auto sink = _sink_factory->create(
-          model::ntp(output_topic.ns, output_topic.tp, ntp.tp.partition));
-        if (!sink) {
-            throw std::runtime_error("unable to create transform sink");
-        }
-        sinks.push_back(*std::move(sink));
+        auto sink = std::make_unique<rpc_client_sink>(
+          model::ntp(output_topic.ns, output_topic.tp, ntp.tp.partition),
+          _client);
+        sinks.push_back(std::move(sink));
+
+        auto offset_tracker = std::make_unique<offset_tracker_impl>(
+          id, ntp.tp.partition, _client);
+
         co_return std::make_unique<processor>(
           id,
           ntp,
           meta,
           *std::move(engine),
           std::move(cb),
-          *std::move(src),
+          std::move(src),
           std::move(sinks),
+          std::move(offset_tracker),
           p);
     }
 
 private:
     mutex _mu;
     wasm_engine_factory _wasm_engine_factory;
-    std::unique_ptr<source::factory> _source_factory;
-    std::unique_ptr<sink::factory> _sink_factory;
+    cluster::partition_manager* _partition_manager;
+    rpc::client* _client;
     absl::flat_hash_map<model::offset, std::unique_ptr<wasm::engine>> _cache;
 };
 
@@ -302,12 +278,6 @@ service::service(
 service::~service() = default;
 
 ss::future<> service::start() {
-    std::unique_ptr<partition_source_factory> source_factory
-      = std::make_unique<partition_source_factory>(
-        &_partition_manager->local());
-    std::unique_ptr<sink::factory> sink_factory
-      = std::make_unique<rpc_client_factory>(&_rpc_client->local());
-
     _manager = std::make_unique<manager<ss::lowres_clock>>(
       _self,
       std::make_unique<registry_adapter>(
@@ -316,8 +286,8 @@ ss::future<> service::start() {
         [this](model::transform_metadata meta) {
             return create_engine(std::move(meta));
         },
-        std::move(source_factory),
-        std::move(sink_factory)));
+        &_partition_manager->local(),
+        &_rpc_client->local()));
     co_await _manager->start();
     register_notifications();
 }

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -80,13 +80,13 @@ public:
     explicit partition_source(kafka::partition_proxy p)
       : _partition(std::move(p)) {}
 
-    ss::future<kafka::offset> load_latest_offset() final {
+    kafka::offset latest_offset() final {
         auto result = _partition.last_stable_offset();
         if (result.has_error()) {
             throw std::runtime_error(
               kafka::make_error_code(result.error()).message());
         }
-        co_return model::offset_cast(result.value());
+        return model::offset_cast(result.value());
     }
 
     ss::future<model::record_batch_reader>

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -66,7 +66,7 @@ public:
     source& operator=(source&&) = delete;
     virtual ~source() = default;
 
-    virtual ss::future<kafka::offset> load_latest_offset() = 0;
+    virtual kafka::offset latest_offset() = 0;
     virtual ss::future<model::record_batch_reader>
     read_batch(kafka::offset, ss::abort_source*) = 0;
 

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -72,4 +72,31 @@ public:
 
     using factory = detail::factory<source>;
 };
+
+/**
+ * Transforms are at least once delivery, which we achieve by committing
+ * progress on the input topic offset periodically.
+ */
+class offset_tracker {
+public:
+    offset_tracker() = default;
+    offset_tracker(const offset_tracker&) = delete;
+    offset_tracker(offset_tracker&&) = delete;
+    offset_tracker& operator=(const offset_tracker&) = delete;
+    offset_tracker& operator=(offset_tracker&&) = delete;
+    virtual ~offset_tracker() = default;
+
+    /**
+     * Load the latest offset we've committed.
+     */
+    virtual ss::future<std::optional<kafka::offset>>
+    load_committed_offset() = 0;
+
+    /**
+     * Commit progress. The offset here is how far on the input partition we've
+     * transformed and successfully written to the output topic.
+     */
+    virtual ss::future<> commit_offset(kafka::offset) = 0;
+};
+
 } // namespace transform

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -16,26 +16,6 @@
 #include "model/transform.h"
 
 namespace transform {
-namespace detail {
-
-/**
- * A factory for sources and sinks.
- *
- * Use sink::factory or source::factory instead.
- */
-template<typename T>
-class factory {
-public:
-    factory() = default;
-    factory(const factory&) = delete;
-    factory& operator=(const factory&) = delete;
-    factory(factory&&) = delete;
-    factory& operator=(factory&&) = delete;
-    virtual ~factory() = default;
-
-    virtual std::optional<std::unique_ptr<T>> create(model::ntp) = 0;
-};
-} // namespace detail
 
 /**
  * The output sink for Wasm transforms.
@@ -50,8 +30,6 @@ public:
     virtual ~sink() = default;
 
     virtual ss::future<> write(ss::chunked_fifo<model::record_batch>) = 0;
-
-    using factory = detail::factory<sink>;
 };
 
 /**
@@ -69,8 +47,6 @@ public:
     virtual kafka::offset latest_offset() = 0;
     virtual ss::future<model::record_batch_reader>
     read_batch(kafka::offset, ss::abort_source*) = 0;
-
-    using factory = detail::factory<source>;
 };
 
 /**

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -35,11 +35,12 @@ ss::future<model::record_batch> fake_sink::read() {
     _batches.pop_front();
     co_return batch;
 }
-ss::future<kafka::offset> fake_source::load_latest_offset() {
+
+kafka::offset fake_source::latest_offset() {
     if (_batches.empty()) {
-        co_return kafka::offset(0);
+        return kafka::offset(0);
     }
-    co_return kafka::next_offset(_batches.rbegin()->first);
+    return kafka::next_offset(_batches.rbegin()->first);
 }
 
 ss::future<model::record_batch_reader>

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -11,55 +11,58 @@
 
 #include "transform/tests/test_fixture.h"
 
+#include "model/fundamental.h"
+
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/lowres_clock.hh>
 
 #include <gtest/gtest.h>
 
 #include <exception>
+#include <iostream>
 
 namespace transform::testing {
 ss::future<> fake_sink::write(ss::chunked_fifo<model::record_batch> batches) {
     for (auto& batch : batches) {
-        co_await _batches.push_eventually(std::move(batch));
+        _batches.push_back(std::move(batch));
     }
+    _cond_var.broadcast();
+    co_return;
 }
 ss::future<model::record_batch> fake_sink::read() {
-    return _batches.pop_eventually();
+    co_await _cond_var.wait(1s, [this] { return !_batches.empty(); });
+    auto batch = std::move(_batches.front());
+    _batches.pop_front();
+    co_return batch;
 }
 ss::future<kafka::offset> fake_source::load_latest_offset() {
-    co_return _latest_offset;
+    if (_batches.empty()) {
+        co_return kafka::offset(0);
+    }
+    co_return kafka::next_offset(_batches.rbegin()->first);
 }
+
 ss::future<model::record_batch_reader>
 fake_source::read_batch(kafka::offset offset, ss::abort_source* as) {
-    EXPECT_EQ(offset, _latest_offset);
-    if (!_batches.empty()) {
-        model::record_batch_reader::data_t batches;
-        while (!_batches.empty()) {
-            batches.push_back(_batches.pop());
+    auto sub = as->subscribe([this]() noexcept { _cond_var.broadcast(); });
+    co_await _cond_var.wait([this, as, offset] {
+        if (as->abort_requested()) {
+            return true;
         }
-        _latest_offset = model::offset_cast(
-          model::next_offset(batches.back().last_offset()));
-        co_return model::make_memory_record_batch_reader(std::move(batches));
-    }
-    auto sub = as->subscribe(
-      // NOLINTNEXTLINE(cppcoreguidelines-avoid-reference-coroutine-parameters)
-      [this](const std::optional<std::exception_ptr>& ex) noexcept {
-          _batches.abort(ex.value_or(
-            std::make_exception_ptr(ss::abort_requested_exception())));
-      });
-    if (!sub) {
-        _batches.abort(
-          std::make_exception_ptr(ss::abort_requested_exception()));
-    }
-    auto batch = co_await _batches.pop_eventually();
-    _latest_offset = model::offset_cast(
-      model::next_offset(batch.last_offset()));
-    sub->unlink();
-    co_return model::make_memory_record_batch_reader(std::move(batch));
+        auto it = _batches.lower_bound(offset);
+        return it != _batches.end();
+    });
+    as->check();
+    auto it = _batches.lower_bound(offset);
+    co_return model::make_memory_record_batch_reader(it->second.copy());
 }
+
 ss::future<> fake_source::push_batch(model::record_batch batch) {
-    co_await _batches.push_eventually(std::move(batch));
+    _batches.emplace(model::offset_cast(batch.last_offset()), std::move(batch));
+    _cond_var.broadcast();
+    co_return;
 }
+
 uint64_t fake_wasm_engine::memory_usage_size_bytes() const {
     // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
     return 64_KiB;

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -12,6 +12,7 @@
 #include "transform/tests/test_fixture.h"
 
 #include "model/fundamental.h"
+#include "transform/logger.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/lowres_clock.hh>

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -78,4 +78,17 @@ private:
     ss::condition_variable _cond_var;
 };
 
+class fake_offset_tracker : public offset_tracker {
+public:
+    ss::future<std::optional<kafka::offset>> load_committed_offset() override;
+
+    ss::future<> commit_offset(kafka::offset o) override;
+
+    ss::future<> wait_for_committed_offset(kafka::offset);
+
+private:
+    std::optional<kafka::offset> _committed;
+    ss::condition_variable _cond_var;
+};
+
 } // namespace transform::testing

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -56,7 +56,7 @@ class fake_source : public source {
 public:
     explicit fake_source() = default;
 
-    ss::future<kafka::offset> load_latest_offset() override;
+    kafka::offset latest_offset() override;
     ss::future<model::record_batch_reader>
     read_batch(kafka::offset offset, ss::abort_source* as) override;
 

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -192,7 +192,7 @@ class processor_tracker : public processor_factory {
             std::move(meta),
             ss::make_shared<testing::fake_wasm_engine>(),
             [](auto, auto, auto) {},
-            std::make_unique<testing::fake_source>(kafka::offset(1)),
+            std::make_unique<testing::fake_source>(),
             make_sink(),
             p)
           , _track_fn(std::move(cb)) {

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -194,6 +194,7 @@ class processor_tracker : public processor_factory {
             [](auto, auto, auto) {},
             std::make_unique<testing::fake_source>(),
             make_sink(),
+            std::make_unique<testing::fake_offset_tracker>(),
             p)
           , _track_fn(std::move(cb)) {
             _track_fn(lifecycle_status::created);

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -28,7 +28,7 @@ public:
     void SetUp() override {
         ss::shared_ptr<wasm::engine> engine
           = ss::make_shared<testing::fake_wasm_engine>();
-        auto src = std::make_unique<testing::fake_source>(_offset);
+        auto src = std::make_unique<testing::fake_source>();
         _src = src.get();
         auto sink = std::make_unique<testing::fake_sink>();
         std::vector<std::unique_ptr<transform::sink>> sinks;
@@ -52,7 +52,7 @@ public:
 
     model::record_batch make_tiny_batch() {
         return model::test::make_random_batch(model::test::record_batch_spec{
-          .offset = kafka::offset_cast(_offset++),
+          .offset = kafka::offset_cast(++_offset),
           .allow_compression = false,
           .count = 1});
     }
@@ -62,8 +62,13 @@ public:
     model::record_batch read_batch() { return _sinks[0]->read().get(); }
     uint64_t error_count() const { return _error_count; }
 
+    void restart() {
+        _p->stop().get();
+        _p->start().get();
+    }
+
 private:
-    static constexpr kafka::offset start_offset = kafka::offset(9);
+    static constexpr kafka::offset start_offset = kafka::offset(0);
 
     kafka::offset _offset = start_offset;
     std::unique_ptr<transform::processor> _p;

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include <memory>
+
 namespace transform {
 namespace {
 class ProcessorTestFixture : public ::testing::Test {
@@ -34,6 +36,7 @@ public:
         std::vector<std::unique_ptr<transform::sink>> sinks;
         _sinks.push_back(sink.get());
         sinks.push_back(std::move(sink));
+        auto offset_tracker = std::make_unique<testing::fake_offset_tracker>();
         _p = std::make_unique<transform::processor>(
           testing::my_transform_id,
           testing::my_ntp,
@@ -45,6 +48,7 @@ public:
             const model::transform_metadata&) { ++_error_count; },
           std::move(src),
           std::move(sinks),
+          std::move(offset_tracker),
           &_probe);
         _p->start().get();
     }

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -128,6 +128,9 @@ ss::future<> processor::start() {
         vlog(_logger.warn, "error starting processor engine: {}", ex);
         _error_callback(_id, _ntp, _meta);
     }
+    _as = {};
+    _consumer_transform_pipe = ss::queue<model::record_batch>(1);
+    _transform_producer_pipe = ss::queue<transformed_batch>(1);
     _task = when_all_shutdown(
       run_consumer_loop(), run_transform_loop(), run_producer_loop());
 }

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -53,27 +53,33 @@ private:
     probe* _probe;
 };
 
-ss::future<ss::chunked_fifo<model::record_batch>>
-drain_queue(ss::queue<model::record_batch>* queue, probe* p) {
+struct drain_result {
+    ss::chunked_fifo<model::record_batch> batches;
+    kafka::offset latest_offset;
+};
+
+ss::future<drain_result>
+drain_queue(ss::queue<transformed_batch>* queue, probe* p) {
     static constexpr size_t max_batches_bytes = 1_MiB;
-    ss::chunked_fifo<model::record_batch> output;
     if (queue->empty()) {
         co_await queue->not_empty();
     }
+    drain_result result;
     size_t batches_size = 0;
     while (!queue->empty()) {
-        auto& batch = queue->front();
-        auto batch_size = batch.size_bytes();
-        batches_size += batch_size;
+        auto batch_size = queue->front().batch.size_bytes();
+        batches_size += queue->front().batch.size_bytes();
         // ensure if there is a large batch we make some progress
         // otherwise cap how much data we send to the sink at once.
-        if (!output.empty() && batches_size > max_batches_bytes) {
+        if (!result.batches.empty() && batches_size > max_batches_bytes) {
             break;
         }
         p->increment_write_bytes(batch_size);
-        output.push_back(queue->pop());
+        auto transformed = queue->pop();
+        result.latest_offset = transformed.input_offset;
+        result.batches.push_back(std::move(transformed.batch));
     }
-    co_return output;
+    co_return result;
 }
 
 /**
@@ -170,15 +176,17 @@ ss::future<> processor::run_consumer_loop() {
 ss::future<> processor::run_transform_loop() {
     while (!_as.abort_requested()) {
         auto batch = co_await _consumer_transform_pipe.pop_eventually();
+        auto offset = model::offset_cast(batch.last_offset());
         batch = co_await _engine->transform(std::move(batch), _probe);
-        co_await _transform_producer_pipe.push_eventually(std::move(batch));
+        co_await _transform_producer_pipe.push_eventually(
+          {.batch = std::move(batch), .input_offset = offset});
     }
 }
 
 ss::future<> processor::run_producer_loop() {
     while (!_as.abort_requested()) {
-        auto batches = co_await drain_queue(&_transform_producer_pipe, _probe);
-        co_await _sinks[0]->write(std::move(batches));
+        auto drained = co_await drain_queue(&_transform_producer_pipe, _probe);
+        co_await _sinks[0]->write(std::move(drained.batches));
     }
 }
 

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -153,7 +153,7 @@ ss::future<> processor::poll_sleep() {
 }
 
 ss::future<> processor::run_consumer_loop() {
-    auto offset = co_await _source->load_latest_offset();
+    auto offset = _source->latest_offset();
     vlog(_logger.trace, "starting at offset {}", offset);
     while (!_as.abort_requested()) {
         auto reader = co_await _source->read_batch(offset, &_as);

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -172,6 +172,9 @@ ss::future<> processor::run_consumer_loop() {
     auto offset = co_await load_start_offset();
     vlog(_logger.trace, "starting at offset {}", offset);
     while (!_as.abort_requested()) {
+        // TODO(rockwood): It's possible that the stored is deleted due to
+        // retention policy since the last successful commit. We should handle
+        // this by restarting from the low watermark.
         auto reader = co_await _source->read_batch(offset, &_as);
         auto last_offset = co_await std::move(reader).consume(
           queue_output_consumer(&_consumer_transform_pipe, _probe),

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -102,6 +102,7 @@ processor::processor(
   error_callback cb,
   std::unique_ptr<source> source,
   std::vector<std::unique_ptr<sink>> sinks,
+  std::unique_ptr<offset_tracker> offset_tracker,
   probe* p)
   : _id(id)
   , _ntp(std::move(ntp))
@@ -109,6 +110,7 @@ processor::processor(
   , _engine(std::move(engine))
   , _source(std::move(source))
   , _sinks(std::move(sinks))
+  , _offset_tracker(std::move(offset_tracker))
   , _error_callback(std::move(cb))
   , _probe(p)
   , _consumer_transform_pipe(1)

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -55,6 +55,7 @@ public:
       error_callback,
       std::unique_ptr<source>,
       std::vector<std::unique_ptr<sink>>,
+      std::unique_ptr<offset_tracker>,
       probe*);
     processor(const processor&) = delete;
     processor(processor&&) = delete;
@@ -85,6 +86,7 @@ private:
     ss::shared_ptr<wasm::engine> _engine;
     std::unique_ptr<source> _source;
     std::vector<std::unique_ptr<sink>> _sinks;
+    std::unique_ptr<offset_tracker> _offset_tracker;
     error_callback _error_callback;
     probe* _probe;
 

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -28,6 +28,15 @@
 namespace transform {
 
 /**
+ * A holder of the result of a transform, along with the input offset the batch
+ * was read at.
+ */
+struct transformed_batch {
+    model::record_batch batch;
+    kafka::offset input_offset;
+};
+
+/**
  * A processor is the driver of a transform for a single partition.
  *
  * At it's heart it's a fiber that reads->transforms->writes batches
@@ -80,7 +89,7 @@ private:
     probe* _probe;
 
     ss::queue<model::record_batch> _consumer_transform_pipe;
-    ss::queue<model::record_batch> _transform_producer_pipe;
+    ss::queue<transformed_batch> _transform_producer_pipe;
 
     ss::abort_source _as;
     ss::future<> _task;

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -75,6 +75,7 @@ private:
     ss::future<> run_transform_loop();
     ss::future<> run_producer_loop();
     ss::future<> poll_sleep();
+    ss::future<kafka::offset> load_start_offset();
 
     template<typename... Future>
     ss::future<> when_all_shutdown(Future&&...);


### PR DESCRIPTION
Track and commit the offset at which transforms have progressed on the input topic.

Currently, this is a very naive implementation to split up the reviews. There are two pieces of followup work:

* Batch commits per core at a 3s interval
* Handle retention removing the data at the committed offset (by restarting at the low watermark).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
