### PR TITLE
ducktape: Log stray rpk processes after cutoff

### DIFF
--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -62,11 +62,13 @@ public:
 
     void register_segment(materialized_segment_state& s);
 
-    ss::future<segment_reader_units> get_segment_reader_units();
+    ss::future<segment_reader_units>
+    get_segment_reader_units(storage::opt_abort_source_t as);
 
-    ss::future<ssx::semaphore_units> get_partition_reader_units();
+    ss::future<ssx::semaphore_units>
+    get_partition_reader_units(storage::opt_abort_source_t as);
 
-    ss::future<segment_units> get_segment_units();
+    ss::future<segment_units> get_segment_units(storage::opt_abort_source_t as);
 
     materialized_manifest_cache& get_materialized_manifest_cache();
 

--- a/src/v/cloud_storage/read_path_probes.cc
+++ b/src/v/cloud_storage/read_path_probes.cc
@@ -148,7 +148,11 @@ ts_read_path_probe::ts_read_path_probe() {
               },
               sm::description("Chunk hydration latency histogram"))
               .aggregate(aggregate_labels),
-
+            sm::make_counter(
+              "hydrations_in_progress",
+              [this] { return _hydrations_in_progress; },
+              sm::description("Active hydrations in progress"))
+              .aggregate(aggregate_labels),
             sm::make_counter(
               "downloads_throttled_sum",
               [this] { return get_downloads_throttled_sum(); },
@@ -159,5 +163,12 @@ ts_read_path_probe::ts_read_path_probe() {
           });
     }
 }
+
+track_hydrations::track_hydrations(ts_read_path_probe& probe)
+  : _probe(probe) {
+    _probe.hydration_started();
+}
+
+track_hydrations::~track_hydrations() { _probe.hydration_finished(); }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/read_path_probes.h
+++ b/src/v/cloud_storage/read_path_probes.h
@@ -78,6 +78,9 @@ public:
         return _downloads_throttled_sum;
     }
 
+    void hydration_started() { _hydrations_in_progress++; }
+    void hydration_finished() { _hydrations_in_progress--; }
+
 private:
     int32_t _cur_materialized_segments = 0;
 
@@ -94,9 +97,24 @@ private:
     size_t _chunks_hydrated = 0;
     hist_t _chunk_hydration_latency;
     size_t _downloads_throttled_sum = 0;
+    size_t _hydrations_in_progress = 0;
 
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;
+};
+
+class track_hydrations {
+public:
+    explicit track_hydrations(ts_read_path_probe&);
+    ~track_hydrations();
+
+    track_hydrations(const track_hydrations&) = delete;
+    track_hydrations& operator=(const track_hydrations&) = delete;
+    track_hydrations(track_hydrations&&) = delete;
+    track_hydrations& operator=(track_hydrations&&) = delete;
+
+private:
+    ts_read_path_probe& _probe;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -487,10 +487,11 @@ private:
     }
 
     ss::future<> init_cursor(storage::log_reader_config config) {
-        auto segment_unit
-          = co_await _partition->materialized().get_segment_units();
+        auto segment_unit = co_await _partition->materialized()
+                              .get_segment_units(config.abort_source);
         auto segment_reader_unit
-          = co_await _partition->materialized().get_segment_reader_units();
+          = co_await _partition->materialized().get_segment_reader_units(
+            config.abort_source);
 
         async_view_search_query_t query;
         if (config.first_timestamp.has_value()) {
@@ -665,11 +666,11 @@ private:
               _next_segment_base_offset,
               _view_cursor->get_status());
 
-            auto segment_unit
-              = co_await _partition->materialized().get_segment_units();
+            auto segment_unit = co_await _partition->materialized()
+                                  .get_segment_units(config.abort_source);
             auto segment_reader_unit
-              = co_await _partition->materialized().get_segment_reader_units();
-
+              = co_await _partition->materialized().get_segment_reader_units(
+                config.abort_source);
             auto maybe_manifest = _view_cursor->manifest();
             if (
               maybe_manifest.has_value()
@@ -937,7 +938,8 @@ remote_partition::aborted_transactions(offset_range offsets) {
             // in a failure to materialise. This should be transient however.
             // One solution for this is to grab all the required segment units
             // up front at the start of the function.
-            auto segment_unit = co_await materialized().get_segment_units();
+            auto segment_unit = co_await materialized().get_segment_units(
+              std::nullopt);
             auto path = stm_manifest.generate_segment_path(*it);
             auto m = get_or_materialize_segment(
               path, *it, std::move(segment_unit));
@@ -985,7 +987,8 @@ remote_partition::aborted_transactions(offset_range offsets) {
           });
 
         for (const auto& [meta, path] : meta_to_materialize) {
-            auto segment_unit = co_await materialized().get_segment_units();
+            auto segment_unit = co_await materialized().get_segment_units(
+              std::nullopt);
             auto m = get_or_materialize_segment(
               path, meta, std::move(segment_unit));
             auto tx = co_await m->second->segment->aborted_transactions(
@@ -1091,7 +1094,8 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
       config,
       _segments.size());
 
-    auto units = co_await _api.materialized().get_partition_reader_units();
+    auto units = co_await _api.materialized().get_partition_reader_units(
+      config.abort_source);
     auto ot_state = ss::make_lw_shared<storage::offset_translator_state>(
       get_ntp());
     auto impl = std::make_unique<partition_record_batch_reader_impl>(

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -227,6 +227,10 @@ public:
             auto sub = config.abort_source->get().subscribe([this]() noexcept {
                 vlog(_ctxlog.debug, "abort requested via config.abort_source");
                 if (_reader) {
+                    vlog(
+                      _ctxlog.debug,
+                      "abort requested via config.abort_source for reader {}",
+                      _reader->identifier);
                     _partition->evict_segment_reader(std::move(_reader));
                 }
             });
@@ -826,7 +830,7 @@ ss::future<> remote_partition::start() {
 
 void remote_partition::evict_segment_reader(
   std::unique_ptr<remote_segment_batch_reader> reader) {
-    _eviction_pending.push_back(std::move(reader));
+    _eviction_pending.emplace_back(std::move(reader));
     _has_evictions_cvar.signal();
 }
 

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -501,6 +501,7 @@ ss::future<> remote_segment::do_hydrate_segment() {
     auto reservation = co_await _cache.reserve_space(
       _size + storage::segment_index::estimate_size(_size), 1);
 
+    track_hydrations t{_ts_probe};
     auto res = co_await _api.download_segment(
       _bucket,
       _path,
@@ -953,6 +954,8 @@ ss::future<> remote_segment::hydrate_chunk(segment_chunk_range range) {
       *this, std::move(range)};
 
     auto measurement = _ts_probe.chunk_hydration_latency();
+    track_hydrations t{_ts_probe};
+
     auto res = co_await _api.download_segment(
       _bucket, _path, std::move(consumer), rtc, std::make_pair(start, end));
     if (res != download_result::success) {

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -332,6 +332,8 @@ class remote_segment_batch_reader final {
     friend class remote_segment_batch_consumer;
 
 public:
+    ss::sstring identifier;
+
     remote_segment_batch_reader(
       ss::lw_shared_ptr<remote_segment>,
       const storage::log_reader_config& config,

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -138,7 +138,9 @@ public:
                   .finally([this]() {
                       vlog(
                         klog.debug,
-                        "Connection input_shutdown; aborting operations");
+                        "Connection input_shutdown; aborting operations for "
+                        "client: {}",
+                        conn->addr);
                       return _as.request_abort_ex(std::system_error(
                         std::make_error_code(std::errc::connection_aborted)));
                   })

--- a/src/v/utils/adjustable_semaphore.h
+++ b/src/v/utils/adjustable_semaphore.h
@@ -81,6 +81,15 @@ public:
         return ss::get_units(_sem, units);
     }
 
+    /**
+     * Blocking get units: will block until units are available or until abort
+     * source is triggered.
+     */
+    ss::future<ssx::semaphore_units>
+    get_units(size_t units, ss::abort_source& as) {
+        return ss::get_units(_sem, units, as);
+    }
+
     size_t current() const noexcept { return _sem.current(); }
     ssize_t available_units() const noexcept { return _sem.available_units(); }
 

--- a/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_reader_stress_test.py
@@ -117,6 +117,7 @@ class TieredStorageReaderStressTest(RedpandaTest):
             segment_reader_delay_count = 0
             materialize_segment_delay_count = 0
             connection_count = 0
+            hydrations_count = 0
             for family in metrics:
                 for sample in family.samples:
                     if sample.name == "redpanda_cloud_storage_readers":
@@ -132,6 +133,11 @@ class TieredStorageReaderStressTest(RedpandaTest):
                     elif sample.name == "redpanda_rpc_active_connections":
                         if sample.labels["redpanda_server"] == "kafka":
                             connection_count += int(sample.value)
+            for family in self.redpanda.metrics(
+                    node, metrics_endpoint=MetricsEndpoint.METRICS):
+                for sample in family.samples:
+                    if sample.name == "vectorized_cloud_storage_read_path_hydrations_in_progress_total":
+                        hydrations_count += int(sample.value)
 
             stats = {
                 "segment_readers": segment_reader_count,
@@ -140,7 +146,8 @@ class TieredStorageReaderStressTest(RedpandaTest):
                 "partition_readers_delayed": partition_reader_delay_count,
                 "materialize_segments_delayed":
                 materialize_segment_delay_count,
-                "connections": connection_count
+                "connections": connection_count,
+                "hydrations_count": hydrations_count
             }
             self.logger.debug(f"stats[{node.name}] = {stats}")
             results[node] = stats
@@ -293,22 +300,32 @@ class TieredStorageReaderStressTest(RedpandaTest):
             # all have been trimmed.
             assert stats['segment_readers']
 
-        def connections_closed():
+        def wait_for_stat(fn, label):
             for node, stats in self._get_stats().items():
-                if stats['connections'] > 0:
+                if metric := fn(stats):
                     self.logger.debug(
-                        f"Node {node.name} still has {stats['connections']} connections open"
-                    )
+                        f"Node {node.name} still has {metric} {label}")
                     return False
-
             return True
 
-        self.logger.info("Waiting for all Kafka connections to close")
-
-        default_timequery_timeout = 5
+        """
+        Active chunk hydrations block remote segment readers, which in turn keep kafka connections open. 
+        A connection can only be closed once the download finishes, so we wait for active downloads to finish first.
+        """
+        self.logger.info("Waiting for active hydrations to finish")
         self.redpanda.wait_until(
-            connections_closed,
-            timeout_sec=default_timequery_timeout,
+            lambda: wait_for_stat(lambda s: s['hydrations_count'],
+                                  'active hydrations'),
+            timeout_sec=15,
+            backoff_sec=1,
+            err_msg="Waiting for active hydrations to finish")
+
+        # Once downloads are done, connections should be closed very shortly after.
+        self.logger.info("Waiting for all Kafka connections to close")
+        self.redpanda.wait_until(
+            lambda: wait_for_stat(lambda s: s["connections"],
+                                  "kafka connections"),
+            timeout_sec=3,
             backoff_sec=1,
             err_msg="Waiting for Kafka connections to close")
 


### PR DESCRIPTION
The test stops all rpk timequeries and waits for them to finish. The additional logging shows if any rpk processes are still running after the cutoff point, which may cause leaky kafka connections.

FIXES #12382 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
