### PR TITLE
ducktape/deps: use absolute path to tinygo

### DIFF
--- a/tests/docker/ducktape-deps/tinygo
+++ b/tests/docker/ducktape-deps/tinygo
@@ -6,4 +6,4 @@ if [ $(uname -m) = "aarch64" ]; then
 else
   export ARCHID="amd64"
 fi
-curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 "https://github.com/redpanda-data/tinygo/releases/download/v0.30.0-rpk1/tinygo-linux-${ARCHID}.tar.gz" | tar -xz -C usr/local/tinygo/ --strip 1
+curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 "https://github.com/redpanda-data/tinygo/releases/download/v0.30.0-rpk1/tinygo-linux-${ARCHID}.tar.gz" | tar -xz -C /usr/local/tinygo/ --strip 1


### PR DESCRIPTION
CDT runs this script not at `/` but somewhere else, so this script
fails when run in CDT.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
