### PR TITLE
perf: Add new configuration to the OMB test

### DIFF
--- a/tests/rptest/perf/ts_read_openmessaging_test.py
+++ b/tests/rptest/perf/ts_read_openmessaging_test.py
@@ -76,10 +76,24 @@ class TSReadOpenmessagingTest(RedpandaTest):
             "warmup_duration_minutes": 5,
         }
 
-        benchmark = OpenMessagingBenchmark(self._ctx,
-                                           self.redpanda,
-                                           driver=driver_idx,
-                                           workload=[workload, validator])
+        wide_read_workload = {
+            "name": "WideRead625kLoad",
+            "topics": 1,
+            "partitions_per_topic": 600,
+            "subscriptions_per_topic": 2,
+            "consumer_per_subscription": 5,
+            "producers_per_topic": 16,
+            "producer_rate": 625000,
+            "consumer_backlog_size_GB": 10,
+            "test_duration_minutes": 10,
+            "warmup_duration_minutes": 5,
+        }
+
+        benchmark = OpenMessagingBenchmark(
+            self._ctx,
+            self.redpanda,
+            driver=driver_idx,
+            workload=[wide_read_workload, validator])
         benchmark.start()
         benchmark_time_min = benchmark.benchmark_time(
         ) + TSReadOpenmessagingTest.BENCHMARK_WAIT_TIME_MIN


### PR DESCRIPTION
The configuration is supposed to trigger wide-read guardrails. It uses large number of partitions and multiple consumers/subscriptions. The workload is running for 15 minutes + 5 minute warmup.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none