### PR TITLE
[v23.2.x] Control consistency checks in the upload loop and STM independently

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1703,18 +1703,33 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
                        - (total.num_succeeded + total.num_cancelled);
 
     std::vector<cloud_storage::segment_meta> mdiff;
-    std::optional<model::offset_delta> delta_offset_end;
-    std::optional<model::offset> last_offset;
-    auto last_segment = manifest().last_segment();
-    if (
-      last_segment.has_value()
-      && last_segment->delta_offset_end != model::offset_delta{}) {
-        delta_offset_end = last_segment->delta_offset_end;
-        last_offset = last_segment->committed_offset;
-    }
     const bool checks_disabled
       = config::shard_local_cfg()
           .cloud_storage_disable_upload_consistency_checks.value();
+    if (!checks_disabled) {
+        std::vector<cloud_storage::segment_meta> meta;
+        for (size_t i = 0; i < segment_results.size(); i++) {
+            meta.push_back(scheduled[ixupload[i]].meta.value());
+        }
+        size_t num_accepted = manifest().safe_segment_meta_to_add(
+          std::move(meta));
+        if (num_accepted < segment_results.size()) {
+            vlog(
+              _rtclog.warn,
+              "Metadata inconsistency detected, {} segments uploaded but only "
+              "{} can be added",
+              segment_results.size(),
+              num_accepted);
+            _probe->gap_detected(model::offset(
+              static_cast<int64_t>(segment_results.size() - num_accepted)));
+        }
+        vassert(
+          num_accepted <= segment_results.size(),
+          "Accepted {} segments but only {} segments are uploaded",
+          num_accepted,
+          segment_results.size());
+        segment_results.resize(num_accepted);
+    }
     for (size_t i = 0; i < segment_results.size(); i++) {
         if (
           segment_results[i].result()
@@ -1739,43 +1754,6 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
                 if (!segment_meta_matches_stats(*upload.meta, stats, _rtclog)) {
                     break;
                 }
-            }
-        }
-        if (
-          !checks_disabled && segment_kind == segment_upload_kind::non_compacted
-          && upload.meta.has_value() && last_offset.has_value()
-          && upload.meta->base_offset > last_offset.value()) {
-            // This code block is executed only for non-compacted uploads
-            // which are adding new segments and not replacing existing
-            // ones.
-            if (
-              delta_offset_end.has_value() && upload.meta.has_value()
-              && upload.meta->delta_offset != delta_offset_end) {
-                vlog(
-                  _rtclog.error,
-                  "Delta offset of the uploaded segment {} doesn't match "
-                  "with expected value of {}",
-                  upload.meta->delta_offset,
-                  delta_offset_end);
-                _probe->gap_detected(last_offset.value());
-                break;
-            } else {
-                delta_offset_end = upload.meta->delta_offset_end;
-            }
-            if (
-              last_offset.has_value() && upload.meta.has_value()
-              && upload.meta->base_offset
-                   != model::next_offset(last_offset.value())) {
-                vlog(
-                  _rtclog.error,
-                  "Base offset of the uploaded segment {} doesn't align "
-                  "with previous segment with committed offset {}",
-                  upload.meta->base_offset,
-                  model::next_offset(last_offset.value()));
-                _probe->gap_detected(last_offset.value());
-                break;
-            } else {
-                last_offset = upload.meta->committed_offset;
             }
         }
 

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -910,43 +910,286 @@ bool partition_manifest::add(
     return add(m);
 }
 
-bool partition_manifest::safe_segment_meta_to_add(const segment_meta& m) {
-    if (_segments.empty()) {
-        // The empty manifest can be started from any offset. If we deleted all
-        // segments due to retention we should start from last uploaded offset.
-        // The reuploads are not possible if the manifest is empty.
-        return _last_offset == model::offset{0}
-               || model::next_offset(_last_offset) == m.base_offset;
+namespace {
+// This code block contains bits of scrubber logic.
+enum class anomaly_type {
+    missing_delta,
+    non_monotonical_delta,
+    committed_smaller,
+    end_delta_smaller,
+    offset_gap,
+    offset_overlap,
+};
+
+struct anomaly_meta {
+    anomaly_type type;
+    segment_meta at;
+    std::optional<segment_meta> previous;
+
+    auto operator<=>(anomaly_meta const& other) const {
+        return std::tie(
+                 type, at.base_offset, at.committed_offset, at.size_bytes)
+               <=> std::tie(
+                 other.type,
+                 other.at.base_offset,
+                 other.at.committed_offset,
+                 other.at.size_bytes);
     }
-    auto last = _segments.last_segment().value();
-    auto next = model::next_offset(last.committed_offset);
-    if (m.base_offset == next) {
-        return last.delta_offset_end == m.delta_offset;
+};
+
+std::ostream& operator<<(std::ostream& o, anomaly_type m) {
+    switch (m) {
+    case anomaly_type::missing_delta:
+        o << "missing_delta";
+        break;
+    case anomaly_type::non_monotonical_delta:
+        o << "non_monotonical_delta";
+        break;
+    case anomaly_type::committed_smaller:
+        o << "committed_smaller";
+        break;
+    case anomaly_type::end_delta_smaller:
+        o << "end_delta_smaller";
+        break;
+    case anomaly_type::offset_gap:
+        o << "offset_gap";
+        break;
+    case anomaly_type::offset_overlap:
+        o << "offset_overlap";
+        break;
+    };
+    return o;
+}
+
+using segment_meta_anomalies = std::set<anomaly_meta>;
+
+void scrub_segment_meta(
+  const segment_meta& current,
+  const std::optional<segment_meta>& previous,
+  segment_meta_anomalies& detected) {
+    // After one segment has a delta offset, all subsequent segments
+    // should have a delta offset too.
+    if (
+      previous && previous->delta_offset != model::offset_delta{}
+      && current.delta_offset == model::offset_delta{}) {
+        detected.insert(anomaly_meta{
+          .type = anomaly_type::missing_delta,
+          .at = current,
+          .previous = previous});
     }
-    if (m.base_offset > next) {
-        // Base offset of the uploaded segment overshoots the expected value
-        return false;
+
+    // The delta offset field of a segment should always be greater or
+    // equal to that of the previous one.
+    if (
+      previous && previous->delta_offset != model::offset_delta{}
+      && current.delta_offset != model::offset_delta{}
+      && previous->delta_offset > current.delta_offset) {
+        detected.insert(anomaly_meta{
+          .type = anomaly_type::non_monotonical_delta,
+          .at = current,
+          .previous = previous});
     }
-    // Check reupload correctness
-    // The segment should be aligned with existing segments in the manifest but
-    // there should be more than one segment covered by 'm'.
-    auto it = _segments.find(m.base_offset);
-    if (it == _segments.end()) {
-        return false;
+
+    // The committed offset of a segment should always be greater or equal
+    // to the base offset.
+    if (current.committed_offset < current.base_offset) {
+        detected.insert(
+          anomaly_meta{.type = anomaly_type::committed_smaller, .at = current});
     }
-    if (it->committed_offset == m.committed_offset) {
-        // 'm' is a reupload of an individual segment, the segment should have
-        // different size
-        return it->size_bytes != m.size_bytes;
+
+    // The end delta offset of a segment should always be greater or equal
+    // to the base delta offset.
+    if (
+      current.delta_offset != model::offset_delta{}
+      && current.delta_offset_end != model::offset_delta{}
+      && current.delta_offset_end < current.delta_offset) {
+        detected.insert(
+          anomaly_meta{.type = anomaly_type::end_delta_smaller, .at = current});
     }
-    ++it;
-    while (it != _segments.end()) {
-        if (it->committed_offset == m.committed_offset) {
-            return true;
+
+    // The base offset of a given segment should be equal to the committed
+    // offset of the previous segment plus one. Otherwise, if the base offset is
+    // greater, we have a gap in the log.
+    if (
+      previous
+      && model::next_offset(previous->committed_offset) < current.base_offset) {
+        detected.insert(anomaly_meta{
+          .type = anomaly_type::offset_gap,
+          .at = current,
+          .previous = previous});
+    }
+
+    // The base offset of a given segment should be equal to the committed
+    // offset of the previous segment plus one. Otherwise, if the base offset is
+    // lower, we have overlapping segments in the log.
+    if (
+      previous
+      && model::next_offset(previous->committed_offset) > current.base_offset) {
+        detected.insert(anomaly_meta{
+          .type = anomaly_type::offset_overlap,
+          .at = current,
+          .previous = previous});
+    }
+}
+} // namespace
+
+size_t partition_manifest::safe_segment_meta_to_add(
+  std::vector<segment_meta> meta_list) const {
+    struct manifest_substitute {
+        model::offset last_offset;
+        std::optional<segment_meta> last_segment;
+        size_t num_accepted{0};
+    };
+
+    manifest_substitute subst{
+      .last_offset = _last_offset,
+      .last_segment = last_segment(),
+    };
+
+    for (const auto& m : meta_list) {
+        if (_segments.empty() && !subst.last_segment.has_value()) {
+            // The empty manifest can be started from any offset. If we deleted
+            // all segments due to retention we should start from last uploaded
+            // offset. The reuploads are not possible if the manifest is empty.
+            const bool is_safe = subst.last_offset == model::offset{0}
+                                 || model::next_offset(_last_offset)
+                                      == m.base_offset;
+
+            if (!is_safe) {
+                vlog(
+                  cst_log.error,
+                  "[{}] New segment does not line up with last offset of empty "
+                  "log: "
+                  "last_offset: {}, new_segment: {}",
+                  _ntp,
+                  subst.last_offset,
+                  m);
+                break;
+            }
+            subst.last_offset = m.committed_offset;
+            subst.last_segment = m;
+            subst.num_accepted++;
+        } else {
+            // We have segments to check
+            auto format_seg_meta_anomalies =
+              [](const segment_meta_anomalies& smas) {
+                  if (smas.empty()) {
+                      return ss::sstring{};
+                  }
+
+                  std::vector<anomaly_type> types;
+                  for (const auto& a : smas) {
+                      types.push_back(a.type);
+                  }
+
+                  return ssx::sformat(
+                    "{{anomaly_types: {}, new_segment: {}, previous_segment: "
+                    "{}}}",
+                    types,
+                    smas.begin()->at,
+                    smas.begin()->previous);
+              };
+
+            auto it = _segments.find(m.base_offset);
+            if (it == _segments.end()) {
+                // Segment added to tip of the log
+                const auto last_seg = subst.last_segment;
+                vassert(
+                  last_seg.has_value(),
+                  "Empty manifest, base_offset: {}",
+                  m.base_offset);
+
+                segment_meta_anomalies anomalies;
+                scrub_segment_meta(m, last_seg, anomalies);
+                if (!anomalies.empty()) {
+                    vlog(
+                      cst_log.error,
+                      "[{}] New segment does not line up with previous "
+                      "segment: {}",
+                      _ntp,
+                      format_seg_meta_anomalies(anomalies));
+                    break;
+                }
+                // Only update if we extending the log
+                subst.last_offset = m.committed_offset;
+                subst.last_segment = m;
+                subst.num_accepted++;
+                continue;
+            } else {
+                // Segment reupload case:
+                // The segment should be aligned with existing segments in the
+                // manifest but there should be at least one segment covered by
+                // 'm'.
+                if (it != _segments.begin()) {
+                    // Firstly, check that the replacement lines up with the
+                    // segment preceeding it if one exists.
+                    const auto prev_segment_it = _segments.prev(it);
+                    segment_meta_anomalies anomalies;
+                    scrub_segment_meta(m, *prev_segment_it, anomalies);
+                    if (!anomalies.empty()) {
+                        vlog(
+                          cst_log.error,
+                          "[{}] New replacement segment does not line up with "
+                          "previous "
+                          "segment: {}",
+                          _ntp,
+                          format_seg_meta_anomalies(anomalies));
+                        break;
+                    }
+                }
+
+                if (it->committed_offset == m.committed_offset) {
+                    // 'm' is a reupload of an individual segment, the segment
+                    // should have different size
+                    if (it->size_bytes == m.size_bytes) {
+                        vlog(
+                          cst_log.error,
+                          "[{}] New replacement segment has the same size as "
+                          "replaced "
+                          "segment: new_segment: {}, replaced_segment: {}",
+                          _ntp,
+                          m,
+                          *it);
+                        break;
+                    }
+                    subst.num_accepted++;
+                    continue;
+                }
+
+                // 'm' is a reupload which merges multiple segments. The
+                // committed offset of 'm' should match an existing segment.
+                // Otherwise, the re-upload changes segment boundaries and is
+                // *not valid*.
+                ++it;
+                bool boundary_found = false;
+                while (it != _segments.end()) {
+                    if (it->committed_offset == m.committed_offset) {
+                        boundary_found = true;
+                        break;
+                    }
+                    ++it;
+                }
+
+                if (!boundary_found) {
+                    vlog(
+                      cst_log.error,
+                      "[{}] New replacement segment does not match the "
+                      "committed "
+                      "offset of "
+                      "any previous segment: new_segment: {}",
+                      _ntp,
+                      m);
+                    break;
+                }
+                subst.num_accepted++;
+            }
         }
-        ++it;
     }
-    return false;
+    return subst.num_accepted;
+}
+
+bool partition_manifest::safe_segment_meta_to_add(const segment_meta& m) const {
+    return safe_segment_meta_to_add(std::vector<segment_meta>{m}) == 1;
 }
 
 partition_manifest

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -328,7 +328,10 @@ public:
     bool add(const segment_name& name, const segment_meta& meta);
 
     /// Return 'true' if the segment meta can be added safely
-    bool safe_segment_meta_to_add(const segment_meta& meta);
+    bool safe_segment_meta_to_add(const segment_meta& meta) const;
+    /// Return number of segments (counting from the beginning of the list) that
+    /// can be added safely.
+    size_t safe_segment_meta_to_add(std::vector<segment_meta> list) const;
 
     /// \brief Truncate the manifest (remove entries from the manifest)
     ///

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -994,7 +994,7 @@ void archival_metadata_stm::apply_add_segment(const segment& segment) {
     auto meta = segment.meta;
     bool disable_safe_add
       = config::shard_local_cfg()
-          .cloud_storage_disable_upload_consistency_checks.value();
+          .cloud_storage_disable_metadata_consistency_checks.value();
     if (!disable_safe_add && !_manifest->safe_segment_meta_to_add(meta)) {
         auto last = _manifest->last_segment();
         vlog(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1582,6 +1582,14 @@ configuration::configuration()
       "violations. Normally, this options should be disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       false)
+  , cloud_storage_disable_metadata_consistency_checks(
+      *this,
+      "cloud_storage_disable_metadata_consistency_checks",
+      "Disable all metadata consistency checks. This will allow redpanda to "
+      "replay logs with inconsistent tiered-storage metadata. Normally, this "
+      "option should be disabled.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -308,6 +308,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       cloud_storage_topic_purge_grace_period_ms;
     property<bool> cloud_storage_disable_upload_consistency_checks;
+    property<bool> cloud_storage_disable_metadata_consistency_checks;
 
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;


### PR DESCRIPTION
Currently, both STM and upload loop are checking segments for consistency violations. This may create problems when we're replaying the log generated by old redpanda version. In order to be able to enable checks only for new segments we need two different configuration options. 

This PR also unifies all consistency checks by introducing plural version of the `safe_segment_meta_to_add` method. This method accepts list of segments and performs consistency checks on them. Method returns number of segments that passed the check. The caller of the method then can remove segments that didn't pass the check by truncating the list of segments.

Fixes #14504
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Improved Tiered-Storage metadata consistency