### PR TITLE
tests/cluster_config_test: _check_value_everywhere retry and better error message

### DIFF
--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -177,6 +177,7 @@ class ClusterConfigHelpersMixin:
                 node.account.hostname: self.admin.get_cluster_config(node)[key]
                 for node in self.redpanda.nodes
             }
+            self.logger.debug(f"config {values=}, {expect_value=}")
             return all(actual_value == expect_value
                        for _, actual_value in values.items())
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -169,23 +169,32 @@ class HasRedpandaAndAdmin(Protocol):
 
 class ClusterConfigHelpersMixin:
     def _check_value_everywhere(self: HasRedpandaAndAdmin, key, expect_value):
-        values: dict[str, str] = {}
+        config_versions: dict[str, int] = {}
 
-        def _check_all():
-            nonlocal values
-            values = {
-                node.account.hostname: self.admin.get_cluster_config(node)[key]
-                for node in self.redpanda.nodes
+        def _check_version():
+            nonlocal config_versions
+            config_versions = {
+                status["node_id"]: status["config_version"]
+                for status in self.admin.get_cluster_config_status()
             }
-            self.logger.debug(f"config {values=}, {expect_value=}")
-            return all(actual_value == expect_value
-                       for _, actual_value in values.items())
+            self.logger.debug(f"config statuses: {config_versions}")
+            # all the node have the same version iff the set contains only one element
+            return len(set(config_versions.values())) == 1
 
-        def _assert_msg():
-            nonlocal values
-            return f"Wrong value on some nodes: {key}!={expect_value} in {values}"
+        def _assert_version_msg():
+            return f"Not all the nodes are at the same config_version: {config_versions}"
 
-        wait_until(_check_all, timeout_sec=5, err_msg=_assert_msg)
+        # wait for config_version to be the same on all the nodes
+        wait_until(_check_version, timeout_sec=5, err_msg=_assert_version_msg)
+
+        # we expect that key is at expect_value by now
+        values = {
+            node.account.hostname: self.admin.get_cluster_config(node)[key]
+            for node in self.redpanda.nodes
+        }
+        assert all(
+            actual_value == expect_value for actual_value in values.values()
+        ), f"Wrong value on some nodes: {key}!={expect_value} in {values}"
 
     def _check_propagated_and_persistent(self: HasRedpandaAndAdmin, key,
                                          expect_value):


### PR DESCRIPTION
Issues #13787 and #13507 fail because they may observe a config being propagated to the nodes.

From the test executor's point of view, this interleaving is possible:

1. successfully set value on node 1, operation is propagated to the controller log of the cluster
2. read the correct value from node 1
3. read the old value from node 2
4. the test fails because of an eager assert
5. node 2 applies new value from its controller log

This pr waits for the config_version to be the same on all the nodes, with a 5s timeout, before checking that the config value is the same on all the nodes.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes #13507 
Fixes #13787 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none