### PR TITLE
Additional enhancements to the audit framework

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -53,7 +53,7 @@ client::client(const YAML::Node& cfg, external_mitigate mitigater)
   , _wait_or_start_update_metadata{[this](wait_or_start::tag tag) {
       return update_metadata(tag);
   }}
-  , _producer{_config, _topic_cache, _brokers, [this](std::exception_ptr ex) {
+  , _producer{_config, _topic_cache, _brokers, _config.produce_ack_level(), [this](std::exception_ptr ex) {
       return mitigate_error(std::move(ex));
   }}
   , _external_mitigate(std::move(mitigater)) {}

--- a/src/v/kafka/client/client.h
+++ b/src/v/kafka/client/client.h
@@ -93,7 +93,8 @@ public:
           _config.retries(),
           _config.retry_base_backoff(),
           std::move(func),
-          [this](std::exception_ptr ex) { return mitigate_error(ex); });
+          [this](std::exception_ptr ex) { return mitigate_error(ex); },
+          _as);
     }
 
     /// \brief Dispatch a request to any broker.
@@ -226,6 +227,7 @@ private:
 
     ss::noncopyable_function<ss::future<>(std::exception_ptr)>
       _external_mitigate;
+    ss::abort_source _as;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/client/config_utils.cc
+++ b/src/v/kafka/client/config_utils.cc
@@ -18,6 +18,7 @@
 #include "kafka/client/configuration.h"
 #include "seastarx.h"
 #include "security/acl.h"
+#include "utils/string_switch.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/coroutine/exception.hh>
@@ -82,6 +83,16 @@ ss::future<> set_client_credentials(
         client.config().scram_username.set_value(client_cfg.scram_username());
         client.config().scram_password.set_value(client_cfg.scram_password());
     });
+}
+
+model::compression compression_from_str(std::string_view v) {
+    return string_switch<model::compression>(v)
+      .match("none", model::compression::none)
+      .match("gzip", model::compression::gzip)
+      .match("snappy", model::compression::snappy)
+      .match("lz4", model::compression::lz4)
+      .match("zstd", model::compression::zstd)
+      .default_match(model::compression::none);
 }
 
 } // namespace kafka::client

--- a/src/v/kafka/client/config_utils.h
+++ b/src/v/kafka/client/config_utils.h
@@ -14,6 +14,7 @@
 #include "cluster/fwd.h"
 #include "config/fwd.h"
 #include "kafka/client/fwd.h"
+#include "model/compression.h"
 #include "seastarx.h"
 #include "security/acl.h"
 
@@ -38,5 +39,7 @@ void set_client_credentials(
 ss::future<> set_client_credentials(
   kafka::client::configuration const& client_cfg,
   ss::sharded<kafka::client::client>& client);
+
+model::compression compression_from_str(std::string_view v);
 
 } // namespace kafka::client

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -79,6 +79,19 @@ configuration::configuration()
           }
           return std::nullopt;
       })
+  , produce_ack_level(
+      *this,
+      "produce_ack_level",
+      "Number of acknowledgments the producer requires the leader to have "
+      "received before considering a request complete, choices are 0, 1 and -1",
+      {},
+      -1,
+      [](int16_t acks) -> std::optional<ss::sstring> {
+          if (acks < -1 || acks > 1) {
+              return ss::format("Validation failed for acks: {}", acks);
+          }
+          return std::nullopt;
+      })
   , consumer_request_timeout(
       *this,
       "consumer_request_timeout_ms",

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -60,6 +60,25 @@ configuration::configuration()
       "Delay (in milliseconds) to wait before sending batch",
       {},
       100ms)
+  , produce_compression_type(
+      *this,
+      "produce_compression_type",
+      "Enable or disable compression by the kafka client. Specify 'none' to "
+      "disable compression or one of the supported types [gzip, snappy, lz4, "
+      "zstd]",
+      {},
+      "none",
+      [](const ss::sstring& v) -> std::optional<ss::sstring> {
+          constexpr auto supported_types = std::to_array<std::string_view>(
+            {"none", "gzip", "snappy", "lz4", "zstd"});
+          const auto found = std::find(
+            supported_types.cbegin(), supported_types.cend(), v);
+          if (found == supported_types.end()) {
+              return ss::format(
+                "{} is not a supported client compression type", v);
+          }
+          return std::nullopt;
+      })
   , consumer_request_timeout(
       *this,
       "consumer_request_timeout_ms",

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -34,6 +34,7 @@ struct configuration final : public config::config_store {
     config::property<int32_t> produce_batch_size_bytes;
     config::property<std::chrono::milliseconds> produce_batch_delay;
     config::property<ss::sstring> produce_compression_type;
+    config::property<int16_t> produce_ack_level;
     config::property<std::chrono::milliseconds> consumer_request_timeout;
     config::property<int32_t> consumer_request_max_bytes;
     config::property<std::chrono::milliseconds> consumer_session_timeout;

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -33,6 +33,7 @@ struct configuration final : public config::config_store {
     config::property<int32_t> produce_batch_record_count;
     config::property<int32_t> produce_batch_size_bytes;
     config::property<std::chrono::milliseconds> produce_batch_delay;
+    config::property<ss::sstring> produce_compression_type;
     config::property<std::chrono::milliseconds> consumer_request_timeout;
     config::property<int32_t> consumer_request_max_bytes;
     config::property<std::chrono::milliseconds> consumer_session_timeout;

--- a/src/v/kafka/client/produce_partition.h
+++ b/src/v/kafka/client/produce_partition.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "kafka/client/config_utils.h"
 #include "kafka/client/configuration.h"
 #include "kafka/client/exceptions.h"
 #include "kafka/client/produce_batcher.h"
@@ -32,7 +33,7 @@ public:
 
     produce_partition(const configuration& config, consumer&& c)
       : _config{config}
-      , _batcher{}
+      , _batcher{compression_from_str(config.produce_compression_type())}
       , _timer{[this]() { try_consume(true); }}
       , _consumer{std::move(c)} {}
 

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -35,12 +35,14 @@ public:
       const configuration& config,
       topic_cache& topic_cache,
       brokers& brokers,
+      int16_t acks,
       error_handler&& error_handler)
       : _config{config}
       , _partitions{}
       , _error_handler(std::move(error_handler))
       , _topic_cache(topic_cache)
-      , _brokers(brokers) {}
+      , _brokers(brokers)
+      , _acks(acks) {}
 
     ss::future<produce_response::partition>
     produce(model::topic_partition tp, model::record_batch&& batch);
@@ -80,6 +82,7 @@ private:
     error_handler _error_handler;
     topic_cache& _topic_cache;
     brokers& _brokers;
+    int16_t _acks;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -48,8 +48,9 @@ public:
     produce(model::topic_partition tp, model::record_batch&& batch);
 
     ss::future<> stop() {
+        _as.request_abort();
         return ssx::parallel_transform(
-          std::move(_partitions),
+          _partitions,
           [](partitions_t::value_type p) { return p.second->stop(); });
     }
 
@@ -83,6 +84,7 @@ private:
     topic_cache& _topic_cache;
     brokers& _brokers;
     int16_t _acks;
+    ss::abort_source _as;
 };
 
 } // namespace kafka::client

--- a/src/v/kafka/client/test/produce.cc
+++ b/src/v/kafka/client/test/produce.cc
@@ -80,3 +80,65 @@ FIXTURE_TEST(produce_reconnect, kafka_client_fixture) {
 
     client.stop().get();
 }
+
+FIXTURE_TEST(produce_clean_shutdown, kafka_client_fixture) {
+    using namespace std::chrono_literals;
+
+    info("Waiting for leadership");
+    wait_for_controller_leadership().get();
+
+    auto tp = model::topic_partition(model::topic("t"), model::partition_id(0));
+    auto client = make_connected_client();
+    client.config().retry_base_backoff.set_value(1ms);
+
+    /// Set a high retry value that previous to the changes to the
+    /// retry_with_migitation loops, would hold up the client from exiting
+    /// during shutdown
+    client.config().retries.set_value(size_t(10000));
+
+    info("Connecting client");
+    wait_for_controller_leadership().get();
+
+    auto produce_to_unknown_topic = [&client, tp]() {
+        info("Producing to unknown topic");
+        auto bat = make_batch(model::offset(0), 2);
+        return client.produce_record_batch(tp, std::move(bat))
+          .then([](auto res) {
+              BOOST_REQUIRE_EQUAL(
+                res.error_code, kafka::error_code::operation_not_attempted);
+              BOOST_REQUIRE_EQUAL(res.base_offset, model::offset(-1));
+          });
+    };
+
+    auto shutdown_client = [&client]() {
+        info("Shutting down client");
+        /// Sleep for 2s to allow the client to send its first produce request
+        /// (from the method above) and be stuck in a never ending retry /
+        /// mitigation state.
+        return ss::sleep(2s).then([&client] {
+            return client.stop().then([] { info("Client shutdown"); });
+        });
+    };
+
+    /// Ensure the test explicity fails and terminates in the case stop() fails
+    /// to work, as the program would indefinitely hang
+    ss::abort_source as;
+    auto verify
+      = ss::sleep_abortable(10s, as)
+          .then([] {
+              vassert(
+                false,
+                "Failed to shutdown client within 10 seconds after stop() was "
+                "called");
+          })
+          .handle_exception_type([](const ss::sleep_aborted&) {});
+
+    /// If this line hangs for more then 10s, the vassert above will shutdown
+    /// the program
+    ss::when_all_succeed(produce_to_unknown_topic(), shutdown_client()).get();
+
+    /// ... otherwise on success the above async work will be cancelled and the
+    /// program can exit gracefully
+    as.request_abort();
+    verify.get();
+}

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -74,14 +74,16 @@ std::invoke_result_t<Func> gated_retry_with_mitigation_impl(
   int32_t retries,
   std::chrono::milliseconds retry_base_backoff,
   Func func,
-  ErrFunc errFunc) {
+  ErrFunc errFunc,
+  std::optional<std::reference_wrapper<ss::abort_source>> as = std::nullopt) {
     return ss::try_with_gate(
       retry_gate,
       [retries,
        retry_base_backoff,
        &retry_gate,
        func{std::move(func)},
-       errFunc{std::move(errFunc)}]() {
+       errFunc{std::move(errFunc)},
+       as]() {
           return retry_with_mitigation(
             retries,
             retry_base_backoff,
@@ -89,7 +91,8 @@ std::invoke_result_t<Func> gated_retry_with_mitigation_impl(
                 retry_gate.check();
                 return func();
             },
-            errFunc);
+            errFunc,
+            as);
       });
 }
 

--- a/src/v/kafka/client/utils.h
+++ b/src/v/kafka/client/utils.h
@@ -37,13 +37,14 @@ auto retry_with_mitigation(
   int32_t retries,
   std::chrono::milliseconds retry_base_backoff,
   Func func,
-  ErrFunc errFunc) {
+  ErrFunc errFunc,
+  std::optional<std::reference_wrapper<ss::abort_source>> as = std::nullopt) {
     using namespace std::chrono_literals;
     return ss::do_with(
       std::move(func),
       std::move(errFunc),
       std::exception_ptr(),
-      [retries, retry_base_backoff](
+      [retries, retry_base_backoff, as](
         const Func& func, ErrFunc& errFunc, std::exception_ptr& eptr) {
           return retry_with_backoff(
             retries,
@@ -61,7 +62,8 @@ auto retry_with_mitigation(
                       return Futurator::make_exception_future(eptr);
                   });
             },
-            retry_base_backoff);
+            retry_base_backoff,
+            as);
       });
 }
 

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -380,6 +380,8 @@ public:
         return _request_contains_audit_topic;
     }
 
+    bool authorized_auditor() const { return _conn->authorized_auditor(); }
+
     cluster::security_frontend& security_frontend() const {
         return _conn->server().security_frontend();
     }

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1232,8 +1232,11 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
     request.data.topic_names.erase(
       unauthorized_it, request.data.topic_names.end());
 
-    const auto& kafka_nodelete_topics
+    auto kafka_nodelete_topics
       = config::shard_local_cfg().kafka_nodelete_topics();
+    if (config::shard_local_cfg().audit_enabled()) {
+        kafka_nodelete_topics.push_back(model::kafka_audit_logging_topic());
+    }
     auto nodelete_it = std::partition(
       request.data.topic_names.begin(),
       request.data.topic_names.end(),

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -146,8 +146,6 @@ private:
             }
         }();
 
-        audit_authn(req, auth_state);
-
         try {
             if constexpr (required_auth == auth_level::superuser) {
                 auth_state.require_superuser();
@@ -162,10 +160,12 @@ private:
             }
 
         } catch (const ss::httpd::base_exception& ex) {
+            audit_authn(req, auth_state);
             audit_authz(req, auth_state, httpd_authorized::no, ex.what());
             throw;
         }
 
+        audit_authn(req, auth_state);
         audit_authz(req, auth_state, httpd_authorized::yes);
 
         return auth_state;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -211,6 +211,11 @@ static void set_auditing_kafka_client_defaults(
     if (!client_config.produce_ack_level.is_overriden()) {
         client_config.produce_ack_level.set_value(int16_t(1));
     }
+    /// explicity override the scram details as the client will need to use
+    /// broker generated ephemeral credentials
+    client_config.scram_password.reset();
+    client_config.scram_username.reset();
+    client_config.sasl_mechanism.reset();
 }
 
 application::application(ss::sstring logger_name)

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -208,6 +208,9 @@ static void set_auditing_kafka_client_defaults(
     if (!client_config.produce_compression_type.is_overriden()) {
         client_config.produce_compression_type.set_value("zstd");
     }
+    if (!client_config.produce_ack_level.is_overriden()) {
+        client_config.produce_ack_level.set_value(int16_t(1));
+    }
 }
 
 application::application(ss::sstring logger_name)

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -205,6 +205,9 @@ static void set_auditing_kafka_client_defaults(
         client_config.client_identifier.set_value(
           std::make_optional<ss::sstring>("audit_log_client"));
     }
+    if (!client_config.produce_compression_type.is_overriden()) {
+        client_config.produce_compression_type.set_value("zstd");
+    }
 }
 
 application::application(ss::sstring logger_name)

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -499,4 +499,8 @@ private:
     acl_entry_filter _acl;
 };
 
+/// Name of the principal the kafka client for auditing will be using
+inline const acl_principal audit_principal{
+  principal_type::ephemeral_user, "__auditing"};
+
 } // namespace security

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -50,11 +50,6 @@ std::ostream& operator<<(std::ostream& os, event_type t) {
     }
 }
 
-/// TODO: Create a new ephemeral user for the audit principal so even clients
-/// instantiated by pandaproxy cannot modify or produce to the audit topic
-static const security::acl_principal audit_principal{
-  security::principal_type::ephemeral_user, "__auditing"};
-
 /// Contains a kafka client and a sempahore to bound the memory allocated
 /// by it. This class may be allocated/deallocated on the owning shard depending
 /// on the value of the global audit toggle config option (audit_enabled)
@@ -227,9 +222,6 @@ ss::future<> audit_client::set_auditing_permissions() {
       model::kafka_audit_logging_topic,
       security::pattern_type::literal};
 
-    /// TODO: Add rules for User:* deny to things like deleting the topic
-    /// and other unwanted behavior. User:* should be allowed to ::describe
-    /// and alter topic configs
     co_await _controller->get_security_frontend().local().create_acls(
       {security::acl_binding{audit_topic_pattern, acl_create_entry},
        security::acl_binding{audit_topic_pattern, acl_write_entry}},

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -89,7 +89,7 @@ public:
       security::audit::returns_auditable_resource_vector Func,
       typename... Args>
     bool
-    enqueue_authz_audit_event(kafka::api_key api, Func func, Args... args) {
+    enqueue_authz_audit_event(kafka::api_key api, Func func, Args&&... args) {
         if (auto val = should_enqueue_audit_event(api); val.has_value()) {
             return (bool)*val;
         }
@@ -99,7 +99,7 @@ public:
     }
 
     template<typename... Args>
-    bool enqueue_authz_audit_event(kafka::api_key api, Args... args) {
+    bool enqueue_authz_audit_event(kafka::api_key api, Args&&... args) {
         if (auto val = should_enqueue_audit_event(api); val.has_value()) {
             return (bool)*val;
         }

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -184,6 +184,13 @@ private:
       = std::underlying_type_t<event_type>(event_type::num_elements);
     std::bitset<enabled_set_bitlength> _enabled_event_types{0};
 
+    /// This will be true when the client detects that there is an issue with
+    /// authorization configuration. Auth must be enabled so the client
+    /// principal can be queried. This is needed so that redpanda can give
+    /// special permission to the audit client to do things like produce to the
+    /// audit topic.
+    bool _auth_misconfigured{false};
+
     /// Shutdown primitives
     ss::gate _gate;
     ss::abort_source _as;

--- a/src/v/utils/retry.h
+++ b/src/v/utils/retry.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "seastarx.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/reactor.hh>
@@ -42,14 +43,17 @@ template<typename Func, typename DurationType = std::chrono::seconds, typename P
   && BackoffPolicy<Policy>
 // clang-format on
 ss::futurize_t<std::invoke_result_t<Func>> retry_with_backoff(
-  int max_retries, Func&& f, DurationType base_backoff = DurationType{1}) {
+  int max_retries,
+  Func&& f,
+  DurationType base_backoff = DurationType{1},
+  std::optional<std::reference_wrapper<ss::abort_source>> as = std::nullopt) {
     using ss::stop_iteration;
     using ret = ss::futurize<std::invoke_result_t<Func>>;
     return ss::do_with(
       0,
       Policy{},
       (typename ret::promise_type){},
-      [f = std::forward<Func>(f), max_retries, base_backoff](
+      [f = std::forward<Func>(f), max_retries, as, base_backoff](
         int& attempt,
         Policy& backoff_policy,
         typename ret::promise_type& promise) mutable {
@@ -58,7 +62,17 @@ ss::futurize_t<std::invoke_result_t<Func>> retry_with_backoff(
                              &backoff_policy,
                              &promise,
                              max_retries,
+                             as,
                              base_backoff]() mutable {
+                     if (as.has_value()) {
+                         try {
+                             as->get().check();
+                         } catch (const std::exception& e) {
+                             promise.set_exception(e);
+                         }
+                         return ss::make_ready_future<stop_iteration>(
+                           stop_iteration::yes);
+                     }
                      attempt++;
                      return f()
                        .then([&promise](auto&&... vals) {
@@ -72,6 +86,7 @@ ss::futurize_t<std::invoke_result_t<Func>> retry_with_backoff(
                          [&attempt,
                           &backoff_policy,
                           max_retries,
+                          as,
                           &promise,
                           base_backoff](std::exception_ptr e) mutable {
                              if (attempt > max_retries) {
@@ -84,9 +99,16 @@ ss::futurize_t<std::invoke_result_t<Func>> retry_with_backoff(
                              // retry
 
                              auto next = backoff_policy.next_backoff();
-                             return ss::sleep(base_backoff * next).then([] {
-                                 return stop_iteration::no;
-                             });
+                             auto sleep_dur = base_backoff * next;
+                             auto f = (as.has_value())
+                                        ? ss::sleep_abortable(sleep_dur, *as)
+                                        : ss::sleep(sleep_dur * next);
+                             return f.then([] { return stop_iteration::no; })
+                               .handle_exception(
+                                 [&promise](std::exception_ptr e) {
+                                     promise.set_exception(e);
+                                     return stop_iteration::yes;
+                                 });
                          });
                  })
             .then([&promise] { return promise.get_future(); });

--- a/src/v/utils/retry.h
+++ b/src/v/utils/retry.h
@@ -69,9 +69,9 @@ ss::futurize_t<std::invoke_result_t<Func>> retry_with_backoff(
                              as->get().check();
                          } catch (const std::exception& e) {
                              promise.set_exception(e);
+                             return ss::make_ready_future<stop_iteration>(
+                               stop_iteration::yes);
                          }
-                         return ss::make_ready_future<stop_iteration>(
-                           stop_iteration::yes);
                      }
                      attempt++;
                      return f()

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -484,8 +484,11 @@ class Admin:
     def put_feature(self, feature_name, body):
         return self._request("PUT", f"features/{feature_name}", json=body)
 
-    def get_license(self, node=None):
-        return self._request("GET", "features/license", node=node).json()
+    def get_license(self, node=None, timeout=None):
+        return self._request("GET",
+                             "features/license",
+                             node=node,
+                             timeout=timeout).json()
 
     def put_license(self, license):
         return self._request("PUT", "features/license", data=license)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -163,6 +163,12 @@ PREV_VERSION_LOG_ALLOW_LIST = [
     "abs - .*FeatureNotYetSupportedForHierarchicalNamespaceAccounts"
 ]
 
+AUDIT_LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [
+    re.compile(".*Failed to audit authentication.*"),
+    re.compile(".*Failed to append authz event to audit log.*"),
+    re.compile(".*Failed to append authentication event to audit log.*")
+]
+
 # Path to the LSAN suppressions file
 LSAN_SUPPRESSIONS_FILE = "/opt/lsan_suppressions.txt"
 

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -268,7 +268,7 @@ class AuditLogTestSecurityConfig(SecurityConfig):
         return self._user_cert
 
 
-class AuditLogTestsBase(RedpandaTest):
+class AuditLogTestBase(RedpandaTest):
     """Base test object for testing the audit logs"""
     audit_log = "__audit_log"
     kafka_rpc_service_name = "kafka rpc protocol"
@@ -301,7 +301,7 @@ class AuditLogTestsBase(RedpandaTest):
                 self.security.principal_mapping_rules
             ]
 
-        super(AuditLogTestsBase,
+        super(AuditLogTestBase,
               self).__init__(test_context=test_context,
                              extra_rp_conf=self.extra_rp_conf,
                              log_config=self.log_config,
@@ -426,8 +426,9 @@ class AuditLogTestsBase(RedpandaTest):
                                  service_name, record):
         for items in expected:
             for expected_api_op, resource_entry in items.items():
-                if AuditLogTestsBase.api_resource_match(
-                        expected_api_op, resource_entry, service_name, record):
+                if AuditLogTestBase.api_resource_match(expected_api_op,
+                                                       resource_entry,
+                                                       service_name, record):
                     return True
 
         return False
@@ -595,11 +596,11 @@ class AuditLogTestsBase(RedpandaTest):
         return records
 
 
-class AuditLogTestsAdminApi(AuditLogTestsBase):
+class AuditLogTestAdminApi(AuditLogTestBase):
     """Validates that audit logs are generated from admin API
     """
     def __init__(self, test_context):
-        super(AuditLogTestsAdminApi,
+        super(AuditLogTestAdminApi,
               self).__init__(test_context=test_context,
                              log_config=LoggingConfig('info',
                                                       logger_levels={
@@ -721,12 +722,12 @@ class AuditLogTestsAdminApi(AuditLogTestsBase):
                               patch_result['config_version'])
 
 
-class AuditLogTestsKafkaApi(AuditLogTestsBase):
+class AuditLogTestKafkaApi(AuditLogTestBase):
     """Validates that the Kafka API generates audit messages
     """
     def __init__(self, test_context):
 
-        super(AuditLogTestsKafkaApi,
+        super(AuditLogTestKafkaApi,
               self).__init__(test_context=test_context,
                              audit_log_config=AuditLogConfig(num_partitions=1,
                                                              event_types=[]),
@@ -1021,7 +1022,7 @@ class AuditLogTestsKafkaApi(AuditLogTestsBase):
             raise exc
 
 
-class AuditLogTestsKafkaAuthnApi(AuditLogTestsBase):
+class AuditLogTestKafkaAuthnApi(AuditLogTestBase):
     """Validates SASL/SCRAM authentication messages
     """
     username = 'test'
@@ -1029,7 +1030,7 @@ class AuditLogTestsKafkaAuthnApi(AuditLogTestsBase):
     algorithm = 'SCRAM-SHA-256'
 
     def __init__(self, test_context):
-        super(AuditLogTestsKafkaAuthnApi, self).__init__(
+        super(AuditLogTestKafkaAuthnApi, self).__init__(
             test_context=test_context,
             audit_log_config=AuditLogConfig(num_partitions=1,
                                             event_types=['authenticate']),
@@ -1124,7 +1125,7 @@ class AuditLogTestsKafkaAuthnApi(AuditLogTestsBase):
             records) == 1, f'Expected only one record, got {len(records)}'
 
 
-class AuditLogTestsKafkaTlsApi(AuditLogTestsBase):
+class AuditLogTestKafkaTlsApi(AuditLogTestBase):
     """
     Tests that validate audit log messages for users authenticated via mTLS
     """
@@ -1155,7 +1156,7 @@ class AuditLogTestsKafkaTlsApi(AuditLogTestsBase):
         self._audit_log_client_config.require_client_auth = False
         self._audit_log_client_config.enable_broker_tls = False
 
-        super(AuditLogTestsKafkaTlsApi, self).__init__(
+        super(AuditLogTestKafkaTlsApi, self).__init__(
             test_context=test_context,
             audit_log_config=AuditLogConfig(num_partitions=1,
                                             event_types=['authenticate']),
@@ -1206,7 +1207,7 @@ class AuditLogTestsKafkaTlsApi(AuditLogTestsBase):
             records) == 1, f'Expected only one record got {len(records)}'
 
 
-class AuditLogTestsOauth(AuditLogTestsBase):
+class AuditLogTestOauth(AuditLogTestBase):
     """
     Tests that validate audit log messages for users authenticated via OAUTH
     """
@@ -1223,7 +1224,7 @@ class AuditLogTestsOauth(AuditLogTestsBase):
 
         self.keycloak = KeycloakService(test_context)
 
-        super(AuditLogTestsOauth, self).__init__(
+        super(AuditLogTestOauth, self).__init__(
             test_context=test_context,
             audit_log_config=AuditLogConfig(num_partitions=1,
                                             event_types=['authenticate']),

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -572,8 +572,8 @@ class AuditLogTestsAdminApi(AuditLogTestsBase):
                 regex = re.compile(
                     "http:\/\/(?P<address>.*):(?P<port>\d+)\/v1\/(?P<handler>.*)"
                 )
-                match = regex.match(
-                        record['http_request']['url']['url_string'])
+                string = record['http_request']['url']['url_string']
+                match = regex.match(string)
                 if match is None:
                     raise RuntimeError(f'Record out of spec: {record}')
                 return match.group('handler') in matches

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -787,7 +787,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                     "name": f"{topic_name}",
                     "type": "topic"
                 }, self.kafka_rpc_service_name), 1),
-            AbsoluteTestItem(
+            RangeTestItem(
                 f'Attempt group offset delete',
                 lambda: self.execute_command_ignore_error(
                     partial(self.super_rpk.offset_delete, "fake",
@@ -795,7 +795,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                 partial(self.api_resource_match, "offset_delete", {
                     "name": "fake",
                     "type": "group"
-                }, self.kafka_rpc_service_name),
+                }, self.kafka_rpc_service_name), 1,
                 5),  # expect five because rpk will retry
             RangeTestItem(
                 f'Attempting delete records for {topic_name}',

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -27,7 +27,7 @@ from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import CloudStorageType, SISettings, RESTART_LOG_ALLOW_LIST, IAM_ROLES_API_CALL_ALLOW_LIST, get_cloud_storage_type, RedpandaService
+from rptest.services.redpanda import CloudStorageType, SISettings, AUDIT_LOG_ALLOW_LIST, RESTART_LOG_ALLOW_LIST, IAM_ROLES_API_CALL_ALLOW_LIST, get_cloud_storage_type, RedpandaService
 from rptest.services.redpanda_installer import RedpandaInstaller, RedpandaVersionLine
 from rptest.services.metrics_check import MetricCheck
 from rptest.tests.redpanda_test import RedpandaTest
@@ -531,7 +531,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 # Should not succeed!
                 assert False
 
-    @cluster(num_nodes=3)
+    @cluster(num_nodes=3, log_allow_list=AUDIT_LOG_ALLOW_LIST)
     def test_valid_settings(self):
         """
         Bulk exercise of all config settings & the schema endpoint:


### PR DESCRIPTION
This PR bundles up a few smaller enhancements to auditing that were omitted from previous PRs to keep them brief and within scope. Changes here include:

Modify `kafka/client` to:
- Compress batches when using the `produce_records` API
- Set the `ack` level on call to `produce`
- Make retries abortable, that way the client won't block on shutdown if stuck in a mitigation loop

Modify auditing to:
- Use compressed option when producing to audit topic
- Default produce to audit topic with acks==1 level
- Prevent deletion of audit log by normal kafka clients
- Blocks calls to produce onto audit log unless done by audit client
- Have the k/client in auditing unconditionally use ephemeral credentials 

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Batches produced to the audit log will now be compressed
* External kafka clients will be blocked from producing to the audit log and can only delete it when auditing is disabled
* Option to produce to the audit log at configurable ack level
