### PR TITLE
build: add sanitizer option to open-source build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,13 @@ if(NOT HAVE_Redpanda_LINKER_FLAGS)
 endif()
 add_link_options(${Redpanda_LINKER_FLAGS})
 
+# enable sanitizers. will propogate to all targets, including dependencies
+option(Redpanda_ENABLE_SANITIZERS "Enable sanitizers (address, leak, undefined)" OFF)
+if(Redpanda_ENABLE_SANITIZERS)
+  add_link_options(-fsanitize=address,leak,undefined)
+  add_compile_options(-fsanitize=address,leak,undefined)
+endif()
+
 include(dependencies)
 include(v_library)
 include(testing)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -40,6 +40,13 @@
       }
     },
     {
+      "name": "sanitize",
+      "hidden": true,
+      "cacheVariables": {
+        "Redpanda_ENABLE_SANITIZERS": "ON"
+      }
+    },
+    {
       "name": "release",
       "inherits": ["base", "release-type", "shared"]
     },
@@ -49,11 +56,11 @@
     },
     {
       "name": "debug",
-      "inherits": ["base", "debug-type", "shared"]
+      "inherits": ["base", "debug-type", "shared", "sanitize"]
     },
     {
       "name": "debug-static",
-      "inherits": ["base", "debug-type", "static"]
+      "inherits": ["base", "debug-type", "static", "sanitize"]
     }
   ],
   "buildPresets": [


### PR DESCRIPTION
build: add sanitizer option to open-source build

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

