### PR TITLE
rpk: add schema registry port to rpk container table

### DIFF
--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -393,7 +393,7 @@ func renderClusterInfo(c common.Client) ([]*common.NodeState, error) {
 		return nil, nil
 	}
 
-	tw := out.NewTable("Node-ID", "Status", "Kafka-Address", "Admin-Address", "Proxy-Address")
+	tw := out.NewTable("Node-ID", "Status", "Kafka-Address", "Admin-Address", "Proxy-Address", "Schema-Registry-Address")
 	defer tw.Flush()
 	sort.Slice(nodes, func(i, j int) bool {
 		return nodes[i].ID < nodes[j].ID
@@ -402,6 +402,7 @@ func renderClusterInfo(c common.Client) ([]*common.NodeState, error) {
 		kafka := nodeAddr(node.HostKafkaPort)
 		admin := nodeAddr(node.HostAdminPort)
 		proxy := nodeAddr(node.HostProxyPort)
+		schema := nodeAddr(node.HostSchemaPort)
 		if node.HostKafkaPort == 0 {
 			kafka = "-"
 		}
@@ -411,12 +412,16 @@ func renderClusterInfo(c common.Client) ([]*common.NodeState, error) {
 		if node.HostProxyPort == 0 {
 			proxy = "-"
 		}
+		if node.HostSchemaPort == 0 {
+			schema = "-"
+		}
 		tw.PrintStrings(
 			fmt.Sprint(node.ID),
 			node.Status,
 			kafka,
 			admin,
 			proxy,
+			schema,
 		)
 	}
 	return nodes, nil


### PR DESCRIPTION
The output looks like this:

```
NODE-ID  STATUS   KAFKA-ADDRESS    ADMIN-ADDRESS    PROXY-ADDRESS    SCHEMA-REGISTRY-ADDRESS
0        running  127.0.0.1:42629  127.0.0.1:46853  127.0.0.1:40787  127.0.0.1:42233
```

Users will see this in the output of `rpk container start` and `rpk container status`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* rpk container: the exposed schema registry port will now be available in the output of `start` and `status`.