### PR TITLE
[v23.2.x] archival: reset in-memory partition manifest to uploaded manifest

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -620,7 +620,7 @@ private:
     // Held while the inner segment upload/manifest sync loop is running,
     // to enable code that uses _paused to wait until ongoing activity
     // has stopped.
-    ss::semaphore _uploads_active{1};
+    ssx::named_semaphore<ss::lowres_clock> _uploads_active{1, "uploads_active"};
 
     config::binding<std::chrono::milliseconds> _housekeeping_interval;
     simple_time_jitter<ss::lowres_clock> _housekeeping_jitter;

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -578,13 +578,147 @@ ss::future<std::error_code> archival_metadata_stm::cleanup_metadata(
     co_return co_await builder.replicate();
 }
 
+ss::future<bool>
+archival_metadata_stm::sync(model::timeout_clock::duration timeout) {
+    // If there's any replications pending, wait for them to complete.
+    // Note that we throw away the result and use Raft's committed offset
+    // below. If replication failed, exit unsuccessfully.
+
+    if (_last_replicate) {
+        auto fut = std::exchange(_last_replicate, std::nullopt).value();
+
+        if (!fut.available()) {
+            vlog(
+              _logger.debug, "Waiting for ongoing replication before syncing");
+        }
+
+        try {
+            const auto before = model::timeout_clock::now();
+
+            const auto res = co_await ss::with_timeout(
+              before + timeout, std::move(fut));
+
+            const auto after = model::timeout_clock::now();
+            // Update the timeout whille accounting for under/overflow.
+            const auto duration = after > before
+                                    ? after - before
+                                    : ss::lowres_clock::duration{0};
+
+            if (duration >= timeout) {
+                throw ss::timed_out_error{};
+            }
+
+            timeout -= duration;
+
+            if (!res) {
+                vlog(
+                  _logger.warn,
+                  "Replication failed for archival STM command: {}",
+                  res.error());
+                co_return false;
+            }
+        } catch (const ss::timed_out_error&) {
+            vlog(_logger.error, "Replication wait for archival STM timed out");
+            co_return false;
+        } catch (...) {
+            vlog(
+              _logger.error,
+              "Replication failed for archival STM command: {}",
+              std::current_exception());
+            co_return false;
+        }
+    }
+
+    if (!_raft->is_leader()) {
+        co_return false;
+    }
+
+    const auto last_applied_term = _insync_term;
+    const auto last_applied_offset = _manifest->get_insync_offset();
+    const auto current_term = _raft->term();
+    const auto committed_offset = _raft->committed_offset();
+
+    if (
+      last_applied_term == current_term
+      && last_applied_offset < committed_offset) {
+        // Case 1: we have already synced (once or more) during the current
+        // term, but need to sync again (e.g. re-starting the archiver to
+        // apply topic configs)
+        vlog(
+          _logger.debug,
+          "Syncing archival STM from last applied offset {} to committed "
+          "offest {} in term {}",
+          last_applied_offset,
+          committed_offset,
+          current_term);
+
+        const bool synced = co_await wait_no_throw(
+          committed_offset, model::timeout_clock::now() + timeout);
+
+        if (!synced) {
+            vlog(
+              _logger.warn,
+              "Failed to sync archival STM from offset {} to offest {} in "
+              "term {}",
+              last_applied_offset,
+              committed_offset,
+              current_term);
+        }
+
+        co_return synced;
+    } else {
+        // Case 2: we have not synced since the last term (e.g. on
+        // leadership changes)
+        vlog(
+          _logger.debug,
+          "Syncing archival STM to latest term {} from term {}",
+          current_term,
+          last_applied_term);
+        const bool synced = co_await persisted_stm::sync(timeout);
+
+        if (!synced) {
+            vlog(_logger.warn, "Failed to sync archival STM to latest term");
+        }
+
+        co_return synced;
+    }
+}
+
 ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
   model::record_batch batch, ss::abort_source& as) {
-    auto current_term = _insync_term;
-    auto fut = _raft->replicate(
-      current_term,
-      model::make_memory_record_batch_reader(std::move(batch)),
-      raft::replicate_options{raft::consistency_level::quorum_ack});
+    vassert(
+      !_last_replicate.has_value(),
+      "Concurrent replication of archival STM commands");
+    vassert(
+      !_lock.try_get_units().has_value(),
+      "Attempt to replicate STM command while not under lock");
+
+    const auto current_term = _insync_term;
+
+    ss::promise<result<raft::replicate_result>> replication_promise;
+    _last_replicate = replication_promise.get_future();
+
+    auto fut
+      = _raft
+          ->replicate(
+            current_term,
+            model::make_memory_record_batch_reader(std::move(batch)),
+            raft::replicate_options{raft::consistency_level::quorum_ack})
+          .then_wrapped(
+            [replication_promise = std::move(replication_promise)](
+              auto f) mutable -> ss::future<result<raft::replicate_result>> {
+                if (f.failed()) {
+                    const auto ex_ptr = f.get_exception();
+                    replication_promise.set_exception(ex_ptr);
+                    return ss::make_exception_future<
+                      result<raft::replicate_result>>(ex_ptr);
+                } else {
+                    const auto res = f.get();
+                    replication_promise.set_value(res);
+                    return ss::make_ready_future<
+                      result<raft::replicate_result>>(res);
+                }
+            });
 
     // Raft's replicate() doesn't take an external abort source, and
     // archiver is shut down before consensus, so we must wrap this
@@ -710,11 +844,11 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
 
 ss::future<> archival_metadata_stm::apply(model::record_batch b) {
     if (b.header().type == model::record_batch_type::prefix_truncate) {
-        // Special case handling for prefix_truncate batches: these originate
-        // in log_eviction_stm, but affect the entire partition, local and
-        // cloud storage alike. Despite the record originating elsewhere, note
-        // that the STM is still deterministic, as records are applied in
-        // order and are not allowed to fail.
+        // Special case handling for prefix_truncate batches: these
+        // originate in log_eviction_stm, but affect the entire partition,
+        // local and cloud storage alike. Despite the record originating
+        // elsewhere, note that the STM is still deterministic, as records
+        // are applied in order and are not allowed to fail.
         b.for_each_record(
           [this, base_offset = b.base_offset()](model::record&& r) {
               _last_dirty_at = base_offset + model::offset{r.offset_delta()};
@@ -955,8 +1089,8 @@ ss::future<stm_snapshot> archival_metadata_stm::take_snapshot() {
 }
 
 model::offset archival_metadata_stm::max_collectible_offset() {
-    // From Redpanda 22.3 up, the ntp_config's impression of whether archival
-    // is enabled is authoritative.
+    // From Redpanda 22.3 up, the ntp_config's impression of whether
+    // archival is enabled is authoritative.
     bool collect_all = !_raft->log_config().is_archival_enabled();
     bool is_read_replica = _raft->log_config().is_read_replica_mode_enabled();
 
@@ -971,9 +1105,9 @@ model::offset archival_metadata_stm::max_collectible_offset() {
     if (collect_all || is_read_replica) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
-        // In read-replicas the state machine exists and stores segments from
-        // the remote manifest. Since nothing is uploaded there is no need to
-        // interact with local retention.
+        // In read-replicas the state machine exists and stores segments
+        // from the remote manifest. Since nothing is uploaded there is no
+        // need to interact with local retention.
         return model::offset::max();
     }
     auto lo = get_last_offset();
@@ -1126,7 +1260,8 @@ void archival_metadata_stm::apply_spillover(const spillover_cmd& so) {
         _manifest->spillover(so.manifest_meta);
         vlog(
           _logger.debug,
-          "Spillover command applied, new start offset: {}, new last offset: "
+          "Spillover command applied, new start offset: {}, new last "
+          "offset: "
           "{}",
           get_start_offset(),
           get_last_offset());

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -192,7 +192,10 @@ public:
       model::term_id term,
       const cloud_storage::partition_manifest& manifest);
 
-    using persisted_stm::sync;
+    // Attempts to bring the archival STM in sync with the log.
+    // Returns "true" if it has synced succesfully *and* the replica
+    // is still the leader with the correct term.
+    ss::future<bool> sync(model::timeout_clock::duration timeout);
 
     model::offset get_start_offset() const;
     model::offset get_last_offset() const;
@@ -232,6 +235,8 @@ private:
       ss::lowres_clock::time_point deadline,
       ss::abort_source&);
 
+    // Replicate commands in a batch and wait for their application.
+    // Should be called under _lock to ensure linearisability
     ss::future<std::error_code>
     do_replicate_commands(model::record_batch, ss::abort_source&);
 
@@ -294,6 +299,9 @@ private:
 
     // The offset of the last record that modified this stm
     model::offset _last_dirty_at;
+
+    // The last replication future
+    std::optional<ss::future<result<raft::replicate_result>>> _last_replicate;
 
     cloud_storage::remote& _cloud_storage_api;
     features::feature_table& _feature_table;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1039,8 +1039,12 @@ partition::transfer_leadership(transfer_leadership_request req) {
     auto archival_timeout
       = config::shard_local_cfg().cloud_storage_graceful_transfer_timeout_ms();
     if (_archiver && archival_timeout.has_value()) {
-        complete_archiver.emplace(
-          [a = _archiver.get()]() { a->complete_transfer_leadership(); });
+        complete_archiver.emplace([this]() {
+            if (_archiver) {
+                _archiver->complete_transfer_leadership();
+            }
+        });
+
         vlog(
           clusterlog.debug,
           "transfer_leadership[{}]: entering archiver prepare",

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1162,7 +1162,8 @@ partition::unsafe_reset_remote_partition_manifest_from_json(iobuf json_buf) {
     co_await replicate_unsafe_reset(std::move(req_m));
 }
 
-ss::future<> partition::unsafe_reset_remote_partition_manifest_from_cloud() {
+ss::future<>
+partition::unsafe_reset_remote_partition_manifest_from_cloud(bool force) {
     vlog(
       clusterlog.info,
       "[{}] Unsafe manifest reset from cloud state requested",
@@ -1215,7 +1216,7 @@ ss::future<> partition::unsafe_reset_remote_partition_manifest_from_cloud() {
 
     // Attempt the reset
     auto future_result = co_await ss::coroutine::as_future(
-      do_unsafe_reset_remote_partition_manifest_from_cloud());
+      do_unsafe_reset_remote_partition_manifest_from_cloud(force));
 
     // Reconstruct the archiver and start it if needed
     co_await start_archiver();
@@ -1224,7 +1225,8 @@ ss::future<> partition::unsafe_reset_remote_partition_manifest_from_cloud() {
     future_result.get();
 }
 
-ss::future<> partition::do_unsafe_reset_remote_partition_manifest_from_cloud() {
+ss::future<>
+partition::do_unsafe_reset_remote_partition_manifest_from_cloud(bool force) {
     const auto initial_rev = _raft->log_config().get_initial_revision();
     const auto bucket = [this]() {
         if (is_read_replica_mode_enabled()) {
@@ -1262,13 +1264,23 @@ ss::future<> partition::do_unsafe_reset_remote_partition_manifest_from_cloud() {
     const auto max_collectible
       = _raft->log()->stm_manager()->max_collectible_offset();
     if (new_manifest.get_last_offset() < max_collectible) {
-        throw std::runtime_error(ssx::sformat(
+        auto msg = ssx::sformat(
           "Applying the cloud manifest would cause data loss since the last "
           "offset in the downloaded manifest is below the max_collectible "
           "offset "
           "{} < {}",
           new_manifest.get_last_offset(),
-          max_collectible));
+          max_collectible);
+
+        if (!force) {
+            throw std::runtime_error(msg);
+        }
+
+        vlog(
+          clusterlog.warn,
+          "[{}] {}. Proceeding since the force flag was used.",
+          ntp(),
+          msg);
     }
 
     co_await replicate_unsafe_reset(std::move(new_manifest));

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -434,9 +434,29 @@ public:
 
     result<std::vector<raft::follower_metrics>> get_follower_metrics() const;
 
-    ss::future<> unsafe_reset_remote_partition_manifest(iobuf buf);
+    // Attempt to reset the partition manifest of a cloud storage partition
+    // from an iobuf containing the JSON representation of the manifest.
+    //
+    // Warning: in order to call this safely, one must stop the archiver
+    // manually whilst ensuring that the max collectible offset reported
+    // by the archival metadata STM remains stable. Prefer its sibling
+    // which resets from the cloud state.
+    //
+    // Returns a failed future if unsuccessful.
+    ss::future<>
+    unsafe_reset_remote_partition_manifest_from_json(iobuf json_buf);
+
+    // Attempt to reset the partition manifest of a cloud storage partition
+    // to the one last uploaded to cloud storage.
+    // Returns a failed future if unsuccessful.
+    ss::future<> unsafe_reset_remote_partition_manifest_from_cloud();
 
 private:
+    ss::future<>
+    replicate_unsafe_reset(cloud_storage::partition_manifest manifest);
+
+    ss::future<> do_unsafe_reset_remote_partition_manifest_from_cloud();
+
     ss::future<std::optional<storage::timequery_result>>
       cloud_storage_timequery(storage::timequery_config);
 

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -64,6 +64,7 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    bool should_construct_archiver();
     /// Part of constructor that we may sometimes need to do again
     /// after a configuration change.
     void maybe_construct_archiver();
@@ -491,7 +492,11 @@ private:
     ss::shared_ptr<cloud_storage::async_manifest_view>
       _cloud_storage_manifest_view;
     ss::shared_ptr<cloud_storage::remote_partition> _cloud_storage_partition;
+
+    static constexpr auto archiver_reset_mutex_timeout = 10s;
+    ssx::semaphore _archiver_reset_mutex{1, "archiver_reset"};
     std::unique_ptr<archival::ntp_archiver> _archiver;
+
     std::optional<cloud_storage_clients::bucket_name> _read_replica_bucket{
       std::nullopt};
     bool _remote_delete_enabled{storage::ntp_config::default_remote_delete};

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -448,14 +448,19 @@ public:
 
     // Attempt to reset the partition manifest of a cloud storage partition
     // to the one last uploaded to cloud storage.
+    //
+    // If `force` is true, the safety checks will be disregarded, which
+    // may lead to data loss.
+    //
     // Returns a failed future if unsuccessful.
-    ss::future<> unsafe_reset_remote_partition_manifest_from_cloud();
+    ss::future<> unsafe_reset_remote_partition_manifest_from_cloud(bool force);
 
 private:
     ss::future<>
     replicate_unsafe_reset(cloud_storage::partition_manifest manifest);
 
-    ss::future<> do_unsafe_reset_remote_partition_manifest_from_cloud();
+    ss::future<>
+    do_unsafe_reset_remote_partition_manifest_from_cloud(bool force);
 
     ss::future<std::optional<storage::timequery_result>>
       cloud_storage_timequery(storage::timequery_config);

--- a/src/v/cluster/persisted_stm.cc
+++ b/src/v/cluster/persisted_stm.cc
@@ -487,7 +487,7 @@ template<supported_stm_snapshot T>
 ss::future<bool> persisted_stm<T>::wait_no_throw(
   model::offset offset,
   model::timeout_clock::time_point deadline,
-  std::optional<std::reference_wrapper<ss::abort_source>> as) {
+  std::optional<std::reference_wrapper<ss::abort_source>> as) noexcept {
     return wait(offset, deadline, as)
       .then([] { return true; })
       .handle_exception_type([](const ss::abort_requested_exception&) {

--- a/src/v/cluster/persisted_stm.h
+++ b/src/v/cluster/persisted_stm.h
@@ -199,7 +199,8 @@ public:
     ss::future<bool> wait_no_throw(
       model::offset offset,
       model::timeout_clock::time_point,
-      std::optional<std::reference_wrapper<ss::abort_source>> = std::nullopt);
+      std::optional<std::reference_wrapper<ss::abort_source>>
+      = std::nullopt) noexcept;
 
 private:
     ss::future<> wait_offset_committed(

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -177,6 +177,43 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/v1/cloud_storage/unsafe_reset_metadata_from_cloud/{namespace}/{topic}/{partition}",
+      "operations": [
+        {
+          "method": "POST",
+          "summary": "Resets the manifest to the one in cloud storage, updating all replicas with the given manifest. The request is refused if applying the change would cause data loss.",
+          "operationId": "unsafe_reset_metadata_from_cloud",
+          "nickname": "unsafe_reset_metadata_from_cloud",
+          "parameters": [
+            {
+              "name": "namespace",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "topic",
+              "in": "path",
+              "required": true,
+              "type": "string"
+            },
+            {
+              "name": "partition",
+              "in": "path",
+              "required": true,
+              "type": "integer"
+            }
+          ],
+          "responseMessages": [
+            {
+              "code": 200,
+              "message": "Partition metadata is reset"
+            }
+          ]
+        }
+      ]
     }
   ],
   "models": {

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -183,7 +183,7 @@
       "operations": [
         {
           "method": "POST",
-          "summary": "Resets the manifest to the one in cloud storage, updating all replicas with the given manifest. The request is refused if applying the change would cause data loss.",
+          "summary": "Resets the manifest to the one in cloud storage, updating all replicas with the given manifest. The request is refused if applying the change would cause data loss and the force query parameter is unspecified or false.",
           "operationId": "unsafe_reset_metadata_from_cloud",
           "nickname": "unsafe_reset_metadata_from_cloud",
           "parameters": [
@@ -204,6 +204,12 @@
               "in": "path",
               "required": true,
               "type": "integer"
+            },
+            {
+              "name": "force",
+              "in": "query",
+              "required": false,
+              "type": "boolean"
             }
           ],
           "responseMessages": [

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -5273,6 +5273,48 @@ ss::future<std::unique_ptr<ss::http::reply>> admin_server::get_manifest(
       });
 }
 
+ss::future<std::unique_ptr<ss::http::reply>>
+admin_server::unsafe_reset_metadata_from_cloud(
+  std::unique_ptr<ss::http::request> request,
+  std::unique_ptr<ss::http::reply> reply) {
+    reply->set_content_type("json");
+
+    auto ntp = parse_ntp_from_request(request->param);
+    if (need_redirect_to_leader(ntp, _metadata_cache)) {
+        vlog(
+          logger.info,
+          "Need to redirect unsafe reset metadata from cloud request");
+        throw co_await redirect_to_leader(*request, ntp);
+    }
+
+    const auto shard = _shard_table.local().shard_for(ntp);
+    if (!shard) {
+        throw ss::httpd::not_found_exception(fmt::format(
+          "{} could not be found on the node. Perhaps it has been moved "
+          "during the redirect.",
+          ntp));
+    }
+
+    try {
+        co_await _partition_manager.invoke_on(
+          *shard, [ntp = std::move(ntp), shard](auto& pm) {
+              auto partition = pm.get(ntp);
+              if (!partition) {
+                  throw ss::httpd::not_found_exception(
+                    fmt::format("Could not find {} on shard {}", ntp, *shard));
+              }
+
+              return partition
+                ->unsafe_reset_remote_partition_manifest_from_cloud();
+          });
+    } catch (const std::runtime_error& err) {
+        throw ss::httpd::server_error_exception(err.what());
+    }
+
+    reply->set_status(ss::http::reply::status_type::ok);
+    co_return reply;
+}
+
 void admin_server::register_shadow_indexing_routes() {
     register_route<superuser>(
       ss::httpd::shadow_indexing_json::sync_local_state,
@@ -5322,6 +5364,16 @@ void admin_server::register_shadow_indexing_routes() {
         std::unique_ptr<ss::http::reply> rep) {
           return get_manifest(std::move(req), std::move(rep));
       });
+
+    request_handler_fn unsafe_reset_metadata_from_cloud_handler =
+      [this](auto req, auto reply) {
+          return unsafe_reset_metadata_from_cloud(
+            std::move(req), std::move(reply));
+      };
+
+    register_route<superuser>(
+      ss::httpd::shadow_indexing_json::unsafe_reset_metadata_from_cloud,
+      std::move(unsafe_reset_metadata_from_cloud_handler));
 }
 
 constexpr std::string_view to_string_view(service_kind kind) {

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -5295,9 +5295,11 @@ admin_server::unsafe_reset_metadata_from_cloud(
           ntp));
     }
 
+    bool force = get_boolean_query_param(*request, "force");
+
     try {
         co_await _partition_manager.invoke_on(
-          *shard, [ntp = std::move(ntp), shard](auto& pm) {
+          *shard, [ntp = std::move(ntp), shard, force](auto& pm) {
               auto partition = pm.get(ntp);
               if (!partition) {
                   throw ss::httpd::not_found_exception(
@@ -5305,7 +5307,7 @@ admin_server::unsafe_reset_metadata_from_cloud(
               }
 
               return partition
-                ->unsafe_reset_remote_partition_manifest_from_cloud();
+                ->unsafe_reset_remote_partition_manifest_from_cloud(force);
           });
     } catch (const std::runtime_error& err) {
         throw ss::httpd::server_error_exception(err.what());

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -4885,8 +4885,9 @@ admin_server::unsafe_reset_metadata(
               buf.append(content.data(), content.size());
               content = {};
 
-              return partition->unsafe_reset_remote_partition_manifest(
-                std::move(buf));
+              return partition
+                ->unsafe_reset_remote_partition_manifest_from_json(
+                  std::move(buf));
           });
     } catch (const std::runtime_error& err) {
         throw ss::httpd::server_error_exception(err.what());

--- a/src/v/redpanda/admin_server.h
+++ b/src/v/redpanda/admin_server.h
@@ -439,6 +439,9 @@ private:
     ss::future<std::unique_ptr<ss::http::reply>> unsafe_reset_metadata(
       std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
     ss::future<std::unique_ptr<ss::http::reply>>
+      unsafe_reset_metadata_from_cloud(
+        std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
+    ss::future<std::unique_ptr<ss::http::reply>>
       initiate_topic_scan_and_recovery(
         std::unique_ptr<ss::http::request>, std::unique_ptr<ss::http::reply>);
     ss::future<ss::json::json_return_type>

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -475,6 +475,12 @@ class Admin:
             f"debug/unsafe_reset_metadata/{topic}/{partition}",
             json=manifest)
 
+    def unsafe_reset_metadata_from_cloud(self, namespace, topic, partition):
+        return self._request(
+            'POST',
+            f"cloud_storage/unsafe_reset_metadata_from_cloud/{namespace}/{topic}/{partition}"
+        )
+
     def put_feature(self, feature_name, body):
         return self._request("PUT", f"features/{feature_name}", json=body)
 

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -11,6 +11,8 @@ import random
 import re
 import time
 from collections import defaultdict
+from datetime import datetime, timedelta
+from requests.exceptions import HTTPError
 
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
@@ -37,7 +39,7 @@ from rptest.util import (
     wait_for_local_storage_truncate,
 )
 from rptest.utils.mode_checks import skip_debug_mode
-from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP
+from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP, quiesce_uploads
 
 
 class EndToEndShadowIndexingBase(EndToEndTest):
@@ -421,6 +423,91 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
         assert consumer.consumer_status.validator.invalid_reads == 0
         # validate that messages from the manifests that were removed from the manifest are not readable
         assert consumer.consumer_status.validator.valid_reads == messages_to_read
+
+    @cluster(
+        num_nodes=4,
+        log_allow_list=["Applying the cloud manifest would cause data loss"])
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_reset_from_cloud(self, cloud_storage_type):
+        """
+        Test the unsafe_reset_metadata_from_cloud endpoint by repeatedly
+        calling it to re-set the manifest from the uploaded one while
+        producing to the partition. Once the produce finishes, wait for
+        all uploads to complete and do a full read of the log to bubble
+        up any inconsistencies.
+        """
+        msg_size = 2056
+        self.redpanda.set_cluster_config({
+            "cloud_storage_housekeeping_interval_ms":
+            10000,
+            "cloud_storage_spillover_manifest_max_segments":
+            10
+        })
+
+        # Set a very low local retetion to race manifest resets wih retention
+        self.rpk.alter_topic_config(self.topic, 'retention.local.target.bytes',
+                                    self.segment_size * 1)
+
+        msg_per_segment = self.segment_size // msg_size
+        total_messages = 250 * msg_per_segment
+        producer = KgoVerifierProducer(self.test_context,
+                                       self.redpanda,
+                                       self.topic,
+                                       msg_size=msg_size,
+                                       msg_count=total_messages,
+                                       rate_limit_bps=1024 * 1024 * 5)
+
+        producer.start()
+
+        resets_done = 0
+        resets_refused = 0
+        resets_failed = 0
+
+        seconds_between_reset = 10
+        next_reset = datetime.now() + timedelta(seconds=seconds_between_reset)
+
+        # Repeatedly reset the manifest while producing to the partition
+        while not producer.is_complete():
+            now = datetime.now()
+            if now >= next_reset:
+                try:
+                    self.redpanda._admin.unsafe_reset_metadata_from_cloud(
+                        namespace="kafka", topic=self.topic, partition=0)
+                    resets_done += 1
+                except HTTPError as ex:
+                    if "would cause data loss" in ex.response.text:
+                        resets_refused += 1
+                    else:
+                        resets_failed += 1
+                    self.logger.info(f"Reset from cloud failed: {ex}")
+                next_reset = now + timedelta(seconds=seconds_between_reset)
+
+            time.sleep(2)
+
+        producer.wait(timeout_sec=120)
+        producer.free()
+
+        self.logger.info(
+            f"Producer workload complete: {resets_done=}, {resets_refused=}, {resets_failed=}"
+        )
+
+        assert resets_done + resets_refused > 0, "No resets done during the test"
+        assert resets_failed == 0, f"{resets_failed} resets failed during the test"
+
+        # Wait for all uploads to complete and read the log in full.
+        # This should highlight any data consistency issues.
+        # Note that we are re-using the node where the producer ran,
+        # which allows for validation of the consumed offests.
+        quiesce_uploads(self.redpanda, [self.topic], timeout_sec=120)
+
+        consumer = KgoVerifierSeqConsumer(self.test_context,
+                                          self.redpanda,
+                                          self.topic,
+                                          debug_logs=True,
+                                          trace_logs=True)
+
+        consumer.start()
+        consumer.wait(timeout_sec=120)
 
     @cluster(num_nodes=5)
     @matrix(cloud_storage_type=get_cloud_storage_type())


### PR DESCRIPTION
Backport of :
* #13896: I had to omit the tests added in the original PR since they use gtest and support for that was not back ported.
* #14597: This mostly back ported fine. In v23.2 `partition::start` does not construct the archiver. That's done in the constructor instead. This means that the we don't have to grab the new archiver lock in `partition::start` for the backport.