### PR TITLE
conf: update Redpanda configuration file

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 Redpanda Data, Inc.
+# Copyright 2023 Redpanda Data, Inc.
 #
 # Use of this software is governed by the Business Source License
 # included in the file licenses/BSL.md
@@ -22,11 +22,22 @@ redpanda:
     address: "0.0.0.0"
     port: 33145
 
+  # Redpanda server for other nodes to connect too
+  advertised_rpc_api:
+    address: "127.0.0.1"
+    port: 33145
+
   # Kafka transport
   kafka_api:
   - address: "0.0.0.0"
     port: 9092
 
+  # Kafka transport for other nodes to connect too
+  advertised_kafka_api:
+  - address: "127.0.0.1"
+    port: 9092
+
+  # Admin server includes metrics, and cluster management
   admin:
     address: "0.0.0.0"
     port: 9644
@@ -35,10 +46,10 @@ redpanda:
   # not recomended for production use
   developer_mode: true
 
-# Enable Pandaproxy
+# Enable Pandaproxy on port 8082
 pandaproxy: {}
 
-# Enable Schema Registry
+# Enable Schema Registry on port 8081
 schema_registry: {}
 
 rpk:

--- a/src/go/rpk/pkg/config/params_test.go
+++ b/src/go/rpk/pkg/config/params_test.go
@@ -236,8 +236,16 @@ func TestRedpandaSampleFile(t *testing.T) {
 				Address: "0.0.0.0",
 				Port:    33145,
 			},
+			AdvertisedRPCAPI: &SocketAddress{
+				Address: "127.0.0.1",
+				Port:    33145,
+			},
 			KafkaAPI: []NamedAuthNSocketAddress{{
 				Address: "0.0.0.0",
+				Port:    9092,
+			}},
+			AdvertisedKafkaAPI: []NamedSocketAddress{{
+				Address: "127.0.0.1",
 				Port:    9092,
 			}},
 			AdminAPI: []NamedSocketAddress{{
@@ -289,6 +297,12 @@ func TestRedpandaSampleFile(t *testing.T) {
     admin:
         - address: 0.0.0.0
           port: 9644
+    advertised_rpc_api:
+        address: 127.0.0.1
+        port: 33145
+    advertised_kafka_api:
+        - address: 127.0.0.1
+          port: 9092
     developer_mode: true
 rpk:
     coredump_dir: /var/lib/redpanda/coredump


### PR DESCRIPTION
We don't allow advertised addresses of `0.0.0.0` so in our example
configuration explicitly set localhost configuration values.

This allows Redpanda to boot using this configuration.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
