### PR TITLE
wasm: fix cache assertion

### DIFF
--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -186,9 +186,7 @@ class engine_cache {
 public:
     void
     put(model::offset offset, const ss::shared_ptr<shared_engine>& engine) {
-        auto [_, inserted] = _cache.insert_or_assign(
-          offset, engine->weak_from_this());
-        vassert(inserted, "expected engine to be inserted");
+        _cache.insert_or_assign(offset, engine->weak_from_this());
     }
 
     ss::future<mutex::units> lock() { return _mu.get_units(); }
@@ -320,9 +318,7 @@ ss::future<ss::shared_ptr<factory>> caching_runtime::make_factory(
     // cores, and we can't do that here because of the inheritance).
     auto created = ss::make_shared<cached_factory>(
       ss::make_foreign(std::move(factory)), offset, &_engine_caches);
-    auto [_, inserted] = _factory_cache.insert_or_assign(
-      offset, created->weak_from_this());
-    vassert(inserted, "expected factory to be inserted");
+    _factory_cache.insert_or_assign(offset, created->weak_from_this());
 
     co_return created;
 }

--- a/src/v/wasm/tests/wasm_cache_test.cc
+++ b/src/v/wasm/tests/wasm_cache_test.cc
@@ -282,4 +282,29 @@ TEST_F(WasmCacheTest, GC) {
     EXPECT_EQ(gc(), 1);
 }
 
+TEST_F(WasmCacheTest, FactoryReplacementBeforeGC) {
+    auto meta = random_metadata();
+    auto factory = make_factory_async(meta).get();
+    EXPECT_EQ(state()->factories, 1);
+    factory = nullptr;
+    EXPECT_EQ(state()->factories, 0);
+    // Catches a bug when we were asserting incorrectly because a factory was
+    // replaced in the cache instead of being inserted.
+    factory = make_factory_async(meta).get();
+    EXPECT_EQ(state()->factories, 1);
+}
+
+TEST_F(WasmCacheTest, EngineReplacementBeforeGC) {
+    auto meta = random_metadata();
+    auto factory = ss::make_foreign(make_factory(meta));
+    auto engine = factory->make_engine().get();
+    EXPECT_EQ(state()->engines, 1);
+    engine = nullptr;
+    EXPECT_EQ(state()->engines, 0);
+    // Catches a bug when we were asserting incorrectly because an engine was
+    // replaced in the cache instead of being inserted.
+    engine = factory->make_engine().get();
+    EXPECT_EQ(state()->engines, 1);
+}
+
 } // namespace wasm


### PR DESCRIPTION
This assertion in the wasm cache is invalid - we could be replacing a weak nullptr (hence using `insert_or_assign`). Remove the assertion and add a test for replacing an engine.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
