### PR TITLE
3rdparty: Disable tests and tools for ada

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -71,9 +71,12 @@ fetch_dep(GTest
   REPO https://github.com/google/googletest
   TAG v1.14.0)
 
+set(ADA_TESTING OFF)
+set(ADA_TOOLS OFF)
+set(ADA_BENCHMARKS OFF)
 fetch_dep(ada
   REPO https://github.com/ada-url/ada
-  TAG v2.7.2)
+  TAG v2.7.3)
 
 if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
   set(TINYGO_TARBALL "tinygo-linux-amd64.tar.gz")

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -9,6 +9,7 @@ please keep this up to date with every new library use.
 | software        | license                            |
 | :----------     | :------------                      |
 | abseil          | Apache License 2                   |
+| ada             | Apache License 2 / MIT             |
 | avro            | Apache License 2                   |
 | base64          | BSD 2                              |
 | boost libraries | Boost Software License Version 1.0 |


### PR DESCRIPTION
ada uses CPM: https://github.com/cpm-cmake/CPM.cmake

Disable ADA_TESTING, ADA_TOOLS, ADA_BENCHMARKING to prevent CPM from downloading 3rdparty repositories.

I'm still seeing this message:
```
Generating ada.cpp, ada.h, ada_c.h, demo.cpp, demo.c, README.md
fatal: detected dubious ownership in repository at '/var/lib/buildkite-agent/builds/buildkite-amd64-builders-i-0d17fc136ea6bdd74-1/redpanda/redpanda'
```

Also add the license.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
