### PR TITLE
Added log end offset to out of range log entry

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -332,11 +332,13 @@ static ss::future<read_result> do_read_from_ntp(
         vlog(
           klog.warn,
           "fetch offset out of range for {}, requested offset: {}, "
-          "partition start offset: {}, high watermark: {}, ec: {}",
+          "partition start offset: {}, high watermark: {}, log end offset: {} "
+          "ec: {}",
           ntp_config.ktp(),
           ntp_config.cfg.start_offset,
           kafka_partition->start_offset(),
           kafka_partition->high_watermark(),
+          kafka_partition->log_end_offset(),
           offset_ec);
 
         co_return read_result(

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -43,7 +43,7 @@ public:
         virtual kafka::leader_epoch leader_epoch() const = 0;
         virtual ss::future<std::optional<model::offset>>
           get_leader_epoch_last_offset(kafka::leader_epoch) const = 0;
-        virtual bool is_elected_leader() const = 0;
+
         virtual bool is_leader() const = 0;
         virtual ss::future<std::error_code> linearizable_barrier() = 0;
         virtual ss::future<error_code>
@@ -103,8 +103,6 @@ public:
     prefix_truncate(model::offset o, ss::lowres_clock::time_point deadline) {
         return _impl->prefix_truncate(o, deadline);
     }
-
-    bool is_elected_leader() const { return _impl->is_elected_leader(); }
 
     bool is_leader() const { return _impl->is_leader(); }
 

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -37,6 +37,7 @@ public:
           sync_effective_start(model::timeout_clock::duration) = 0;
         virtual model::offset start_offset() const = 0;
         virtual model::offset high_watermark() const = 0;
+        virtual model::offset log_end_offset() const = 0;
         virtual checked<model::offset, error_code>
         last_stable_offset() const = 0;
         virtual kafka::leader_epoch leader_epoch() const = 0;
@@ -88,6 +89,7 @@ public:
     model::offset start_offset() const { return _impl->start_offset(); }
 
     model::offset high_watermark() const { return _impl->high_watermark(); }
+    model::offset log_end_offset() const { return _impl->log_end_offset(); }
 
     checked<model::offset, error_code> last_stable_offset() const {
         return _impl->last_stable_offset();

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -136,10 +136,6 @@ public:
         return _translator->from_log_offset(maybe_lso);
     }
 
-    bool is_elected_leader() const final {
-        return _partition->is_elected_leader();
-    }
-
     bool is_leader() const final { return _partition->is_leader(); }
 
     ss::future<error_code>

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -89,7 +89,7 @@ public:
      * According to Kafka protocol semantics a log_end_offset is an offset that
      * is assigned to the next record produced to a log
      */
-    model::offset log_end_offset() const {
+    model::offset log_end_offset() const final {
         if (_partition->is_read_replica_mode_enabled()) {
             if (_partition->cloud_data_available()) {
                 return model::next_offset(_partition->next_cloud_offset());

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -442,7 +442,6 @@ private:
         get_leader_epoch_last_offset(kafka::leader_epoch) const final {
             throw std::runtime_error("unimplemented");
         }
-        bool is_elected_leader() const final { return true; }
         bool is_leader() const final { return true; }
         ss::future<std::error_code> linearizable_barrier() final {
             throw std::runtime_error("unimplemented");

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -428,6 +428,9 @@ private:
         model::offset high_watermark() const final {
             throw std::runtime_error("unimplemented");
         }
+        model::offset log_end_offset() const final {
+            throw std::runtime_error("unimplemented");
+        }
         checked<model::offset, kafka::error_code>
         last_stable_offset() const final {
             throw std::runtime_error("unimplemented");


### PR DESCRIPTION
Fetch offset is validated against the log end offset. In order to get the full view of partition added log end offset to log entry indicating offset out of range error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- more information when investigating offset out of range errors