### PR TITLE
Audit app lifecycle

### DIFF
--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -20,6 +20,8 @@
 #include "security/acl.h"
 #include "security/audit/client_probe.h"
 #include "security/audit/logger.h"
+#include "security/audit/schemas/application_activity.h"
+#include "security/audit/schemas/types.h"
 #include "security/ephemeral_credential_store.h"
 #include "storage/parser_utils.h"
 #include "utils/retry.h"
@@ -681,6 +683,13 @@ bool audit_log_manager::is_client_enabled() const {
       ss::this_shard_id() == client_shard_id,
       "Must be called on audit client shard");
     return _sink->is_enabled();
+}
+
+bool audit_log_manager::report_redpanda_app_event(is_started app_started) {
+    return enqueue_app_lifecycle_event(
+      app_started == is_started::yes
+        ? application_lifecycle::activity_id::start
+        : application_lifecycle::activity_id::stop);
 }
 
 bool audit_log_manager::do_enqueue_audit_event(

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -27,11 +27,14 @@
 #include "utils/retry.h"
 
 #include <seastar/core/sleep.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <memory>
 
 namespace security::audit {
+
+static constexpr std::string_view subsystem_name = "Audit System";
 
 std::ostream& operator<<(std::ostream& os, event_type t) {
     switch (t) {
@@ -621,6 +624,17 @@ ss::future<> audit_log_manager::start() {
     }
     _audit_enabled.watch([this] {
         try {
+            if (!enqueue_app_lifecycle_event(
+                  _audit_enabled() ? application_lifecycle::activity_id::start
+                                   : application_lifecycle::activity_id::stop,
+                  ss::sstring{subsystem_name})) {
+                vlog(adtlog.error, "Failed to enqueue audit lifecycle event");
+                if (_audit_enabled()) {
+                    throw std::runtime_error(
+                      "Failed to enqueue audit lifecycle event for audit "
+                      "system start");
+                }
+            }
             _sink->toggle(_audit_enabled());
         } catch (const ss::gate_closed_exception&) {
             vlog(
@@ -634,11 +648,25 @@ ss::future<> audit_log_manager::start() {
     });
     if (_audit_enabled()) {
         vlog(adtlog.info, "Starting audit_log_manager");
+        if (!this->enqueue_app_lifecycle_event(
+              application_lifecycle::activity_id::start,
+              ss::sstring{subsystem_name})) {
+            vlog(adtlog.error, "Failed to enqueue audit lifecycle start event");
+            // TODO I should error here, yeah?
+        }
         co_await _sink->start();
     }
 }
 
 ss::future<> audit_log_manager::stop() {
+    if (ss::this_shard_id() == client_shard_id) {
+        if (!enqueue_app_lifecycle_event(
+              application_lifecycle::activity_id::stop,
+              ss::sstring{subsystem_name})) {
+            vlog(
+              adtlog.error, "Failed to enqueue audit subsystem shutdown event");
+        }
+    }
     _drain_timer.cancel();
     _as.request_abort();
     if (ss::this_shard_id() == client_shard_id) {

--- a/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
+++ b/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
@@ -210,11 +210,15 @@ static const ss::sstring test_http_request_ser{
 static const sa::product test_product{
   .name = "test-product",
   .vendor_name = ss::sstring{sa::vendor_name},
-  .version = ss::sstring{redpanda_git_version()}};
+  .version = ss::sstring{redpanda_git_version()},
+  .feature = sa::feature{.name = "test-feature"}};
 
 static const ss::sstring test_product_ser{
   R"(
 {
+  "feature": {
+    "name": "test-feature"
+  },
   "name": "test-product",
   "vendor_name": ")"
   + ss::sstring{sa::vendor_name} + R"(",
@@ -412,22 +416,22 @@ BOOST_AUTO_TEST_CASE(validate_application_lifecycle) {
 
     auto ser = sa::rjson_serialize(app_lifecycle);
 
-    const ss::sstring expected{
+    const auto expected = fmt::format(
       R"(
-{
+{{
   "category_uid": 6,
   "class_uid": 6002,
-  "metadata": )"
-      + metadata_ser + R"(,
+  "metadata": {metadata},
   "severity_id": 1,
-  "time": )"
-      + ss::to_sstring(now) + R"(,
+  "time": {time},
   "type_uid": 600203,
   "activity_id": 3,
-  "app": )"
-      + test_product_ser + R"(
-}
-)"};
+  "app": {product}
+}}
+)",
+      fmt::arg("metadata", metadata_ser),
+      fmt::arg("time", ss::to_sstring(app_lifecycle.get_time())),
+      fmt::arg("product", test_product_ser));
 
     BOOST_REQUIRE_EQUAL(ser, ::json::minify(expected));
 }

--- a/src/v/security/audit/schemas/types.h
+++ b/src/v/security/audit/schemas/types.h
@@ -116,15 +116,24 @@ struct api {
     auto equality_fields() const { return std::tie(operation, service); }
 };
 
+// Information about the software product feature that generated the event
+// https://schema.ocsf.io/1.0.0/objects/feature?extensions=
+struct feature {
+    ss::sstring name;
+
+    auto equality_fields() const { return std::tie(name); }
+};
+
 // Characteristics of a software product
 // https://schema.ocsf.io/1.0.0/objects/product?extensions=
 struct product {
     ss::sstring name;
     ss::sstring vendor_name;
     ss::sstring version;
+    std::optional<feature> feature;
 
     auto equality_fields() const {
-        return std::tie(name, vendor_name, version);
+        return std::tie(name, vendor_name, version, feature);
     }
 };
 
@@ -357,8 +366,19 @@ inline void rjson_serialize(Writer<StringBuffer>& w, const sa::api& api) {
     w.EndObject();
 }
 
+inline void rjson_serialize(Writer<StringBuffer>& w, const sa::feature& f) {
+    w.StartObject();
+    w.Key("name");
+    rjson_serialize(w, f.name);
+    w.EndObject();
+}
+
 inline void rjson_serialize(Writer<StringBuffer>& w, const sa::product& p) {
     w.StartObject();
+    if (p.feature.has_value()) {
+        w.Key("feature");
+        rjson_serialize(w, p.feature.value());
+    }
     w.Key("name");
     rjson_serialize(w, p.name);
     w.Key("vendor_name");

--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -694,4 +694,16 @@ make_application_lifecycle(application_lifecycle::activity_id activity_id) {
       create_timestamp_t()};
 }
 
+application_lifecycle make_application_lifecycle(
+  application_lifecycle::activity_id activity_id, ss::sstring feature_name) {
+    auto product = redpanda_product();
+    product.feature = feature{.name = std::move(feature_name)};
+
+    return {
+      activity_id,
+      std::move(product),
+      severity_id::informational,
+      create_timestamp_t()};
+}
+
 } // namespace security::audit

--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -685,4 +685,13 @@ api_activity make_api_activity_event(
       unmapped_data(auth_result)};
 }
 
+application_lifecycle
+make_application_lifecycle(application_lifecycle::activity_id activity_id) {
+    return {
+      activity_id,
+      redpanda_product(),
+      severity_id::informational,
+      create_timestamp_t()};
+}
+
 } // namespace security::audit

--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -62,6 +62,7 @@
 #include "security/request_auth.h"
 #include "security/scram_authenticator.h"
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/smp.hh>
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -212,7 +213,7 @@ timestamp_t create_timestamp_t(std::chrono::time_point<Clock> time_point) {
                          .count());
 }
 
-template<typename Clock>
+template<typename Clock = ss::lowres_system_clock>
 timestamp_t create_timestamp_t() {
     return create_timestamp_t(Clock::now());
 }
@@ -524,7 +525,7 @@ api_activity make_api_activity_event(
       from_ss_endpoint(req.get_client_address()),
       authorized ? api_activity::status_id::success
                  : api_activity::status_id::failure,
-      create_timestamp_t<std::chrono::system_clock>(),
+      create_timestamp_t(),
       unmapped_data()};
 }
 
@@ -546,7 +547,7 @@ authentication make_authentication_event(
       r.is_authenticated() ? authentication::status_id::success
                            : authentication::status_id::failure,
       std::nullopt,
-      create_timestamp_t<std::chrono::system_clock>(),
+      create_timestamp_t(),
       user_from_request_auth_result(r)};
 }
 
@@ -613,7 +614,7 @@ authentication make_authentication_failure_event(
       severity_id::informational,
       authentication::status_id::failure,
       reason,
-      create_timestamp_t<std::chrono::system_clock>(),
+      create_timestamp_t(),
       user{.name = r, .type_id = user::type::unknown}};
 }
 
@@ -680,7 +681,7 @@ api_activity make_api_activity_event(
         .name = ss::sstring{client_id.value_or("")}},
       auth_result.authorized ? api_activity::status_id::success
                              : api_activity::status_id::failure,
-      create_timestamp_t<std::chrono::system_clock>(),
+      create_timestamp_t(),
       unmapped_data(auth_result)};
 }
 

--- a/src/v/security/audit/schemas/utils.h
+++ b/src/v/security/audit/schemas/utils.h
@@ -207,4 +207,7 @@ api_activity make_api_activity_event(
   std::optional<std::string_view> client_id,
   std::vector<resource_detail> additional_resources);
 
+application_lifecycle
+make_application_lifecycle(application_lifecycle::activity_id activity_id);
+
 } // namespace security::audit

--- a/src/v/security/audit/schemas/utils.h
+++ b/src/v/security/audit/schemas/utils.h
@@ -210,4 +210,7 @@ api_activity make_api_activity_event(
 application_lifecycle
 make_application_lifecycle(application_lifecycle::activity_id activity_id);
 
+application_lifecycle make_application_lifecycle(
+  application_lifecycle::activity_id activity_id, ss::sstring feature_name);
+
 } // namespace security::audit


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Add audit messages to monitor the life cycle of the application and audit log manager.

Force push [`62f8fcc`](https://github.com/redpanda-data/redpanda/compare/577babafe622040e06ee23b4bfc11155faf91148..62f8fcc37ab5b91563fcfc419377eced2469b281):

* Rebased off of dev

Force push [`0829549`](https://github.com/redpanda-data/redpanda/compare/62f8fcc37ab5b91563fcfc419377eced2469b281..0829549f80dc1dfa7671b5d7e1a8bd1125b9d086):

* Removed `audit_schemas.py` file that snuck in from rebase

Force push [`4824ad3`](https://github.com/redpanda-data/redpanda/compare/0829549f80dc1dfa7671b5d7e1a8bd1125b9d086..4824ad361d4e26f16842aa379efdd15873693586):

* Fixed flaky test

Force push `77bef0a`:

* Updates from PR comments

Force push `d935717`:

* Fix for flakey unit test

Force push `a743b7f`:

* Rebase off dev to fix merge conflict

Force push `83bce6c`:

* Rebase off of dev

Force push `3d90071`:

* Yet another rebase due to another PR sneaking in while rebasing off of a previous dev

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none