### PR TITLE
test: temporary mark ok_to_fail registry tests

### DIFF
--- a/tests/rptest/tests/rpk_registry_test.py
+++ b/tests/rptest/tests/rpk_registry_test.py
@@ -18,6 +18,7 @@ from rptest.clients.rpk import RpkTool, RpkException
 from rptest.services import tls
 from rptest.tests.pandaproxy_test import User, PandaProxyTLSProvider
 from rptest.util import expect_exception
+from ducktape.mark import ok_to_fail
 
 schema1_avro_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 schema2_avro_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"string","default":"foo"}]}'
@@ -283,6 +284,7 @@ class RpkRegistryTest(RedpandaTest):
         assert len(out) == 0
         assert len(out_deleted) == 0
 
+    @ok_to_fail
     @cluster(num_nodes=3)
     def test_produce_consume_avro(self):
         # First we register the schemas with their references.
@@ -347,6 +349,7 @@ class RpkRegistryTest(RedpandaTest):
         assert json.loads(msg["value"]) == expected_msg_1
         assert json.loads(msg["key"]) == expected_msg_2
 
+    @ok_to_fail
     @cluster(num_nodes=3)
     def test_produce_consume_proto(self):
         # First we register the schemas with their references.


### PR DESCRIPTION
It's failing constantly and we are working on a solution. Issue reported: #14619


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes


* none
