### PR TITLE
[v23.1.x] archival: avoid replicating empty read replica batch

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -529,6 +529,12 @@ ss::future<cloud_storage::download_result> ntp_archiver::sync_manifest() {
                 break;
             }
         }
+        if (mdiff.empty()) {
+            vlog(
+              _rtclog.debug,
+              "No difference between cloud manifest and in-memory manifest");
+            co_return cloud_storage::download_result::success;
+        }
 
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();


### PR DESCRIPTION
NOTE: This doesn't exist in v23.2.x and above.

Empty batches aren't well-handled and can result in corrupted segments. This commit adjusts read replicas to avoid this when there is no difference between the remote manifest and in-memory manifest.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [x] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
* Fixes a bug in read replicas that were subject to unstable leadership that could create corrupted local segment files (note, segments in the cloud are safe).
