### PR TITLE
transform: batch offset commits per core

### DIFF
--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -219,7 +219,7 @@ public:
         co_return it->second;
     }
 
-    ss::future<errc> put(absl::flat_hash_map<Key, Value> kvs) {
+    ss::future<errc> put(absl::btree_map<Key, Value> kvs) {
         auto holder = _gate.hold();
         auto units = co_await _snapshot_lock.hold_read_lock();
         if (!co_await sync(sync_timeout)) {

--- a/src/v/cluster/distributed_kv_stm_types.h
+++ b/src/v/cluster/distributed_kv_stm_types.h
@@ -14,6 +14,7 @@
 #include "model/fundamental.h"
 #include "serde/serde.h"
 
+#include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_map.h>
 
 #include <cstdint>
@@ -182,7 +183,7 @@ struct kv_data_value
 
 template<class Key, class Value>
 static simple_batch_builder
-make_kv_data_batch(absl::flat_hash_map<Key, Value> kvs) {
+make_kv_data_batch(absl::btree_map<Key, Value> kvs) {
     simple_batch_builder builder(
       model::record_batch_type::raft_data, model::offset(0));
     for (auto& [k, v] : kvs) {

--- a/src/v/cluster/tests/distributed_kv_stm_tests.cc
+++ b/src/v/cluster/tests/distributed_kv_stm_tests.cc
@@ -51,7 +51,7 @@ FIXTURE_TEST(test_stm_basic, stm_test_fixture) {
     BOOST_REQUIRE(result2);
     BOOST_REQUIRE_EQUAL(result.value(), result2.value());
 
-    absl::flat_hash_map<test_key, test_value> kvs;
+    absl::btree_map<test_key, test_value> kvs;
     kvs[0] = 99;
     kvs[1] = 100;
 
@@ -81,7 +81,7 @@ FIXTURE_TEST(test_batched_put, stm_test_fixture) {
         BOOST_REQUIRE_EQUAL(result.value(), model::partition_id{0});
     }
 
-    absl::flat_hash_map<test_key, test_value> kvs;
+    absl::btree_map<test_key, test_value> kvs;
     for (int i = 0; i < 30; i++) {
         kvs[i] = test_value{i};
     }
@@ -151,7 +151,7 @@ FIXTURE_TEST(test_stm_snapshots, stm_test_fixture) {
 
     for (int i = 0; i < 99; i++) {
         for (int j = 0; j < 10; j++) {
-            absl::flat_hash_map<test_key, test_value> kvs;
+            absl::btree_map<test_key, test_value> kvs;
             kvs[i] = test_value{j};
             auto result = stm.put(kvs).get0();
             BOOST_REQUIRE(result == cluster::errc::success);

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -152,6 +152,12 @@ configuration::configuration()
       "Enables WebAssembly powered Data Transforms directly in the broker",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       false)
+  , data_transforms_commit_interval_ms(
+      *this,
+      "data_transforms_commit_interval_ms",
+      "The interval at which Data Transforms commits progress.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      3s)
   , wasm_per_core_memory_reservation(
       *this,
       "wasm_per_core_memory_reservation",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -69,6 +69,7 @@ struct configuration final : public config_store {
 
     // Data Transforms
     property<bool> data_transforms_enabled;
+    property<std::chrono::milliseconds> data_transforms_commit_interval_ms;
 
     // Wasm
     bounded_property<size_t> wasm_per_core_memory_reservation;

--- a/src/v/ssx/sleep_abortable.h
+++ b/src/v/ssx/sleep_abortable.h
@@ -24,9 +24,9 @@
 
 namespace ssx {
 /// Same as seastar::abort_source but accepts multiple abort sources
-template<typename... AbortSource>
+template<typename Clock = seastar::steady_clock_type, typename... AbortSource>
 seastar::future<>
-sleep_abortable(seastar::lowres_clock::duration dur, AbortSource&... src) {
+sleep_abortable(typename Clock::duration dur, AbortSource&... src) {
     struct as_state : seastar::weakly_referencable<as_state> {
         std::vector<
           seastar::optimized_optional<seastar::abort_source::subscription>>
@@ -48,7 +48,7 @@ sleep_abortable(seastar::lowres_clock::duration dur, AbortSource&... src) {
     state->subscriptions.reserve(sizeof...(AbortSource));
     as_callback cb(*state);
     (cb.state->subscriptions.push_back(src.subscribe(cb)), ...);
-    return seastar::sleep_abortable(dur, cb.state->as)
+    return seastar::sleep_abortable<Clock>(dur, cb.state->as)
       .finally([st = std::move(state)] {});
 }
 } // namespace ssx

--- a/src/v/ssx/sleep_abortable.h
+++ b/src/v/ssx/sleep_abortable.h
@@ -24,7 +24,7 @@
 
 namespace ssx {
 /// Same as seastar::abort_source but accepts multiple abort sources
-template<typename Clock = seastar::steady_clock_type, typename... AbortSource>
+template<typename Clock = seastar::lowres_clock, typename... AbortSource>
 seastar::future<>
 sleep_abortable(typename Clock::duration dur, AbortSource&... src) {
     struct as_state : seastar::weakly_referencable<as_state> {

--- a/src/v/test_utils/async.h
+++ b/src/v/test_utils/async.h
@@ -17,6 +17,7 @@
 #include "vassert.h"
 
 #include <seastar/core/future-util.hh>
+#include <seastar/core/idle_cpu_handler.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sleep.hh>
@@ -113,6 +114,41 @@ inline void flush_tasks() {
 #ifndef NDEBUG
     ss::sleep(10ms).get();
 #endif
+}
+
+/**
+ * This allows us to wait for the seastar queue to be drained.
+ *
+ * This can used when we need to wait for manual_clock tasks to
+ * execute to ensure that task execution is deterministic. Because in
+ * debug mode seastar randomizes task order, so there is no way to wait
+ * for those tasks to be executed outside of draining the seastar queue.
+ *
+ * The above function's caveats are valid for this function, but it does not
+ * require the sleep hack.
+ */
+inline ss::future<> drain_task_queue() {
+    return ss::smp::invoke_on_all([] {
+        // Using an optional ensures that this is a noop on subsequent idle CPU
+        // callbacks.
+        std::optional<ss::promise<>> p;
+        p.emplace();
+        auto fut = p->get_future();
+        ss::set_idle_cpu_handler(
+          [p = std::move(p)](ss::work_waiting_on_reactor) mutable {
+              if (!p) {
+                  return ss::idle_cpu_handler_result::no_more_work;
+              }
+              p->set_value();
+              p.reset();
+              // this tells the reactor loop to go back and check
+              // for more work, which we should have just enqueued because of
+              // completing the promise above.
+              return ss::idle_cpu_handler_result::
+                interrupted_by_higher_priority_task;
+          });
+        return fut;
+    });
 }
 
 }; // namespace tests

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     logger.h
     transform_processor.h
     transform_manager.h
+    commit_batcher.h
     io.h
   SRCS
     api.cc
@@ -13,6 +14,7 @@ v_cc_library(
     logger.cc
     transform_processor.cc
     transform_manager.cc
+    commit_batcher.cc
   DEPS
     v::wasm
     v::model

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -15,6 +15,7 @@
 #include "cluster/partition_manager.h"
 #include "cluster/plugin_frontend.h"
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "features/feature_table.h"
 #include "kafka/server/partition_proxy.h"
 #include "kafka/server/replicated_partition.h"
@@ -47,7 +48,6 @@ namespace transform {
 namespace {
 constexpr auto wasm_binary_timeout = std::chrono::seconds(3);
 constexpr auto metadata_timeout = std::chrono::seconds(1);
-constexpr auto commit_interval = std::chrono::seconds(3);
 
 class rpc_client_sink final : public sink {
 public:
@@ -313,7 +313,7 @@ service::~service() = default;
 
 ss::future<> service::start() {
     _batcher = std::make_unique<commit_batcher<ss::lowres_clock>>(
-      commit_interval,
+      config::shard_local_cfg().data_transforms_commit_interval_ms.bind(),
       std::make_unique<rpc_offset_committer>(&_rpc_client->local()));
 
     _manager = std::make_unique<manager<ss::lowres_clock>>(

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -22,6 +22,7 @@
 #include "model/timeout_clock.h"
 #include "model/transform.h"
 #include "resource_mgmt/io_priority.h"
+#include "transform/commit_batcher.h"
 #include "transform/io.h"
 #include "transform/logger.h"
 #include "transform/rpc/client.h"
@@ -31,6 +32,7 @@
 #include "wasm/api.h"
 #include "wasm/cache.h"
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/smp.hh>
@@ -38,12 +40,14 @@
 #include <seastar/util/optimized_optional.hh>
 
 #include <memory>
+#include <stdexcept>
 
 namespace transform {
 
 namespace {
 constexpr auto wasm_binary_timeout = std::chrono::seconds(3);
 constexpr auto metadata_timeout = std::chrono::seconds(1);
+constexpr auto commit_interval = std::chrono::seconds(3);
 
 class rpc_client_sink final : public sink {
 public:
@@ -135,10 +139,14 @@ private:
 class offset_tracker_impl : public offset_tracker {
 public:
     offset_tracker_impl(
-      model::transform_id tid, model::partition_id pid, rpc::client* client)
+      model::transform_id tid,
+      model::partition_id pid,
+      rpc::client* client,
+      commit_batcher<>* batcher)
       : _tid(tid)
       , _pid(pid)
-      , _client(client) {}
+      , _client(client)
+      , _batcher(batcher) {}
 
     ss::future<std::optional<kafka::offset>> load_committed_offset() override {
         auto result = co_await _client->offset_fetch(
@@ -157,37 +165,15 @@ public:
     }
 
     ss::future<> commit_offset(kafka::offset offset) override {
-        // TODO(rockwood): We should be batching commits so commiting scales
-        // with the number of cores, not the number of partitions.
-        auto coordinator = co_await _client->find_coordinator(
-          {.id = _tid, .partition = _pid});
-        if (coordinator.has_error()) {
-            cluster::errc ec = coordinator.error();
-            throw std::runtime_error(ss::format(
-              "error committing offset: {}",
-              cluster::error_category().message(int(ec))));
-        }
-        absl::btree_map<
-          model::transform_offsets_key,
-          model::transform_offsets_value>
-          batch;
-        batch.emplace(
-          model::transform_offsets_key{.id = _tid, .partition = _pid},
-          model::transform_offsets_value{.offset = offset});
-
-        cluster::errc ec = co_await _client->batch_offset_commit(
-          coordinator.value(), std::move(batch));
-        if (ec != cluster::errc::success) {
-            throw std::runtime_error(ss::format(
-              "error committing offset: {}",
-              cluster::error_category().message(int(ec))));
-        }
+        return _batcher->commit_offset(
+          {.id = _tid, .partition = _pid}, {.offset = offset});
     }
 
 private:
     model::transform_id _tid;
     model::partition_id _pid;
     rpc::client* _client;
+    commit_batcher<>* _batcher;
 };
 
 using wasm_engine_factory = ss::noncopyable_function<
@@ -199,10 +185,12 @@ public:
     proc_factory(
       wasm_engine_factory factory,
       cluster::partition_manager* partition_manager,
-      rpc::client* client)
+      rpc::client* client,
+      commit_batcher<>* batcher)
       : _wasm_engine_factory(std::move(factory))
       , _partition_manager(partition_manager)
-      , _client(client) {}
+      , _client(client)
+      , _batcher(batcher) {}
 
     ss::future<std::unique_ptr<processor>> create_processor(
       model::transform_id id,
@@ -230,7 +218,7 @@ public:
         sinks.push_back(std::move(sink));
 
         auto offset_tracker = std::make_unique<offset_tracker_impl>(
-          id, ntp.tp.partition, _client);
+          id, ntp.tp.partition, _client, _batcher);
 
         co_return std::make_unique<processor>(
           id,
@@ -250,6 +238,29 @@ private:
     cluster::partition_manager* _partition_manager;
     rpc::client* _client;
     absl::flat_hash_map<model::offset, std::unique_ptr<wasm::engine>> _cache;
+    commit_batcher<>* _batcher;
+};
+
+class rpc_offset_committer : public offset_committer {
+public:
+    explicit rpc_offset_committer(rpc::client* client)
+      : _client(client) {}
+
+    ss::future<result<model::partition_id, cluster::errc>>
+    find_coordinator(model::transform_offsets_key key) override {
+        return _client->find_coordinator(key);
+    }
+
+    ss::future<cluster::errc> batch_commit(
+      model::partition_id coordinator,
+      absl::btree_map<
+        model::transform_offsets_key,
+        model::transform_offsets_value> batch) override {
+        return _client->batch_offset_commit(coordinator, std::move(batch));
+    }
+
+private:
+    rpc::client* _client;
 };
 
 } // namespace
@@ -294,6 +305,10 @@ service::service(
 service::~service() = default;
 
 ss::future<> service::start() {
+    _batcher = std::make_unique<commit_batcher<ss::lowres_clock>>(
+      commit_interval,
+      std::make_unique<rpc_offset_committer>(&_rpc_client->local()));
+
     _manager = std::make_unique<manager<ss::lowres_clock>>(
       _self,
       std::make_unique<registry_adapter>(
@@ -303,7 +318,9 @@ ss::future<> service::start() {
             return create_engine(std::move(meta));
         },
         &_partition_manager->local(),
-        &_rpc_client->local()));
+        &_rpc_client->local(),
+        _batcher.get()));
+    co_await _batcher->start();
     co_await _manager->start();
     register_notifications();
 }
@@ -383,6 +400,9 @@ ss::future<> service::stop() {
     // manager.
     if (_manager) {
         co_await _manager->stop();
+    }
+    if (_batcher) {
+        co_await _batcher->stop();
     }
 }
 

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -101,6 +101,7 @@ private:
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<rpc::client>* _rpc_client;
     std::unique_ptr<manager<ss::lowres_clock>> _manager;
+    std::unique_ptr<commit_batcher<ss::lowres_clock>> _batcher;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>
       _notification_cleanups;
 };

--- a/src/v/transform/commit_batcher.cc
+++ b/src/v/transform/commit_batcher.cc
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/commit_batcher.h"
+
+#include "cluster/errc.h"
+#include "rpc/backoff_policy.h"
+#include "ssx/sleep_abortable.h"
+#include "transform/logger.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/coroutine/as_future.hh>
+
+#include <iterator>
+
+namespace transform {
+
+template<typename ClockType>
+commit_batcher<ClockType>::commit_batcher(
+  ClockType::duration commit_interval, std::unique_ptr<offset_committer> oc)
+  : _offset_committer(std::move(oc))
+  , _commit_interval(commit_interval)
+  , _timer(
+      [this] { ssx::spawn_with_gate(_gate, [this] { return flush(); }); }) {}
+
+template<typename ClockType>
+ss::future<> commit_batcher<ClockType>::start() {
+    ssx::spawn_with_gate(_gate, [this] { return find_coordinator_loop(); });
+    return ss::now();
+}
+
+template<typename ClockType>
+ss::future<> commit_batcher<ClockType>::find_coordinator_loop() {
+    using namespace std::chrono;
+    constexpr static auto base_backoff = 100ms;
+    constexpr static auto max_backoff = 5000ms;
+    auto backoff = ::rpc::make_exponential_backoff_policy<ClockType>(
+      base_backoff, max_backoff);
+    while (!_gate.is_closed()) {
+        co_await _unbatched_cond_var.wait(
+          [this] { return !_unbatched.empty() || _gate.is_closed(); });
+        bool was_all_failures = co_await assign_coordinators();
+        if (!was_all_failures) {
+            backoff.reset();
+            continue;
+        }
+        backoff.next_backoff();
+        try {
+            co_await ss::sleep_abortable<ClockType>(
+              backoff.current_backoff_duration(), _as);
+        } catch (const ss::sleep_aborted&) {
+            // do nothing, we're shutting down.
+        }
+    }
+}
+
+template<typename ClockType>
+ss::future<bool> commit_batcher<ClockType>::assign_coordinators() {
+    bool was_all_failures = !_unbatched.empty();
+    auto it = _unbatched.begin();
+    while (it != _unbatched.end() && !_gate.is_closed()) {
+        model::transform_offsets_key key = it->first;
+        auto fut = co_await ss::coroutine::as_future<
+          result<model::partition_id, cluster::errc>>(
+          _offset_committer->find_coordinator(key));
+        if (fut.failed()) {
+            vlog(
+              tlog.warn,
+              "unable to determine key ({}) coordinator: {}",
+              key,
+              fut.get_exception());
+            it = _unbatched.upper_bound(key);
+            continue;
+        }
+        auto result = fut.get();
+        if (result.has_error()) {
+            vlog(
+              tlog.warn,
+              "unable to determine key ({}) coordinator: {}",
+              key,
+              cluster::error_category().message(int(result.error())));
+            it = _unbatched.upper_bound(key);
+            continue;
+        }
+        was_all_failures = false;
+        model::partition_id coordinator = result.value();
+        auto entry = _unbatched.extract(key);
+        // It's possible that the value was removed while the request was being
+        // made, in that case just skip the update.
+        if (!entry) {
+            it = _unbatched.upper_bound(key);
+            continue;
+        }
+        _batched[coordinator].insert_or_assign(entry.key(), entry.mapped());
+        _coordinator_cache[key] = coordinator;
+        if (!_timer.armed()) {
+            _timer.arm(_commit_interval);
+        }
+        it = _unbatched.upper_bound(key);
+    }
+    co_return was_all_failures;
+}
+
+template<typename ClockType>
+ss::future<> commit_batcher<ClockType>::stop() {
+    _timer.cancel();
+    _as.request_abort();
+    _unbatched_cond_var.signal();
+    co_await _gate.close();
+    co_await flush();
+}
+
+template<typename ClockType>
+ss::future<> commit_batcher<ClockType>::wait_for_previous_flushes(
+  model::transform_offsets_key, ss::abort_source* as) {
+    try {
+        co_await ssx::sleep_abortable<ClockType>(_commit_interval, *as, _as);
+    } catch (const ss::sleep_aborted&) {
+        // do nothing as we're shutting down, callers will do the right thing
+    }
+}
+
+template<typename ClockType>
+void commit_batcher<ClockType>::preload(model::transform_offsets_key) {
+    // For now, don't do anything, we will resolve it first time they key needs
+    // to commit a batch. In the future we can preload this, mostly to surface
+    // any errors (like too many keys, etc) before reading and processing any
+    // batches.
+}
+
+template<typename ClockType>
+void commit_batcher<ClockType>::unload(model::transform_offsets_key key) {
+    // Erase the key from the coordinator cache so that we don't
+    _coordinator_cache.erase(key);
+    _unbatched.erase(key);
+    // We don't need to clear batched, we can allow it to be flushed async.
+}
+
+template<typename ClockType>
+ss::future<> commit_batcher<ClockType>::commit_offset(
+  model::transform_offsets_key k, model::transform_offsets_value v) {
+    auto _ = _gate.hold();
+    auto it = _coordinator_cache.find(k);
+    if (it == _coordinator_cache.end()) {
+        _unbatched.insert_or_assign(k, v);
+        _unbatched_cond_var.signal();
+    } else {
+        _batched[it->second].insert_or_assign(k, v);
+        if (!_timer.armed()) {
+            _timer.arm(_commit_interval);
+        }
+    }
+    return ss::now();
+}
+
+template<typename ClockType>
+ss::future<> commit_batcher<ClockType>::flush() {
+    absl::btree_map<model::partition_id, kv_map> batched;
+    _batched.swap(batched);
+    co_await ss::parallel_for_each(
+      std::make_move_iterator(batched.begin()),
+      std::make_move_iterator(batched.end()),
+      [this](auto entry) {
+          return do_flush(entry.first, std::move(entry.second));
+      });
+}
+
+template<typename ClockType>
+ss::future<> commit_batcher<ClockType>::do_flush(
+  model::partition_id coordinator, kv_map batch) {
+    auto fut = co_await ss::coroutine::as_future<cluster::errc>(
+      _offset_committer->batch_commit(coordinator, std::move(batch)));
+    if (fut.failed()) {
+        vlog(
+          tlog.warn,
+          "unable to commit batch (coordinator={}): {}",
+          coordinator,
+          fut.get_exception());
+        co_return;
+    }
+    cluster::errc ec = fut.get();
+    if (ec == cluster::errc::success) {
+        co_return;
+    }
+    vlog(
+      tlog.warn,
+      "unable to commit batch (coordinator={}): {}",
+      coordinator,
+      cluster::error_category().message(int(ec)));
+}
+
+template class commit_batcher<ss::lowres_clock>;
+template class commit_batcher<ss::manual_clock>;
+
+} // namespace transform

--- a/src/v/transform/commit_batcher.h
+++ b/src/v/transform/commit_batcher.h
@@ -12,11 +12,14 @@
 #pragma once
 
 #include "cluster/errc.h"
+#include "config/property.h"
 #include "model/fundamental.h"
 #include "model/transform.h"
 #include "outcome.h"
 
 #include <seastar/core/abort_source.hh>
+
+#include <chrono>
 
 namespace transform {
 
@@ -78,7 +81,8 @@ class commit_batcher {
 
 public:
     explicit commit_batcher(
-      ClockType::duration commit_interval, std::unique_ptr<offset_committer>);
+      config::binding<std::chrono::milliseconds> commit_interval,
+      std::unique_ptr<offset_committer>);
 
     ss::future<> start();
     ss::future<> stop();
@@ -153,7 +157,7 @@ private:
 
     ss::condition_variable _unbatched_cond_var;
     std::unique_ptr<offset_committer> _offset_committer;
-    ClockType::duration _commit_interval;
+    config::binding<std::chrono::milliseconds> _commit_interval;
     ss::timer<ClockType> _timer;
     ss::abort_source _as;
     ss::gate _gate;

--- a/src/v/transform/commit_batcher.h
+++ b/src/v/transform/commit_batcher.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/errc.h"
+#include "model/fundamental.h"
+#include "model/transform.h"
+#include "outcome.h"
+
+#include <seastar/core/abort_source.hh>
+
+namespace transform {
+
+/**
+ * An interface for a offset tracking KV store writer.
+ *
+ * It supports determining the owner of a given key, and then batch commiting
+ * values for a partition within the KV store.
+ */
+class offset_committer {
+public:
+    offset_committer() = default;
+    offset_committer(const offset_committer&) = default;
+    offset_committer(offset_committer&&) = default;
+    offset_committer& operator=(const offset_committer&) = default;
+    offset_committer& operator=(offset_committer&&) = default;
+    virtual ~offset_committer() = default;
+
+    /**
+     * Lookup which partition owns a given key.
+     */
+    virtual ss::future<result<model::partition_id, cluster::errc>>
+      find_coordinator(model::transform_offsets_key) = 0;
+
+    /**
+     * Commit a batch of data for a partition.
+     *
+     * The partition **must** be owner of every key in the batch.
+     */
+    virtual ss::future<cluster::errc> batch_commit(
+      model::partition_id coordinator,
+      absl::
+        btree_map<model::transform_offsets_key, model::transform_offsets_value>)
+      = 0;
+};
+
+/**
+ * Batches commits of current processor offsets.
+ *
+ * This is required to make offset commits a function of the number of cores in
+ * the system instead of a function of the number of processors. This is highly
+ * desirable and allows for a much higher amount of processors in the system
+ * without needing a more advanced mechanism for sharding the transform offset
+ * store or a dynamic backpressure/throttling mechanism.
+ *
+ * We periodically commit all offsets as a single batch at a fixed interval.
+ * There is a seperate loop that maps key to the corresponding shard so that the
+ * RPC traffic for looking up the coordinator is also a scaling function based
+ * on cores. There is no GC mechanism for removing a coordinator -> key mapping
+ * and instead it's expected that processors explicitly unregister their mapping
+ * when shutdown.
+ */
+template<typename ClockType = ss::lowres_clock>
+class commit_batcher {
+    static_assert(
+      std::is_same_v<ClockType, ss::lowres_clock>
+        || std::is_same_v<ClockType, ss::manual_clock>,
+      "Only lowres or manual clocks are supported");
+
+public:
+    explicit commit_batcher(
+      ClockType::duration commit_interval, std::unique_ptr<offset_committer>);
+
+    ss::future<> start();
+    ss::future<> stop();
+
+    /**
+     * When moving nodes, we need to give the previous node a chance to commit
+     * the pending interval otherwise leadership changes will likely cause
+     * duplicate processing.
+     *
+     * While the duplicates are inevitable in our current system, reduce the
+     * likelyhood of these by waiting for the previous node to flush it's commit
+     * offsets. We do this by assuming every node has the same commit interval
+     * and waiting for one commit interval to pass. This is a best effort to
+     * allow for flushing at the cost of latency. However, we mostly try to keep
+     * leadership stable, so this should not make a large difference in
+     * practice.
+     */
+    ss::future<>
+    wait_for_previous_flushes(model::transform_offsets_key, ss::abort_source*);
+
+    /**
+     * Preload the coordinator information for a given key.
+     *
+     * This is not a requirement as partitions can change and internally the
+     * batcher will handle reloading the partition for a key.
+     */
+    void preload(model::transform_offsets_key);
+
+    /**
+     * Unload the coordinator information as it's not going to be needed anymore
+     * (no more calls to `commit_offset` will be called on this core).
+     *
+     * This is a used instead of a cache eviction algorithm so it's important
+     * that users of this class call this to unload the key and reduce memory
+     * usage.
+     */
+    void unload(model::transform_offsets_key);
+
+    /**
+     * Enqueue a commit to be batched with other commits.
+     */
+    ss::future<> commit_offset(
+      model::transform_offsets_key, model::transform_offsets_value);
+
+    /**
+     * Flush all of the pending commits to the underlying offset_committer.
+     */
+    ss::future<> flush();
+
+private:
+    ss::future<> find_coordinator_loop();
+    /**
+     * Return true if all requests to find coordinators failed.
+     *
+     * This can be used by the coordinator loop to backoff if requests are
+     * failing instead of retrying in a loop.
+     */
+    ss::future<bool> assign_coordinators();
+
+    using kv_map = absl::
+      btree_map<model::transform_offsets_key, model::transform_offsets_value>;
+
+    /**
+     * Flush all of the pending commits to the underlying offset_committer.
+     */
+    ss::future<> do_flush(model::partition_id, kv_map);
+
+    kv_map _unbatched;
+    absl::btree_map<model::partition_id, kv_map> _batched;
+    absl::btree_map<model::transform_offsets_key, model::partition_id>
+      _coordinator_cache;
+
+    ss::condition_variable _unbatched_cond_var;
+    std::unique_ptr<offset_committer> _offset_committer;
+    ClockType::duration _commit_interval;
+    ss::timer<ClockType> _timer;
+    ss::abort_source _as;
+    ss::gate _gate;
+};
+
+} // namespace transform

--- a/src/v/transform/fwd.h
+++ b/src/v/transform/fwd.h
@@ -15,6 +15,8 @@ namespace transform {
 class service;
 template<typename ClockType>
 class manager;
+template<typename ClockType>
+class commit_batcher;
 class processor;
 class probe;
 namespace rpc {

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -62,6 +62,18 @@ public:
     offset_tracker& operator=(offset_tracker&&) = delete;
     virtual ~offset_tracker() = default;
 
+    virtual ss::future<> start() = 0;
+    virtual ss::future<> stop() = 0;
+
+    /**
+     * When processors are moved, it's possible to still have pending flushes
+     * outstanding, so wait for those to be flushed.
+     *
+     * For more discussion on this method, see
+     * `commit_batcher::wait_for_previous_flushes`.
+     */
+    virtual ss::future<> wait_for_previous_flushes(ss::abort_source*) = 0;
+
     /**
      * Load the latest offset we've committed.
      */

--- a/src/v/transform/rpc/client.cc
+++ b/src/v/transform/rpc/client.cc
@@ -572,26 +572,30 @@ ss::future<find_coordinator_response> client::do_remote_find_coordinator(
     co_return response.value();
 }
 
-ss::future<cluster::errc> client::offset_commit(
-  model::transform_offsets_key key, model::transform_offsets_value value) {
-    return retry([key, value, this] { return offset_commit_once(key, value); });
+ss::future<cluster::errc> client::batch_offset_commit(
+  model::partition_id coordinator,
+  absl::btree_map<model::transform_offsets_key, model::transform_offsets_value>
+    kvs) {
+    return retry([coordinator, kvs = std::move(kvs), this] {
+        return batch_offset_commit_once(coordinator, kvs);
+    });
 }
 
-ss::future<cluster::errc> client::offset_commit_once(
-  model::transform_offsets_key key, model::transform_offsets_value value) {
-    auto coordinator = co_await find_coordinator(key);
-    if (!coordinator) {
-        co_return coordinator.error();
+ss::future<cluster::errc> client::batch_offset_commit_once(
+  model::partition_id coordinator,
+  absl::btree_map<model::transform_offsets_key, model::transform_offsets_value>
+    kvs) {
+    if (kvs.empty()) {
+        co_return cluster::errc::success;
     }
 
-    auto ntp = offsets_ntp(coordinator.value());
+    auto ntp = offsets_ntp(coordinator);
     auto leader = _leaders->get_leader_node(ntp);
     if (!leader) {
         co_return cluster::errc::not_leader;
     }
 
-    offset_commit_request request{coordinator.value()};
-    request.add(key, value);
+    offset_commit_request request{coordinator, std::move(kvs)};
 
     vlog(
       log.trace, "offset_commit_once_request(node={}): {}", *leader, request);

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -74,8 +74,11 @@ public:
       result<std::optional<model::transform_offsets_value>, cluster::errc>>
       offset_fetch(model::transform_offsets_key);
 
-    ss::future<cluster::errc> offset_commit(
-      model::transform_offsets_key, model::transform_offsets_value);
+    ss::future<cluster::errc> batch_offset_commit(
+      model::partition_id coordinator,
+      absl::btree_map<
+        model::transform_offsets_key,
+        model::transform_offsets_value>);
 
     ss::future<model::cluster_transform_report> generate_report();
 
@@ -120,8 +123,11 @@ private:
 
     ss::future<result<model::partition_id, cluster::errc>>
       find_coordinator_once(model::transform_offsets_key);
-    ss::future<cluster::errc> offset_commit_once(
-      model::transform_offsets_key, model::transform_offsets_value);
+    ss::future<cluster::errc> batch_offset_commit_once(
+      model::partition_id coordinator,
+      absl::btree_map<
+        model::transform_offsets_key,
+        model::transform_offsets_value>);
     ss::future<
       result<std::optional<model::transform_offsets_value>, cluster::errc>>
       offset_fetch_once(model::transform_offsets_key);

--- a/src/v/transform/rpc/serde.h
+++ b/src/v/transform/rpc/serde.h
@@ -296,19 +296,18 @@ struct offset_commit_request
     using rpc_adl_exempt = std::true_type;
 
     offset_commit_request() = default;
-    explicit offset_commit_request(model::partition_id c)
-      : coordinator(c) {}
+    explicit offset_commit_request(
+      model::partition_id c,
+      absl::btree_map<
+        model::transform_offsets_key,
+        model::transform_offsets_value> kvs)
+      : coordinator(c)
+      , kvs(std::move(kvs)) {}
 
-    void
-    add(model::transform_offsets_key key, model::transform_offsets_value val) {
-        kvs.insert({key, val});
-    }
-
-    absl::flat_hash_map<
-      model::transform_offsets_key,
-      model::transform_offsets_value>
-      kvs;
     model::partition_id coordinator;
+    absl::
+      btree_map<model::transform_offsets_key, model::transform_offsets_value>
+        kvs;
 
     friend std::ostream&
     operator<<(std::ostream&, const offset_commit_request&);

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -860,8 +860,12 @@ TEST_P(TransformRpcTest, TestTransformOffsetRPCs) {
             ASSERT_EQ(read_result.value(), std::nullopt);
             auto request_val = model::transform_offsets_value{
               .offset = kafka::offset{j}};
-            auto result
-              = client()->offset_commit(request_key, request_val).get();
+            auto coordinator = client()->find_coordinator(request_key).get();
+            ASSERT_TRUE(coordinator.has_value());
+            auto result = client()
+                            ->batch_offset_commit(
+                              coordinator.value(), {{request_key, request_val}})
+                            .get();
             ASSERT_EQ(result, cluster::errc::success)
               << "request (" << i << "," << j << ")";
             read_result = client()->offset_fetch(request_key).get();

--- a/src/v/transform/tests/CMakeLists.txt
+++ b/src/v/transform/tests/CMakeLists.txt
@@ -39,3 +39,17 @@ rp_test(
   ARGS "-- -c 1"
   LABELS transform
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME
+    transform_commit_batcher
+  SOURCES
+    commit_batcher_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::transform
+  ARGS "-- -c 1"
+  LABELS transform
+)

--- a/src/v/transform/tests/commit_batcher_test.cc
+++ b/src/v/transform/tests/commit_batcher_test.cc
@@ -10,6 +10,7 @@
  */
 
 #include "cluster/errc.h"
+#include "config/property.h"
 #include "model/fundamental.h"
 #include "model/transform.h"
 #include "random/generators.h"
@@ -32,6 +33,7 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <iterator>
 #include <memory>
 #include <stdexcept>
@@ -185,7 +187,10 @@ public:
 
         _foc = foc.get();
         _batcher = std::make_unique<commit_batcher<ss::manual_clock>>(
-          commit_interval, std::move(foc));
+          config::mock_binding(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+              commit_interval)),
+          std::move(foc));
         _batcher->start().get();
         _batcher_running = true;
     }

--- a/src/v/transform/tests/commit_batcher_test.cc
+++ b/src/v/transform/tests/commit_batcher_test.cc
@@ -1,0 +1,334 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/errc.h"
+#include "model/fundamental.h"
+#include "model/transform.h"
+#include "random/generators.h"
+#include "test_utils/async.h"
+#include "test_utils/randoms.h"
+#include "transform/commit_batcher.h"
+#include "transform/logger.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/core/print.hh>
+
+#include <absl/container/btree_map.h>
+#include <absl/container/btree_set.h>
+#include <absl/strings/numbers.h>
+#include <absl/strings/str_cat.h>
+#include <absl/strings/str_split.h>
+#include <fmt/ostream.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <iterator>
+#include <memory>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+namespace transform {
+namespace {
+
+using namespace std::chrono;
+
+struct committed_offset {
+    model::transform_id id;
+    model::partition_id partition;
+    kafka::offset offset;
+
+    friend auto operator<=>(const committed_offset&, const committed_offset&)
+      = default;
+    friend bool operator==(const committed_offset&, const committed_offset&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const committed_offset& co) {
+        fmt::print(os, "{}/{}@{}", co.id(), co.partition(), co.offset());
+        return os;
+    }
+
+    /**
+     * Parse an offset in the form of "id/partition@offset"
+     */
+    static committed_offset parse(std::string_view s) {
+        std::vector<std::string_view> splits = absl::StrSplit(s, '/');
+        if (splits.size() != 2) {
+            throw std::runtime_error(
+              ss::format("invalid committed_offset: {}", s));
+        }
+        std::string_view id = splits[0];
+        splits = absl::StrSplit(splits[1], '@');
+        if (splits.size() != 2) {
+            throw std::runtime_error(
+              ss::format("invalid committed_offset: {}", s));
+        }
+        std::string_view partition = splits[0];
+        std::string_view offset = splits[1];
+        committed_offset result;
+        bool valid = true;
+        valid &= absl::SimpleAtoi(id, &result.id);
+        valid &= absl::SimpleAtoi(partition, &result.partition);
+        valid &= absl::SimpleAtoi(offset, &result.offset);
+        if (!valid) {
+            throw std::runtime_error(
+              ss::format("invalid committed_offset: {}", s));
+        }
+        return result;
+    }
+};
+
+using offset_map = absl::
+  btree_map<model::transform_offsets_key, model::transform_offsets_value>;
+
+class fake_offset_committer : public offset_committer {
+public:
+    fake_offset_committer(
+      std::vector<model::partition_id> partitions, size_t limit)
+      : _partitions(std::move(partitions))
+      , _limit(limit) {}
+
+    void adjust_limit(size_t limit) { _limit = limit; }
+    void inject_coordinator_failures(int count) {
+        _coordinator_failures = count;
+    }
+    void inject_commit_failures(int count) { _commit_failures = count; }
+
+    ss::future<result<model::partition_id, cluster::errc>>
+    find_coordinator(model::transform_offsets_key key) override {
+        if (_coordinator_failures-- > 0) {
+            throw std::runtime_error("injected error finding coordinator");
+        }
+        vlog(tlog.info, "find_coordinator={}", key);
+        auto it = _mapping.find(key);
+        if (it != _mapping.end()) {
+            co_return it->second;
+        }
+        if (_mapping.size() >= _limit) {
+            co_return cluster::errc::trackable_keys_limit_exceeded;
+        }
+        model::partition_id coordinator = random_generators::random_choice(
+          _partitions);
+        _mapping.emplace(key, coordinator);
+        co_return coordinator;
+    }
+
+    ss::future<cluster::errc>
+    batch_commit(model::partition_id coordinator, offset_map batch) override {
+        vlog(tlog.info, "batch_commit={}->{}", coordinator, batch.size());
+        for (const auto& [k, v] : batch) {
+            auto c = co_await find_coordinator(k);
+            if (c.has_error()) {
+                co_return c.error();
+            }
+            if (c.value() != coordinator) {
+                co_return cluster::errc::not_leader;
+            }
+        }
+        _cond_var.broadcast();
+        if (_commit_failures-- > 0) {
+            throw std::runtime_error("injected error committing");
+        }
+        offset_map& m = _offsets[coordinator];
+        m.swap(batch);
+        m.merge(batch);
+        co_return cluster::errc::success;
+    }
+
+    ss::future<> wait_for_next_commit() { return _cond_var.wait(); }
+
+    absl::btree_set<committed_offset> committed() const {
+        absl::btree_set<committed_offset> result;
+        for (const auto& by_partition : _offsets) {
+            for (const auto& e : by_partition.second) {
+                result.emplace(e.first.id, e.first.partition, e.second.offset);
+            }
+        }
+        return result;
+    }
+
+private:
+    ss::condition_variable _cond_var;
+    std::vector<model::partition_id> _partitions;
+    size_t _limit;
+    int64_t _coordinator_failures = 0;
+    int64_t _commit_failures = 0;
+    absl::btree_map<model::transform_offsets_key, model::partition_id> _mapping;
+    absl::btree_map<model::partition_id, offset_map> _offsets;
+};
+
+constexpr static auto commit_interval = 5s;
+constexpr static auto default_key_limit = 10;
+
+class OffsetBatcherTest : public testing::Test {
+public:
+    void SetUp() override {
+        std::vector<model::partition_id> partitions = {
+          model::partition_id(1),
+          model::partition_id(2),
+          model::partition_id(3),
+        };
+
+        auto foc = std::make_unique<fake_offset_committer>(
+          partitions, default_key_limit);
+
+        _foc = foc.get();
+        _batcher = std::make_unique<commit_batcher<ss::manual_clock>>(
+          commit_interval, std::move(foc));
+        _batcher->start().get();
+        _batcher_running = true;
+    }
+
+    void TearDown() override {
+        if (_batcher_running) {
+            stop_batcher();
+        }
+        _batcher = nullptr;
+    }
+
+    void stop_batcher() {
+        _batcher->stop().get();
+        _batcher_running = false;
+    }
+
+    void enqueue(std::string_view s) {
+        auto co = committed_offset::parse(s);
+        _batcher
+          ->commit_offset(
+            {.id = co.id, .partition = co.partition}, {.offset = co.offset})
+          .get();
+    }
+
+    void unload(std::string_view s) {
+        auto co = committed_offset::parse(absl::StrCat(s, "@0"));
+        _batcher->unload({.id = co.id, .partition = co.partition});
+    }
+
+    void advance(ss::manual_clock::duration d) {
+        ss::manual_clock::advance(d);
+        // Drain the task queue so that all clock events have ran.
+        drain_task_queue();
+    }
+
+    void drain_task_queue() {
+        // Drain the task queue so that all clock events have ran.
+        tests::drain_task_queue().get();
+    }
+
+    void set_max_keys(size_t max) { _foc->adjust_limit(max); }
+    void inject_coordinator_failures(int c) {
+        _foc->inject_coordinator_failures(c);
+    }
+    void inject_commit_failures(int c) { _foc->inject_commit_failures(c); }
+
+    auto committed() { return _foc->committed(); }
+
+    auto after_next_commit() {
+        auto fut = _foc->wait_for_next_commit();
+        while (!fut.available()) {
+            advance(1s);
+        }
+        return committed();
+    }
+
+    template<typename... Args>
+    auto committed_are(Args... args) {
+        absl::btree_set<committed_offset> s;
+        make_offset_set(s, args...);
+        return ::testing::ContainerEq(s);
+    }
+
+private:
+    template<typename... Rest>
+    void make_offset_set(absl::btree_set<committed_offset>&)
+    requires(sizeof...(Rest) == 0)
+    {}
+
+    template<typename... Rest>
+    void make_offset_set(
+      absl::btree_set<committed_offset>& output,
+      std::string_view s,
+      Rest... rest) {
+        output.emplace(committed_offset::parse(s));
+        make_offset_set(output, rest...);
+    }
+
+    fake_offset_committer* _foc = nullptr;
+    bool _batcher_running = false;
+    std::unique_ptr<commit_batcher<ss::manual_clock>> _batcher;
+};
+
+TEST_F(OffsetBatcherTest, Smoke) {
+    enqueue("1/1@2");
+    enqueue("1/2@3");
+    enqueue("1/3@1");
+    EXPECT_THAT(after_next_commit(), committed_are("1/1@2", "1/2@3", "1/3@1"));
+    enqueue("1/2@10");
+    EXPECT_THAT(after_next_commit(), committed_are("1/1@2", "1/2@10", "1/3@1"));
+}
+
+TEST_F(OffsetBatcherTest, CoordinatorLimit) {
+    set_max_keys(2);
+    enqueue("1/1@2");
+    enqueue("1/2@3");
+    enqueue("1/3@1");
+    EXPECT_THAT(after_next_commit(), committed_are("1/1@2", "1/2@3"));
+    // We always retry coordinator requests until they pass
+    set_max_keys(3);
+    EXPECT_THAT(after_next_commit(), committed_are("1/1@2", "1/2@3", "1/3@1"));
+}
+
+TEST_F(OffsetBatcherTest, CoordinatorLimitUnload) {
+    set_max_keys(1);
+    enqueue("1/1@2");
+    enqueue("1/2@3");
+    EXPECT_THAT(after_next_commit(), committed_are("1/1@2"));
+    // Unloading removes pending coordinator lookups
+    set_max_keys(3);
+    unload("1/2");
+    enqueue("1/1@3");
+    EXPECT_THAT(after_next_commit(), committed_are("1/1@3"));
+}
+
+TEST_F(OffsetBatcherTest, StopDoesNotLookupCoordinators) {
+    enqueue("1/1@3");
+    stop_batcher();
+    EXPECT_THAT(committed(), committed_are());
+}
+
+TEST_F(OffsetBatcherTest, StopFlushesPendingCommits) {
+    enqueue("1/1@2");
+    // Enqueue so that the coordinator is already loaded.
+    EXPECT_THAT(after_next_commit(), committed_are("1/1@2"));
+    enqueue("1/1@3");
+    stop_batcher();
+    EXPECT_THAT(committed(), committed_are("1/1@3"));
+}
+
+TEST_F(OffsetBatcherTest, FlushFailuresAreNotRetried) {
+    enqueue("1/1@2");
+    inject_commit_failures(1);
+    EXPECT_THAT(after_next_commit(), committed_are());
+    enqueue("1/2@1");
+    EXPECT_THAT(after_next_commit(), committed_are("1/2@1"));
+}
+
+TEST_F(OffsetBatcherTest, CoordinatorLookupsAreRetried) {
+    enqueue("1/1@2");
+    inject_coordinator_failures(3);
+    EXPECT_THAT(after_next_commit(), committed_are("1/1@2"));
+}
+
+} // namespace
+} // namespace transform

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -72,6 +72,10 @@ uint64_t fake_wasm_engine::memory_usage_size_bytes() const {
 ss::future<> fake_wasm_engine::start() { return ss::now(); }
 ss::future<> fake_wasm_engine::stop() { return ss::now(); }
 
+ss::future<> fake_offset_tracker::stop() { co_return; }
+
+ss::future<> fake_offset_tracker::start() { co_return; }
+
 ss::future<> fake_offset_tracker::commit_offset(kafka::offset o) {
     _committed = o;
     _cond_var.broadcast();
@@ -88,4 +92,7 @@ ss::future<> fake_offset_tracker::wait_for_committed_offset(kafka::offset o) {
       1s, [this, o] { return _committed && *_committed >= o; });
 }
 
+ss::future<> fake_offset_tracker::wait_for_previous_flushes(ss::abort_source*) {
+    co_return;
+}
 } // namespace transform::testing

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -80,6 +80,10 @@ private:
 
 class fake_offset_tracker : public offset_tracker {
 public:
+    ss::future<> start() override;
+    ss::future<> stop() override;
+    ss::future<> wait_for_previous_flushes(ss::abort_source*) override;
+
     ss::future<std::optional<kafka::offset>> load_committed_offset() override;
 
     ss::future<> commit_offset(kafka::offset o) override;


### PR DESCRIPTION
In order to scale the number of processors that can concurrently run in a cluster, we create a batcher for commit requests so that commits scale with the number of cores, not the number of processors.

There is an unfortunate effect here that we delay processors for a commit interval before starting up, as we need to wait for other nodes to potenially flush the latest commit information. Otherwise everytime there is a leadership transfer it becomes very likely that we process duplicates, while we can't prevent duplicates in the current architecture, we can reduce their likelyhood with this approach.

The main benefit of this work is that we can punt further down the road the need to dynamically scale (and migrate existing data of) the internal topic we use for tracking offset positions.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
