### PR TITLE
cloud_storage: Use abort source when waiting for semaphore units

### DIFF
--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -62,11 +62,13 @@ public:
 
     void register_segment(materialized_segment_state& s);
 
-    ss::future<segment_reader_units> get_segment_reader_units();
+    ss::future<segment_reader_units>
+    get_segment_reader_units(storage::opt_abort_source_t as);
 
-    ss::future<ssx::semaphore_units> get_partition_reader_units();
+    ss::future<ssx::semaphore_units>
+    get_partition_reader_units(storage::opt_abort_source_t as);
 
-    ss::future<segment_units> get_segment_units();
+    ss::future<segment_units> get_segment_units(storage::opt_abort_source_t as);
 
     materialized_manifest_cache& get_materialized_manifest_cache();
 

--- a/src/v/utils/adjustable_semaphore.h
+++ b/src/v/utils/adjustable_semaphore.h
@@ -81,6 +81,15 @@ public:
         return ss::get_units(_sem, units);
     }
 
+    /**
+     * Blocking get units: will block until units are available or until abort
+     * source is triggered.
+     */
+    ss::future<ssx::semaphore_units>
+    get_units(size_t units, ss::abort_source& as) {
+        return ss::get_units(_sem, units, as);
+    }
+
     size_t current() const noexcept { return _sem.current(); }
     ssize_t available_units() const noexcept { return _sem.available_units(); }
 


### PR DESCRIPTION
Partially fixes https://github.com/redpanda-data/redpanda/issues/12382

When waiting for resource during creation of a remote partition/segment reader, we wait for semaphore units at some places. During this wait if the client disconnects the wait is not interrupted. 

The log reader config used to create readers has an optional reference to an abort source, which is connected to the kafka connection, and is triggered when the connection shuts down.

This change wires in the abort source to the waiting for units, so we can abort the wait if the connection is killed. 

Part of the delay in connections going down in https://github.com/redpanda-data/redpanda/issues/12382 is due to several readers' creation blocked on acquiring units, while the rpk process had been killed several seconds ago. When units are available the readers immediately detect the abort source is triggered and the connection closes, but the delay causes test to fail.

This is not the only reason for this delay in connections being closed, so this is a partial fix for that issue.


Note: The wait for units during `abort_transactions` does not use an abort source. It ideally should, but that requires passing down the abort source from much higher up the call chain and should be another PR.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
