### PR TITLE
[v23.2.x] tests/htt: import missing regex package that breaks tests

### DIFF
--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -26,6 +26,7 @@ from rptest.services.redpanda import (RESTART_LOG_ALLOW_LIST,
                                       MetricsEndpoint, SISettings)
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from ducktape.mark import ok_to_fail
+import re
 
 kiB = 1024
 MiB = kiB * kiB


### PR DESCRIPTION
CDT fails with `Failed to import rptest.scale_tests.high_throughput_test, which may indicate a broken test that cannot be loaded: NameError: name 're' is not defined` leading our nightlies to fail. ref https://redpandadata.slack.com/archives/C0365QZSTLM/p1698901767072869
https://buildkite.com/redpanda/redpanda/builds/40276

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
