### PR TITLE
lower log_segment_size for testing purposes

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -49,7 +49,8 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "16777216",
        .visibility = visibility::tunable},
-      1_MiB)
+      1_MiB,
+      {.min = 1_KiB})
   , log_segment_size_max(
       *this,
       "log_segment_size_max",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -40,7 +40,7 @@ configuration::configuration()
      .example = "2147483648",
      .visibility = visibility::tunable},
     128_MiB,
-    {.min = 1_MiB})
+    {.min = 1_KiB})
   , log_segment_size_min(
       *this,
       "log_segment_size_min",

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -371,6 +371,7 @@ class SISettings:
                  test_context,
                  *,
                  log_segment_size: int = 16 * 1000000,
+                 log_segment_size_min: Optional[int] = None,
                  cloud_storage_cache_chunk_size: Optional[int] = None,
                  cloud_storage_credentials_source: str = 'config_file',
                  cloud_storage_access_key: str = 'panda-user',
@@ -432,6 +433,7 @@ class SISettings:
             assert False, f"Unexpected value provided for 'cloud_storage_type' injected arg: {self.cloud_storage_type}"
 
         self.log_segment_size = log_segment_size
+        self.log_segment_size_min = log_segment_size_min
         self.cloud_storage_cache_chunk_size = cloud_storage_cache_chunk_size
         self.cloud_storage_cache_size = cloud_storage_cache_size
         self.cloud_storage_cache_max_objects = cloud_storage_cache_max_objects
@@ -540,6 +542,9 @@ class SISettings:
                 'cloud_storage_azure_shared_key'] = self.cloud_storage_azure_shared_key
 
         conf["log_segment_size"] = self.log_segment_size
+        if self.log_segment_size_min is not None:
+            conf["log_segment_size_min"] = self.log_segment_size_min
+
         if (self.cloud_storage_cache_chunk_size):
             conf[
                 "cloud_storage_cache_chunk_size"] = self.cloud_storage_cache_chunk_size

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1125,7 +1125,7 @@ class EndToEndSpilloverTest(RedpandaTest):
     def __init__(self, test_context):
         self.si_settings = SISettings(
             test_context,
-            log_segment_size=1024,
+            log_segment_size_min=1024,
             fast_uploads=True,
             cloud_storage_housekeeping_interval_ms=10000,
             cloud_storage_spillover_manifest_max_segments=10)
@@ -1216,6 +1216,7 @@ class EndToEndThrottlingTest(RedpandaTest):
         self.si_settings = SISettings(
             test_context,
             log_segment_size=1024,
+            log_segment_size_min=1024,
             fast_uploads=True,
             # Set small throughput limit to trigger throttling
             cloud_storage_max_throughput_per_shard=5 * 1024 * 1024)

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -51,6 +51,7 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
             self.extra_rp_conf[
                 'cloud_storage_spillover_manifest_max_segments'] = 10
             self.si_settings.log_segment_size = 1024
+            self.si_settings.log_segment_size_min = 1024
             self.si_settings.fast_uploads = True,
             self.si_settings.cloud_storage_housekeeping_interval_ms = 10000
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

some tests set log_segment_size to 1kb to stress storage code path. this is possible during the bootstrap phase (see https://github.com/redpanda-data/redpanda/pull/14622)

this pr officialize 1kb as the lower bound for log_segment_size, relying on the soft bound of log_segment_size_min and sane defaults.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none 