### PR TITLE
wasm: add metrics for wasm CPU time

### DIFF
--- a/src/v/wasm/engine_probe.h
+++ b/src/v/wasm/engine_probe.h
@@ -36,12 +36,14 @@ public:
     ~engine_probe_impl();
     void report_memory_usage_delta(int64_t);
     void report_max_memory_delta(int64_t);
+    void increment_cpu_time(ss::steady_clock_type::duration d);
 
 private:
     ss::sstring _name;
     engine_probe_cache* _cache;
     int64_t _memory_usage = 0;
     int64_t _max_memory = 0;
+    ss::steady_clock_type::duration _cpu_time = std::chrono::seconds(0);
     metrics::public_metric_groups _public_metrics;
 };
 } // namespace internal
@@ -49,7 +51,10 @@ private:
 /**
  * A probe for all types of wasm engines.
  *
- * Used to track things like memory and CPU usage.
+ * Used to track things like memory and CPU usage across multiple engines. There
+ * are cases (ie deployment) where there maybe multiple versions of the same
+ * probe on the same core at once, so this class is a small utility around
+ * ensuring we only report the delta for gauges.
  */
 class engine_probe {
 public:
@@ -60,6 +65,7 @@ public:
     engine_probe& operator=(engine_probe&&) = default;
     ~engine_probe();
 
+    void increment_cpu_time(ss::steady_clock_type::duration);
     void report_memory_usage(uint32_t);
     void report_max_memory(uint32_t);
 

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -466,6 +466,25 @@ private:
         check_error(error.get());
     }
 
+    /**
+     * Run a WebAssembly call until completion, after the "future" is done
+     * completing the results from the computation (as well as errors) are
+     * available.
+     */
+    ss::future<>
+    execute(handle<wasmtime_call_future_t, wasmtime_call_future_delete> fut) {
+        // Poll the call future to completion, yielding to the scheduler when
+        // the future yields.
+        while (!wasmtime_call_future_poll(fut.get())) {
+            if (_pending_host_function) {
+                auto host_future = std::exchange(_pending_host_function, {});
+                co_await std::move(host_future).value();
+                continue;
+            }
+            co_await ss::coroutine::maybe_yield();
+        }
+    }
+
     ss::future<> create_instance() {
         // The underlying "data" for this store is our engine, which is what
         // allows our host functions to access the actual module for that host
@@ -511,16 +530,7 @@ private:
             &trap_ptr,
             &error_ptr)};
 
-        // Poll the call future to completion, yielding to the scheduler when
-        // the future yields.
-        while (!wasmtime_call_future_poll(fut.get())) {
-            if (_pending_host_function) {
-                auto host_future = std::exchange(_pending_host_function, {});
-                co_await std::move(host_future).value();
-                continue;
-            }
-            co_await ss::coroutine::maybe_yield();
-        }
+        co_await execute(std::move(fut));
 
         // Now that the call future has returned as completed, we can assume the
         // out pointers have been set, we need to check them for errors.
@@ -551,16 +561,7 @@ private:
             &trap_ptr,
             &err_ptr)};
 
-        // Poll the call future to completion, yielding to the scheduler when
-        // the future yields.
-        while (!wasmtime_call_future_poll(fut.get())) {
-            if (_pending_host_function) {
-                auto host_future = std::exchange(_pending_host_function, {});
-                co_await std::move(host_future).value();
-                continue;
-            }
-            co_await ss::coroutine::maybe_yield();
-        }
+        co_await execute(std::move(fut));
 
         // Now that the call future has returned as completed, we can assume the
         // out pointers have been set, we need to check them for errors.


### PR DESCRIPTION
The last resource that we need metrics for within WebAssembly is CPU usage. This adds to our existing engine probe CPU metrics, and then adds the reporting in Wasmtime. We don't report CPU time of async host functions, only for sync host functions since the scheduler gets involved and it's tricky to correctly measure.

Benchmarks showed that the time measurement performance impact is negligible (within the noise of variability between runs).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
