### PR TITLE
[v23.2.x] ducktape/cloud_storage: Ignore accessdenied errors

### DIFF
--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1485,7 +1485,11 @@ class TopicRecoveryTest(RedpandaTest):
                                        self.rpk_producer_maker, topics)
         self.do_run(test_case)
 
-    @cluster(num_nodes=4, log_allow_list=TRANSIENT_ERRORS)
+    @cluster(
+        num_nodes=4,
+        log_allow_list=TRANSIENT_ERRORS + [
+            r'unexpected REST API error "" detected, code: AccessDenied, .* resource: /recovery_state/kafka/.*'
+        ])
     @matrix(cloud_storage_type=get_cloud_storage_type())
     def test_admin_api_recovery(self, cloud_storage_type):
         topics = [


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14302
Fixes: https://github.com/redpanda-data/redpanda/issues/14737,