### PR TITLE
transform: reader improvements

### DIFF
--- a/src/v/ssx/tests/future_util.cc
+++ b/src/v/ssx/tests/future_util.cc
@@ -9,6 +9,7 @@
 
 #include "ssx/future-util.h"
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/manual_clock.hh>
 #include <seastar/testing/thread_test_case.hh>
 
@@ -111,5 +112,38 @@ SEASTAR_THREAD_TEST_CASE(with_timeout_abortable_test) {
 
         seastar::manual_clock::advance(100ms);
         BOOST_CHECK_THROW(res.get(), seastar::abort_requested_exception);
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(with_timeout_abortable_custom_ex_test) {
+    // It's possible to throw custom exceptions with abort_source, make sure
+    // we propagate them correctly.
+    class custom_abort_exception : public std::exception {};
+    {
+        // Already aborted source
+        seastar::abort_source as;
+        as.request_abort_ex(custom_abort_exception{});
+
+        auto f = seastar::sleep<seastar::manual_clock>(50ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+        auto res = ssx::with_timeout_abortable(
+          std::move(f), seastar::manual_clock::time_point::max(), as);
+        BOOST_CHECK_THROW(res.get(), custom_abort_exception);
+        // f has to resolve or LSAN thinks there are leaks
+        seastar::manual_clock::advance(50ms);
+    }
+    {
+        seastar::abort_source as;
+
+        auto f = seastar::sleep<seastar::manual_clock>(50ms).then(
+          [] { return seastar::make_ready_future<int>(123); });
+        auto res = ssx::with_timeout_abortable(
+          std::move(f), seastar::manual_clock::time_point::max(), as);
+
+        seastar::manual_clock::advance(10ms);
+        as.request_abort_ex(custom_abort_exception{});
+        BOOST_CHECK_THROW(res.get(), custom_abort_exception);
+        // f has to resolve or LSAN thinks there are leaks
+        seastar::manual_clock::advance(40ms);
     }
 }

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -44,6 +44,9 @@ public:
     source& operator=(source&&) = delete;
     virtual ~source() = default;
 
+    virtual ss::future<> start() = 0;
+    virtual ss::future<> stop() = 0;
+
     virtual kafka::offset latest_offset() = 0;
     virtual ss::future<model::record_batch_reader>
     read_batch(kafka::offset, ss::abort_source*) = 0;

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -37,6 +37,10 @@ ss::future<model::record_batch> fake_sink::read() {
     co_return batch;
 }
 
+ss::future<> fake_source::start() { co_return; }
+
+ss::future<> fake_source::stop() { co_return; }
+
 kafka::offset fake_source::latest_offset() {
     if (_batches.empty()) {
         return kafka::offset(0);

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -54,6 +54,8 @@ class fake_source : public source {
 public:
     explicit fake_source() = default;
 
+    ss::future<> start() override;
+    ss::future<> stop() override;
     kafka::offset latest_offset() override;
     ss::future<model::record_batch_reader>
     read_batch(kafka::offset offset, ss::abort_source* as) override;

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -175,9 +175,6 @@ ss::future<> processor::run_consumer_loop() {
     auto offset = co_await load_start_offset();
     vlog(_logger.trace, "starting at offset {}", offset);
     while (!_as.abort_requested()) {
-        // TODO(rockwood): It's possible that the stored is deleted due to
-        // retention policy since the last successful commit. We should handle
-        // this by restarting from the low watermark.
         auto reader = co_await _source->read_batch(offset, &_as);
         auto last_offset = co_await std::move(reader).consume(
           queue_output_consumer(&_consumer_transform_pipe, _probe),

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -126,6 +126,7 @@ processor::processor(
 ss::future<> processor::start() {
     try {
         co_await _engine->start();
+        co_await _source->start();
         co_await _offset_tracker->start();
     } catch (const std::exception& ex) {
         vlog(_logger.warn, "error starting processor engine: {}", ex);
@@ -144,8 +145,9 @@ ss::future<> processor::stop() {
     _consumer_transform_pipe.abort(ex);
     _transform_producer_pipe.abort(ex);
     co_await std::exchange(_task, ss::now());
-    co_await _engine->stop();
+    co_await _source->stop();
     co_await _offset_tracker->stop();
+    co_await _engine->stop();
 }
 
 ss::future<> processor::poll_sleep() {


### PR DESCRIPTION
Two improvements to reading data in the transform subsystem:

1. Support log truncation by always starting reads at the beginning of the log
2. Limit the amount of bytes we get back from the reader. The limit is hardcoded
   (and also a soft limit), but is better than the previous unlimited maximum.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
