### PR TITLE
wasm: cleanup batching

### DIFF
--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -19,6 +19,7 @@
 #include "serde/envelope.h"
 #include "utils/named_type.h"
 
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/sstring.hh>
 
 #include <absl/container/btree_map.h>
@@ -225,6 +226,12 @@ public:
      * Create a transformed record - validating the format is correct.
      */
     static std::optional<transformed_data> create_validated(iobuf);
+
+    /**
+     * Create a batch from transformed_data.
+     */
+    static model::record_batch
+      make_batch(model::timestamp, ss::chunked_fifo<transformed_data>);
 
     /**
      * Generate a serialized record from the following metadata.

--- a/src/v/transform/rpc/client.cc
+++ b/src/v/transform/rpc/client.cc
@@ -199,6 +199,9 @@ client::client(
 
 ss::future<cluster::errc> client::produce(
   model::topic_partition tp, ss::chunked_fifo<model::record_batch> batches) {
+    if (batches.empty()) {
+        co_return cluster::errc::success;
+    }
     produce_request req;
     req.topic_data.emplace_back(std::move(tp), std::move(batches));
     req.timeout = timeout;

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -39,13 +39,21 @@ static const model::transform_metadata my_metadata{
 
 class fake_wasm_engine : public wasm::engine {
 public:
+    enum class mode {
+        noop,
+        filter,
+    };
+
     ss::future<model::record_batch>
-    transform(model::record_batch batch, wasm::transform_probe*) override {
-        co_return batch;
-    }
+    transform(model::record_batch batch, wasm::transform_probe*) override;
+
+    void set_mode(mode m);
 
     ss::future<> start() override;
     ss::future<> stop() override;
+
+private:
+    mode _mode = mode::noop;
 };
 
 class fake_source : public source {

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -77,7 +77,9 @@ drain_queue(ss::queue<transformed_batch>* queue, probe* p) {
         p->increment_write_bytes(batch_size);
         auto transformed = queue->pop();
         result.latest_offset = transformed.input_offset;
-        result.batches.push_back(std::move(transformed.batch));
+        if (transformed.batch.record_count() > 0) {
+            result.batches.push_back(std::move(transformed.batch));
+        }
     }
     co_return result;
 }


### PR DESCRIPTION
This patchset cleans up the way we create batches from transformed records and fixes an issue with writing empty batches.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
