### PR TITLE
[v23.2.x] dt/memory_stress_test: Mark `test_fetch_with_many_partitions` `@ok_to_fail`

### DIFF
--- a/tests/rptest/tests/memory_stress_test.py
+++ b/tests/rptest/tests/memory_stress_test.py
@@ -36,6 +36,7 @@ class MemoryStressTest(RedpandaTest):
         # enabling each test case to customize its ResourceSettings
         pass
 
+    @ok_to_fail
     @cluster(num_nodes=5)
     @skip_debug_mode
     @parametrize(memory_share_for_fetch=0.05)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/12497
Fixes: https://github.com/redpanda-data/redpanda/issues/14754,