### PR TITLE
s3: Log xml body in case of ill-formed reply

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -908,6 +908,11 @@ iobuf_to_delete_objects_result(iobuf&& buf) {
           s3_log.error,
           "DeleteObjects response parse failed: {}",
           std::current_exception());
+        if (s3_log.is_enabled(ss::log_level::trace)) {
+            std::stringstream outs;
+            boost::property_tree::write_xml(outs, root);
+            vlog(s3_log.trace, "Response XML: {}", outs.str());
+        }
         throw;
     }
     return result;


### PR DESCRIPTION
`DeleteRecords` response sometimes do not contain `DeleteResult` XML field. Log the XML object on trace level in this case.

It's not clear why this might happen. This behavior is clearly outside of the S3 REST API spec. We should probably just ignore this on CI. But to know for sure we need to actually know what was the content of the reply.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none