### PR TITLE
[v23.2.x] cloud_storage: Use abort source when waiting for semaphore units

### DIFF
--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -58,11 +58,13 @@ public:
 
     void register_segment(materialized_segment_state& s);
 
-    ss::future<segment_reader_units> get_segment_reader_units();
+    ss::future<segment_reader_units>
+    get_segment_reader_units(storage::opt_abort_source_t as);
 
-    ss::future<ssx::semaphore_units> get_partition_reader_units(size_t);
+    ss::future<ssx::semaphore_units>
+    get_partition_reader_units(size_t, storage::opt_abort_source_t as);
 
-    ss::future<segment_units> get_segment_units();
+    ss::future<segment_units> get_segment_units(storage::opt_abort_source_t as);
 
     materialized_manifest_cache& get_materialized_manifest_cache();
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -484,10 +484,11 @@ private:
     }
 
     ss::future<> init_cursor(storage::log_reader_config config) {
-        auto segment_unit
-          = co_await _partition->materialized().get_segment_units();
+        auto segment_unit = co_await _partition->materialized()
+                              .get_segment_units(config.abort_source);
         auto segment_reader_unit
-          = co_await _partition->materialized().get_segment_reader_units();
+          = co_await _partition->materialized().get_segment_reader_units(
+            config.abort_source);
 
         async_view_search_query_t query;
         if (config.first_timestamp.has_value()) {
@@ -662,11 +663,11 @@ private:
               _next_segment_base_offset,
               _view_cursor->get_status());
 
-            auto segment_unit
-              = co_await _partition->materialized().get_segment_units();
+            auto segment_unit = co_await _partition->materialized()
+                                  .get_segment_units(config.abort_source);
             auto segment_reader_unit
-              = co_await _partition->materialized().get_segment_reader_units();
-
+              = co_await _partition->materialized().get_segment_reader_units(
+                config.abort_source);
             auto maybe_manifest = _view_cursor->manifest();
             if (
               maybe_manifest.has_value()
@@ -934,7 +935,8 @@ remote_partition::aborted_transactions(offset_range offsets) {
             // in a failure to materialise. This should be transient however.
             // One solution for this is to grab all the required segment units
             // up front at the start of the function.
-            auto segment_unit = co_await materialized().get_segment_units();
+            auto segment_unit = co_await materialized().get_segment_units(
+              std::nullopt);
             auto path = stm_manifest.generate_segment_path(*it);
             auto m = get_or_materialize_segment(
               path, *it, std::move(segment_unit));
@@ -982,7 +984,8 @@ remote_partition::aborted_transactions(offset_range offsets) {
           });
 
         for (const auto& [meta, path] : meta_to_materialize) {
-            auto segment_unit = co_await materialized().get_segment_units();
+            auto segment_unit = co_await materialized().get_segment_units(
+              std::nullopt);
             auto m = get_or_materialize_segment(
               path, meta, std::move(segment_unit));
             auto tx = co_await m->second->segment->aborted_transactions(
@@ -1083,7 +1086,8 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
       config,
       _segments.size());
 
-    auto units = co_await _api.materialized().get_partition_reader_units(1);
+    auto units = co_await _api.materialized().get_partition_reader_units(
+      1, config.abort_source);
     auto ot_state = ss::make_lw_shared<storage::offset_translator_state>(
       get_ntp());
     auto impl = std::make_unique<partition_record_batch_reader_impl>(

--- a/src/v/utils/adjustable_semaphore.h
+++ b/src/v/utils/adjustable_semaphore.h
@@ -81,6 +81,15 @@ public:
         return ss::get_units(_sem, units);
     }
 
+    /**
+     * Blocking get units: will block until units are available or until abort
+     * source is triggered.
+     */
+    ss::future<ssx::semaphore_units>
+    get_units(size_t units, ss::abort_source& as) {
+        return ss::get_units(_sem, units, as);
+    }
+
     size_t current() const noexcept { return _sem.current(); }
     ssize_t available_units() const noexcept { return _sem.available_units(); }
 


### PR DESCRIPTION
Partially fixes https://github.com/redpanda-data/redpanda/issues/12382

Fixes #14757
Backport of the #14637

When waiting for resource during creation of a remote partition/segment reader, we wait for semaphore units at some places. During this wait if the client disconnects the wait is not interrupted. 

The log reader config used to create readers has an optional reference to an abort source, which is connected to the kafka connection, and is triggered when the connection shuts down.

This change wires in the abort source to the waiting for units, so we can abort the wait if the connection is killed. 

Part of the delay in connections going down in https://github.com/redpanda-data/redpanda/issues/12382 is due to several readers' creation blocked on acquiring units, while the rpk process had been killed several seconds ago. When units are available the readers immediately detect the abort source is triggered and the connection closes, but the delay causes test to fail.

This is not the only reason for this delay in connections being closed, so this is a partial fix for that issue.


Note: The wait for units during `abort_transactions` does not use an abort source. It ideally should, but that requires passing down the abort source from much higher up the call chain and should be another PR.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
