### PR TITLE
security/oidc: Allow mapping of principals

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -141,6 +141,9 @@ ss::future<> controller::wire_up() {
             ss::sharded_parameter([] {
                 return config::shard_local_cfg()
                   .oidc_clock_skew_tolerance.bind();
+            }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg().oidc_principal_mapping.bind();
             }));
       })
       .then([this] { return _tp_state.start(); })

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -17,6 +17,7 @@
 #include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "security/gssapi_principal_mapper.h"
 #include "security/mtls.h"
+#include "security/oidc_principal_mapping.h"
 #include "security/oidc_url_parser.h"
 #include "ssx/sformat.h"
 #include "storage/chunk_cache.h"
@@ -2740,6 +2741,13 @@ configuration::configuration()
       "iat claims in the token.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::chrono::seconds{} * 30)
+  , oidc_principal_mapping(
+      *this,
+      "oidc_principal_mapping",
+      "Rule for mapping JWT Payload claim to a Redpanda User Principal",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      "$.sub",
+      security::oidc::validate_principal_mapping_rule)
   , http_authentication(
       *this,
       "http_authentication",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -520,6 +520,7 @@ struct configuration final : public config_store {
     property<ss::sstring> oidc_discovery_url;
     property<ss::sstring> oidc_token_audience;
     property<std::chrono::seconds> oidc_clock_skew_tolerance;
+    property<ss::sstring> oidc_principal_mapping;
 
     // HTTP Authentication
     property<std::vector<ss::sstring>> http_authentication;

--- a/src/v/json/pointer.h
+++ b/src/v/json/pointer.h
@@ -1,0 +1,24 @@
+// Copyright 2022 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "json/document.h"
+
+#include <rapidjson/pointer.h>
+
+namespace json {
+
+template<typename Encoding = json::UTF8<>>
+using GenericPointer
+  = rapidjson::GenericPointer<GenericValue<Encoding>, throwing_allocator>;
+
+using Pointer = GenericPointer<>;
+
+} // namespace json

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -17,6 +17,7 @@ v_cc_library(
     scram_authenticator.cc
     gssapi_authenticator.cc
     oidc_authenticator.cc
+    oidc_principal_mapping.cc
     oidc_service.cc
     credential.cc
     request_auth.cc

--- a/src/v/security/config_rcl.cc
+++ b/src/v/security/config_rcl.cc
@@ -9,6 +9,7 @@
  */
 
 #include "security/gssapi_principal_mapper.h"
+#include "security/mtls.h"
 #include "security/oidc_error.h"
 #include "security/oidc_principal_mapping.h"
 #include "security/oidc_url_parser.h"
@@ -186,6 +187,15 @@ result<parsed_url> parse_url(std::string_view url_view) {
     return result;
 }
 
+static constexpr std::string_view mapping_rule_pattern
+  = R"(\/((\\.|[^\\/])*)\/((\\.|[^\\/])*)\/([LU]?).*?|(.*?))";
+
+constexpr std::optional<std::string_view> make_sv(const std::csub_match& sm) {
+    return sm.matched
+             ? std::string_view{sm.first, static_cast<size_t>(sm.length())}
+             : std::optional<std::string_view>{std::nullopt};
+}
+
 result<principal_mapping_rule>
 parse_principal_mapping_rule(std::string_view mapping) {
     if (!mapping.starts_with("$.")) {
@@ -200,7 +210,41 @@ parse_principal_mapping_rule(std::string_view mapping) {
         return errc::invalid_principal_mapping;
     }
 
-    return principal_mapping_rule{std::move(pointer)};
+    std::regex rule_parser{
+      mapping_rule_pattern.begin(),
+      mapping_rule_pattern.length(),
+      std::regex_constants::ECMAScript | std::regex_constants::optimize};
+
+    tls::rule rule;
+    if (slash != std::string_view::npos) {
+        auto rule_str = mapping.substr(slash);
+        std::cmatch components_match;
+        if (!std::regex_search(
+              rule_str.begin(),
+              rule_str.end(),
+              components_match,
+              rule_parser,
+              std::regex_constants::match_default)) {
+            return errc::invalid_principal_mapping;
+        }
+        if (components_match.prefix().matched) {
+            return errc::invalid_principal_mapping;
+        }
+        if (components_match.suffix().matched) {
+            return errc::invalid_principal_mapping;
+        }
+        if (!components_match[1].matched) {
+            return errc::invalid_principal_mapping;
+        }
+        const auto adjust_case = make_sv(components_match[5]);
+        rule = {
+          *make_sv(components_match[1]),
+          make_sv(components_match[3]),
+          tls::rule::make_lower{adjust_case == "L"},
+          tls::rule::make_upper{adjust_case == "U"}};
+    }
+
+    return principal_mapping_rule{std::move(pointer), std::move(rule)};
 }
 
 std::optional<ss::sstring>

--- a/src/v/security/fwd.h
+++ b/src/v/security/fwd.h
@@ -22,6 +22,7 @@ namespace oidc {
 class jws;
 class jwt;
 class service;
+class principal_mapping_rule;
 class verifier;
 
 } // namespace oidc

--- a/src/v/security/jwt.h
+++ b/src/v/security/jwt.h
@@ -11,6 +11,7 @@
 
 #include "json/document.h"
 #include "json/ostreamwrapper.h"
+#include "json/pointer.h"
 #include "json/writer.h"
 #include "oncore.h"
 #include "outcome.h"
@@ -252,6 +253,15 @@ public:
     // Retrieve the Claim named claim.
     auto claim(std::string_view claim) const {
         return detail::string_view(_payload, claim);
+    }
+
+    // Retrieve the Claim by JSON Pointer.
+    std::optional<std::string_view> claim(json::Pointer const& p) const {
+        auto claim = p.Get(_payload);
+        if (!claim || !claim->IsString()) {
+            return std::nullopt;
+        }
+        return detail::as_string_view(*claim);
     }
 
     // Retrieve the Algorithm Header Parameter

--- a/src/v/security/jwt.h
+++ b/src/v/security/jwt.h
@@ -14,6 +14,7 @@
 #include "json/writer.h"
 #include "oncore.h"
 #include "outcome.h"
+#include "security/oidc_error.h"
 #include "utils/string_switch.h"
 #include "utils/utf8.h"
 
@@ -32,92 +33,6 @@
 #include <iosfwd>
 #include <optional>
 #include <string_view>
-#include <system_error>
-
-namespace security::oidc {
-
-enum class errc {
-    success = 0,
-    metadata_invalid,
-    jwks_invalid,
-    jwk_invalid,
-    jws_invalid_parts,
-    jws_invalid_b64,
-    jws_invalid_sig,
-    jwt_invalid_json,
-    jwt_invalid_typ,
-    jwt_invalid_alg,
-    jwt_invalid_kid,
-    jwt_invalid_iss,
-    jwt_invalid_aud,
-    jwt_invalid_exp,
-    jwt_invalid_iat,
-    jwt_invalid_nbf,
-    jwt_invalid_sub,
-    kid_not_found,
-};
-
-struct errc_category final : public std::error_category {
-    const char* name() const noexcept final { return "security::oidc::errc"; }
-
-    std::string message(int c) const final {
-        switch (static_cast<errc>(c)) {
-        case errc::success:
-            return "Success";
-        case errc::metadata_invalid:
-            return "Invalid metadata";
-        case errc::jwks_invalid:
-            return "Invalid jwks";
-        case errc::jwk_invalid:
-            return "Invalid jwk";
-        case errc::jws_invalid_parts:
-            return "Invalid jws: Expected three parts, is the JWT signed?";
-        case errc::jws_invalid_b64:
-            return "Invalid jws: Base64UrlDecode failed";
-        case errc::jws_invalid_sig:
-            return "Invalid jws: Signature failed";
-        case errc::jwt_invalid_json:
-            return "Invalid jwt: Not JSON";
-        case errc::jwt_invalid_typ:
-            return "Invalid jwt.typ";
-        case errc::jwt_invalid_alg:
-            return "Invalid jwt.alg";
-        case errc::jwt_invalid_kid:
-            return "Invalid jwt.kid";
-        case errc::jwt_invalid_iss:
-            return "Invalid jwt.iss";
-        case errc::jwt_invalid_aud:
-            return "Invalid jwt.aud";
-        case errc::jwt_invalid_exp:
-            return "Invalid jwt.exp";
-        case errc::jwt_invalid_iat:
-            return "Invalid jwt.iat";
-        case errc::jwt_invalid_nbf:
-            return "Invalid jwt.nbf";
-        case errc::jwt_invalid_sub:
-            return "Invalid jwt.sub";
-        case errc::kid_not_found:
-            return "kid not found";
-        }
-    }
-};
-
-inline const std::error_category& error_category() noexcept {
-    static errc_category e;
-    return e;
-}
-
-inline std::error_code make_error_code(errc e) noexcept {
-    return {static_cast<int>(e), error_category()};
-}
-
-} // namespace security::oidc
-
-namespace std {
-template<>
-struct is_error_code_enum<security::oidc::errc> : true_type {};
-
-} // namespace std
 
 namespace security::oidc {
 

--- a/src/v/security/oidc_authenticator.h
+++ b/src/v/security/oidc_authenticator.h
@@ -26,6 +26,7 @@ struct authentication_data {
 result<authentication_data> authenticate(
   jws const& jws,
   verifier const& verifier,
+  principal_mapping_rule const& mapping,
   std::string_view issuer,
   std::string_view audience,
   std::chrono::seconds clock_skew_tolerance,
@@ -33,6 +34,7 @@ result<authentication_data> authenticate(
 
 result<authentication_data> authenticate(
   jwt const& jwt,
+  principal_mapping_rule const& mapping,
   std::string_view issuer,
   std::string_view audience,
   std::chrono::seconds clock_skew_tolerance,

--- a/src/v/security/oidc_error.h
+++ b/src/v/security/oidc_error.h
@@ -31,7 +31,9 @@ enum class errc {
     jwt_invalid_iat,
     jwt_invalid_nbf,
     jwt_invalid_sub,
+    jwt_invalid_principal,
     kid_not_found,
+    invalid_principal_mapping,
 };
 
 struct errc_category final : public std::error_category {
@@ -73,8 +75,12 @@ struct errc_category final : public std::error_category {
             return "Invalid jwt.nbf";
         case errc::jwt_invalid_sub:
             return "Invalid jwt.sub";
+        case errc::jwt_invalid_principal:
+            return "Invalid jwt claim, it must result in a non-empty string";
         case errc::kid_not_found:
             return "kid not found";
+        case errc::invalid_principal_mapping:
+            return "invalid principal mapping rule";
         }
     }
 };

--- a/src/v/security/oidc_error.h
+++ b/src/v/security/oidc_error.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include <system_error>
+
+namespace security::oidc {
+
+enum class errc {
+    success = 0,
+    metadata_invalid,
+    jwks_invalid,
+    jwk_invalid,
+    jws_invalid_parts,
+    jws_invalid_b64,
+    jws_invalid_sig,
+    jwt_invalid_json,
+    jwt_invalid_typ,
+    jwt_invalid_alg,
+    jwt_invalid_kid,
+    jwt_invalid_iss,
+    jwt_invalid_aud,
+    jwt_invalid_exp,
+    jwt_invalid_iat,
+    jwt_invalid_nbf,
+    jwt_invalid_sub,
+    kid_not_found,
+};
+
+struct errc_category final : public std::error_category {
+    const char* name() const noexcept final { return "security::oidc::errc"; }
+
+    std::string message(int c) const final {
+        switch (static_cast<errc>(c)) {
+        case errc::success:
+            return "Success";
+        case errc::metadata_invalid:
+            return "Invalid metadata";
+        case errc::jwks_invalid:
+            return "Invalid jwks";
+        case errc::jwk_invalid:
+            return "Invalid jwk";
+        case errc::jws_invalid_parts:
+            return "Invalid jws: Expected three parts, is the JWT signed?";
+        case errc::jws_invalid_b64:
+            return "Invalid jws: Base64UrlDecode failed";
+        case errc::jws_invalid_sig:
+            return "Invalid jws: Signature failed";
+        case errc::jwt_invalid_json:
+            return "Invalid jwt: Not JSON";
+        case errc::jwt_invalid_typ:
+            return "Invalid jwt.typ";
+        case errc::jwt_invalid_alg:
+            return "Invalid jwt.alg";
+        case errc::jwt_invalid_kid:
+            return "Invalid jwt.kid";
+        case errc::jwt_invalid_iss:
+            return "Invalid jwt.iss";
+        case errc::jwt_invalid_aud:
+            return "Invalid jwt.aud";
+        case errc::jwt_invalid_exp:
+            return "Invalid jwt.exp";
+        case errc::jwt_invalid_iat:
+            return "Invalid jwt.iat";
+        case errc::jwt_invalid_nbf:
+            return "Invalid jwt.nbf";
+        case errc::jwt_invalid_sub:
+            return "Invalid jwt.sub";
+        case errc::kid_not_found:
+            return "kid not found";
+        }
+    }
+};
+
+inline const std::error_category& error_category() noexcept {
+    static errc_category e;
+    return e;
+}
+
+inline std::error_code make_error_code(errc e) noexcept {
+    return {static_cast<int>(e), error_category()};
+}
+
+} // namespace security::oidc
+
+namespace std {
+
+template<>
+struct is_error_code_enum<security::oidc::errc> : true_type {};
+
+} // namespace std

--- a/src/v/security/oidc_principal_mapping.cc
+++ b/src/v/security/oidc_principal_mapping.cc
@@ -23,7 +23,12 @@ result<acl_principal> principal_mapping_rule::apply(jwt const& jwt) const {
         return errc::jwt_invalid_principal;
     }
 
-    return {principal_type::user, ss::sstring{claim.value()}};
+    auto principal = _mapping.apply(claim.value());
+    if (principal.value_or("").empty()) {
+        return errc::jwt_invalid_principal;
+    }
+
+    return {principal_type::user, std::move(principal).value()};
 }
 
 } // namespace security::oidc

--- a/src/v/security/oidc_principal_mapping.cc
+++ b/src/v/security/oidc_principal_mapping.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "security/oidc_principal_mapping.h"
+
+#include "security/jwt.h"
+#include "security/logger.h"
+
+#include <rapidjson/pointer.h>
+
+namespace security::oidc {
+
+result<acl_principal> principal_mapping_rule::apply(jwt const& jwt) const {
+    auto claim = jwt.claim(_claim);
+    if (claim.value_or("").empty()) {
+        return errc::jwt_invalid_principal;
+    }
+
+    return {principal_type::user, ss::sstring{claim.value()}};
+}
+
+} // namespace security::oidc

--- a/src/v/security/oidc_principal_mapping.h
+++ b/src/v/security/oidc_principal_mapping.h
@@ -14,6 +14,7 @@
 #include "seastarx.h"
 #include "security/acl.h"
 #include "security/fwd.h"
+#include "security/mtls.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -25,8 +26,9 @@ class principal_mapping_rule {
 public:
     principal_mapping_rule() = default;
 
-    explicit principal_mapping_rule(json::Pointer&& claim)
-      : _claim{} {
+    explicit principal_mapping_rule(json::Pointer&& claim, tls::rule mapping)
+      : _claim{}
+      , _mapping{std::move(mapping)} {
         swap(_claim, claim);
     }
 
@@ -34,6 +36,7 @@ public:
 
 private:
     json::Pointer _claim{"/sub"};
+    tls::rule _mapping;
 };
 
 result<principal_mapping_rule> parse_principal_mapping_rule(std::string_view);

--- a/src/v/security/oidc_principal_mapping.h
+++ b/src/v/security/oidc_principal_mapping.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+#include "config/property.h"
+#include "json/pointer.h"
+#include "outcome.h"
+#include "seastarx.h"
+#include "security/acl.h"
+#include "security/fwd.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <optional>
+
+namespace security::oidc {
+
+class principal_mapping_rule {
+public:
+    principal_mapping_rule() = default;
+
+    explicit principal_mapping_rule(json::Pointer&& claim)
+      : _claim{} {
+        swap(_claim, claim);
+    }
+
+    result<acl_principal> apply(jwt const& jwt) const;
+
+private:
+    json::Pointer _claim{"/sub"};
+};
+
+result<principal_mapping_rule> parse_principal_mapping_rule(std::string_view);
+std::optional<ss::sstring>
+validate_principal_mapping_rule(ss::sstring const& rule);
+
+} // namespace security::oidc

--- a/src/v/security/oidc_service.h
+++ b/src/v/security/oidc_service.h
@@ -28,7 +28,8 @@ public:
       config::binding<std::vector<ss::sstring>> http_authentication,
       config::binding<ss::sstring> discovery_url,
       config::binding<ss::sstring> token_audience,
-      config::binding<std::chrono::seconds> clock_skew_tolerance);
+      config::binding<std::chrono::seconds> clock_skew_tolerance,
+      config::binding<ss::sstring> mapping);
     service(service&&) = delete;
     service& operator=(service&&) = delete;
     service(service const&) = delete;
@@ -39,6 +40,7 @@ public:
     ss::future<> stop();
 
     verifier const& get_verifier() const;
+    principal_mapping_rule const& get_principal_mapping_rule() const;
     std::string_view audience() const;
     result<std::string_view> issuer() const;
     std::chrono::seconds clock_skew_tolerance() const;

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ rp_test(
     gssapi_principal_mapper_test.cc
     jwt_test.cc
     url_test.cc
+    oidc_principal_mapping_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka_protocol v::storage v::security
   LABELS kafka

--- a/src/v/security/tests/jwt_test.cc
+++ b/src/v/security/tests/jwt_test.cc
@@ -9,6 +9,7 @@
 
 #include "security/jwt.h"
 #include "security/oidc_authenticator.h"
+#include "security/oidc_principal_mapping.h"
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/testing/thread_test_case.hh>
@@ -289,9 +290,12 @@ BOOST_DATA_TEST_CASE(test_oidc_authenticate, bdata::make(oidc_auth_data), d) {
     auto update = v.update_keys(std::move(jwks).assume_value());
     BOOST_REQUIRE(!update.has_error());
 
+    security::oidc::principal_mapping_rule mapping;
+
     auto auth = security::oidc::authenticate(
       std::move(jws).assume_value(),
       v,
+      mapping,
       d.issuer,
       d.audience,
       d.clock_skew_tolerance,
@@ -425,6 +429,7 @@ BOOST_DATA_TEST_CASE(
     BOOST_REQUIRE(!jwt.has_error());
     auto auth = oidc::authenticate(
       jwt.assume_value(),
+      security::oidc::principal_mapping_rule{},
       d.issuer,
       d.audience,
       d.clock_skew_tolerance,

--- a/src/v/security/tests/oidc_principal_mapping_test.cc
+++ b/src/v/security/tests/oidc_principal_mapping_test.cc
@@ -1,0 +1,101 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/property.h"
+#include "json/document.h"
+#include "security/jwt.h"
+#include "security/oidc_principal_mapping.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <boost/test/data/test_case.hpp>
+#include <boost/test/unit_test.hpp>
+#include <boost/test/unit_test_suite.hpp>
+
+namespace bdata = boost::unit_test::data;
+
+struct principal_mapping_test_data {
+    std::string_view token_payload;
+    config::binding<ss::sstring> mapping;
+    result<security::acl_principal> principal;
+
+    friend std::ostream&
+    operator<<(std::ostream& os, principal_mapping_test_data const& d) {
+        fmt::print(
+          os,
+          "payload: {}, mapping: {}, principal: {}",
+          d.token_payload,
+          d.mapping(),
+          d.principal.has_error()
+            ? std::string_view{d.principal.assume_error().message()}
+            : std::string_view(d.principal.assume_value().name()));
+        return os;
+    }
+};
+const auto principal_mapping_data = std::to_array<principal_mapping_test_data>(
+  {// sub (default)
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.sub"),
+    security::acl_principal{security::principal_type::user, "subject"}},
+   // empty sub
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.sub"),
+    security::oidc::errc::jwt_invalid_principal},
+   // no sub
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.sub"),
+    security::oidc::errc::jwt_invalid_principal},
+   // email
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "email": "user@example.com", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.email"),
+    security::acl_principal{
+      security::principal_type::user, "user@example.com"}},
+   // empty email
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "email": "", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.email"),
+    security::oidc::errc::jwt_invalid_principal},
+   // no email
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.email"),
+    security::oidc::errc::jwt_invalid_principal},
+   // nested principal
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "user_info": {"name": "user", "email": "user@example.com"},  "aud": "redpanda", "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.user_info.email"),
+    security::acl_principal{
+      security::principal_type::user, "user@example.com"}},
+   // invalid nested principal
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "user_info": "not object",  "aud": "redpanda", "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.user_info.email"),
+    security::oidc::errc::jwt_invalid_principal}});
+BOOST_DATA_TEST_CASE(
+  test_principal_mapper, bdata::make(principal_mapping_data), d) {
+    auto mapping = security::oidc::parse_principal_mapping_rule(d.mapping());
+    BOOST_REQUIRE(mapping.has_value());
+    auto mapper = std::move(mapping).assume_value();
+
+    json::Document header;
+    header.Parse(R"({"alg": "RS256", "typ": "JWT", "kid": "42"})");
+    json::Document payload;
+    payload.Parse(d.token_payload.data(), d.token_payload.length());
+    auto jwt = security::oidc::jwt::make(std::move(header), std::move(payload));
+    BOOST_REQUIRE(!jwt.has_error());
+
+    auto principal = mapper.apply(jwt.assume_value());
+    if (
+      d.principal.has_error()
+      && d.principal.assume_error() != security::oidc::errc::success) {
+        BOOST_REQUIRE(principal.has_error());
+        BOOST_REQUIRE_EQUAL(
+          principal.assume_error(), d.principal.assume_error());
+        return;
+    }
+
+    BOOST_REQUIRE(principal.has_value());
+    BOOST_REQUIRE_EQUAL(principal.assume_value(), d.principal.assume_value());
+}

--- a/src/v/security/tests/oidc_principal_mapping_test.cc
+++ b/src/v/security/tests/oidc_principal_mapping_test.cc
@@ -40,39 +40,63 @@ struct principal_mapping_test_data {
 };
 const auto principal_mapping_data = std::to_array<principal_mapping_test_data>(
   {// sub (default)
-   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject",
+     "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
     config::mock_binding<ss::sstring>("$.sub"),
     security::acl_principal{security::principal_type::user, "subject"}},
    // empty sub
-   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "", "aud":
+     ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
     config::mock_binding<ss::sstring>("$.sub"),
     security::oidc::errc::jwt_invalid_principal},
    // no sub
-   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "aud":
+     ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
     config::mock_binding<ss::sstring>("$.sub"),
     security::oidc::errc::jwt_invalid_principal},
    // email
-   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "email": "user@example.com", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject",
+     "email": "user@example.com", "aud": ["redpanda", "wrong"], "exp":
+     1695887942, "iat": 1695887942})",
     config::mock_binding<ss::sstring>("$.email"),
     security::acl_principal{
       security::principal_type::user, "user@example.com"}},
    // empty email
-   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "email": "", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject",
+     "email": "", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat":
+     1695887942})",
     config::mock_binding<ss::sstring>("$.email"),
     security::oidc::errc::jwt_invalid_principal},
    // no email
-   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject",
+     "aud": ["redpanda", "wrong"], "exp": 1695887942, "iat": 1695887942})",
     config::mock_binding<ss::sstring>("$.email"),
     security::oidc::errc::jwt_invalid_principal},
    // nested principal
-   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "user_info": {"name": "user", "email": "user@example.com"},  "aud": "redpanda", "exp": 1695887942, "iat": 1695887942})",
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject",
+     "user_info": {"name": "user", "email": "user@example.com"},  "aud":
+     "redpanda", "exp": 1695887942, "iat": 1695887942})",
     config::mock_binding<ss::sstring>("$.user_info.email"),
     security::acl_principal{
       security::principal_type::user, "user@example.com"}},
    // invalid nested principal
-   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "user_info": "not object",  "aud": "redpanda", "exp": 1695887942, "iat": 1695887942})",
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject",
+     "user_info": "not object",  "aud": "redpanda", "exp": 1695887942, "iat":
+     1695887942})",
     config::mock_binding<ss::sstring>("$.user_info.email"),
-    security::oidc::errc::jwt_invalid_principal}});
+    security::oidc::errc::jwt_invalid_principal},
+   // extract user from email
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "email": "user@example.com", "aud": "redpanda", "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.email/([^@]+)@.*/$1/"),
+    security::acl_principal{security::principal_type::user, "user"}},
+   // extract uppercase user from email
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "email": "user@example.com", "aud": "redpanda", "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.email/([^@]+)@.*/$1/U"),
+    security::acl_principal{security::principal_type::user, "USER"}},
+   // extract lowercase user from email
+   {R"({"iss": "http://docker-rp-1:8080/realms/demorealm", "sub": "subject", "email": "USER@example.com", "aud": "redpanda", "exp": 1695887942, "iat": 1695887942})",
+    config::mock_binding<ss::sstring>("$.email/([^@]+)@.*/$1/L"),
+    security::acl_principal{security::principal_type::user, "user"}}});
 BOOST_DATA_TEST_CASE(
   test_principal_mapper, bdata::make(principal_mapping_data), d) {
     auto mapping = security::oidc::parse_principal_mapping_rule(d.mapping());

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -562,6 +562,9 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         # Don't modify oidc_discovery_url, if it's invalid, logging will break the test.
         exclude_settings.add('oidc_discovery_url')
 
+        # Don't modify oidc_principal mapping, the value is complex and tested elsewhere.
+        exclude_settings.add('oidc_principal_mapping')
+
         initial_config = self.admin.get_cluster_config()
 
         for name, p in schema_properties.items():


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/core-internal/issues/847

## Docs
New cluster configuration options:
| option | description | default |
| -- | -- | -- |
| `oidc_principal_mapping` | "Rule for mapping JWT Payload claim to a Redpanda User Principal" | `$.sub` |

The rule mapping is as follows:

```
rule                = "$" segments [ mapping ]
segments            = "." fieldname { "." fieldname }
mapping             = "/" regex_pattern "/" replacement_pattern "/" [ case_modifier ]
replacement_pattern = replacement_element { replacement_element }
replacement_match   = "$" digit
replacement_element = replacement_match | arbitrary_text
case_modifier       = "L" | "U"
```

The mapping part is very similar to the [mtls principal mapping](https://docs.redpanda.com/current/manage/security/authentication/#configure-mtls-with-authentication).

E.g. if the JWT has the following claims:
```JSON
{
  "sub": "user",
  "user_info": {
    "name": "User",
    "email": "user@example.com"
  }
}
```
The default rule: `$.sub` would give: `user`.
To extract the principal from the email field: `$.user_info.email/([^@]+)@+*/$1/L` -> `user`
As above, but reject if the domain doesn't match: `$.user_info.email/([^@]+)@example.com/$1/L`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
