### PR TITLE
rptest: fix use of partitions_min in htt

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -484,8 +484,8 @@ class HighThroughputTest(PreallocNodesTest):
 
         # create default topics
         # Use lower partitions limit
-        self._create_default_topics(
-            num_partitions=self.tier_config.partitions_min, num_replicas=3)
+        self._create_default_topics(num_partitions=self._partitions_min,
+                                    num_replicas=3)
 
         # Initialize all 3 nodes with proper values
         swarm = []


### PR DESCRIPTION
Fixes #14760
Follow-up to PR #14640

fix usage of _partitions_min

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
