### PR TITLE
cloud_storage: add metrics from cloud storage scrubber

### DIFF
--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -252,6 +252,16 @@ bool anomalies::has_value() const {
            || segment_metadata_anomalies.size() > 0;
 }
 
+size_t anomalies::count_segment_meta_anomaly_type(anomaly_type type) const {
+    auto begin = segment_metadata_anomalies.begin();
+    auto end = segment_metadata_anomalies.end();
+    const auto count = std::count_if(begin, end, [&type](const auto& anomaly) {
+        return anomaly.type == type;
+    });
+
+    return static_cast<size_t>(count);
+}
+
 anomalies& anomalies::operator+=(anomalies&& other) {
     missing_partition_manifest |= other.missing_partition_manifest;
     missing_spillover_manifests.insert(

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -406,6 +406,8 @@ struct anomalies
 
     bool has_value() const;
 
+    size_t count_segment_meta_anomaly_type(anomaly_type type) const;
+
     anomalies& operator+=(anomalies&&);
 
     friend bool operator==(const anomalies& lhs, const anomalies& rhs);

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -434,7 +434,6 @@ kafka_stages partition::replicate_in_stages(
 
 ss::future<> partition::start(std::optional<topic_configuration> topic_cfg) {
     const auto& ntp = _raft->ntp();
-    _probe.setup_metrics(ntp);
     raft::state_machine_manager_builder builder;
     // special cases for id_allocator and transaction coordinator partitions
     if (is_id_allocator_topic(ntp)) {
@@ -541,6 +540,10 @@ ss::future<> partition::start(std::optional<topic_configuration> topic_cfg) {
                 *_cloud_storage_probe);
         }
     }
+
+    // Start the probe after the partition is fully initialised, but before
+    // starting everything.
+    _probe.setup_metrics(ntp);
 
     if (_cloud_storage_manifest_view) {
         co_await _cloud_storage_manifest_view->start();

--- a/src/v/cluster/partition_probe.h
+++ b/src/v/cluster/partition_probe.h
@@ -87,6 +87,8 @@ private:
     void setup_public_metrics(const model::ntp&);
     void setup_internal_metrics(const model::ntp&);
 
+    void setup_public_scrubber_metric(const model::ntp&);
+
 private:
     const partition& _partition;
     uint64_t _records_produced{0};

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -206,7 +206,7 @@ class BucketScrubSelfTest(RedpandaTest):
         segment_key = None
         for o in self.redpanda.cloud_storage_client.list_objects(
                 self.si_settings.cloud_storage_bucket):
-            if ".log" in o.key and view.is_segment_part_of_a_manifest(o):
+            if ".log" in o.key and view.find_segment_in_manifests(o):
                 segment_key = o.key
                 break
 

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -634,7 +634,7 @@ class FastCheck(BaseCase):
         s3_snapshot = BucketView(self.redpanda, topics=expected_topics)
         segments = [
             item for item in self._s3.list_objects(self._bucket)
-            if s3_snapshot.is_segment_part_of_a_manifest(item)
+            if s3_snapshot.find_segment_in_manifests(item)
         ]
         for seg in segments:
             components = parse_s3_segment_path(seg.key)

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -717,12 +717,12 @@ class SpillMeta:
     def make(ntpr: NTPR, path: str):
         base, last, base_kafka, last_kafka, base_ts, last_ts = SpillMeta._parse_path(
             ntpr, path)
-        return SpillMeta(base=base,
-                         last=last,
-                         base_kafka=base_kafka,
-                         last_kafka=last_kafka,
-                         base_ts=base_ts,
-                         last_ts=last_ts,
+        return SpillMeta(base=int(base),
+                         last=int(last),
+                         base_kafka=int(base_kafka),
+                         last_kafka=int(last_kafka),
+                         base_ts=int(base_ts),
+                         last_ts=int(last_ts),
                          ntpr=ntpr,
                          path=path)
 


### PR DESCRIPTION
This PR introduces a number of new metrics which report cloud
storage anomalies for a topic. They are all bundled under the same
metric name, but use different labels. This commit only adds them to
public metrics and the granularity is topic level.

Overall, the cardinality should increase by 9 * topic_count *
broker_count. The metrics are reported from each broker, but only the
leader can report non-zero values.

The metric has the following form: `redpanda_cloud_storage_anomalies redpanda_namespace={} redpanda_topic={} redpanda_type={} redpanda_severity={}`.

Fixes #14796

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
