### PR TITLE
rpk: select FQN of msg in SR schema when producing

### DIFF
--- a/src/go/rpk/pkg/serde/proto_test.go
+++ b/src/go/rpk/pkg/serde/proto_test.go
@@ -125,6 +125,14 @@ message Person {
 			expRecord: `{"name":"igor","id":123,"isAdmin":true,"email":"test@redpanda.com"}`,
 			expIdx:    []int{0},
 		}, {
+			name:      "simple - complete record, no FQN",
+			schema:    testSimpleSchema,
+			msgType:   "",
+			schemaID:  1,
+			record:    `{"name":"igor","id":123,"isAdmin":true,"email":"test@redpanda.com"}`,
+			expRecord: `{"name":"igor","id":123,"isAdmin":true,"email":"test@redpanda.com"}`,
+			expIdx:    []int{0},
+		}, {
 			name:      "simple - without optional field",
 			schema:    testSimpleSchema,
 			msgType:   "Person",
@@ -154,6 +162,12 @@ message Person {
 			record:    `{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"1111","type":0},{"number":"2222","type":1},{"number":"33333","type":2}]}`,
 			expRecord: `{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"1111"},{"number":"2222","type":"PHONE_TYPE_MOBILE"},{"number":"33333","type":"PHONE_TYPE_HOME"}]}`,
 			expIdx:    []int{0},
+		}, {
+			name:      "complex - complete record, no FQN should fail",
+			schema:    testComplexSchema,
+			schemaID:  3,
+			record:    `{"name":"rogger","id":123,"email":"test@redpanda.com","phones":[{"number":"1111","type":0},{"number":"2222","type":1},{"number":"33333","type":2}]}`,
+			expEncErr: true,
 		}, {
 			name:      "complex - complete record, using index 1 message",
 			schema:    testComplexSchema,

--- a/src/go/rpk/pkg/serde/serde.go
+++ b/src/go/rpk/pkg/serde/serde.go
@@ -52,6 +52,11 @@ func NewSerde(ctx context.Context, cl *sr.Client, schema *sr.Schema, schemaID in
 		if err != nil {
 			return nil, fmt.Errorf("unable to compile proto schema: %v", err)
 		}
+		// If the proto FQN is not provided, but we only have one message, we
+		// use that.
+		if protoFQN == "" && compiled.FindFileByPath(inMemFileName).Messages().Len() == 1 {
+			protoFQN = string(compiled.FindFileByPath(inMemFileName).Messages().Get(0).Name())
+		}
 		var encFn serdeFunc
 		// If there is no FQN, most likely we are trying to decode only.
 		if protoFQN != "" {
@@ -73,7 +78,7 @@ func NewSerde(ctx context.Context, cl *sr.Client, schema *sr.Schema, schemaID in
 // EncodeRecord will encode the given record using the internal encodeFn.
 func (s *Serde) EncodeRecord(record []byte) ([]byte, error) {
 	if s.encodeFn == nil {
-		return nil, errors.New("encoder not found")
+		return nil, errors.New("encoder not found; please provide the fully qualified name of the message you are trying to encode")
 	}
 	return s.encodeFn(record)
 }


### PR DESCRIPTION
rpk now will auto-select the fully qualified name of the message when running 'rpk topic produce' if the schema only contains a single message.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

No release notes here since this is a feature that is not yet released:

## Release Notes
* none


