### PR TITLE
tm_stm: add tx to cache on create

### DIFF
--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -697,6 +697,8 @@ ss::future<tm_stm::op_status> tm_stm::do_register_new_producer(
         co_return tm_stm::op_status::unknown;
     }
 
+    _cache->set_mem(tx.etag, tx_id, tx);
+
     co_return tm_stm::op_status::success;
 }
 

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -510,6 +510,8 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                        backoff_sec=2,
                        err_msg="Failed to establish current leader")
 
+        # Issue a leadership transfer
+        graceful_transfer()
         # Add some records
         add_records()
         # Issue a leadership transfer


### PR DESCRIPTION
A test using transaction would randomly fail with
`INVALID_PRODUCER_ID_MAPPING` if the transaction coordinator leader would change between the producer issued `InitProducerId` and `AddPartitionsToTxn`. Since [Fixes Unknown Server Errors (USE) in transactions][1], this should not happen as we cache transaction state and fetch it from all nodes. However, it appears we forgot to cache the state after the `InitProducerId` request. This PR fixes that and updates a test that catches the problem and validates the fix.

Fixes #13736

[1]: https://github.com/redpanda-data/redpanda/pull/7591

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fix a bug where producer would get `INVALID_PRODUCER_ID_MAPPING` if the leader of the transaction coordinator partition would change.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
