### PR TITLE
build: install abseil for the open-source build

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -108,6 +108,11 @@ FetchContent_Declare(
   SYSTEM
   SOURCE_SUBDIR crates/c-api)
 
+set(ABSL_PROPAGATE_CXX_STD ON)
+fetch_dep(abseil
+  REPO https://github.com/abseil/abseil-cpp
+  TAG 20220623.0)
+
 FetchContent_MakeAvailable(
     fmt
     rapidjson
@@ -120,7 +125,8 @@ FetchContent_MakeAvailable(
     tinygo
     wasmtime
     hdrhistogram
-    ada)
+    ada
+    abseil)
 
 add_library(Crc32c::crc32c ALIAS crc32c)
 add_library(aklomp::base64 ALIAS base64)


### PR DESCRIPTION
We want to support Ubuntu in our open-source build.

The version of Abseil in Ubuntu Mantic is compatible with the version we use in our private build. However, for reasons not yet known, the installation of Abseil in Ubuntu is configured to not auto-detect absl::string_view replacement for std::string_view, breaking several things in cloud storage and wasm which assume that these types are the same.

Update. In the Debian package configure patch:

```
  - To minimize the possibility of future ABI breakage, treat absl::any,
    absl::optional, absl::string_view, and absl::variant as their own types
    (rather than aliases for the std:: versions), and compile everything in an
    inline namespace.
```

Which I guess is a fine policy. But we want to build from source, so here we are.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
