### PR TITLE
[v23.2.x] ducktape: Update librdkafka and confluent-kafka to v2.2.0

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -211,6 +211,8 @@ COPY --chown=0:0 --chmod=0755 tests/setup.py /root/tests/
 RUN python3 -m pip install --upgrade --force pip && \
     python3 -m pip install --force --no-cache-dir -e /root/tests/
 
+RUN python3 -m pip install --force-reinstall --no-cache-dir --no-binary :all: confluent-kafka==2.2.0
+
 # seastar addrress to line utility depends on 'file' pkg
 RUN apt update && \
     apt install -y file && \

--- a/tests/docker/ducktape-deps/librdkafka
+++ b/tests/docker/ducktape-deps/librdkafka
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 mkdir /opt/librdkafka
-curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.0.2.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
+curl -SL "https://github.com/confluentinc/librdkafka/archive/refs/tags/v2.2.0.tar.gz" | tar -xz --strip-components=1 -C /opt/librdkafka
 cd /opt/librdkafka
 ./configure
 make -j$(nproc)

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -15,9 +15,9 @@ setup(
     install_requires=[
         'ducktape@git+https://github.com/redpanda-data/ducktape.git@fd01d72b8c82ae852986bb288c69818c7ffb4de8',
         'prometheus-client==0.9.0', 'pyyaml==6.0', 'kafka-python==2.0.2',
-        'crc32c==2.2', 'confluent-kafka==2.0.2', 'zstandard==0.15.2',
-        'xxhash==2.0.2', 'protobuf==4.21.8', 'fastavro==1.4.9',
-        'psutil==5.9.0', 'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
+        'crc32c==2.2', 'zstandard==0.15.2', 'xxhash==2.0.2',
+        'protobuf==4.21.8', 'fastavro==1.4.9', 'psutil==5.9.0',
+        'numpy==1.22.3', 'pygal==3.0', 'pytest==7.1.2',
         'jump-consistent-hash==3.2.0', 'azure-storage-blob==12.14.1',
         'kafkatest@git+https://github.com/apache/kafka.git@058589b03db686803b33052d574ce887fb5cfbd1#egg=kafkatest&subdirectory=tests',
         'grpcio==1.57.0', 'grpcio-tools==1.57', 'grpcio-status==1.57.0',


### PR DESCRIPTION
Addresses issue https://github.com/redpanda-data/devprod/issues/903

for running tests on cdt against v23.2.x rc release, unable to build packer image with error:
```
==> redpanda-testing.amazon-ebs.ubuntu:          66 | #error "confluent-kafka-python requires librdkafka v2.2.0 or later. Install the latest version of librdkafka from the Confluent repositories, see http://docs.confluent.io/current/installation.html"
```
seems like we need commit e09c68ad40a23a9f15178615cbd053a2cde288d4 from PR #13822 to be backported:
```console
git cherry-pick -x e09c68ad40a23a9f15178615cbd053a2cde288d4
```
backport was clean:
```
Auto-merging tests/docker/Dockerfile
Auto-merging tests/setup.py
[v23.2.x-confluent-kafka-v2.2.0 e66e0f14da] ducktape: Update librdkafka and confluent-kafka to v2.2.0
 Author: Oren Leiman <oren.leiman@redpanda.com>
 Date: Thu Sep 28 17:58:47 2023 -0700
 3 files changed, 6 insertions(+), 4 deletions(-)
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
