### PR TITLE
Fix for `leader_ack` consistency level (do not advance last visible offset beyond majority replicated)

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2904,7 +2904,6 @@ ss::future<> consensus::maybe_commit_configuration(ssx::semaphore_units u) {
 
 ss::future<>
 consensus::do_maybe_update_leader_commit_idx(ssx::semaphore_units u) {
-    auto lstats = _log->offsets();
     // Raft paper:
     //
     // If there exists an N such that N > commitIndex, a majority
@@ -2947,7 +2946,7 @@ consensus::do_maybe_update_leader_commit_idx(ssx::semaphore_units u) {
         // if we successfully acknowledged all quorum writes we can make pending
         // relaxed consistency requests visible
         if (_commit_index >= _last_quorum_replicated_index) {
-            maybe_update_last_visible_index(lstats.dirty_offset);
+            maybe_update_last_visible_index(_majority_replicated_index);
         } else {
             // still have to wait for some quorum consistency requests to be
             // committed

--- a/tests/rptest/tests/simple_e2e_test.py
+++ b/tests/rptest/tests/simple_e2e_test.py
@@ -7,12 +7,24 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import random
+import threading
+import time
+from rptest.services.failure_injector import FailureInjector, FailureSpec
 from rptest.services.cluster import cluster
 from rptest.clients.types import TopicSpec
+from rptest.services.redpanda import SISettings
 from rptest.tests.end_to_end import EndToEndTest
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class SimpleEndToEndTest(EndToEndTest):
+    def __init__(self, test_context, *args, **kwargs):
+
+        super(SimpleEndToEndTest, self).__init__(test_context=test_context,
+                                                 *args,
+                                                 **kwargs)
+
     @cluster(num_nodes=6)
     def test_correctness_while_evicitng_log(self):
         '''
@@ -69,3 +81,57 @@ class SimpleEndToEndTest(EndToEndTest):
         assert error is not None
         assert "Consumed from an unexpected" in str(
             error) or "is behind the current committed offset" in str(error)
+
+    @skip_debug_mode
+    @cluster(num_nodes=6)
+    def test_leader_acks(self):
+        ev = threading.Event()
+
+        def inject_failures():
+            fi = FailureInjector(self.redpanda)
+            while not ev.is_set():
+
+                node = random.choice(self.redpanda.nodes)
+                fi.inject_failure(
+                    FailureSpec(type=FailureSpec.FAILURE_KILL,
+                                length=0,
+                                node=node))
+                time.sleep(5)
+
+        # use small segment size to enable log eviction
+        self.start_redpanda(num_nodes=3,
+                            si_settings=SISettings(
+                                test_context=self.test_context,
+                                fast_uploads=True),
+                            extra_rp_conf={
+                                "log_segment_size":
+                                1048576,
+                                "retention_bytes":
+                                5242880,
+                                "default_topic_replications":
+                                3,
+                                "raft_replica_max_pending_flush_bytes":
+                                1024 * 1024 * 1024 * 1024,
+                                "raft_flush_timer_interval_ms":
+                                3000000
+                            })
+
+        spec = TopicSpec(name="verify-leader-ack",
+                         partition_count=16,
+                         replication_factor=3)
+        self.client().create_topic(spec)
+
+        self.topic = spec.name
+
+        self.start_producer(2, throughput=10000, acks=1)
+
+        self.start_consumer(1)
+        self.await_startup()
+        thread = threading.Thread(target=inject_failures, daemon=True)
+        thread.start()
+
+        self.run_validation(min_records=100000,
+                            producer_timeout_sec=300,
+                            consumer_timeout_sec=300)
+        ev.set()
+        thread.join()


### PR DESCRIPTION
When Raft handles replicate requests of mixed consistency levels it has
to separately track the visibility of both type of replicate requests.
i.e. `quorum_ack` requests should not be visible to readers until they
are successfully replicated and flushed on the majority of nodes while
for `leader_ack` requests it is enough to have them acknowledged and not
flushed by majority of nodes. When `quorum_ack` batch is committed then
all subsequent majority replicated `leader_ack` batches may become
immediately visible to consumers if they are majority confirmed. Fixed
bug in Raft where the majority replication wasn't validated correctly
and 'dirty' batches were made visible to the consumer. It might lead to
situation in which consumer read batches which were then not available
on newly elected leader.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- prevents consumer from reading not majority acknowledged data