### PR TITLE
[v23.2.x] tm_stm: add tx to cache on create

### DIFF
--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -685,6 +685,8 @@ ss::future<tm_stm::op_status> tm_stm::do_register_new_producer(
         co_return tm_stm::op_status::unknown;
     }
 
+    _cache->set_mem(tx.etag, tx_id, tx);
+
     co_return tm_stm::op_status::success;
 }
 

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -510,6 +510,8 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                        backoff_sec=2,
                        err_msg="Failed to establish current leader")
 
+        # Issue a leadership transfer
+        graceful_transfer()
         # Add some records
         add_records()
         # Issue a leadership transfer


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14784
Fixes: https://github.com/redpanda-data/redpanda/issues/14799,