### PR TITLE
cluster/topics_frontend: fix log statement

### DIFF
--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -816,6 +816,7 @@ ss::future<std::error_code> topics_frontend::move_partition_replicas(
               "Trying to move partition {} to {} with reconfiguration policy "
               "of {} but fast partition movement feature is not yet active",
               ntp,
+              new_replica_set,
               policy);
         }
         move_partition_replicas_cmd cmd(


### PR DESCRIPTION
The missing argument caused logging to fail, which somehow caused a
crash. I'm still figuring out why fail to log caused a crash, but at 
least this prevents that code path from happening.

Fixes: #14804

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
