### PR TITLE
tests: hotfixes for running cdt tests on cloudv2

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -141,17 +141,19 @@ class CloudCleanup():
         _message = f"-> cluster '{_cluster['name']}', " \
                    f"{_cluster['createdAt']}, {_type} "
         if _type in ['FMC']:
-            if _ensure_date(_createdDate):
-                _message += f"| skipped '{_cluster['name']}', " \
-                            "36h delay not passed"
-                self.log.info(_message)
-                return False
+            _message += f"| status: '{_cluster['state']}' "
+            if _state in ['ready']:
+                if not _ensure_date(_createdDate):
+                    _log_skip(_message)
+                    return False
+                else:
+                    # Just request deletion right away
+                    out = self.cloudv2.delete_resource(handle)
+                    _log_deleted(_message)
+                    return out
             else:
-                # Just request deletion right away
-                out = self.cloudv2.delete_resource(handle)
-                _message += "| deleted"
+                _message += "| skipping non-ready FMC clouds"
                 self.log.info(_message)
-                return out
         elif _type in ['BYOC']:
             # Check if provider is the same
             # This is relevant only for BYOC as

--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -217,7 +217,7 @@ class CloudCleanup():
                     return False
                 # Just delete the cluster resource
                 out = self.cloudv2.delete_resource(handle)
-                _log_deleted()
+                _log_deleted(_message)
                 self.log.debug(f"Returned:\n{out}")
                 return True
             # All other states need to wait for 36h

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -1155,6 +1155,8 @@ class CloudCluster():
 
         if self.config.install_pack_ver == 'latest':
             install_pack_ver = self._get_latest_install_pack_ver()
+        else:
+            install_pack_ver = self.config.install_pack_ver
         params = {
             'cloud_provider': self.config.provider,
             'cluster_type': self.config.type,

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -127,6 +127,7 @@ class LiveClusterParams:
     connection_type: str = 'public'
     namespace_uuid: str = None
     name: str = None
+    last_status: str = ""
     consoleUrl: str = ""
     network_id: str = None
     network_cidr: str = None
@@ -354,11 +355,17 @@ class CloudCluster():
                                           params=params)
         for c in clusters:
             if c['name'] == self.current.name:
+                self._logger.debug(f"Cluster status: {c['state']}")
+                self.current.last_status = c['state']
                 if c['state'] == 'ready':
                     return True
                 elif c['state'] == 'unknown':
                     raise RuntimeError("Creation failed (state 'unknown') "
                                        f"for '{self.config.provider}'")
+                elif c['state'] == 'deleting':
+                    raise RuntimeError("Creation failed (state 'deleting') "
+                                       f"for '{self.config.provider}'")
+
         return False
 
     def _cluster_status(self, status):
@@ -690,7 +697,8 @@ class CloudCluster():
                        timeout_sec=self.CHECK_TIMEOUT_SEC,
                        backoff_sec=self.CHECK_BACKOFF_SEC,
                        err_msg='Unable to deterimine readiness '
-                       f'of cloud cluster {self.current.name}')
+                       f'of cloud cluster {self.current.name}; '
+                       f'last state {self.current.last_status}')
 
             self.config.id, self.current.network_id = \
                 self._get_cluster_id_and_network_id()


### PR DESCRIPTION
related to issue https://github.com/redpanda-data/redpanda/issues/14765

to get some of the fixes from WIP PR #14787 merged first, cherry-picking:

```console
git cherry-pick -x 8091429aa3303edcb569fc277b3f5bae0871c9bc 35eae8825b528aaf9f2461760a553a0bf528eee6 53e93dd472d2abd1bd562956e52d75b9ea436ff6 600849d1d384bc5d41b79b355e745bc8f1ca8a3d
```

no conflicts:
```
[hotfix-cdt-cloudv2 14de049acb] ci: Cloud cleanup hotfix
 Author: Alex Savatieiev <a.savex@gmail.com>
 Date: Mon Nov 6 16:12:00 2023 -0600
 1 file changed, 1 insertion(+), 1 deletion(-)
[hotfix-cdt-cloudv2 c6a5b4f24a] rptest: Cloud install_pack_version hotfix
 Author: Alex Savatieiev <a.savex@gmail.com>
 Date: Mon Nov 6 16:12:53 2023 -0600
 1 file changed, 2 insertions(+)
[hotfix-cdt-cloudv2 396480a6b7] ci: Fix deletion of FMC clouds
 Author: Alex Savatieiev <a.savex@gmail.com>
 Date: Mon Nov 6 17:24:45 2023 -0600
 1 file changed, 11 insertions(+), 9 deletions(-)
[hotfix-cdt-cloudv2 e623900da9] rptest: Updates on cluster creation status flow
 Author: Alex Savatieiev <a.savex@gmail.com>
 Date: Mon Nov 6 18:46:13 2023 -0600
 1 file changed, 9 insertions(+), 1 deletion(-)
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
