### PR TITLE
transform/processor: lag metrics

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_transform.go
+++ b/src/go/rpk/pkg/adminapi/api_transform.go
@@ -44,6 +44,7 @@ type PartitionTransformStatus struct {
 	Partition int `json:"partition"`
 	// Status is an enum of: ["running", "inactive", "errored", "unknown"].
 	Status string `json:"status"`
+	Lag    int    `json:"lag"`
 }
 
 // EnvironmentVariable is a configuration key/value that can be injected into to a data transform.

--- a/src/go/rpk/pkg/cli/transform/list_test.go
+++ b/src/go/rpk/pkg/cli/transform/list_test.go
@@ -27,16 +27,19 @@ func setupTestData() []adminapi.TransformMetadata {
 					NodeID:    0,
 					Partition: 1,
 					Status:    "running",
+					Lag:       1,
 				},
 				{
 					NodeID:    0,
 					Partition: 2,
 					Status:    "running",
+					Lag:       1,
 				},
 				{
 					NodeID:    1,
 					Partition: 3,
 					Status:    "inactive",
+					Lag:       5,
 				},
 			},
 		},
@@ -52,6 +55,7 @@ func setupTestData() []adminapi.TransformMetadata {
 					NodeID:    0,
 					Partition: 1,
 					Status:    "errored",
+					Lag:       99,
 				},
 			},
 		},
@@ -91,9 +95,9 @@ func TestPrintSummaryView(t *testing.T) {
 	s := summarizedView(setupTestData())
 	cases := []testCase{
 		Text(`
-NAME      INPUT TOPIC  OUTPUT TOPIC     RUNNING
-foo2bar   foo          bar              2 / 3
-scrubber  pii          cleaned, munged  0 / 1
+NAME      INPUT TOPIC  OUTPUT TOPIC     RUNNING  LAG
+foo2bar   foo          bar              2 / 3    7
+scrubber  pii          cleaned, munged  0 / 1    99
 `),
 		JSON(t, s),
 		YAML(t, s),
@@ -111,14 +115,14 @@ func TestPrintDetailView(t *testing.T) {
 	cases := []testCase{
 		Text(`
 foo2bar, foo → bar
-      PARTITION  NODE  STATUS
-      1          0     running
-      2          0     running
-      3          1     inactive
+      PARTITION  NODE  STATUS    LAG
+      1          0     running   1
+      2          0     running   1
+      3          1     inactive  5
 
 scrubber, pii → cleaned, munged
-      PARTITION  NODE  STATUS
-      1          0     errored
+      PARTITION  NODE  STATUS   LAG
+      1          0     errored  99
 `),
 		JSON(t, d),
 		YAML(t, d),

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -94,7 +94,13 @@ operator<<(std::ostream& os, const transform_offsets_value& value) {
 
 std::ostream&
 operator<<(std::ostream& os, const transform_report::processor& p) {
-    fmt::print(os, "{{id: {}, status: {}, node: {}}}", p.id, p.status, p.node);
+    fmt::print(
+      os,
+      "{{id: {}, status: {}, node: {}, lag: {}}}",
+      p.id,
+      p.status,
+      p.node,
+      p.lag);
     return os;
 }
 

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -135,11 +135,12 @@ struct transform_report
         model::partition_id id;
         state status;
         model::node_id node;
+        int64_t lag;
         friend bool operator==(const processor&, const processor&) = default;
 
         friend std::ostream& operator<<(std::ostream&, const processor&);
 
-        auto serde_fields() { return std::tie(id, status, node); }
+        auto serde_fields() { return std::tie(id, status, node, lag); }
     };
 
     transform_report() = default;

--- a/src/v/redpanda/admin/api-doc/transform.json
+++ b/src/v/redpanda/admin/api-doc/transform.json
@@ -130,6 +130,10 @@
           "type": "int",
           "description": "partition in the input topic"
         },
+        "lag": {
+          "type": "int",
+          "description": "number of records to be processed"
+        },
         "status": {
           "type": "string",
           "enum": [

--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -6357,6 +6357,7 @@ admin_server::list_transforms(std::unique_ptr<ss::http::request>) {
               s.partition = processor.id();
               s.node_id = processor.node();
               s.status = convert_transform_status(processor.status);
+              s.lag = processor.lag;
               meta.status.push(s);
           }
           return meta;

--- a/src/v/transform/probe.cc
+++ b/src/v/transform/probe.cc
@@ -44,6 +44,14 @@ void probe::setup_metrics(ss::sstring transform_name) {
         .aggregate({sm::shard_label}));
     metric_defs.emplace_back(
       sm::make_counter(
+        "processor_lag",
+        [this] { return _lag; },
+        sm::description("The pending available on the input topic that have "
+                        "yet to be processed"),
+        labels)
+        .aggregate({sm::shard_label}));
+    metric_defs.emplace_back(
+      sm::make_counter(
         "processor_failures",
         [this] { return _failures; },
         sm::description(
@@ -80,4 +88,6 @@ void probe::state_change(processor_state_change change) {
         _processor_state[*change.to] += 1;
     }
 }
+void probe::report_lag(int64_t delta) { _lag += delta; }
+
 } // namespace transform

--- a/src/v/transform/probe.h
+++ b/src/v/transform/probe.h
@@ -33,11 +33,13 @@ public:
     void increment_write_bytes(uint64_t bytes);
     void increment_failure();
     void state_change(processor_state_change);
+    void report_lag(int64_t delta);
 
 private:
     uint64_t _read_bytes = 0;
     uint64_t _write_bytes = 0;
     uint64_t _failures = 0;
+    uint64_t _lag = 0;
     absl::flat_hash_map<model::transform_report::processor::state, uint64_t>
       _processor_state;
 };

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -463,6 +463,7 @@ model::cluster_transform_report manager<ClockType>::compute_report() const {
             .id = id,
             .status = entry.current_state(),
             .node = _self,
+            .lag = p->current_lag(),
           });
     }
     return report;

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -247,4 +247,5 @@ model::transform_id processor::id() const { return _id; }
 const model::ntp& processor::ntp() const { return _ntp; }
 const model::transform_metadata& processor::meta() const { return _meta; }
 bool processor::is_running() const { return !_task.available(); }
+int64_t processor::current_lag() const { return _last_reported_lag; }
 } // namespace transform

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -14,6 +14,7 @@
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "model/timeout_clock.h"
+#include "prometheus/prometheus_sanitize.h"
 #include "random/simple_time_jitter.h"
 #include "transform/logger.h"
 #include "units.h"
@@ -150,6 +151,8 @@ ss::future<> processor::stop() {
     co_await _source->stop();
     co_await _offset_tracker->stop();
     co_await _engine->stop();
+    // reset lag now that we've stopped
+    report_lag(0);
 }
 
 ss::future<> processor::poll_sleep() {
@@ -166,10 +169,12 @@ ss::future<> processor::poll_sleep() {
 ss::future<kafka::offset> processor::load_start_offset() {
     co_await _offset_tracker->wait_for_previous_flushes(&_as);
     auto latest_committed = co_await _offset_tracker->load_committed_offset();
-    if (latest_committed) {
-        co_return kafka::next_offset(latest_committed.value());
-    }
     auto latest = _source->latest_offset();
+    if (latest_committed) {
+        auto start_offset = kafka::next_offset(latest_committed.value());
+        report_lag(latest - start_offset);
+        co_return start_offset;
+    }
     // We "commit" at the previous offset so that we resume at the latest.
     co_await _offset_tracker->commit_offset(kafka::prev_offset(latest));
     co_return latest;
@@ -211,6 +216,7 @@ ss::future<> processor::run_producer_loop() {
         auto drained = co_await drain_queue(&_transform_producer_pipe, _probe);
         co_await _sinks[0]->write(std::move(drained.batches));
         co_await _offset_tracker->commit_offset(drained.latest_offset);
+        report_lag(_source->latest_offset() - drained.latest_offset);
     }
 }
 
@@ -229,6 +235,12 @@ ss::future<> processor::handle_run_loop(ss::future<> fut) {
         vlog(_logger.warn, "error running transform: {}", ex);
         _error_callback(_id, _ntp, _meta);
     }
+}
+
+void processor::report_lag(int64_t lag) {
+    int64_t delta = lag - _last_reported_lag;
+    _probe->report_lag(delta);
+    _last_reported_lag = lag;
 }
 
 model::transform_id processor::id() const { return _id; }

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -70,6 +70,7 @@ public:
     model::transform_id id() const;
     const model::ntp& ntp() const;
     const model::transform_metadata& meta() const;
+    int64_t current_lag() const;
 
 private:
     ss::future<> run_consumer_loop();

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "metrics/metrics.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_reader.h"
@@ -76,6 +77,7 @@ private:
     ss::future<> run_producer_loop();
     ss::future<> poll_sleep();
     ss::future<kafka::offset> load_start_offset();
+    void report_lag(int64_t);
 
     template<typename... Future>
     ss::future<> when_all_shutdown(Future&&...);
@@ -97,5 +99,7 @@ private:
     ss::abort_source _as;
     ss::future<> _task;
     prefix_logger _logger;
+
+    int64_t _last_reported_lag = 0;
 };
 } // namespace transform

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -128,6 +128,7 @@ class RpkWasmListProcessorResponse(typing.NamedTuple):
     partition: int
     # running | inactive | errored | unknown
     status: str
+    lag: int
 
 
 class RpkWasmListResponse(typing.NamedTuple):
@@ -1584,6 +1585,7 @@ class RpkTool:
                 node_id=loaded["node_id"],
                 partition=loaded["partition"],
                 status=loaded["status"],
+                lag=loaded["lag"],
             )
 
         def transform_from_json(loaded):


### PR DESCRIPTION
Create metrics for how far behind transforms are. This is important to
know if a user needs to scale up or improve the performance of their
transforms.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
