### PR TITLE
rpk: support topic name strategy in `rpk topic produce`

### DIFF
--- a/src/go/rpk/pkg/cli/topic/produce.go
+++ b/src/go/rpk/pkg/cli/topic/produce.go
@@ -16,6 +16,8 @@ import (
 	"io"
 	"os"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -44,10 +46,10 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		tombstone              bool
 		allowAutoTopicCreation bool
 
-		schemaID    int
-		keySchemaID int
-		protoFQN    string
-		protoKeyFQN string
+		schemaIDFlag    string
+		keySchemaIDFLag string
+		protoFQN        string
+		protoKeyFQN     string
 
 		timeout time.Duration
 	)
@@ -116,7 +118,12 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				out.Die("invalid empty format")
 			}
 
-			isSchemaRegistry := schemaID >= 0 || keySchemaID >= 0
+			keySchemaID, isKeyTopicName, err := parseSchemaIDFlag(keySchemaIDFLag)
+			out.MaybeDie(err, "unable to parse '--schema-key-id' flag: %v", err)
+			schemaID, isValTopicName, err := parseSchemaIDFlag(keySchemaIDFLag)
+			out.MaybeDie(err, "unable to parse '--schema-id' flag: %v", err)
+
+			isSchemaRegistry := isKeyTopicName || isValTopicName || keySchemaID >= 0 || schemaID >= 0
 			// If the user is using schema registry, we want to use the json
 			// format: %v{json} and %k{json}.
 			if isSchemaRegistry {
@@ -151,7 +158,7 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			defer cl.Close()
 			defer cl.Flush(context.Background())
 
-			var keySerde, valSerde *serde.Serde
+			var defaultKeySerde, defaultValSerde *serde.Serde
 			var srCl *sr.Client
 			if isSchemaRegistry {
 				srCl, err = schemaregistry.NewClient(fs, p)
@@ -161,14 +168,18 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				out.MaybeDie(err, "unable to query schemas from the registry: %v", err)
 
 				if keySchema != nil {
-					keySerde, err = serde.NewSerde(cmd.Context(), srCl, keySchema, keySchemaID, protoKeyFQN)
+					defaultKeySerde, err = serde.NewSerde(cmd.Context(), srCl, keySchema, keySchemaID, protoKeyFQN)
 					out.MaybeDie(err, "unable to build serializer for the key schema: %v", err)
 				}
 				if valSchema != nil {
-					valSerde, err = serde.NewSerde(cmd.Context(), srCl, valSchema, schemaID, protoFQN)
+					defaultValSerde, err = serde.NewSerde(cmd.Context(), srCl, valSchema, schemaID, protoFQN)
 					out.MaybeDie(err, "unable to build serializer for the value schema: %v", err)
 				}
 			}
+
+			// This is just the cache for TopicName strategy
+			// [topicName-key|value]:serde.
+			serdeCache := make(map[string]*serde.Serde)
 			for {
 				r := &kgo.Record{
 					Partition: partition,
@@ -186,15 +197,35 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				if r.Topic == "" && defaultTopic == "" {
 					out.Die("topic to produce to is missing, check --help for produce syntax")
 				}
+				topicName := defaultTopic
+				if topicName == "" {
+					topicName = r.Topic
+				}
 				if tombstone && len(r.Value) == 0 {
 					r.Value = nil
 				}
-				if keySerde != nil {
+				if defaultKeySerde != nil || isKeyTopicName {
+					keySerde := defaultKeySerde
+					if isKeyTopicName && keySerde == nil {
+						keySerde, err = serdeFromTopicName(cmd.Context(), srCl, topicName, "key", protoKeyFQN, serdeCache)
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "unable to build key serializer using TopicNameStrategy for topic %q: %v\n", topicName, err)
+							return
+						}
+					}
 					record, err := keySerde.EncodeRecord(r.Key)
 					out.MaybeDie(err, "unable to encode key: %v", err)
 					r.Key = record
 				}
-				if valSerde != nil {
+				if defaultValSerde != nil || isValTopicName {
+					valSerde := defaultValSerde
+					if isValTopicName && valSerde == nil {
+						valSerde, err = serdeFromTopicName(cmd.Context(), srCl, topicName, "value", protoFQN, serdeCache)
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "unable to build value serializer using TopicNameStrategy for topic %q: %v\n", topicName, err)
+							return
+						}
+					}
 					record, err := valSerde.EncodeRecord(r.Value)
 					out.MaybeDie(err, "unable to encode value: %v", err)
 					r.Value = record
@@ -223,8 +254,8 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.Flags().StringVarP(&key, "key", "k", "", "A fixed key to use for each record (parsed input keys take precedence)")
 	cmd.Flags().BoolVarP(&tombstone, "tombstone", "Z", false, "Produce empty values as tombstones")
 	cmd.Flags().BoolVar(&allowAutoTopicCreation, "allow-auto-topic-creation", false, "Auto-create non-existent topics; requires auto_create_topics_enabled on the broker")
-	cmd.Flags().IntVar(&schemaID, "schema-id", -1, "Schema ID to encode the record value with")
-	cmd.Flags().IntVar(&keySchemaID, "schema-key-id", -1, "Schema ID to encode the record key with")
+	cmd.Flags().StringVar(&schemaIDFlag, "schema-id", "", "Schema ID to encode the record value with, use 'topic' for TopicName strategy")
+	cmd.Flags().StringVar(&keySchemaIDFLag, "schema-key-id", "", "Schema ID to encode the record key with, use 'topic' for TopicName strategy")
 	cmd.Flags().StringVar(&protoFQN, "proto-msg-type", "", "Name of the protobuf message type to be used to encode the record value using schema registry")
 	cmd.Flags().StringVar(&protoKeyFQN, "proto-key-msg-type", "", "Name of the protobuf message type to be used to encode the record key using schema registry")
 
@@ -255,6 +286,42 @@ func querySchemas(ctx context.Context, cl *sr.Client, keySchemaID, valSchemaID i
 		valSchema = &vSch
 	}
 	return
+}
+
+func parseSchemaIDFlag(flag string) (int, bool, error) {
+	if flag == "" {
+		return -1, false, nil
+	}
+	if strings.ToLower(flag) == "topic" {
+		return -1, true, nil
+	}
+	parsed, err := strconv.Atoi(flag)
+	if err != nil {
+		return -1, false, fmt.Errorf("unable to parse %q: %v; use either a number or 'topic'", flag, err)
+	}
+	return parsed, false, nil
+}
+
+// serdeFromTopicName returns a new serde.Serde based on the topicName strategy.
+// First, it searches if the serde is cached, if not, it will query the latest
+// schema with subject name: <topic>-<suffix> and cache the result.
+func serdeFromTopicName(ctx context.Context, cl *sr.Client, topic, suffix, protoFQN string, serdeCache map[string]*serde.Serde) (*serde.Serde, error) {
+	var newSerde *serde.Serde
+	schSubjectName := topic + "-" + suffix
+	if s, ok := serdeCache[schSubjectName]; ok {
+		newSerde = s
+	} else {
+		schema, err := cl.SchemaByVersion(ctx, schSubjectName, -1)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get schema with name %q using TopicName strategy: %v", schSubjectName, err)
+		}
+		newSerde, err = serde.NewSerde(ctx, cl, &schema.Schema, schema.ID, protoFQN)
+		if err != nil {
+			return nil, fmt.Errorf("unable to build serializer for the schema: %v", err)
+		}
+		serdeCache[schSubjectName] = newSerde
+	}
+	return newSerde, nil
 }
 
 const helpProduce = `Produce records to a topic.
@@ -349,6 +416,24 @@ the following will read three headers that begin and end with a space and are
 separated by an equal:
 
     %H{3}%h{ %k=%v }
+
+SCHEMA-REGISTRY
+
+Records can be encoded using a specified schema from our schema registry. Use
+the '--schema-id' or '--schema-key-id' flags to define the schema ID, rpk will
+retrieve the schemas and encode the record accordingly.
+
+Additionally, utilizing 'topic' in the mentioned flags allows for the use of the
+Topic Name Strategy. This strategy identifies a schema subject name based on the
+topic itself. For example:
+
+Produce to 'foo', encode using the latest schema in the subject 'foo-value':
+    rpk topic produce foo --schema-id=topic
+
+For protobuf schemas, you can specify the fully qualified name of the message
+you want the record to be encoded with. Use the 'proto-msg-type' flag or
+'proto-key-msg-type'. If the schema contains only one message, specifying the
+message name is unnecessary.
 
 EXAMPLES
 

--- a/src/go/rpk/pkg/cli/topic/produce.go
+++ b/src/go/rpk/pkg/cli/topic/produce.go
@@ -120,7 +120,7 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 			keySchemaID, isKeyTopicName, err := parseSchemaIDFlag(keySchemaIDFLag)
 			out.MaybeDie(err, "unable to parse '--schema-key-id' flag: %v", err)
-			schemaID, isValTopicName, err := parseSchemaIDFlag(keySchemaIDFLag)
+			schemaID, isValTopicName, err := parseSchemaIDFlag(schemaIDFlag)
 			out.MaybeDie(err, "unable to parse '--schema-id' flag: %v", err)
 
 			isSchemaRegistry := isKeyTopicName || isValTopicName || keySchemaID >= 0 || schemaID >= 0
@@ -256,8 +256,8 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd.Flags().BoolVar(&allowAutoTopicCreation, "allow-auto-topic-creation", false, "Auto-create non-existent topics; requires auto_create_topics_enabled on the broker")
 	cmd.Flags().StringVar(&schemaIDFlag, "schema-id", "", "Schema ID to encode the record value with, use 'topic' for TopicName strategy")
 	cmd.Flags().StringVar(&keySchemaIDFLag, "schema-key-id", "", "Schema ID to encode the record key with, use 'topic' for TopicName strategy")
-	cmd.Flags().StringVar(&protoFQN, "proto-msg-type", "", "Name of the protobuf message type to be used to encode the record value using schema registry")
-	cmd.Flags().StringVar(&protoKeyFQN, "proto-key-msg-type", "", "Name of the protobuf message type to be used to encode the record key using schema registry")
+	cmd.Flags().StringVar(&protoFQN, "schema-type", "", "Name of the protobuf message type to be used to encode the record value using schema registry")
+	cmd.Flags().StringVar(&protoKeyFQN, "schema-key-type", "", "Name of the protobuf message type to be used to encode the record key using schema registry")
 
 	// Deprecated
 	cmd.Flags().IntVarP(new(int), "num", "n", 1, "")
@@ -431,9 +431,12 @@ Produce to 'foo', encode using the latest schema in the subject 'foo-value':
     rpk topic produce foo --schema-id=topic
 
 For protobuf schemas, you can specify the fully qualified name of the message
-you want the record to be encoded with. Use the 'proto-msg-type' flag or
-'proto-key-msg-type'. If the schema contains only one message, specifying the
-message name is unnecessary.
+you want the record to be encoded with. Use the 'schema-type' flag or
+'schema-key-type'. If the schema contains only one message, specifying the
+message name is unnecessary. For example:
+
+Produce to 'foo', using schema ID 1, message FQN Person.Name
+    rpk topic produce foo --schema-id 1 --schema-type Person.Name
 
 EXAMPLES
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -471,10 +471,10 @@ class RpkTool:
             cmd += ["--schema-key-id", f'{schema_key_id}']
             use_schema_registry = True
         if proto_msg is not None:
-            cmd += ["--proto-msg-type", proto_msg]
+            cmd += ["--schema-type", proto_msg]
             use_schema_registry = True
         if proto_key_msg is not None:
-            cmd += ["--proto-key-msg-type", proto_key_msg]
+            cmd += ["--schema-key-type", proto_key_msg]
             use_schema_registry = True
 
         # Run remote process with a slightly higher timeout than the


### PR DESCRIPTION
Fxes #13874 

This change allows the user to follow the topicNameStrategy when producing to a topic using `rpk topic produce`. The idea is to pass a value of 'topic' to either schema-ID flag:

**Example:**

Full flow:
```
$ cat ~/code/tmp/sample.proto
syntax = "proto3";

package foo.bar;

message Person {
  string name = 1;
  int32 id = 2;  // Unique ID number for this person.
  string email = 3;

  enum PhoneType {
    PHONE_TYPE_UNSPECIFIED = 0;
    PHONE_TYPE_MOBILE = 1;
    PHONE_TYPE_HOME = 2;
    PHONE_TYPE_WORK = 3;
  }

  message PhoneNumber {
    string number = 1;
    PhoneType type = 2;
  }

  repeated PhoneNumber phones = 4;
}

message AddressBook {
  repeated Person people = 1;
}

$ rpk registry schema create test-value --schema ~/code/tmp/sample.proto
SUBJECT     VERSION  ID    TYPE
test-value  1        10    PROTOBUF

# Please note that no schema ID is provided, just 'topic'.
$ echo '{"number":"+12341234","type":1}' | rpk topic produce test --schema-id topic --schema-type foo.bar.Person.PhoneNumber 
Produced to partition 0 at offset 104 with timestamp 1699388037087.

# Without decoding
$ rpk topic consume test -o 104:105
{
  "topic": "test",
  "value": "\u0000\u0000\u0000\u0000\n\u0004\u0000\u0000\u0010\u0001\n\t+12341234",
  "timestamp": 1699388037087,
  "partition": 0,
  "offset": 104
}

# Decoding the message
$ rpk topic consume test -o 104:105 --use-schema-registry 
{
  "topic": "test",
  "value": "{\"number\":\"+12341234\",\"type\":\"PHONE_TYPE_MOBILE\"}",
  "timestamp": 1699388037087,
  "partition": 0,
  "offset": 104
}
```

We are also renaming these flags to a more generic name:
- `proto-msg-type` -> `schema-type`
- `proto-key-msg-type` -> `schema-key-type`


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

This is an unreleased feature, release notes are in the original PR for decoding and encoding respectively.

## Release Notes


* none
