### PR TITLE
User friendly errors on cluster creation and initial cluster check to fail fast on resource limitations

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -256,7 +256,19 @@ class HighThroughputTest(PreallocNodesTest):
             self.redpanda._cloud_cluster.config.install_pack_auth_type,
             self.redpanda._cloud_cluster.config.install_pack_auth)
         install_pack_version = self.redpanda._cloud_cluster.config.install_pack_ver
+
+        # Load install pack and check profile
         install_pack = install_pack_client.getInstallPack(install_pack_version)
+        self.logger.info(f"Loaded install pack '{install_pack['version']}': "
+                         f"Redpanda v{install_pack['redpanda_version']}, "
+                         f"created at '{install_pack['created_at']}'")
+        if self.config_profile_name not in install_pack['config_profiles']:
+            # throw user friendly error
+            _profiles = ", ".join(
+                [f"'{k}'" for k in install_pack['config_profiles']])
+            raise RuntimeError(
+                f"'{self.config_profile_name}' not found among config profiles: {_profiles}"
+            )
         config_profile = install_pack['config_profiles'][
             self.config_profile_name]
         cluster_config = config_profile['cluster_config']


### PR DESCRIPTION
When there is not enough instances of needed type on provider side, initial cluster creation struggles to even add cluster to CloudV2 API listing. To eliminate 1h wait, fail after 2 min if initial cluster spec not created

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none