### PR TITLE
cloud_storage: Add client address to fetch and log reader config

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -237,7 +237,16 @@ public:
                 _reader = {};
             }
         }
+
+        vlog(
+          _ctxlog.trace,
+          "partition_record_batch_reader_impl:: start: creating cursor: {}",
+          config);
         co_await init_cursor(config);
+        vlog(
+          _ctxlog.trace,
+          "partition_record_batch_reader_impl:: start: created cursor: {}",
+          config);
         _partition->_ts_probe.reader_created();
     }
 
@@ -306,7 +315,10 @@ public:
                 co_return storage_t{};
             }
             if (_reader->config().over_budget) {
-                vlog(_ctxlog.debug, "We're over-budget, stopping");
+                vlog(
+                  _ctxlog.debug,
+                  "We're over-budget, stopping, config: {}",
+                  _reader->config());
                 // We need to stop in such way that will keep the
                 // reader in the reusable state, so we could reuse
                 // it on next iteration
@@ -557,7 +569,9 @@ private:
       segment_reader_units segment_reader_unit) {
         vlog(
           _ctxlog.debug,
-          "partition_record_batch_reader_impl initialize reader state");
+          "partition_record_batch_reader_impl initialize reader state, config: "
+          "{}",
+          config);
         auto [reader, next_offset] = find_cached_reader(
           manifest,
           config,
@@ -572,7 +586,8 @@ private:
           _ctxlog.debug,
           "partition_record_batch_reader_impl initialize reader state - "
           "segment not "
-          "found");
+          "found, config: {}",
+          config);
         _reader = {};
         _next_segment_base_offset = {};
     }
@@ -1086,7 +1101,8 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
     std::ignore = deadline;
     vlog(
       _ctxlog.debug,
-      "remote partition make_reader invoked, config: {}, num segments {}",
+      "remote partition make_reader invoked (waiting for units), config: {}, "
+      "num segments {}",
       config,
       _segments.size());
 
@@ -1094,6 +1110,14 @@ ss::future<storage::translating_reader> remote_partition::make_reader(
       config.abort_source);
     auto ot_state = ss::make_lw_shared<storage::offset_translator_state>(
       get_ntp());
+
+    vlog(
+      _ctxlog.trace,
+      "remote partition make_reader invoked (units acquired), config: {}, "
+      "num segments {}",
+      config,
+      _segments.size());
+
     auto impl = std::make_unique<partition_record_batch_reader_impl>(
       shared_from_this(), ot_state, std::move(units));
     co_await impl->start(config);
@@ -1120,7 +1144,8 @@ remote_partition::timequery(storage::timequery_config cfg) {
       cfg.prio,
       cfg.type_filter,
       cfg.time,
-      cfg.abort_source);
+      cfg.abort_source,
+      cfg.client_address);
 
     // Construct a reader that will skip to the requested timestamp
     // by virtue of log_reader_config::start_timestamp

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -172,11 +172,12 @@ struct fetch_config {
     std::optional<model::rack_id> consumer_rack_id;
     std::optional<std::reference_wrapper<ssx::sharded_abort_source>>
       abort_source;
+    std::optional<model::client_address_t> client_address;
 
     friend std::ostream& operator<<(std::ostream& o, const fetch_config& cfg) {
         fmt::print(
           o,
-          R"({{"start_offset": {}, "max_offset": {}, "isolation_lvl": {}, "max_bytes": {}, "strict_max_bytes": {}, "skip_read": {}, "current_leader_epoch:" {}, "follower_read:" {}, "consumer_rack_id": {}, "abortable": {}, "aborted": {}}})",
+          R"({{"start_offset": {}, "max_offset": {}, "isolation_lvl": {}, "max_bytes": {}, "strict_max_bytes": {}, "skip_read": {}, "current_leader_epoch:" {}, "follower_read:" {}, "consumer_rack_id": {}, "abortable": {}, "aborted": {}, "client_address": {}}})",
           cfg.start_offset,
           cfg.max_offset,
           cfg.isolation_level,
@@ -189,7 +190,8 @@ struct fetch_config {
           cfg.abort_source.has_value(),
           cfg.abort_source.has_value()
             ? cfg.abort_source.value().get().abort_requested()
-            : false);
+            : false,
+          cfg.client_address.value_or(model::client_address_t{"unknown"}));
         return o;
     }
 };

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -422,6 +422,8 @@ static_assert(
 
 std::ostream& operator<<(std::ostream&, const shadow_indexing_mode&);
 
+using client_address_t = named_type<ss::sstring, struct client_address_tag>;
+
 } // namespace model
 
 namespace kafka {

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -174,6 +174,7 @@ ss::future<> server::apply_proto(
         [this, conn, cq_units = std::move(cq_units)](ss::future<> f) {
             print_exceptional_future(
               std::move(f), "applying protocol", conn->addr);
+            vlog(_log.trace, "shutting down connection {}", conn->addr);
             return conn->shutdown().then_wrapped(
               [this, addr = conn->addr](ss::future<> f) {
                   print_exceptional_future(std::move(f), "shutting down", addr);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -67,6 +67,10 @@ std::ostream& operator<<(std::ostream& o, const log_reader_config& cfg) {
       << (cfg.abort_source.has_value()
             ? cfg.abort_source.value().get().abort_requested()
             : false);
+
+    if (cfg.client_address.has_value()) {
+        o << ", client_address:" << cfg.client_address.value();
+    }
     return o << "}";
 }
 

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -222,23 +222,28 @@ struct append_result {
 using opt_abort_source_t
   = std::optional<std::reference_wrapper<ss::abort_source>>;
 
+using opt_client_address_t = std::optional<model::client_address_t>;
+
 struct timequery_config {
     timequery_config(
       model::timestamp t,
       model::offset o,
       ss::io_priority_class iop,
       std::optional<model::record_batch_type> type_filter,
-      opt_abort_source_t as = std::nullopt) noexcept
+      opt_abort_source_t as = std::nullopt,
+      opt_client_address_t client_addr = std::nullopt) noexcept
       : time(t)
       , max_offset(o)
       , prio(iop)
       , type_filter(type_filter)
-      , abort_source(as) {}
+      , abort_source(as)
+      , client_address(std::move(client_addr)) {}
     model::timestamp time;
     model::offset max_offset;
     ss::io_priority_class prio;
     std::optional<model::record_batch_type> type_filter;
     opt_abort_source_t abort_source;
+    opt_client_address_t client_address;
 
     friend std::ostream& operator<<(std::ostream& o, const timequery_config&);
 };
@@ -326,6 +331,8 @@ struct log_reader_config {
     // historical read-once workloads like compaction).
     bool skip_batch_cache{false};
 
+    opt_client_address_t client_address;
+
     log_reader_config(
       model::offset start_offset,
       model::offset max_offset,
@@ -334,7 +341,8 @@ struct log_reader_config {
       ss::io_priority_class prio,
       std::optional<model::record_batch_type> type_filter,
       std::optional<model::timestamp> time,
-      opt_abort_source_t as)
+      opt_abort_source_t as,
+      opt_client_address_t client_addr = std::nullopt)
       : start_offset(start_offset)
       , max_offset(max_offset)
       , min_bytes(min_bytes)
@@ -342,7 +350,8 @@ struct log_reader_config {
       , prio(prio)
       , type_filter(type_filter)
       , first_timestamp(time)
-      , abort_source(as) {}
+      , abort_source(as)
+      , client_address(std::move(client_addr)) {}
 
     /**
      * Read offsets [start, end].
@@ -351,7 +360,8 @@ struct log_reader_config {
       model::offset start_offset,
       model::offset max_offset,
       ss::io_priority_class prio,
-      opt_abort_source_t as = std::nullopt)
+      opt_abort_source_t as = std::nullopt,
+      opt_client_address_t client_addr = std::nullopt)
       : log_reader_config(
         start_offset,
         max_offset,
@@ -360,7 +370,8 @@ struct log_reader_config {
         prio,
         std::nullopt,
         std::nullopt,
-        as) {}
+        as,
+        std::move(client_addr)) {}
 
     friend std::ostream& operator<<(std::ostream& o, const log_reader_config&);
 };


### PR DESCRIPTION
The tiered storage read path has several points where a kafka connection has to block for resources such as semaphore units, downloads, copying files around etc. The reader config which links the kafka API to tiered storage read path only shares log offsets, which makes it hard to identify which specific connection may be blocked for resources in the read path.

In this changeset the client address is added to the kafka fetch config and the log reader config, and the address is then used in the read path to log when waiting for resources at trace level. This makes it somwhat easier to identify in logs as to which connections are stuck.

The client address is optional.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
