### PR TITLE
fixed rendering transaction status

### DIFF
--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1877,7 +1877,7 @@ list_transactions_handler::handle(request_context ctx, ss::smp_service_group) {
                 list_transaction_state tx_state;
                 tx_state.transactional_id = tx.id;
                 tx_state.producer_id = kafka::producer_id(tx.pid.id);
-                tx_state.transaction_state = ss::sstring(tx.get_status());
+                tx_state.transaction_state = ss::sstring(tx.get_kafka_status());
                 response.data.transaction_states.push_back(std::move(tx_state));
             }
         }

--- a/tests/rptest/tests/transaction_kafka_api_test.py
+++ b/tests/rptest/tests/transaction_kafka_api_test.py
@@ -167,7 +167,10 @@ class TxKafkaApiTest(RedpandaTest):
 
         txs_info = self.kafka_cli.list_transactions()
         assert len(txs_info) > 0
-        for tx in txs_info:
-            tx_info = self.kafka_cli.describe_transaction(
-                tx["TransactionalId"])
-            assert int(tx_info["ProducerId"]) == int(tx["ProducerId"])
+        for tx_from_list in txs_info:
+            tx_from_describe = self.kafka_cli.describe_transaction(
+                tx_from_list["TransactionalId"])
+
+            for f in ["TransactionalId", "TransactionState", "ProducerId"]:
+                assert tx_from_describe[f] == tx_from_list[f]
+            assert tx_from_list["TransactionState"] != "Unknown"


### PR DESCRIPTION
Previously the status was rendered directly as a string representation
of Redpanda internal status. Changed it to Kafka used status strings.

All the credits goes to @bharathv as he found this issue

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

- Fixed transaction status being incorrectly reported when listing transactions via Kafka API
