### PR TITLE
net: GNUTLS_E_DECRYPTION_FAILED is_reconnect_error

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -38,6 +38,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case GNUTLS_E_UNSUPPORTED_VERSION_PACKET:
         case GNUTLS_E_NO_CIPHER_SUITES:
         case GNUTLS_E_PREMATURE_TERMINATION:
+        case GNUTLS_E_DECRYPTION_FAILED:
             return true;
         default:
             return false;

--- a/tests/rptest/tests/rpk_registry_test.py
+++ b/tests/rptest/tests/rpk_registry_test.py
@@ -284,7 +284,6 @@ class RpkRegistryTest(RedpandaTest):
         assert len(out) == 0
         assert len(out_deleted) == 0
 
-    @ok_to_fail
     @cluster(num_nodes=3)
     def test_produce_consume_avro(self):
         # First we register the schemas with their references.
@@ -349,7 +348,6 @@ class RpkRegistryTest(RedpandaTest):
         assert json.loads(msg["value"]) == expected_msg_1
         assert json.loads(msg["key"]) == expected_msg_2
 
-    @ok_to_fail
     @cluster(num_nodes=3)
     def test_produce_consume_proto(self):
         # First we register the schemas with their references.


### PR DESCRIPTION
Add `GNUTLS_E_DECRYPTION_FAILED` to `is_reconnect_error`.

This error has been seen at the end of consume with rpk.

Fixes https://github.com/redpanda-data/redpanda/issues/14619

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Improvements

* Redpanda: Lower the log level if `GNUTLS_E_DECRYPTION_FAILED` is encountered.

