### PR TITLE
features: retire serde controller commands feature

### DIFF
--- a/src/v/cluster/config_frontend.cc
+++ b/src/v/cluster/config_frontend.cc
@@ -100,7 +100,7 @@ ss::future<config_frontend::patch_result> config_frontend::do_patch(
           clusterlog.trace,
           "patch: writing delta with version {}",
           projected_version);
-        return replicate_and_wait(_stm, _features, _as, std::move(cmd), timeout)
+        return replicate_and_wait(_stm, _as, std::move(cmd), timeout)
           .then([projected_version](std::error_code errc) {
               return patch_result{.errc = errc, .version = projected_version};
           });
@@ -123,8 +123,7 @@ ss::future<std::error_code> config_frontend::set_status(
     auto data = cluster_config_status_cmd_data();
     data.status = status;
     auto cmd = cluster_config_status_cmd(status.node, data);
-    co_return co_await replicate_and_wait(
-      _stm, _features, _as, std::move(cmd), timeout);
+    co_return co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
 }
 
 /**

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -715,15 +715,11 @@ controller::create_cluster(const bootstrap_cluster_cmd_data cmd_data) {
         }
 
         vlog(clusterlog.info, "Creating cluster UUID {}", cmd_data.uuid);
-        model::record_batch b = serde_serialize_cmd(
-          bootstrap_cluster_cmd{0, cmd_data});
-        // cluster::replicate_and_wait() cannot be used here because it checks
-        // for serde_raft_0 feature to be enabled. Before a cluster is here,
-        // no feature is active, however the bootstrap_cluster_cmd is serde-only
-        const std::error_code errc = co_await _stm.local().replicate_and_wait(
-          std::move(b),
+        const std::error_code errc = co_await replicate_and_wait(
+          _stm,
+          _as,
+          bootstrap_cluster_cmd{0, cmd_data},
           model::timeout_clock::now() + 30s,
-          _as.local(),
           std::nullopt);
         if (errc == errc::success) {
             vlog(clusterlog.info, "Cluster UUID created {}", cmd_data.uuid);

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -328,8 +328,7 @@ feature_manager::replicate_feature_update_cmd(feature_update_cmd_data data) {
     );
 
     auto timeout = model::timeout_clock::now() + status_retry;
-    auto err = co_await replicate_and_wait(
-      _stm, _feature_table, _as, std::move(cmd), timeout);
+    auto err = co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
     if (err == errc::not_leader) {
         // Harmless, we lost leadership so the new controller
         // leader is responsible for picking up where we left off.
@@ -527,8 +526,7 @@ feature_manager::update_license(security::license&& license) {
         .redpanda_license = license},
       0 // unused
     );
-    auto err = co_await replicate_and_wait(
-      _stm, _feature_table, _as, std::move(cmd), timeout);
+    auto err = co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
     if (err) {
         co_return err;
     }
@@ -602,8 +600,7 @@ feature_manager::write_action(cluster::feature_update_action action) {
           std::move(data),
           0 // unused
         );
-        return replicate_and_wait(
-          _stm, _feature_table, _as, std::move(cmd), timeout);
+        return replicate_and_wait(_stm, _as, std::move(cmd), timeout);
     }
 }
 

--- a/src/v/cluster/members_frontend.cc
+++ b/src/v/cluster/members_frontend.cc
@@ -119,7 +119,6 @@ members_frontend::set_maintenance_mode(model::node_id id, bool enabled) {
     if (leader == _self) {
         co_return co_await replicate_and_wait(
           _stm,
-          _feature_table,
           _as,
           maintenance_mode_cmd(id, enabled),
           _node_op_timeout + model::timeout_clock::now());

--- a/src/v/cluster/members_frontend.h
+++ b/src/v/cluster/members_frontend.h
@@ -57,7 +57,6 @@ private:
       model::node_id id, std::optional<model::term_id> term = std::nullopt) {
         return replicate_and_wait(
           _stm,
-          _feature_table,
           _as,
           T(id, 0),
           _node_op_timeout + model::timeout_clock::now(),

--- a/src/v/cluster/members_manager.cc
+++ b/src/v/cluster/members_manager.cc
@@ -1182,7 +1182,6 @@ ss::future<result<join_node_reply>> members_manager::replicate_new_node_uuid(
     // Otherwise, replicate a request to register the UUID.
     auto errc = co_await replicate_and_wait(
       _controller_stm,
-      _feature_table,
       _as,
       register_node_uuid_cmd(node_uuid, node_id),
       model::timeout_clock::now() + 30s);
@@ -1673,7 +1672,6 @@ ss::future<std::error_code> members_manager::add_node(model::broker broker) {
     }
     return replicate_and_wait(
       _controller_stm,
-      _feature_table,
       _as,
       add_node_cmd(0, std::move(broker)),
       _join_timeout + model::timeout_clock::now());
@@ -1686,7 +1684,6 @@ ss::future<std::error_code> members_manager::update_node(model::broker broker) {
 
     return replicate_and_wait(
       _controller_stm,
-      _feature_table,
       _as,
       update_node_cfg_cmd(0, std::move(broker)),
       _join_timeout + model::timeout_clock::now());

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -100,13 +100,13 @@ ss::future<std::error_code> security_frontend::create_user(
   security::scram_credential credential,
   model::timeout_clock::time_point tout) {
     create_user_cmd cmd(std::move(username), std::move(credential));
-    return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
+    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
 }
 
 ss::future<std::error_code> security_frontend::delete_user(
   security::credential_user username, model::timeout_clock::time_point tout) {
     delete_user_cmd cmd(std::move(username), 0 /* unused */);
-    return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
+    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
 }
 
 ss::future<std::error_code> security_frontend::update_user(
@@ -114,7 +114,7 @@ ss::future<std::error_code> security_frontend::update_user(
   security::scram_credential credential,
   model::timeout_clock::time_point tout) {
     update_user_cmd cmd(std::move(username), std::move(credential));
-    return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
+    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
 }
 
 ss::future<std::vector<errc>> security_frontend::create_acls(
@@ -180,11 +180,7 @@ ss::future<std::vector<errc>> security_frontend::do_create_acls(
     errc err;
     try {
         auto ec = co_await replicate_and_wait(
-          _stm,
-          _features,
-          _as,
-          std::move(cmd),
-          model::timeout_clock::now() + timeout);
+          _stm, _as, std::move(cmd), model::timeout_clock::now() + timeout);
         err = map_errc(ec);
     } catch (const std::exception& e) {
         vlog(clusterlog.warn, "Unable to create ACLs: {}", e);
@@ -222,11 +218,7 @@ ss::future<std::vector<delete_acls_result>> security_frontend::do_delete_acls(
     errc err;
     try {
         auto ec = co_await replicate_and_wait(
-          _stm,
-          _features,
-          _as,
-          std::move(cmd),
-          model::timeout_clock::now() + timeout);
+          _stm, _as, std::move(cmd), model::timeout_clock::now() + timeout);
         err = map_errc(ec);
     } catch (const std::exception& e) {
         vlog(clusterlog.warn, "Unable to delete ACLs: {}", e);

--- a/src/v/cluster/tests/commands_serialization_test.cc
+++ b/src/v/cluster/tests/commands_serialization_test.cc
@@ -135,7 +135,7 @@ FIXTURE_TEST(test_serde_only_cmd, cmd_test_fixture) {
 FIXTURE_TEST(test_create_topic_cmd_serialization, cmd_test_fixture) {
     auto cmd = make_create_topic_cmd("test_tp", 2, 3);
 
-    auto batch = cluster::serialize_cmd(cmd).get0();
+    auto batch = cluster::serde_serialize_cmd(cmd);
     auto deser = cluster::deserialize(
                    std::move(batch),
                    cluster::make_commands_list<cluster::create_topic_cmd>())
@@ -162,7 +162,7 @@ FIXTURE_TEST(test_create_topic_cmd_serialization, cmd_test_fixture) {
 FIXTURE_TEST(test_delete_topic_cmd_serialization, cmd_test_fixture) {
     auto cmd = make_delete_topic_cmd("test_tp");
 
-    auto batch = cluster::serialize_cmd(cmd).get0();
+    auto batch = cluster::serde_serialize_cmd(cmd);
     auto deser = cluster::deserialize(
                    std::move(batch),
                    cluster::make_commands_list<cluster::delete_topic_cmd>())
@@ -182,7 +182,7 @@ FIXTURE_TEST(test_move_partition_replicass_command, cmd_test_fixture) {
     };
     auto cmd = make_move_partition_replicas_cmd(ntp, replicas);
 
-    auto batch = cluster::serialize_cmd(cmd).get0();
+    auto batch = cluster::serde_serialize_cmd(cmd);
     auto deser
       = cluster::deserialize(
           std::move(batch),

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -115,16 +115,12 @@ FIXTURE_TEST(
   test_dispatching_happy_path_delete, topic_table_updates_dispatcher_fixture) {
     create_topics();
     dispatcher
-      .apply_update(
-        serialize_cmd(cluster::delete_topic_cmd(
-                        make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2")))
-          .get0())
+      .apply_update(serde_serialize_cmd(cluster::delete_topic_cmd(
+        make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2"))))
       .get0();
     dispatcher
-      .apply_update(
-        serialize_cmd(cluster::delete_topic_cmd(
-                        make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3")))
-          .get0())
+      .apply_update(serde_serialize_cmd(cluster::delete_topic_cmd(
+        make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3"))))
       .get0();
 
     auto md = table.local().all_topics_metadata();

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -300,7 +300,7 @@ ss::future<topic_result> topics_frontend::do_update_topic_properties(
         }
 
         auto ec = co_await replicate_and_wait(
-          _stm, _features, _as, std::move(cmd), timeout);
+          _stm, _as, std::move(cmd), timeout);
         co_return topic_result(std::move(update.tp_ns), map_errc(ec));
     } catch (...) {
         vlog(
@@ -498,7 +498,7 @@ ss::future<topic_result> topics_frontend::replicate_create_topic(
           random_generators::internal::gen);
     }
 
-    return replicate_and_wait(_stm, _features, _as, std::move(cmd), timeout)
+    return replicate_and_wait(_stm, _as, std::move(cmd), timeout)
       .then_wrapped([tp_ns = std::move(tp_ns), units = std::move(units)](
                       ss::future<std::error_code> f) mutable {
           try {
@@ -585,7 +585,7 @@ ss::future<topic_result> topics_frontend::do_delete_topic(
           tp_ns);
         delete_topic_cmd cmd(tp_ns, tp_ns);
 
-        return replicate_and_wait(_stm, _features, _as, std::move(cmd), timeout)
+        return replicate_and_wait(_stm, _as, std::move(cmd), timeout)
           .then_wrapped(
             [tp_ns = std::move(tp_ns)](ss::future<std::error_code> f) mutable {
                 try {
@@ -628,7 +628,7 @@ ss::future<topic_result> topics_frontend::do_delete_topic(
       {.topic = {.nt = tp_ns, .initial_revision_id = remote_revision},
        .mode = mode});
 
-    return replicate_and_wait(_stm, _features, _as, std::move(cmd), timeout)
+    return replicate_and_wait(_stm, _as, std::move(cmd), timeout)
       .then_wrapped(
         [tp_ns = std::move(tp_ns)](ss::future<std::error_code> f) mutable {
             try {
@@ -685,7 +685,7 @@ ss::future<topic_result> topics_frontend::do_purged_topic(
     std::error_code repl_ec;
     try {
         repl_ec = co_await replicate_and_wait(
-          _stm, _features, _as, std::move(cmd), deadline);
+          _stm, _as, std::move(cmd), deadline);
     } catch (...) {
         vlog(
           clusterlog.warn,
@@ -823,7 +823,7 @@ ss::future<std::error_code> topics_frontend::move_partition_replicas(
           std::move(ntp), std::move(new_replica_set));
 
         co_return co_await replicate_and_wait(
-          _stm, _features, _as, std::move(cmd), tout, term);
+          _stm, _as, std::move(cmd), tout, term);
     }
     update_partition_replicas_cmd cmd(
       0, // unused
@@ -833,7 +833,7 @@ ss::future<std::error_code> topics_frontend::move_partition_replicas(
         .policy = policy});
 
     co_return co_await replicate_and_wait(
-      _stm, _features, _as, std::move(cmd), tout, term);
+      _stm, _as, std::move(cmd), tout, term);
 }
 
 ss::future<std::error_code> topics_frontend::force_update_partition_replicas(
@@ -850,7 +850,7 @@ ss::future<std::error_code> topics_frontend::force_update_partition_replicas(
       force_partition_reconfiguration_cmd_data{std::move(new_replica_set)}};
 
     co_return co_await replicate_and_wait(
-      _stm, _features, _as, std::move(cmd), tout, term);
+      _stm, _as, std::move(cmd), tout, term);
 }
 
 ss::future<std::error_code> topics_frontend::cancel_moving_partition_replicas(
@@ -870,7 +870,7 @@ ss::future<std::error_code> topics_frontend::cancel_moving_partition_replicas(
       cancel_moving_partition_replicas_cmd_data(force_abort_update::no));
 
     co_return co_await replicate_and_wait(
-      _stm, _features, _as, std::move(cmd), timeout, term);
+      _stm, _as, std::move(cmd), timeout, term);
 }
 
 ss::future<std::error_code> topics_frontend::abort_moving_partition_replicas(
@@ -890,7 +890,7 @@ ss::future<std::error_code> topics_frontend::abort_moving_partition_replicas(
       cancel_moving_partition_replicas_cmd_data(force_abort_update::yes));
 
     co_return co_await replicate_and_wait(
-      _stm, _features, _as, std::move(cmd), timeout, term);
+      _stm, _as, std::move(cmd), timeout, term);
 }
 
 ss::future<std::error_code> topics_frontend::finish_moving_partition_replicas(
@@ -914,7 +914,7 @@ ss::future<std::error_code> topics_frontend::finish_moving_partition_replicas(
         finish_moving_partition_replicas_cmd cmd(
           std::move(ntp), std::move(new_replica_set));
 
-        return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
+        return replicate_and_wait(_stm, _as, std::move(cmd), tout);
     }
 
     return _connections.local()
@@ -956,7 +956,7 @@ ss::future<std::error_code> topics_frontend::revert_cancel_partition_move(
         revert_cancel_partition_move_cmd cmd(
           0, revert_cancel_partition_move_cmd_data{.ntp = std::move(ntp)});
 
-        return replicate_and_wait(_stm, _features, _as, std::move(cmd), tout);
+        return replicate_and_wait(_stm, _as, std::move(cmd), tout);
     }
 
     return _connections.local()
@@ -1056,8 +1056,7 @@ ss::future<std::error_code> topics_frontend::set_topic_partitions_disabled(
         .disabled = disabled,
       });
 
-    co_return co_await replicate_and_wait(
-      _stm, _features, _as, std::move(cmd), timeout);
+    co_return co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
 }
 
 ss::future<bool>
@@ -1117,7 +1116,7 @@ ss::future<topic_result> topics_frontend::do_create_partition(
 
     try {
         auto ec = co_await replicate_and_wait(
-          _stm, _features, _as, std::move(cmd), timeout);
+          _stm, _as, std::move(cmd), timeout);
         co_return topic_result(tp_ns, map_errc(ec));
     } catch (...) {
         vlog(
@@ -1448,8 +1447,7 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
 
     move_topic_replicas_cmd cmd(topic, std::move(new_assignments));
 
-    co_return co_await replicate_and_wait(
-      _stm, _features, _as, std::move(cmd), timeout);
+    co_return co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
 }
 
 ss::future<std::error_code> topics_frontend::decrease_replication_factor(
@@ -1496,8 +1494,7 @@ ss::future<std::error_code> topics_frontend::decrease_replication_factor(
 
     move_topic_replicas_cmd cmd(topic, std::move(new_assignments));
 
-    co_return co_await replicate_and_wait(
-      _stm, _features, _as, std::move(cmd), timeout);
+    co_return co_await replicate_and_wait(_stm, _as, std::move(cmd), timeout);
 }
 
 allocation_request make_allocation_request(

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -25,8 +25,6 @@ namespace features {
 
 std::string_view to_string_view(feature f) {
     switch (f) {
-    case feature::serde_raft_0:
-        return "serde_raft_0";
     case feature::license:
         return "license";
     case feature::raft_improved_configuration:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -37,7 +37,6 @@ struct feature_table_snapshot;
 /// only used at runtime.  Therefore it is safe to re-use an integer that
 /// has been made available by another feature being retired.
 enum class feature : std::uint64_t {
-    serde_raft_0 = 1ULL << 5U,
     license = 1ULL << 6U,
     raft_improved_configuration = 1ULL << 7U,
     transaction_ga = 1ULL << 8U,
@@ -93,6 +92,7 @@ inline const std::unordered_set<std::string_view> retired_features = {
   "mtls_authentication",
   "rm_stm_kafka_cache",
   "transaction_ga",
+  "serde_raft_0",
 };
 
 /**
@@ -146,12 +146,6 @@ struct feature_spec {
 };
 
 constexpr static std::array feature_schema{
-  feature_spec{
-    cluster::cluster_version{5},
-    "serde_raft_0",
-    feature::serde_raft_0,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{5},
     "license",

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -313,7 +313,7 @@ FIXTURE_TEST(feature_table_old_snapshot, feature_table_fixture) {
     snapshot.version = features::feature_table::get_earliest_logical_version();
     snapshot.states = {
       features::feature_state_snapshot{
-        .name = "serde_raft_0",
+        .name = "license",
         .state = feature_state::state::available,
       },
       features::feature_state_snapshot{
@@ -326,7 +326,7 @@ FIXTURE_TEST(feature_table_old_snapshot, feature_table_fixture) {
 
     // Fast-forwarded feature should still be active.
     BOOST_CHECK(
-      ft.get_state(feature::serde_raft_0).get_state()
+      ft.get_state(feature::license).get_state()
       == feature_state::state::active);
     // A feature with explicit available_policy should be activated by the
     // snapshot.


### PR DESCRIPTION
As the feature was introduced in cluster version `5` we may retire it and make code a little simpler. Another benefit is releasing one bit for future features.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none