### PR TITLE
net: Expose total sent/recv bytes on public_metrics

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -129,7 +129,8 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
         sm::make_total_bytes(
           "bytes_fetched_total",
           [this] { return _bytes_fetched; },
-          sm::description("Total number of bytes fetched"),
+          sm::description("Total number of bytes fetched (not all might be "
+                          "returned to the client)"),
           labels),
         sm::make_total_bytes(
           "cloud_storage_segments_metadata_bytes",
@@ -233,7 +234,8 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
         sm::make_total_bytes(
           "request_bytes_total",
           [this] { return _bytes_fetched; },
-          sm::description("Total number of bytes consumed per topic"),
+          sm::description("Total number of bytes fetched (not all "
+                          "might be returned to the client)"),
           {request_label("consume"),
            ns_label(ntp.ns()),
            topic_label(ntp.tp.topic()),

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -145,6 +145,21 @@ void server_probe::setup_public_metrics(
           sm::description("Count of currently active connections"),
           {server_label(proto)})
           .aggregate({sm::shard_label}),
+        sm::make_total_bytes(
+          "received_bytes",
+          [this] { return _in_bytes; },
+          sm::description(ssx::sformat(
+            "{}: Number of bytes received from the clients in valid requests",
+            proto)),
+          {server_label(proto)})
+          .aggregate({sm::shard_label}),
+        sm::make_total_bytes(
+          "sent_bytes",
+          [this] { return _out_bytes; },
+          sm::description(
+            ssx::sformat("{}: Number of bytes sent to clients", proto)),
+          {server_label(proto)})
+          .aggregate({sm::shard_label}),
       });
 }
 


### PR DESCRIPTION
Exposes the total sent and received bytes server metrics on public
metrics.

Right now there is only the partition probes which can be used to
approximate the bytes sent and received. However, they actually
represent the amount of bytes read for a fetch request and hence can be
massively off if only a part of it is returned to the client because of
`fetch.max.bytes` reasons.

We already track the total aggregated number of bytes returned to
clients. On internal metrics they are exposed as
`vectorized_[kafka|interna]_rpc_[sent|received]_bytes`.

Expose them on public metrics as well. They will follow the existing
server probe metrics pattern for public metrics:

```
$ curl -s localhost:9644/public_metrics | grep -E "sent_bytes|received_bytes"
// HELP redpanda_rpc_received_bytes internal: Number of bytes received from the clients in valid requests
// TYPE redpanda_rpc_received_bytes counter
redpanda_rpc_received_bytes{redpanda_server="kafka"} 325
redpanda_rpc_received_bytes{redpanda_server="internal"} 0
// HELP redpanda_rpc_sent_bytes internal: Number of bytes sent to clients
// TYPE redpanda_rpc_sent_bytes counter
redpanda_rpc_sent_bytes{redpanda_server="kafka"} 3629
redpanda_rpc_sent_bytes{redpanda_server="internal"} 0
```

This adds a total of 4 series for a very core set of metrics shouldn't
be controversial in terms of metrics count.

Fixes https://github.com/redpanda-data/redpanda/issues/10963
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Expose metric for total sent/received bytes from clients public_metrics

