### PR TITLE
rptest: cleanup unused tests in test_suite_cloud.yml

### DIFF
--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -14,5 +14,3 @@ cloud:
     - tests/rpk_topic_test.py::RpkToolTest.test_consume_from_partition
     - tests/services_self_test.py::SimpleSelfTest
     - tests/services_self_test.py::OpenBenchmarkSelfTest
-    - scale_tests/high_throughput_test.py::HighThroughputTest2.test_throughput_simple
-    - scale_tests/high_throughput_test.py::HighThroughputTest2.test_max_connections


### PR DESCRIPTION
this PR is no urgent. `HighThroughputTest2` class no longer exists, but tests still run.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
