### PR TITLE
rptest: ok_to_fail test_decommission_and_add

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -778,6 +778,7 @@ class HighThroughputTest(PreallocNodesTest):
                 f"Low throughput while preparing for the test: {_throughput}: {e}"
             )
 
+    @ok_to_fail
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_and_add(self):
         """


### PR DESCRIPTION
set as `@ok_to_fail` for now while we work out details of how the operation should perform

related issue: https://github.com/redpanda-data/redpanda/issues/14766

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none