### PR TITLE
cloud_storage_clients: Fix xml parsing when searching for error code in response

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -861,12 +861,13 @@ ss::future<> s3_client::do_delete_object(
       });
 }
 
-static std::variant<client::delete_objects_result, rest_error_response>
+std::variant<client::delete_objects_result, rest_error_response>
 iobuf_to_delete_objects_result(iobuf&& buf) {
     auto root = util::iobuf_to_ptree(std::move(buf), s3_log);
     auto result = client::delete_objects_result{};
     try {
-        if (root.count("Error.Code") > 0) {
+        if (auto error_code = root.get_optional<ss::sstring>("Error.Code");
+            error_code) {
             // This is an error response. S3 can reply with 200 error code and
             // error response in the body.
             constexpr const char* empty = "";

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -243,4 +243,7 @@ private:
     ss::shared_ptr<client_probe> _probe;
 };
 
+std::variant<client::delete_objects_result, rest_error_response>
+iobuf_to_delete_objects_result(iobuf&& buf);
+
 } // namespace cloud_storage_clients


### PR DESCRIPTION
FIXES: #14014 

When searching for error codes in an XML tree, ptree::count which we used does not honor dot paths. The change uses get_optional and adds some tests for the method.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
