### PR TITLE
[v23.2.x] cloud_storage_clients: Fix xml parsing when searching for error code in response

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -861,12 +861,13 @@ ss::future<> s3_client::do_delete_object(
       });
 }
 
-static std::variant<client::delete_objects_result, rest_error_response>
+std::variant<client::delete_objects_result, rest_error_response>
 iobuf_to_delete_objects_result(iobuf&& buf) {
     auto root = util::iobuf_to_ptree(std::move(buf), s3_log);
     auto result = client::delete_objects_result{};
     try {
-        if (root.count("Error.Code") > 0) {
+        if (auto error_code = root.get_optional<ss::sstring>("Error.Code");
+            error_code) {
             // This is an error response. S3 can reply with 200 error code and
             // error response in the body.
             constexpr const char* empty = "";

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -243,4 +243,7 @@ private:
     ss::shared_ptr<client_probe> _probe;
 };
 
+std::variant<client::delete_objects_result, rest_error_response>
+iobuf_to_delete_objects_result(iobuf&& buf);
+
 } // namespace cloud_storage_clients


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14848
Fixes: https://github.com/redpanda-data/redpanda/issues/14850,