### PR TITLE
rptest: improve redpanda_pid method

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2998,8 +2998,12 @@ class RedpandaService(RedpandaServiceBase):
                 # The pid is listed first, that's all we need
                 return int(line.split()[0])
             return None
-        except (RemoteCommandError, ValueError):
-            return None
+        except RemoteCommandError as e:
+            # 1 - No processes matched or none of them could be signalled.
+            if e.exit_status == 1:
+                return None
+
+            raise e
 
     def started_nodes(self):
         return self._started

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2984,7 +2984,7 @@ class RedpandaService(RedpandaServiceBase):
     def remove_local_data(self, node):
         node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/data/*")
 
-    def redpanda_pid(self, node, timeout=None, silent=True):
+    def redpanda_pid(self, node, timeout=None):
         try:
             cmd = "pgrep --list-full --exact redpanda"
             for line in node.account.ssh_capture(cmd, timeout_sec=10):
@@ -2993,8 +2993,7 @@ class RedpandaService(RedpandaServiceBase):
                 if "--version" in line:
                     continue
 
-                if silent == False:
-                    self.logger.debug(f"pgrep output: {line}")
+                self.logger.debug(f"pgrep output: {line}")
 
                 # The pid is listed first, that's all we need
                 return int(line.split()[0])

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2984,7 +2984,7 @@ class RedpandaService(RedpandaServiceBase):
     def remove_local_data(self, node):
         node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/data/*")
 
-    def redpanda_pid(self, node, timeout=None):
+    def redpanda_pid(self, node):
         try:
             cmd = "pgrep --list-full --exact redpanda"
             for line in node.account.ssh_capture(cmd, timeout_sec=10):

--- a/tests/rptest/services/redpanda_monitor.py
+++ b/tests/rptest/services/redpanda_monitor.py
@@ -34,9 +34,7 @@ class RedpandaMonitor(BackgroundThreadService):
                 try:
                     self.redpanda.logger.info(
                         f"RedpandaMonitor checking {n.account.hostname}")
-                    pid = self.redpanda.redpanda_pid(n,
-                                                     timeout=3,
-                                                     silent=False)
+                    pid = self.redpanda.redpanda_pid(n)
                     if pid is None:
                         started_dead_nodes.append(n)
 

--- a/tests/rptest/services/redpanda_monitor.py
+++ b/tests/rptest/services/redpanda_monitor.py
@@ -40,7 +40,8 @@ class RedpandaMonitor(BackgroundThreadService):
 
                 except Exception as e:
                     self.redpanda.logger.warn(
-                        f"Failed to fetch PID for node {n.account.hostname}")
+                        f"Failed to fetch PID for node {n.account.hostname}: {e}"
+                    )
 
             for n in started_dead_nodes:
                 self.redpanda.remove_from_started_nodes(n)


### PR DESCRIPTION
This method is used often to identify if redpanda is still running. If
the error is not propagated then the caller can't differentiate between
redpanda process not existing vs call failing.

Should help debug issues like #7679.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
