### PR TITLE
segment_meta_cstore: handle gaps and overlaps

### DIFF
--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -343,7 +343,7 @@ public:
                 // replacements either start before or exactly at 0
                 return size_t{0};
             }
-            auto candidate = _base_offset.find(offset_seg_it->first());
+            auto candidate = _base_offset.lower_bound(offset_seg_it->first());
             if (candidate.is_end()) {
                 // replacements are append only, return an index that will
                 // signal this
@@ -398,12 +398,11 @@ public:
           last_hint_tosave,
           _hints.end()};
 
-        auto unchanged_committed_offset
-          = replacement_store.last_committed_offset().value_or(
-            model::offset::min());
+        auto unchanged_base_offset = replacement_store._base_offset.last_value()
+                                       .value_or(model::offset::min()());
 
         // iterator pointing to first segment not cloned into replacement_store
-        auto old_segments_it = upper_bound(unchanged_committed_offset());
+        auto old_segments_it = upper_bound(unchanged_base_offset);
         auto old_segments_end = end();
 
         // merge replacements and old segments into new store
@@ -413,9 +412,9 @@ public:
             ++offset_seg_it;
 
             auto old_seg = dereference(old_segments_it);
-            // append old segments with committed offset smaller than
+            // append old segments with base_offset smaller than
             // replacement
-            while (old_seg.committed_offset < replacement_base_offset) {
+            while (old_seg.base_offset < replacement_base_offset) {
                 replacement_store.append(old_seg);
                 details::increment_all(old_segments_it);
                 if (old_segments_it == old_segments_end) {

--- a/src/v/cloud_storage/segment_meta_cstore.cc
+++ b/src/v/cloud_storage/segment_meta_cstore.cc
@@ -1009,7 +1009,9 @@ public:
         if (_write_buffer.size() > 1) {
             auto not_replaced_segment = std::find_if(
               std::next(m_it), _write_buffer.end(), [&](auto& kv) {
-                  return kv.first > m.committed_offset;
+                  // first element with a committed offset that spans over the
+                  // range of m
+                  return kv.second.committed_offset > m.committed_offset;
               });
             // if(next(m_it) == not_replaced_segment) there is nothing to erase,
             // _write_buffer.erase would do nothing


### PR DESCRIPTION
segment_meta_cstore assumes that the segments form a continuous sequence (no gaps) and that replacements are aligned to pre-existing segments. 

a segment landing on a gap would erroneously end up appended to the store, due to the use of exact search to find the insertion point. the fix for this is to switch to lower_bound to search for the insertion point.

overlaps would ruin the merge loop, due to the assumption that [n].committed_offset <[n+i].base_offset. the fix for this is to switch to base_offset only check for the "<" operation.

the insert operation, that uses a map as a buffer, is also updated to allow for overlaps. the buffer is empty most of the time, due to the usage pattern in redpanda that triggers frequent flushes, so a bug here would go likely unnoticed.
before, the code would search for the first segment completely after the range covered by the new segment. now it searches
for the first segment that ends after the range covered by the new segment.

Related https://github.com/redpanda-data/core-internal/issues/892

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* removed assumptions of no gaps and alignment from segment_meta_cstore 