### PR TITLE
rptest: bump FINISH_TIMEOUT_SEC from 10 min to 20 min in test_max_connections

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -470,10 +470,10 @@ class HighThroughputTest(PreallocNodesTest):
 
     @cluster(num_nodes=9)
     def test_max_connections(self):
-        # Huge timeout for safety, 10 min
+        # Huge timeout for safety, 20 min
         # Most of the tiers will end in <5 min
         # Except for the 5-7 that will take >5 min
-        FINISH_TIMEOUT_SEC = 600
+        FINISH_TIMEOUT_SEC = 1200
         PRODUCER_TIMEOUT_MS = FINISH_TIMEOUT_SEC * 1000
 
         # setup ProducerSwarm parameters


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/cloudv2/issues/10385

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none