### PR TITLE
schema_registry: Support the compatible format for CONFIG value

### DIFF
--- a/src/v/pandaproxy/schema_registry/test/storage.cc
+++ b/src/v/pandaproxy/schema_registry/test/storage.cc
@@ -95,6 +95,16 @@ constexpr std::string_view config_value_sv{
 const pps::config_value config_value{
   .compat = pps::compatibility_level::forward_transitive};
 
+constexpr std::string_view config_value_sub_sv{
+  R"({
+  "subject": "my-kafka-value",
+  "compatibilityLevel": "FORWARD_TRANSITIVE"
+})"};
+const pps::config_value config_value_sub{
+
+  .compat = pps::compatibility_level::forward_transitive,
+  .sub{pps::subject{"my-kafka-value"}}};
+
 constexpr std::string_view delete_subject_key_sv{
   R"({
   "keytype": "DELETE_SUBJECT",
@@ -159,6 +169,15 @@ BOOST_AUTO_TEST_CASE(test_storage_serde) {
 
         auto str = ppj::rjson_serialize(config_value);
         BOOST_CHECK_EQUAL(str, ::json::minify(config_value_sv));
+    }
+
+    {
+        auto val = ppj::rjson_parse(
+          config_value_sub_sv.data(), pps::config_value_handler<>{});
+        BOOST_CHECK_EQUAL(config_value_sub, val);
+
+        auto str = ppj::rjson_serialize(config_value_sub);
+        BOOST_CHECK_EQUAL(str, ::json::minify(config_value_sub_sv));
     }
 
     {


### PR DESCRIPTION
An example of a config record to be supported.

```json
{
  "topic": "_schemas",
  "key": "{\"keytype\":\"CONFIG\",\"subject\":\"test-ben1234\",\"magic\":0}",
  "value": "{\"subject\":\"test-ben1234\",\"compatibilityLevel\":\"FULL_TRANSITIVE\"}",
  "timestamp": 1699574968787,
  "partition": 0,
  "offset": 2
}
```
The subject field in the value is not checked against the key.

Fixes: https://github.com/redpanda-data/core-internal/issues/882

Signed-off-by: Ben Pope <ben@redpanda.com>

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Improvements

* Schema Registry: Improve compatibility of reading schemas that were created by another registry.
