### PR TITLE
[v23.2.x] net: GNUTLS_E_DECRYPTION_FAILED is_reconnect_error

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -40,6 +40,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case GNUTLS_E_UNSUPPORTED_VERSION_PACKET:
         case GNUTLS_E_NO_CIPHER_SUITES:
         case GNUTLS_E_PREMATURE_TERMINATION:
+        case GNUTLS_E_DECRYPTION_FAILED:
             return true;
         default:
             return false;


### PR DESCRIPTION
Backport https://github.com/redpanda-data/redpanda/pull/14823 to branch v23.2.x.

Fixes #14832 