### PR TITLE
[v23.1.x] net: GNUTLS_E_DECRYPTION_FAILED is_reconnect_error

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -38,6 +38,7 @@ bool is_reconnect_error(const std::system_error& e) {
         case GNUTLS_E_UNSUPPORTED_VERSION_PACKET:
         case GNUTLS_E_NO_CIPHER_SUITES:
         case GNUTLS_E_PREMATURE_TERMINATION:
+        case GNUTLS_E_DECRYPTION_FAILED:
             return true;
         default:
             return false;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14823

Fixes #14833