### PR TITLE
transform: guard against double stops

### DIFF
--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -72,9 +72,21 @@ ss::future<> fake_source::push_batch(model::record_batch batch) {
     co_return;
 }
 
-ss::future<> fake_wasm_engine::start() { return ss::now(); }
+ss::future<> fake_wasm_engine::start() {
+    if (_started) {
+        throw std::logic_error("starting already started wasm engine");
+    }
+    _started = true;
+    co_return;
+}
 
-ss::future<> fake_wasm_engine::stop() { return ss::now(); }
+ss::future<> fake_wasm_engine::stop() {
+    if (!_started) {
+        throw std::logic_error("stopping already stopped wasm engine");
+    }
+    _started = false;
+    co_return;
+}
 
 ss::future<> fake_offset_tracker::stop() { co_return; }
 

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -53,6 +53,7 @@ public:
     ss::future<> stop() override;
 
 private:
+    bool _started = false;
     mode _mode = mode::noop;
 };
 

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -85,9 +85,11 @@ public:
     uint64_t error_count() const { return _error_count; }
 
     void restart() {
-        _p->stop().get();
-        _p->start().get();
+        stop();
+        start();
     }
+    void stop() { _p->stop().get(); }
+    void start() { _p->start().get(); }
 
 private:
     static constexpr kafka::offset start_offset = kafka::offset(0);
@@ -102,6 +104,11 @@ private:
     probe _probe;
 };
 } // namespace
+
+TEST_F(ProcessorTestFixture, HandlesDoubleStops) {
+    stop();
+    stop();
+}
 
 TEST_F(ProcessorTestFixture, ProcessOne) {
     auto batch = make_tiny_batch();

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -110,6 +110,11 @@ public:
         }
     }
 
+    ~shared_engine() override {
+        vassert(
+          _ref_count == 0, "expected engine to be stopped before destruction");
+    }
+
 private:
     mutex _mu;
     size_t _ref_count = 0;


### PR DESCRIPTION
It's possible that a stopped processor (due to errors) is
stopped again because of shutdown or removal. This messes up the ref
counting in the cached engine. To guard against this we need to not call
stop twice on the engine.

Two options: Make the processor guard against double stops, don't call
stop twice in the processor. I think it's a the safer option to guard
against double stops in the processor, as the bookkeeping in the
processor is already fairly complex and this seems simpler.

Happy to take suggestions for alternative fixes.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
