### PR TITLE
redpanda: Make `redpanda_cpu_busy_seconds_total` a counter

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -589,7 +589,7 @@ void application::setup_public_metrics() {
       .invoke_on_all([](auto& public_metrics) {
           public_metrics.groups.add_group(
             "cpu",
-            {sm::make_gauge(
+            {sm::make_counter(
               "busy_seconds_total",
               [] {
                   return std::chrono::duration<double>(


### PR DESCRIPTION
It's monotonically increasing; conceptually it's a counter.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [x] v22.3.x

## Release Notes

### Improvements

* redpanda: Make `redpanda_cpu_busy_seconds_total` metric a counter instead of a gauge.
