### PR TITLE
build: enable ccache for open-source build

### DIFF
--- a/.github/workflows/build-redpanda.yml
+++ b/.github/workflows/build-redpanda.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest-64
     strategy:
       matrix:
-        os: ["fedora:38", "ubuntu:mantic"]
+        os: ["ubuntu:mantic", "fedora:38"]
     container:
       image: ${{ matrix.os }}
     steps:
@@ -34,12 +34,23 @@ jobs:
           uses: actions/checkout@v4
         - name: dependencies
           run: ./install-dependencies.sh
+        - name: cache directory
+          run: mkdir /mnt/ccache
+        - name: ccache
+          uses: actions/cache@v3
+          with:
+            path: /mnt/ccache
+            key: ${{ github.job }}-${{ matrix.os }}
+        - name: update path
+          run: |
+            echo "/usr/lib/ccache" >> $GITHUB_PATH
+            echo "/usr/lib64/ccache" >> $GITHUB_PATH
         - name: configure
           env:
-            CC: clang
-            CXX: clang++
-            CC_LD: lld
-            CXX_LD: lld
+            CCACHE_DIR: /mnt/ccache
           run: cmake --preset release
         - name: build
+          env:
+            CCACHE_DIR: /mnt/ccache
+            CCACHE_COMPRESSLEVEL: 6
           run: ninja -C build/release

--- a/.github/workflows/build-redpanda.yml
+++ b/.github/workflows/build-redpanda.yml
@@ -22,6 +22,7 @@ on:
 
 jobs:
   build:
+    if: github.event.pull_request.draft == false
     name: build redpanda
     runs-on: ubuntu-latest-64
     strategy:

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -26,6 +26,7 @@ fi
 
 deb_deps=(
   cargo
+  ccache
   clang
   cmake
   git
@@ -60,6 +61,7 @@ fedora_deps=(
   boost-devel
   c-ares-devel
   cargo
+  ccache
   clang
   cmake
   compiler-rt


### PR DESCRIPTION
Enables ccache for open-source build.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.
Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none

