### PR TITLE
io: make io::cache formattable

### DIFF
--- a/src/v/io/cache.h
+++ b/src/v/io/cache.h
@@ -12,6 +12,8 @@
 
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/parent_from_member.hpp>
+#include <fmt/core.h>
+#include <fmt/format.h>
 
 #include <algorithm>
 #include <optional>
@@ -671,3 +673,23 @@ bool cache<T, Hook, Evictor, Cost>::evict_main() noexcept {
  */
 
 } // namespace experimental::io
+
+template<
+  typename T,
+  experimental::io::cache_hook T::*Hook,
+  experimental::io::cache_evictor<T> Evictor,
+  experimental::io::cache_cost<T> Cost>
+struct fmt::formatter<experimental::io::cache<T, Hook, Evictor, Cost>>
+  : fmt::formatter<std::string_view> {
+    template<typename FormatContext>
+    auto format(
+      const experimental::io::cache<T, Hook, Evictor, Cost>& cache,
+      FormatContext& ctx) const {
+        const auto stat = cache.stat();
+        return fmt::format_to(
+          ctx.out(),
+          "main {} small {}",
+          stat.main_queue_size,
+          stat.small_queue_size);
+    }
+};

--- a/src/v/io/tests/cache_test.cc
+++ b/src/v/io/tests/cache_test.cc
@@ -683,6 +683,20 @@ TEST_F(CacheTest, NoEvictable) {
     }
 }
 
+TEST_F(CacheTest, Formattable) {
+    entry e0;
+    entry e1;
+    entry e2;
+    EXPECT_EQ(fmt::format("{}", *cache), "main 0 small 0");
+    cache_insert_main(e0);
+    EXPECT_EQ(fmt::format("{}", *cache), "main 1 small 0");
+    cache_insert_small(e1);
+    EXPECT_EQ(fmt::format("{}", *cache), "main 1 small 1");
+    cache_insert_small(e2);
+    EXPECT_EQ(fmt::format("{}", *cache), "main 1 small 2");
+    cleanup(e0, e1, e2);
+}
+
 TEST(CacheTestCustom, CustomCost) {
     struct entry {
         io::cache_hook hook;


### PR DESCRIPTION
Provides a fmt::formatter for io::cache.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

