### PR TITLE
storage: use hash map in compaction

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1048,6 +1048,16 @@ configuration::configuration()
        .visibility = visibility::tunable},
       128_MiB,
       {.min = 16_MiB, .max = 100_GiB})
+  , storage_compaction_key_map_memory(
+      *this,
+      "storage_compaction_key_map_memory",
+      "Maximum number of bytes that may be used on each shard by compaction"
+      "key-offset maps",
+      {.needs_restart = needs_restart::no,
+       .example = "1073741824",
+       .visibility = visibility::tunable},
+      128_MiB,
+      {.min = 16_MiB, .max = 100_GiB})
   , max_compacted_log_segment_size(
       *this,
       "max_compacted_log_segment_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -216,6 +216,7 @@ struct configuration final : public config_store {
     bounded_property<uint64_t> storage_target_replay_bytes;
     bounded_property<uint64_t> storage_max_concurrent_replay;
     bounded_property<uint64_t> storage_compaction_index_memory;
+    bounded_property<uint64_t> storage_compaction_key_map_memory;
     property<size_t> max_compacted_log_segment_size;
     property<std::optional<std::chrono::seconds>>
       storage_ignore_timestamps_in_future_sec;

--- a/src/v/storage/key_offset_map.cc
+++ b/src/v/storage/key_offset_map.cc
@@ -179,9 +179,9 @@ model::offset hash_key_offset_map::max_offset() const { return max_offset_; }
 size_t hash_key_offset_map::size() const { return size_; }
 size_t hash_key_offset_map::capacity() const { return capacity_; }
 
-seastar::future<> hash_key_offset_map::reset(size_t size) {
+seastar::future<> hash_key_offset_map::initialize(size_t size_bytes) {
     co_await fragmented_vector_clear_async(entries_);
-    while (entries_.memory_size() < size) {
+    while (entries_.memory_size() < size_bytes) {
         for (size_t i = 0; i < entries_.elements_per_fragment(); ++i) {
             entries_.push_back(entry{});
         }
@@ -203,7 +203,7 @@ seastar::future<> hash_key_offset_map::reset(size_t size) {
     probe_count_ = 0;
 }
 
-seastar::future<> hash_key_offset_map::initialize() {
+seastar::future<> hash_key_offset_map::reset() {
     co_await fragmented_vector_fill_async(entries_, entry{});
     size_ = 0;
     max_offset_ = model::offset{};

--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -128,14 +128,14 @@ public:
      * container which may otherwise incur reactor stalls when freed as part of
      * the destructor cleanup.
      */
-    seastar::future<> reset(size_t size);
+    seastar::future<> initialize(size_t size_bytes);
 
     /**
      * Initialize prepares the container for use in a new context by resetting
      * every element to an initial state. This call does not change the size of
      * the container.
      */
-    seastar::future<> initialize();
+    seastar::future<> reset();
 
     /**
      * The ratio of hash table searches (e.g. one get or put) to the number of

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -20,6 +20,7 @@
 #include "seastarx.h"
 #include "storage/batch_cache.h"
 #include "storage/file_sanitizer_types.h"
+#include "storage/key_offset_map.h"
 #include "storage/log.h"
 #include "storage/log_housekeeping_meta.h"
 #include "storage/ntp_config.h"
@@ -274,6 +275,10 @@ private:
     logs_type _logs;
     compaction_list_type _logs_list;
     batch_cache _batch_cache;
+
+    // Hash key-map to use across multiple compactions to reuse reserved memory
+    // rather than reallocating repeatedly.
+    std::unique_ptr<hash_key_offset_map> _compaction_hash_key_map;
     ss::gate _open_gate;
     ss::abort_source _abort_source;
 

--- a/src/v/storage/tests/key_offset_map_test.cc
+++ b/src/v/storage/tests/key_offset_map_test.cc
@@ -34,7 +34,7 @@ public:
  */
 class default_sized_hash_key_offset_map : public storage::hash_key_offset_map {
 public:
-    default_sized_hash_key_offset_map() { reset(1_MiB).get(); }
+    default_sized_hash_key_offset_map() { initialize(1_MiB).get(); }
 };
 
 using test_types = ::testing::
@@ -193,7 +193,7 @@ TYPED_TEST(KeyOffsetMapTest, UpdateSucceedsWhenFull) {
 
 TEST(HashKeyOffsetMapTest, HitRate) {
     storage::hash_key_offset_map map;
-    map.reset(20_MiB).get();
+    map.initialize(20_MiB).get();
 
     int i = 0;
     while (true) {
@@ -210,7 +210,7 @@ TEST(HashKeyOffsetMapTest, HitRate) {
 
 TEST(HashKeyOffsetMapTest, Initialize) {
     storage::hash_key_offset_map map;
-    map.reset(1_MiB).get();
+    map.initialize(1_MiB).get();
 
     // fill it up with keys with offset 100
     for (int i = 0;; ++i) {
@@ -241,7 +241,7 @@ TEST(HashKeyOffsetMapTest, Initialize) {
     EXPECT_EQ(map.size(), orig_size);
 
     // but now we'll initialize it
-    map.initialize().get();
+    map.reset().get();
     EXPECT_EQ(map.size(), 0);
 
     // now try to write the 99 offsets


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Uses a `hash_key_offset_map` in sliding window compaction. When configured to use windowed compaction, each shard will initialize 128MiB dedicated for the map, and pass it to the compaction implementations to be reused. Each  compaction zeroes out the entries before starting.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
