### PR TITLE
config: re-enable archival_metadata_stm consistency checks

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1847,7 +1847,7 @@ configuration::configuration()
       "replay logs with inconsistent tiered-storage metadata. Normally, this "
       "option should be disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      true)
+      false)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",


### PR DESCRIPTION
These were disabled originally because it prevented older partitions that had inconsistencies from bootstrapping properly, starting them in incomplete states. It was made the default to ensure sweeping adherence to "the old" data model, where inconsistencies were originally written and applied to the metadata.

Upon disabling the checks, we ran into trouble applying certain operations, sometimes resulting in a crash (see #14856).

So, this commit re-enables the consistency checks by default, with the expectation that, when we do need to ignore inconsistent operations in the log, we'll enable them only as needed.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Enables archival metadata consistency checks by default. Note that these checks apply to metadata that has already been persisted in the log, and can result in data written in older versions of Redpanda being loaded in an incomplete state. To disable, use the `cloud_storage_disable_metadata_consistency_checks` cluster property.
 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
