### PR TITLE
transform: read committed isolation

### DIFF
--- a/src/v/kafka/server/fwd.h
+++ b/src/v/kafka/server/fwd.h
@@ -19,12 +19,13 @@ class coordinator_ntp_mapper;
 class fetch_session_cache;
 class group_manager;
 class group_router;
+class partition_proxy;
 class quota_manager;
-class snc_quota_manager;
 class request_context;
 class rm_group_frontend;
 class rm_group_proxy_impl;
-class usage_manager;
 class snc_quota_context;
+class snc_quota_manager;
+class usage_manager;
 
 } // namespace kafka

--- a/src/v/model/record_batch_reader.cc
+++ b/src/v/model/record_batch_reader.cc
@@ -269,6 +269,14 @@ record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
         ss::chunked_fifo<model::record_batch>>(std::move(batches)));
 }
 
+record_batch_reader make_fragmented_memory_record_batch_reader(
+  ss::chunked_fifo<model::record_batch> batches) {
+    return make_fragmented_memory_record_batch_reader(
+      make_fragmented_memory_storage_batches<
+        false,
+        ss::chunked_fifo<model::record_batch>>(std::move(batches)));
+}
+
 ss::future<record_batch_reader::data_t> consume_reader_to_memory(
   record_batch_reader reader, timeout_clock::time_point timeout) {
     class memory_batch_consumer {

--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -321,6 +321,9 @@ record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
 record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch>);
 
+record_batch_reader make_fragmented_memory_record_batch_reader(
+  ss::chunked_fifo<model::record_batch>);
+
 record_batch_reader make_generating_record_batch_reader(
   ss::noncopyable_function<ss::future<record_batch_reader::data_t>()>);
 

--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -83,6 +83,12 @@ const T& random_choice(const std::vector<T>& elements) {
 }
 
 template<typename T>
+T& random_choice(std::vector<T>& elements) {
+    auto idx = get_int<size_t>(0, elements.size() - 1);
+    return elements[idx];
+}
+
+template<typename T>
 T random_choice(std::initializer_list<T> choices) {
     auto idx = get_int<size_t>(0, choices.size() - 1);
     auto& choice = *(choices.begin() + idx);

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -15,6 +15,7 @@ v_cc_library(
     transform_processor.cc
     transform_manager.cc
     commit_batcher.cc
+    txn_reader.cc
   DEPS
     v::wasm
     v::model

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -47,7 +47,20 @@ public:
     virtual ss::future<> start() = 0;
     virtual ss::future<> stop() = 0;
 
+    /*
+     * Get the latest offset in the log to read from.
+     */
     virtual kafka::offset latest_offset() = 0;
+
+    /**
+     * Read from the log starting at a given offset, aborting when requested.
+     *
+     * NOTE: It's important in terms of lifetimes that the source **always**
+     * outlives any reader returned from this method.
+     *
+     * NOTE: It's not valid to have pending futures outstanding from this
+     * method before calling stop.
+     */
     virtual ss::future<model::record_batch_reader>
     read_batch(kafka::offset, ss::abort_source*) = 0;
 };

--- a/src/v/transform/tests/CMakeLists.txt
+++ b/src/v/transform/tests/CMakeLists.txt
@@ -53,3 +53,18 @@ rp_test(
   ARGS "-- -c 1"
   LABELS transform
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME
+    transform_txn_reader
+  SOURCES
+    txn_reader_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::model_test_utils
+    v::transform
+  ARGS "-- -c 1"
+  LABELS transform
+)

--- a/src/v/transform/tests/txn_reader_test.cc
+++ b/src/v/transform/tests/txn_reader_test.cc
@@ -1,0 +1,542 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "gmock/gmock.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
+#include "model/tests/random_batch.h"
+#include "model/timeout_clock.h"
+#include "random/generators.h"
+#include "storage/record_batch_builder.h"
+#include "transform/txn_reader.h"
+
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/util/variant_utils.hh>
+
+#include <absl/algorithm/container.h>
+#include <absl/container/btree_set.h>
+#include <absl/container/flat_hash_map.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace transform {
+namespace {
+
+struct begin_txn {};
+struct data_batch {};
+struct commit_txn {};
+struct abort_txn {};
+
+using log_data = std::variant<begin_txn, data_batch, commit_txn, abort_txn>;
+
+struct pid {
+    int64_t id;
+    int16_t epoch = 0;
+
+    auto operator<=>(const pid&) const = default;
+};
+
+struct producer {
+    pid pid;
+    std::vector<log_data> data;
+};
+
+class predetermined_aborted_transaction_tracker
+  : public aborted_transaction_tracker {
+public:
+    explicit predetermined_aborted_transaction_tracker(
+      std::vector<model::tx_range> aborted)
+      : _aborted(std::move(aborted)) {}
+
+    ss::future<std::vector<model::tx_range>>
+    compute_aborted_transactions(model::offset base, model::offset max) final {
+        std::vector<model::tx_range> ranges;
+        std::copy_if(
+          _aborted.begin(),
+          _aborted.end(),
+          std::back_inserter(ranges),
+          [base, max](model::tx_range range) {
+              return range.first <= max && range.last >= base;
+          });
+        co_return ranges;
+    }
+
+private:
+    std::vector<model::tx_range> _aborted;
+};
+
+struct aborted_txn_range {
+    pid p;
+    model::offset start;
+    model::offset end;
+};
+
+std::unique_ptr<predetermined_aborted_transaction_tracker>
+make_aborted_txns(const std::vector<aborted_txn_range>& aborts) {
+    std::vector<model::tx_range> tracked;
+    tracked.reserve(aborts.size());
+    for (const auto& aborted : aborts) {
+        tracked.emplace_back(
+          model::producer_identity(aborted.p.id, aborted.p.epoch),
+          aborted.start,
+          aborted.end);
+    }
+    return std::make_unique<predetermined_aborted_transaction_tracker>(tracked);
+}
+
+model::record_batch_reader
+make_reader(const std::initializer_list<
+            std::reference_wrapper<const model::record_batch>>& batches) {
+    ss::circular_buffer<model::record_batch> buffer;
+    for (const auto& b : batches) {
+        buffer.push_back(b.get().copy());
+    }
+    return model::make_memory_record_batch_reader(std::move(buffer));
+}
+
+std::vector<model::record_batch>
+read_to_vector(model::record_batch_reader reader) {
+    std::vector<model::record_batch> v;
+    auto read = model::consume_reader_to_memory(
+                  std::move(reader), model::no_timeout)
+                  .get();
+    std::copy(
+      std::move_iterator(read.begin()),
+      std::move_iterator(read.end()),
+      std::back_inserter(v));
+    return v;
+}
+
+struct test_case {
+    std::string name;
+    std::vector<producer> producers;
+};
+
+class TransactionReaderTest : public testing::Test {
+public:
+    std::unique_ptr<aborted_transaction_tracker>
+    make_aborted_transaction_tracker() {
+        return std::make_unique<predetermined_aborted_transaction_tracker>(
+          _aborted);
+    }
+
+    template<typename T, typename... Args>
+    auto create_batches(pid p, T head, Args... rest) {
+        if constexpr (std::is_same_v<T, begin_txn>) {
+            make_batch(p, head);
+            return create_batches<Args...>(p, std::forward<Args>(rest)...);
+        } else {
+            auto b = std::make_tuple(make_batch(p, head));
+            if constexpr (sizeof...(Args) == 0) {
+                vassert(
+                  _pending_txns.empty(),
+                  "pending transactions are still outstanding");
+                return std::move(b);
+            } else {
+                return std::tuple_cat(
+                  std::move(b),
+                  create_batches<Args...>(p, std::forward<Args>(rest)...));
+            }
+        }
+    }
+
+    model::record_batch_reader
+    construct_log_reader(std::vector<producer> producers) {
+        // Reverse the log data so we can pop_back
+        for (producer& p : producers) {
+            std::reverse(p.data.begin(), p.data.end());
+        }
+        ss::chunked_fifo<model::record_batch_reader::data_t> full_log;
+        while (!producers.empty()) {
+            constexpr static int max_batches = 10;
+            auto batch_size = random_generators::get_int<size_t>(
+              1, max_batches);
+            ss::circular_buffer<model::record_batch> batches;
+            while (batches.size() < batch_size && !producers.empty()) {
+                auto& selected = random_generators::random_choice(producers);
+                auto batch = make_batch(selected.pid, selected.data.back());
+                if (batch) {
+                    batches.push_back(std::move(*batch));
+                }
+                selected.data.pop_back();
+                std::erase_if(
+                  producers, [](const producer& p) { return p.data.empty(); });
+            }
+            if (!batches.empty()) {
+                full_log.emplace_back(std::move(batches));
+            }
+        }
+        vassert(
+          _pending_txns.empty(), "pending transactions are still outstanding");
+        return model::make_generating_record_batch_reader(
+          [log = std::move(full_log)]() mutable {
+              if (log.empty()) {
+                  return ss::make_ready_future<
+                    model::record_batch_reader::data_t>();
+              }
+              auto front = std::move(log.front());
+              log.pop_front();
+              return ss::make_ready_future<model::record_batch_reader::data_t>(
+                std::move(front));
+          });
+    }
+
+    std::vector<model::record_batch> committed_batches() const {
+        std::vector<model::record_batch> copy;
+        copy.reserve(_committed_log.size());
+        for (const auto& batch : _committed_log) {
+            copy.push_back(batch.copy());
+        }
+        return copy;
+    }
+
+private:
+    struct pending_txn {
+        model::offset start;
+        std::vector<model::record_batch> batches;
+    };
+
+    std::optional<model::record_batch> make_batch(pid p, log_data d) {
+        return std::visit(
+          [this, p](auto d) -> std::optional<model::record_batch> {
+              return make_batch(p, d);
+          },
+          d);
+    }
+    std::optional<model::record_batch> make_batch(pid p, begin_txn) {
+        auto [_, inserted] = _pending_txns.emplace(p, _current_offset);
+        vassert(inserted, "invalid nested txn");
+        // There are no records associated with starting a txn
+        return std::nullopt;
+    }
+    model::record_batch make_batch(pid p, data_batch) {
+        constexpr static int max_batch_size = 8;
+        auto batch = model::test::make_random_batch(
+          model::test::record_batch_spec{
+            .offset = model::next_offset(_current_offset),
+            .count = random_generators::get_int(1, max_batch_size),
+            .enable_idempotence = true,
+            .producer_id = p.id,
+            .producer_epoch = p.epoch,
+            .base_sequence = _pid_sequences[p] + 1,
+            .is_transactional = _pending_txns.contains(p),
+          });
+        // increment the seqno for the pid
+        _pid_sequences[p] = batch.header().base_sequence
+                            + batch.header().last_offset_delta;
+        _current_offset = batch.header().last_offset();
+        auto it = _pending_txns.find(p);
+        if (it != _pending_txns.end()) {
+            it->second.batches.push_back(batch.copy());
+        }
+        _committed_log.push_back(batch.copy());
+        return batch;
+    }
+
+    model::record_batch make_batch(pid p, commit_txn) {
+        vassert(_pending_txns.erase(p) > 0, "invalid commit without begin");
+        iobuf key;
+        key.append("\x00\x00\x00\x00", 4);
+        return make_control_batch(p, std::move(key));
+    }
+    model::record_batch make_batch(pid p, abort_txn) {
+        auto pending = _pending_txns.extract(p);
+        vassert(!pending.empty(), "invalid abort without begin");
+        const auto& aborted_batches = pending.mapped().batches;
+        // Remove the aborted records from the log
+        // We remove records from the log instead of waiting to add records
+        // until commit so that we keep the original order if other producers
+        // add records in the meantime.
+        std::erase_if(
+          _committed_log,
+          [&aborted_batches](const model::record_batch& committed) {
+              return absl::c_find(aborted_batches, committed)
+                     != aborted_batches.end();
+          });
+        _aborted.emplace_back(
+          model::producer_identity(p.id, p.epoch),
+          pending.mapped().start,
+          _current_offset);
+        iobuf key;
+        key.append("\x00\x00\x00\x01", 4);
+        return make_control_batch(p, std::move(key));
+    }
+
+    model::record_batch make_control_batch(pid p, iobuf key) {
+        storage::record_batch_builder builder(
+          model::record_batch_type::raft_data, _current_offset++);
+        builder.set_producer_identity(p.id, p.epoch);
+        builder.set_control_type();
+        builder.add_raw_kv(std::move(key), std::nullopt);
+        return std::move(builder).build();
+    }
+
+    model::offset _current_offset = model::offset(0);
+    absl::btree_map<pid, pending_txn> _pending_txns;
+    absl::btree_map<pid, int32_t> _pid_sequences;
+    std::vector<model::tx_range> _aborted;
+    std::vector<model::record_batch> _committed_log;
+};
+
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+MATCHER_P2(
+  IsBetween,
+  a,
+  b,
+  absl::StrCat(
+    negation ? "isn't" : "is",
+    " between ",
+    testing::PrintToString(a),
+    " and ",
+    testing::PrintToString(b))) {
+    return a <= arg && arg <= b;
+}
+
+// A matcher to compare a reference wrapper to it's original type.
+MATCHER_P(
+  ByRefImpl,
+  a,
+  absl::StrCat(
+    negation ? "isn't" : "is", " equal to ", testing::PrintToString(a.get()))) {
+    return a.get() == arg;
+}
+
+// A helper matcher to compare containers of non-copyable types, as by default
+// gtest requires that arguments here are copyable.
+template<typename... Args>
+auto ElementsAre(const Args&... args) {
+    return ::testing::ElementsAre(ByRefImpl(std::ref(args))...);
+}
+
+TEST_F(TransactionReaderTest, WithinRange) {
+    auto [data, abort] = create_batches(
+      pid{.id = 1}, begin_txn(), data_batch(), abort_txn());
+
+    std::vector<std::pair<model::offset, model::offset>> ranges = {
+      {model::prev_offset(data.base_offset()), data.last_offset()},
+      {data.base_offset(), model::next_offset(data.last_offset())},
+      {data.base_offset(), data.last_offset()},
+    };
+    for (auto range : ranges) {
+        auto tracker = make_aborted_txns(
+          {{pid{.id = 1}, range.first, range.second}});
+
+        auto actual = read_to_vector(
+          model::make_record_batch_reader<read_committed_reader>(
+            std::move(tracker), make_reader({data, abort})));
+        EXPECT_THAT(actual, IsEmpty());
+    }
+}
+
+TEST_F(TransactionReaderTest, OutsideRange) {
+    auto [data, abort] = create_batches(
+      pid{.id = 1}, begin_txn(), data_batch(), commit_txn());
+
+    std::vector<std::pair<model::offset, model::offset>> ranges = {
+      {model::next_offset(data.base_offset()), data.last_offset()},
+      {data.base_offset(), model::prev_offset(data.last_offset())},
+      {model::next_offset(data.base_offset()),
+       model::prev_offset(data.last_offset())},
+    };
+
+    for (auto range : ranges) {
+        // ensure our ranges are inclusive
+        auto tracker = make_aborted_txns(
+          {{pid{.id = 1}, range.first, range.second}});
+
+        auto actual = read_to_vector(
+          model::make_record_batch_reader<read_committed_reader>(
+            std::move(tracker), make_reader({data, abort})));
+        EXPECT_THAT(actual, ElementsAre(data));
+    }
+}
+
+class RandomizedTransactionReaderTest
+  : public TransactionReaderTest
+  , public testing::WithParamInterface<test_case> {};
+
+TEST_P(RandomizedTransactionReaderTest, ReadsOnlyCommittedRecords) {
+    auto reader = construct_log_reader(GetParam().producers);
+    // Wrap the reader with our filtering logic
+    auto log = read_to_vector(
+      model::make_record_batch_reader<read_committed_reader>(
+        make_aborted_transaction_tracker(), std::move(reader)));
+    // We should only have committed data
+    EXPECT_EQ(log, committed_batches());
+    auto aborted = make_aborted_transaction_tracker()
+                     ->compute_aborted_transactions(
+                       model::offset::min(), model::offset::max())
+                     .get();
+    for (const auto& batch : log) {
+        model::producer_identity pid(
+          batch.header().producer_id, batch.header().producer_epoch);
+        EXPECT_FALSE(batch.header().attrs.is_control());
+        if (!batch.header().attrs.is_transactional()) {
+            continue;
+        }
+        for (const auto& aborted_tx : aborted) {
+            if (aborted_tx.pid != pid) {
+                continue;
+            }
+            EXPECT_THAT(
+              batch.base_offset(),
+              Not(IsBetween(aborted_tx.first, aborted_tx.last)));
+            EXPECT_THAT(
+              batch.last_offset(),
+              Not(IsBetween(aborted_tx.first, aborted_tx.last)));
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  RandomizedTransactions,
+  RandomizedTransactionReaderTest,
+  testing::Values(
+    test_case{
+    .name = "one_aborted_txn",
+      .producers = {
+        producer{
+          .pid = {.id = 1},
+          .data = {
+            begin_txn(),
+            data_batch(),
+            abort_txn(),
+          },
+        },
+      },
+    },
+    test_case{
+      .name = "one_committed_txn",
+      .producers = {
+         producer{
+           .pid = {.id = 1},
+           .data = {
+             begin_txn(),
+             data_batch(),
+             commit_txn(),
+           },
+         },
+      },
+    },
+    test_case{
+      .name = "commit_abort_commit",
+      .producers = {
+         producer{
+           .pid = {.id = 1},
+           .data = {
+             begin_txn(),
+             data_batch(),
+             commit_txn(),
+
+             begin_txn(),
+             data_batch(),
+             abort_txn(),
+
+             begin_txn(),
+             data_batch(),
+             commit_txn(),
+           },
+         },
+      },
+    },
+    test_case{
+      .name = "two_producers",
+      .producers = {
+         producer{
+           .pid = {.id = 1},
+           .data = {
+              begin_txn(),
+              data_batch(),
+              commit_txn(),
+
+              begin_txn(),
+              data_batch(),
+              abort_txn(),
+
+              begin_txn(),
+              data_batch(),
+              commit_txn(),
+           },
+         },
+         producer{
+           .pid = {.id = 2},
+           .data = {
+              data_batch(),
+              data_batch(),
+              data_batch(),
+              data_batch(),
+              data_batch(),
+              data_batch(),
+           },
+         },
+      },
+    },
+    test_case{
+    .name = "three_producers",
+      .producers = {
+         producer{
+           .pid = {.id = 1},
+           .data = {
+              begin_txn(),
+              data_batch(),
+              data_batch(),
+              data_batch(),
+              commit_txn(),
+           },
+         },
+         producer{
+           .pid = {.id = 2},
+           .data = {
+              begin_txn(),
+              data_batch(),
+              data_batch(),
+              data_batch(),
+              abort_txn(),
+
+              begin_txn(),
+              data_batch(),
+              data_batch(),
+              data_batch(),
+              abort_txn(),
+
+              begin_txn(),
+              data_batch(),
+              data_batch(),
+              data_batch(),
+              abort_txn(),
+           },
+         },
+         producer{
+           .pid = {.id = 3},
+           .data = {
+              data_batch(),
+              begin_txn(),
+              data_batch(),
+              data_batch(),
+              data_batch(),
+              commit_txn(),
+              data_batch(),
+           },
+         },
+      },
+    }), 
+    [](const auto& test) { return test.param.name; });
+
+} // namespace
+} // namespace transform

--- a/src/v/transform/txn_reader.cc
+++ b/src/v/transform/txn_reader.cc
@@ -99,6 +99,14 @@ struct drain_result {
 class drainer {
 public:
     explicit drainer(model::record_batch_reader::storage_t initial) {
+        // TODO(perf): This initial slice is iterated over twice, once to look
+        // for control/transactional batches, and another time here.
+        //
+        // It's possible to combine the passes at the cost of more complex code.
+        // If we do tackle this optimization one should ensure that the pass
+        // through of the originally loaded slices if there are no control/txn
+        // batches does not copy the batches over to a new buffer if it's not
+        // needed.
         ss::visit(
           initial,
           [this](model::record_batch_reader::data_t& d) {

--- a/src/v/transform/txn_reader.cc
+++ b/src/v/transform/txn_reader.cc
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/txn_reader.h"
+
+#include "kafka/server/partition_proxy.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/timeout_clock.h"
+#include "model/timestamp.h"
+
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/util/variant_utils.hh>
+
+#include <absl/container/btree_set.h>
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <ostream>
+#include <ranges>
+#include <vector>
+
+namespace transform {
+
+namespace {
+
+class aborted_transaction_tracker_impl : public aborted_transaction_tracker {
+public:
+    aborted_transaction_tracker_impl(
+      kafka::partition_proxy* partition,
+      ss::lw_shared_ptr<const storage::offset_translator_state> translator)
+      : _partition(partition)
+      , _translator(std::move(translator)) {}
+
+    ss::future<std::vector<model::tx_range>>
+    compute_aborted_transactions(model::offset base, model::offset max) final {
+        return _partition->aborted_transactions(base, max, _translator);
+    }
+
+private:
+    kafka::partition_proxy* _partition;
+    ss::lw_shared_ptr<const storage::offset_translator_state> _translator;
+};
+
+} // namespace
+
+std::unique_ptr<aborted_transaction_tracker>
+aborted_transaction_tracker::create_default(
+  kafka::partition_proxy* proxy,
+  ss::lw_shared_ptr<const storage::offset_translator_state> translator) {
+    return std::make_unique<aborted_transaction_tracker_impl>(
+      proxy, std::move(translator));
+}
+
+namespace {
+
+const model::record_batch_reader::data_t&
+readonly_data_view(const model::record_batch_reader::storage_t& batches) {
+    using data_t = model::record_batch_reader::data_t;
+    using foreign_data_t = model::record_batch_reader::foreign_data_t;
+    return ss::visit(
+      batches,
+      [](const data_t& data) { return std::ref(data); },
+      [](const foreign_data_t& data) -> std::reference_wrapper<const data_t> {
+          return std::ref(*data.buffer);
+      });
+}
+
+bool contains_control_or_txn_batch(
+  const model::record_batch_reader::storage_t& batches) {
+    for (const model::record_batch& batch : readonly_data_view(batches)) {
+        model::record_batch_attributes attrs = batch.header().attrs;
+        if (attrs.is_control() || attrs.is_transactional()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+struct drain_result {
+    std::optional<std::pair<model::offset, model::offset>> txn_range;
+    ss::chunked_fifo<model::record_batch> batches;
+};
+
+class drainer {
+public:
+    explicit drainer(model::record_batch_reader::storage_t initial) {
+        ss::visit(
+          initial,
+          [this](model::record_batch_reader::data_t& d) {
+              for (auto& batch : d) {
+                  process(std::move(batch));
+              }
+          },
+          [this](model::record_batch_reader::foreign_data_t& d) {
+              for (const auto& batch : *d.buffer) {
+                  process(batch.copy());
+              }
+          });
+    }
+
+    ss::future<ss::stop_iteration> operator()(model::record_batch batch) {
+        process(std::move(batch));
+        return ss::make_ready_future<ss::stop_iteration>(
+          ss::stop_iteration::no);
+    }
+
+    drain_result end_of_stream() { return std::move(_result); }
+
+private:
+    void process(model::record_batch batch) {
+        model::record_batch_attributes attrs = batch.header().attrs;
+        // It's possible that there are only control batches, which then we
+        // don't have to filter out any aborts.
+        if (attrs.is_transactional()) {
+            if (!_result.txn_range) {
+                _result.txn_range.emplace(
+                  batch.base_offset(), batch.last_offset());
+            }
+            _result.txn_range->second = batch.last_offset();
+        }
+        _result.batches.push_back(std::move(batch));
+    }
+
+    drain_result _result;
+};
+
+bool is_aborted(
+  const model::record_batch& batch,
+  const absl::btree_set<model::tx_range, std::greater<>>& aborted_txns) {
+    model::producer_identity pid = {
+      batch.header().producer_id, batch.header().producer_epoch};
+    auto it = aborted_txns.lower_bound(
+      {pid, batch.base_offset(), model::offset::max()});
+
+    if (it == aborted_txns.end()) {
+        return false;
+    }
+    // If the pids match, and the batch lies within the abort range, then this
+    // batch is aborted.
+    return it->pid == pid && batch.base_offset() >= it->first
+           && batch.last_offset() <= it->last;
+}
+
+std::unique_ptr<model::record_batch_reader::impl> make_txn_filtered_reader(
+  ss::chunked_fifo<model::record_batch> batches,
+  const absl::btree_set<model::tx_range, std::greater<>>& aborted_txns) {
+    ss::chunked_fifo<model::record_batch> filtered;
+    for (auto& batch : batches) {
+        auto attrs = batch.header().attrs;
+        if (attrs.is_transactional() && is_aborted(batch, aborted_txns)) {
+            continue;
+        }
+        if (attrs.is_control()) {
+            continue;
+        }
+        filtered.push_back(std::move(batch));
+    }
+    return model::make_fragmented_memory_record_batch_reader(
+             std::move(filtered))
+      .release();
+}
+
+} // namespace
+
+read_committed_reader::read_committed_reader(
+  std::unique_ptr<aborted_transaction_tracker> tracker,
+  model::record_batch_reader reader)
+  : _tracker(std::move(tracker))
+  , _underlying(std::move(reader).release()) {}
+
+void read_committed_reader::print(std::ostream& os) {
+    os << "transform::txn_reader{}";
+}
+
+bool read_committed_reader::is_end_of_stream() const {
+    return _underlying->is_end_of_stream();
+}
+
+ss::future<model::record_batch_reader::storage_t>
+read_committed_reader::do_load_slice(
+  model::timeout_clock::time_point deadline) {
+    model::record_batch_reader::storage_t loaded
+      = co_await _underlying->do_load_slice(deadline);
+    // We delete the tracker when we've filtered the stream already.
+    if (!_tracker || !contains_control_or_txn_batch(loaded)) {
+        co_return loaded;
+    }
+    auto [txn_offset_range, batches] = co_await _underlying->consume(
+      drainer(std::move(loaded)), deadline);
+    absl::btree_set<model::tx_range, std::greater<>> aborted_txn_markers;
+    if (txn_offset_range) {
+        auto [base_offset, last_offset] = txn_offset_range.value();
+        auto txn_ranges = co_await _tracker->compute_aborted_transactions(
+          base_offset, last_offset);
+        aborted_txn_markers.insert(txn_ranges.begin(), txn_ranges.end());
+    }
+    // Mark stream as filtered by deleting the tracker.
+    _tracker = nullptr;
+    _underlying = make_txn_filtered_reader(
+      std::move(batches), aborted_txn_markers);
+    co_return co_await _underlying->do_load_slice(deadline);
+}
+
+} // namespace transform

--- a/src/v/transform/txn_reader.h
+++ b/src/v/transform/txn_reader.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/fwd.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "ssx/sformat.h"
+#include "storage/fwd.h"
+
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/shared_ptr.hh>
+
+#include <absl/container/btree_map.h>
+#include <fmt/ostream.h>
+
+#include <memory>
+
+namespace transform {
+
+// An interface for computing what transactions are aborted within a given range
+// of a partition.
+class aborted_transaction_tracker {
+public:
+    aborted_transaction_tracker() = default;
+    aborted_transaction_tracker(const aborted_transaction_tracker&) = delete;
+    aborted_transaction_tracker(aborted_transaction_tracker&&) = delete;
+    aborted_transaction_tracker& operator=(const aborted_transaction_tracker&)
+      = delete;
+    aborted_transaction_tracker& operator=(aborted_transaction_tracker&&)
+      = delete;
+    virtual ~aborted_transaction_tracker() = default;
+
+    // Create the default tracker that uses a partition proxy and the
+    // offset_translator state.
+    static std::unique_ptr<aborted_transaction_tracker> create_default(
+      kafka::partition_proxy*,
+      ss::lw_shared_ptr<const storage::offset_translator_state>);
+
+    // Compute the ranges of transactions that are aborted for a given range
+    // within the log.
+    virtual ss::future<std::vector<model::tx_range>>
+    compute_aborted_transactions(model::offset base, model::offset max) = 0;
+};
+
+// A record_batch_reader that filters out aborted transactions (as well as
+// control batches). The wrapped reader will produce a stream of batches that
+// are committed and do not have control batches.
+//
+// This reader streams results until it finds a control or transactional batch.
+// At this point, results are buffered until the reader reaches the end of the
+// stream, at which point we determine the aborted transactions + control
+// batches within that range and filter them out.
+//
+// The stream optimization is to minimize latency unless transactions are used.
+class read_committed_reader : public model::record_batch_reader::impl {
+public:
+    read_committed_reader(
+      std::unique_ptr<aborted_transaction_tracker>, model::record_batch_reader);
+
+    bool is_end_of_stream() const override;
+
+    ss::future<model::record_batch_reader::storage_t>
+    do_load_slice(model::timeout_clock::time_point deadline) override;
+
+    void print(std::ostream& os) override;
+
+private:
+    std::unique_ptr<aborted_transaction_tracker> _tracker;
+    std::unique_ptr<model::record_batch_reader::impl> _underlying;
+};
+
+} // namespace transform


### PR DESCRIPTION
Use read committed isolation level for transforms.

Fixes an issue where we don't filter out control messages nor
do we drop aborted transactions before we surface batches to
the WebAssembly transform.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
