### PR TITLE
io: add storage provider

### DIFF
--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -21,7 +21,7 @@ message(STATUS "RP_ENABLE_BENCHMARK_TESTS=${RP_ENABLE_BENCHMARK_TESTS}")
 
 function (rp_test)
   set(options
-    FIXTURE_TEST UNIT_TEST BENCHMARK_TEST GTEST)
+    FIXTURE_TEST UNIT_TEST BENCHMARK_TEST GTEST USE_CWD)
   set(oneValueArgs BINARY_NAME TIMEOUT PREPARE_COMMAND POST_COMMAND)
   set(multiValueArgs
     INCLUDES
@@ -126,10 +126,15 @@ function (rp_test)
       set(gtest_option "--gtest")
   endif()
 
+  set(root_option "--root /dev/shm/vectorized_io")
+  if (RP_TEST_USE_CWD)
+      set(root_option "")
+  endif()
+
   if(NOT skip_test)
     add_test (
       NAME ${RP_TEST_BINARY_NAME}
-      COMMAND bash -c "${RUNNER} --binary=$<TARGET_FILE:${RP_TEST_BINARY_NAME}> ${gtest_option} ${prepare_command} ${post_command} ${files_to_copy} ${RP_TEST_ARGS} "
+      COMMAND bash -c "${RUNNER} --binary=$<TARGET_FILE:${RP_TEST_BINARY_NAME}> ${gtest_option} ${root_option} ${prepare_command} ${post_command} ${files_to_copy} ${RP_TEST_ARGS} "
       )
     set_tests_properties(${RP_TEST_BINARY_NAME} PROPERTIES LABELS "${RP_TEST_LABELS}")
     if(RP_TEST_TIMEOUT)

--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -1,1 +1,11 @@
+v_cc_library(
+  NAME io
+  SRCS
+    persistence.cc
+  DEPS
+    Seastar::seastar
+    absl::btree
+    absl::flat_hash_map
+)
+
 add_subdirectory(tests)

--- a/src/v/io/persistence.cc
+++ b/src/v/io/persistence.cc
@@ -86,7 +86,8 @@ uint64_t disk_persistence::disk_file::disk_read_dma_alignment() const noexcept {
     return file_.disk_read_dma_alignment();
 }
 
-uint64_t disk_persistence::disk_file::disk_write_dma_alignment() const noexcept {
+uint64_t
+disk_persistence::disk_file::disk_write_dma_alignment() const noexcept {
     return file_.disk_write_dma_alignment();
 }
 
@@ -115,7 +116,8 @@ disk_persistence::open(std::filesystem::path path) noexcept {
 }
 
 memory_persistence::memory_persistence()
-  : memory_persistence(default_alignment, default_alignment, default_alignment) {}
+  : memory_persistence(
+    default_alignment, default_alignment, default_alignment) {}
 
 memory_persistence::memory_persistence(
   // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
@@ -215,7 +217,9 @@ seastar::future<size_t> memory_persistence::memory_file::dma_write(
     });
 }
 
-seastar::future<> memory_persistence::memory_file::close() noexcept { co_return; }
+seastar::future<> memory_persistence::memory_file::close() noexcept {
+    co_return;
+}
 
 uint64_t
 memory_persistence::memory_file::disk_read_dma_alignment() const noexcept {
@@ -227,11 +231,13 @@ memory_persistence::memory_file::disk_write_dma_alignment() const noexcept {
     return persistence_->disk_write_dma_alignment_;
 }
 
-uint64_t memory_persistence::memory_file::memory_dma_alignment() const noexcept {
+uint64_t
+memory_persistence::memory_file::memory_dma_alignment() const noexcept {
     return persistence_->memory_dma_alignment_;
 }
 
-seastar::future<> memory_persistence::memory_file::ensure_capacity(size_t size) {
+seastar::future<>
+memory_persistence::memory_file::ensure_capacity(size_t size) {
     // futurized to avoid reactor stalls for large capacity expansions
     return seastar::do_until(
       [this, size] { return capacity_ >= size; },
@@ -280,8 +286,8 @@ memory_persistence::memory_file::read(uint64_t pos, char* buffer, size_t len) {
     co_return bytes_read;
 }
 
-seastar::future<size_t>
-memory_persistence::memory_file::write(uint64_t pos, const char* buf, size_t len) {
+seastar::future<size_t> memory_persistence::memory_file::write(
+  uint64_t pos, const char* buf, size_t len) {
     if (len == 0) {
         // don't expand capacity with a zero-length write at @pos
         co_return 0;

--- a/src/v/io/persistence.cc
+++ b/src/v/io/persistence.cc
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/persistence.h"
+
+#include "units.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/util/later.hh>
+
+#include <span>
+
+namespace {
+/*
+ * build an alignment error to return from read/write
+ */
+seastar::future<size_t> make_alignment_error(
+  std::string_view op, std::string_view arg, auto val, uint64_t alignment) {
+    auto msg = fmt::format(
+      R"(Op "{}" arg "{}" with value {} expects alignment {})",
+      op,
+      arg,
+      val,
+      alignment);
+    return seastar::make_exception_future<size_t>(
+      std::system_error(std::error_code(EINVAL, std::system_category()), msg));
+}
+
+/*
+ * helper for checking alignment of read/write
+ */
+std::optional<seastar::future<size_t>> check_alignment(
+  std::string_view name,
+  uint64_t pos,
+  const char* buf,
+  size_t len, // NOLINT(bugprone-easily-swappable-parameters)
+  uint64_t memory_alignment,
+  uint64_t disk_alignment) {
+    if (pos % disk_alignment) {
+        return make_alignment_error(name, "pos", pos, disk_alignment);
+    }
+
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+    if (auto ptr = reinterpret_cast<std::uintptr_t>(buf);
+        ptr % memory_alignment) {
+        return make_alignment_error(name, "buf", ptr, memory_alignment);
+    }
+
+    if (len % disk_alignment) {
+        return make_alignment_error(name, "len", len, disk_alignment);
+    }
+
+    return std::nullopt;
+}
+} // namespace
+
+namespace experimental::io {
+
+disk_persistence::disk_file::disk_file(seastar::file f)
+  : file_(std::move(f)) {}
+
+seastar::future<size_t> disk_persistence::disk_file::dma_read(
+  uint64_t pos, char* buf, size_t len) noexcept {
+    return file_.dma_read(pos, buf, len);
+}
+
+seastar::future<size_t> disk_persistence::disk_file::dma_write(
+  uint64_t pos, const char* buf, size_t len) noexcept {
+    return file_.dma_write(pos, buf, len);
+}
+
+seastar::future<> disk_persistence::disk_file::close() noexcept {
+    return file_.close();
+}
+
+uint64_t disk_persistence::disk_file::disk_read_dma_alignment() const noexcept {
+    return file_.disk_read_dma_alignment();
+}
+
+uint64_t disk_persistence::disk_file::disk_write_dma_alignment() const noexcept {
+    return file_.disk_write_dma_alignment();
+}
+
+uint64_t disk_persistence::disk_file::memory_dma_alignment() const noexcept {
+    return file_.memory_dma_alignment();
+}
+
+seastar::temporary_buffer<char>
+disk_persistence::allocate(uint64_t alignment, size_t size) noexcept {
+    return seastar::temporary_buffer<char>::aligned(alignment, size);
+}
+
+seastar::future<seastar::shared_ptr<persistence::file>>
+disk_persistence::create(std::filesystem::path path) noexcept {
+    using of = seastar::open_flags;
+    const auto flags = of::create | of::exclusive | of::rw;
+    auto file = co_await seastar::open_file_dma(path.string(), flags);
+    co_return seastar::make_shared<disk_file>(std::move(file));
+}
+
+seastar::future<seastar::shared_ptr<persistence::file>>
+disk_persistence::open(std::filesystem::path path) noexcept {
+    const auto flags = seastar::open_flags::rw;
+    auto file = co_await seastar::open_file_dma(path.string(), flags);
+    co_return seastar::make_shared<disk_file>(std::move(file));
+}
+
+memory_persistence::memory_persistence()
+  : memory_persistence(default_alignment, default_alignment, default_alignment) {}
+
+memory_persistence::memory_persistence(
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  uint64_t disk_read_dma_alignment,
+  uint64_t disk_write_dma_alignment,
+  uint64_t memory_dma_alignment)
+  : disk_read_dma_alignment_(disk_read_dma_alignment)
+  , disk_write_dma_alignment_(disk_write_dma_alignment)
+  , memory_dma_alignment_(memory_dma_alignment) {}
+
+/*
+ * The temporary buffer alignment helper used here is based on posix_memalign,
+ * which appears to allow the size to be less than alignment. However, the
+ * Seastar implementation of posix_memalign is apparently not compliant, and
+ * will a non-aligned (and no error) pointer in some cases where the size is not
+ * a multiple of alignment (much closer to aligned_alloc() behavior). To
+ * accomodate this difference the memory file system transparently rounds up the
+ * request to avoid this case when using Seastar's allocator in release mode.
+ *
+ * This only matters for the in-memory file system because Seastar's file system
+ * interface already has stricter requirements that avoid this case implicitly.
+ * We want to be able to use the in-memory file system to get weird with
+ * alignments and test edge cases.
+ */
+seastar::temporary_buffer<char>
+memory_persistence::allocate(uint64_t alignment, size_t size) noexcept {
+    auto ret = seastar::temporary_buffer<char>::aligned(
+      alignment, seastar::align_up(size, alignment));
+    ret.trim(size);
+    return ret;
+}
+
+seastar::future<seastar::shared_ptr<persistence::file>>
+memory_persistence::create(std::filesystem::path path) noexcept {
+    auto ret = files_.try_emplace(
+      path, seastar::make_shared<memory_file>(this));
+    if (!ret.second) {
+        return seastar::make_exception_future<
+          seastar::shared_ptr<persistence::file>>(
+          std::filesystem::filesystem_error(
+            "File exists",
+            path,
+            std::error_code(EEXIST, std::system_category())));
+    }
+    return seastar::make_ready_future<seastar::shared_ptr<persistence::file>>(
+      ret.first->second);
+}
+
+seastar::future<seastar::shared_ptr<persistence::file>>
+memory_persistence::open(std::filesystem::path path) noexcept {
+    auto it = files_.find(path);
+    if (it == files_.end()) {
+        return seastar::make_exception_future<
+          seastar::shared_ptr<persistence::file>>(
+          std::filesystem::filesystem_error(
+            "File does not exist",
+            path,
+            std::error_code(ENOENT, std::system_category())));
+    }
+    return seastar::make_ready_future<seastar::shared_ptr<persistence::file>>(
+      it->second);
+}
+
+memory_persistence::memory_file::memory_file(memory_persistence* persistence)
+  : persistence_(persistence) {}
+
+seastar::future<size_t> memory_persistence::memory_file::dma_read(
+  uint64_t pos, char* buf, size_t len) noexcept {
+    if (auto err = check_alignment(
+          "dma_read",
+          pos,
+          buf,
+          len,
+          memory_dma_alignment(),
+          disk_read_dma_alignment());
+        err.has_value()) {
+        return std::move(err.value());
+    }
+    return read(pos, buf, len);
+}
+
+seastar::future<size_t> memory_persistence::memory_file::dma_write(
+  uint64_t pos, const char* buf, size_t len) noexcept {
+    if (auto err = check_alignment(
+          "dma_write",
+          pos,
+          buf,
+          len,
+          memory_dma_alignment(),
+          disk_write_dma_alignment());
+        err.has_value()) {
+        return std::move(err.value());
+    }
+    return write(pos, buf, len).then([this, pos](size_t written) {
+        size_ = std::max(size_, pos + written);
+        return written;
+    });
+}
+
+seastar::future<> memory_persistence::memory_file::close() noexcept { co_return; }
+
+uint64_t
+memory_persistence::memory_file::disk_read_dma_alignment() const noexcept {
+    return persistence_->disk_read_dma_alignment_;
+}
+
+uint64_t
+memory_persistence::memory_file::disk_write_dma_alignment() const noexcept {
+    return persistence_->disk_write_dma_alignment_;
+}
+
+uint64_t memory_persistence::memory_file::memory_dma_alignment() const noexcept {
+    return persistence_->memory_dma_alignment_;
+}
+
+seastar::future<> memory_persistence::memory_file::ensure_capacity(size_t size) {
+    // futurized to avoid reactor stalls for large capacity expansions
+    return seastar::do_until(
+      [this, size] { return capacity_ >= size; },
+      [this] {
+          data_.emplace(capacity_, chunk_size);
+          capacity_ += chunk_size;
+          return seastar::make_ready_future<>();
+      });
+}
+
+seastar::future<size_t>
+memory_persistence::memory_file::read(uint64_t pos, char* buffer, size_t len) {
+    if (pos >= size_) {
+        co_return 0;
+    }
+
+    std::span output(buffer, len);
+
+    auto it = data_.upper_bound(pos);
+    // first chunk that starts strictly after pos ensures that begin() will
+    // never be returned since zero is the smallest possible offset.
+    it = std::prev(it);
+
+    size_t bytes_read = 0;
+    len = std::min(len, size_ - pos);
+    while (len) {
+        assert(it != data_.end());
+
+        auto chunk_pos = pos - it->first;
+        auto chunk_len = std::min(len, chunk_size - chunk_pos);
+
+        std::span chunk(it->second.get(), it->second.size());
+        auto src = chunk.subspan(chunk_pos);
+        auto dst = output.subspan(bytes_read);
+        std::copy_n(src.begin(), chunk_len, dst.begin());
+
+        bytes_read += chunk_len;
+        pos += chunk_len;
+        len -= chunk_len;
+
+        ++it;
+
+        co_await seastar::maybe_yield();
+    }
+
+    co_return bytes_read;
+}
+
+seastar::future<size_t>
+memory_persistence::memory_file::write(uint64_t pos, const char* buf, size_t len) {
+    if (len == 0) {
+        // don't expand capacity with a zero-length write at @pos
+        co_return 0;
+    }
+    co_await ensure_capacity(pos + len);
+
+    auto it = data_.upper_bound(pos);
+    // first chunk that starts strictly after pos ensures that begin() will
+    // never be returned since zero is the smallest possible offset.
+    it = std::prev(it);
+
+    size_t written = 0;
+    std::span input(buf, len);
+    while (len) {
+        assert(it != data_.end());
+
+        auto chunk_pos = pos - it->first;
+        auto chunk_len = std::min(len, chunk_size - chunk_pos);
+
+        std::span chunk(it->second.get_write(), it->second.size());
+        auto src = input.subspan(written);
+        auto dst = chunk.subspan(chunk_pos);
+        std::copy_n(src.begin(), chunk_len, dst.begin());
+
+        written += chunk_len;
+        pos += chunk_len;
+        len -= chunk_len;
+
+        ++it;
+
+        co_await seastar::maybe_yield();
+    }
+
+    co_return written;
+}
+
+} // namespace experimental::io

--- a/src/v/io/persistence.h
+++ b/src/v/io/persistence.h
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <seastar/core/file.hh>
+#include <seastar/core/future.hh>
+
+#include <absl/container/btree_map.h>
+#include <absl/container/flat_hash_map.h>
+
+#include <filesystem>
+
+namespace experimental::io {
+
+/**
+ * An abstract persistence interface.
+ *
+ * This interface is used to provide storage access to the io subsystem.
+ *
+ * Rationale
+ * =========
+ *
+ * Forcing file access to pass through a dedicated interface makes it easy to
+ * audit the set of low-level io primitives used in redpanda. Additionally,
+ * implementations can be constructed that are useful in testing, such offering
+ * functionality like fault injection and fuzzing.
+ */
+class persistence {
+public:
+    persistence() = default;
+    persistence(const persistence&) = delete;
+    persistence(persistence&&) = delete;
+    persistence& operator=(const persistence&) = delete;
+    persistence& operator=(persistence&&) = delete;
+    virtual ~persistence() = default;
+
+    /**
+     * An abstract file interface.
+     */
+    class file {
+    public:
+        file() = default;
+        file(const file&) = delete;
+        file(file&&) = delete;
+        file& operator=(const file&) = delete;
+        file& operator=(file&&) = delete;
+        virtual ~file() = default;
+
+        /**
+         * Read \p size bytes at \p offset into \p buf.
+         */
+        virtual seastar::future<size_t>
+        dma_read(uint64_t offset, char* buf, size_t) noexcept = 0;
+
+        /**
+         * Write \p size bytes from \p buf to \p offset.
+         */
+        virtual seastar::future<size_t>
+        dma_write(uint64_t offset, const char* buf, size_t size) noexcept = 0;
+
+        /**
+         * Close the file.
+         */
+        virtual seastar::future<> close() noexcept = 0;
+
+        /**
+         * Required alignment for offsets being read.
+         */
+        [[nodiscard]] virtual uint64_t disk_read_dma_alignment() const noexcept
+          = 0;
+
+        /**
+         * Required alignment for offsets being written.
+         */
+        [[nodiscard]] virtual uint64_t disk_write_dma_alignment() const noexcept
+          = 0;
+
+        /**
+         * Required alignment for I/O memory.
+         */
+        [[nodiscard]] virtual uint64_t memory_dma_alignment() const noexcept
+          = 0;
+    };
+
+    /**
+     * Allocate at least \p size bytes with \p alignment.
+     */
+    virtual seastar::temporary_buffer<char>
+    allocate(uint64_t alignment, size_t size) noexcept = 0;
+
+    /**
+     * Create a new file at the specified \p path.
+     */
+    virtual seastar::future<seastar::shared_ptr<file>>
+      create(std::filesystem::path) noexcept = 0;
+
+    /**
+     * Open the file at the specified \p path.
+     */
+    virtual seastar::future<seastar::shared_ptr<file>>
+      open(std::filesystem::path) noexcept = 0;
+};
+
+/**
+ * An implementation of \ref persistence that proxies directly to Seastar I/O
+ * interfaces.
+ */
+class disk_persistence final : public persistence {
+public:
+    /**
+     * An implementation of \ref persistence::file that proxies directly to
+     * Seastar I/O interfaces.
+     */
+    class disk_file final : public file {
+    public:
+        /**
+         * Construct instance from Seastar \p file.
+         */
+        explicit disk_file(seastar::file file);
+
+        seastar::future<size_t>
+        dma_read(uint64_t, char*, size_t) noexcept override;
+
+        seastar::future<size_t>
+        dma_write(uint64_t, const char*, size_t) noexcept override;
+
+        seastar::future<> close() noexcept override;
+
+        uint64_t disk_read_dma_alignment() const noexcept override;
+        uint64_t disk_write_dma_alignment() const noexcept override;
+        uint64_t memory_dma_alignment() const noexcept override;
+
+    private:
+        seastar::file file_;
+    };
+
+    seastar::temporary_buffer<char>
+    allocate(uint64_t alignment, size_t size) noexcept override;
+
+    seastar::future<seastar::shared_ptr<file>>
+    create(std::filesystem::path path) noexcept override;
+
+    seastar::future<seastar::shared_ptr<file>>
+    open(std::filesystem::path path) noexcept override;
+};
+
+/**
+ * An implementation of \ref persistence that stores all data in memory.
+ *
+ * The in-memory file system is fast, making it possible to run large parameter
+ * tests much faster than using the disk-backed file system. However, there are
+ * benefits that go beyond speed. The in-memory file system allows us to
+ * customize properties like alignment requirements while continuing to have a
+ * working storage layer. This is useful because it lets us test scenarios that
+ * would be difficult to construct in practice, such as using an OS or hardware
+ * with uncommon alignment requirements.
+ */
+class memory_persistence : public persistence {
+    static constexpr uint64_t default_alignment = 4096;
+
+public:
+    /**
+     * Create a \ref memory_persistence.
+     */
+    memory_persistence();
+
+    /**
+     * Create a memory_persistence with specific alignment requirements.
+     */
+    memory_persistence(
+      uint64_t disk_read_dma_alignment,
+      uint64_t disk_write_dma_alignment,
+      uint64_t memory_dma_alignment);
+
+    /**
+     * An implementation of \ref persistence::file that stores all data in
+     * memory.
+     */
+    class memory_file final : public file {
+        static constexpr uint64_t chunk_size = 4096;
+
+    public:
+        /**
+         * Create an empty file in the underlying \p persistence.
+         */
+        explicit memory_file(memory_persistence* persistence);
+
+        seastar::future<size_t>
+        dma_read(uint64_t pos, char* buf, size_t len) noexcept override;
+
+        seastar::future<size_t>
+        dma_write(uint64_t pos, const char* buf, size_t len) noexcept override;
+
+        seastar::future<> close() noexcept override;
+
+        uint64_t disk_read_dma_alignment() const noexcept override;
+        uint64_t disk_write_dma_alignment() const noexcept override;
+        uint64_t memory_dma_alignment() const noexcept override;
+
+    private:
+        seastar::future<> ensure_capacity(size_t);
+        seastar::future<size_t> read(uint64_t, char*, size_t);
+        seastar::future<size_t> write(uint64_t, const char*, size_t);
+
+        size_t size_{0};
+        size_t capacity_{0};
+        memory_persistence* persistence_;
+        absl::btree_map<size_t, seastar::temporary_buffer<char>> data_;
+    };
+
+    seastar::temporary_buffer<char>
+    allocate(uint64_t alignment, size_t size) noexcept override;
+
+    seastar::future<seastar::shared_ptr<file>>
+    create(std::filesystem::path path) noexcept override;
+
+    seastar::future<seastar::shared_ptr<file>>
+    open(std::filesystem::path path) noexcept override;
+
+private:
+    uint64_t disk_read_dma_alignment_;
+    uint64_t disk_write_dma_alignment_;
+    uint64_t memory_dma_alignment_;
+
+    struct fs_path_hash {
+        std::size_t
+        operator()(const std::filesystem::path& path) const noexcept {
+            return std::filesystem::hash_value(path);
+        }
+    };
+
+    absl::flat_hash_map<
+      std::filesystem::path,
+      seastar::shared_ptr<memory_file>,
+      fs_path_hash>
+      files_;
+};
+
+} // namespace experimental::io

--- a/src/v/io/tests/CMakeLists.txt
+++ b/src/v/io/tests/CMakeLists.txt
@@ -1,11 +1,15 @@
 rp_test(
   UNIT_TEST
   GTEST
+  USE_CWD
   BINARY_NAME io
   SOURCES
+    common.cc
     cache_test.cc
     interval_map_test.cc
+    persistence_test.cc
   LIBRARIES
     v::gtest_main
+    v::io
     absl::btree
 )

--- a/src/v/io/tests/common.cc
+++ b/src/v/io/tests/common.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/tests/common.h"
+
+#include "units.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/util/later.hh>
+
+#include <random>
+#include <span>
+
+seastar::future<seastar::temporary_buffer<char>>
+make_random_data(size_t size, std::optional<uint64_t> alignment) {
+    static constexpr size_t chunk_size = 32_KiB;
+
+    static thread_local std::random_device rd;
+    static thread_local std::
+      independent_bits_engine<std::mt19937, CHAR_BIT, unsigned char>
+        eng(rd());
+
+    auto data = [&] {
+        if (alignment.has_value()) {
+            return seastar::temporary_buffer<char>::aligned(
+              alignment.value(), size);
+        } else {
+            return seastar::temporary_buffer<char>(size);
+        }
+    }();
+
+    uint64_t offset = 0;
+    std::span<char> span(data.get_write(), data.size());
+
+    while (true) {
+        auto len = std::min(span.size() - offset, chunk_size);
+        if (len == 0) {
+            break;
+        }
+
+        auto chunk = span.subspan(offset, len);
+        std::generate(chunk.begin(), chunk.end(), [&] { return eng(); });
+        offset += len;
+
+        co_await seastar::maybe_yield();
+    }
+
+    co_return data;
+}

--- a/src/v/io/tests/common.h
+++ b/src/v/io/tests/common.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <seastar/core/temporary_buffer.hh>
+
+/**
+ * Generate random data for use in tests.
+ */
+seastar::future<seastar::temporary_buffer<char>>
+make_random_data(size_t size, std::optional<uint64_t> alignment = std::nullopt);

--- a/src/v/io/tests/persistence_test.cc
+++ b/src/v/io/tests/persistence_test.cc
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/persistence.h"
+#include "io/tests/common.h"
+#include "test_utils/test.h"
+#include "units.h"
+
+#include <seastar/util/defer.hh>
+#include <seastar/util/file.hh>
+#include <seastar/util/tmp_file.hh>
+
+namespace io = experimental::io;
+
+template<typename T>
+class PersistenceTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        dir = seastar::make_tmp_dir(".").get();
+        fn = make_filename();
+    }
+
+    void TearDown() override {
+        for (auto& file : open_files) {
+            file->close().get();
+        }
+        dir.remove().get();
+    }
+
+    std::filesystem::path make_filename() {
+        return dir.get_path() / fmt::format("file.{}", count++);
+    }
+
+    // fs::create wrapper that records file to close after test finishes
+    auto create(std::filesystem::path path) {
+        auto f = this->fs.create(path).get();
+        open_files.push_back(f);
+        return f;
+    }
+
+    // fs::open wrapper that records file to close after test finishes
+    auto open(std::filesystem::path path) {
+        auto f = this->fs.open(path).get();
+        open_files.push_back(f);
+        return f;
+    }
+
+    T fs;
+    seastar::tmp_dir dir;
+    std::filesystem::path fn;
+    int count{0};
+    std::vector<seastar::shared_ptr<io::persistence::file>> open_files;
+};
+
+/*
+ * used to create memory file system types with different default alignments
+ * that can be used to drive the TYPED_TEST_SUITE below.
+ */
+template<uint64_t read, uint64_t write, uint64_t memory>
+class memfs_align : public io::memory_persistence {
+public:
+    memfs_align()
+      : memory_persistence(read, write, memory) {}
+};
+
+using PersistenceTypes = ::testing::Types<
+  io::disk_persistence,
+  io::memory_persistence,
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+  memfs_align<512, 1024, 8192>,
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+  memfs_align<16_KiB, 32_KiB, 64_KiB>,
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+  memfs_align<4096, 1024, 8192>,
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+  memfs_align<4096, 1024, 2048>,
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+  memfs_align<512, 2048, 1024>>;
+
+TYPED_TEST_SUITE(PersistenceTest, PersistenceTypes);
+
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define EXPECT_THROW_WITH_ALIGNMENT_WARNING(expression, exception)             \
+    EXPECT_THROW(expression, exception)                                        \
+      << "Expected failure due to alignment. Are you running tests on "        \
+         "`tmpfs` or another file system that doesn't enforce direct I/O "     \
+         "alignemnt?";
+
+TYPED_TEST(PersistenceTest, Create) { EXPECT_TRUE(this->create(this->fn)); }
+
+TYPED_TEST(PersistenceTest, CreateAlreadyExists) {
+    this->create(this->fn);
+    EXPECT_THROW(
+      this->fs.create(this->fn).get(), std::filesystem::filesystem_error);
+}
+
+TYPED_TEST(PersistenceTest, Open) {
+    this->create(this->fn);
+    EXPECT_TRUE(this->open(this->fn));
+}
+
+TYPED_TEST(PersistenceTest, OpenDoesNotExist) {
+    EXPECT_THROW(
+      this->fs.open(this->fn).get(), std::filesystem::filesystem_error);
+}
+
+TYPED_TEST(PersistenceTest, WriteOffsetAlignment) {
+    auto f = this->create(this->fn);
+
+    // normal alignment and size
+    const auto buf = this->fs.allocate(
+      f->memory_dma_alignment(), f->disk_write_dma_alignment());
+
+    EXPECT_NO_THROW(f->dma_write(0, buf.get(), buf.size()).get());
+
+    // write offset is not aligned
+    EXPECT_THROW_WITH_ALIGNMENT_WARNING(
+      f->dma_write(1, buf.get(), buf.size()).get(), std::system_error);
+}
+
+TYPED_TEST(PersistenceTest, WriteMemoryAlignment) {
+    auto f = this->create(this->fn);
+
+    // correct memory alignment, extra space allocated for adjustments
+    const auto buf = this->fs.allocate(
+      f->memory_dma_alignment(), f->disk_write_dma_alignment() + 1);
+
+    // correct memory alignment, correct size alignment
+    EXPECT_NO_THROW(f->dma_write(0, buf.get(), buf.size() - 1).get());
+
+    // incorrect memory alignment, correct size alignment
+    EXPECT_THROW_WITH_ALIGNMENT_WARNING(
+      f->dma_write(0, buf.get() + 1, buf.size() - 1).get(), std::system_error);
+}
+
+TYPED_TEST(PersistenceTest, WriteSizeAlignment) {
+    auto f = this->create(this->fn);
+
+    // normal alignment and size
+    const auto buf = this->fs.allocate(
+      f->memory_dma_alignment(), f->disk_write_dma_alignment());
+
+    EXPECT_NO_THROW(f->dma_write(0, buf.get(), buf.size()).get());
+
+    // write size is not aligned
+    EXPECT_THROW_WITH_ALIGNMENT_WARNING(
+      f->dma_write(0, buf.get(), buf.size() - 1).get(), std::system_error);
+}
+
+TYPED_TEST(PersistenceTest, ReadOffsetAlignment) {
+    auto f = this->create(this->fn);
+
+    {
+        // need data to make it to alignment checks in read path. need at least
+        // read size, but it also needs to be write aligned
+        const auto size = seastar::align_up(
+          f->disk_read_dma_alignment(), f->disk_write_dma_alignment());
+        const auto buf = this->fs.allocate(f->memory_dma_alignment(), size);
+        f->dma_write(0, buf.get(), buf.size()).get();
+    }
+
+    // normal alignment and size
+    auto buf = this->fs.allocate(
+      f->memory_dma_alignment(), f->disk_read_dma_alignment());
+
+    EXPECT_NO_THROW(f->dma_read(0, buf.get_write(), buf.size()).get());
+
+    // read offset is not aligned
+    EXPECT_THROW_WITH_ALIGNMENT_WARNING(
+      f->dma_read(1, buf.get_write(), buf.size()).get(), std::system_error);
+}
+
+TYPED_TEST(PersistenceTest, ReadMemoryAlignment) {
+    auto f = this->create(this->fn);
+
+    {
+        // need data to make it to alignment checks in read path. need at least
+        // read size, but it also needs to be write aligned
+        const auto size = seastar::align_up(
+          f->disk_read_dma_alignment() + 1, f->disk_write_dma_alignment());
+        const auto buf = this->fs.allocate(f->memory_dma_alignment(), size);
+        f->dma_write(0, buf.get(), buf.size()).get();
+    }
+
+    auto buf = this->fs.allocate(
+      f->memory_dma_alignment(), f->disk_read_dma_alignment() + 1);
+
+    EXPECT_NO_THROW(f->dma_read(0, buf.get_write(), buf.size() - 1).get());
+
+    // read memory is not aligned
+    EXPECT_THROW_WITH_ALIGNMENT_WARNING(
+      f->dma_read(0, buf.get_write() + 1, buf.size() - 1).get(),
+      std::system_error);
+}
+
+TYPED_TEST(PersistenceTest, ReadSizeAlignment) {
+    auto f = this->create(this->fn);
+
+    {
+        // need data to make it to alignment checks in read path. need at least
+        // read size, but it also needs to be write aligned
+        const auto size = seastar::align_up(
+          f->disk_read_dma_alignment(), f->disk_write_dma_alignment());
+        const auto buf = this->fs.allocate(f->memory_dma_alignment(), size);
+        f->dma_write(0, buf.get(), buf.size()).get();
+    }
+
+    auto buf = this->fs.allocate(
+      f->memory_dma_alignment(), f->disk_read_dma_alignment());
+
+    EXPECT_NO_THROW(f->dma_read(0, buf.get_write(), buf.size()).get());
+
+    // read size is not aligned
+    EXPECT_THROW_WITH_ALIGNMENT_WARNING(
+      f->dma_read(0, buf.get_write(), buf.size() - 1).get(), std::system_error);
+}
+
+TYPED_TEST(PersistenceTest, Close) {
+    auto f = this->fs.create(this->fn).get();
+    f->close().get();
+}
+
+TYPED_TEST(PersistenceTest, ReadWrite) {
+    constexpr auto test_size = 64_KiB;
+
+    auto f = this->create(this->fn);
+
+    for (auto write_len = f->disk_write_dma_alignment(); write_len <= test_size;
+         write_len += f->disk_write_dma_alignment()) {
+        /*
+         * for a particular write length, write the entire file
+         */
+        const auto input = make_random_data(test_size).get();
+        for (uint64_t offset = 0; offset < test_size;) {
+            auto length = std::min(write_len, test_size - offset);
+            auto tmp = this->fs.allocate(f->memory_dma_alignment(), length);
+            // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+            std::memcpy(tmp.get_write(), input.get() + offset, tmp.size());
+            auto size = f->dma_write(offset, tmp.get(), tmp.size()).get();
+            offset += size;
+        }
+
+        /*
+         * for a particular read length, read the entire file
+         */
+        for (auto read_len = f->disk_read_dma_alignment();
+             read_len <= test_size;
+             read_len += f->disk_read_dma_alignment()) {
+            auto output = make_random_data(input.size()).get();
+            EXPECT_NE(input, output);
+
+            for (uint64_t offset = 0; offset < test_size;) {
+                auto length = std::min(read_len, test_size - offset);
+                auto tmp = this->fs.allocate(f->memory_dma_alignment(), length);
+                auto size
+                  = f->dma_read(offset, tmp.get_write(), tmp.size()).get();
+                // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+                std::memcpy(output.get_write() + offset, tmp.get(), tmp.size());
+                offset += size;
+            }
+
+            /*
+             * data read should be the same as that which was written
+             */
+            EXPECT_EQ(input, output);
+        }
+    }
+}
+
+TEST(MemoryPersistenceTest, CustomAlignment) {
+    std::vector<seastar::shared_ptr<io::persistence::file>> open_files;
+    auto cleanup = seastar::defer([&open_files] {
+        for (auto& file : open_files) {
+            file->close().get();
+        }
+    });
+
+    // default alignments
+    io::memory_persistence dfs;
+    auto df = dfs.create("file").get();
+    open_files.push_back(df);
+
+    // custom alignments
+    io::memory_persistence cfs(1, 2, 3);
+    auto cf = cfs.create("file").get();
+    open_files.push_back(cf);
+
+    EXPECT_NE(cf->disk_read_dma_alignment(), df->disk_read_dma_alignment());
+    EXPECT_NE(cf->disk_write_dma_alignment(), df->disk_write_dma_alignment());
+    EXPECT_NE(cf->memory_dma_alignment(), df->memory_dma_alignment());
+
+    EXPECT_EQ(cf->disk_read_dma_alignment(), 1);
+    EXPECT_EQ(cf->disk_write_dma_alignment(), 2);
+    EXPECT_EQ(cf->memory_dma_alignment(), 3);
+}

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -176,7 +176,7 @@ class BacktraceCapture(threading.Thread):
 
 
 class TestRunner():
-    def __init__(self, prepare_command, post_command, binary, repeat,
+    def __init__(self, root, prepare_command, post_command, binary, repeat,
                  copy_files, gtest, *args):
         self.prepare_command = prepare_command
         self.post_command = post_command
@@ -184,7 +184,7 @@ class TestRunner():
         self.repeat = repeat if repeat is not None else 1
         self.copy_files = copy_files
         self.gtest = gtest
-        self.root = "/dev/shm/vectorized_io"
+        self.root = root
         os.makedirs(self.root, exist_ok=True)
 
         # make args a list
@@ -381,10 +381,17 @@ def main():
                             action="append",
                             help='copy file to test execution directory')
         parser.add_argument('--gtest', action='store_true')
+        parser.add_argument('--root',
+                            type=str,
+                            default=None,
+                            help="Working directory (default = cwd)")
         return parser
 
     parser = generate_options()
     options, program_options = parser.parse_known_args()
+
+    if options.root is None:
+        options.root = os.getcwd()
 
     if not options.binary:
         parser.print_help()
@@ -395,9 +402,9 @@ def main():
     logger.setLevel(getattr(logging, options.log.upper()))
     logger.info("%s *args=%s" % (options, program_options))
 
-    runner = TestRunner(options.pre, options.post, options.binary,
-                        options.repeat, options.copy_file, options.gtest,
-                        *program_options)
+    runner = TestRunner(options.root, options.pre, options.post,
+                        options.binary, options.repeat, options.copy_file,
+                        options.gtest, *program_options)
     runner.run()
     return 0
 


### PR DESCRIPTION
Adds disk and in-memory providers for the unified io proof-of-concept.

The storage provider gives access to storage for the io subsystem. There are two implementations, one that passes directly to Seastar I/O's subsystem and is intended for production cases. The second is an in-memory implementation that is useful in testing for speed and for enabling parameter exploration (e.g. alignments) that would not work on a real file system.

In addition to testing, the provider abstraction is a centralized location to implementation fault injection, tracking open-files, and allowing users (code) of I/O to be easier to identify.

One thing you may notice is that the disk-baesd file system of course provides cross-core uniqueness of files with no effort because this is enforced by the OS. This is not the case for the in-memory file system that tracks open-files in a simple index. It's open question so far as to how far we'll take enforcement. One option is to wrap the abstraction in a sharded<> service that provides stronger semantics across cores. This just isn't an issue that is necessary to address yet.

Coverage 🤠 
```
[nwatkins@fedora coverage]$ src/v/io/tests/io_rpunit
[nwatkins@fedora coverage]$ ../../tools/gcovr src/v/io
------------------------------------------------------------------------------
                           GCC Code Coverage Report
Directory: ../..
------------------------------------------------------------------------------
File                                       Lines    Exec  Cover   Missing
------------------------------------------------------------------------------
src/v/io/cache.h                             116     116   100%
src/v/io/interval_map.h                       50      50   100%
src/v/io/provider.cc                         163     163   100%
src/v/io/provider.h                            4       4   100%
src/v/io/tests/cache_test.cc                 504     504   100%
src/v/io/tests/common.cc                      23      21    91%   32-33
src/v/io/tests/interval_map_test.cc          223     223   100%
src/v/io/tests/provider_test.cc              129     128    99%   33
------------------------------------------------------------------------------
TOTAL                                       1212    1209    99%
------------------------------------------------------------------------------
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

