### PR TITLE
cloud_storage: improve description of cache_op_miss

### DIFF
--- a/src/v/cloud_storage/cache_probe.cc
+++ b/src/v/cloud_storage/cache_probe.cc
@@ -130,8 +130,8 @@ cache_probe::cache_probe() {
             sm::make_counter(
               "miss",
               [this] { return _num_miss_gets; },
-              sm::description("Number of get requests that are not satisfied "
-                              "from the cache."))
+              sm::description("Number of failed get requests because of "
+                              "missing object in the cache."))
               .aggregate(aggregate_labels),
             sm::make_gauge(
               "in_progress_files",


### PR DESCRIPTION
This commit improves the description of
`redpanda_cloud_storage_cache_op_miss` to indicate cache is evicted unexpectedly.

Discussion with @abhijat https://redpandadata.slack.com/archives/C02BDN76HUK/p1697173009089389
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Improve description of `redpanda_cloud_storage_cache_op_miss`

