### PR TITLE
[v23.1.x] redpanda: Make `redpanda_cpu_busy_seconds_total` a counter

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -532,7 +532,7 @@ void application::setup_public_metrics() {
       .invoke_on_all([](auto& public_metrics) {
           public_metrics.groups.add_group(
             "cpu",
-            {sm::make_gauge(
+            {sm::make_counter(
               "busy_seconds_total",
               [] {
                   return std::chrono::duration<double>(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14905
