### PR TITLE
wasm/sr: initialize internal topic

### DIFF
--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -54,6 +54,7 @@ public:
     sharded_store& schema_store() { return _store; }
     request_authenticator& authenticator() { return _auth; }
     ss::future<> mitigate_error(std::exception_ptr);
+    ss::future<> ensure_started() { return _ensure_started().discard_result(); }
 
 private:
     ss::future<> do_start();


### PR DESCRIPTION
Ensure that we start the schema registry if the first thing to use it is wasm.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
