### PR TITLE
config: make wasm memory user configurable

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -170,7 +170,7 @@ configuration::configuration()
       {
         .needs_restart = needs_restart::yes,
         .example = std::to_string(25_MiB),
-        .visibility = visibility::tunable,
+        .visibility = visibility::user,
       },
       20_MiB,
       {.min = 64_KiB, .max = 100_GiB})
@@ -185,7 +185,7 @@ configuration::configuration()
       {
         .needs_restart = needs_restart::yes,
         .example = std::to_string(5_MiB),
-        .visibility = visibility::tunable,
+        .visibility = visibility::user,
       },
       2_MiB,
       // WebAssembly uses 64KiB pages and has a 32bit address space


### PR DESCRIPTION
This is how a user specifies how much memory they can give wasm and how
much a single function has, so make it more visible for them.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
