### PR TITLE
rpk: add no-browser to `cloud login`

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/byoc/install.go
+++ b/src/go/rpk/pkg/cli/cloud/byoc/install.go
@@ -76,7 +76,7 @@ func loginAndEnsurePluginVersion(ctx context.Context, fs afero.Fs, cfg *config.C
 	} else {
 		token, err = oauth.LoadFlow(ctx, fs, cfg, auth0.NewClient(overrides), false)
 		if err != nil {
-			return "", "", false, fmt.Errorf("unable to load the cloud token: %w", err)
+			return "", "", false, fmt.Errorf("unable to load the cloud token: %w. You may need to logout with 'rpk cloud logout --clear-credentials' and try again", err)
 		}
 	}
 

--- a/src/go/rpk/pkg/cli/cloud/byoc/install.go
+++ b/src/go/rpk/pkg/cli/cloud/byoc/install.go
@@ -74,7 +74,7 @@ func loginAndEnsurePluginVersion(ctx context.Context, fs afero.Fs, cfg *config.C
 	if overrides.CloudToken != "" {
 		token = overrides.CloudToken
 	} else {
-		token, err = oauth.LoadFlow(ctx, fs, cfg, auth0.NewClient(overrides))
+		token, err = oauth.LoadFlow(ctx, fs, cfg, auth0.NewClient(overrides), false)
 		if err != nil {
 			return "", "", false, fmt.Errorf("unable to load the cloud token: %w", err)
 		}

--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -90,6 +90,8 @@ want to disable automatic profile creation and selection, use --no-profile.
 				if e := (*oauth.BadClientTokenError)(nil); errors.As(err, &e) && cc {
 					fmt.Println(`You may need to clear your client ID and secret with 'rpk cloud logout --clear-credentials',
 and then re-specify the client credentials next time you log in.`)
+				} else {
+					fmt.Println(`You may need to clear your credentials with 'rpk cloud logout --clear-credentials', and login again`)
 				}
 				os.Exit(1)
 			}

--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -29,7 +29,7 @@ import (
 )
 
 func newLoginCommand(fs afero.Fs, p *config.Params) *cobra.Command {
-	var save, noProfile bool
+	var save, noProfile, noBrowser bool
 	cmd := &cobra.Command{
 		Use:   "login",
 		Short: "Log in to the Redpanda cloud",
@@ -48,6 +48,8 @@ SSO
 This will automatically launch your default web browser and prompt you to 
 authenticate via our Redpanda Cloud page. Once you have successfully 
 authenticated, you will be ready to use rpk cloud commands.
+
+You may opt out of auto-opening the browser by passing the '--no-browser' flag.
 
 CLIENT CREDENTIALS
 
@@ -82,7 +84,7 @@ want to disable automatic profile creation and selection, use --no-profile.
 			if auth != nil {
 				cc = auth.HasClientCredentials()
 			}
-			_, err = oauth.LoadFlow(cmd.Context(), fs, cfg, auth0.NewClient(cfg.DevOverrides()))
+			_, err = oauth.LoadFlow(cmd.Context(), fs, cfg, auth0.NewClient(cfg.DevOverrides()), noBrowser)
 			if err != nil {
 				fmt.Printf("Unable to login to Redpanda Cloud (%v).\n", err)
 				if e := (*oauth.BadClientTokenError)(nil); errors.As(err, &e) && cc {
@@ -116,6 +118,7 @@ and then re-specify the client credentials next time you log in.`)
 
 	p.InstallCloudFlags(cmd)
 	cmd.Flags().BoolVar(&noProfile, "no-profile", false, "Skip automatic profile creation and any associated prompts")
+	cmd.Flags().BoolVar(&noBrowser, "no-browser", false, "Opt out of auto-opening authentication URL")
 	cmd.Flags().BoolVar(&save, "save", false, "Save environment or flag specified client ID and client secret to the configuration file")
 	return cmd
 }

--- a/src/go/rpk/pkg/oauth/load.go
+++ b/src/go/rpk/pkg/oauth/load.go
@@ -39,7 +39,7 @@ func LoadFlow(ctx context.Context, fs afero.Fs, cfg *config.Config, cl Client, n
 	// We want to update the actual auth.
 	yAct, err := cfg.ActualRpkYamlOrEmpty()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("unable to load your rpk.yaml file: %v", err)
 	}
 	authAct := yAct.Auth(yAct.CurrentCloudAuth)
 	if authAct == nil {

--- a/src/go/rpk/pkg/oauth/load.go
+++ b/src/go/rpk/pkg/oauth/load.go
@@ -14,7 +14,7 @@ import (
 //
 // This function is expected to be called at the start of most commands, and it
 // saves the token and client ID to the passed cloud config.
-func LoadFlow(ctx context.Context, fs afero.Fs, cfg *config.Config, cl Client) (token string, err error) {
+func LoadFlow(ctx context.Context, fs afero.Fs, cfg *config.Config, cl Client, noUI bool) (token string, err error) {
 	// We want to avoid creating a root owned file. If the file exists, we
 	// just chmod with rpkos.ReplaceFile and keep old perms even with sudo.
 	// If the file does not exist, we will always be creating it to write
@@ -30,7 +30,7 @@ func LoadFlow(ctx context.Context, fs afero.Fs, cfg *config.Config, cl Client) (
 	if authVir.HasClientCredentials() {
 		resp, err = ClientCredentialFlow(ctx, cl, authVir)
 	} else {
-		resp, err = DeviceFlow(ctx, cl, authVir)
+		resp, err = DeviceFlow(ctx, cl, authVir, noUI)
 	}
 	if err != nil {
 		return "", fmt.Errorf("unable to retrieve a cloud token: %w", err)

--- a/src/go/rpk/pkg/oauth/load_test.go
+++ b/src/go/rpk/pkg/oauth/load_test.go
@@ -87,7 +87,7 @@ func TestLoadFlow(t *testing.T) {
 			}
 			cfg, err := p.Load(fs)
 			require.NoError(t, err)
-			gotToken, err := LoadFlow(context.Background(), fs, cfg, &m)
+			gotToken, err := LoadFlow(context.Background(), fs, cfg, &m, false)
 			if tt.expErr {
 				require.Error(t, err)
 				return

--- a/src/go/rpk/pkg/oauth/oauth.go
+++ b/src/go/rpk/pkg/oauth/oauth.go
@@ -64,7 +64,7 @@ func ClientCredentialFlow(ctx context.Context, cl Client, auth *config.RpkCloudA
 	if auth.AuthToken != "" && auth.ClientID != "" {
 		expired, err := ValidateToken(auth.AuthToken, cl.Audience(), auth.ClientID)
 		if err != nil {
-			return Token{}, err
+			return Token{}, fmt.Errorf("unable to validate your authorization token: %v", err)
 		}
 		if !expired {
 			return Token{AccessToken: auth.AuthToken}, nil

--- a/src/go/rpk/pkg/oauth/oauth_test.go
+++ b/src/go/rpk/pkg/oauth/oauth_test.go
@@ -242,7 +242,7 @@ func TestDeviceFlow(t *testing.T) {
 				mockDeviceToken: tt.mDevToken,
 				mockDevice:      tt.mDevice,
 			}
-			got, err := DeviceFlow(context.Background(), &cl, tt.auth)
+			got, err := DeviceFlow(context.Background(), &cl, tt.auth, false)
 			if tt.expErr {
 				require.Error(t, err)
 				return


### PR DESCRIPTION
This PR:
- 1e302e426a35dfba827b989512f1718d77505e15 : adds `--no-browser` flag to `rpk cloud login` for non-UI users who are trying to login to Redpanda cloud using rpk. Fixes #14837
-  4c21514ddac9574bf936c3887e4c8addf5ca13c2 : Provides better error messages and hints in case of failure of `rpk cloud login` or when executing rpk cloud commands. Fixes #13980

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* add `--no-browser` flag to `rpk cloud login` for non-UI users of rpk.
