### PR TITLE
wasm: lower fuel interval

### DIFF
--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -78,8 +78,8 @@ constexpr size_t max_host_function_stack_usage = vm_stack_size
 // based and configurable, but until that work, this is the simpler option.
 constexpr uint64_t fuel_amount = 5'000'000'000;
 // This interval in the above experiment allowed for Wasm to take up CPU for no
-// more than 4 milliseconds max at once.
-constexpr uint64_t fuel_yield_interval = 10'000'000;
+// more than 1 millisecond max at once.
+constexpr uint64_t fuel_yield_interval = 2'000'000;
 
 template<typename T, auto fn>
 struct deleter {


### PR DESCRIPTION
This lowers the amount of fuel before we switch back to allowing the
reactor to run. Effectively simple tests show this limits wasm to ~1ms
of blocking time.

I am also thinking about making these tunables, but I'm not sold on us
using fuel long term (we may switch to time based limiting). So I'm holding 
off on that. Maybe it will make sense to convert a time unit into fuel and 
just make the tunable based on time, I suspect we'd only want this available
as an emergency hatch if user code is timing out on new input.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
