### PR TITLE
admin: handle transform errors with 400s

### DIFF
--- a/src/v/redpanda/admin_server.cc
+++ b/src/v/redpanda/admin_server.cc
@@ -1110,6 +1110,15 @@ ss::future<> admin_server::throw_on_error(
             throw ss::httpd::base_exception(
               fmt::format("Too many requests: {}", ec.message()),
               ss::http::reply::status_type::too_many_requests);
+        case cluster::errc::transform_does_not_exist:
+        case cluster::errc::transform_invalid_update:
+        case cluster::errc::transform_invalid_create:
+        case cluster::errc::transform_invalid_source:
+        case cluster::errc::transform_invalid_environment:
+        case cluster::errc::source_topic_not_exists:
+        case cluster::errc::source_topic_still_in_use:
+            throw ss::httpd::bad_request_exception(
+              fmt::format("{}", ec.message()));
         default:
             throw ss::httpd::server_error_exception(
               fmt::format("Unexpected cluster error: {}", ec.message()));


### PR DESCRIPTION
These are expected transform errors that means the user tried to do
something wrong with transforms, we should return 400s in this case.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
