### PR TITLE
model: add gate to batch reader

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -102,7 +102,10 @@ ss::future<storage::translating_reader> replicated_partition::make_reader(
             });
         }
 
-        ss::future<> finally() noexcept final { return _underlying->finally(); }
+        ss::future<> finally() noexcept final {
+            co_await _underlying->finally();
+            co_await impl::finally();
+        }
 
     private:
         std::unique_ptr<model::record_batch_reader::impl> _underlying;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -147,7 +147,10 @@ public:
 
     ss::future<storage_t> do_load_slice(model::timeout_clock::time_point) final;
 
-    ss::future<> finally() noexcept final { return _iterator.close(); }
+    ss::future<> finally() noexcept final {
+        co_await _iterator.close();
+        co_await impl::finally();
+    }
 
     void print(std::ostream& os) final {
         fmt::print(os, "storage::log_reader. config {}", _config);


### PR DESCRIPTION
This ensures we keep state open for as long as data is being loaded, provided finally() is called before destructing a reader.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
