### PR TITLE
cluster/service: fix plugin RPCs

### DIFF
--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -798,17 +798,23 @@ service::do_get_partition_state(partition_state_request req) {
 
 ss::future<upsert_plugin_response>
 service::upsert_plugin(upsert_plugin_request&& req, rpc::streaming_context&) {
+    // Capture the request values in this coroutine
+    auto transform = std::move(req.transform);
+    auto deadline = model::timeout_clock::now() + req.timeout;
     co_await ss::coroutine::switch_to(get_scheduling_group());
     auto ec = co_await _plugin_frontend.local().upsert_transform(
-      std::move(req.transform), model::timeout_clock::now() + req.timeout);
+      std::move(transform), deadline);
     co_return upsert_plugin_response{.ec = ec};
 }
 
 ss::future<remove_plugin_response>
 service::remove_plugin(remove_plugin_request&& req, rpc::streaming_context&) {
+    // Capture the request values in this coroutine
+    auto name = std::move(req.name);
+    auto deadline = model::timeout_clock::now() + req.timeout;
     co_await ss::coroutine::switch_to(get_scheduling_group());
     auto result = co_await _plugin_frontend.local().remove_transform(
-      std::move(req.name), model::timeout_clock::now() + req.timeout);
+      name, deadline);
     co_return remove_plugin_response{.uuid = result.uuid, .ec = result.ec};
 }
 


### PR DESCRIPTION
It's not safe to access the reference across scheduling points.

We should probably modify the RPC generator script to pass these by value.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
