### PR TITLE
model/transform: fix last_offset_delta for transformed batches

### DIFF
--- a/src/v/model/tests/transform_test.cc
+++ b/src/v/model/tests/transform_test.cc
@@ -195,6 +195,7 @@ TEST(TransformedDataTest, MakeBatch) {
     EXPECT_EQ(
       transformed_batch.header().type, model::record_batch_type::raft_data);
     EXPECT_EQ(transformed_batch.header().record_count, 4);
+    EXPECT_EQ(transformed_batch.header().last_offset_delta, 3);
     EXPECT_EQ(
       transformed_batch.header().crc,
       model::crc_record_batch(transformed_batch));

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -188,6 +188,7 @@ model::record_batch transformed_data::make_batch(
     // transforms.
     header.producer_id = -1;
 
+    header.last_offset_delta = i - 1;
     header.record_count = i;
     header.size_bytes = int32_t(
       model::packed_record_batch_header_size + serialized_records.size_bytes());


### PR DESCRIPTION
We need to set this value correctly otherwise we create invalid batches

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
