### PR TITLE
Transactions API Authorization

### DIFF
--- a/src/v/kafka/server/handlers/txn_offset_commit.cc
+++ b/src/v/kafka/server/handlers/txn_offset_commit.cc
@@ -27,6 +27,11 @@ struct txn_offset_commit_ctx {
     txn_offset_commit_request request;
     ss::smp_service_group ssg;
 
+    absl::flat_hash_map<
+      model::topic,
+      std::vector<txn_offset_commit_response_partition>>
+      unauthorized_tps;
+
     // topic partitions found not to existent prior to processing. responses for
     // these are patched back into the final response after processing.
     absl::flat_hash_map<
@@ -47,6 +52,12 @@ ss::future<response_ptr> txn_offset_commit(txn_offset_commit_ctx& octx) {
     return octx.rctx.groups()
       .txn_offset_commit(std::move(octx.request))
       .then([&octx](txn_offset_commit_response resp) {
+          for (auto& topic : octx.unauthorized_tps) {
+              resp.data.topics.push_back(txn_offset_commit_response_topic{
+                .name = topic.first,
+                .partitions = std::move(topic.second),
+              });
+          }
           if (unlikely(!octx.nonexistent_tps.empty())) {
               /*
                * copy over partitions for topics that had some partitions
@@ -87,6 +98,16 @@ ss::future<response_ptr> txn_offset_commit_handler::handle(
     if (unlikely(ctx.recovery_mode_enabled())) {
         return ctx.respond(
           txn_offset_commit_response{request, error_code::policy_violation});
+    } else if (!ctx.authorized(
+                 security::acl_operation::write,
+                 transactional_id{request.data.transactional_id})) {
+        return ctx.respond(txn_offset_commit_response{
+          request, error_code::transactional_id_authorization_failed});
+    } else if (!ctx.authorized(
+                 security::acl_operation::read,
+                 group_id{request.data.group_id})) {
+        return ctx.respond(txn_offset_commit_response{
+          request, error_code::group_authorization_failed});
     }
 
     txn_offset_commit_ctx octx(std::move(ctx), std::move(request), ssg);
@@ -113,7 +134,17 @@ ss::future<response_ptr> txn_offset_commit_handler::handle(
         const auto topic_name = model::topic(it->name);
         model::topic_namespace_view tn(model::kafka_namespace, topic_name);
 
-        if (octx.rctx.metadata_cache().contains(tn)) {
+        if (!octx.rctx.authorized(security::acl_operation::read, topic_name)) {
+            auto& parts = octx.unauthorized_tps[it->name];
+            parts.reserve(it->partitions.size());
+            absl::c_transform(
+              it->partitions, parts.begin(), [](const auto& part) {
+                  return txn_offset_commit_response_partition{
+                    .partition_index = part.partition_index,
+                    .error_code = error_code::topic_authorization_failed};
+              });
+            it->partitions.clear();
+        } else if (octx.rctx.metadata_cache().contains(tn)) {
             /*
              * check if each partition exists
              */

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -874,6 +874,19 @@ add_offsets_to_txn_handler::handle(request_context ctx, ss::smp_service_group) {
             add_offsets_to_txn_response response;
             response.data.error_code = error_code::policy_violation;
             return ctx.respond(response);
+        } else if (!ctx.authorized(
+                     security::acl_operation::write,
+                     transactional_id{request.data.transactional_id})) {
+            add_offsets_to_txn_response response;
+            response.data.error_code
+              = error_code::transactional_id_authorization_failed;
+            return ctx.respond(response);
+        } else if (!ctx.authorized(
+                     security::acl_operation::read,
+                     group_id{request.data.group_id})) {
+            add_offsets_to_txn_response response;
+            response.data.error_code = error_code::group_authorization_failed;
+            return ctx.respond(response);
         }
 
         cluster::add_offsets_tx_request tx_request{

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -8,25 +8,29 @@
 # by the Apache License, Version 2.0
 
 from collections import defaultdict
+from contextlib import contextmanager
 from rptest.services.cluster import cluster
-from rptest.util import wait_until_result
+from rptest.util import wait_until_result, expect_exception
 from rptest.clients.types import TopicSpec
 from time import sleep, time
+from typing import Optional
 from os.path import join
+import json
 
 import uuid
 import random
 
 from ducktape.utils.util import wait_until
+from ducktape.errors import TimeoutError
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
-from rptest.services.redpanda import RedpandaService, make_redpanda_service
-from rptest.clients.default import DefaultClient
+from rptest.services.redpanda import RedpandaService, SecurityConfig, SaslCredentials
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
 import confluent_kafka as ck
 from rptest.services.admin import Admin
-from rptest.services.redpanda_installer import RedpandaInstaller, wait_for_num_versions
-from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda_installer import wait_for_num_versions
+from rptest.clients.rpk import RpkTool, AclList
+from rptest.clients.python_librdkafka import PythonLibrdkafka
 
 from rptest.tests.cluster_features_test import FeaturesTestBase
 
@@ -45,6 +49,38 @@ class TransactionsMixin:
             timeout_sec=30,
             backoff_sec=2,
             err_msg=f"Can't find a coordinator for tx.id={txid}")
+
+    def on_delivery(self, err, _):
+        assert err is None, err
+
+    def generate_data(self, topic, num_records, extra_cfg={}):
+        producer_cfg = {
+            'bootstrap.servers': self.redpanda.brokers(),
+        }
+        producer_cfg.update(extra_cfg)
+        producer = ck.Producer(producer_cfg)
+
+        for i in range(num_records):
+            producer.produce(topic.name,
+                             str(i),
+                             str(i),
+                             on_delivery=self.on_delivery)
+
+        producer.flush()
+
+    def consume(self, consumer, max_records=10, timeout_s=2):
+        def consume_records():
+            records = consumer.consume(max_records, timeout_s)
+
+            if (records != None) and (len(records) != 0):
+                return True, records
+            else:
+                return False, records
+
+        return wait_until_result(consume_records,
+                                 timeout_sec=30,
+                                 backoff_sec=2,
+                                 err_msg="Can not consume data")
 
 
 class TransactionsTest(RedpandaTest, TransactionsMixin):
@@ -65,36 +101,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         self.output_t = self.topics[1]
         self.max_records = 100
         self.admin = Admin(self.redpanda)
-
-    def on_delivery(self, err, msg):
-        assert err == None, msg
-
-    def generate_data(self, topic, num_records):
-        producer = ck.Producer({
-            'bootstrap.servers': self.redpanda.brokers(),
-        })
-
-        for i in range(num_records):
-            producer.produce(topic.name,
-                             str(i),
-                             str(i),
-                             on_delivery=self.on_delivery)
-
-        producer.flush()
-
-    def consume(self, consumer, max_records=10, timeout_s=2):
-        def consume_records():
-            records = consumer.consume(max_records, timeout_s)
-
-            if (records != None) and (len(records) != 0):
-                return True, records
-            else:
-                False
-
-        return wait_until_result(consume_records,
-                                 timeout_sec=30,
-                                 backoff_sec=2,
-                                 err_msg="Can not consume data")
 
     @cluster(num_nodes=3)
     def find_coordinator_creates_tx_topics_test(self):
@@ -820,6 +826,280 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
             num_consumed += len(records)
 
         assert num_consumed == should_be_consumed
+
+
+@contextmanager
+def expect_kafka_error(err: Optional[ck.KafkaError] = None):
+    try:
+        yield
+    except ck.KafkaException as e:
+        if e.args[0].code() != err:
+            raise
+    else:
+        if err is not None:
+            raise RuntimeError("Expected an exception!")
+
+
+@contextmanager
+def try_transaction(producer: ck.Producer,
+                    consumer: ck.Consumer,
+                    send_offset_err: Optional[ck.KafkaError] = None,
+                    commit_err: Optional[ck.KafkaError] = None):
+    producer.begin_transaction()
+
+    yield
+
+    producer.flush(0.0)
+
+    with expect_kafka_error(send_offset_err):
+        producer.send_offsets_to_transaction(
+            consumer.position(consumer.assignment()),
+            consumer.consumer_group_metadata())
+
+    with expect_kafka_error(commit_err):
+        producer.commit_transaction()
+
+    if send_offset_err is not None or commit_err is not None:
+        producer.abort_transaction()
+
+
+class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
+    topics = (TopicSpec(partition_count=1, replication_factor=3),
+              TopicSpec(partition_count=1, replication_factor=3))
+
+    USER_1 = SaslCredentials("user-1", "password", "SCRAM-SHA-256")
+    USER_2 = SaslCredentials("user-2", "password", "SCRAM-SHA-256")
+
+    def __init__(self, test_context):
+        extra_rp_conf = {
+            "enable_leader_balancer": False,
+            "partition_autobalancing_mode": "off",
+        }
+
+        super().__init__(test_context=test_context,
+                         extra_rp_conf=extra_rp_conf,
+                         log_level="trace")
+
+        self.security = SecurityConfig()
+        self.security.kafka_enable_authorization = True
+        self.security.enable_sasl = True
+        self.security.require_client_auth = True
+        self.security.endpoint_authn_method = 'sasl'
+
+        self.redpanda.set_security_settings(self.security)
+
+        self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
+
+        self.input_t = self.topics[0]
+        self.output_t = self.topics[1]
+        self.max_records = 100
+        self.admin = Admin(self.redpanda)
+
+        self.rpk = RpkTool(self.redpanda,
+                           username=self.superuser.username,
+                           password=self.superuser.password,
+                           sasl_mechanism=self.superuser.algorithm)
+
+    def setUp(self):
+        super().setUp()
+        self.admin.create_user(self.USER_1.username, self.USER_1.password,
+                               self.USER_1.algorithm)
+        self.admin.create_user(self.USER_2.username, self.USER_2.password,
+                               self.USER_2.algorithm)
+
+    def sasl_cfg(self, user):
+        return {
+            'sasl.username': user.username,
+            'sasl.password': user.password,
+            'sasl.mechanism': user.algorithm,
+            'security.protocol': 'sasl_plaintext',
+        }
+
+    def sasl_txn_producer(self, user, cfg={}):
+        cfg.update(self.sasl_cfg(user))
+        p = ck.Producer(cfg)
+        p.init_transactions()
+        return p
+
+    def sasl_consumer(self, user, cfg={}):
+        cfg.update(self.sasl_cfg(user))
+        return ck.Consumer(cfg)
+
+    def allow_principal_sync(self, principal, operations, resource,
+                             resource_name):
+
+        self.rpk.sasl_allow_principal(principal, operations, resource,
+                                      resource_name)
+
+        def acl_ready():
+            lst = AclList.parse_raw(self.rpk.acl_list())
+            return [
+                lst.has_permission(principal, op, resource, resource_name)
+                for op in operations
+            ]
+
+        wait_until(lambda: acl_ready(),
+                   timeout_sec=5,
+                   backoff_sec=1,
+                   err_msg="ACL not updated in time")
+
+    @cluster(num_nodes=3)
+    def init_transactions_authz_test(self):
+        producer_cfg = {
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': 10000,
+        }
+
+        user = self.USER_1
+
+        self.redpanda.logger.debug("init_transactions should fail without ACL")
+        with expect_kafka_error(
+                ck.KafkaError.TRANSACTIONAL_ID_AUTHORIZATION_FAILED):
+            producer = self.sasl_txn_producer(user, cfg=producer_cfg)
+
+        self.allow_principal_sync(user.username, ['write'], 'transactional-id',
+                                  '0')
+
+        producer = self.sasl_txn_producer(user, cfg=producer_cfg)
+
+    @cluster(num_nodes=3)
+    def simple_authz_test(self):
+        consume_user = self.USER_1
+        produce_user = self.USER_2
+
+        self.allow_principal_sync(produce_user.username, ['all'], 'topic',
+                                  self.input_t.name)
+        self.generate_data(self.input_t,
+                           self.max_records,
+                           extra_cfg=self.sasl_cfg(produce_user))
+
+        producer_cfg = {
+            'bootstrap.servers': self.redpanda.brokers(),
+            'transactional.id': '0',
+            'transaction.timeout.ms': 10000,
+        }
+        consumer_cfg = {
+            'bootstrap.servers': self.redpanda.brokers(),
+            'group.id': "test",
+            'auto.offset.reset': 'earliest',
+            'enable.auto.commit': False,
+        }
+
+        self.allow_principal_sync(consume_user.username, ['read'], 'topic',
+                                  self.input_t.name)
+        self.allow_principal_sync(consume_user.username, ['read'], 'group',
+                                  'test')
+        self.allow_principal_sync(produce_user.username, ['write'],
+                                  'transactional-id', '0')
+        # TODO(oren): what's this one for?
+        self.allow_principal_sync(produce_user.username, ['read'], 'topic',
+                                  self.output_t.name)
+
+        consumer = self.sasl_consumer(consume_user, cfg=consumer_cfg)
+        consumer.subscribe([self.input_t])
+        records = self.consume(consumer)
+        assert records is not None
+
+        producer = self.sasl_txn_producer(produce_user, cfg=producer_cfg)
+
+        def on_delivery_purged(err, _):
+            assert err is not None and err.code() == ck.KafkaError._PURGE_QUEUE
+
+        def process_records(producer, records, on_delivery, history=[]):
+            for record in records:
+                assert record.error(
+                ) is None, f"Consume error: {record.error()}"
+                history.append(record)
+                producer.produce(self.output_t.name,
+                                 record.value(),
+                                 record.key(),
+                                 on_delivery=on_delivery)
+
+        with try_transaction(
+                producer,
+                consumer,
+                send_offset_err=ck.KafkaError.GROUP_AUTHORIZATION_FAILED,
+                commit_err=ck.KafkaError.GROUP_AUTHORIZATION_FAILED):
+            process_records(producer, records, on_delivery_purged)
+
+        self.allow_principal_sync(produce_user.username, ['read'], 'group',
+                                  'test')
+
+        producer = self.sasl_txn_producer(produce_user, cfg=producer_cfg)
+        with try_transaction(
+                producer,
+                consumer,
+                commit_err=ck.KafkaError.TOPIC_AUTHORIZATION_FAILED):
+            process_records(producer, records, on_delivery_purged)
+
+        self.allow_principal_sync(produce_user.username, ['write'], 'topic',
+                                  self.output_t.name)
+
+        # Now we have all the requisite permissions set up, and we should be able to
+        # make progress
+
+        producer = self.sasl_txn_producer(produce_user, cfg=producer_cfg)
+
+        num_consumed_records = 0
+        consumed_from_input_topic = []
+
+        # Process the records we have sitting in memory
+
+        with try_transaction(producer, consumer):
+            process_records(producer, records, self.on_delivery,
+                            consumed_from_input_topic)
+            num_consumed_records += len(records)
+
+        # then consume the rest, transactionwise
+
+        while num_consumed_records != self.max_records:
+            # Imagine that consume got broken, we read the same record twice and overshoot the condition
+            assert num_consumed_records < self.max_records
+
+            records = self.consume(consumer)
+            assert records is not None
+
+            with try_transaction(producer, consumer):
+                process_records(producer, records, self.on_delivery,
+                                consumed_from_input_topic)
+
+            num_consumed_records += len(records)
+
+        consumer.close()
+        assert len(consumed_from_input_topic) == self.max_records
+
+        self.allow_principal_sync(consume_user.username, ['read'], 'topic',
+                                  self.output_t.name)
+        self.allow_principal_sync(consume_user.username, ['read'], 'group',
+                                  'testtest')
+
+        consumer = self.sasl_consumer(
+            consume_user,
+            cfg={
+                'group.id': 'testtest',
+                'bootstrap.servers': self.redpanda.brokers(),
+                'auto.offset.reset': 'earliest',
+            },
+        )
+        consumer.subscribe([self.output_t])
+
+        index_from_input = 0
+
+        while index_from_input < self.max_records:
+            records = self.consume(consumer)
+            for record in records:
+                assert record.error(
+                ) is None, f"Consume error: {record.error()}"
+                assert record.key(
+                ) == consumed_from_input_topic[index_from_input].key(
+                ), f'Records key does not match from input {consumed_from_input_topic[index_from_input].key()}, from output {record.key()}'
+                assert record.value(
+                ) == consumed_from_input_topic[index_from_input].value(
+                ), f'Records value does not match from input {consumed_from_input_topic[index_from_input].value()}, from output {record.value()}'
+                index_from_input += 1
+
+        assert consumer.poll(timeout=3) is None
 
 
 class GATransaction_v22_1_UpgradeTest(RedpandaTest):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds authorization checks to transaction related API handlers.

Requirements were culled from the reference implementation, as follows:

### `end_txn`
- WRITE permissions for TRANSACTIONAL_ID
	- TRANSACTIONAL_ID_AUTHORIZATION_FAILED
### `add_offsets_to_txn`
- WRITE permissions for TRANSACTIONAL_ID
	- TRANSACTIONAL_ID_AUTHORIZATION_FAILED
- READ permissions for GROUP_ID
	- GROUP_AUTHORIZATION_FAILED
- NOTE: Calls `handleAddPartitionsToTransaction` for the offset topic
   - Presumably no check expected here as the topic is internal?
### `add_partitions_to_txn`
- WRITE permissions for TRANSACTIONAL_ID
- Filters topics by WRITE permission 
	- TOPIC AUTHORIZATION_FAILED for those partitions
	- Failed checks cause the whole transaction to fail
### `txn_offset_commit`
- WRITE permissions for TRANSACTIONAL_ID
	- TRANSACTIONAL_ID_AUTHORIZATION_FAILED
- READ permissions for GROUP_ID
	- GROUP_AUTHORIZATION_FAILED
	- **QUESTION**: May have misread this. Should it be WRITE?
- Filters topics by READ permission
- Return error for only nonexistent or unauthorized topics

Other transaction related functions already implementing authorization checks:

- `find_coordinator`
- `list_transactions`
- `describe_transactions`

Fixes https://github.com/redpanda-data/core-internal/issues/855

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Adds previously missing authorization checks to Transactions API

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
