### PR TITLE
transform: fix translation errors

### DIFF
--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -115,8 +115,8 @@ struct transform_offsets_value
     auto serde_fields() { return std::tie(offset); }
 };
 
-static const model::topic transform_offsets_topic("transform_offsets");
-static const model::topic_namespace transform_offsets_nt(
+inline const model::topic transform_offsets_topic("transform_offsets");
+inline const model::topic_namespace transform_offsets_nt(
   model::kafka_internal_namespace, transform_offsets_topic);
 
 /**

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -229,7 +229,7 @@ ss::future<result<iobuf, cluster::errc>> local_service::load_wasm_binary(
         kafka::partition_proxy* partition) mutable {
           storage::log_reader_config reader_config(
             /*start_offset=*/offset,
-            /*max_offset=*/model::next_offset(offset),
+            /*max_offset=*/offset,
             /*min_bytes=*/0,
             /*max_bytes=*/1,
             /*prio=*/wasm_read_priority(),

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -191,7 +191,7 @@ ss::future<kafka::offset> processor::load_start_offset() {
 
 ss::future<> processor::run_consumer_loop() {
     auto offset = co_await load_start_offset();
-    vlog(_logger.trace, "starting at offset {}", offset);
+    vlog(_logger.debug, "starting at offset {}", offset);
     while (!_as.abort_requested()) {
         auto reader = co_await _source->read_batch(offset, &_as);
         auto last_offset = co_await std::move(reader).consume(


### PR DESCRIPTION
Fixes some out of range translation errors I was seeing for empty topics. This is due to `model::prev_offset(0) == model::offset::min()`, and when passed as a max range throws an error as it cannot be translated. This doesn't happen in the fetch path due to short circuiting of empty reads before translation.

Additionally, fix an off by one error in loading wasm binaries. This isn't an issue in practice due to the bytes limit we have, but this clarifies the code. Also correct an issue in the data transform test. Lots of off by one errors :sigh:

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
