### PR TITLE
rm_stm: interface for highest producer_id

### DIFF
--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -321,6 +321,10 @@ public:
     ss::future<std::vector<rm_stm::tx_range>>
     aborted_transactions_cloud(const cloud_storage::offset_range& offsets);
 
+    model::producer_id highest_producer_id() {
+        return _rm_stm->highest_producer_id();
+    }
+
     const ss::shared_ptr<cluster::archival_metadata_stm>&
     archival_meta_stm() const {
         return _archival_meta_stm;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -131,6 +131,14 @@ public:
     ss::future<fragmented_vector<rm_stm::tx_range>>
       aborted_transactions(model::offset, model::offset);
 
+    /**
+     * Returns highest producer ID of any batch that has been applied to this
+     * partition. Note that the corresponding transactions may or may not have
+     * been committed or aborted; the only certainty of this ID is that it has
+     * been used.
+     */
+    model::producer_id highest_producer_id() const;
+
     model::offset max_collectible_offset() override {
         const auto lso = last_stable_offset();
         if (lso < model::offset{0}) {
@@ -633,6 +641,9 @@ private:
     metrics::internal_metric_groups _metrics;
     ss::abort_source _as;
     ss::gate _gate;
+    // Highest producer ID applied to this stm.
+    model::producer_id _highest_producer_id;
+
     friend struct ::rm_stm_test_fixture;
 };
 

--- a/src/v/cluster/tx_snapshot_utils.cc
+++ b/src/v/cluster/tx_snapshot_utils.cc
@@ -212,6 +212,7 @@ ss::future<> async_adl<tx_snapshot>::to(iobuf& out, tx_snapshot snap) {
       out, std::move(snap.tx_data));
     co_await detail::async_adl_list<fvec<cluster::expiration_snapshot>>{}.to(
       out, std::move(snap.expiration));
+    reflection::serialize(out, snap.highest_producer_id);
 }
 
 ss::future<tx_snapshot> async_adl<tx_snapshot>::from(iobuf_parser& in) {
@@ -235,6 +236,7 @@ ss::future<tx_snapshot> async_adl<tx_snapshot>::from(iobuf_parser& in) {
     result.expiration
       = co_await detail::async_adl_list<fvec<cluster::expiration_snapshot>>{}
           .from(in);
+    result.highest_producer_id = reflection::adl<model::producer_id>{}.from(in);
     co_return result;
 }
 

--- a/src/v/cluster/tx_snapshot_utils.h
+++ b/src/v/cluster/tx_snapshot_utils.h
@@ -125,6 +125,7 @@ struct tx_snapshot {
 
     fragmented_vector<tx_data_snapshot> tx_data;
     fragmented_vector<expiration_snapshot> expiration;
+    model::producer_id highest_producer_id{};
 
     bool operator==(const tx_snapshot&) const = default;
 };


### PR DESCRIPTION
Across recoveries of a cluster, the next producer_id used by the id_allocator needs to be reset to avoid using any that may have been used previously. So, this commit begins tracking the highest seen so far, and exposes it for use by the upload path (to come in a subsequent commit).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
