### PR TITLE
rptest: fix exception in getting init cluster spec

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -681,7 +681,7 @@ class CloudCluster():
                 c = self._get_cluster(_cluster_id)
                 self.current.last_status = c['state']
             except Exception as e:
-                raise RuntimeError("Failed to get initial cluster spec")
+                raise RuntimeError("Failed to get initial cluster spec") from e
 
             # In case of BYOC cluster, do some additional stuff to create it
             if self.config.type == CLOUD_TYPE_BYOC:

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -681,9 +681,7 @@ class CloudCluster():
                 c = self._get_cluster(_cluster_id)
                 self.current.last_status = c['state']
             except Exception as e:
-                self.log.error()
-                raise RuntimeError(
-                    "# ERROR: Failed to get initial cluster spec")
+                raise RuntimeError("Failed to get initial cluster spec")
 
             # In case of BYOC cluster, do some additional stuff to create it
             if self.config.type == CLOUD_TYPE_BYOC:


### PR DESCRIPTION
fix ducktape testing on cloud using FMC

https://buildkite.com/redpanda/vtools/builds/10641
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 182, in _do_run
    self.setup_test()
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 260, in setup_test
    self.test.setup()
  File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/test.py", line 91, in setup
    self.setUp()
  File "/home/ubuntu/redpanda/tests/rptest/tests/services_self_test.py", line 250, in setUp
    self.redpanda.start()
  File "/home/ubuntu/redpanda/tests/rptest/services/redpanda.py", line 1549, in start
    cluster_id = self._cloud_cluster.create(superuser=superuser)
  File "/home/ubuntu/redpanda/tests/rptest/services/redpanda_cloud.py", line 684, in create
    self.log.error()
AttributeError: 'CloudCluster' object has no attribute 'log'
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none