### PR TITLE
config: replace legacy min/max with configuration constraints

### DIFF
--- a/src/v/config/CMakeLists.txt
+++ b/src/v/config/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     rjson_serialization.cc
     validators.cc
     throughput_control_group.cc
+    constraints.cc
   DEPS
     v::json
     v::model

--- a/src/v/config/base_property.h
+++ b/src/v/config/base_property.h
@@ -128,6 +128,10 @@ public:
     virtual std::optional<std::string_view> units_name() const = 0;
     virtual bool is_nullable() const = 0;
     virtual bool is_array() const = 0;
+    virtual bool is_signed() const = 0;
+    virtual bool is_unsigned() const = 0;
+    virtual bool is_bool() const = 0;
+    virtual bool is_milliseconds() const = 0;
     virtual std::optional<std::string_view> example() const = 0;
     virtual std::vector<ss::sstring> enum_values() const { return {}; };
 

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2782,7 +2782,17 @@ configuration::configuration()
       "are allowed.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {"BASIC"},
-      validate_http_authn_mechanisms) {}
+      validate_http_authn_mechanisms)
+  , constraints(
+      *this,
+      "constraints",
+      "A sequence of constraints for cluster-level configs",
+      {.needs_restart = needs_restart::no,
+       .example
+       = R"([{'name': 'default_topic_replications','type': 'restrict','min': 3, 'max': 9}])",
+       .visibility = visibility::user},
+      {},
+      validate_constraints) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -14,6 +14,7 @@
 #include "config/broker_endpoint.h"
 #include "config/client_group_byte_rate_quota.h"
 #include "config/config_store.h"
+#include "config/constraints.h"
 #include "config/convert.h"
 #include "config/data_directory_path.h"
 #include "config/endpoint_tls_config.h"
@@ -528,6 +529,9 @@ struct configuration final : public config_store {
 
     // HTTP Authentication
     property<std::vector<ss::sstring>> http_authentication;
+
+    // Constraints
+    one_or_many_map_property<constraint_t> constraints;
 
     configuration();
 

--- a/src/v/config/constraints.cc
+++ b/src/v/config/constraints.cc
@@ -553,6 +553,31 @@ void constraint_clamp_topic_config(
             *archival_enabled_opt, *fetch_enabled_opt);
     }
 }
+
+std::vector<std::string_view> constraint_supported_properties() {
+    std::vector<std::string_view> names;
+    names.push_back(config::shard_local_cfg().default_topic_partitions.name());
+    names.push_back(config::shard_local_cfg().default_topic_replication.name());
+    names.push_back(config::shard_local_cfg().log_compression_type.name());
+    names.push_back(config::shard_local_cfg().log_cleanup_policy.name());
+    names.push_back(
+      config::shard_local_cfg().log_message_timestamp_type.name());
+    names.push_back(config::shard_local_cfg().log_segment_size.name());
+    names.push_back(config::shard_local_cfg().retention_bytes.name());
+    names.push_back(config::shard_local_cfg().log_retention_ms.name());
+    names.push_back(
+      config::shard_local_cfg().cloud_storage_enable_remote_read.name());
+    names.push_back(
+      config::shard_local_cfg().cloud_storage_enable_remote_write.name());
+    names.push_back(config::shard_local_cfg().kafka_batch_max_bytes.name());
+    names.push_back(
+      config::shard_local_cfg().retention_local_target_bytes_default.name());
+    names.push_back(
+      config::shard_local_cfg().retention_local_target_ms_default.name());
+    names.push_back(config::shard_local_cfg().log_segment_ms.name());
+
+    return names;
+}
 } // namespace config
 
 namespace YAML {

--- a/src/v/config/constraints.cc
+++ b/src/v/config/constraints.cc
@@ -12,8 +12,17 @@
 #include "cluster/types.h"
 #include "config/base_property.h"
 #include "config/configuration.h"
+#include "kafka/server/handlers/topics/types.h"
+#include "model/fundamental.h"
+#include "vlog.h"
+
+#include <seastar/util/log.hh>
+
+#include <limits>
 
 namespace config {
+inline ss::logger constraints_log{"constraints"};
+
 std::string_view to_string_view(constraint_type type) {
     switch (type) {
     case constraint_type::restrikt:
@@ -44,6 +53,505 @@ std::ostream& operator<<(std::ostream& os, const constraint_t& constraint) {
       [&os](const auto range) { os << range; });
 
     return os;
+}
+
+namespace {
+template<typename T, typename RangeMinT>
+bool valid_min(
+  const tristate<T>& topic_val, const std::optional<RangeMinT>& min) {
+    if (min) {
+        // Disabled state means infinite which is always greater than the
+        // minimum
+        if (topic_val.is_disabled()) {
+            return true;
+        }
+
+        // An undefined topic value implicity breaks the minimum because
+        // "nothing" is not within any range.
+        if (!topic_val.has_optional_value()) {
+            return false;
+        }
+
+        return topic_val.value() >= static_cast<T>(*min);
+    }
+
+    // Topic value is valid if minimum is undefined because there is no bound to
+    // compare
+    return true;
+}
+
+template<typename T, typename RangeMaxT>
+bool valid_max(
+  const tristate<T>& topic_val, const std::optional<RangeMaxT> max) {
+    if (max) {
+        // Disabled state means infinite which is always greater than the
+        // maximum
+        if (topic_val.is_disabled()) {
+            return false;
+        }
+
+        // An undefined topic value implicity breaks the maximum because
+        // "nothing" is not within any range. Not to be confused with disabled
+        // state.
+        if (!topic_val.has_optional_value()) {
+            return false;
+        }
+
+        return topic_val.value() <= static_cast<T>(*max);
+    }
+
+    // Topic value is valid if maximum is undefined because there is no bound to
+    // compare
+    return true;
+}
+
+template<typename T, typename RangeT>
+bool within_range(
+  const tristate<T>& topic_val,
+  const range_values<RangeT>& range,
+  const model::topic& topic,
+  const std::string_view& topic_property) {
+    if (!(valid_min(topic_val, range.min) && valid_max(topic_val, range.max))) {
+        vlog(
+          constraints_log.error,
+          "Constraints failure[value out-of-range]: topic property {}.{}, "
+          "value {}",
+          topic(),
+          topic_property,
+          topic_val);
+        return false;
+    }
+
+    // Otherwise, the topic value is valid
+    return true;
+}
+
+template<typename T>
+bool matches_cluster_property_value(
+  const tristate<T>& topic_val,
+  const std::optional<T>& cluster_val,
+  const constraint_enabled_t& enabled,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::string_view& cluster_property) {
+    if (enabled == constraint_enabled_t::no) {
+        // A constraint that is turned off (i.e., no) means that the broker
+        // should not compare the topic property to the cluster one. This
+        // implies the the topic property automatically satisfies the
+        // constraint.
+        return true;
+    }
+
+    // A constraint with "enabled" flag means that the topic property must match
+    // the cluster one. An undefined topic value or cluster value could not
+    // match the other, this implies that the constraint is not satisfied.
+    if (!topic_val.has_optional_value() || !cluster_val) {
+        return false;
+    }
+
+    if (topic_val.value() != *cluster_val) {
+        vlog(
+          constraints_log.error,
+          "Constraints failure[does not match the cluster property {}]: "
+          "topic property {}.{}, value {}",
+          cluster_property,
+          topic(),
+          topic_property,
+          topic_val);
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Returns true if the topic-level value satisfies the constraint.
+ * \param topic_val: the topic value
+ * \param constraint: the constraint to evaluate
+ * \param property_name: name of the cluster-level property
+ * \param cluster_opt: the value from the cluster-level property
+ */
+template<typename T>
+bool validate_value(
+  const tristate<T>& topic_val,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::string_view& cluster_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    if (constraint.name == cluster_property) {
+        return ss::visit(
+          constraint.flags,
+          [&topic_val,
+           &topic,
+           &topic_property,
+           &cluster_property,
+           &cluster_opt](const constraint_enabled_t enabled) {
+              return matches_cluster_property_value(
+                topic_val,
+                cluster_opt,
+                enabled,
+                topic,
+                topic_property,
+                cluster_property);
+          },
+          [&topic_val, &topic, &topic_property](const auto range) {
+              return within_range(topic_val, range, topic, topic_property);
+          });
+    }
+    return false;
+}
+
+template<typename T>
+bool validate_value(
+  const std::optional<T>& topic_opt,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::string_view& cluster_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    auto tri = tristate<T>{topic_opt};
+
+    return validate_value(
+      tri, constraint, topic, topic_property, cluster_property, cluster_opt);
+}
+} // namespace
+
+bool topic_config_satisfies_constraint(
+  const cluster::topic_configuration& topic_cfg,
+  const constraint_t& constraint) {
+    auto partition_count_tri = tristate(
+      std::make_optional(topic_cfg.partition_count));
+    auto replication_factor_tri = tristate(
+      std::make_optional(topic_cfg.replication_factor));
+    bool ret
+      = validate_value(
+          partition_count_tri,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_partition_count,
+          config::shard_local_cfg().default_topic_partitions.name())
+        || validate_value(
+          replication_factor_tri,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_replication_factor,
+          config::shard_local_cfg().default_topic_replication.name())
+        || validate_value<model::compression>(
+          topic_cfg.properties.compression,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_compression,
+          config::shard_local_cfg().log_compression_type.name(),
+          config::shard_local_cfg().log_compression_type())
+        || validate_value<model::cleanup_policy_bitflags>(
+          topic_cfg.properties.cleanup_policy_bitflags,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_cleanup_policy,
+          config::shard_local_cfg().log_cleanup_policy.name(),
+          config::shard_local_cfg().log_cleanup_policy())
+        || validate_value<model::timestamp_type>(
+          topic_cfg.properties.timestamp_type,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_timestamp_type,
+          config::shard_local_cfg().log_message_timestamp_type.name(),
+          config::shard_local_cfg().log_message_timestamp_type())
+        || validate_value(
+          topic_cfg.properties.segment_size,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_segment_size,
+          config::shard_local_cfg().log_segment_size.name())
+        || validate_value(
+          topic_cfg.properties.retention_bytes,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_retention_bytes,
+          config::shard_local_cfg().retention_bytes.name())
+        || validate_value(
+          topic_cfg.properties.retention_duration,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_retention_duration,
+          config::shard_local_cfg().log_retention_ms.name())
+        || validate_value(
+          topic_cfg.properties.batch_max_bytes,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_max_message_bytes,
+          config::shard_local_cfg().kafka_batch_max_bytes.name())
+        || validate_value(
+          topic_cfg.properties.retention_local_target_bytes,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_retention_local_target_bytes,
+          config::shard_local_cfg().retention_local_target_bytes_default.name())
+        || validate_value(
+          topic_cfg.properties.retention_local_target_ms,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_retention_local_target_ms,
+          config::shard_local_cfg().retention_local_target_ms_default.name())
+        || validate_value(
+          topic_cfg.properties.segment_ms,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_segment_ms,
+          config::shard_local_cfg().log_segment_ms.name());
+
+    if (topic_cfg.properties.shadow_indexing) {
+        auto fetch_enabled_opt = std::make_optional(
+          model::is_fetch_enabled(*topic_cfg.properties.shadow_indexing));
+        auto archival_enabled_opt = std::make_optional(
+          model::is_archival_enabled(*topic_cfg.properties.shadow_indexing));
+        ret
+          = ret
+            || validate_value<bool>(
+              fetch_enabled_opt,
+              constraint,
+              topic_cfg.tp_ns.tp,
+              kafka::topic_property_remote_read,
+              config::shard_local_cfg().cloud_storage_enable_remote_read.name(),
+              config::shard_local_cfg().cloud_storage_enable_remote_read())
+            || validate_value<bool>(
+              archival_enabled_opt,
+              constraint,
+              topic_cfg.tp_ns.tp,
+              kafka::topic_property_remote_write,
+              config::shard_local_cfg()
+                .cloud_storage_enable_remote_write.name(),
+              config::shard_local_cfg().cloud_storage_enable_remote_write());
+    }
+
+    return ret;
+}
+
+namespace {
+template<typename T, typename RangeT>
+void range_clamp(
+  tristate<T>& topic_val,
+  const range_values<RangeT>& range,
+  const model::topic& topic,
+  const std::string_view& topic_property) {
+    if (!valid_min(topic_val, range.min)) {
+        vlog(
+          constraints_log.warn,
+          "Overwriting topic property to constraint min: topic property {}.{}, "
+          "min {}",
+          topic(),
+          topic_property,
+          range.min);
+        // NOTE: valid_min checks if the minimum opt is defined, so it is OK to
+        // de-reference it here.
+        topic_val = tristate<T>{static_cast<T>(*range.min)};
+    }
+
+    if (!valid_max(topic_val, range.max)) {
+        vlog(
+          constraints_log.warn,
+          "Overwriting topic property to constraint max: topic property {}.{}, "
+          "max {}",
+          topic(),
+          topic_property,
+          range.max);
+        // NOTE: valid_max checks if the maximum opt is defined, so it is OK to
+        // de-reference it here.
+        topic_val = tristate<T>{static_cast<T>(*range.max)};
+    }
+}
+
+template<typename T>
+void cluster_property_clamp(
+  tristate<T>& topic_val,
+  const std::optional<T>& cluster_val,
+  const constraint_enabled_t& enabled,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::string_view& cluster_property) {
+    if (enabled == constraint_enabled_t::no) {
+        // Since the constraint is turned off, there is no need to clamp
+        return;
+    }
+
+    if (!topic_val.has_optional_value() || !cluster_val) {
+        return;
+    }
+
+    vlog(
+      constraints_log.warn,
+      "Overwriting topic property to the cluster property {}: topic property "
+      "{}.{}, "
+      "value {}",
+      cluster_property,
+      topic(),
+      topic_property,
+      topic_val);
+    topic_val = tristate<T>{cluster_val};
+}
+
+/**
+ * Assigns the constraint range or cluster-level value to the topic-level value
+ * \param topic_val: the topic value
+ * \param constraint: the constraint to evaluate
+ * \param property_name: name of the cluster-level property
+ * \param cluster_opt: the value from the cluster-level property
+ */
+template<typename T>
+void clamp_value(
+  tristate<T>& topic_val,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::string_view& cluster_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    if (constraint.name == cluster_property) {
+        ss::visit(
+          constraint.flags,
+          [&topic_val,
+           &topic,
+           &topic_property,
+           &cluster_property,
+           &cluster_opt](const constraint_enabled_t enabled) {
+              cluster_property_clamp(
+                topic_val,
+                cluster_opt,
+                enabled,
+                topic,
+                topic_property,
+                cluster_property);
+          },
+          [&topic_val, &topic, &topic_property](const auto range) {
+              range_clamp(topic_val, range, topic, topic_property);
+          });
+    }
+}
+
+template<typename T>
+void clamp_value(
+  std::optional<T>& topic_opt,
+  const constraint_t& constraint,
+  const model::topic& topic,
+  const std::string_view& topic_property,
+  const std::string_view& cluster_property,
+  const std::optional<T> cluster_opt = std::nullopt) {
+    auto tri = tristate<T>{topic_opt};
+    clamp_value(
+      tri, constraint, topic, topic_property, cluster_property, cluster_opt);
+    // The tristate is not in disabled state since it was assigned an optional
+    // earlier.
+    topic_opt = tri.get_optional();
+}
+} // namespace
+
+void constraint_clamp_topic_config(
+  cluster::topic_configuration& topic_cfg, const constraint_t& constraint) {
+    auto partition_count_tri = tristate(
+      std::make_optional(topic_cfg.partition_count));
+    auto replication_factor_tri = tristate(
+      std::make_optional(topic_cfg.replication_factor));
+    clamp_value(
+      partition_count_tri,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_partition_count,
+      config::shard_local_cfg().default_topic_partitions.name());
+    topic_cfg.partition_count = partition_count_tri.value();
+    clamp_value(
+      replication_factor_tri,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_replication_factor,
+      config::shard_local_cfg().default_topic_replication.name());
+    topic_cfg.replication_factor = replication_factor_tri.value();
+    clamp_value<model::compression>(
+      topic_cfg.properties.compression,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_compression,
+      config::shard_local_cfg().log_compression_type.name(),
+      config::shard_local_cfg().log_compression_type());
+    clamp_value<model::cleanup_policy_bitflags>(
+      topic_cfg.properties.cleanup_policy_bitflags,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_cleanup_policy,
+      config::shard_local_cfg().log_cleanup_policy.name(),
+      config::shard_local_cfg().log_cleanup_policy());
+    clamp_value<model::timestamp_type>(
+      topic_cfg.properties.timestamp_type,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_timestamp_type,
+      config::shard_local_cfg().log_message_timestamp_type.name(),
+      config::shard_local_cfg().log_message_timestamp_type());
+    clamp_value(
+      topic_cfg.properties.segment_size,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_segment_size,
+      config::shard_local_cfg().log_segment_size.name());
+    clamp_value(
+      topic_cfg.properties.retention_bytes,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_retention_bytes,
+      config::shard_local_cfg().retention_bytes.name());
+    clamp_value(
+      topic_cfg.properties.retention_duration,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_retention_duration,
+      config::shard_local_cfg().log_retention_ms.name());
+    clamp_value(
+      topic_cfg.properties.batch_max_bytes,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_max_message_bytes,
+      config::shard_local_cfg().kafka_batch_max_bytes.name());
+    clamp_value(
+      topic_cfg.properties.retention_local_target_bytes,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_retention_local_target_bytes,
+      config::shard_local_cfg().retention_local_target_bytes_default.name());
+    clamp_value(
+      topic_cfg.properties.retention_local_target_ms,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_retention_local_target_ms,
+      config::shard_local_cfg().retention_local_target_ms_default.name());
+    clamp_value(
+      topic_cfg.properties.segment_ms,
+      constraint,
+      topic_cfg.tp_ns.tp,
+      kafka::topic_property_segment_ms,
+      config::shard_local_cfg().log_segment_ms.name());
+
+    if (topic_cfg.properties.shadow_indexing) {
+        auto fetch_enabled_opt = std::make_optional(
+          model::is_fetch_enabled(*topic_cfg.properties.shadow_indexing));
+        auto archival_enabled_opt = std::make_optional(
+          model::is_archival_enabled(*topic_cfg.properties.shadow_indexing));
+        clamp_value<bool>(
+          fetch_enabled_opt,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_remote_read,
+          config::shard_local_cfg().cloud_storage_enable_remote_read.name(),
+          config::shard_local_cfg().cloud_storage_enable_remote_read());
+        clamp_value<bool>(
+          archival_enabled_opt,
+          constraint,
+          topic_cfg.tp_ns.tp,
+          kafka::topic_property_remote_write,
+          config::shard_local_cfg().cloud_storage_enable_remote_write.name(),
+          config::shard_local_cfg().cloud_storage_enable_remote_write());
+        topic_cfg.properties.shadow_indexing
+          = model::get_shadow_indexing_mode_impl(
+            *archival_enabled_opt, *fetch_enabled_opt);
+    }
 }
 } // namespace config
 

--- a/src/v/config/constraints.cc
+++ b/src/v/config/constraints.cc
@@ -1,0 +1,190 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/constraints.h"
+
+#include "cluster/types.h"
+#include "config/base_property.h"
+#include "config/configuration.h"
+
+namespace config {
+std::string_view to_string_view(constraint_type type) {
+    switch (type) {
+    case constraint_type::restrikt:
+        return "restrict";
+    case constraint_type::clamp:
+        return "clamp";
+    }
+}
+
+template<>
+std::optional<constraint_type>
+from_string_view<constraint_type>(std::string_view sv) {
+    return string_switch<std::optional<constraint_type>>(sv)
+      .match("restrict", constraint_type::restrikt)
+      .match("clamp", constraint_type::clamp);
+}
+
+std::ostream& operator<<(std::ostream& os, const constraint_t& constraint) {
+    os << ssx::sformat(
+      "name: {} type: {}",
+      constraint.name,
+      config::to_string_view(constraint.type));
+    ss::visit(
+      constraint.flags,
+      [&os](const config::constraint_enabled_t enabled) {
+          os << ssx::sformat(" enabled: {}", enabled);
+      },
+      [&os](const auto range) { os << range; });
+
+    return os;
+}
+} // namespace config
+
+namespace YAML {
+
+template<typename T>
+void encode_range(Node& node, config::range_values<T>& range) {
+    if (range.min) {
+        node["min"] = *range.min;
+    }
+    if (range.max) {
+        node["max"] = *range.max;
+    }
+}
+
+Node convert<config::constraint_t>::encode(const type& rhs) {
+    Node node;
+    node["name"] = rhs.name;
+    node["type"] = ss::sstring(config::to_string_view(rhs.type));
+
+    ss::visit(
+      rhs.flags,
+      [&node](config::constraint_enabled_t enabled) {
+          node["enabled"] = enabled == config::constraint_enabled_t::yes;
+      },
+      [&node](auto range) { encode_range(node, range); });
+
+    return node;
+}
+
+template<typename T>
+config::range_values<T> decode_range(const Node& node) {
+    config::range_values<T> range;
+    if (node["min"] && !node["min"].IsNull()) {
+        range.min = node["min"].as<T>();
+    }
+
+    if (node["max"] && !node["max"].IsNull()) {
+        range.max = node["max"].as<T>();
+    }
+    return range;
+}
+
+template<typename T>
+bool maybe_decode_range(const Node& node, config::constraint_t& constraint) {
+    auto range = decode_range<T>(node);
+    if (!range.min && !range.max) {
+        return false;
+    }
+
+    constraint.flags = range;
+    return true;
+}
+
+// Used to run a condition based on the type of the property.
+template<typename SignedFunc, typename UnsignedFunc, typename ElseFunc>
+auto ternary_property_op(
+  const config::base_property& property,
+  SignedFunc&& signed_condition,
+  UnsignedFunc&& unsigned_condition,
+  ElseFunc&& else_condition) {
+    if (property.is_signed() || property.is_milliseconds()) {
+        return signed_condition();
+    } else if (property.is_unsigned() && !property.is_bool()) {
+        return unsigned_condition();
+    } else {
+        return else_condition();
+    }
+}
+
+bool convert<config::constraint_t>::decode(const Node& node, type& rhs) {
+    for (const auto& s : {"name", "type"}) {
+        if (!node[s]) {
+            return false;
+        }
+    }
+
+    rhs.name = node["name"].as<ss::sstring>();
+
+    auto type_opt = config::from_string_view<config::constraint_type>(
+      node["type"].as<ss::sstring>());
+    if (type_opt) {
+        rhs.type = *type_opt;
+    } else {
+        return false;
+    }
+
+    // Here, we decode constraint flags based on the property type
+    return ternary_property_op(
+      config::shard_local_cfg().get(rhs.name),
+      [&node, &rhs] { return maybe_decode_range<int64_t>(node, rhs); },
+      [&node, &rhs] { return maybe_decode_range<uint64_t>(node, rhs); },
+      [&node, &rhs] {
+          // For "enabled" contraints
+          if (node["enabled"] && !node["enabled"].IsNull()) {
+              rhs.flags = config::constraint_enabled_t(
+                node["enabled"].as<bool>());
+              return true;
+          }
+
+          return false;
+      });
+}
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_enabled_t& ep) {
+    w.Bool(bool(ep));
+}
+
+template<typename T>
+void rjson_serialize_range(
+  json::Writer<json::StringBuffer>& w, config::range_values<T>& range) {
+    if (range.min) {
+        w.Key("min");
+        rjson_serialize(w, range.min);
+    }
+    if (range.max) {
+        w.Key("max");
+        rjson_serialize(w, range.max);
+    }
+}
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_t& constraint) {
+    w.StartObject();
+    w.Key("name");
+    w.String(constraint.name);
+    w.Key("type");
+    w.String(ss::sstring(config::to_string_view(constraint.type)));
+    ss::visit(
+      constraint.flags,
+      [&w](config::constraint_enabled_t enabled) {
+          w.Key("enabled");
+          rjson_serialize(w, enabled);
+      },
+      [&w](auto range) { rjson_serialize_range(w, range); });
+    w.EndObject();
+}
+
+} // namespace json

--- a/src/v/config/constraints.cc
+++ b/src/v/config/constraints.cc
@@ -14,6 +14,7 @@
 #include "config/configuration.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "model/fundamental.h"
+#include "units.h"
 #include "vlog.h"
 
 #include <seastar/util/log.hh>
@@ -578,6 +579,15 @@ std::vector<std::string_view> constraint_supported_properties() {
 
     return names;
 }
+
+std::optional<constraint_t> get_constraint(const constraint_t::key_type name) {
+    const auto& constraints = config::shard_local_cfg().constraints();
+    if (auto found = constraints.find(name); found != constraints.end()) {
+        return std::make_optional(found->second);
+    }
+
+    return std::nullopt;
+}
 } // namespace config
 
 namespace YAML {
@@ -680,7 +690,6 @@ bool convert<config::constraint_t>::decode(const Node& node, type& rhs) {
           return false;
       });
 }
-
 } // namespace YAML
 
 namespace json {

--- a/src/v/config/constraints.h
+++ b/src/v/config/constraints.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "config/convert.h"
+#include "config/from_string_view.h"
+#include "config/property.h"
+#include "json/json.h"
+#include "ssx/sformat.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <yaml-cpp/node/node.h>
+
+#include <optional>
+#include <string>
+
+namespace cluster {
+struct topic_configuration;
+} // namespace cluster
+
+namespace config {
+enum class constraint_type {
+    restrikt = 0,
+    clamp = 1,
+};
+
+std::string_view to_string_view(constraint_type type);
+
+template<>
+std::optional<constraint_type>
+from_string_view<constraint_type>(std::string_view sv);
+
+using constraint_enabled_t = ss::bool_class<struct constraint_enabled_tag>;
+
+namespace {
+template<typename T>
+struct range_values {
+    std::optional<T> min;
+    std::optional<T> max;
+
+    range_values() = default;
+    range_values(std::optional<T> min_opt, std::optional<T> max_opt)
+      : min{std::move(min_opt)}
+      , max{std::move(max_opt)} {}
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const range_values<T>& range) {
+        os << ssx::sformat(" min: {}, max: {}", range.min, range.max);
+        return os;
+    }
+
+    friend bool operator==(const range_values&, const range_values&) = default;
+    friend bool operator!=(const range_values&, const range_values&) = default;
+};
+} // namespace
+
+// Captures the flags that constraints could hold
+struct constraint_t {
+    using key_type = ss::sstring;
+
+    ss::sstring name;
+    constraint_type type;
+
+    std::variant<
+      range_values<int64_t>,
+      range_values<uint64_t>,
+      constraint_enabled_t>
+      flags;
+
+    static ss::sstring key_name() { return "name"; }
+
+    const ss::sstring& key() const { return name; }
+
+    friend bool operator==(const constraint_t&, const constraint_t&) = default;
+
+    friend std::ostream& operator<<(std::ostream& os, const constraint_t& args);
+};
+
+namespace detail {
+
+template<>
+consteval std::string_view property_type_name<constraint_t>() {
+    return "config::constraint_t";
+}
+
+} // namespace detail
+} // namespace config
+
+namespace YAML {
+template<>
+struct convert<config::constraint_t> {
+    using type = config::constraint_t;
+    static Node encode(const type& rhs);
+    static bool decode(const Node& node, type& rhs);
+};
+
+} // namespace YAML
+
+namespace json {
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_enabled_t& ep);
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const config::constraint_t& ep);
+
+} // namespace json

--- a/src/v/config/constraints.h
+++ b/src/v/config/constraints.h
@@ -86,6 +86,20 @@ struct constraint_t {
     friend std::ostream& operator<<(std::ostream& os, const constraint_t& args);
 };
 
+/**
+ * Returns true if the topic configuration satifies the constraint
+ * \param topic_cfg: the topic configuration
+ * \param constraint: the constraint
+ */
+bool topic_config_satisfies_constraint(
+  const cluster::topic_configuration&, const constraint_t&);
+
+/**
+ * Clamps topic properties based on the constraint
+ */
+void constraint_clamp_topic_config(
+  cluster::topic_configuration&, const constraint_t&);
+
 namespace detail {
 
 template<>

--- a/src/v/config/constraints.h
+++ b/src/v/config/constraints.h
@@ -100,6 +100,11 @@ bool topic_config_satisfies_constraint(
 void constraint_clamp_topic_config(
   cluster::topic_configuration&, const constraint_t&);
 
+/**
+ * List properties that support constraints
+ */
+std::vector<std::string_view> constraint_supported_properties();
+
 namespace detail {
 
 template<>

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -125,6 +125,14 @@ public:
 
     bool is_array() const override;
 
+    bool is_signed() const override;
+
+    bool is_unsigned() const override;
+
+    bool is_bool() const override;
+
+    bool is_milliseconds() const override;
+
     bool is_overriden() const { return is_required() || _value != _default; }
 
     bool is_default() const override { return _value == _default; }
@@ -702,6 +710,31 @@ bool property<T>::is_array() const {
     return detail::is_array<T>();
 }
 
+template<typename T>
+bool property<T>::is_signed() const {
+    return std::is_signed_v<T>;
+}
+
+template<typename T>
+bool property<T>::is_unsigned() const {
+    return std::is_unsigned_v<T>;
+}
+
+template<typename T>
+bool property<T>::is_bool() const {
+    return std::is_same_v<T, bool>;
+}
+
+template<typename T>
+bool property<T>::is_milliseconds() const {
+    if constexpr (reflection::is_std_optional<T>) {
+        return std::
+          is_same_v<typename T::value_type, std::chrono::milliseconds>;
+    } else {
+        return std::is_same_v<T, std::chrono::milliseconds>;
+    }
+}
+
 /*
  * Same as property<std::vector<T>> but will also decode a single T. This can be
  * useful for dealing with backwards compatibility or creating easier yaml
@@ -908,5 +941,4 @@ private:
         }
     }
 };
-
 }; // namespace config

--- a/src/v/config/tests/CMakeLists.txt
+++ b/src/v/config/tests/CMakeLists.txt
@@ -19,3 +19,14 @@ rp_test(
   LIBRARIES v::seastar_testing_main v::config
   LABELS config
 )
+
+set(gtest_srcs
+    config_constraints_gtests.cc
+    validator_gtests.cc)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_configuration
+  SOURCES ${gtest_srcs}
+  LIBRARIES v::gtest_main v::config v::kafka)

--- a/src/v/config/tests/config_constraints_gtests.cc
+++ b/src/v/config/tests/config_constraints_gtests.cc
@@ -1,0 +1,234 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/types.h"
+#include "config/bounded_property.h"
+#include "config/configuration.h"
+#include "config/property.h"
+#include "config/tests/constraint_utils.h"
+#include "kafka/server/handlers/topics/topic_utils.h"
+#include "model/fundamental.h"
+#include "test_utils/test.h"
+
+namespace {
+
+struct test_config : public config::config_store {
+    config::bounded_property<int16_t> default_topic_replication;
+    config::property<model::cleanup_policy_bitflags> log_cleanup_policy;
+    config::retention_duration_property log_retention_ms;
+    config::one_or_many_map_property<config::constraint_t> restrict_constraints;
+    config::one_or_many_map_property<config::constraint_t> clamp_constraints;
+
+    test_config()
+      : default_topic_replication(
+        *this, "default_topic_replications", "An integral property", {}, 1, {})
+      , log_cleanup_policy(
+          *this,
+          "log_cleanup_policy",
+          "An enum property",
+          {},
+          model::cleanup_policy_bitflags::deletion)
+      , log_retention_ms(*this, "log_retention_ms", "A ms property", {}, 1h)
+      , restrict_constraints(
+          *this,
+          "restrict_constraints",
+          "A sequence of constraints for testing configs with restrict "
+          "constraint "
+          "type",
+          {},
+          make_constraints(config::constraint_type::restrikt))
+      , clamp_constraints(
+          *this,
+          "clamp_constraints",
+          "A sequence of constraints for testing configs with clamp constraint "
+          "type",
+          {},
+          make_constraints(config::constraint_type::clamp)) {}
+};
+
+bool is_valid(
+  const ss::sstring key,
+  const cluster::topic_configuration& topic_cfg,
+  const std::unordered_map<
+    config::constraint_t::key_type,
+    config::constraint_t>& constraints) {
+    return config::topic_config_satisfies_constraint(
+      topic_cfg, constraints.at(key));
+}
+
+TEST(ConfigConstraintsTest, ConstraintValidation) {
+    auto cfg = test_config{};
+    const auto& constraints = cfg.restrict_constraints();
+    cluster::topic_configuration topic_cfg;
+
+    auto name = ss::sstring{"log_cleanup_policy"};
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::deletion;
+    EXPECT_TRUE(is_valid(name, topic_cfg, constraints));
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    EXPECT_FALSE(is_valid(name, topic_cfg, constraints));
+
+    name = ss::sstring{"default_topic_replications"};
+    topic_cfg.replication_factor = LIMIT_MIN;
+    EXPECT_TRUE(is_valid(name, topic_cfg, constraints));
+    topic_cfg.replication_factor = LIMIT_MAX;
+    EXPECT_TRUE(is_valid(name, topic_cfg, constraints));
+    topic_cfg.replication_factor = LIMIT_MIN - 1;
+    EXPECT_FALSE(is_valid(name, topic_cfg, constraints));
+    topic_cfg.replication_factor = LIMIT_MAX + 1;
+    EXPECT_FALSE(is_valid(name, topic_cfg, constraints));
+
+    name = ss::sstring{"log_retention_ms"};
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS);
+    EXPECT_TRUE(is_valid(name, topic_cfg, constraints));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS);
+    EXPECT_TRUE(is_valid(name, topic_cfg, constraints));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS - 1ms);
+    EXPECT_FALSE(is_valid(name, topic_cfg, constraints));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS + 1ms);
+    EXPECT_FALSE(is_valid(name, topic_cfg, constraints));
+}
+
+void do_clamp(
+  const ss::sstring key,
+  cluster::topic_configuration& topic_cfg,
+  const std::unordered_map<
+    config::constraint_t::key_type,
+    config::constraint_t>& constraints) {
+    auto clamp = [](
+                   cluster::topic_configuration& topic_cfg,
+                   const config::constraint_t& constraint) {
+        config::constraint_clamp_topic_config(topic_cfg, constraint);
+    };
+    return clamp(topic_cfg, constraints.at(key));
+}
+
+TEST(ConfigConstraintsTest, ConstraintClamping) {
+    auto cfg = test_config{};
+    const auto& constraints = cfg.clamp_constraints();
+    cluster::topic_configuration topic_cfg;
+
+    // Check enum clamp constraint
+    auto name = ss::sstring{"log_cleanup_policy"};
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::deletion;
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.cleanup_policy_bitflags, cfg.log_cleanup_policy());
+    topic_cfg.properties.cleanup_policy_bitflags
+      = model::cleanup_policy_bitflags::compaction;
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.cleanup_policy_bitflags, cfg.log_cleanup_policy());
+
+    // Check integral clamp constraint
+    name = ss::sstring{"default_topic_replications"};
+    topic_cfg.replication_factor = LIMIT_MIN;
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MIN);
+    topic_cfg.replication_factor = LIMIT_MAX;
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MAX);
+    topic_cfg.replication_factor = LIMIT_MIN - 1;
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MIN);
+    topic_cfg.replication_factor = LIMIT_MAX + 1;
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MAX);
+
+    // Check ms clamp constraint
+    name = ss::sstring{"log_retention_ms"};
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS);
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>(LIMIT_MIN_MS));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS);
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>(LIMIT_MAX_MS));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MIN_MS - 1ms);
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>(LIMIT_MIN_MS));
+    topic_cfg.properties.retention_duration
+      = tristate<std::chrono::milliseconds>(LIMIT_MAX_MS + 1ms);
+    do_clamp(name, topic_cfg, constraints);
+    EXPECT_EQ(
+      topic_cfg.properties.retention_duration,
+      tristate<std::chrono::milliseconds>(LIMIT_MAX_MS));
+}
+
+TEST(ConfigConstraintsTest, ConstraintApply) {
+    auto cfg = test_config{};
+    auto name = ss::sstring{"default_topic_replications"};
+    auto& restrict_constraint = cfg.restrict_constraints().at(name);
+    auto& clamp_constraint = cfg.clamp_constraints().at(name);
+
+    // Test valid config
+    {
+        cluster::topic_configuration topic_cfg;
+        topic_cfg.replication_factor = LIMIT_MIN;
+        std::vector<kafka::creatable_topic_result> err_vec;
+
+        // Restrict constraint - expect no error
+        apply_constraint(
+          topic_cfg,
+          restrict_constraint,
+          kafka::creatable_topic_result{},
+          std::back_inserter(err_vec));
+        EXPECT_TRUE(err_vec.empty());
+
+        // Clamp constraint - expect that the RF is unchanged
+        auto copy_rf = topic_cfg.replication_factor;
+        apply_constraint(
+          topic_cfg,
+          clamp_constraint,
+          kafka::creatable_topic_result{},
+          std::back_inserter(err_vec));
+        EXPECT_EQ(topic_cfg.replication_factor, copy_rf);
+    }
+
+    // Test invalid config
+    {
+        cluster::topic_configuration topic_cfg;
+        topic_cfg.replication_factor = LIMIT_MIN - 1;
+        std::vector<kafka::creatable_topic_result> err_vec;
+        kafka::creatable_topic_result err_res{
+          .name = model::topic{"test_topic"}};
+
+        // Restrict constraint - expect error
+        apply_constraint(
+          topic_cfg, restrict_constraint, err_res, std::back_inserter(err_vec));
+        EXPECT_EQ(err_vec.size(), 1);
+        EXPECT_EQ(err_vec[0].error_code, kafka::error_code::invalid_config);
+        EXPECT_TRUE(err_vec[0].error_message.has_value());
+        EXPECT_EQ(
+          *err_vec[0].error_message,
+          ss::sstring{
+            "Configuration breaks constraint default_topic_replications"});
+
+        // Clamp constraint - expect that the RF is the minimum
+        apply_constraint(
+          topic_cfg, clamp_constraint, err_res, std::back_inserter(err_vec));
+        EXPECT_EQ(topic_cfg.replication_factor, LIMIT_MIN);
+    }
+}
+
+} // namespace

--- a/src/v/config/tests/constraint_utils.h
+++ b/src/v/config/tests/constraint_utils.h
@@ -1,0 +1,50 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/constraints.h"
+
+#include <chrono>
+#include <optional>
+#include <unordered_map>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr static int16_t LIMIT_MIN = 3;
+constexpr static int16_t LIMIT_MAX = 10;
+constexpr static std::chrono::milliseconds LIMIT_MIN_MS = 1s;
+constexpr static std::chrono::milliseconds LIMIT_MAX_MS = 5s;
+
+std::unordered_map<config::constraint_t::key_type, config::constraint_t>
+make_constraints(config::constraint_type type) {
+    auto integral_constraint_t = config::constraint_t{
+      .name = "default_topic_replications",
+      .type = type,
+      .flags = config::range_values<int64_t>(LIMIT_MIN, LIMIT_MAX)};
+    auto enum_constraint_t = config::constraint_t{
+      .name = "log_cleanup_policy",
+      .type = type,
+      .flags = config::constraint_enabled_t::yes};
+    auto ms_constraint_t = config::constraint_t{
+      .name = "log_retention_ms",
+      .type = type,
+      .flags = config::range_values<int64_t>(
+        LIMIT_MIN_MS.count(), LIMIT_MAX_MS.count())};
+
+    std::unordered_map<config::constraint_t::key_type, config::constraint_t>
+      res;
+    res.reserve(3);
+    res[integral_constraint_t.name] = std::move(integral_constraint_t);
+    res[enum_constraint_t.name] = std::move(enum_constraint_t);
+    res[ms_constraint_t.name] = std::move(ms_constraint_t);
+    return res;
+}
+
+} // namespace

--- a/src/v/config/tests/validator_gtests.cc
+++ b/src/v/config/tests/validator_gtests.cc
@@ -1,0 +1,28 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "config/tests/constraint_utils.h"
+#include "config/validators.h"
+#include "test_utils/test.h"
+
+TEST(ConfigConstraintsTest, InvaldConstraintConfig) {
+    auto valid_constraints = make_constraints(
+      config::constraint_type::restrikt);
+    auto invalid_integral_constraints = std::
+      unordered_map<config::constraint_t::key_type, config::constraint_t>{
+        {"invalid-integral",
+         config::constraint_t{
+           .name = "invalid-integral",
+           .type = config::constraint_type::restrikt,
+           .flags = config::range_values<int64_t>(LIMIT_MAX, LIMIT_MIN)}}};
+
+    EXPECT_FALSE(config::validate_constraints(valid_constraints).has_value());
+    EXPECT_TRUE(
+      config::validate_constraints(invalid_integral_constraints).has_value());
+}

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "config/client_group_byte_rate_quota.h"
+#include "config/constraints.h"
 #include "seastarx.h"
 
 #include <seastar/core/sstring.hh>
@@ -47,4 +48,6 @@ validate_non_empty_string_opt(const std::optional<ss::sstring>&);
 std::optional<ss::sstring>
 validate_audit_event_types(const std::vector<ss::sstring>& vs);
 
+std::optional<ss::sstring> validate_constraints(
+  const std::unordered_map<ss::sstring, config::constraint_t>&);
 }; // namespace config

--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -20,7 +20,7 @@ set(handlers_srcs
   server/handlers/alter_partition_reassignments.cc
   server/handlers/list_partition_reassignments.cc
   server/handlers/handler_interface.cc
-  server/handlers/topics/types.cc
+  server/handlers/topics/config_map.cc
   server/handlers/topics/topic_utils.cc
   server/handlers/delete_records.cc
   server/handlers/describe_producers.cc

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -15,6 +15,7 @@
 #include "config/configuration.h"
 #include "kafka/protocol/errors.h"
 #include "kafka/protocol/timeout.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/quota_manager.h"

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -502,7 +502,7 @@ static void report_broker_config(
     add_broker_config_if_requested(
       resource,
       result,
-      "num.partitions",
+      topic_property_partition_count,
       config::shard_local_cfg().default_topic_partitions,
       include_synonyms,
       maybe_make_documentation(

--- a/src/v/kafka/server/handlers/topics/config_map.cc
+++ b/src/v/kafka/server/handlers/topics/config_map.cc
@@ -1,4 +1,4 @@
-// Copyright 2020 Redpanda Data, Inc.
+// Copyright 2023 Redpanda Data, Inc.
 //
 // Use of this software is governed by the Business Source License
 // included in the file licenses/BSL.md
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "kafka/server/handlers/topics/types.h"
+#include "kafka/server/handlers/topics/config_map.h"
 
 #include "cluster/types.h"
 #include "config/configuration.h"
@@ -105,16 +105,7 @@ get_shadow_indexing_mode(const config_map_t& config) {
           = config::shard_local_cfg().cloud_storage_enable_remote_read();
     }
 
-    model::shadow_indexing_mode mode = model::shadow_indexing_mode::disabled;
-    if (*arch_enabled) {
-        mode = model::shadow_indexing_mode::archival;
-    }
-    if (*si_enabled) {
-        mode = mode == model::shadow_indexing_mode::archival
-                 ? model::shadow_indexing_mode::full
-                 : model::shadow_indexing_mode::fetch;
-    }
-    return mode;
+    return model::get_shadow_indexing_mode_impl(*arch_enabled, *si_enabled);
 }
 
 // Special case for options where Kafka allows -1

--- a/src/v/kafka/server/handlers/topics/config_map.h
+++ b/src/v/kafka/server/handlers/topics/config_map.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "cluster/types.h"
+#include "kafka/protocol/schemata/create_topics_request.h"
+#include "kafka/protocol/schemata/create_topics_response.h"
+#include "kafka/server/handlers/topics/types.h"
+
+#include <boost/lexical_cast.hpp>
+
+namespace kafka {
+
+inline creatable_topic_result
+from_cluster_topic_result(const cluster::topic_result& err) {
+    return {.name = err.tp_ns.tp, .error_code = map_topic_error_code(err.ec)};
+}
+
+config_map_t config_map(const std::vector<createable_topic_config>& config);
+config_map_t config_map(const std::vector<creatable_topic_configs>& config);
+
+cluster::custom_assignable_topic_configuration
+to_cluster_type(const creatable_topic& t);
+
+config_map_t from_cluster_type(const cluster::topic_properties&);
+} // namespace kafka

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -12,7 +12,8 @@
 #pragma once
 #include "cluster/fwd.h"
 #include "cluster/types.h"
-#include "kafka/server/handlers/topics/types.h"
+#include "config/constraints.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/validators.h"
 #include "model/timeout_clock.h"
 #include "seastarx.h"

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Redpanda Data, Inc.
+ * Copyright 2023 Redpanda Data, Inc.
  *
  * Use of this software is governed by the Business Source License
  * included in the file licenses/BSL.md
@@ -10,17 +10,12 @@
  */
 
 #pragma once
-#include "cluster/types.h"
-#include "kafka/protocol/schemata/create_topics_request.h"
-#include "kafka/protocol/schemata/create_topics_response.h"
 #include "kafka/server/errors.h"
 #include "model/fundamental.h"
 #include "model/namespace.h"
 #include "utils/absl_sstring_hash.h"
 
 #include <absl/container/flat_hash_map.h>
-#include <boost/algorithm/string.hpp>
-#include <boost/lexical_cast.hpp>
 
 #include <array>
 
@@ -63,6 +58,8 @@ static constexpr std::string_view topic_property_retention_local_target_ms
   = "retention.local.target.ms";
 static constexpr std::string_view topic_property_replication_factor
   = "replication.factor";
+static constexpr std::string_view topic_property_partition_count
+  = "num.partitions";
 static constexpr std::string_view topic_property_remote_delete
   = "redpanda.remote.delete";
 static constexpr std::string_view topic_property_segment_ms = "segment.ms";
@@ -134,17 +131,4 @@ struct topic_op_result {
     error_code ec;
     std::optional<ss::sstring> err_msg;
 };
-
-inline creatable_topic_result
-from_cluster_topic_result(const cluster::topic_result& err) {
-    return {.name = err.tp_ns.tp, .error_code = map_topic_error_code(err.ec)};
-}
-
-config_map_t config_map(const std::vector<createable_topic_config>& config);
-config_map_t config_map(const std::vector<creatable_topic_configs>& config);
-
-cluster::custom_assignable_topic_configuration
-to_cluster_type(const creatable_topic& t);
-
-config_map_t from_cluster_type(const cluster::topic_properties&);
 } // namespace kafka

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -12,6 +12,7 @@
 #pragma once
 #include "kafka/protocol/schemata/create_topics_request.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/types.h"
 
 namespace kafka {

--- a/src/v/kafka/server/tests/create_topics_test.cc
+++ b/src/v/kafka/server/tests/create_topics_test.cc
@@ -9,6 +9,7 @@
 
 #include "kafka/protocol/create_topics.h"
 #include "kafka/protocol/metadata.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "redpanda/tests/fixture.h"
 #include "resource_mgmt/io_priority.h"

--- a/src/v/kafka/server/tests/types_conversion_tests.cc
+++ b/src/v/kafka/server/tests/types_conversion_tests.cc
@@ -9,8 +9,8 @@
 
 #include "cluster/types.h"
 #include "kafka/protocol/schemata/create_topics_request.h"
+#include "kafka/server/handlers/topics/config_map.h"
 #include "kafka/server/handlers/topics/topic_utils.h"
-#include "kafka/server/handlers/topics/types.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -424,6 +424,20 @@ std::ostream& operator<<(std::ostream&, const shadow_indexing_mode&);
 
 using client_address_t = named_type<ss::sstring, struct client_address_tag>;
 
+inline shadow_indexing_mode
+get_shadow_indexing_mode_impl(bool arch_enabled, bool si_enabled) {
+    model::shadow_indexing_mode mode = model::shadow_indexing_mode::disabled;
+    if (arch_enabled) {
+        mode = model::shadow_indexing_mode::archival;
+    }
+    if (si_enabled) {
+        mode = mode == model::shadow_indexing_mode::archival
+                 ? model::shadow_indexing_mode::full
+                 : model::shadow_indexing_mode::fetch;
+    }
+
+    return mode;
+}
 } // namespace model
 
 namespace kafka {

--- a/src/v/redpanda/admin/api-doc/cluster_config.json
+++ b/src/v/redpanda/admin/api-doc/cluster_config.json
@@ -29,6 +29,13 @@
               "schema": {"type": "integer"},
               "required": false,
               "description": "If nonzero, do not apply any changes (but still do validation and return 400 on errors)"
+            },
+            {
+              "in": "query",
+              "name": "report_clamp_constraints",
+              "schema": {"type": "boolean"},
+              "required": false,
+              "description": "If true, topics that break clamp constraints generate errors, otherwise a message is logged"
             }
           ],
           "responses": {

--- a/tests/rptest/clients/constraints.py
+++ b/tests/rptest/clients/constraints.py
@@ -1,0 +1,33 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from enum import Enum
+
+
+class ConstraintType(str, Enum):
+    RESTRIKT = 'restrict'
+    CLAMP = 'clamp'
+
+
+# Match the cluster configuration defaults
+DEFAULT_SEGMENT_SIZE_CONSTRAINT = {
+    'name': 'log_segment_size',
+    'type': 'clamp',
+    'min': 1048576
+}
+
+DEFAULT_SEGMENT_MS_CONSTRAINT = {
+    'name': 'log_segment_ms',
+    'type': 'clamp',
+    'min': 600000,
+    'max': 31536000000
+}
+
+DEFAULT_CONSTRAINTS = [
+    DEFAULT_SEGMENT_SIZE_CONSTRAINT, DEFAULT_SEGMENT_MS_CONSTRAINT
+]

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -116,6 +116,8 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
             args += ["--config", f"retention.ms={spec.retention_ms}"]
         if spec.max_message_bytes:
             args += ["--config", f"max.message.bytes={spec.max_message_bytes}"]
+        if spec.compression_type:
+            args += ["--config", f"compression.type={spec.compression_type}"]
         return self._run("kafka-topics.sh", args)
 
     def create_topic_partitions(self, topic, partitions):

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -88,7 +88,7 @@ class TopicSpec:
                  partition_count=1,
                  replication_factor=3,
                  cleanup_policy=CLEANUP_DELETE,
-                 compression_type=COMPRESSION_PRODUCER,
+                 compression_type=None,
                  message_timestamp_type=TIMESTAMP_CREATE_TIME,
                  segment_bytes=None,
                  retention_bytes=None,

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -16,6 +16,7 @@ from ducktape.utils.util import wait_until, TimeoutError
 import numpy
 
 from rptest.services.cluster import cluster
+from rptest.clients.constraints import DEFAULT_SEGMENT_MS_CONSTRAINT
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.utils.si_utils import nodes_report_cloud_segments
@@ -258,6 +259,13 @@ class ManyPartitionsTest(PreallocNodesTest):
 
     def __init__(self, test_ctx, *args, **kwargs):
         self._ctx = test_ctx
+        constraints = [
+            DEFAULT_SEGMENT_MS_CONSTRAINT, {
+                'name': 'log_segment_size',
+                'type': 'clamp',
+                'min': 1024
+            }
+        ]
         super(ManyPartitionsTest, self).__init__(
             test_ctx,
             *args,
@@ -301,7 +309,7 @@ class ManyPartitionsTest(PreallocNodesTest):
                 # cloud segments as possible. To that end, bounding the segment
                 # size isn't productive.
                 'cloud_storage_segment_size_min': 1,
-                'log_segment_size_min': 1024,
+                'constraints': constraints,
 
                 # Disable segment merging: when we create many small segments
                 # to pad out tiered storage metadata, we don't want them to

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -383,6 +383,7 @@ class Admin:
                              remove=None,
                              force=False,
                              dry_run=False,
+                             report_clamp_constraints=False,
                              node=None):
         if upsert is None:
             upsert = {}
@@ -395,6 +396,8 @@ class Admin:
             params['force'] = 'true'
         if dry_run:
             params['dry_run'] = 'true'
+        if report_clamp_constraints:
+            params['report_clamp_constraints'] = 'true'
 
         if params:
             joined = "&".join([f"{k}={v}" for k, v in params.items()])

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1064,7 +1064,16 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             Example("kafka_qdc_enable", "true", True),
             Example("append_chunk_size", "32768", 32768),
             Example("superusers", "['bob','alice']", ["bob", "alice"]),
-            Example("storage_min_free_bytes", "1234567890", 1234567890)
+            Example("storage_min_free_bytes", "1234567890", 1234567890),
+            Example(
+                "constraints",
+                "[{'name': 'default_topic_replications','type': 'restrict','min': 3, 'max': 9}]",
+                [{
+                    'name': 'default_topic_replications',
+                    'type': 'restrict',
+                    'min': 3,
+                    'max': 9
+                }])
         ]
 
         def yamlize(input) -> str:
@@ -1102,6 +1111,9 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             ("kafka_qdc_enable", "rhubarb"),
             ("append_chunk_size", "-123"),
             ("superusers", "43"),
+            ("constraints",
+             "[{'name': 'default_topic_replications','type': 'restrict','min': 9, 'max': 3}]"
+             ),
         ]
         for key, strval in invalid_examples:
             try:
@@ -1118,6 +1130,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             ("kafka_qdc_enable", False),
             ("append_chunk_size", 16384),
             ("superusers", []),
+            ("constraints", []),
         ]
         for key, expect_default in default_examples:
             self.rpk.cluster_config_set(key, "")

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -9,6 +9,7 @@
 from collections import namedtuple
 import json
 import logging
+import os
 import pprint
 import random
 import re
@@ -1888,3 +1889,98 @@ class ClusterConfigLegacyDefaultTest(RedpandaTest, ClusterConfigHelpersMixin):
         self.redpanda.set_cluster_config({self.key: expected})
 
         self._check_value_everywhere(self.key, expected)
+
+
+class ConfigConstraintsTest(RedpandaTest):
+    RETENTION_MS = 86400000  # 1 day
+    RETENTION_MS_MIN = RETENTION_MS // 2
+    RETENTION_MS_MAX = RETENTION_MS * 2
+    topics = [TopicSpec(retention_ms=RETENTION_MS)]
+
+    # All topics retention.ms must be in [min,max] range
+    LOG_RETENTION_CONSTRAINT = {
+        'name': 'log_retention_ms',
+        'type': 'restrict',
+        'min': RETENTION_MS_MIN,
+        'max': RETENTION_MS_MAX
+    }
+
+    # All topics cleanup policy must be cluster default (delete)
+    LOG_CLEANUP_CONSTRAINT = {
+        'name': 'log_cleanup_policy',
+        'type': 'restrict',
+        'enabled': True
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(ConfigConstraintsTest, self).__init__(extra_rp_conf={
+            "constraints":
+            [self.LOG_RETENTION_CONSTRAINT, self.LOG_CLEANUP_CONSTRAINT]
+        },
+                                                    *args,
+                                                    **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_constraint_configs_persist(self):
+        # Check that configuration constraints persist between broker restart.
+
+        admin = Admin(self.redpanda)
+        target_broker = self.redpanda.nodes[0]
+
+        # After first boot, the preset constraints should be returned by the Admin API.
+        res = admin.get_cluster_config(node=target_broker)
+        assert 'constraints' in res
+        assert type(res['constraints']) == list
+        constraints = sorted(res['constraints'], key=lambda con: con['name'])
+        self.logger.debug(json.dumps(constraints, indent=2))
+        assert constraints[0] == self.LOG_CLEANUP_CONSTRAINT
+        assert constraints[1] == self.LOG_RETENTION_CONSTRAINT
+
+        self.redpanda.restart_nodes([target_broker])
+
+        # Admin API should report the same constraints after restart
+        res = admin.get_cluster_config(node=target_broker)
+        assert 'constraints' in res
+        assert type(res['constraints']) == list
+        constraints = sorted(res['constraints'], key=lambda con: con['name'])
+        self.logger.debug(json.dumps(constraints, indent=2))
+        assert constraints[0] == self.LOG_CLEANUP_CONSTRAINT
+        assert constraints[1] == self.LOG_RETENTION_CONSTRAINT
+
+        # Constraints should also appear in the config cache file
+        cache_path = f"{self.redpanda.DATA_DIR}/config_cache.yaml"
+        assert target_broker.account.exists(cache_path)
+
+        cached_cluster_config = {}
+        with tempfile.TemporaryDirectory() as d:
+            target_broker.account.copy_from(cache_path, d)
+            with open(os.path.join(d, "config_cache.yaml")) as f:
+                cached_cluster_config = yaml.full_load(f.read())
+
+        self.logger.debug(json.dumps(cached_cluster_config, indent=2))
+
+        assert 'constraints' in cached_cluster_config
+        assert type(cached_cluster_config['constraints']) == str
+        constraints = json.loads(cached_cluster_config['constraints'])
+        assert type(constraints) == list
+        constraints = sorted(constraints, key=lambda con: con['name'])
+        assert constraints[0] == self.LOG_CLEANUP_CONSTRAINT
+        assert constraints[1] == self.LOG_RETENTION_CONSTRAINT
+
+
+class ConfigConstraintsParseTest(RedpandaTest):
+    topics = [TopicSpec()]
+
+    LOG_RETENTION_CONSTRAINT = {'name': 'log_retention_ms', 'type': 'restrict'}
+
+    def __init__(self, *args, **kwargs):
+        super(ConfigConstraintsParseTest, self).__init__(
+            extra_rp_conf={"constraints": [self.LOG_RETENTION_CONSTRAINT]},
+            *args,
+            **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_failed_yaml_parse(self):
+        # Search for the yaml parse error
+        pattern = ".*Invalid bootstrap property 'constraints'.*TypedBadConversion<config::constraint_t>.*"
+        assert self.redpanda.search_log_all(pattern)

--- a/tests/rptest/tests/workload_upgrade_config_defaults.py
+++ b/tests/rptest/tests/workload_upgrade_config_defaults.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from rptest.clients.constraints import DEFAULT_SEGMENT_SIZE_CONSTRAINT, DEFAULT_SEGMENT_MS_CONSTRAINT
 from rptest.services.admin import Admin
 from rptest.services.workload_protocol import PWorkload
 
@@ -35,4 +36,47 @@ class SetLogSegmentMsMinConfig(PWorkload):
     def on_cluster_upgraded(self, version: tuple[int, int, int]) -> int:
         prop_val = self.admin.get_cluster_config()[PROP_NAME]
         assert prop_val == PROP_NEW_VALUE, f"{PROP_NAME} did not maintain the value {PROP_NEW_VALUE} that was set before upgrading. {version=}"
+        return PWorkload.DONE
+
+
+class DefaultConfigConstraints(PWorkload):
+    def __init__(self, ctx) -> None:
+        self.ctx = ctx
+        self.admin = Admin(self.ctx.redpanda)
+
+    def _check_segment_clamps(self, res: dict, expected_segment_ms_min: int):
+        segment_size_min = res['log_segment_size_min']
+        expected_segment_size_min = DEFAULT_SEGMENT_SIZE_CONSTRAINT['min']
+        assert segment_size_min == expected_segment_size_min, f'expected log_segment_size_min={expected_segment_size_min}, {segment_size_min=}'
+        segment_size_max = res['log_segment_size_max']
+        assert segment_size_max == None, f'expected undefined log_segment_size_max, {segment_size_max=}'
+        segment_ms_min = res['log_segment_ms_min']
+        assert segment_ms_min == expected_segment_ms_min, f'expected log_segment_ms_min={expected_segment_ms_min}, {segment_ms_min=}'
+        segment_ms_max = res['log_segment_ms_max']
+        expected_segment_ms_max = DEFAULT_SEGMENT_MS_CONSTRAINT['max']
+        assert segment_ms_max == expected_segment_ms_max, f'expected log_segment_ms_max={expected_segment_ms_max}, {segment_ms_max=}'
+
+    def get_earliest_applicable_release(self):
+        # version before configuration constraint support
+        return (23, 2)
+
+    def begin(self):
+        # Before cluster upgrade, there is no constraints config and the legacy clamps exist
+
+        res = self.admin.get_cluster_config()
+        self._check_segment_clamps(res, expected_segment_ms_min=60000)
+        assert 'constraints' not in res, 'expected constraints config not found'
+
+    def on_cluster_upgraded(self, version: tuple[int, int, int]) -> int:
+        # After cluster upgrade, expect constraints as a cluster config and it is pre-populated with
+        # legacy clamps for segment size and lifetime. NOTE: log_segment_ms_min was updated to 10min for 23.3.x
+        # legacy clamps are deprected but still in use.
+        res = self.admin.get_cluster_config()
+        self._check_segment_clamps(
+            res, expected_segment_ms_min=DEFAULT_SEGMENT_MS_CONSTRAINT['min'])
+        assert 'constraints' in res, 'expected to find constraints config'
+        assert type(res['constraints']
+                    ) == list, 'expected constraint config to be a list'
+        assert len(res['constraints']) == 0, 'expected empty constraints list'
+
         return PWorkload.DONE

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -21,7 +21,7 @@ from rptest.tests.workload_producer_consumer import ProducerConsumerWorkload
 from rptest.tests.workload_dummy import DummyWorkload, MinimalWorkload
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.workload_license import LicenseWorkload
-from rptest.tests.workload_upgrade_config_defaults import SetLogSegmentMsMinConfig
+from rptest.tests.workload_upgrade_config_defaults import SetLogSegmentMsMinConfig, DefaultConfigConstraints
 from rptest.utils.mode_checks import skip_debug_mode
 from ducktape.mark import matrix, ok_to_fail
 
@@ -167,6 +167,7 @@ class RedpandaUpgradeTest(PreallocNodesTest):
             MinimalWorkload(self),
             ProducerConsumerWorkload(self),
             SetLogSegmentMsMinConfig(self),
+            DefaultConfigConstraints(self),
             # NOTE: due to issue/13180 the next workload is temporarily disabled
             # LicenseWorkload(self),
         ]


### PR DESCRIPTION
Deprecates legacy configs for segment size and segment ms min/max. Uses configuration constraints in their place.

Fixes: #14018 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* None
