### PR TITLE
c/archival_stm: translate sync error to not_leader error code

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -376,7 +376,7 @@ ss::future<std::error_code> command_batch_builder::replicate() {
         auto timeout = now < _deadline ? _deadline - now : 0ms;
         return _stm.get().sync(timeout).then([this](bool success) {
             if (!success) {
-                return ss::make_ready_future<std::error_code>(errc::timeout);
+                return ss::make_ready_future<std::error_code>(errc::not_leader);
             }
             auto batch = std::move(_builder).build();
             return _stm.get().do_replicate_commands(std::move(batch), _as);


### PR DESCRIPTION
When `persisted_stm::sync()` method fails it is indicating that the current node is not longer a leader. The `sync()` executed before `replicate` call in archival stm `command_batch_builder` prevents replicate from being called. The end result for such an error is deterministic and we can translate the sync error to `not_leader` error code.

Fixes: #14898

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none