### PR TITLE
storage: clean up logging in compaction code

### DIFF
--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -103,10 +103,15 @@ ss::future<model::offset> build_offset_map(
             cfg.asrc->check();
         }
         const auto& seg = iter->get();
+        vlog(gclog.debug, "Adding segment to offset map: {}", seg->filename());
         auto read_lock = co_await seg->read_lock();
         if (seg->is_closed()) {
             // Stop early if the segment e.g. has been prefix truncated. We'll
             // make do with the offset map we have so far.
+            vlog(
+              gclog.debug,
+              "Stopping add to offset map, segment closed: {}",
+              seg->filename());
             break;
         }
         auto seg_fully_indexed = co_await build_offset_map_for_segment(
@@ -116,6 +121,7 @@ ss::future<model::offset> build_offset_map(
             // indexed a segment, but it's safe to use this index. If no new
             // segments come in, the next time we compact, we need to start
             // from this segment for completeness.
+            vlog(gclog.debug, "Segment not fully indexed: {}", seg->filename());
             break;
         }
         min_segment_fully_indexed = seg->offsets().base_offset;


### PR DESCRIPTION
Adds some log lines that should be helpful in identifying different stages done and decisions made in windowed compaction, and demotes a couple info log lines to debug level.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
