### PR TITLE
security/audit: More audit enhancements 

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -216,7 +216,7 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
                      none;
         };
         if (
-          cfg.cloud_storage_enabled
+          cfg.audit_enabled || cfg.cloud_storage_enabled
           || cfg.partition_autobalancing_mode
                == model::partition_autobalancing_mode::continuous
           || has_gssapi() || has_schma_id_validation()) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1382,7 +1382,7 @@ configuration::configuration()
       "audit log records. Disable and re-enable auditing for changes to take "
       "affect",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      1_MiB)
+      16_MiB)
   , audit_queue_drain_interval_ms(
       *this,
       "audit_queue_drain_interval_ms",
@@ -1392,16 +1392,16 @@ configuration::configuration()
       "the risk of data loss during hard shutdowns.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       500ms)
-  , audit_max_queue_elements_per_shard(
+  , audit_queue_max_buffer_size_per_shard(
       *this,
-      "audit_max_queue_elements_per_shard",
-      "Maximum number of allowed elements in the audit buffers, per shard. "
+      "audit_queue_max_buffer_size_per_shard",
+      "Maximum amount of memory allowed in the audit buffer per shard "
       "Once this value is reached, any request handlers that cannot enqueue "
       "audit messages will return a non retryable error to the client. Note "
       "that this only will occur when handling requests that are currently "
       "enabled for auditing.",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      100000)
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      1_MiB)
   , audit_enabled_event_types(
       *this,
       "audit_enabled_event_types",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -272,7 +272,7 @@ struct configuration final : public config_store {
     property<std::optional<int16_t>> audit_log_replication_factor;
     property<size_t> audit_client_max_buffer_size;
     property<std::chrono::milliseconds> audit_queue_drain_interval_ms;
-    property<size_t> audit_max_queue_elements_per_shard;
+    property<size_t> audit_queue_max_buffer_size_per_shard;
     property<std::vector<ss::sstring>> audit_enabled_event_types;
     property<std::vector<ss::sstring>> audit_excluded_topics;
     property<std::vector<ss::sstring>> audit_excluded_principals;

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -95,6 +95,8 @@ std::string_view to_string_view(feature f) {
         return "disabling_partitions";
     case feature::cloud_metadata_cluster_recovery:
         return "cloud_metadata_cluster_recovery";
+    case feature::audit_logging:
+        return "audit_logging";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -72,6 +72,7 @@ enum class feature : std::uint64_t {
     fast_partition_reconfiguration = 1ULL << 38U,
     disabling_partitions = 1ULL << 39U,
     cloud_metadata_cluster_recovery = 1ULL << 40U,
+    audit_logging = 1ULL << 41U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -355,6 +356,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{11},
     "cloud_metadata_cluster_recovery",
     feature::cloud_metadata_cluster_recovery,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{11},
+    "audit_logging",
+    feature::audit_logging,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always}};
 

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -243,7 +243,7 @@ ss::future<produce_response> client::produce_records(
         if (!p_id) {
             p_id = co_await gated_retry_with_mitigation([&, this]() {
                        return _topic_cache.partition_for(topic, record);
-                   }).handle_exception_type([](const topic_error&) {
+                   }).handle_exception([](std::exception_ptr) {
                 // Assume auto topic creation is on and assign to first
                 // partition
                 return model::partition_id{0};

--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -145,9 +145,14 @@ ss::future<> client::update_metadata(wait_or_start::tag) {
 }
 
 ss::future<> client::apply(metadata_response res) {
-    co_await _brokers.apply(std::move(res.data.brokers));
-    co_await _topic_cache.apply(std::move(res.data.topics));
-    _controller = res.data.controller_id;
+    try {
+        co_await _brokers.apply(std::move(res.data.brokers));
+        co_await _topic_cache.apply(std::move(res.data.topics));
+        _controller = res.data.controller_id;
+    } catch (const std::exception& ex) {
+        vlog(kclog.debug, "{}Failed to apply metadata request", *this);
+        throw;
+    }
 }
 
 ss::future<> client::mitigate_error(std::exception_ptr ex) {

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -79,6 +79,13 @@ configuration::configuration()
           }
           return std::nullopt;
       })
+  , produce_shutdown_delay(
+      *this,
+      "produce_shutdown_delay_ms",
+      "Delay (in milliseconds) to allow for final flush of buffers before "
+      "shutting down",
+      {},
+      0ms)
   , produce_ack_level(
       *this,
       "produce_ack_level",

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -34,6 +34,7 @@ struct configuration final : public config::config_store {
     config::property<int32_t> produce_batch_size_bytes;
     config::property<std::chrono::milliseconds> produce_batch_delay;
     config::property<ss::sstring> produce_compression_type;
+    config::property<std::chrono::milliseconds> produce_shutdown_delay;
     config::property<int16_t> produce_ack_level;
     config::property<std::chrono::milliseconds> consumer_request_timeout;
     config::property<int32_t> consumer_request_max_bytes;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -211,6 +211,9 @@ static void set_auditing_kafka_client_defaults(
     if (!client_config.produce_ack_level.is_overriden()) {
         client_config.produce_ack_level.set_value(int16_t(1));
     }
+    if (!client_config.produce_shutdown_delay.is_overriden()) {
+        client_config.produce_shutdown_delay.set_value(3000ms);
+    }
     /// explicity override the scram details as the client will need to use
     /// broker generated ephemeral credentials
     client_config.scram_password.reset();

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -241,6 +241,7 @@ ss::future<> audit_client::configure() {
         co_await set_client_credentials();
         co_await set_auditing_permissions();
         co_await create_internal_topic();
+        co_await _client.connect();
 
         /// Retries should be "infinite", to avoid dropping data, there is a
         /// known issue within the client setting this value to size_t::max
@@ -326,10 +327,6 @@ ss::future<> audit_client::update_status(kafka::produce_response response) {
 }
 
 ss::future<> audit_client::mitigate_error(std::exception_ptr eptr) {
-    if (_gate.is_closed() || _as.abort_requested()) {
-        /// TODO: Investigate looping behavior on shutdown
-        co_return;
-    }
     vlog(adtlog.trace, "mitigate_error: {}", eptr);
     auto f = ss::now();
     try {

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -318,6 +318,10 @@ private:
     /// audit topic.
     bool _auth_misconfigured{false};
 
+    /// Represents whether the feature is actually active, not the
+    /// representation of the config variable
+    bool _effectively_enabled{false};
+
     /// Shutdown primitives
     ss::gate _gate;
     ss::abort_source _as;

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -203,22 +203,6 @@ public:
           make_api_activity_event(req, user, svc_name)));
     }
 
-    /// Enqueue an event to be produced onto an audit log partition.  This will
-    /// always enqueue the event (if auditing is enabled).  This is used for
-    /// items like authentication events or application events.
-    ///
-    /// Returns: bool representing if the audit msg was successfully moved into
-    /// the queue or not. If unsuccessful this means the audit subsystem cannot
-    /// publish messages. Consumers of this API should react accordingly, i.e.
-    /// return an error to the client.
-    template<InheritsFromOCSFBase T>
-    bool enqueue_mandatory_audit_event(T&& t) {
-        if (auto val = should_enqueue_audit_event(); val.has_value()) {
-            return (bool)*val;
-        }
-        return do_enqueue_audit_event(std::make_unique<T>(std::forward<T>(t)));
-    }
-
     /// Returns the number of items pending to be written to auditing log
     ///
     /// Note does not include records already sent to client

--- a/src/v/security/audit/schemas/schemas.h
+++ b/src/v/security/audit/schemas/schemas.h
@@ -47,6 +47,7 @@ public:
 
     virtual ss::sstring to_json() const = 0;
     virtual size_t key() const noexcept = 0;
+    virtual size_t estimated_size() const noexcept = 0;
     virtual void increment(timestamp_t) const = 0;
     virtual category_uid get_category_uid() const = 0;
     virtual class_uid get_class_uid() const = 0;
@@ -62,6 +63,11 @@ public:
     void increment(timestamp_t event_time) const final {
         this->_count++;
         this->_end_time = event_time;
+    }
+
+    size_t estimated_size() const noexcept final {
+        return sizeof(*this)
+               + estimated_ocsf_size(*static_cast<const Derived*>(this));
     }
 
     size_t key() const noexcept final {
@@ -175,6 +181,51 @@ private:
         boost::hash_combine(h, std::hash<type_uid>()(_type_uid));
 
         return h;
+    }
+
+    /// Method to estimate the size of an ocsf message
+    ///
+    /// This works by iterating on the fields within the tuple returned by the
+    /// 'equality_fields()' method. This method is implemented on all ocsf
+    /// structures.
+    ///
+    /// The returned size is 'estimated' because it doesn't take into account
+    /// things like padding and any fields that a struct contains that it did
+    /// not include in its return value for 'equality_fields()'. Currently
+    /// the only example of this is the 'network_endpoint' struct.
+    template<typename T>
+    size_t estimated_ocsf_size(const T& t) const noexcept {
+        size_t sz = 0;
+        if constexpr (reflection::is_std_vector<T>) {
+            sz += sizeof(t);
+            for (const auto& element : t) {
+                sz += estimated_ocsf_size(element);
+            }
+        } else if constexpr (reflection::is_std_optional<T>) {
+            sz += sizeof(t);
+            if (t.has_value()) {
+                sz += estimated_ocsf_size(*t);
+            }
+        } else if constexpr (std::is_same_v<ss::sstring, T>) {
+            sz += sizeof(ss::sstring) + t.size();
+        } else if constexpr (std::is_enum_v<T>) {
+            sz += sizeof(std::underlying_type_t<T>(t));
+        } else if constexpr (
+          std::is_integral_v<T> || reflection::is_ss_bool_class<T>) {
+            sz += sizeof(t);
+        } else if constexpr (reflection::is_rp_named_type<T>) {
+            sz += estimated_ocsf_size(t());
+        } else if constexpr (has_equality_fields<T>) {
+            std::apply(
+              [this, &sz](auto&&... xs) {
+                  ((sz += this->estimated_ocsf_size(xs)), ...);
+              },
+              t.equality_fields());
+        } else {
+            static_assert(
+              always_false_v<T>, "Unsupported type passed to ocsf_size()");
+        }
+        return sz;
     }
 };
 } // namespace security::audit

--- a/src/v/security/audit/schemas/schemas.h
+++ b/src/v/security/audit/schemas/schemas.h
@@ -37,6 +37,12 @@ type_uid get_ocsf_type(class_uid class_uid, T activity_id) {
 
 class ocsf_base_impl {
 public:
+    /// Instances of this class are moveable but not copyable
+    ocsf_base_impl() = default;
+    ocsf_base_impl(ocsf_base_impl&&) = default;
+    ocsf_base_impl& operator=(ocsf_base_impl&&) = default;
+    ocsf_base_impl(const ocsf_base_impl&) = delete;
+    ocsf_base_impl& operator=(const ocsf_base_impl&) = delete;
     virtual ~ocsf_base_impl() = default;
 
     virtual ss::sstring to_json() const = 0;

--- a/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
+++ b/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
@@ -1086,3 +1086,46 @@ BOOST_AUTO_TEST_CASE(make_authn_event_failure) {
     auto ser = sa::rjson_serialize(authn);
     BOOST_REQUIRE_EQUAL(ser, ::json::minify(expected));
 }
+
+BOOST_AUTO_TEST_CASE(test_ocsf_size) {
+    auto req = test_http_request();
+    req.http_headers.push_back(req.http_headers[0]); // Add another element
+
+    const ss::socket_address client_addr{ss::ipv4_addr("10.0.0.1", 12345)};
+    const ss::socket_address server_addr{ss::ipv4_addr("10.1.1.1", 23456)};
+    auto http_req = ss::http::request::make(
+      req.http_method, req.url.hostname, req.url.url_string);
+    http_req.parse_query_param();
+    http_req._client_address = client_addr;
+    http_req._server_address = server_addr;
+    http_req._version = req.version;
+    http_req._headers["User-Agent"] = req.user_agent;
+    http_req._headers["Authorization"] = "You shouldn't see this at all";
+    http_req.protocol_name = req.url.scheme;
+
+    const ss::sstring username = "test";
+    const ss::sstring service_name = "test-service";
+    const auto authn = sa::make_authentication_failure_event(
+      http_req, security::credential_user{username}, service_name, "FAILURE");
+
+    size_t estimated_size = sizeof(sa::ocsf_base_event<sa::authentication>);
+    const auto& [activity_id, auth_protocol, auth_protocol_id, dest_endpoint_host, is_cleartext, is_mfa, service, src_endpoint_host, status_id, status_detail, user]
+      = authn.equality_fields();
+    estimated_size += sizeof(activity_id);
+    estimated_size += sizeof(ss::sstring) + auth_protocol.size();
+    estimated_size += sizeof(auth_protocol_id);
+    estimated_size += sizeof(ss::sstring) + dest_endpoint_host.size();
+    estimated_size += sizeof(is_cleartext);
+    estimated_size += sizeof(is_mfa);
+    estimated_size += sizeof(ss::sstring) + service.name.size();
+    estimated_size += sizeof(ss::sstring) + src_endpoint_host.size();
+    estimated_size += sizeof(status_id);
+    estimated_size
+      += sizeof(std::optional<ss::sstring>)
+         + (status_detail.has_value() ? sizeof(ss::sstring) + status_detail->size() : 0);
+    estimated_size += user.domain.size() + user.name.size() + user.uid.size()
+                      + sizeof(user.type_id) + (sizeof(ss::sstring) * 3);
+
+    BOOST_CHECK_EQUAL(estimated_size, 376);
+    BOOST_CHECK_EQUAL(authn.estimated_size(), 376);
+}

--- a/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
+++ b/src/v/security/audit/schemas/tests/ocsf_schemas_test.cc
@@ -1105,8 +1105,17 @@ BOOST_AUTO_TEST_CASE(test_ocsf_size) {
 
     const ss::sstring username = "test";
     const ss::sstring service_name = "test-service";
-    const auto authn = sa::make_authentication_failure_event(
-      http_req, security::credential_user{username}, service_name, "FAILURE");
+    auto authn = sa::make_authentication_event(sa::authentication_event_options {
+      .server_addr = {fmt::format("{}", http_req.get_server_address().addr()), http_req.get_server_address().port(), http_req.get_server_address().addr().in_family()},
+      .svc_name = service_name,
+      .client_addr = {fmt::format("{}", http_req.get_client_address().addr()), http_req.get_client_address().port(), http_req.get_client_address().addr().in_family()},
+      .is_cleartext = sa::authentication::used_cleartext::no,
+      .user = {
+        .name = username,
+        .type_id = sa::user::type::unknown,
+      },
+      .error_reason = "FAILURE"
+    });
 
     size_t estimated_size = sizeof(sa::ocsf_base_event<sa::authentication>);
     const auto& [activity_id, auth_protocol, auth_protocol_id, dest_endpoint_host, is_cleartext, is_mfa, service, src_endpoint_host, status_id, status_detail, user]

--- a/src/v/security/audit/tests/audit_log_test.cc
+++ b/src/v/security/audit/tests/audit_log_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "cluster/types.h"
+#include "kafka/client/test/fixture.h"
 #include "kafka/types.h"
 #include "redpanda/tests/fixture.h"
 #include "security/audit/audit_log_manager.h"
@@ -48,33 +49,37 @@ ss::future<size_t> pending_audit_events(sa::audit_log_manager& m) {
       std::plus<>());
 }
 
-FIXTURE_TEST(test_audit_init_phase, redpanda_thread_fixture) {
-    /// Initialize auditing configurations
-    ss::smp::invoke_on_all([this] {
+ss::future<> set_auditing_config_options(size_t event_size) {
+    return ss::smp::invoke_on_all([event_size] {
         std::vector<ss::sstring> enabled_types{"management", "consume"};
         config::shard_local_cfg().get("audit_enabled").set_value(false);
         config::shard_local_cfg()
           .get("audit_log_replication_factor")
           .set_value(std::make_optional(int16_t(1)));
         config::shard_local_cfg()
-          .get("audit_max_queue_elements_per_shard")
-          .set_value(size_t(5));
+          .get("audit_queue_max_buffer_size_per_shard")
+          .set_value(event_size * 100);
         config::shard_local_cfg()
           .get("audit_queue_drain_interval_ms")
           .set_value(std::chrono::milliseconds(60000));
         config::shard_local_cfg()
           .get("audit_enabled_event_types")
           .set_value(enabled_types);
-        auto& node_config = config::node();
-        node_config.get("kafka_api")
-          .set_value(std::vector<config::broker_authn_endpoint>{
-            config::broker_authn_endpoint{
-              .address = net::unresolved_address("127.0.0.1", kafka_port),
-              .authn_method = config::broker_authn_method::sasl}});
-    }).get();
+    });
+}
+
+FIXTURE_TEST(test_audit_init_phase, kafka_client_fixture) {
+    /// Knowing the size of one event allows to set a predetermined maximum
+    /// shard allowance for auditing that way backpressure is applied when
+    /// anticipated
+    const size_t event_size = make_random_audit_event().estimated_size();
+    info("Single event size bytes: {}", event_size);
 
     ss::global_logger_registry().set_logger_level(
       "auditing", ss::log_level::trace);
+
+    set_auditing_config_options(event_size).get();
+    enable_sasl_and_restart("username");
 
     wait_for_controller_leadership().get0();
     auto& audit_mgr = app.audit_mgr;
@@ -93,7 +98,7 @@ FIXTURE_TEST(test_audit_init_phase, redpanda_thread_fixture) {
     BOOST_CHECK_EQUAL(pending_audit_events(audit_mgr.local()).get0(), n_events);
 
     /// with auditing enabled, the system should block when the threshold of
-    /// 5 records has been surpassed
+    /// audit_queue_max_buffer_size_per_shard has been reached
     ss::smp::invoke_on_all([] {
         config::shard_local_cfg().get("audit_enabled").set_value(true);
     }).get();
@@ -104,56 +109,40 @@ FIXTURE_TEST(test_audit_init_phase, redpanda_thread_fixture) {
         model::kafka_namespace, model::kafka_audit_logging_topic))})
       .get();
 
+    /// Wait until the run loops are available, otherwise enqueuing events will
+    /// pass through
+    info("Waiting until the audit fibers are up");
+    tests::cooperative_spin_wait_with_timeout(10s, [&audit_mgr] {
+        return audit_mgr.local().is_effectively_enabled();
+    }).get();
+
     /// Verify auditing can enqueue up until the max configured, and further
     /// calls to enqueue return false, signifying action did not occur.
-    const auto rs = audit_mgr
-                      .map([](sa::audit_log_manager& m) {
-                          uint32_t n_enqueued = 0;
-                          for (auto i = 0; i < 20; ++i) {
-                              bool enqueued = m.enqueue_audit_event(
-                                sa::event_type::management,
-                                make_random_audit_event());
-                              if (enqueued) {
-                                  n_enqueued++;
-                              }
-                          }
-                          return n_enqueued;
-                      })
-                      .get();
-
-    // With a single CPU, we expect a total of 3 events to be enqueued
-    // There already exists a create topics event and a lifecycle event
-    // With two CPUs, we expect each to enqueue 4, where one shard has lifecycle
-    // and the other create topics
-    // With three or more CPUs, we would expect 2 CPUs to enqueue 4 and the
-    // others to enqueue 5
-
-    auto expected_count = [](uint32_t enqueue_count) {
-        if (enqueue_count == 3) {
-            return ss::smp::count == 1 ? 1 : 0;
-        } else if (enqueue_count == 4) {
-            return ss::smp::count == 1 ? 0 : 2;
-        } else if (enqueue_count == 5) {
-            return ss::smp::count > 2 ? int(ss::smp::count) - 2 : 0;
-        } else {
-            return 0;
+    auto enqueue_some = [event_size](sa::audit_log_manager& m) {
+        bool success = true;
+        for (auto i = 0; i < 200; ++i) {
+            const bool can_enqueue = m.avaiable_reservation() >= event_size;
+            if (m.enqueue_audit_event(
+                  sa::event_type::management, make_random_audit_event())) {
+                success &= can_enqueue;
+            } else {
+                success &= !can_enqueue;
+            }
         }
+        return success;
     };
+    info("Enqueue 200 records per shard");
+    const bool success
+      = audit_mgr
+          .map_reduce0(std::move(enqueue_some), true, std::logical_and<>())
+          .get();
 
-    const auto equal_to = [](auto a) {
-        return [a](auto b) { return std::equal_to<>()(a, b); };
-    };
-
-    BOOST_CHECK_EQUAL(
-      expected_count(3), std::count_if(rs.cbegin(), rs.cend(), equal_to(3)));
-    BOOST_CHECK_EQUAL(
-      expected_count(4), std::count_if(rs.cbegin(), rs.cend(), equal_to(4)));
-    BOOST_CHECK_EQUAL(
-      expected_count(5), std::count_if(rs.cbegin(), rs.cend(), equal_to(5)));
-
-    BOOST_CHECK_EQUAL(
-      pending_audit_events(audit_mgr.local()).get0(),
-      size_t(5 * ss::smp::count));
+    /// Since different messages related to application lifecycle may be
+    /// enqueued during program execution, the test solely asserts that at any
+    /// given time "if enough memory reservation does or does not exist, should
+    /// the next enqueue work or not". Success is determined if the expectation
+    /// matches the observed outcome, on all attempts, across all shards.
+    BOOST_CHECK(success);
 
     /// Verify auditing doesn't enqueue the non configured types
     BOOST_CHECK(audit_mgr.local().enqueue_audit_event(
@@ -166,24 +155,19 @@ FIXTURE_TEST(test_audit_init_phase, redpanda_thread_fixture) {
     /// Toggle the audit switch a few times
     for (auto i = 0; i < 5; ++i) {
         const bool val = i % 2 != 0;
+        info("Toggling audit_enabled() to {}", val);
         ss::smp::invoke_on_all([val] {
             config::shard_local_cfg().get("audit_enabled").set_value(val);
-        }).get0();
-        audit_mgr
-          .invoke_on(
-            0,
-            [val](sa::audit_log_manager& m) {
-                return tests::cooperative_spin_wait_with_timeout(
-                  10s, [&m, val] { return m.is_client_enabled() == val; });
-            })
-          .get0();
+        }).get();
+        tests::cooperative_spin_wait_with_timeout(10s, [&audit_mgr, val] {
+            return audit_mgr.local().is_effectively_enabled() == val;
+        }).get();
     }
-    /// Ensure in the off state even with buffers filled, no data is lost
     BOOST_CHECK(!config::shard_local_cfg().audit_enabled());
-    BOOST_CHECK_EQUAL(
-      pending_audit_events(audit_mgr.local()).get0(),
-      size_t(5 * ss::smp::count));
 
+    /// Ensure with auditing disabled that there is no backpressure applied
+    /// All enqueues should passthrough with success
+    const size_t number_events = pending_audit_events(audit_mgr.local()).get();
     const bool enqueued = audit_mgr
                             .map_reduce0(
                               [](sa::audit_log_manager& m) {
@@ -197,8 +181,25 @@ FIXTURE_TEST(test_audit_init_phase, redpanda_thread_fixture) {
 
     BOOST_CHECK(enqueued);
     BOOST_CHECK_EQUAL(
-      pending_audit_events(audit_mgr.local()).get0(),
-      size_t(5 * ss::smp::count));
+      pending_audit_events(audit_mgr.local()).get0(), number_events);
+
+    /// Verify that eventually, all messages are drained
+    ss::smp::invoke_on_all([] {
+        config::shard_local_cfg().get("audit_enabled").set_value(true);
+        /// Lower the fiber loop interval from 60s (set high so that messages
+        /// wouldn't be sent quicker then they could be enqueued) to a smaller
+        /// interval so test can end quick as records are written and purged
+        /// from each shards audit fibers queue.
+        config::shard_local_cfg()
+          .get("audit_queue_drain_interval_ms")
+          .set_value(std::chrono::milliseconds(10));
+    }).get();
+    info("Waiting for all records to drain");
+    tests::cooperative_spin_wait_with_timeout(30s, [&audit_mgr] {
+        return pending_audit_events(audit_mgr.local()).then([](size_t pending) {
+            return pending == 0;
+        });
+    }).get();
 
     BOOST_TEST_MESSAGE("End of test");
 }

--- a/src/v/security/audit/tests/audit_log_test.cc
+++ b/src/v/security/audit/tests/audit_log_test.cc
@@ -80,6 +80,7 @@ FIXTURE_TEST(test_audit_init_phase, redpanda_thread_fixture) {
     auto& audit_mgr = app.audit_mgr;
 
     /// with auditing disabled, calls to enqueue should be no-ops
+    const auto n_events = pending_audit_events(audit_mgr.local()).get0();
     audit_mgr
       .invoke_on_all([](sa::audit_log_manager& m) {
           for (auto i = 0; i < 20; ++i) {
@@ -89,8 +90,7 @@ FIXTURE_TEST(test_audit_init_phase, redpanda_thread_fixture) {
       })
       .get0();
 
-    BOOST_CHECK_EQUAL(
-      pending_audit_events(audit_mgr.local()).get0(), size_t(0));
+    BOOST_CHECK_EQUAL(pending_audit_events(audit_mgr.local()).get0(), n_events);
 
     /// with auditing enabled, the system should block when the threshold of
     /// 5 records has been surpassed

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -549,6 +549,11 @@ class AuditLogTestBase(RedpandaTest):
 
             def ingest(self, records):
                 new_records = records[self.next_offset_ingest:]
+                if len(new_records) == 0:
+                    self.logger.debug(
+                        f"No new records observed, currently have read {len(records)} records so far"
+                    )
+                    return
                 self.next_offset_ingest = len(records)
                 new_records = [json.loads(msg['value']) for msg in records]
                 self.logger.info(f"Ingested: {len(new_records)} records")

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -17,6 +17,7 @@ import re
 import requests
 import socket
 import time
+import random
 from typing import Any, Optional
 
 from ducktape.cluster.cluster import ClusterNode
@@ -619,27 +620,50 @@ class AuditLogTestsAppLifecycle(AuditLogTestBase):
     def __init__(self, test_context):
         super(AuditLogTestsAppLifecycle,
               self).__init__(test_context=test_context,
-                             audit_log_config=AuditLogConfig(event_types=[]))
+                             audit_log_config=AuditLogConfig(event_types=[]),
+                             log_config=LoggingConfig('info',
+                                                      logger_levels={
+                                                          'auditing': 'trace',
+                                                          'kafka/client':
+                                                          'trace',
+                                                      }))
+
+    @staticmethod
+    def is_lifecycle_match(feature: Optional[str], is_start: bool, record):
+        expected_activity_id = 3 if is_start else 4
+
+        return record['class_uid'] == 6002 and record[
+            'activity_id'] == expected_activity_id and (
+                (feature is not None and 'feature' in record['app']
+                 and record['app']['feature']['name'] == feature) or
+                (feature is None and 'feature' not in record['app']))
 
     @cluster(num_nodes=5)
     def test_app_lifecycle(self):
-        def is_lifecycle_match(feature: Optional[str], is_start: bool, record):
-            expected_activity_id = 3 if is_start else 4
-
-            return record['class_uid'] == 6002 and record[
-                'activity_id'] == expected_activity_id and (
-                    (feature is not None and 'feature' in record['app']
-                     and record['app']['feature']['name'] == feature) or
-                    (feature is None and 'feature' not in record['app']))
-
         _ = self.find_matching_record(
-            partial(is_lifecycle_match, "Audit System",
-                    True), lambda record_count: record_count == 3,
+            partial(AuditLogTestsAppLifecycle.is_lifecycle_match,
+                    "Audit System", True),
+            lambda record_count: record_count == 3,
             "Single redpanda audit start event per node")
 
-        _ = self.find_matching_record(partial(is_lifecycle_match, None, True),
-                                      lambda record_count: record_count == 3,
-                                      "Single redpanda start event per node")
+        _ = self.find_matching_record(
+            partial(AuditLogTestsAppLifecycle.is_lifecycle_match, None,
+                    True), lambda record_count: record_count == 3,
+            "Single redpanda start event per node")
+
+    @cluster(num_nodes=5)
+    def test_drain_on_audit_disabled(self):
+        """
+        Test the drain on disabling of audit is working properly by setting audit_enabled
+        to False and asserting that the stop application_lifecycle event is observed"""
+
+        self._modify_cluster_config({'audit_enabled': False})
+
+        _ = self.find_matching_record(
+            partial(AuditLogTestsAppLifecycle.is_lifecycle_match,
+                    "Audit System", False),
+            lambda record_count: record_count == 3,
+            "One stop event observed for shutdown node")
 
 
 class AuditLogTestAdminApi(AuditLogTestBase):


### PR DESCRIPTION
This PR compiles a few unrelated auditing changes into a single PR.  Listed, they are:
- Integration with `v/feature` so auditing can only truly be enabled when the cluster is fully upgraded: [#868](https://github.com/redpanda-data/core-internal/issues/868)
- Best effort attempt to drain audit log on clean shutdown of node or disable of audit feature flag: [#901](https://github.com/redpanda-data/core-internal/issues/901)
- Bugfix preventing copies of OCSF structures
- Implemented audit queue backpressure by size bytes removing previous method of accounting by raw number of elements enqueued: [#14099](https://github.com/redpanda-data/redpanda/issues/14099)
- Misc. test refactor 

Fixes: #14099 
Fixes: https://github.com/redpanda-data/core-internal/issues/868
Fixes: https://github.com/redpanda-data/core-internal/issues/901

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixed a bug where OCSF messages were being copied instead of moved

### Improvements

* Changes `audit_max_queue_elements_per_shard` config option to `audit_queue_max_buffer_size_per_shard` for accounting how much memory to allocate per shard for queued accounting messages
* Auditing will now try to drain messages as best it can before clean shutdown or disable of the `audit_enabled` feature flag
