### PR TITLE
security/oidc: Add metrics, JWKS refresh and Some admin endpoints

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -147,6 +147,10 @@ ss::future<> controller::wire_up() {
             }),
             ss::sharded_parameter([] {
                 return config::shard_local_cfg().oidc_principal_mapping.bind();
+            }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .oidc_keys_refresh_interval.bind();
             }));
       })
       .then([this] { return _tp_state.start(); })

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2775,6 +2775,13 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       "$.sub",
       security::oidc::validate_principal_mapping_rule)
+  , oidc_keys_refresh_interval(
+      *this,
+      "oidc_keys_refresh_interval",
+      "The frequency of refreshing the JSON Web Keys (JWKS) used to validate "
+      "access tokens.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      1h)
   , http_authentication(
       *this,
       "http_authentication",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -525,6 +525,7 @@ struct configuration final : public config_store {
     property<ss::sstring> oidc_token_audience;
     property<std::chrono::seconds> oidc_clock_skew_tolerance;
     property<ss::sstring> oidc_principal_mapping;
+    property<std::chrono::seconds> oidc_keys_refresh_interval;
 
     // HTTP Authentication
     property<std::vector<ss::sstring>> http_authentication;

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -1,0 +1,15 @@
+"oidc_whoami_response": {
+    "description": "Details of the provided bearer token.",
+    "type": "object",
+    "properties": {
+        "id": {
+            "description": "Mapped principal for autherization.",
+            "type": "string"
+        },
+        "expire": {
+            "description": "Unix timestamp of the expiry of the token.",
+            "format": "uint64",
+            "type": "int"
+        }
+    }
+}

--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -12,4 +12,13 @@
             "type": "int"
         }
     }
+},
+"oidc_keys_cache_invalidate_error_response": {
+    "type": "object",
+    "properties": {
+        "error_message": {
+            "description": "The error message.",
+            "type": "string"
+        }
+    }
 }

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -61,4 +61,21 @@
             }
         }
     }
+},
+"/v1/security/oidc/whoami": {
+    "get": {
+        "summary": "Obtain the principal and details of the JWT passed in the bearer token",
+        "operationId": "oidc_whoami",
+        "responses": {
+            "200": {
+                "description": "Successful response",
+                "schema": {
+                    "$ref": "#/definitions/oidc_whoami_response"
+                }
+            },
+            "401": {
+                "description": "Unauthorized"
+            }
+        }
+    }
 }

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -78,4 +78,21 @@
             }
         }
     }
+},
+"/v1/security/oidc/keys/cache_invalidate": {
+    "post": {
+        "summary": "Reload the keys from the Identity Provider",
+        "operationId": "oidc_keys_cache_invalidate",
+        "responses": {
+            "200": {
+                "description": "Successful response"
+            },
+            "500": {
+                "description": "Keys failed to reload",
+                "schema": {
+                    "$ref": "#/definitions/oidc_keys_cache_invalidate_error_response"
+                }
+            }
+        }
+    }
 }

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -422,6 +422,8 @@ private:
       delete_user_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       update_user_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      oidc_whoami_handler(std::unique_ptr<ss::http::request>);
 
     /// Kafka routes
     ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -424,6 +424,8 @@ private:
       update_user_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       oidc_whoami_handler(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+    oidc_keys_cache_invalidate_handler(std::unique_ptr<ss::http::request> req);
 
     /// Kafka routes
     ss::future<ss::json::json_return_type>

--- a/src/v/security/exceptions.h
+++ b/src/v/security/exceptions.h
@@ -22,9 +22,8 @@ namespace security {
 
 struct exception final : public std::runtime_error {
 public:
-    explicit exception(errc e, std::string_view msg)
-      : std::runtime_error(
-        fmt::format("{}: {}", make_error_code(e).message(), msg)) {}
+    explicit exception(std::error_code e, std::string_view msg)
+      : std::runtime_error(fmt::format("{}: {}", e.message(), msg)) {}
 };
 
 } // namespace security

--- a/src/v/security/oidc_service.cc
+++ b/src/v/security/oidc_service.cc
@@ -443,4 +443,6 @@ principal_mapping_rule const& service::get_principal_mapping_rule() const {
     return _impl->_rule;
 }
 
+ss::future<> service::refresh_keys() { return _impl->update_jwks(); }
+
 } // namespace security::oidc

--- a/src/v/security/oidc_service.h
+++ b/src/v/security/oidc_service.h
@@ -46,6 +46,8 @@ public:
     result<std::string_view> issuer() const;
     std::chrono::seconds clock_skew_tolerance() const;
 
+    ss::future<> refresh_keys();
+
 private:
     struct impl;
     std::unique_ptr<impl> _impl;

--- a/src/v/security/oidc_service.h
+++ b/src/v/security/oidc_service.h
@@ -29,7 +29,8 @@ public:
       config::binding<ss::sstring> discovery_url,
       config::binding<ss::sstring> token_audience,
       config::binding<std::chrono::seconds> clock_skew_tolerance,
-      config::binding<ss::sstring> mapping);
+      config::binding<ss::sstring> mapping,
+      config::binding<std::chrono::seconds> jwks_refresh_interval);
     service(service&&) = delete;
     service& operator=(service&&) = delete;
     service(service const&) = delete;

--- a/src/v/security/request_auth.h
+++ b/src/v/security/request_auth.h
@@ -134,3 +134,6 @@ private:
     config::binding<bool> _require_auth;
     config::binding<std::vector<ss::sstring>> _superusers;
 };
+
+inline constexpr std::string_view authz_basic_prefix = "Basic ";
+inline constexpr std::string_view authz_bearer_prefix = "Bearer ";

--- a/tests/rptest/tests/redpanda_oauth_test.py
+++ b/tests/rptest/tests/redpanda_oauth_test.py
@@ -119,6 +119,17 @@ class RedpandaOIDCTestBase(Test):
                                         email='myapp@customer.com')
         return self.keycloak.admin_ll.get_user_id(service_user)
 
+    def get_client_credentials_token(self, cfg):
+        token_endpoint_url = urlparse(cfg.token_endpoint)
+        openid = KeycloakOpenID(
+            server_url=
+            f'{token_endpoint_url.scheme}://{token_endpoint_url.netloc}',
+            client_id=cfg.client_id,
+            client_secret_key=cfg.client_secret,
+            realm_name=DEFAULT_REALM,
+            verify=True)
+        return openid.token(grant_type="client_credentials")
+
 
 class RedpandaOIDCTest(RedpandaOIDCTestBase):
     @cluster(num_nodes=4)
@@ -154,15 +165,7 @@ class RedpandaOIDCTest(RedpandaOIDCTestBase):
                    == expected_topics,
                    timeout_sec=5)
 
-        token_endpoint_url = urlparse(cfg.token_endpoint)
-        openid = KeycloakOpenID(
-            server_url=
-            f'{token_endpoint_url.scheme}://{token_endpoint_url.netloc}',
-            client_id=cfg.client_id,
-            client_secret_key=cfg.client_secret,
-            realm_name=DEFAULT_REALM,
-            verify=True)
-        token = openid.token(grant_type="client_credentials")
+        token = self.get_client_credentials_token(cfg)
 
         def check_pp_topics():
             response = requests.get(


### PR DESCRIPTION
## Documentation:
### New cluster configuration options:
| option | description | default |
| -- | -- | -- |
| `oidc_keys_refresh_interval` | "The frequency of refreshing the JSON Web Keys (JWKS) used to validate access tokens." | `1h` |

### New Admin API endpoins:
```json
"/v1/security/oidc/whoami": {
    "get": {
        "summary": "Obtain the principal and details of the JWT passed in the bearer token",
        "operationId": "oidc_whoami",
        "responses": {
            "200": {
                "description": "Successful response",
                "schema": {
                    "description": "Details of the provided bearer token.",
                    "type": "object",
                    "properties": {
                        "id": {
                            "description": "Mapped principal for autherization.",
                            "type": "string"
                        },
                        "expire": {
                            "description": "Unix timestamp of the expiry of the token.",
                            "format": "uint64",
                            "type": "int"
                        }
                    }
                }
            },
            "401": {
                "description": "Unauthorized"
            }
        }
    }
},
"/v1/security/oidc/keys/cache_invalidate": {
    "post": {
        "summary": "Reload the keys from the Identity Provider",
        "operationId": "oidc_keys_cache_invalidate",
        "responses": {
            "200": {
                "description": "Successful response"
            },
            "500": {
                "description": "Keys failed to reload",
                "schema": {
                     "type": "object",
                     "properties": {
                         "error_message": {
                             "description": "The error message.",
                            "type": "string"
                        } 
                    }
                }
            }
        }
    }
}
```

### New metrics

E.g.:
```
# HELP redpanda_security_idp_errors_total Number of requests that returned with an error.
# TYPE redpanda_security_idp_errors_total counter
redpanda_security_idp_errors_total{redpanda_domain="dev-ltxchcls4igzho78.us.auth0.com",redpanda_mechanism="oidc",shard="0"} 0
redpanda_security_idp_errors_total{redpanda_domain="dev-ltxchcls4igzho78.us.auth0.com",redpanda_mechanism="oidc",shard="1"} 0
# HELP redpanda_security_idp_latency_seconds Latency of requests to the Identity Provider
# TYPE redpanda_security_idp_latency_seconds histogram
redpanda_security_idp_latency_seconds_sum{redpanda_domain="dev-ltxchcls4igzho78.us.auth0.com",redpanda_mechanism="oidc",shard="0"} 0.672952
redpanda_security_idp_latency_seconds_count{redpanda_domain="dev-ltxchcls4igzho78.us.auth0.com",redpanda_mechanism="oidc",shard="0"} 2
redpanda_security_idp_latency_seconds_bucket{le="0.000255",redpanda_domain="dev-ltxchcls4igzho78.us.auth0.com",redpanda_mechanism="oidc",shard="0"} 0
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
