### PR TITLE
k/server: Audit successful fetch authz only onces

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -747,12 +747,16 @@ class simple_fetch_planner final : public fetch_planner::impl {
                 }
             }
 
+            // We audit successful messages only on the initial fetch
+            audit_on_success audit{octx.initial_fetch};
+
             /**
              * if not authorized do not include into a plan
              */
             if (!octx.rctx.authorized(
                   security::acl_operation::read,
-                  fp.topic_partition.get_topic())) {
+                  fp.topic_partition.get_topic(),
+                  audit)) {
                 resp_it->set(make_partition_response_error(
                   fp.topic_partition.get_partition(),
                   error_code::topic_authorization_failed));


### PR DESCRIPTION
Analysis on LRC showed that fetch audit events were driving up consume and produce latencies due to the excessive number of events being generated for the same successful authz event.

This change adds new authorized method in request_context.h that will only audit successful commands when a flag is set.

Fetch handler will only enable that flag on the initial fetch pass.

Fixes: #14988

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none