### PR TITLE
storage: consider segments with only non-data batches as compacted

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -576,10 +576,12 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     }
     vlog(
       gclog.debug,
-      "[{}] built offset map with {} keys (max allowed {})",
+      "[{}] built offset map with {} keys (max allowed {}), max indexed "
+      "key offset: {}",
       config().ntp(),
       map.size(),
-      map.capacity());
+      map.capacity(),
+      map.max_offset());
 
     auto segment_modify_lock = co_await _segment_rewrite_lock.get_units();
     for (auto& seg : segs) {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -587,7 +587,20 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
             cfg.asrc->check();
         }
         if (seg->offsets().base_offset > map.max_offset()) {
-            break;
+            // The map was built from newest to oldest segments within this
+            // sliding range. If we see a new segment whose offsets are all
+            // higher than those indexed, it may be because the segment is
+            // entirely comprised of non-data batches. Mark it as compacted so
+            // we can progress through compactions.
+            seg->mark_as_finished_windowed_compaction();
+            vlog(
+              gclog.debug,
+              "[{}] treating segment as compacted, offsets fall above highest "
+              "indexed key {}, likely because they are non-data batches: {}",
+              config().ntp(),
+              map.max_offset(),
+              seg->filename());
+            continue;
         }
         // TODO: implement a segment replacement strategy such that each term
         // tries to write only one segment (or more if the term had a large


### PR DESCRIPTION
    When the final segments in a sliding range contains only non-data
    batches, we could previously end up recompacting the same range over and
    over again. Consider the given sliding range, where segment [20, 25) is
    all non-data batches.

    [0, 10)[10, 20)[20, 25)

    The compacted indices only contains data keys, so the key offset map
    will only reflect data up to offset 20. Because of this, we would skip
    compacting [20, 25) and leave the segment as is.

    Subsequent attempts to compact would see that there is an uncompacted
    segment, and attempt to compact the sliding range again, thinking that
    the uncompacted data is new data to be merged in.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
