### PR TITLE
[v23.2.x] c/archival_stm: translate sync error to not_leader error code

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -321,7 +321,7 @@ ss::future<std::error_code> command_batch_builder::replicate() {
         auto timeout = now < _deadline ? _deadline - now : 0ms;
         return _stm.get().sync(timeout).then([this](bool success) {
             if (!success) {
-                return ss::make_ready_future<std::error_code>(errc::timeout);
+                return ss::make_ready_future<std::error_code>(errc::not_leader);
             }
             auto batch = std::move(_builder).build();
             return _stm.get().do_replicate_commands(std::move(batch), _as);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14978
Fixes: https://github.com/redpanda-data/redpanda/issues/14996,