### PR TITLE
ducktape/cloud_storage: Increase producer msg count

### DIFF
--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -79,7 +79,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
                                     redpanda=self.redpanda,
                                     topic=self.topic,
                                     msg_size=1024,
-                                    msg_count=10000,
+                                    msg_count=20000,
                                     use_transactions=False,
                                     msgs_per_transaction=10,
                                     debug_logs=True,


### PR DESCRIPTION
During the model test the expectation is that at least seven or eight segments will be downloaded for TS_Read. The test produces 10MiB of data, 1MiB segment size and sets 3MiB as local retention size. The actual segments uploaded are roughly 2MiB each, resulting in fewer downloads.

This change doubles producer message count so that we need to produce and later download more segments to consume.

partially fixes #14266 (this issue wraps multiple CI failures)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none