### PR TITLE
rptest: ignore instead of short-circuiting skip_debug_mode tests

### DIFF
--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -15,6 +15,7 @@ from rptest.services.redpanda import CloudTierName, make_redpanda_service, Cloud
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.default import DefaultClient
 from rptest.util import Scale
+from rptest.utils import mode_checks
 from rptest.clients.types import TopicSpec
 from rptest.services.redpanda_installer import RedpandaInstaller, RedpandaVersion, RedpandaVersionLine, RedpandaVersionTriple
 from rptest.clients.rpk import RpkTool
@@ -88,7 +89,7 @@ class RedpandaTest(Test):
         the much slower debug builds of redpanda, which generally cannot
         keep up with significant quantities of data or partition counts.
         """
-        return os.environ.get('BUILD_TYPE', None) == 'debug'
+        return mode_checks.is_debug_mode()
 
     @property
     def ci_mode(self):

--- a/tests/rptest/utils/mode_checks.py
+++ b/tests/rptest/utils/mode_checks.py
@@ -1,6 +1,7 @@
-import functools
+import os
 
 from ducktape.cluster.cluster_spec import ClusterSpec
+from ducktape.mark import ignore
 
 
 def allocate_and_free(cluster, logger):
@@ -33,33 +34,35 @@ def cleanup_on_early_exit(caller):
         allocate_and_free(test_context.cluster, caller.logger)
 
 
-def skip_debug_mode(func):
+def is_debug_mode():
+    return os.environ.get('BUILD_TYPE', None) == 'debug'
+
+
+def skip_debug_mode(*args, **kwargs):
     """
-    Decorator applied to a test class method. The property `debug_mode` should be present
-    on the object.
+    Test method decorator which signals to the test runner to ignore a given test.
 
-    If set to true, the wrapped function call is skipped, and a cleanup action
-    is performed instead.
+    Example::
 
-    If set to false, the wrapped function (usually a test case) is called.
+        When no parameters are provided to the @ignore decorator, ignore all parametrizations of the test function
+
+        @skip_debug_mode  # Ignore all parametrizations
+        @parametrize(x=1, y=0)
+        @parametrize(x=2, y=3)
+        def the_test(...):
+            ...
+
+    Example::
+
+        If parameters are supplied to the @skip_debug_mode decorator, only skip the parametrization with matching parameter(s)
+
+        @skip_debug_mode(x=2, y=3)
+        @parametrize(x=1, y=0)  # This test will run as usual
+        @parametrize(x=2, y=3)  # This test will be ignored
+        def the_test(...):
+            ...
     """
-    @functools.wraps(func)
-    def f(*args, **kwargs):
-        assert args, 'skip_debug_mode must be placed on a test method in a class'
-
-        caller = args[0]
-
-        assert hasattr(
-            caller, 'debug_mode'
-        ), 'skip_debug_mode called on object which does not have debug_mode attribute'
-        assert hasattr(
-            caller,
-            'logger'), 'skip_debug_mode called on object which has no logger'
-        if caller.debug_mode:
-            caller.logger.info(
-                "Skipping test in debug mode (requires release build)")
-            cleanup_on_early_exit(caller)
-            return None
-        return func(*args, **kwargs)
-
-    return f
+    if is_debug_mode():
+        return ignore(args, kwargs)
+    else:
+        return args[0]


### PR DESCRIPTION
rptest: ignore instead of short-circuiting skip_debug_mode tests

By now I have run a few times tests with `@skip_debug_build` decoration and cheered when I saw them as passed in the report table. Only to learn later that no tests were actually run... With this change, the result 
 table will actually indicate that tests were ignored.

Before:

```
run time:         8.493 seconds
tests run:        1
passed:           1
```

After:

```
run time:         0.009 seconds
tests run:        1
passed:           0
ignored:          1
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
