### PR TITLE
rptest: ignore test_consume_miss_cache for now

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -1088,7 +1088,7 @@ class HighThroughputTest(PreallocNodesTest):
     # The testcase occasionally fails on various parts:
     # - toing on `_consume_from_offset(self.topic, 1, p_id, "newest", 30)`
     # - failing to ensure all manifests are in the cloud in `stop_and_scrub_object_storage`
-    @ok_to_fail
+    @ignore
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_consume_miss_cache(self):
         # create default topics


### PR DESCRIPTION
change from `@ok_to_fail` to `@ignore` since the test is now taking so long to run that it is affecting subsequent tests.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none