### PR TITLE
storage: fix some compaction races with suffix truncation

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -560,7 +560,8 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     simple_key_offset_map map(cfg.key_offset_map_max_keys);
     model::offset idx_start_offset;
     try {
-        idx_start_offset = co_await build_offset_map(cfg, segs, map);
+        idx_start_offset = co_await build_offset_map(
+          cfg, segs, _stm_manager, _manager.resources(), *_probe, map);
     } catch (...) {
         auto eptr = std::current_exception();
         if (ssx::is_shutdown_exception(eptr)) {

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -148,6 +148,9 @@ ss::future<index_state> deduplicate_segment(
   probe& probe,
   offset_delta_time should_offset_delta_times) {
     auto read_holder = co_await seg->read_lock();
+    if (seg->is_closed()) {
+        throw segment_closed_exception();
+    }
     auto rdr = internal::create_segment_full_reader(
       seg, cfg, probe, std::move(read_holder));
     auto copy_reducer = internal::copy_data_segment_reducer(

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -90,7 +90,12 @@ ss::future<bool> build_offset_map_for_segment(
 }
 
 ss::future<model::offset> build_offset_map(
-  const compaction_config& cfg, const segment_set& segs, key_offset_map& m) {
+  const compaction_config& cfg,
+  const segment_set& segs,
+  ss::lw_shared_ptr<storage::stm_manager> stm_manager,
+  storage_resources& resources,
+  storage::probe& probe,
+  key_offset_map& m) {
     if (segs.empty()) {
         throw std::runtime_error("No segments to build offset map");
     }
@@ -113,6 +118,23 @@ ss::future<model::offset> build_offset_map(
               "Stopping add to offset map, segment closed: {}",
               seg->filename());
             break;
+        }
+        segment_full_path idx_path = seg->path().to_compacted_index();
+        while (true) {
+            auto state = co_await internal::detect_compaction_index_state(
+              idx_path, cfg);
+            if (!internal::compacted_index_needs_rebuild(state)) {
+                break;
+            }
+            // Rebuilding the compaction index will take the read lock again,
+            // so release here.
+            read_lock.return_all();
+            co_await internal::rebuild_compaction_index(
+              *iter, stm_manager, cfg, probe, resources);
+
+            // Take the lock again before checking the compaction index state
+            // to avoid races with truncations while building the offset map.
+            read_lock = co_await seg->read_lock();
         }
         auto seg_fully_indexed = co_await build_offset_map_for_segment(
           cfg, *seg, m);

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -164,6 +164,11 @@ ss::future<compacted_offset_list>
 ss::future<bool>
   detect_if_segment_already_compacted(std::filesystem::path, compaction_config);
 
+bool compacted_index_needs_rebuild(compacted_index::recovery_state state);
+
+ss::future<compacted_index::recovery_state>
+detect_compaction_index_state(segment_full_path p, compaction_config cfg);
+
 /// \brief creates a model::record_batch_reader from segment meta
 ///
 model::record_batch_reader create_segment_full_reader(

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -41,6 +41,15 @@ ss::future<compaction_result> self_compact_segment(
   storage::storage_resources&,
   offset_delta_time apply_offset);
 
+/// \brief, rebuilds a given segment's compacted index. This method acquires
+/// locks on the segment.
+ss::future<> rebuild_compaction_index(
+  ss::lw_shared_ptr<segment> s,
+  ss::lw_shared_ptr<storage::stm_manager> stm_manager,
+  compaction_config cfg,
+  storage::probe& pb,
+  storage_resources& resources);
+
 /*
  * Concatentate segments into a minimal new segment.
  *


### PR DESCRIPTION
This PR addresses some races between suffix truncation and compactions:
- A race between truncation and self compaction where the compacted index is removed during compaction. This would result in a thrown exception during compaction, but is somewhat benign since subsequent self compaction attempts will rebuild the compacted index. Still, this PR fixes this race by tweaking some segment locking.
- The above same race, but with windowed compaction. Unlike above, windowed compaction wouldn't subsequently try to rebuild the compacted index. Instead, it would to compact the same sequence of segments over and over, failing once it got to the segment with no compacted index. To address this, this PR adds the behavior of self compaction to windowed compaction, where if the compaction sees a missing compacted index, it rebuilds it before proceeding.

Fixes https://github.com/redpanda-data/redpanda/issues/15013

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
