### PR TITLE
archival: log segment collector status

### DIFF
--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -24,6 +24,19 @@
 namespace archival {
 
 struct upload_candidate {
+    enum class creation_status {
+        success,
+        err_size_unchanged,
+        err_offset_inside_batch,
+        err_no_segments,
+        err_head_seek,
+        err_tail_seek,
+        err_file_range,
+        err_no_segment,
+        err_no_ntp_config,
+        err_no_content,
+    };
+
     segment_name exposed_name;
     model::offset starting_offset;
     size_t file_offset;
@@ -35,7 +48,9 @@ struct upload_candidate {
     model::term_id term;
     std::vector<ss::lw_shared_ptr<storage::segment>> sources;
     std::vector<cloud_storage::remote_segment_path> remote_sources;
+    creation_status status{upload_candidate::creation_status::success};
 
+    friend std::ostream& operator<<(std::ostream& s, creation_status cs);
     friend std::ostream& operator<<(std::ostream& s, const upload_candidate& c);
 };
 


### PR DESCRIPTION
An explicit status is added segment collector to help with logging, previously we inferred the status from looking at the candidate fields and interpreting zero values as failure to collect.

This status is only used for logging.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
