### PR TITLE
ci: remove redundant plugin install on cleanup

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -196,11 +196,10 @@ class CloudCleanup():
                     return False
                 # Uninstall/Install plugin
                 try:
-                    _message += "| update plugin "
+                    _message += "| clean plugin "
                     self.utils.rpk_plugin_uninstall('byoc')
-                    self.utils.rpk_cloud_byoc_install(_id)
                 except Exception as e:
-                    _message += "| ERROR: failed to update byoc plugin " \
+                    _message += "| ERROR: failed to clean byoc plugin " \
                                 f"for '{_id}': {e}"
                     self.log.error(_message)
                     return False


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
