### PR TITLE
base_named_type: defaulted comparison operators

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -829,7 +829,7 @@ FIXTURE_TEST(
     // The start kafka offset doesn't change, only the override changes.
     BOOST_REQUIRE_EQUAL(
       archival_stm->manifest().get_start_kafka_offset_override(),
-      model::offset(200));
+      kafka::offset(200));
     BOOST_REQUIRE_EQUAL(
       archival_stm->get_start_kafka_offset(), kafka::offset(1000));
     BOOST_REQUIRE_EQUAL(archival_stm->get_start_offset(), model::offset(1000));
@@ -842,7 +842,7 @@ FIXTURE_TEST(
       archival_stm->get_start_kafka_offset(), kafka::offset(1000));
     BOOST_REQUIRE_EQUAL(
       archival_stm->manifest().get_start_kafka_offset_override(),
-      model::offset(1200));
+      kafka::offset(1200));
     BOOST_REQUIRE_EQUAL(archival_stm->get_start_offset(), model::offset(1000));
 
     // Advancing the start offset past the override resets the override.

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -141,7 +141,9 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
             // range.
             auto so = manifest.get_start_kafka_offset().value_or(
               kafka::offset::min());
-            if (config.start_offset < so && config.max_offset > so) {
+            if (
+              model::offset_cast(config.start_offset) < so
+              && model::offset_cast(config.max_offset) > so) {
                 mit = manifest.begin();
             }
         }
@@ -932,7 +934,7 @@ remote_partition::aborted_transactions(offset_range offsets) {
     const auto& stm_manifest = _manifest_view->stm_manifest();
     const auto so = stm_manifest.get_start_offset();
     std::vector<model::tx_range> result;
-    if (so.has_value() && offsets.begin > so.value()) {
+    if (so.has_value() && offsets.begin > model::offset_cast(so.value())) {
         // Here we have to use kafka offsets to locate the segments and
         // redpanda offsets to extract aborted transactions metadata because
         // tx-manifests contains redpanda offsets.

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1107,7 +1107,7 @@ public:
 
         if (header.type == model::record_batch_type::raft_data) {
             auto next = rp_to_kafka(header.last_offset()) + model::offset(1);
-            if (next > _config.start_offset) {
+            if (kafka::offset_cast(next) > _config.start_offset) {
                 _config.start_offset = kafka::offset_cast(next);
             }
         }
@@ -1122,7 +1122,9 @@ public:
           header,
           _parent._cur_delta);
 
-        if (rp_to_kafka(header.base_offset) > _config.max_offset) {
+        if (
+          rp_to_kafka(header.base_offset)
+          > model::offset_cast(_config.max_offset)) {
             vlog(
               _ctxlog.debug,
               "[{}] accept_batch_start stop parser because {} > {}(kafka "
@@ -1148,7 +1150,8 @@ public:
         // The segment can be scanned from the begining so we should skip
         // irrelevant batches.
         if (unlikely(
-              rp_to_kafka(header.last_offset()) < _config.start_offset)) {
+              rp_to_kafka(header.last_offset())
+              < model::offset_cast(_config.start_offset))) {
             vlog(
               _ctxlog.debug,
               "[{}] accept_batch_start skip because "

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -929,19 +929,22 @@ FIXTURE_TEST(
     BOOST_REQUIRE(first_term_query.has_value());
     BOOST_REQUIRE(first_term_query.value().has_value());
     BOOST_REQUIRE_EQUAL(
-      first_term_query.value().value(), first_term_last_offset);
+      kafka::offset_cast(first_term_query.value().value()),
+      first_term_last_offset);
 
     auto second_term_query = view.get_term_last_offset(model::term_id{2}).get();
     BOOST_REQUIRE(second_term_query.has_value());
     BOOST_REQUIRE(second_term_query.value().has_value());
     BOOST_REQUIRE_EQUAL(
-      second_term_query.value().value(), second_term_last_offset);
+      kafka::offset_cast(second_term_query.value().value()),
+      second_term_last_offset);
 
     auto third_term_query = view.get_term_last_offset(model::term_id{3}).get();
     BOOST_REQUIRE(third_term_query.has_value());
     BOOST_REQUIRE(third_term_query.value().has_value());
     BOOST_REQUIRE_EQUAL(
-      third_term_query.value().value(), third_term_last_offset);
+      kafka::offset_cast(third_term_query.value().value()),
+      third_term_last_offset);
 
     auto future_term_query
       = view.get_term_last_offset(model::term_id{100}).get();

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -1404,14 +1404,14 @@ SEASTAR_THREAD_TEST_CASE(test_partition_manifest_start_kafka_offset_advance) {
 
     BOOST_REQUIRE(m.advance_start_kafka_offset(kafka::offset(80)));
     BOOST_REQUIRE_EQUAL(m.get_start_kafka_offset_override(), kafka::offset(80));
-    BOOST_REQUIRE_EQUAL(m.get_start_kafka_offset(), model::offset(0));
+    BOOST_REQUIRE_EQUAL(m.get_start_kafka_offset(), kafka::offset(0));
     BOOST_REQUIRE_EQUAL(m.get_start_offset(), model::offset(0));
 
     // Moving the start offset ahead of the kafka override removes the
     // override.
     BOOST_REQUIRE(m.advance_start_offset(model::offset(100)));
     BOOST_REQUIRE_EQUAL(m.get_start_kafka_offset_override(), kafka::offset{});
-    BOOST_REQUIRE_EQUAL(m.get_start_kafka_offset(), model::offset(90));
+    BOOST_REQUIRE_EQUAL(m.get_start_kafka_offset(), kafka::offset(90));
     BOOST_REQUIRE_EQUAL(m.get_start_offset(), model::offset(100));
 
     BOOST_REQUIRE(m.advance_start_kafka_offset(kafka::offset(180)));

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -458,7 +458,7 @@ std::vector<cloud_storage_fixture::expectation> make_imposter_expectations(
           "computed segment delta {}, segment {}",
           segment_delta,
           s);
-        BOOST_REQUIRE(segment_delta <= s.base_offset);
+        BOOST_REQUIRE(model::offset_cast(segment_delta) <= s.base_offset());
         cloud_storage::partition_manifest::segment_meta meta{
           .is_compacted = false,
           .size_bytes = s.bytes.size(),

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1386,7 +1386,7 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
               return ss::now();
           }
           auto p_id = assignment.id;
-          if (assignment.replicas.size() > new_replication_factor) {
+          if (assignment.replicas.size() > new_replication_factor()) {
               vlog(
                 clusterlog.warn,
                 "Current size of replicas {} > new_replication_factor {} for "
@@ -1473,7 +1473,7 @@ ss::future<std::error_code> topics_frontend::decrease_replication_factor(
           if (error) {
               return ss::now();
           }
-          if (assignment.replicas.size() < new_replication_factor) {
+          if (assignment.replicas.size() < new_replication_factor()) {
               error = errc::topic_invalid_replication_factor;
               return ss::now();
           }

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -180,7 +180,7 @@ replicated_partition::aborted_transactions_remote(
 bool replicated_partition::may_read_from_cloud(kafka::offset start_offset) {
     return _partition->is_remote_fetch_enabled()
            && _partition->cloud_data_available()
-           && (start_offset < _translator->from_log_offset(_partition->raft_start_offset()));
+           && (start_offset < model::offset_cast(_translator->from_log_offset(_partition->raft_start_offset())));
 }
 
 ss::future<std::vector<cluster::rm_stm::tx_range>>

--- a/src/v/kafka/server/tests/config_utils_test.cc
+++ b/src/v/kafka/server/tests/config_utils_test.cc
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE(parse_and_set_topic_replication_factor_test) {
       "3",
       kafka::config_resource_operation::set,
       rep_factor_validator{});
-    BOOST_REQUIRE_EQUAL(property.value, 3);
+    BOOST_REQUIRE_EQUAL(property.value, cluster::replication_factor{3});
 
     auto is_pos_error = [](const validation_error& ex) {
         return ss::sstring(ex.what()).contains("positive");

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -300,7 +300,7 @@ ss::future<> persist_snapshot(
 }
 group_configuration deserialize_configuration(iobuf_parser& parser) {
     const auto version = serde::peek_version(parser);
-    if (likely(version >= group_configuration::v_6)) {
+    if (likely(version >= group_configuration::v_6())) {
         return serde::read<group_configuration>(parser);
     }
 
@@ -308,7 +308,7 @@ group_configuration deserialize_configuration(iobuf_parser& parser) {
 }
 group_configuration deserialize_nested_configuration(iobuf_parser& parser) {
     const auto version = serde::peek_version(parser);
-    if (likely(version >= group_configuration::v_6)) {
+    if (likely(version >= group_configuration::v_6())) {
         return serde::read_nested<group_configuration>(parser, 0UL);
     }
 

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -33,24 +33,14 @@ public:
     base_named_type& operator=(base_named_type&& o) noexcept = default;
     base_named_type(const base_named_type& o) noexcept = default;
     base_named_type& operator=(const base_named_type& o) noexcept = default;
-    constexpr bool operator==(const base_named_type& other) const {
-        return _value == other._value;
-    }
-    constexpr bool operator!=(const base_named_type& other) const {
-        return _value != other._value;
-    }
-    constexpr bool operator<(const base_named_type& other) const {
-        return _value < other._value;
-    }
-    constexpr bool operator>(const base_named_type& other) const {
-        return _value > other._value;
-    }
-    constexpr bool operator<=(const base_named_type& other) const {
-        return _value <= other._value;
-    }
-    constexpr bool operator>=(const base_named_type& other) const {
-        return _value >= other._value;
-    }
+
+    friend constexpr bool
+    operator==(const base_named_type&, const base_named_type&) noexcept
+      = default;
+    friend constexpr auto
+    operator<=>(const base_named_type&, const base_named_type&) noexcept
+      = default;
+
     constexpr base_named_type& operator++() {
         ++_value;
         return *this;
@@ -86,19 +76,13 @@ public:
     }
 
     // provide overloads for naked type
-    constexpr bool operator==(const type& other) const {
-        return _value == other;
+    friend constexpr bool
+    operator==(const base_named_type& lhs, const type& rhs) noexcept {
+        return lhs._value == rhs;
     }
-    constexpr bool operator!=(const type& other) const {
-        return _value != other;
-    }
-    constexpr bool operator<(const type& other) const { return _value < other; }
-    constexpr bool operator>(const type& other) const { return _value > other; }
-    constexpr bool operator<=(const type& other) const {
-        return _value <= other;
-    }
-    constexpr bool operator>=(const type& other) const {
-        return _value >= other;
+    friend constexpr auto
+    operator<=>(const base_named_type& lhs, const type& rhs) noexcept {
+        return lhs._value <=> rhs;
     }
 
     // explicit getter
@@ -132,7 +116,7 @@ public:
 
     template<typename... Args>
     requires std::constructible_from<T, Args...>
-    explicit base_named_type(Args&&... args)
+    explicit constexpr base_named_type(Args&&... args)
       : _value(std::forward<Args>(args)...) {}
 
     base_named_type(base_named_type&& o) noexcept(move_noexcept) = default;
@@ -144,39 +128,45 @@ public:
 
     base_named_type& operator=(const base_named_type& o) = default;
 
-    bool operator==(const base_named_type& other) const {
-        return _value == other._value;
-    }
-    bool operator!=(const base_named_type& other) const {
-        return _value != other._value;
-    }
-    bool operator<(const base_named_type& other) const {
-        return _value < other._value;
-    }
-    bool operator>(const base_named_type& other) const {
-        return _value > other._value;
-    }
-    bool operator<=(const base_named_type& other) const {
-        return _value <= other._value;
-    }
-    bool operator>=(const base_named_type& other) const {
-        return _value >= other._value;
+    // provide overloads for naked type
+    friend bool
+    operator==(const base_named_type& lhs, const type& rhs) noexcept {
+        return lhs._value == rhs;
     }
 
-    // provide overloads for naked type
-    bool operator==(const type& other) const { return _value == other; }
-    bool operator!=(const type& other) const { return _value != other; }
-    bool operator<(const type& other) const { return _value < other; }
-    bool operator>(const type& other) const { return _value > other; }
-    bool operator<=(const type& other) const { return _value <= other; }
-    bool operator>=(const type& other) const { return _value >= other; }
+    friend auto
+    operator<=>(const base_named_type& lhs, const type& rhs) noexcept
+      -> std::strong_ordering {
+        // roundabout way to cope with type when it does not provide <=>
+        if constexpr (std::three_way_comparable_with<type, type>)
+            return lhs._value <=> rhs;
+        else {
+            if (lhs._value == rhs) {
+                return std::strong_ordering::equal;
+            } else if (lhs._value < rhs) {
+                return std::strong_ordering::less;
+            } else {
+                return std::strong_ordering::greater;
+            }
+        }
+    }
+
+    // these can be constexpr in c++23
+    friend bool
+    operator==(const base_named_type& lhs, const base_named_type& rhs) noexcept
+      = default;
+    friend auto operator<=>(
+      const base_named_type& lhs, const base_named_type& rhs) noexcept {
+        // delegate to <=> type version
+        return lhs <=> rhs._value;
+    }
 
     // explicit getter
-    const type& operator()() const& { return _value; }
-    type operator()() && { return std::move(_value); }
+    constexpr const type& operator()() const& { return _value; }
+    constexpr type operator()() && { return std::move(_value); }
     // implicit conversion operator
-    operator const type&() const& { return _value; }
-    operator type() && { return std::move(_value); }
+    constexpr operator const type&() const& { return _value; }
+    constexpr operator type() && { return std::move(_value); }
 
     friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
         return o << "{" << t() << "}";

--- a/src/v/utils/tests/named_type_tests.cc
+++ b/src/v/utils/tests/named_type_tests.cc
@@ -79,3 +79,31 @@ BOOST_AUTO_TEST_CASE(named_type_rvalue_overload) {
 
     BOOST_REQUIRE_EQUAL(str, r);
 }
+
+static_assert(
+  !std::equality_comparable_with<
+    named_type<int, struct tag_0>,
+    named_type<int, struct tag_1>>,
+  "arithmetic named_types can't be compared directly");
+static_assert(
+  !std::equality_comparable_with<
+    named_type<ss::sstring, struct tag_a>,
+    named_type<ss::sstring, struct tag_b>>,
+  "non-arithmetic named_types can't be compared directly");
+
+using named_sstring = named_type<ss::sstring, struct named_sstring_tag>;
+static_assert(std::equality_comparable_with<named_sstring, ss::sstring>);
+static_assert(std::equality_comparable_with<
+              std::reference_wrapper<named_sstring>,
+              std::reference_wrapper<named_sstring>>);
+static_assert(std::equality_comparable_with<
+              named_sstring,
+              std::reference_wrapper<named_sstring>>);
+
+using named_int = named_type<int, struct named_int_tag>;
+static_assert(std::equality_comparable_with<named_int, int>);
+static_assert(std::equality_comparable_with<
+              std::reference_wrapper<named_int>,
+              std::reference_wrapper<named_int>>);
+static_assert(
+  std::equality_comparable_with<named_int, std::reference_wrapper<named_int>>);


### PR DESCRIPTION
Implemented defaulted comparison operators for base_named_type. 

Adding these fixed #15027 and exposes some disallowed comparisons in the codebase (mostly tests). 

The first commit is about fixing uint8_t <=> named_type(int8_t) comparison in raft/consensus utils. It's done by unwrapping the named_type and allowing comparison by integer promotion to a common wider type.

The second commit handles model::offset <=> kafka::offset, either unwrapping or changing the type when possible.

The third commit is the change itself and a static assert that two distinct named_type cannot be compared. The check fails without this commit
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes https://github.com/redpanda-data/redpanda/issues/15027

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
