### PR TITLE
c/topic_table: fix force_update replicas_revisions update

### DIFF
--- a/src/v/cluster/partition_balancer_state.cc
+++ b/src/v/cluster/partition_balancer_state.cc
@@ -119,7 +119,7 @@ partition_balancer_state::apply_snapshot(const controller_snapshot& snap) {
 
             if (auto it = topic.updates.find(p_id); it != topic.updates.end()) {
                 const auto& update = it->second;
-                if (update.state == reconfiguration_state::in_progress) {
+                if (!is_cancelled_state(update.state)) {
                     replicas = &update.target_assignment;
                 }
             }

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -498,15 +498,10 @@ partition_allocator::apply_snapshot(const controller_snapshot& snap) {
                 }
 
                 // final counts depend on the update state
-                switch (update.state) {
-                case reconfiguration_state::in_progress:
-                case reconfiguration_state::force_update:
-                    final_replicas = &update.target_assignment;
-                    break;
-                case reconfiguration_state::cancelled:
-                case reconfiguration_state::force_cancelled:
+                if (is_cancelled_state(update.state)) {
                     final_replicas = &partition.replicas;
-                    break;
+                } else {
+                    final_replicas = &update.target_assignment;
                 }
             } else {
                 final_replicas = &partition.replicas;

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -134,9 +134,7 @@ public:
 
         ~in_progress_update() {
             _probe.handle_update_finish(_previous_replicas, _target_replicas);
-            if (
-              _state == reconfiguration_state::cancelled
-              || _state == reconfiguration_state::force_cancelled) {
+            if (is_cancelled_state(_state)) {
                 _probe.handle_update_cancel_finish(
                   _previous_replicas, _target_replicas);
                 ;
@@ -151,9 +149,7 @@ public:
         const reconfiguration_state& get_state() const { return _state; }
 
         void set_state(reconfiguration_state state, model::revision_id rev) {
-            if (
-              _state == reconfiguration_state::in_progress
-              && (state == reconfiguration_state::cancelled || state == reconfiguration_state::force_cancelled)) {
+            if (!is_cancelled_state(_state) && is_cancelled_state(state)) {
                 _probe.handle_update_cancel(
                   _previous_replicas, _target_replicas);
             }

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -168,6 +168,14 @@ public:
             return _target_replicas;
         }
 
+        const replicas_t& get_resulting_replicas() const {
+            if (is_cancelled_state(_state)) {
+                return _previous_replicas;
+            } else {
+                return _target_replicas;
+            }
+        }
+
         const model::revision_id& get_update_revision() const {
             return _update_revision;
         }

--- a/src/v/cluster/topic_updates_dispatcher.cc
+++ b/src/v/cluster/topic_updates_dispatcher.cc
@@ -490,15 +490,10 @@ topic_updates_dispatcher::collect_in_progress(
             continue;
         }
         const auto state = it->second.get_state();
-        if (state == reconfiguration_state::in_progress) {
-            in_progress[p.id] = it->second.get_previous_replicas();
-        } else {
-            vassert(
-              state == reconfiguration_state::cancelled
-                || state == reconfiguration_state::force_cancelled,
-              "Invalid reconfiguration state: {}",
-              state);
+        if (is_cancelled_state(state)) {
             in_progress[p.id] = it->second.get_target_replicas();
+        } else {
+            in_progress[p.id] = it->second.get_previous_replicas();
         }
     }
     return in_progress;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -4142,6 +4142,19 @@ enum class reconfiguration_state {
     force_cancelled = 3
 };
 
+inline bool is_cancelled_state(reconfiguration_state rs) {
+    switch (rs) {
+    case reconfiguration_state::in_progress:
+    case reconfiguration_state::force_update:
+        return false;
+    case reconfiguration_state::cancelled:
+    case reconfiguration_state::force_cancelled:
+        return true;
+    default:
+        __builtin_unreachable();
+    }
+}
+
 std::ostream& operator<<(std::ostream&, reconfiguration_state);
 
 struct replica_bytes {


### PR DESCRIPTION
Introduce `is_cancelled_state` predicate that determines if the partition replicas update is cancelled and use it everywhere. This fixes the bug where `replicas_revisions` map in the topic table was not updated after force-update was finished.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
