### PR TITLE
Restore highest producer ID during cluster recovery

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -195,6 +195,7 @@ v_cc_library(
     cloud_metadata/cluster_recovery_backend.cc
     cloud_metadata/key_utils.cc
     cloud_metadata/manifest_downloads.cc
+    cloud_metadata/producer_id_recovery_manager.cc
     cloud_metadata/uploader.cc
   DEPS
     Seastar::seastar

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -15,6 +15,7 @@
 #include "cloud_storage/types.h"
 #include "cluster/cloud_metadata/cluster_manifest.h"
 #include "cluster/cloud_metadata/manifest_downloads.h"
+#include "cluster/cloud_metadata/producer_id_recovery_manager.h"
 #include "cluster/cluster_recovery_reconciler.h"
 #include "cluster/cluster_recovery_table.h"
 #include "cluster/cluster_utils.h"
@@ -61,6 +62,7 @@ cluster_recovery_backend::cluster_recovery_backend(
   cluster::config_frontend& config_frontend,
   cluster::security_frontend& security_frontend,
   cluster::topics_frontend& topics_frontend,
+  ss::shared_ptr<producer_id_recovery_manager> producer_id_recovery,
   ss::sharded<cluster_recovery_table>& recovery_table,
   consensus_ptr raft0)
   : _recovery_manager(mgr)
@@ -77,6 +79,7 @@ cluster_recovery_backend::cluster_recovery_backend(
   , _config_frontend(config_frontend)
   , _security_frontend(security_frontend)
   , _topics_frontend(topics_frontend)
+  , _producer_id_recovery(std::move(producer_id_recovery))
   , _recovery_table(recovery_table)
   , _raft0(std::move(raft0)) {}
 

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.h
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.h
@@ -12,6 +12,7 @@
 
 #include "cloud_storage/cache_service.h"
 #include "cloud_storage/remote.h"
+#include "cluster/cloud_metadata/producer_id_recovery_manager.h"
 #include "cluster/cluster_recovery_manager.h"
 #include "cluster/cluster_recovery_reconciler.h"
 #include "cluster/cluster_recovery_table.h"
@@ -50,6 +51,7 @@ public:
       cluster::config_frontend&,
       cluster::security_frontend&,
       cluster::topics_frontend&,
+      ss::shared_ptr<producer_id_recovery_manager> producer_id_recovery,
       ss::sharded<cluster_recovery_table>&,
       consensus_ptr raft0);
 
@@ -111,6 +113,8 @@ private:
     cluster::config_frontend& _config_frontend;
     cluster::security_frontend& _security_frontend;
     cluster::topics_frontend& _topics_frontend;
+
+    ss::shared_ptr<producer_id_recovery_manager> _producer_id_recovery;
 
     // State that backs the recoveries managed by this manager. Sharded so that
     // the status of the controller recovery is propagated across cores.

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.h
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.h
@@ -45,6 +45,7 @@ public:
       security::credential_store&,
       security::acl_store&,
       cluster::topic_table&,
+      cluster::controller_api&,
       cluster::feature_manager&,
       cluster::config_frontend&,
       cluster::security_frontend&,
@@ -99,6 +100,7 @@ private:
     security::credential_store& _creds;
     security::acl_store& _acls;
     cluster::topic_table& _topics;
+    cluster::controller_api& _controller_api;
 
     // Abstractions that drive replicated changes to controller state.
     cluster::feature_manager& _feature_manager;

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.h
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.h
@@ -63,6 +63,10 @@ public:
     ss::future<> recover_until_term_change();
 
 private:
+    // Syncs the leader in the given term, ensuring it is still leader.
+    // Returns false if not, or if no recovery is active.
+    ss::future<bool> sync_in_term(ss::abort_source& term_as, model::term_id);
+
     ss::future<cluster::errc> apply_controller_actions_in_term(
       model::term_id,
       cloud_metadata::controller_snapshot_reconciler::controller_actions);

--- a/src/v/cluster/cloud_metadata/error_outcome.h
+++ b/src/v/cluster/cloud_metadata/error_outcome.h
@@ -24,6 +24,7 @@ enum class error_outcome {
     term_has_changed,
     not_ready,
     ntp_not_found,
+    rpc_error,
 };
 
 struct error_outcome_category final : public std::error_category {
@@ -49,6 +50,8 @@ struct error_outcome_category final : public std::error_category {
             return "Not ready";
         case error_outcome::ntp_not_found:
             return "NTP not found";
+        case error_outcome::rpc_error:
+            return "RPC error";
         default:
             return fmt::format("Unknown outcome ({})", c);
         }

--- a/src/v/cluster/cloud_metadata/producer_id_recovery_manager.cc
+++ b/src/v/cluster/cloud_metadata/producer_id_recovery_manager.cc
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cluster/cloud_metadata/producer_id_recovery_manager.h"
+
+#include "cluster/controller_service.h"
+#include "cluster/health_monitor_types.h"
+#include "cluster/id_allocator_frontend.h"
+#include "cluster/logger.h"
+#include "cluster/members_table.h"
+#include "cluster/types.h"
+#include "model/metadata.h"
+#include "model/record.h"
+
+namespace cluster::cloud_metadata {
+
+producer_id_recovery_manager::producer_id_recovery_manager(
+  ss::sharded<cluster::members_table>& members_table,
+  ss::sharded<rpc::connection_cache>& conn_cache,
+  ss::sharded<cluster::id_allocator_frontend>& id_allocator)
+  : members_table_(members_table)
+  , conn_cache_(conn_cache)
+  , id_allocator_(id_allocator) {}
+
+ss::future<cloud_metadata::error_outcome>
+producer_id_recovery_manager::recover() const {
+    vlog(clusterlog.info, "Recovering highest producer id");
+    auto highest_pid_res = co_await get_cluster_highest_pid();
+    if (highest_pid_res.has_error()) {
+        co_return highest_pid_res.error();
+    }
+    auto highest_pid = highest_pid_res.value();
+    if (highest_pid == model::producer_id{}) {
+        vlog(clusterlog.info, "No valid producer ids found");
+        co_return error_outcome::success;
+    }
+    vlog(clusterlog.info, "Found highest producer id {}", highest_pid);
+    auto next_id = model::producer_id{highest_pid() + 1};
+    auto reply = co_await id_allocator_.local().reset_next_id(
+      next_id, timeout_);
+    if (reply.ec != cluster::errc::success) {
+        co_return error_outcome::rpc_error;
+    }
+    vlog(clusterlog.info, "Reset highest producer id to {}", next_id);
+    co_return error_outcome::success;
+}
+
+ss::future<result<model::producer_id, error_outcome>>
+producer_id_recovery_manager::get_node_highest_pid(
+  const model::broker& broker) const {
+    vlog(
+      clusterlog.debug,
+      "Looking for producer id on node {} ({})",
+      broker.id(),
+      broker.rpc_address());
+    auto reply_res = co_await with_client<cluster::controller_client_protocol>(
+      self_.id(),
+      conn_cache_,
+      broker.id(),
+      broker.rpc_address(),
+      rpc_tls_config_,
+      timeout_,
+      [this](controller_client_protocol c) mutable {
+          return c
+            .highest_producer_id(
+              producer_id_lookup_request{}, rpc::client_opts(timeout_))
+            .then(&rpc::get_ctx_data<producer_id_lookup_reply>);
+      });
+    if (reply_res.has_error()) {
+        co_return error_outcome::rpc_error;
+    }
+    vlog(
+      clusterlog.debug,
+      "Found producer id {} on node {} ({})",
+      reply_res.value().highest_producer_id,
+      broker.id(),
+      broker.rpc_address());
+    co_return reply_res.value().highest_producer_id;
+}
+
+ss::future<result<model::producer_id, error_outcome>>
+producer_id_recovery_manager::get_cluster_highest_pid() const {
+    std::vector<ss::future<result<model::producer_id, error_outcome>>> futs;
+    futs.reserve(members_table_.local().node_count());
+    for (const auto& [node_id, meta] : members_table_.local().nodes()) {
+        if (
+          meta.state.get_membership_state()
+          == model::membership_state::removed) {
+            continue;
+        }
+        futs.emplace_back(get_node_highest_pid(meta.broker));
+    }
+    vlog(clusterlog.debug, "Looking for producer id on {} nodes", futs.size());
+    auto pids = co_await ss::when_all_succeed(futs.begin(), futs.end());
+    model::producer_id highest_pid;
+    for (const auto& pid : pids) {
+        if (pid.has_error()) {
+            co_return pid.error();
+        }
+        highest_pid = std::max(pid.value(), highest_pid);
+    }
+    co_return highest_pid;
+}
+
+} // namespace cluster::cloud_metadata

--- a/src/v/cluster/cloud_metadata/producer_id_recovery_manager.h
+++ b/src/v/cluster/cloud_metadata/producer_id_recovery_manager.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+#include "cluster/cloud_metadata/error_outcome.h"
+#include "cluster/cluster_utils.h"
+#include "cluster/fwd.h"
+#include "config/node_config.h"
+#include "model/record.h"
+#include "rpc/connection_cache.h"
+#include "seastarx.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace cluster::cloud_metadata {
+
+class producer_id_recovery_manager {
+public:
+    producer_id_recovery_manager(
+      ss::sharded<cluster::members_table>& members_table,
+      ss::sharded<rpc::connection_cache>& conn_cache,
+      ss::sharded<id_allocator_frontend>& id_allocator);
+
+    ss::future<cloud_metadata::error_outcome> recover() const;
+
+private:
+    ss::future<result<model::producer_id, cloud_metadata::error_outcome>>
+    get_cluster_highest_pid() const;
+    ss::future<result<model::producer_id, cloud_metadata::error_outcome>>
+    get_node_highest_pid(const model::broker&) const;
+
+    ss::sharded<cluster::members_table>& members_table_;
+    ss::sharded<rpc::connection_cache>& conn_cache_;
+    ss::sharded<id_allocator_frontend>& id_allocator_;
+    const model::broker self_{cluster::make_self_broker(config::node())};
+    const config::tls_config rpc_tls_config_{config::node().rpc_server_tls()};
+    const std::chrono::seconds timeout_{5};
+};
+
+} // namespace cluster::cloud_metadata

--- a/src/v/cluster/cloud_metadata/tests/CMakeLists.txt
+++ b/src/v/cluster/cloud_metadata/tests/CMakeLists.txt
@@ -41,12 +41,15 @@ rp_test(
   FIXTURE_TEST
   GTEST
   BINARY_NAME gtest_cluster_cloud_metadata
-  SOURCES cluster_recovery_backend_test.cc
+  SOURCES
+    cluster_recovery_backend_test.cc
+    producer_id_recovery_test.cc
   LIBRARIES
     v::application
     v::kafka_test_utils
     v::gtest_main
     v::s3_imposter
+    v::storage_test_utils
   ARGS "-- -c 1"
   LABELS cluster
 )

--- a/src/v/cluster/cloud_metadata/tests/producer_id_recovery_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/producer_id_recovery_test.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "cloud_storage/tests/manual_fixture.h"
+#include "cluster/cloud_metadata/producer_id_recovery_manager.h"
+#include "cluster/id_allocator_frontend.h"
+#include "cluster/partition.h"
+#include "cluster/tests/tx_compaction_utils.h"
+#include "model/fundamental.h"
+#include "model/namespace.h"
+#include "redpanda/tests/fixture.h"
+#include "test_utils/test.h"
+
+#include <gtest/gtest.h>
+
+static ss::logger test_log("pid_recovery");
+
+using namespace cluster::cloud_metadata;
+
+class ProducerIdRecoveryTest
+  : public cloud_storage_manual_multinode_test_base
+  , public seastar_test {
+public:
+    ss::future<> SetUpAsync() override {
+        cluster::topic_properties props;
+        props.cleanup_policy_bitflags
+          = model::cleanup_policy_bitflags::compaction;
+        co_await add_topic({model::kafka_namespace, topic_name}, 1, props);
+        co_await wait_for_leader(ntp);
+
+        partition = app.partition_manager.local().get(ntp).get();
+        log = partition->log();
+    }
+
+    void generate_txn_data(int num_txns) {
+        cluster::random_tx_generator::spec spec{
+          ._num_txes = num_txns,
+          ._num_rolls = 3,
+          ._types = cluster::random_tx_generator::mixed,
+          ._interleave = true,
+          ._compact = false};
+        cluster::random_tx_generator{}.run_workload(
+          spec, partition->raft()->term(), partition->rm_stm(), log);
+    }
+
+protected:
+    const model::topic topic_name{"pid_recovery_test_topic"};
+    const model::ntp ntp{model::kafka_namespace, topic_name, 0};
+    cluster::partition* partition;
+    ss::shared_ptr<storage::log> log;
+};
+
+class ProducerIdRecoveryParamTest
+  : public ProducerIdRecoveryTest
+  , public ::testing::WithParamInterface<bool> {};
+
+TEST_P(ProducerIdRecoveryParamTest, TestBasicRecovery) {
+    bool init_id_allocator_tp = GetParam();
+    auto num_txns = 10;
+    auto last_pid = model::producer_id{num_txns - 1};
+    generate_txn_data(num_txns);
+    ASSERT_EQ(last_pid, partition->rm_stm()->highest_producer_id());
+
+    // Because our workload is fake, we shouldn't have used any id_allocator
+    // IDs. We can validate this by checking the existence of the id_allocator.
+    auto& topics_table = app.controller->get_topics_state().local();
+    ASSERT_FALSE(
+      topics_table.get_topic_metadata(model::id_allocator_nt).has_value());
+
+    if (init_id_allocator_tp) {
+        auto id_reply = app.id_allocator_frontend.local().allocate_id(1s).get();
+        ASSERT_EQ(1, id_reply.id);
+        ASSERT_TRUE(
+          topics_table.get_topic_metadata(model::id_allocator_nt).has_value());
+    }
+
+    // Regardless of what whether we previously initialized the id_allocator,
+    // we should see it after recovery.
+    producer_id_recovery_manager recovery_mgr(
+      app.controller->get_members_table(),
+      app._connection_cache,
+      app.id_allocator_frontend);
+    ASSERT_EQ(error_outcome::success, recovery_mgr.recover().get());
+    ASSERT_TRUE(
+      topics_table.get_topic_metadata(model::id_allocator_nt).has_value());
+
+    // We should start we our data left off.
+    auto id_reply = app.id_allocator_frontend.local().allocate_id(1s).get();
+    ASSERT_EQ(last_pid() + 1, id_reply.id);
+
+    id_reply = app.id_allocator_frontend.local().allocate_id(1s).get();
+    ASSERT_EQ(last_pid() + 2, id_reply.id);
+
+    // In the event we recover while the id_allocator has state, the state
+    // should never go lower.
+    ASSERT_EQ(error_outcome::success, recovery_mgr.recover().get());
+    id_reply = app.id_allocator_frontend.local().allocate_id(1s).get();
+    ASSERT_EQ(last_pid() + 3, id_reply.id);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  ShouldInitIdAllocator, ProducerIdRecoveryParamTest, ::testing::Bool());
+
+TEST_F(ProducerIdRecoveryTest, TestRecoveryDoesntLower) {
+    auto num_txns = 10;
+    auto last_pid = model::producer_id{num_txns - 1};
+    generate_txn_data(num_txns);
+    ASSERT_EQ(last_pid, partition->rm_stm()->highest_producer_id());
+
+    producer_id_recovery_manager recovery_mgr(
+      app.controller->get_members_table(),
+      app._connection_cache,
+      app.id_allocator_frontend);
+    ASSERT_EQ(error_outcome::success, recovery_mgr.recover().get());
+    for (int i = 0; i < 3; i++) {
+        auto id_reply = app.id_allocator_frontend.local().allocate_id(1s).get();
+        ASSERT_EQ(last_pid() + 1 + i, id_reply.id);
+    }
+    ASSERT_EQ(error_outcome::success, recovery_mgr.recover().get());
+    auto id_reply = app.id_allocator_frontend.local().allocate_id(1s).get();
+
+    // The next pid shouldn't go down.
+    ASSERT_EQ(last_pid() + 4, id_reply.id);
+}

--- a/src/v/cluster/cluster_recovery_table.h
+++ b/src/v/cluster/cluster_recovery_table.h
@@ -39,6 +39,21 @@ may_require_controller_recovery(std::optional<recovery_stage> cur_status) {
     }
 };
 
+inline bool
+may_require_producer_id_recovery(std::optional<recovery_stage> cur_stage) {
+    if (!cur_stage.has_value()) {
+        return true;
+    }
+    switch (cur_stage.value()) {
+    case recovery_stage::recovered_tx_coordinator:
+    case recovery_stage::complete:
+    case recovery_stage::failed:
+        return false;
+    default:
+        return true;
+    }
+}
+
 // Tracks the state of recovery attempts performed on the cluster.
 //
 // It is expected this will live on every shard on every node, making it easy

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -639,6 +639,7 @@ ss::future<> controller::start(
               _credentials.local(),
               _authorizer.local().store(),
               _tp_state.local(),
+              _api.local(),
               _feature_manager.local(),
               _config_frontend.local(),
               _security_frontend.local(),

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cloud_storage/fwd.h"
+#include "cluster/cloud_metadata/producer_id_recovery_manager.h"
 #include "cluster/controller_probe.h"
 #include "cluster/controller_stm.h"
 #include "cluster/fwd.h"
@@ -37,6 +38,7 @@ namespace cloud_metadata {
 class cluster_recovery_backend;
 class uploader;
 class offsets_upload_requestor;
+class producer_id_recovery_manager;
 } // namespace cloud_metadata
 
 class cluster_discovery;
@@ -179,7 +181,8 @@ public:
     ss::future<> start(
       cluster_discovery&,
       ss::abort_source&,
-      ss::shared_ptr<cluster::cloud_metadata::offsets_upload_requestor>);
+      ss::shared_ptr<cluster::cloud_metadata::offsets_upload_requestor>,
+      ss::shared_ptr<cluster::cloud_metadata::producer_id_recovery_manager>);
 
     // prevents controller from accepting new requests
     ss::future<> shutdown_input();

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -127,6 +127,11 @@
             "output_type": "transfer_leadership_reply"
         },
         {
+            "name": "highest_producer_id",
+            "input_type": "producer_id_lookup_request",
+            "output_type": "producer_id_lookup_reply"
+        },
+        {
             "name": "cloud_storage_usage",
             "input_type": "cloud_storage_usage_request",
             "output_type": "cloud_storage_usage_reply"

--- a/src/v/cluster/id_allocator.cc
+++ b/src/v/cluster/id_allocator.cc
@@ -31,7 +31,15 @@ id_allocator::allocate_id(allocate_id_request&& req, rpc::streaming_context&) {
     auto timeout = req.timeout;
     return _id_allocator_frontend.local()
       .allocator_router()
-      .find_shard_and_process(std::move(req), model::id_allocator_ntp, timeout);
+      .allocate_router::process_or_dispatch(
+        std::move(req), model::id_allocator_ntp, timeout);
+}
+
+ss::future<reset_id_allocator_reply> id_allocator::reset_id_allocator(
+  reset_id_allocator_request&& req, rpc::streaming_context&) {
+    auto timeout = req.timeout;
+    return _id_allocator_frontend.local().id_reset_router().process_or_dispatch(
+      std::move(req), model::id_allocator_ntp, timeout);
 }
 
 } // namespace cluster

--- a/src/v/cluster/id_allocator.h
+++ b/src/v/cluster/id_allocator.h
@@ -27,6 +27,9 @@ public:
     virtual ss::future<allocate_id_reply>
     allocate_id(allocate_id_request&&, rpc::streaming_context&) final;
 
+    virtual ss::future<reset_id_allocator_reply> reset_id_allocator(
+      reset_id_allocator_request&&, rpc::streaming_context&) final;
+
 private:
     ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;
 };

--- a/src/v/cluster/id_allocator.json
+++ b/src/v/cluster/id_allocator.json
@@ -9,6 +9,11 @@
             "name": "allocate_id",
             "input_type": "allocate_id_request",
             "output_type": "allocate_id_reply"
+        },
+        {
+            "name": "reset_id_allocator",
+            "input_type": "reset_id_allocator_request",
+            "output_type": "reset_id_allocator_reply"
         }
     ]
 }

--- a/src/v/cluster/id_allocator_frontend.h
+++ b/src/v/cluster/id_allocator_frontend.h
@@ -53,11 +53,42 @@ private:
     ss::sharded<partition_manager>& _partition_manager;
 };
 
-class allocate_id_router
-  : public leader_router<
-      allocate_id_request,
-      allocate_id_reply,
-      allocate_id_handler> {
+class reset_id_handler {
+public:
+    explicit reset_id_handler(
+      ss::smp_service_group ssg, ss::sharded<partition_manager>& pm)
+      : _ssg(ssg)
+      , _partition_manager(pm) {}
+
+    using proto_t = id_allocator_client_protocol;
+
+    static ss::sstring process_name() { return "id allocation"; }
+
+    static reset_id_allocator_reply error_resp(cluster::errc e) {
+        return reset_id_allocator_reply{e};
+    }
+
+    static ss::future<result<rpc::client_context<reset_id_allocator_reply>>>
+    dispatch(
+      id_allocator_client_protocol proto,
+      reset_id_allocator_request req,
+      model::timeout_clock::duration timeout);
+
+    ss::future<reset_id_allocator_reply>
+    process(ss::shard_id, reset_id_allocator_request req);
+
+private:
+    ss::smp_service_group _ssg;
+    ss::sharded<partition_manager>& _partition_manager;
+};
+
+using allocate_router
+  = leader_router<allocate_id_request, allocate_id_reply, allocate_id_handler>;
+using reset_router = leader_router<
+  reset_id_allocator_request,
+  reset_id_allocator_reply,
+  reset_id_handler>;
+class allocate_id_router : public allocate_router {
 public:
     allocate_id_router(
       ss::smp_service_group ssg,
@@ -71,6 +102,22 @@ public:
 
 private:
     allocate_id_handler _handler;
+};
+
+class reset_id_router : public reset_router {
+public:
+    reset_id_router(
+      ss::smp_service_group ssg,
+      ss::sharded<cluster::partition_manager>& partition_manager,
+      ss::sharded<cluster::shard_table>&,
+      ss::sharded<cluster::metadata_cache>&,
+      ss::sharded<rpc::connection_cache>&,
+      ss::sharded<partition_leaders_table>&,
+      const model::node_id);
+    ~reset_id_router() = default;
+
+private:
+    reset_id_handler _handler;
 };
 
 // id_allocator_frontend is an frontend of the id_allocator_stm,
@@ -104,6 +151,7 @@ public:
     ss::future<> stop() { return _allocator_router.shutdown(); }
 
     allocate_id_router& allocator_router() { return _allocator_router; }
+    reset_id_router& id_reset_router() { return _id_reset_router; }
 
 private:
     ss::smp_service_group _ssg;
@@ -112,6 +160,7 @@ private:
     std::unique_ptr<cluster::controller>& _controller;
 
     allocate_id_router _allocator_router;
+    reset_id_router _id_reset_router;
 
     // Sets the underlying stm's next id to the given id, returning an error if
     // there was a problem (e.g. not leader, timed out, etc).

--- a/src/v/cluster/id_allocator_frontend.h
+++ b/src/v/cluster/id_allocator_frontend.h
@@ -148,6 +148,9 @@ public:
     ss::future<allocate_id_reply>
     allocate_id(model::timeout_clock::duration timeout);
 
+    ss::future<reset_id_allocator_reply>
+    reset_next_id(model::producer_id, model::timeout_clock::duration timeout);
+
     ss::future<> stop() { return _allocator_router.shutdown(); }
 
     allocate_id_router& allocator_router() { return _allocator_router; }
@@ -168,6 +171,7 @@ private:
       do_reset_next_id(int64_t, model::timeout_clock::duration);
 
     ss::future<bool> try_create_id_allocator_topic();
+    ss::future<bool> ensure_id_allocator_topic_exists();
 
     friend id_allocator;
 };

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -50,6 +50,9 @@ public:
     std::string_view get_name() const final { return "id_allocator_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
+    ss::future<stm_allocation_result>
+    reset_next_id(int64_t, model::timeout_clock::duration timeout);
+
 private:
     // legacy structs left for backward compatibility with the "old"
     // on-disk log format
@@ -100,6 +103,11 @@ private:
     ss::future<bool> set_state(int64_t, model::timeout_clock::duration);
 
     ss::future<> apply(const model::record_batch&) final;
+
+    // Moves the state forward to the given value if the curent id is lower
+    // than it.
+    ss::future<stm_allocation_result>
+      advance_state(int64_t, model::timeout_clock::duration);
 
     ss::future<> write_snapshot();
     ss::future<> apply_local_snapshot(stm_snapshot_header, iobuf&&) override;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -114,6 +114,9 @@ public:
     ss::future<transfer_leadership_reply> transfer_leadership(
       transfer_leadership_request&& r, rpc::streaming_context&) final;
 
+    ss::future<producer_id_lookup_reply> highest_producer_id(
+      producer_id_lookup_request&&, rpc::streaming_context&) final;
+
     ss::future<cloud_storage_usage_reply> cloud_storage_usage(
       cloud_storage_usage_request&& r, rpc::streaming_context&) final;
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3846,6 +3846,36 @@ struct cloud_storage_usage_reply
     }
 };
 
+struct producer_id_lookup_request
+  : serde::envelope<
+      producer_id_lookup_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    producer_id_lookup_request() noexcept = default;
+    auto serde_fields() { return std::tie(); }
+};
+
+struct producer_id_lookup_reply
+  : serde::envelope<
+      producer_id_lookup_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    cluster::errc ec{};
+    model::producer_id highest_producer_id{};
+
+    producer_id_lookup_reply() noexcept = default;
+    explicit producer_id_lookup_reply(cluster::errc e)
+      : ec(e) {}
+    explicit producer_id_lookup_reply(model::producer_id pid)
+      : highest_producer_id(pid) {}
+
+    auto serde_fields() { return std::tie(ec, highest_producer_id); }
+};
+
 struct partition_state_request
   : serde::envelope<
       partition_state_request,

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -113,6 +113,63 @@ struct allocate_id_reply
     auto serde_fields() { return std::tie(id, ec); }
 };
 
+struct reset_id_allocator_request
+  : serde::envelope<
+      reset_id_allocator_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    model::timeout_clock::duration timeout;
+    int64_t producer_id;
+
+    reset_id_allocator_request() noexcept = default;
+
+    explicit reset_id_allocator_request(
+      model::timeout_clock::duration timeout, int64_t producer_id)
+      : timeout(timeout)
+      , producer_id(producer_id) {}
+
+    friend bool operator==(
+      const reset_id_allocator_request&, const reset_id_allocator_request&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const reset_id_allocator_request& req) {
+        fmt::print(
+          o,
+          "timeout: {}, producer_id: {}",
+          req.timeout.count(),
+          req.producer_id);
+        return o;
+    }
+
+    auto serde_fields() { return std::tie(timeout, producer_id); }
+};
+
+struct reset_id_allocator_reply
+  : serde::envelope<
+      reset_id_allocator_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    errc ec;
+
+    reset_id_allocator_reply() noexcept = default;
+
+    explicit reset_id_allocator_reply(errc ec)
+      : ec(ec) {}
+
+    friend bool
+    operator==(const reset_id_allocator_reply&, const reset_id_allocator_reply&)
+      = default;
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const reset_id_allocator_reply& rep) {
+        fmt::print(o, "ec: {}", rep.ec);
+        return o;
+    }
+
+    auto serde_fields() { return std::tie(ec); }
+};
+
 enum class tx_errc {
     none = 0,
     leader_not_found,

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -17,6 +17,7 @@
 #include "cluster/cloud_metadata/offsets_lookup.h"
 #include "cluster/cloud_metadata/offsets_upload_router.h"
 #include "cluster/cloud_metadata/offsets_uploader.h"
+#include "cluster/cloud_metadata/producer_id_recovery_manager.h"
 #include "cluster/config_manager.h"
 #include "cluster/fwd.h"
 #include "cluster/node/local_monitor.h"
@@ -138,6 +139,9 @@ public:
     ss::sharded<cluster::cloud_metadata::offsets_uploader> offsets_uploader;
     ss::sharded<cluster::cloud_metadata::offsets_upload_router>
       offsets_upload_router;
+
+    ss::shared_ptr<cluster::cloud_metadata::producer_id_recovery_manager>
+      producer_id_recovery_manager;
 
     ss::sharded<kafka::coordinator_ntp_mapper> coordinator_ntp_mapper;
     ss::sharded<kafka::group_router> group_router;


### PR DESCRIPTION
This PR restores the highest producer ID used by any uploaded segment data in the previous cluster. To accomplish this, there are a few major components:
- At restore time, the highest producer ID is queried across all nodes, loaded from their manifests, sending out an RPC to all nodes to aggregate the highest producer ID of any partition across all shards.
- To make the above step reliable, a sync point is added just after restoring topics from the controller snapshot, using `wait_for_topics()` to wait for partitions to be bootstrapped before proceeding.
- An RPC is then sent to the id_allocator partition to reset the next ID. A new method is used to persist this next ID using the existing STM commands, and the same routing logic is used to direct the requests to the leader.
- Finally, this is plugged into the cluster_recovery_backend before marking the cluster recovery as complete.

Why can't we just upload a single producer ID from the id_allocator when uploading metadata? Segment uploads are not coordinated by any central entity. This means that if there were a central uploader that queried the highest producer ID from the id_allocator, there would be a strong chance that new transactional segments get initialized and uploaded before the next ID is included in uploaded metadata.

This adds a couple fixture tests to validate the end-to-end behavior. Ducktape tests will follow, once the rest of cluster recovery (offsets recovery) is plugged in.

Fixes https://github.com/redpanda-data/redpanda/issues/9555

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
