### PR TITLE
transform-sdk/go: correct module path

### DIFF
--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -237,7 +237,7 @@ func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
 			c.Dir = p.Path
 			return c.Run()
 		}
-		if err := runGoCli("get", "github.com/redpanda-data/redpanda/src/go/transform-sdk"); err != nil {
+		if err := runGoCli("get", "github.com/redpanda-data/redpanda/src/transform-sdk/go"); err != nil {
 			return fmt.Errorf("unable to go get redpanda transform-sdk: %v", err)
 		}
 		if err := runGoCli("mod", "tidy"); err != nil {

--- a/src/go/rpk/pkg/cli/transform/template/golang/transform.gosrc
+++ b/src/go/rpk/pkg/cli/transform/template/golang/transform.gosrc
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 func main() {

--- a/src/transform-sdk/go/example_mirror_test.go
+++ b/src/transform-sdk/go/example_mirror_test.go
@@ -15,7 +15,7 @@
 package redpanda_test
 
 import (
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 // This example shows the basic usage of the package:

--- a/src/transform-sdk/go/example_regexp_filter_test.go
+++ b/src/transform-sdk/go/example_regexp_filter_test.go
@@ -18,7 +18,7 @@ import (
 	"os"
 	"regexp"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 var (

--- a/src/transform-sdk/go/example_transcoding_test.go
+++ b/src/transform-sdk/go/example_transcoding_test.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"strconv"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 // This example shows a transform that converts CSV into JSON.

--- a/src/transform-sdk/go/go.mod
+++ b/src/transform-sdk/go/go.mod
@@ -1,3 +1,3 @@
-module github.com/redpanda-data/redpanda/src/go/transform-sdk
+module github.com/redpanda-data/redpanda/src/transform-sdk/go
 
 go 1.20

--- a/src/transform-sdk/go/internal/cache/cache_test.go
+++ b/src/transform-sdk/go/internal/cache/cache_test.go
@@ -3,7 +3,7 @@ package cache_test
 import (
 	"testing"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/cache"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/internal/cache"
 )
 
 func expectValue(t *testing.T, c cache.Cache[int, string], key int) string {

--- a/src/transform-sdk/go/internal/testdata/dynamic/transform.go
+++ b/src/transform-sdk/go/internal/testdata/dynamic/transform.go
@@ -19,7 +19,7 @@ import (
 	"encoding/binary"
 	"errors"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 func main() {

--- a/src/transform-sdk/go/internal/testdata/go.mod
+++ b/src/transform-sdk/go/internal/testdata/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/actgardner/gogen-avro/v10 v10.2.1
-	github.com/redpanda-data/redpanda/src/go/transform-sdk v0.0.1
+	github.com/redpanda-data/redpanda/src/transform-sdk/go v0.0.1
 )
 
-replace github.com/redpanda-data/redpanda/src/go/transform-sdk => ../../
+replace github.com/redpanda-data/redpanda/src/transform-sdk/go => ../../

--- a/src/transform-sdk/go/internal/testdata/identity/transform.go
+++ b/src/transform-sdk/go/internal/testdata/identity/transform.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 func main() {

--- a/src/transform-sdk/go/internal/testdata/schema-registry/transform.go
+++ b/src/transform-sdk/go/internal/testdata/schema-registry/transform.go
@@ -17,8 +17,8 @@ package main
 import (
 	"bytes"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/sr"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/sr"
 	"github.com/redpanda-data/wasm-transform-testdata/schema-registry/avro"
 )
 

--- a/src/transform-sdk/go/internal/testdata/transform-error/transform.go
+++ b/src/transform-sdk/go/internal/testdata/transform-error/transform.go
@@ -17,7 +17,7 @@ package main
 import (
 	"errors"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 func main() {

--- a/src/transform-sdk/go/internal/testdata/transform-panic/transform.go
+++ b/src/transform-sdk/go/internal/testdata/transform-panic/transform.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 func main() {

--- a/src/transform-sdk/go/internal/testdata/wasi/transform.go
+++ b/src/transform-sdk/go/internal/testdata/wasi/transform.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 func main() {

--- a/src/transform-sdk/go/processor.go
+++ b/src/transform-sdk/go/processor.go
@@ -19,7 +19,7 @@ import (
 	"time"
 	"unsafe"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/internal/rwbuf"
 )
 
 type batchHeader struct {

--- a/src/transform-sdk/go/serialize.go
+++ b/src/transform-sdk/go/serialize.go
@@ -17,7 +17,7 @@ package redpanda
 import (
 	"encoding/binary"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/internal/rwbuf"
 )
 
 // Reusable slice of record headers

--- a/src/transform-sdk/go/serialize_test.go
+++ b/src/transform-sdk/go/serialize_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/internal/rwbuf"
 )
 
 var (

--- a/src/transform-sdk/go/sr/client.go
+++ b/src/transform-sdk/go/sr/client.go
@@ -21,8 +21,8 @@ import (
 	"strconv"
 	"unsafe"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/cache"
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/internal/cache"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/internal/rwbuf"
 )
 
 // schemaId is an ID of a schema registered with schema registry

--- a/src/transform-sdk/go/sr/encoding.go
+++ b/src/transform-sdk/go/sr/encoding.go
@@ -17,7 +17,7 @@ package sr
 import (
 	"encoding/binary"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/internal/rwbuf"
 )
 
 func decodeSchema(subject string, buf *rwbuf.RWBuf) (s SubjectSchema, err error) {

--- a/src/transform-sdk/go/sr/encoding_test.go
+++ b/src/transform-sdk/go/sr/encoding_test.go
@@ -18,7 +18,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/redpanda-data/redpanda/src/go/transform-sdk/internal/rwbuf"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/internal/rwbuf"
 )
 
 func TestSchemaRoundtrip(t *testing.T) {


### PR DESCRIPTION
These were missed in: https://github.com/redpanda-data/redpanda/pull/14843

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
