### PR TITLE
wasm/alloc: zero fill memory

### DIFF
--- a/src/v/wasm/allocator.cc
+++ b/src/v/wasm/allocator.cc
@@ -97,6 +97,7 @@ stack_memory stack_allocator::allocate(size_t size) {
     if (_tracking_enabled) {
         _live_stacks.emplace(mem.bounds());
     }
+    std::memset(mem.bounds().bottom, 0, mem.size());
     return mem;
 }
 

--- a/src/v/wasm/allocator.cc
+++ b/src/v/wasm/allocator.cc
@@ -20,6 +20,7 @@
 
 #include <sys/mman.h>
 
+#include <span>
 #include <stdexcept>
 #include <unistd.h>
 
@@ -31,6 +32,7 @@ heap_allocator::heap_allocator(config c) {
     for (size_t i = 0; i < c.num_heaps; ++i) {
         auto buffer = ss::allocate_aligned_buffer<uint8_t>(
           _max_size, page_size);
+        std::memset(buffer.get(), 0, _max_size);
         _memory_pool.emplace_back(std::move(buffer), _max_size);
     }
 }
@@ -48,7 +50,8 @@ std::optional<heap_memory> heap_allocator::allocate(request req) {
     return front;
 }
 
-void heap_allocator::deallocate(heap_memory m) {
+void heap_allocator::deallocate(heap_memory m, size_t used_amount) {
+    std::memset(m.data.get(), 0, used_amount);
     _memory_pool.push_back(std::move(m));
 }
 

--- a/src/v/wasm/allocator.h
+++ b/src/v/wasm/allocator.h
@@ -143,7 +143,8 @@ private:
 // Stack memory must be page-aligned and a multiple of page size.
 // Some architectures require this alignment for stacks. Additionally, we
 // always allocate a guard page at the bottom, which is unprotected when memory
-// is "deallocated".
+// is "deallocated". Lastly, memory returned from this allocator is always
+// zero-filled as assumed by the Wasm VM.
 //
 // The allocator also supports the ability to query if the current stack being
 // used has been allocated from this allocator and returns the bounds. This is

--- a/src/v/wasm/allocator.h
+++ b/src/v/wasm/allocator.h
@@ -72,13 +72,19 @@ public:
 
     /**
      * Allocate heap memory by taking a memory instance from the pool.
+     *
+     * Memory returned from this method will be zero-filled.
      */
     std::optional<heap_memory> allocate(request);
 
     /**
      * Deallocate heap memory by returing a memory instance to the pool.
+     *
+     * used_amount is to zero out the used memory from the heap, this is
+     * required so that if only a portion of a large memory space was used we
+     * don't have to touch all the bytes.
      */
-    void deallocate(heap_memory);
+    void deallocate(heap_memory, size_t used_amount);
 
     /**
      * The maximum size of a heap_memory that can be allocated.

--- a/src/v/wasm/tests/wasm_allocator_test.cc
+++ b/src/v/wasm/tests/wasm_allocator_test.cc
@@ -16,10 +16,13 @@
 #include <gtest/gtest.h>
 
 #include <limits>
+#include <span>
 #include <stdexcept>
 #include <unistd.h>
 
 namespace wasm {
+
+using ::testing::Optional;
 
 TEST(HeapAllocatorParamsTest, SizeIsAligned) {
     size_t page_size = ::getpagesize();
@@ -96,6 +99,34 @@ TEST(HeapAllocatorTest, CanReturnMemoryToThePool) {
     EXPECT_FALSE(mem.has_value());
 }
 
+MATCHER(HeapIsZeroed, "is zeroed") {
+    std::span<uint8_t> d = {arg.data.get(), arg.size};
+    for (auto e : d) {
+        if (e != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+TEST(HeapAllocatorTest, MemoryIsZeroFilled) {
+    size_t page_size = ::getpagesize();
+    heap_allocator allocator(heap_allocator::config{
+      .heap_memory_size = page_size,
+      .num_heaps = 1,
+    });
+    heap_allocator::request req{.minimum = page_size, .maximum = page_size};
+    auto allocated = allocator.allocate(req);
+    ASSERT_TRUE(allocated.has_value());
+    EXPECT_THAT(allocated, Optional(HeapIsZeroed()));
+    std::fill_n(allocated->data.get(), 4, 1);
+    allocator.deallocate(*std::move(allocated), 4);
+
+    allocated = allocator.allocate(req);
+    ASSERT_TRUE(allocated.has_value());
+    EXPECT_THAT(allocated, Optional(HeapIsZeroed()));
+}
+
 TEST(StackAllocatorParamsTest, TrackingCanBeEnabled) {
     stack_allocator allocator(stack_allocator::config{
       .tracking_enabled = true,
@@ -116,8 +147,6 @@ TEST(StackAllocatorTest, CanAllocateOne) {
     EXPECT_EQ(stack.size(), page_size * 4);
     EXPECT_EQ(stack.bounds().top - stack.bounds().bottom, page_size * 4);
 }
-
-using ::testing::Optional;
 
 TEST(StackAllocatorTest, CanLookupMemory) {
     stack_allocator allocator(stack_allocator::config{
@@ -162,6 +191,29 @@ TEST(StackAllocatorTest, CanReturnMemoryToThePool) {
     // stack.
     stack = allocator.allocate(page_size * 4);
     EXPECT_EQ(stack.bounds(), bounds);
+}
+
+MATCHER(StackIsZeroed, "is zeroed") {
+    std::span<uint8_t> d = {arg.bounds().bottom, arg.size()};
+    for (auto e : d) {
+        if (e != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+TEST(StackAllocatorTest, MemoryIsZeroFilled) {
+    stack_allocator allocator(stack_allocator::config{
+      .tracking_enabled = true,
+    });
+    size_t page_size = ::getpagesize();
+    auto stack = allocator.allocate(page_size * 4);
+    EXPECT_THAT(stack, StackIsZeroed());
+    std::fill_n(stack.bounds().bottom, 4, 1);
+    allocator.deallocate(std::move(stack));
+    stack = allocator.allocate(page_size * 4);
+    EXPECT_THAT(stack, StackIsZeroed());
 }
 
 } // namespace wasm

--- a/src/v/wasm/tests/wasm_allocator_test.cc
+++ b/src/v/wasm/tests/wasm_allocator_test.cc
@@ -89,7 +89,7 @@ TEST(HeapAllocatorTest, CanReturnMemoryToThePool) {
     EXPECT_FALSE(mem.has_value());
     mem = std::move(allocated.back());
     allocated.pop_back();
-    allocator.deallocate(std::move(*mem));
+    allocator.deallocate(std::move(*mem), /*used_amount=*/0);
     mem = allocator.allocate(req);
     EXPECT_TRUE(mem.has_value());
     mem = allocator.allocate(req);


### PR DESCRIPTION
Wasmtime assumes that memory returned from allocators is zero filled. We need to do this for our custom allocators too.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
