### PR TITLE
Config to attempt cluster recovery when bootstrapping cluster

### DIFF
--- a/src/v/cluster/bootstrap_backend.h
+++ b/src/v/cluster/bootstrap_backend.h
@@ -44,7 +44,8 @@ public:
       ss::sharded<storage::api>&,
       ss::sharded<members_manager>&,
       ss::sharded<features::feature_table>&,
-      ss::sharded<feature_backend>&);
+      ss::sharded<feature_backend>&,
+      ss::sharded<cluster_recovery_table>&);
 
     ss::future<std::error_code> apply_update(model::record_batch);
 
@@ -65,6 +66,7 @@ private:
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<feature_backend>& _feature_backend;
+    ss::sharded<cluster_recovery_table>& _cluster_recovery_table;
     std::optional<model::cluster_uuid> _cluster_uuid_applied;
 };
 

--- a/src/v/cluster/cluster_recovery_manager.cc
+++ b/src/v/cluster/cluster_recovery_manager.cc
@@ -111,8 +111,8 @@ cluster_recovery_manager::initialize_recovery(
     // Replicate an update to start recovery. Once applied, this will update
     // the recovery table.
     cluster_recovery_init_cmd_data data;
-    data.manifest = std::move(manifest);
-    data.bucket = std::move(bucket);
+    data.state.manifest = std::move(manifest);
+    data.state.bucket = std::move(bucket);
     auto errc = co_await replicate_and_wait(
       _controller_stm,
       _sharded_as,

--- a/src/v/cluster/cluster_recovery_table.cc
+++ b/src/v/cluster/cluster_recovery_table.cc
@@ -11,6 +11,7 @@
 #include "cluster/cluster_recovery_table.h"
 
 #include "cluster/cloud_metadata/cluster_manifest.h"
+#include "cluster/cluster_recovery_state.h"
 #include "cluster/logger.h"
 #include "cluster/types.h"
 
@@ -64,10 +65,12 @@ std::error_code cluster_recovery_table::apply(
       "Initializing cluster recovery at offset {} with manifest {} from bucket "
       "{}",
       offset,
-      cmd.value.manifest,
-      cmd.value.bucket);
+      cmd.value.state.manifest,
+      cmd.value.state.bucket);
     _states.emplace_back(
-      std::move(cmd.value.manifest), std::move(cmd.value.bucket));
+      std::move(cmd.value.state.manifest),
+      std::move(cmd.value.state.bucket),
+      wait_for_nodes::no);
     _has_active_recovery.signal();
     return errc::success;
 }

--- a/src/v/cluster/cluster_recovery_table.h
+++ b/src/v/cluster/cluster_recovery_table.h
@@ -92,6 +92,11 @@ public:
         return std::reference_wrapper(_states.back());
     }
 
+    std::error_code apply(
+      model::offset offset,
+      cloud_metadata::cluster_metadata_manifest,
+      cloud_storage_clients::bucket_name,
+      wait_for_nodes wait = wait_for_nodes::no);
     std::error_code apply(model::offset offset, cluster_recovery_init_cmd);
     std::error_code apply(model::offset offset, cluster_recovery_update_cmd);
 

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -241,6 +241,8 @@ private:
 
     ss::future<> cluster_creation_hook(cluster_discovery& discovery);
 
+    std::optional<cloud_storage_clients::bucket_name> get_configured_bucket();
+
     // Checks configuration invariants stored in kvstore
     ss::future<> validate_configuration_invariants();
 

--- a/src/v/cluster/tests/cluster_recovery_table_test.cc
+++ b/src/v/cluster/tests/cluster_recovery_table_test.cc
@@ -25,8 +25,8 @@ namespace cluster {
 namespace {
 cluster_recovery_init_cmd make_init_cmd(int meta_id) {
     cluster_recovery_init_cmd_data data;
-    data.manifest.metadata_id = cluster::cloud_metadata::cluster_metadata_id{
-      meta_id};
+    data.state.manifest.metadata_id
+      = cluster::cloud_metadata::cluster_metadata_id{meta_id};
     return cluster_recovery_init_cmd{0, std::move(data)};
 }
 cluster_recovery_update_cmd make_update_cmd(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3011,10 +3011,30 @@ struct user_and_credential
     security::scram_credential credential;
 };
 
+struct cluster_recovery_init_state
+  : serde::envelope<
+      cluster_recovery_init_state,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    friend bool operator==(
+      const cluster_recovery_init_state&, const cluster_recovery_init_state&)
+      = default;
+
+    auto serde_fields() { return std::tie(manifest, bucket); }
+
+    // Cluster metadata manifest used to define the desired end state of the
+    // recovery.
+    cluster::cloud_metadata::cluster_metadata_manifest manifest;
+
+    // Bucket from which to download the cluster recovery state.
+    cloud_storage_clients::bucket_name bucket;
+};
+
 struct bootstrap_cluster_cmd_data
   : serde::envelope<
       bootstrap_cluster_cmd_data,
-      serde::version<2>,
+      serde::version<3>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
@@ -3028,7 +3048,8 @@ struct bootstrap_cluster_cmd_data
           bootstrap_user_cred,
           node_ids_by_uuid,
           founding_version,
-          initial_nodes);
+          initial_nodes,
+          recovery_state);
     }
 
     model::cluster_uuid uuid;
@@ -3040,6 +3061,9 @@ struct bootstrap_cluster_cmd_data
     // the node that generated the bootstrap record.
     cluster_version founding_version{invalid_version};
     std::vector<model::broker> initial_nodes;
+
+    // If set, begins a cluster recovery using this state as the basis.
+    std::optional<cluster_recovery_init_state> recovery_state;
 };
 
 struct cluster_recovery_init_cmd_data
@@ -3048,19 +3072,15 @@ struct cluster_recovery_init_cmd_data
       serde::version<0>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
+
     friend bool operator==(
       const cluster_recovery_init_cmd_data&,
       const cluster_recovery_init_cmd_data&)
       = default;
 
-    auto serde_fields() { return std::tie(manifest, bucket); }
+    auto serde_fields() { return std::tie(state); }
 
-    // Cluster metadata manifest used to define the desired end state of the
-    // recovery.
-    cluster::cloud_metadata::cluster_metadata_manifest manifest;
-
-    // Bucket from which to download the cluster recovery state.
-    cloud_storage_clients::bucket_name bucket;
+    cluster_recovery_init_state state;
 };
 
 enum class recovery_stage : int8_t {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1652,6 +1652,20 @@ configuration::configuration()
       "Number of attempts metadata operations may be retried.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       5)
+  , cloud_storage_attempt_cluster_recovery_on_bootstrap(
+      *this,
+      "cloud_storage_attempt_cluster_recovery_on_bootstrap",
+      "If set to `true`, when a cluster is started for the first time and "
+      "there is cluster metadata in the configured cloud storage bucket, "
+      "Redpanda automatically starts a cluster recovery from that metadata. If "
+      "using an automated method for deployment where it's not easy to "
+      "predictably determine that a recovery is needed, we recommend setting "
+      "to `true`. Take care to ensure that in such deployments, a cluster "
+      "bootstrap with a given bucket means that any previous cluster using "
+      "that bucket is fully destroyed; otherwise tiered storage subsystems may "
+      "interfere with each other.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , cloud_storage_idle_threshold_rps(
       *this,
       "cloud_storage_idle_threshold_rps",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -321,6 +321,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       cloud_storage_cluster_metadata_upload_timeout_ms;
     property<int16_t> cloud_storage_cluster_metadata_retries;
+    property<bool> cloud_storage_attempt_cluster_recovery_on_bootstrap;
     property<double> cloud_storage_idle_threshold_rps;
     property<int32_t> cloud_storage_background_jobs_quota;
     property<bool> cloud_storage_enable_segment_merging;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
The idea here is that in automated deployments where we don't have a human to run RPK, Redpanda should detect upon starting up a new cluster that a cluster metadata manifest exists in the configured bucket, and should use it to form the basis for cluster recovery automatically by adding the cluster metadata manifest to the cluster recovery table when applying the cluster bootstrap command.

This PR does just that, in the following changes:
- Addition of cluster metadata in the bootstrap cmd. When applied, the state is added to the `cluster_recovery_table`.
- In the cluster creation hook, the leader will look in the configured bucket for any cluster metadata and attempt to use it if any exists, replicating it with the bootstrap cmd.
- Now that cluster recovery can be initialized immediately after bootstrapping the cluster, there's a strong possibility that the entire cluster isn't fully formed by the time the cluster recovery backend reconciles the cluster. So, this also adds an option to the recovery state to signal to the backend that it should wait for the cluster to grow to the size of the original cluster before attempting to rehydrate the controller snapshot.

Fixes https://github.com/redpanda-data/redpanda/issues/14398

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
