### PR TITLE
features: do not retire serde_raft0 feature

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -25,6 +25,8 @@ namespace features {
 
 std::string_view to_string_view(feature f) {
     switch (f) {
+    case feature::serde_raft_0:
+        return "serde_raft_0";
     case feature::license:
         return "license";
     case feature::raft_improved_configuration:

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -37,6 +37,7 @@ struct feature_table_snapshot;
 /// only used at runtime.  Therefore it is safe to re-use an integer that
 /// has been made available by another feature being retired.
 enum class feature : std::uint64_t {
+    serde_raft_0 = 1ULL << 5U,
     license = 1ULL << 6U,
     raft_improved_configuration = 1ULL << 7U,
     transaction_ga = 1ULL << 8U,
@@ -93,7 +94,6 @@ inline const std::unordered_set<std::string_view> retired_features = {
   "mtls_authentication",
   "rm_stm_kafka_cache",
   "transaction_ga",
-  "serde_raft_0",
 };
 
 /**
@@ -147,6 +147,12 @@ struct feature_spec {
 };
 
 constexpr static std::array feature_schema{
+  feature_spec{
+    cluster::cluster_version{5},
+    "serde_raft_0",
+    feature::serde_raft_0,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{5},
     "license",

--- a/src/v/features/tests/feature_table_test.cc
+++ b/src/v/features/tests/feature_table_test.cc
@@ -313,7 +313,7 @@ FIXTURE_TEST(feature_table_old_snapshot, feature_table_fixture) {
     snapshot.version = features::feature_table::get_earliest_logical_version();
     snapshot.states = {
       features::feature_state_snapshot{
-        .name = "license",
+        .name = "serde_raft_0",
         .state = feature_state::state::available,
       },
       features::feature_state_snapshot{
@@ -326,7 +326,7 @@ FIXTURE_TEST(feature_table_old_snapshot, feature_table_fixture) {
 
     // Fast-forwarded feature should still be active.
     BOOST_CHECK(
-      ft.get_state(feature::license).get_state()
+      ft.get_state(feature::serde_raft_0).get_state()
       == feature_state::state::active);
     // A feature with explicit available_policy should be activated by the
     // snapshot.


### PR DESCRIPTION
The `serde_raft0` feature can not be completely retried from the feature table as the feature presence is checked in the previous versions of Redpanda. We need to first remove the checks validating if feature is active and only then retire the feature completely in the next version.

Retiring a feature caused the upgrade test to fail as the feature is expected to be active when some other subsequent features are active.

Fixes: #15046

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
