### PR TITLE
rptest: adjust omb test_retention client count

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -381,8 +381,9 @@ class OMBValidationTest(RedpandaTest):
         # This will have 1/2 the test run with segment deletion occuring.
         test_duration_seconds = max(
             (2 * retention_bytes * partitions) // producer_rate, 5 * 60)
-        total_producers = 10
-        total_consumers = 10
+
+        total_producers = self._producer_count(producer_rate)
+        total_consumers = self._consumer_count(producer_rate * subscriptions)
 
         workload = self.WORKLOAD_DEFAULTS | {
             "name": "RetentionTestWorkload",


### PR DESCRIPTION
Make this test calculate the producer and consumer client count in the same way as test_common, as this is essentially the same test but with frequent segment cleanup.

This bring it into line with the other tests and will use fewer clients in T1.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
