### PR TITLE
transform/rpc: uniform topic creation

### DIFF
--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -119,7 +119,7 @@ private:
 
     ss::future<std::optional<model::node_id>> compute_wasm_binary_ntp_leader();
     ss::future<bool> try_create_wasm_binary_ntp();
-    ss::future<> try_create_transform_offsets_topic();
+    ss::future<bool> try_create_transform_offsets_topic();
 
     ss::future<result<model::partition_id, cluster::errc>>
       find_coordinator_once(model::transform_offsets_key);


### PR DESCRIPTION
Use the same pattern for topic creation, and retry if we successfully
created the topic

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
