### PR TITLE
cluster/plugin: prevent transforms to internal kafka topics

### DIFF
--- a/src/v/cluster/plugin_frontend.h
+++ b/src/v/cluster/plugin_frontend.h
@@ -20,6 +20,8 @@
 #include "seastarx.h"
 #include "utils/mutex.h"
 
+#include <absl/container/flat_hash_set.h>
+
 #include <variant>
 
 #pragma once
@@ -126,7 +128,8 @@ public:
      */
     class validator {
     public:
-        validator(topic_table*, plugin_table*);
+        validator(
+          topic_table*, plugin_table*, absl::flat_hash_set<model::topic>);
 
         // Ensures that the mutation is valid.
         //
@@ -143,6 +146,7 @@ public:
 
         topic_table* _topics;
         plugin_table* _table;
+        absl::flat_hash_set<model::topic> _no_sink_topics;
     };
 
 private:


### PR DESCRIPTION
This prevents folks writing to `__audit` from transforms

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
