### PR TITLE
Feat/partition manifest log path

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -663,7 +663,7 @@ void partition_manifest::set_archive_clean_offset(
           "{} Requested to advance archive_clean_offset to {} which is greater "
           "than the current archive_start_offset {}. The offset won't be "
           "changed. Archive size won't be changed by {} bytes.",
-          _ntp,
+          get_manifest_path(),
           start_rp_offset,
           _archive_start_offset,
           size_bytes);
@@ -687,7 +687,7 @@ void partition_manifest::set_archive_clean_offset(
               "{} archive clean offset moved to {} but the archive size can't "
               "be updated because current size {} is smaller than the update "
               "{}. This needs to be reported and investigated.",
-              _ntp,
+              get_manifest_path(),
               _archive_clean_offset,
               _archive_size_bytes,
               size_bytes);
@@ -803,7 +803,7 @@ bool partition_manifest::advance_start_offset(model::offset new_start_offset) {
               cst_log.error,
               "Previous start offset is not within segment in "
               "manifest for {}: previous_start_offset={}",
-              _ntp,
+              get_manifest_path(),
               previous_start_offset);
             previous_head_segment = _segments.begin();
         }
@@ -970,7 +970,7 @@ size_t partition_manifest::safe_segment_meta_to_add(
                   "[{}] New segment does not line up with last offset of empty "
                   "log: "
                   "last_offset: {}, new_segment: {}",
-                  _ntp,
+                  get_manifest_path(),
                   subst.last_offset,
                   m);
                 break;
@@ -1015,7 +1015,7 @@ size_t partition_manifest::safe_segment_meta_to_add(
                       cst_log.error,
                       "[{}] New segment does not line up with previous "
                       "segment: {}",
-                      _ntp,
+                      get_manifest_path(),
                       format_seg_meta_anomalies(anomalies));
                     break;
                 }
@@ -1041,7 +1041,7 @@ size_t partition_manifest::safe_segment_meta_to_add(
                           "[{}] New replacement segment does not line up with "
                           "previous "
                           "segment: {}",
-                          _ntp,
+                          get_manifest_path(),
                           format_seg_meta_anomalies(anomalies));
                         break;
                     }
@@ -1056,7 +1056,7 @@ size_t partition_manifest::safe_segment_meta_to_add(
                           "[{}] New replacement segment has the same size as "
                           "replaced "
                           "segment: new_segment: {}, replaced_segment: {}",
-                          _ntp,
+                          get_manifest_path(),
                           m,
                           *it);
                         break;
@@ -1086,7 +1086,7 @@ size_t partition_manifest::safe_segment_meta_to_add(
                       "committed "
                       "offset of "
                       "any previous segment: new_segment: {}",
-                      _ntp,
+                      get_manifest_path(),
                       m);
                     break;
                 }
@@ -1204,9 +1204,9 @@ void partition_manifest::spillover(const segment_meta& spillover_meta) {
     if (expected_meta != spillover_meta) {
         vlog(
           cst_log.error,
-          "{} Expected spillover metadata {} doesn't match actual spillover "
+          "[{}] Expected spillover metadata {} doesn't match actual spillover "
           "metadata {}",
-          _ntp,
+          get_manifest_path(),
           expected_meta,
           spillover_meta);
     } else {


### PR DESCRIPTION
log the whole cloud storage path for errors in partition_manifest. this should make easier to inspect cloud files

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none