### PR TITLE
rpk bundle: rearrange and gather more runtime system information in rpk debug bundle

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -114,7 +114,7 @@ and then re-specify the client credentials next time you log in.`)
 				fmt.Printf("    rpk profile create {name} --from-cloud {cluster_id}\n")
 				return
 			}
-			fmt.Print(msg)
+			fmt.Println(msg)
 		},
 	}
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -188,12 +188,12 @@ COMMON FILES
 
  - Data directory structure: A file describing the data directory's contents.
 
- - redpanda configuration: The redpanda configuration file (redpanda.yaml;
+ - Redpanda configuration: The redpanda configuration file (redpanda.yaml;
    SASL credentials are stripped).
 
- - /proc/cpuinfo: CPU information like make, core count, cache, frequency.
-
- - /proc/interrupts: IRQ distribution across CPU cores.
+ - Runtime system information (/proc): Process information, by reading /proc 
+  files like core count, cache, frequency, interrupts, mounted file systems, 
+  memory usage, kernel command line.
 
  - Resource usage data: CPU usage percentage, free memory available for the
    redpanda process.
@@ -209,7 +209,7 @@ COMMON FILES
 
 BARE-METAL
 
- - Kernel logs: The kernel logs ring buffer (syslog).
+ - Kernel: The kernel logs ring buffer (syslog) and parameters (sysctl).
 
  - DNS: The DNS info as reported by 'dig', using the hosts in
    /etc/resolv.conf.

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -105,9 +105,9 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				metricsInterval:         metricsInterval,
 			}
 
-			// to execute the appropriate bundle we look for
-			// kubernetes_service_* env variables as an indicator that we are
-			// in a k8s environment
+			// To execute the appropriate bundle we look for
+			// kubernetes_service_* env variables to identify if we are in a
+			// k8s environment.
 			host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
 			if len(host) == 0 || len(port) == 0 {
 				err = executeBundle(cmd.Context(), bp)

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -62,6 +62,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 
 	steps := []step{
 		saveCPUInfo(ps),
+		saveCmdLine(ps),
 		saveConfig(ps, bp.yActual),
 		saveControllerLogDir(ps, bp.y, bp.controllerLogLimitBytes),
 		saveDataDirStructure(ps, bp.y),
@@ -70,8 +71,11 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveK8SLogs(ctx, ps, bp.namespace, bp.logsSince, bp.logsLimitBytes),
 		saveK8SResources(ctx, ps, bp.namespace),
 		saveKafkaMetadata(ctx, ps, bp.cl),
+		saveMdstat(ps),
+		saveMountedFilesystems(ps),
 		saveNTPDrift(ps),
 		saveResourceUsageData(ps, bp.y),
+		saveSlabInfo(ps),
 	}
 
 	adminAddresses, err := adminAddressesFromK8S(ctx, bp.namespace)

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -52,24 +53,25 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 	defer w.Close()
 
 	ps := &stepParams{
-		fs:      bp.fs,
-		w:       w,
-		timeout: bp.timeout,
+		fs:       bp.fs,
+		w:        w,
+		timeout:  bp.timeout,
+		fileRoot: strings.TrimSuffix(filepath.Base(bp.path), ".zip"),
 	}
 	var errs *multierror.Error
 
 	steps := []step{
-		saveKafkaMetadata(ctx, ps, bp.cl),
-		saveDataDirStructure(ps, bp.y),
-		saveConfig(ps, bp.yActual),
 		saveCPUInfo(ps),
-		saveInterrupts(ps),
-		saveResourceUsageData(ps, bp.y),
-		saveNTPDrift(ps),
-		saveDiskUsage(ctx, ps, bp.y),
+		saveConfig(ps, bp.yActual),
 		saveControllerLogDir(ps, bp.y, bp.controllerLogLimitBytes),
-		saveK8SResources(ctx, ps, bp.namespace),
+		saveDataDirStructure(ps, bp.y),
+		saveDiskUsage(ctx, ps, bp.y),
+		saveInterrupts(ps),
 		saveK8SLogs(ctx, ps, bp.namespace, bp.logsSince, bp.logsLimitBytes),
+		saveK8SResources(ctx, ps, bp.namespace),
+		saveKafkaMetadata(ctx, ps, bp.cl),
+		saveNTPDrift(ps),
+		saveResourceUsageData(ps, bp.y),
 	}
 
 	adminAddresses, err := adminAddressesFromK8S(ctx, bp.namespace)

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -49,6 +49,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+const linuxUtilsRoot = "utils"
+
 // determineFilepath will process the given path and sets:
 //   - File Name: If the path is empty, the filename will be <timestamp>-bundle.zip
 //   - File Extension: if no extension is provided we default to .zip
@@ -609,7 +611,7 @@ func saveNTPDrift(ps *stepParams) step {
 
 		return writeFileToZip(
 			ps,
-			"ntp.txt",
+			filepath.Join(linuxUtilsRoot, "ntp.txt"),
 			marshalled,
 		)
 	}
@@ -621,14 +623,14 @@ func saveSyslog(ps *stepParams) step {
 		if err != nil {
 			return err
 		}
-		return writeFileToZip(ps, "syslog.txt", entries)
+		return writeFileToZip(ps, filepath.Join(linuxUtilsRoot, "syslog.txt"), entries)
 	}
 }
 
 // Saves the output of `dig`.
 func saveDNSData(ctx context.Context, ps *stepParams) step {
 	return func() error {
-		return writeCommandOutputToZip(ctx, ps, "dig.txt", "dig")
+		return writeCommandOutputToZip(ctx, ps, filepath.Join(linuxUtilsRoot, "dig.txt"), "dig")
 	}
 }
 
@@ -638,7 +640,7 @@ func saveDiskUsage(ctx context.Context, ps *stepParams, y *config.RedpandaYaml) 
 		return writeCommandOutputToZip(
 			ctx,
 			ps,
-			"du.txt",
+			filepath.Join(linuxUtilsRoot, "du.txt"),
 			"du", "-h", y.Redpanda.Directory,
 		)
 	}
@@ -668,7 +670,7 @@ func saveLogs(ctx context.Context, ps *stepParams, since, until string, logsLimi
 // Saves the output of `ss`.
 func saveSocketData(ctx context.Context, ps *stepParams) step {
 	return func() error {
-		return writeCommandOutputToZip(ctx, ps, "ss.txt", "ss")
+		return writeCommandOutputToZip(ctx, ps, filepath.Join(linuxUtilsRoot, "ss.txt"), "ss")
 	}
 }
 
@@ -678,7 +680,7 @@ func saveTopOutput(ctx context.Context, ps *stepParams) step {
 		return writeCommandOutputToZip(
 			ctx,
 			ps,
-			"top.txt",
+			filepath.Join(linuxUtilsRoot, "top.txt"),
 			"top", "-b", "-n", "10", "-H", "-d", "1",
 		)
 	}
@@ -690,7 +692,7 @@ func saveVmstat(ctx context.Context, ps *stepParams) step {
 		return writeCommandOutputToZip(
 			ctx,
 			ps,
-			"vmstat.txt",
+			filepath.Join(linuxUtilsRoot, "vmstat.txt"),
 			"vmstat", "-w", "1", "10",
 		)
 	}
@@ -702,7 +704,7 @@ func saveIP(ctx context.Context, ps *stepParams) step {
 		return writeCommandOutputToZip(
 			ctx,
 			ps,
-			"ip.txt",
+			filepath.Join(linuxUtilsRoot, "ip.txt"),
 			"ip", "addr",
 		)
 	}
@@ -714,7 +716,7 @@ func saveLspci(ctx context.Context, ps *stepParams) step {
 		return writeCommandOutputToZip(
 			ctx,
 			ps,
-			"lspci.txt",
+			filepath.Join(linuxUtilsRoot, "lspci.txt"),
 			"lspci",
 		)
 	}
@@ -726,7 +728,7 @@ func saveDmidecode(ctx context.Context, ps *stepParams) step {
 		return writeCommandOutputToZip(
 			ctx,
 			ps,
-			"dmidecode.txt",
+			filepath.Join(linuxUtilsRoot, "dmidecode.txt"),
 			"dmidecode",
 		)
 	}

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -57,9 +57,10 @@ class RpkClusterTest(RedpandaTest):
     def test_debug_bundle(self):
         # The main RpkTool helper runs rpk on the test runner machine -- debug
         # commands are run on redpanda nodes.
-
+        root_name = "bundle"
+        bundle_name = "bundle" + ".zip"
         working_dir = "/tmp"
-        file_path = os.path.join(working_dir, "bundle.zip")
+        file_path = os.path.join(working_dir, bundle_name)
         node = self.redpanda.nodes[0]
 
         rpk_remote = RpkRemoteTool(self.redpanda, node)
@@ -105,27 +106,27 @@ class RpkClusterTest(RedpandaTest):
 
         zf = zipfile.ZipFile(output_file)
         files = zf.namelist()
-        assert 'redpanda.yaml' in files
-        assert 'redpanda.log' in files
+        assert f'{root_name}/redpanda.yaml' in files
+        assert f'{root_name}/redpanda.log' in files
 
         # At least the first controller log is being saved:
-        assert 'controller/0-1-v1.log' in files
+        assert f'{root_name}/controller/0-1-v1.log' in files
 
         # Cluster admin API calls:
-        assert 'admin/brokers.json' in files
-        assert 'admin/cluster_config.json' in files
-        assert 'admin/health_overview.json' in files
+        assert f'{root_name}/admin/brokers.json' in files
+        assert f'{root_name}/admin/cluster_config.json' in files
+        assert f'{root_name}/admin/health_overview.json' in files
 
         # Per-node admin API calls:
         for n in self.redpanda.started_nodes():
             # rpk will save 2 snapsots per metrics endpoint:
-            assert f'metrics/{n.account.hostname}-9644/t0_metrics.txt' in files
-            assert f'metrics/{n.account.hostname}-9644/t1_metrics.txt' in files
-            assert f'metrics/{n.account.hostname}-9644/t0_public_metrics.txt' in files
-            assert f'metrics/{n.account.hostname}-9644/t1_public_metrics.txt' in files
+            assert f'{root_name}/metrics/{n.account.hostname}-9644/t0_metrics.txt' in files
+            assert f'{root_name}/metrics/{n.account.hostname}-9644/t1_metrics.txt' in files
+            assert f'{root_name}/metrics/{n.account.hostname}-9644/t0_public_metrics.txt' in files
+            assert f'{root_name}/metrics/{n.account.hostname}-9644/t1_public_metrics.txt' in files
             # and 1 cluster_view and node_config per node:
-            assert f'admin/cluster_view_{n.account.hostname}-9644.json' in files
-            assert f'admin/node_config_{n.account.hostname}-9644.json' in files
+            assert f'{root_name}/admin/cluster_view_{n.account.hostname}-9644.json' in files
+            assert f'{root_name}/admin/node_config_{n.account.hostname}-9644.json' in files
 
     @cluster(num_nodes=3)
     def test_get_config(self):


### PR DESCRIPTION
This PR:
- 67406299fd76291311c985ed442680ba654b0dd0 Save the debug bundle to a directory with the same name as the generated zip, before compressing. This will allow the user to freely unzip the file without worrying that doing so will clutter their working directory:
```
$ rpk debug bundle 
Creating bundle file...

Debug bundle saved to '1700522672-bundle.zip'
$ unzip -q 1700522672-bundle.zip 

# The unzipped directory is 1700522672-bundle 
$ ls -l 1700522672-bundle 
total 102M
drwxr-xr-x. 2 rvasquez rvasquez  260 Nov 20 15:26 admin
drwxr-xr-x. 2 rvasquez rvasquez 123K Nov 20 15:26 controller
...
```

- 0bc87e83e5adf593fe3c0e8c455c38106d1e6814 Now we group linux commands and utilities in a folder `/utils` inside the bundle.
```
$ ls -l 1700602020-bundle/utils 
total 3032
-rw-r--r--. 1 rvasquez rvasquez    2120 Nov 21 13:27 dig.txt
-rw-r--r--. 1 rvasquez rvasquez     142 Nov 21 13:27 dmidecode.txt
-rw-r--r--. 1 rvasquez rvasquez    4467 Nov 21 13:27 du.txt
-rw-r--r--. 1 rvasquez rvasquez     207 Nov 21 13:27 free.txt
-rw-r--r--. 1 rvasquez rvasquez    5356 Nov 21 13:27 ip.txt
-rw-r--r--. 1 rvasquez rvasquez    2274 Nov 21 13:27 lspci.txt
-rw-r--r--. 1 rvasquez rvasquez     172 Nov 21 13:27 ntp.txt
-rw-r--r--. 1 rvasquez rvasquez  310777 Nov 21 13:27 ss.txt
-rw-r--r--. 1 rvasquez rvasquez  132273 Nov 21 13:27 sysctl.txt
-rw-r--r--. 1 rvasquez rvasquez  167790 Nov 21 13:27 syslog.txt
-rw-r--r--. 1 rvasquez rvasquez 2448839 Nov 21 13:27 top.txt
-rw-r--r--. 1 rvasquez rvasquez    1389 Nov 21 13:27 vmstat.txt
```

- 93e997146970716ad4c0643b87569351c7482631 Adds new information to the bundle. That is, the output of:
  - /proc/mounts
  - /proc/slabinfo
  - /proc/cmdline
  - /proc/mdstat
  - sysctl -a
  - free
 
**Miscellaneous** 
- 18a5c68c2fd651d307d3e2c0da487a4d2389d590 Add a missing new line in `cloud login` Fixes #14885`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements

* rpk debug bundle: now your generated bundle with have a root directory with the same name as the generated file.
* rpk debug bundle now includes more runtime system information.
* rpk debug bundle: output of Linux commands will now be grouped under `/utils` in the generated bundle.
