### PR TITLE
rpk: list all partitions, including disabled

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_partition.go
+++ b/src/go/rpk/pkg/adminapi/api_partition.go
@@ -111,7 +111,10 @@ func (a *AdminAPI) Reconfigurations(ctx context.Context) ([]ReconfigurationsResp
 // disabled is true, only disabled partitions are returned.
 func (a *AdminAPI) AllClusterPartitions(ctx context.Context, withInternal, disabled bool) ([]ClusterPartition, error) {
 	var clusterPartitions []ClusterPartition
-	partitionsURL := fmt.Sprintf("%v?with_internal=%v&disabled=%v", partitionsBaseURL, withInternal, disabled)
+	partitionsURL := fmt.Sprintf("%v?with_internal=%v", partitionsBaseURL, withInternal)
+	if disabled {
+		partitionsURL += "&disabled=true"
+	}
 	return clusterPartitions, a.sendAny(ctx, http.MethodGet, partitionsURL, nil, &clusterPartitions)
 }
 
@@ -119,7 +122,10 @@ func (a *AdminAPI) AllClusterPartitions(ctx context.Context, withInternal, disab
 // a given topic. If disabled is true, only disabled partitions are returned.
 func (a *AdminAPI) TopicClusterPartitions(ctx context.Context, namespace, topic string, disabled bool) ([]ClusterPartition, error) {
 	var clusterPartition []ClusterPartition
-	partitionURL := fmt.Sprintf("%v/%v/%v?disabled=%v", partitionsBaseURL, namespace, topic, disabled)
+	partitionURL := fmt.Sprintf("%v/%v/%v", partitionsBaseURL, namespace, topic)
+	if disabled {
+		partitionURL += "?disabled=true"
+	}
 	return clusterPartition, a.sendAny(ctx, http.MethodGet, partitionURL, nil, &clusterPartition)
 }
 


### PR DESCRIPTION
Redpanda's admin API interprets the absence of the 'disabled' query parameter differently from when its value is set to false.

If it's absent, it will list _all_ partitions, including disabled.

EXAMPLES:
```
# All:
$ rpk cluster partitions list -a 
NAMESPACE       TOPIC               PARTITION  LEADER-ID  REPLICA-CORE   DISABLED
kafka           __consumer_offsets  0          -          [0-5 1-6 2-5]  false
kafka           __consumer_offsets  1          -          [0-6 1-7 2-6]  false
kafka           __consumer_offsets  2          -          [0-7 1-8 2-7]  false
kafka           bar                 0          -          [0-1 1-2 2-1]  false
kafka           bar                 1          -          [0-2 1-3 2-2]  true   <--- #disabled included
kafka           bar                 2          -          [0-3 1-4 2-3]  false
kafka           foo                 0          -          [1-1]          false
kafka_internal  id_allocator        0          -          [0-4 1-5 2-4]  false

# Disabled only 
$ rpk cluster partitions list -a --disabled-only 
NAMESPACE  TOPIC  PARTITION  LEADER-ID  REPLICA-CORE   DISABLED
kafka      bar    1          -          [0-2 1-3 2-2]  true

# Per-topic
$ rpk cluster partitions list bar               
NAMESPACE  TOPIC  PARTITION  LEADER-ID  REPLICA-CORE   DISABLED
kafka      bar    0          -          [0-1 1-2 2-1]  false
kafka      bar    1          -          [0-2 1-3 2-2]  true   <--- #disabled included
kafka      bar    2          -          [0-3 1-4 2-3]  false

# Per-topic, disabled only
$ rpk cluster partitions list bar --disabled-only 
NAMESPACE  TOPIC  PARTITION  LEADER-ID  REPLICA-CORE   DISABLED
kafka      bar    1          -          [0-2 1-3 2-2]  true

```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes


* none
