### PR TITLE
transform/probe: rename metrics

### DIFF
--- a/src/v/transform/probe.cc
+++ b/src/v/transform/probe.cc
@@ -53,7 +53,7 @@ void probe::setup_metrics(ss::sstring transform_name) {
       sm::make_counter(
         "failures",
         [this] { return _failures; },
-        sm::description("The number of processor failures"),
+        sm::description("The number of transform failures"),
         labels)
         .aggregate({sm::shard_label}));
 
@@ -67,13 +67,12 @@ void probe::setup_metrics(ss::sstring transform_name) {
           sm::make_gauge(
             "state",
             [this, s] { return _processor_state[s]; },
-            sm::description(
-              "The number of transform processors in a specific state"),
+            sm::description("The number of transforms in a specific state"),
             state_labels)
             .aggregate({sm::shard_label}));
     }
     _public_metrics.add_group(
-      prometheus_sanitize::metrics_name("transform_processor"), metric_defs);
+      prometheus_sanitize::metrics_name("transform"), metric_defs);
 }
 void probe::increment_write_bytes(uint64_t bytes) { _write_bytes += bytes; }
 void probe::increment_read_bytes(uint64_t bytes) { _read_bytes += bytes; }


### PR DESCRIPTION
Drop the processor lingo as we don't use in docs and it was requested by
product to drop.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
