### PR TITLE
rpk/transform: split tinygo

### DIFF
--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -96,9 +96,9 @@ This initializes a transform project in the foobar directory.
 				}
 			}
 			if lang == "" {
-				langVal, err := out.Pick(project.AllWasmLangs, "select a language:")
+				idx, err := out.PickIndex(project.AllWasmLangsWithDescriptions, "select a language:")
 				out.MaybeDie(err, "unable to determine transform language: %v", err)
-				lang = project.WasmLang(langVal)
+				lang = project.WasmLang(project.AllWasmLangs[idx])
 			}
 			p := transformProject{Name: name, Lang: lang, Path: path}
 
@@ -187,7 +187,10 @@ type genFile struct {
 }
 
 func generateManifest(p transformProject) (map[string][]genFile, error) {
-	if p.Lang == project.WasmLangTinygo {
+	switch p.Lang {
+	case project.WasmLangTinygoNoGoroutines:
+		fallthrough
+	case project.WasmLangTinygoWithGoroutines:
 		rpConfig, err := project.MarshalConfig(project.Config{Name: p.Name, Language: p.Lang})
 		if err != nil {
 			return nil, err
@@ -224,7 +227,10 @@ func executeGenerate(fs afero.Fs, p transformProject) error {
 }
 
 func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
-	if p.Lang == project.WasmLangTinygo {
+	switch p.Lang {
+	case project.WasmLangTinygoNoGoroutines:
+		fallthrough
+	case project.WasmLangTinygoWithGoroutines:
 		g, err := exec.LookPath("go")
 		if err != nil {
 			return fmt.Errorf("go is not available on $PATH, please download and install it: https://go.dev/doc/install")

--- a/src/go/rpk/pkg/cli/transform/project/project.go
+++ b/src/go/rpk/pkg/cli/transform/project/project.go
@@ -20,10 +20,22 @@ import (
 type WasmLang string
 
 const (
-	WasmLangTinygo WasmLang = "tinygo"
+	WasmLangTinygoWithGoroutines WasmLang = "tinygo-with-goroutines"
+	WasmLangTinygoNoGoroutines   WasmLang = "tinygo-no-goroutines"
 )
 
-var AllWasmLangs = []string{"tinygo"}
+var AllWasmLangs = []string{
+	string(WasmLangTinygoNoGoroutines),
+	string(WasmLangTinygoWithGoroutines),
+}
+
+// AllWasmLangsWithDescriptions is AllWasmLangs but with extended descriptions.
+//
+// The order here must match AllWasmLangs.
+var AllWasmLangsWithDescriptions = []string{
+	"Tinygo (no goroutines) - higher throughput",
+	"Tinygo (with goroutines)",
+}
 
 func (l *WasmLang) Set(str string) error {
 	lower := strings.ToLower(str)


### PR DESCRIPTION
Split tinygo into two "language" options, one with the scheduler and one
without. This prevents the need from remembering to always enable the
scheduler and instead one can just pick this at initialization time.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
