### PR TITLE
Add byte-granular memory size to broker properties

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -148,7 +148,8 @@ model::broker make_self_broker(const config::node_config& node_cfg) {
         // TODO: populate or remote etc_props, mount_paths
         .cores = ss::smp::count,
         .available_memory_gb = total_mem_gb,
-        .available_disk_gb = disk_gb});
+        .available_disk_gb = disk_gb,
+        .available_memory_bytes = total_mem});
 }
 
 bool has_local_replicas(

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -170,13 +170,11 @@ std::error_code partition_allocator::check_cluster_limits(
             min_core_count = std::min(min_core_count, b_properties.cores);
         }
 
-        // In redpanda <= 21.11.x, available_memory_gb and available_disk_gb
-        // are not populated.  If they're zero we skip the check later.
         if (min_memory_bytes == 0) {
-            min_memory_bytes = b_properties.available_memory_gb * 1_GiB;
-        } else if (b_properties.available_memory_gb > 0) {
+            min_memory_bytes = b.broker.memory_bytes();
+        } else {
             min_memory_bytes = std::min(
-              min_memory_bytes, b_properties.available_memory_gb * 1_GiB);
+              min_memory_bytes, b.broker.memory_bytes());
         }
 
         if (min_disk_bytes == 0) {
@@ -225,7 +223,7 @@ std::error_code partition_allocator::check_cluster_limits(
         const uint64_t memory_limit = effective_cluster_memory
                                       / memory_per_partition_replica.value();
 
-        if (memory_limit > 0 && proposed_total_partitions > memory_limit) {
+        if (proposed_total_partitions > memory_limit) {
             vlog(
               clusterlog.warn,
               "Refusing to create {} new partitions as total partition count "

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -50,7 +50,8 @@ public:
           model::broker_properties{
             .cores = n_cores,
             .available_memory_gb = 2,
-            .available_disk_gb = uint32_t(total_size / 1_GiB)});
+            .available_disk_gb = uint32_t(total_size / 1_GiB),
+            .available_memory_bytes = 2 * 1_GiB});
 
         _workers.members.local().apply(
           model::offset{}, cluster::add_node_cmd(id, broker));

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -89,7 +89,8 @@ SEASTAR_THREAD_TEST_CASE(broker_metadata_rt_test) {
         .available_memory_gb = 1024,
         .available_disk_gb = static_cast<uint32_t>(10000000000),
         .mount_paths = {"/", "/var/lib"},
-        .etc_props = {{"max_segment_size", "1233451"}}});
+        .etc_props = {{"max_segment_size", "1233451"}},
+        .available_memory_bytes = 1024 * 1_GiB});
     auto d = serialize_roundtrip_rpc(std::move(b));
 
     BOOST_REQUIRE_EQUAL(d.id(), model::node_id(0));
@@ -107,6 +108,7 @@ SEASTAR_THREAD_TEST_CASE(broker_metadata_rt_test) {
     BOOST_REQUIRE_EQUAL(
       d.properties().etc_props.find("max_segment_size")->second, "1233451");
     BOOST_CHECK(d.rack() == std::optional<ss::sstring>("test"));
+    BOOST_REQUIRE_EQUAL(d.properties().available_memory_bytes, 1024 * 1_GiB);
 }
 
 SEASTAR_THREAD_TEST_CASE(partition_assignment_rt_test) {

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -300,6 +300,8 @@ inline void rjson_serialize(
     rjson_serialize(w, b.mount_paths);
     w.Key("etc_props");
     rjson_serialize(w, b.etc_props);
+    w.Key("available_memory_bytes");
+    rjson_serialize(w, b.available_memory_bytes);
     w.EndObject();
 }
 
@@ -309,6 +311,7 @@ inline void read_value(json::Value const& rd, model::broker_properties& obj) {
     read_member(rd, "available_disk_gb", obj.available_disk_gb);
     read_member(rd, "mount_paths", obj.mount_paths);
     read_member(rd, "etc_props", obj.etc_props);
+    read_member(rd, "available_memory_bytes", obj.available_memory_bytes);
 }
 
 inline void

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -15,6 +15,7 @@
 #include "net/unresolved_address.h"
 #include "seastarx.h"
 #include "serde/envelope.h"
+#include "units.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/sstring.hh>
@@ -59,21 +60,16 @@ using initial_revision_id
 using rack_id = named_type<ss::sstring, struct rack_id_model_type>;
 struct broker_properties
   : serde::
-      envelope<broker_properties, serde::version<0>, serde::compat_version<0>> {
+      envelope<broker_properties, serde::version<1>, serde::compat_version<0>> {
     uint32_t cores;
     uint32_t available_memory_gb;
     uint32_t available_disk_gb;
     std::vector<ss::sstring> mount_paths;
     // key=value properties in /etc/redpanda/machine_properties.yaml
     std::unordered_map<ss::sstring, ss::sstring> etc_props;
+    uint64_t available_memory_bytes = 0;
 
-    bool operator==(const broker_properties& other) const {
-        return cores == other.cores
-               && available_memory_gb == other.available_memory_gb
-               && available_disk_gb == other.available_disk_gb
-               && mount_paths == other.mount_paths
-               && etc_props == other.etc_props;
-    }
+    bool operator==(const broker_properties& other) const = default;
 
     friend std::ostream&
     operator<<(std::ostream&, const model::broker_properties&);
@@ -84,7 +80,8 @@ struct broker_properties
           available_memory_gb,
           available_disk_gb,
           mount_paths,
-          etc_props);
+          etc_props,
+          available_memory_bytes);
     }
 };
 
@@ -231,6 +228,17 @@ public:
     }
     const net::unresolved_address& rpc_address() const { return _rpc_address; }
     const std::optional<rack_id>& rack() const { return _rack; }
+
+    /// Returns the memory for this broker in bytes.
+    uint64_t memory_bytes() const {
+        // For redpanda < 23.3, available_memory_bytes is not populated and
+        // will be zero. Fallback to available_memory_gb in that case.
+        if (_properties.available_memory_bytes > 0) {
+            return _properties.available_memory_bytes;
+        }
+
+        return _properties.available_memory_gb * 1_GiB;
+    }
 
     void replace_unassigned_node_id(const node_id id) {
         vassert(

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -191,7 +191,7 @@ std::ostream& operator<<(std::ostream& o, const model::broker_properties& b) {
       o,
       "{{cores {}, mem_available {}, disk_available {}}}",
       b.cores,
-      b.available_memory_gb,
+      b.available_memory_bytes,
       b.available_disk_gb,
       b.mount_paths,
       b.etc_props);

--- a/src/v/raft/tests/type_serialization_tests.cc
+++ b/src/v/raft/tests/type_serialization_tests.cc
@@ -504,9 +504,21 @@ SEASTAR_THREAD_TEST_CASE(snapshot_metadata_roundtrip) {
 }
 
 SEASTAR_THREAD_TEST_CASE(snapshot_metadata_backward_compatibility) {
-    auto n1 = model::random_broker(0, 100);
-    auto n2 = model::random_broker(0, 100);
-    auto n3 = model::random_broker(0, 100);
+    auto bp1 = model::random_broker_properties();
+    // Zero out the available_memory_bytes field which isn't supported
+    // by adl since the field was added after serde serialization became
+    // the default.
+    bp1.available_memory_bytes = 0;
+    auto n1 = model::random_broker(0, 100, bp1);
+
+    auto bp2 = model::random_broker_properties();
+    bp2.available_memory_bytes = 0;
+    auto n2 = model::random_broker(0, 100, bp2);
+
+    auto bp3 = model::random_broker_properties();
+    bp3.available_memory_bytes = 0;
+    auto n3 = model::random_broker(0, 100, bp3);
+
     std::vector<model::broker> nodes{n1, n2, n3};
     raft::group_nodes current{
       .voters

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -90,9 +90,13 @@ class ScaleParameters:
         if self.node_cpus >= 8:
             shard0_reserve = PARTITIONS_PER_SHARD / 2
 
-        # Reserve a few slots for internal partitions, do not be
-        # super specific about how many because we may add some in
-        # future for e.g. audit logging.
+        # Reserve a few slots for internal partitions. This is a count of
+        # partitions and we assume the replication factor is 'replication_factor'
+        # in order to calculate the associated number of partition replicas.
+        #
+        # The way we calculate internal partitions in practice is complicated
+        # and this value is an over-simplification. See generate-tiers.py for
+        # additional details on internal partition calculations.
         internal_partition_slack = 32
 
         # Calculate how many partitions we will aim to create, based
@@ -116,12 +120,12 @@ class ScaleParameters:
         reserved_memory = max(1536, int(0.07 * node_memory) + 1)
         effective_node_memory = node_memory - reserved_memory
 
+        partition_replicas_per_node = int(self.partition_limit *
+                                          replication_factor // node_count)
+
         # Aim to use about half the disk space: set retention limits
         # to enforce that.  This enables traffic tests to run as long
         # as they like without risking filling the disk.
-        partition_replicas_per_node = int(
-            (self.partition_limit * replication_factor) / node_count)
-
         self.retention_bytes = int(
             (node_disk_free / 2) / partition_replicas_per_node)
         self.local_retention_bytes = None
@@ -199,31 +203,32 @@ class ScaleParameters:
             self.expect_bandwidth /= 2
             self.expect_single_bandwidth /= 2
 
-        mb_per_partition = 1
+        # Clamp the node memory to exercise the partition limit.
+        mb_per_partition = 4
+        # Not all internal partitions have rf=replication_factor so this
+        # over-allocates but making it more accurate would be complicated.
+        per_node_slack = internal_partition_slack * replication_factor / node_count
+        partition_mem_total_per_node = mb_per_partition * (
+            partition_replicas_per_node + per_node_slack)
+
+        resource_settings_args = {}
         if not self.redpanda.dedicated_nodes:
             # In docker, assume we're on a laptop drive and not doing
             # real testing, so disable fsync to make test run faster.
-            resource_settings_args = {'bypass_fsync': True}
+            resource_settings_args['bypass_fsync'] = True
 
-            # In docker, make the test a bit more realistic by clamping
-            # memory if nodes have more memory than should be required
-            # to exercise the partition limit.
-            if effective_node_memory > partition_replicas_per_node / mb_per_partition:
-                clamp_memory = mb_per_partition * (
-                    (partition_replicas_per_node + internal_partition_slack) +
-                    reserved_memory)
-
-                # Handy if hacking HARD_PARTITION_LIMIT to something low to run on a workstation
-                clamp_memory = max(clamp_memory, 500)
-                resource_settings_args['memory_mb'] = clamp_memory
-
-            self.redpanda.set_resource_settings(
-                ResourceSettings(**resource_settings_args))
+            # Handy if hacking HARD_PARTITION_LIMIT to something low to run on a workstation
+            partition_mem_total_per_node = max(partition_mem_total_per_node,
+                                               500)
         else:
             # On dedicated nodes we will use an explicit reactor stall threshold
             # as a success condition.
-            self.redpanda.set_resource_settings(
-                ResourceSettings(reactor_stall_threshold=100))
+            resource_settings_args['reactor_stall_threshold'] = 100
+
+        resource_settings_args['memory_mb'] = int(partition_mem_total_per_node)
+
+        self.redpanda.set_resource_settings(
+            ResourceSettings(**resource_settings_args))
 
         self.logger.info(
             f"Selected retention.bytes={self.retention_bytes}, retention.local.target.bytes={self.local_retention_bytes}, segment.bytes={self.segment_size}"
@@ -231,7 +236,7 @@ class ScaleParameters:
 
         # Should not happen on the expected EC2 instance types where
         # the cores-RAM ratio is sufficient to meet our shards-per-core
-        if effective_node_memory < partition_replicas_per_node / mb_per_partition:
+        if effective_node_memory < partition_mem_total_per_node:
             raise RuntimeError(
                 f"Node memory is too small ({node_memory}MB - {reserved_memory}MB)"
             )

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -1064,7 +1064,10 @@ class ManyPartitionsTest(PreallocNodesTest):
                     f"Waiting for {repeater_await_msgs} messages in {t} seconds"
                 )
                 t1 = time.time()
-                repeater.await_progress(repeater_await_msgs, t)
+                repeater.await_progress(
+                    repeater_await_msgs,
+                    t,
+                    err_msg=f"Waiting for repeater messages")
                 t2 = time.time()
 
                 # This is approximate, because await_progress isn't returning the very
@@ -1099,7 +1102,9 @@ class ManyPartitionsTest(PreallocNodesTest):
             t1 = time.time()
             initial_p, _ = repeater.total_messages()
             try:
-                repeater.await_progress(soak_await_msgs, soak_timeout)
+                repeater.await_progress(soak_await_msgs,
+                                        soak_timeout,
+                                        err_msg="Waiting for traffic soak")
             except TimeoutError:
                 t2 = time.time()
                 final_p, _ = repeater.total_messages()

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -266,12 +266,15 @@ class KgoRepeaterService(Service):
             else:
                 return True
 
-        self.logger.debug(f"Waiting for group {self.group_name} to be ready")
+        what = f"Waiting for group {self.group_name} to be ready"
+        self.logger.debug(what)
+
         t1 = time.time()
         try:
             self.redpanda.wait_until(group_ready,
                                      timeout_sec=120,
-                                     backoff_sec=10)
+                                     backoff_sec=10,
+                                     err_msg=what)
         except:
             # On failure, dump stacks on all workers in case there is an apparent client bug to investigate
             for node in self.nodes:
@@ -326,7 +329,7 @@ class KgoRepeaterService(Service):
 
         return produced, consumed
 
-    def await_progress(self, msg_count, timeout_sec):
+    def await_progress(self, msg_count, timeout_sec, err_msg=None):
         """
         Call this in places you want to assert some progress
         is really being made: say how many messages should be
@@ -352,7 +355,10 @@ class KgoRepeaterService(Service):
         # the system isn't at peak throughput (e.g. when it's just warming up)
         timeout_sec = max(timeout_sec, 60)
 
-        self.redpanda.wait_until(check, timeout_sec=timeout_sec, backoff_sec=1)
+        self.redpanda.wait_until(check,
+                                 timeout_sec=timeout_sec,
+                                 backoff_sec=1,
+                                 err_msg=err_msg)
 
 
 @contextmanager

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -549,12 +549,14 @@ class KgoVerifierProducer(KgoVerifierService):
         if not self._status_thread:
             return True
 
-        self.logger.debug(f"{self.who_am_i()} wait: awaiting message count")
+        what = f"{self.who_am_i()} wait: awaiting message count"
+        self.logger.debug(what)
         try:
             self._redpanda.wait_until(lambda: self._status_thread.errored or
                                       self._status.acked >= self._msg_count,
                                       timeout_sec=timeout_sec,
-                                      backoff_sec=self._status_thread.INTERVAL)
+                                      backoff_sec=self._status_thread.INTERVAL,
+                                      err_msg=what)
         except:
             self.stop_node(node)
             raise


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

There's a desire to see how close to the memory limits we can push the shard count and memory per partition. But the current checks in `check_cluster_limits()` only use GiB-granular calculations for the cluster memory which results in overly-pessimistic partition counts if nodes have fractional memory sizes, e.g. 15.9GiB. Add a new `available_memory_bytes` field to `broker_properties` to make these calculations more accurate. Also, update `ManyPartitionsTest` to constrain the available node memory based on the number of partitions and memory per partition. MPT now gives us a solid baseline for further tweaks.

Fixes #13573 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Allow users to create more partitions and allocate fractional GiB memory sizes (e.g. 15.9GiB) 