### PR TITLE
[ v23.2.x] Manual backport: add rpk cluster partitions list 

### DIFF
--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -317,7 +317,7 @@ func (a *AdminAPI) sendAny(ctx context.Context, method, path string, body, into 
 
 		// If err is set, we are retrying after a failure on the previous node
 		if err != nil {
-			fmt.Printf("Request error, trying another node: %s\n", err.Error())
+			zap.L().Warn(fmt.Sprintf("Request error, trying another node: %s", err.Error()))
 			var httpErr *HTTPResponseError
 			if errors.As(err, &httpErr) {
 				status := httpErr.Response.StatusCode

--- a/src/go/rpk/pkg/adminapi/api_partition.go
+++ b/src/go/rpk/pkg/adminapi/api_partition.go
@@ -19,8 +19,8 @@ const partitionsBaseURL = "/v1/cluster/partitions"
 
 // Replica contains the information of a partition replica.
 type Replica struct {
-	NodeID int `json:"node_id"`
-	Core   int `json:"core"`
+	NodeID int `json:"node_id"  yaml:"node_id"`
+	Core   int `json:"core" yaml:"core"`
 }
 
 // Partition is the information returned from the Redpanda admin partitions endpoints.
@@ -60,18 +60,13 @@ type ReconfigurationsResponse struct {
 	ReconciliationStatuses []Status  `json:"reconciliation_statuses"`
 }
 
-type ReplicaAssignment struct {
-	NodeID int `json:"node_id" yaml:"node_id"`
-	Core   int `json:"core" yaml:"core"`
-}
-
 type ClusterPartition struct {
-	Ns          string              `json:"ns" yaml:"ns"`
-	Topic       string              `json:"topic" yaml:"topic"`
-	PartitionID int                 `json:"partition_id" yaml:"partition_id"`
-	LeaderID    *int                `json:"leader_id,omitempty" yaml:"leader_id,omitempty"` // LeaderID may be missing in the response.
-	Replicas    []ReplicaAssignment `json:"replicas" yaml:"replicas"`
-	Disabled    bool                `json:"disabled" yaml:"disabled"`
+	Ns          string    `json:"ns" yaml:"ns"`
+	Topic       string    `json:"topic" yaml:"topic"`
+	PartitionID int       `json:"partition_id" yaml:"partition_id"`
+	LeaderID    *int      `json:"leader_id,omitempty" yaml:"leader_id,omitempty"` // LeaderID may be missing in the response.
+	Replicas    []Replica `json:"replicas" yaml:"replicas"`
+	Disabled    *bool     `json:"disabled,omitempty" yaml:"disabled,omitempty"` // Disabled may be discarded if not present.
 }
 
 // GetPartition returns detailed partition information.
@@ -79,12 +74,13 @@ func (a *AdminAPI) GetPartition(
 	ctx context.Context, namespace, topic string, partition int,
 ) (Partition, error) {
 	var pa Partition
-	return pa, a.sendAny(
-		ctx,
-		http.MethodGet,
-		fmt.Sprintf("/v1/partitions/%s/%s/%d", namespace, topic, partition),
-		nil,
-		&pa)
+	return pa, a.sendAny(ctx, http.MethodGet, fmt.Sprintf("/v1/partitions/%s/%s/%d", namespace, topic, partition), nil, &pa)
+}
+
+// GetTopic returns detailed information of all partitions for a given topic.
+func (a *AdminAPI) GetTopic(ctx context.Context, namespace, topic string) ([]Partition, error) {
+	var pa []Partition
+	return pa, a.sendAny(ctx, http.MethodGet, fmt.Sprintf("/v1/partitions/%s/%s", namespace, topic), nil, &pa)
 }
 
 // Reconfigurations returns the list of ongoing partition reconfigurations.

--- a/src/go/rpk/pkg/adminapi/api_partition.go
+++ b/src/go/rpk/pkg/adminapi/api_partition.go
@@ -94,7 +94,10 @@ func (a *AdminAPI) Reconfigurations(ctx context.Context) ([]ReconfigurationsResp
 // disabled is true, only disabled partitions are returned.
 func (a *AdminAPI) AllClusterPartitions(ctx context.Context, withInternal, disabled bool) ([]ClusterPartition, error) {
 	var clusterPartitions []ClusterPartition
-	partitionsURL := fmt.Sprintf("%v?with_internal=%v&disabled=%v", partitionsBaseURL, withInternal, disabled)
+	partitionsURL := fmt.Sprintf("%v?with_internal=%v", partitionsBaseURL, withInternal)
+	if disabled {
+		partitionsURL += "&disabled=true"
+	}
 	return clusterPartitions, a.sendAny(ctx, http.MethodGet, partitionsURL, nil, &clusterPartitions)
 }
 
@@ -102,6 +105,9 @@ func (a *AdminAPI) AllClusterPartitions(ctx context.Context, withInternal, disab
 // a given topic. If disabled is true, only disabled partitions are returned.
 func (a *AdminAPI) TopicClusterPartitions(ctx context.Context, namespace, topic string, disabled bool) ([]ClusterPartition, error) {
 	var clusterPartition []ClusterPartition
-	partitionURL := fmt.Sprintf("%v/%v/%v?disabled=%v", partitionsBaseURL, namespace, topic, disabled)
+	partitionURL := fmt.Sprintf("%v/%v/%v", partitionsBaseURL, namespace, topic)
+	if disabled {
+		partitionURL += "?disabled=true"
+	}
 	return clusterPartition, a.sendAny(ctx, http.MethodGet, partitionURL, nil, &clusterPartition)
 }

--- a/src/go/rpk/pkg/cli/cluster/partitions/cancel.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/cancel.go
@@ -1,3 +1,12 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package partitions
 
 import (

--- a/src/go/rpk/pkg/cli/cluster/partitions/cancel_hidden.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/cancel_hidden.go
@@ -1,3 +1,12 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package partitions
 
 import (

--- a/src/go/rpk/pkg/cli/cluster/partitions/list.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/list.go
@@ -1,0 +1,152 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package partitions
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/types"
+	"golang.org/x/sync/errgroup"
+)
+
+func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		all          bool
+		disabledOnly bool
+		partitions   []int
+	)
+	cmd := &cobra.Command{
+		Use:     "list [TOPICS]",
+		Aliases: []string{"ls", "describe"},
+		Short:   "List partitions in the cluster",
+		Long: `List partitions in the cluster
+
+This commands lists the cluster-level metadata of all partitions in the cluster.
+It shows the current replica assignments on both brokers and CPU cores for given
+topics. By default, it assumes the "kafka" namespace, but you can specify an
+internal namespace using the "{namespace}/" prefix.
+
+The REPLICA-CORE column displayed in the output table contains a list of
+replicas assignments in the form of: <Node-ID>-<Core>.
+
+EXAMPLES
+
+List all partitions in the cluster.
+  rpk cluster partitions list --all
+
+List all partitions in the cluster, filtering for topic foo and bar.
+  rpk cluster partitions list foo bar
+
+List only the disabled partitions.
+  rpk cluster partitions list -a --only-disabled
+`,
+		Run: func(cmd *cobra.Command, topics []string) {
+			if len(topics) == 0 && !all {
+				cmd.Help()
+				return
+			}
+			if len(topics) > 0 && all {
+				out.Die("flag '--all' cannot be used with topic filters.\n%v", cmd.UsageString())
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+			out.CheckExitCloudAdmin(p)
+
+			cl, err := adminapi.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			var clusterPartitions []adminapi.ClusterPartition
+			var mu sync.Mutex
+			if len(topics) == 0 && all {
+				clusterPartitions, err = cl.AllClusterPartitions(cmd.Context(), true, disabledOnly)
+				out.MaybeDie(err, "unable to query all partitions in the cluster: %v", err)
+			} else {
+				g, egCtx := errgroup.WithContext(cmd.Context())
+				for _, topic := range topics {
+					if topic == "" {
+						out.Die("invalid empty topic\n%v", cmd.UsageString())
+					}
+					nsTopic := strings.SplitN(topic, "/", 2)
+					var ns, topicName string
+					if len(nsTopic) == 1 {
+						ns = "kafka"
+						topicName = nsTopic[0]
+					} else {
+						ns = nsTopic[0]
+						topicName = nsTopic[1]
+					}
+					g.Go(func() error {
+						cPartition, err := cl.TopicClusterPartitions(egCtx, ns, topicName, disabledOnly)
+						if err != nil {
+							return fmt.Errorf("unable to query cluster partition metadata of topic %q: %v", topicName, err)
+						}
+						mu.Lock()
+						clusterPartitions = append(clusterPartitions, cPartition...)
+						mu.Unlock()
+						return nil
+					})
+				}
+				err := g.Wait()
+				out.MaybeDieErr(err)
+			}
+			if partitions != nil {
+				clusterPartitions = filterPartition(clusterPartitions, partitions)
+			}
+			types.Sort(clusterPartitions)
+			tw := out.NewTable("NAMESPACE", "TOPIC", "PARTITION", "LEADER-ID", "REPLICA-CORE", "DISABLED")
+			defer tw.Flush()
+			for _, p := range clusterPartitions {
+				var leader string
+				var replicas []string
+				if p.LeaderID == nil {
+					leader = "-"
+				}
+				for _, r := range p.Replicas {
+					replicas = append(replicas, fmt.Sprintf("%v-%v", r.NodeID, r.Core))
+				}
+				tw.PrintStructFields(struct {
+					Namespace string
+					Topic     string
+					Partition int
+					LeaderID  string
+					Replicas  []string
+					Disabled  bool
+				}{p.Ns, p.Topic, p.PartitionID, leader, replicas, p.Disabled})
+			}
+		},
+	}
+	cmd.Flags().BoolVarP(&all, "all", "a", false, "If true, list all partitions in the cluster")
+	cmd.Flags().BoolVar(&disabledOnly, "only-disabled", false, "If true, list disabled partitions only")
+	cmd.Flags().IntSliceVarP(&partitions, "partition", "p", nil, "Partitions to show current assignments (repeatable)")
+
+	return cmd
+}
+
+// filterPartition filters cPartitions and returns a slice with only the
+// clusterPartitions with ID present in the partitions slice.
+func filterPartition(cPartitions []adminapi.ClusterPartition, partitions []int) (ret []adminapi.ClusterPartition) {
+	pm := make(map[int]bool, 0)
+	for _, p := range partitions {
+		pm[p] = true
+	}
+	for _, c := range cPartitions {
+		if pm[c.PartitionID] {
+			ret = append(ret, c)
+		}
+	}
+	return
+}

--- a/src/go/rpk/pkg/cli/cluster/partitions/list.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/list.go
@@ -10,7 +10,11 @@
 package partitions
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -20,17 +24,19 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/twmb/types"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 )
 
 func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
-		all          bool
-		disabledOnly bool
-		partitions   []int
+		all             bool
+		disabledOnly    bool
+		partitions      []int
+		logFallbackOnce sync.Once
 	)
 	cmd := &cobra.Command{
-		Use:     "list [TOPICS]",
+		Use:     "list [TOPICS...]",
 		Aliases: []string{"ls", "describe"},
 		Short:   "List partitions in the cluster",
 		Long: `List partitions in the cluster
@@ -43,6 +49,9 @@ internal namespace using the "{namespace}/" prefix.
 The REPLICA-CORE column displayed in the output table contains a list of
 replicas assignments in the form of: <Node-ID>-<Core>.
 
+If the DISABLED column contains a '-' value, then it means you are running this
+command against a cluster that does not support the underlying API.
+
 EXAMPLES
 
 List all partitions in the cluster.
@@ -52,7 +61,7 @@ List all partitions in the cluster, filtering for topic foo and bar.
   rpk cluster partitions list foo bar
 
 List only the disabled partitions.
-  rpk cluster partitions list -a --only-disabled
+  rpk cluster partitions list -a --disabled-only
 `,
 		Run: func(cmd *cobra.Command, topics []string) {
 			if len(topics) == 0 && !all {
@@ -73,6 +82,13 @@ List only the disabled partitions.
 			var mu sync.Mutex
 			if len(topics) == 0 && all {
 				clusterPartitions, err = cl.AllClusterPartitions(cmd.Context(), true, disabledOnly)
+				// If the admin API returns a 404, most likely rpk is talking
+				// with an old cluster.
+				if he := (*adminapi.HTTPResponseError)(nil); errors.As(err, &he) {
+					if he.Response.StatusCode == http.StatusNotFound {
+						out.Die("unable to query all partitions in the cluster: %vYou may need to upgrade the cluster to access this feature or try listing per-topic with: 'rpk cluster partition list [TOPICS...]'", err)
+					}
+				}
 				out.MaybeDie(err, "unable to query all partitions in the cluster: %v", err)
 			} else {
 				g, egCtx := errgroup.WithContext(cmd.Context())
@@ -80,19 +96,28 @@ List only the disabled partitions.
 					if topic == "" {
 						out.Die("invalid empty topic\n%v", cmd.UsageString())
 					}
-					nsTopic := strings.SplitN(topic, "/", 2)
-					var ns, topicName string
-					if len(nsTopic) == 1 {
-						ns = "kafka"
-						topicName = nsTopic[0]
-					} else {
-						ns = nsTopic[0]
-						topicName = nsTopic[1]
-					}
+					ns, topicName := nsTopic(topic)
 					g.Go(func() error {
 						cPartition, err := cl.TopicClusterPartitions(egCtx, ns, topicName, disabledOnly)
 						if err != nil {
-							return fmt.Errorf("unable to query cluster partition metadata of topic %q: %v", topicName, err)
+							// If the admin API returns a 404, most likely rpk
+							// is talking with an old cluster.
+							var he *adminapi.HTTPResponseError
+							isNotFoundErr := errors.As(err, &he) && he.Response.StatusCode == http.StatusNotFound
+							if !isNotFoundErr {
+								return fmt.Errorf("unable to query cluster partition metadata of topic %q: %v", topicName, err)
+							}
+							logFallbackOnce.Do(func() {
+								if disabledOnly {
+									zap.L().Sugar().Warn("Admin API 'GET /v1/cluster/partitions' returned 404, trying now with 'GET /v1/partitions'; --disabled-only flag is not supported in this API version")
+								} else {
+									zap.L().Sugar().Warn("Admin API 'GET /v1/cluster/partitions' returned 404, trying now with 'GET /v1/partitions'")
+								}
+							})
+							cPartition, err = topicPartitions(egCtx, cl, ns, topicName)
+							if err != nil {
+								return err
+							}
 						}
 						mu.Lock()
 						clusterPartitions = append(clusterPartitions, cPartition...)
@@ -106,34 +131,82 @@ List only the disabled partitions.
 			if partitions != nil {
 				clusterPartitions = filterPartition(clusterPartitions, partitions)
 			}
-			types.Sort(clusterPartitions)
-			tw := out.NewTable("NAMESPACE", "TOPIC", "PARTITION", "LEADER-ID", "REPLICA-CORE", "DISABLED")
-			defer tw.Flush()
-			for _, p := range clusterPartitions {
-				var leader string
-				var replicas []string
-				if p.LeaderID == nil {
-					leader = "-"
-				}
-				for _, r := range p.Replicas {
-					replicas = append(replicas, fmt.Sprintf("%v-%v", r.NodeID, r.Core))
-				}
-				tw.PrintStructFields(struct {
-					Namespace string
-					Topic     string
-					Partition int
-					LeaderID  string
-					Replicas  []string
-					Disabled  bool
-				}{p.Ns, p.Topic, p.PartitionID, leader, replicas, p.Disabled})
-			}
+			printClusterPartitions(clusterPartitions)
 		},
 	}
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "If true, list all partitions in the cluster")
-	cmd.Flags().BoolVar(&disabledOnly, "only-disabled", false, "If true, list disabled partitions only")
-	cmd.Flags().IntSliceVarP(&partitions, "partition", "p", nil, "Partitions to show current assignments (repeatable)")
+	cmd.Flags().BoolVar(&disabledOnly, "disabled-only", false, "If true, list disabled partitions only")
+	cmd.Flags().IntSliceVarP(&partitions, "partition", "p", nil, "List of comma-separated partitions IDs that you wish to filter the results with")
 
 	return cmd
+}
+
+func printClusterPartitions(clusterPartitions []adminapi.ClusterPartition) {
+	types.Sort(clusterPartitions)
+	tw := out.NewTable("NAMESPACE", "TOPIC", "PARTITION", "LEADER-ID", "REPLICA-CORE", "DISABLED")
+	defer tw.Flush()
+	for _, p := range clusterPartitions {
+		var leader, disabled string
+		var replicas []string
+		if p.LeaderID == nil {
+			leader = "-"
+		} else {
+			leader = strconv.Itoa(*p.LeaderID)
+		}
+		if p.Disabled == nil {
+			disabled = "-"
+		} else {
+			disabled = strconv.FormatBool(*p.Disabled)
+		}
+
+		for _, r := range p.Replicas {
+			replicas = append(replicas, fmt.Sprintf("%v-%v", r.NodeID, r.Core))
+		}
+		tw.PrintStructFields(struct {
+			Namespace string
+			Topic     string
+			Partition int
+			LeaderID  string
+			Replicas  []string
+			Disabled  string
+		}{p.Ns, p.Topic, p.PartitionID, leader, replicas, disabled})
+	}
+}
+
+// nsTopic splits a topic string consisting of <namespace>/<topicName> and
+// returns each component, if the namespace is not specified, returns 'kafka'.
+func nsTopic(nst string) (namespace string, topic string) {
+	nsTopic := strings.SplitN(nst, "/", 2)
+	if len(nsTopic) == 1 {
+		namespace = "kafka"
+		topic = nsTopic[0]
+	} else {
+		namespace = nsTopic[0]
+		topic = nsTopic[1]
+	}
+	return namespace, topic
+}
+
+// topicPartitions query the old v1/partitions/ endpoint and parse the result to
+// the newer /v1/cluster/partitions format.
+func topicPartitions(ctx context.Context, cl *adminapi.AdminAPI, ns, topicName string) ([]adminapi.ClusterPartition, error) {
+	var ret []adminapi.ClusterPartition
+	tPartitions, err := cl.GetTopic(ctx, ns, topicName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to query partition metadata of topic %q: %v", topicName, err)
+	}
+	for _, tp := range tPartitions {
+		tp := tp
+		ret = append(ret, adminapi.ClusterPartition{
+			Ns:          tp.Namespace,
+			Topic:       tp.Topic,
+			PartitionID: tp.PartitionID,
+			LeaderID:    &tp.LeaderID,
+			Replicas:    tp.Replicas,
+			Disabled:    nil, // Just to be explicit, old /v1/partitions did not contain any info on disabled.
+		})
+	}
+	return ret, nil
 }
 
 // filterPartition filters cPartitions and returns a slice with only the

--- a/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
@@ -1,3 +1,12 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package partitions
 
 import (

--- a/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
@@ -14,7 +14,7 @@ import (
 	"github.com/twmb/types"
 )
 
-func newListPartitionMovementsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+func newPartitionMovementsStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
 		completion       int
 		all              bool

--- a/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/move_status.go
@@ -157,7 +157,7 @@ func newPartitionMovementsStatusCommand(fs afero.Fs, p *config.Params) *cobra.Co
 
 	cmd.Flags().BoolVarP(&all, "print-all", "a", false, "Print internal states about movements for debugging")
 	cmd.Flags().BoolVarP(&human, "human-readable", "H", false, "Print the partition size in a human-readable form")
-	cmd.Flags().StringSliceVarP(&partitions, "partition", "p", nil, "Partitions to print the ongoing movements (repeatable)")
+	cmd.Flags().StringSliceVarP(&partitions, "partition", "p", nil, "Partitions to filter ongoing movements status (repeatable)")
 
 	return cmd
 }
@@ -175,7 +175,7 @@ func contains(pReq []string, pRes string) bool {
 
 const helpListMovement = `Show ongoing partition movements.
 
-By default this command lists all the ongoing partition movements in the cluster.
+By default this command lists all ongoing partition movements in the cluster.
 Topics can be specified to print the move status of specific topics. By default,
 this command assumes the "kafka" namespace, but you can use a "namespace/" to
 specify internal namespaces.
@@ -188,7 +188,7 @@ requested partitions:
 
     rpk cluster partitions move-status foo bar --partition 0,1,2
 
-The output contains the following columns, where PARTITION-SIZE is in bytes.
+The output contains the following columns with PARTITION-SIZE in bytes.
 Using -H, it prints the partition size in a human-readable format
 
     NAMESPACE-TOPIC
@@ -200,7 +200,7 @@ Using -H, it prints the partition size in a human-readable format
     BYTES-MOVED
     BYTES-REMAINING
 
-Using "--print-all / -a" the command additionally prints "RECONCILIATION STATUSES"
-which reveals internal states on how the ongoing reconciliations work for debugging
-purposes. That is, reported errors don't necessarily mean real problems.
+Using "--print-all / -a" the command additionally prints the column
+"RECONCILIATION STATUSES", which reveals the internal status of the ongoing
+reconciliations. Reported errors do not necessarily mean real problems.
 `

--- a/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
@@ -1,3 +1,12 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package partitions
 
 import (

--- a/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
@@ -25,6 +25,7 @@ func NewPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	p.InstallSASLFlags(cmd)
 	cmd.AddCommand(
 		newBalancerStatusCommand(fs, p),
+		newListCommand(fs, p),
 		newMovementCancelCommand(fs, p),
 		newMovementCancelCommandHidden(fs, p),
 		newPartitionMovementsStatusCommand(fs, p),

--- a/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
@@ -18,7 +18,7 @@ func NewPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newBalancerStatusCommand(fs, p),
 		newMovementCancelCommand(fs, p),
 		newMovementCancelCommandHidden(fs, p),
-		newListPartitionMovementsCommand(fs, p),
+		newPartitionMovementsStatusCommand(fs, p),
 	)
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cluster/partitions/status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/status.go
@@ -1,3 +1,12 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 package partitions
 
 import (

--- a/src/go/rpk/pkg/cli/generate/app.go
+++ b/src/go/rpk/pkg/cli/generate/app.go
@@ -371,7 +371,7 @@ the user.
 If you are having trouble connecting to your cluster, you can use -X
 admin.hosts=comma,delimited,host:ports to pass a specific admin api address.
 
-Examples:
+EXAMPLES
 
 Generate an app with interactive prompts:
   rpk generate app


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/14862

Fixes #15074

The manual changes are:
- Avoid backporting 560b611be6e16255d819aecd925054e8d10bc99c since it's a fix to a feature not present in v23.3.x
- Removing the JSON/YAML formatter since this feature is not present yet in v23.2.x

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* rpk introduces `rpk cluster partitions list` which lets the user query the list of the partitions for a topic.
