### PR TITLE
rpk: add nodes in recovery mode to cluster health

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_cluster.go
+++ b/src/go/rpk/pkg/adminapi/api_cluster.go
@@ -21,6 +21,7 @@ type ClusterHealthOverview struct {
 	ControllerID              int      `json:"controller_id"`
 	AllNodes                  []int    `json:"all_nodes"`
 	NodesDown                 []int    `json:"nodes_down"`
+	NodesInRecoveryMode       []int    `json:"nodes_in_recovery_mode,omitempty"` // This is nil if not-supported or no nodes in recovery mode.
 	LeaderlessPartitions      []string `json:"leaderless_partitions"`
 	LeaderlessCount           *int     `json:"leaderless_count,omitempty"`
 	UnderReplicatedPartitions []string `json:"under_replicated_partitions"`

--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -97,6 +97,9 @@ func printHealthOverview(hov *adminapi.ClusterHealthOverview) {
 	tw.Print("Controller ID:", hov.ControllerID)
 	tw.Print("All nodes:", hov.AllNodes)
 	tw.Print("Nodes down:", hov.NodesDown)
+	if hov.NodesInRecoveryMode != nil {
+		tw.Print("Nodes in recovery mode:", hov.NodesInRecoveryMode)
+	}
 	tw.Print(lp, hov.LeaderlessPartitions)
 	tw.Print(urp, hov.UnderReplicatedPartitions)
 }


### PR DESCRIPTION
Only if it's present:

```
# If present:
$ rpk cluster health
CLUSTER HEALTH OVERVIEW
=======================
Healthy:                          false
Unhealthy reasons:                [under_replicated_partitions]
Controller ID:                    1
All nodes:                        [0 1 2]
Nodes down:                       []
Nodes in recovery mode:           [0]
Leaderless partitions (0):        []
Under-replicated partitions (4):  [kafka/bar/1 kafka/bar/3 kafka/foo/1 kafka/foo/2]

# If not present (either a cluster that does not support this, or there are no nodes in recovery mode)
$ rpk cluster health
CLUSTER HEALTH OVERVIEW
=======================
Healthy:                          true
Unhealthy reasons:                []
Controller ID:                    1
All nodes:                        [1]
Nodes down:                       []
Leaderless partitions (0):        []
Under-replicated partitions (0):  []
```

Fixes #15104


## Backports Required
- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
