### PR TITLE
bytes/io_iterator_consumer: add backtrace to std::out_of_range error

### DIFF
--- a/src/v/bytes/details/io_iterator_consumer.h
+++ b/src/v/bytes/details/io_iterator_consumer.h
@@ -65,8 +65,8 @@ public:
             return ss::stop_iteration::no;
         });
         if (unlikely(c != n)) {
-            details::throw_out_of_range(
-              "Invalid skip(n). Expected:{}, but skipped:{}", n, c);
+            ss::throw_with_backtrace<std::out_of_range>(fmt::format(
+              "Invalid skip(n). Expected:{}, but skipped:{}", n, c));
         }
     }
     template<typename Output>
@@ -76,8 +76,10 @@ public:
             return ss::stop_iteration::no;
         });
         if (unlikely(c != n)) {
-            details::throw_out_of_range(
-              "Invalid consume_to(n, out), expected:{}, but consumed:{}", n, c);
+            ss::throw_with_backtrace<std::out_of_range>(fmt::format(
+              "Invalid consume_to(n, out), expected:{}, but consumed:{}",
+              n,
+              c));
         }
     }
 
@@ -101,11 +103,11 @@ public:
             return ss::stop_iteration::no;
         });
         if (unlikely(c != n)) {
-            details::throw_out_of_range(
+            ss::throw_with_backtrace<std::out_of_range>(fmt::format(
               "Invalid consume_to(n, placeholder), expected:{}, but "
               "consumed:{}",
               n,
-              c);
+              c));
         }
     }
 


### PR DESCRIPTION
Multiple paths can lead to this exception, so it can be helpful to log the backtrace for debugging purposes

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
