### PR TITLE
archival: fix collector when range start is inside segment

### DIFF
--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -140,6 +140,16 @@ void segment_collector::do_collect(segment_collector_mode mode) {
         }
 
         auto segment_size = result.segment->size_bytes();
+
+        // This is a hack! If the start offset of the range lies inside
+        // the first segment, we treat this segment as free for the purpose
+        // of size accounting. Otherwise, we could use too much of the size
+        // allocation for offests that are not in the range and fall through the
+        // second if statement below before reaching the end of the range.
+        if (result.segment->offsets().base_offset < start) {
+            segment_size = 0;
+        }
+
         if (
           _target_end_inclusive.has_value()
           && result.segment->offsets().committed_offset

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -15,6 +15,7 @@
 #include "cloud_storage/types.h"
 #include "model/metadata.h"
 #include "storage/log_manager.h"
+#include "storage/offset_to_filepos.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/archival.h"
 #include "test_utils/tmp_dir.h"
@@ -1403,4 +1404,102 @@ SEASTAR_THREAD_TEST_CASE(test_adjacent_segment_collection_x_term) {
     BOOST_REQUIRE_EQUAL(run.num_segments, 2);
     BOOST_REQUIRE_EQUAL(run.meta.base_offset(), 0);
     BOOST_REQUIRE_EQUAL(run.meta.committed_offset(), 400);
+}
+
+SEASTAR_THREAD_TEST_CASE(test_collector_from_inside_first_segment) {
+    /*
+     * Test that the segment collector does correct size accounting when the
+  start
+     * of the range is inside a local segment.
+
+          +--------------------------------+------------------+---------------+
+  Local   |0                            999|1000          1099|1100       1199|
+          +--------------------------------+-----------+------+---------------+
+          +-----------------------+--------+------------------+---------------+
+  Cloud   |0                   989|990  999|1000          1099|1100       1199|
+          +-----------------------+--------+------------------+---------------+
+    */
+
+    auto ntp = model::ntp{"test_ns", "test_tpc", 0};
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    auto o = std::make_unique<ntp_config::default_overrides>();
+    b | start(ntp_config{ntp, {data_path}, std::move(o)});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    b | storage::add_segment(0) | storage::add_random_batch(0, 990)
+      | storage::add_random_batch(990, 10) | storage::add_segment(1000)
+      | storage::add_random_batch(1000, 100) | storage::add_segment(1100)
+      | storage::add_random_batch(1100, 100);
+
+    const auto& seg_set = b.get_disk_log_impl().segments();
+    BOOST_REQUIRE_EQUAL(seg_set.size(), 3);
+
+    const auto& first_seg = seg_set.front();
+    const auto split_at = model::offset{990};
+    auto res
+      = convert_begin_offset_to_file_pos(
+          split_at, first_seg, model::timestamp{}, ss::default_priority_class())
+          .get();
+    BOOST_REQUIRE(res.has_value());
+
+    cloud_storage::partition_manifest m;
+    m.add(cloud_storage::segment_meta{
+      .is_compacted = false,
+      .size_bytes = res.value().bytes,
+      .base_offset = first_seg->offsets().base_offset,
+      .committed_offset = split_at - model::offset{1},
+      .delta_offset = model::offset_delta(0),
+      .delta_offset_end = model::offset_delta(0)});
+
+    m.add(cloud_storage::segment_meta{
+      .is_compacted = false,
+      .size_bytes = first_seg->size_bytes() - res.value().bytes,
+      .base_offset = split_at,
+      .committed_offset = first_seg->offsets().committed_offset,
+      .delta_offset = model::offset_delta(0),
+      .delta_offset_end = model::offset_delta(0)});
+
+    for (auto i = 1; i < seg_set.size(); ++i) {
+        const auto& seg = seg_set[i];
+        auto meta = cloud_storage::segment_meta{
+          .is_compacted = false,
+          .size_bytes = seg->size_bytes(),
+          .base_offset = seg->offsets().base_offset,
+          .committed_offset = seg->offsets().committed_offset,
+          .delta_offset = model::offset_delta(0),
+          .delta_offset_end = model::offset_delta(0)};
+        m.add(meta);
+    }
+
+    auto run_size = m.cloud_log_size() - m.begin()->size_bytes;
+    vlog(
+      test_log.info,
+      "[{}, {} ...]",
+      m.begin()->size_bytes,
+      (++m.begin())->size_bytes);
+
+    archival::segment_collector collector{
+      split_at,
+      m,
+      b.get_disk_log_impl(),
+      run_size,
+      m.last_segment()->committed_offset};
+
+    collector.collect_segments(segment_collector_mode::collect_non_compacted);
+    auto candidate = collector
+                       .make_upload_candidate(ss::default_priority_class(), 10s)
+                       .get();
+
+    BOOST_REQUIRE_EQUAL(
+      std::get<upload_candidate_with_locks>(candidate)
+        .candidate.starting_offset,
+      split_at);
+    BOOST_REQUIRE_EQUAL(
+      std::get<upload_candidate_with_locks>(candidate).candidate.final_offset,
+      m.last_segment()->committed_offset);
 }


### PR DESCRIPTION
Consider the following local and cloud log layout:

```
      +-----------------------------+------------------+---------------+
Local |0                         999|1000          1099|1100       1199|
      +-----------------------------+-----------+------+---------------+
      +--------------------+--------+------------------+---------------+
Cloud |0                989|990  999|1000          1099|1100       1199|
      +--------------------+--------+------------------+---------------+
```

Asking the `segment_collector` to collect the [990-1199] range is a perfectly valid thing to do. Previously, this collection would fail. The segment collector does it's own size accounting of the range from local disk and tries to respect the max size provided in the constructor. If the requested range starts inside a segment, then it would previously account for the size of the entire segment. In the example above, we'd account for the entire size of the first segment even though we only needed the last batch. This would lead to running out of size before reaching the end of the range.

This commit proposes a hacky solution where we treat the first segment as free if the offset range to collect starts within it. I also considered determining the required size precisely, but that requires turning a lot of sync code into async.

Fixes #15124

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
* Fix bug which could stop adjacent segment merger from progressing if the start of the reuploaded range
is not aligned with the start of and on-disk segment
