### PR TITLE
archival/tests: fixed delay failure injection

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -205,10 +205,9 @@ TEST_F_CORO(
 
     auto [plagued_node, delay_applied] = co_await with_leader(
       10s, [](raft::raft_node_instance& node) {
-          raft::response_delay fail{
-            .length = 100ms, .on_applied = ss::promise<>{}};
+          raft::response_delay fail{.length = 100ms};
+          auto delay_applied = fail.on_applied.wait();
 
-          auto delay_applied = fail.on_applied->get_future();
           node.inject_failure(raft::msg_type::append_entries, std::move(fail));
           return std::make_tuple(node.get_vnode(), std::move(delay_applied));
       });
@@ -296,10 +295,9 @@ TEST_F_CORO(
 
     auto [plagued_node, delay_applied] = co_await with_leader(
       10s, [](raft::raft_node_instance& node) {
-          raft::response_delay fail{
-            .length = 5s, .on_applied = ss::promise<>{}};
+          raft::response_delay fail{.length = 5s};
 
-          auto delay_applied = fail.on_applied->get_future();
+          auto delay_applied = fail.on_applied.wait();
           node.inject_failure(raft::msg_type::append_entries, std::move(fail));
           return std::make_tuple(node.get_vnode(), std::move(delay_applied));
       });

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -93,7 +93,8 @@ struct raft_node_map {
 
 struct response_delay {
     std::chrono::milliseconds length;
-    std::optional<ss::promise<>> on_applied;
+    ss::condition_variable on_applied;
+    uint64_t applied_counter;
 };
 
 using failure_t = std::variant<response_delay>;
@@ -137,6 +138,8 @@ public:
 
     void inject_failure(msg_type type, failure_t failure);
     void remove_failure(msg_type type);
+    std::optional<std::reference_wrapper<const failure_t>>
+    get_failure(msg_type type) const;
 
     ss::future<> stop();
 
@@ -212,6 +215,8 @@ public:
     ss::future<model::offset> random_batch_base_offset(model::offset max);
 
     void inject_failure(msg_type type, failure_t failure);
+    std::optional<std::reference_wrapper<const failure_t>>
+      get_failure(msg_type) const;
     void remove_failure(msg_type type);
 
 private:


### PR DESCRIPTION
Previously the delay failure contained a promise that was set when failure was injected. Since the failure may be reused for all the nodes in a channel the promise may have been set twice leading to an assertion error.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none