### PR TITLE
Disabled partitions implementation

### DIFF
--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -114,7 +114,7 @@ struct config_t
 
 struct topics_t
   : public serde::
-      envelope<topics_t, serde::version<1>, serde::compat_version<0>> {
+      envelope<topics_t, serde::version<0>, serde::compat_version<0>> {
     // NOTE: layout here is a bit different than in the topic table because it
     // allows more compact storage and more convenient generation of controller
     // backend deltas when applying the snapshot.
@@ -164,10 +164,11 @@ struct topics_t
 
     struct topic_t
       : public serde::
-          envelope<topic_t, serde::version<0>, serde::compat_version<0>> {
+          envelope<topic_t, serde::version<1>, serde::compat_version<0>> {
         topic_metadata_fields metadata;
         absl::node_hash_map<model::partition_id, partition_t> partitions;
         absl::node_hash_map<model::partition_id, update_t> updates;
+        std::optional<topic_disabled_partitions_set> disabled_set;
 
         friend bool operator==(const topic_t&, const topic_t&) = default;
 
@@ -184,13 +185,6 @@ struct topics_t
       nt_revision_hash,
       nt_revision_eq>
       lifecycle_markers;
-
-    absl::node_hash_map<
-      model::topic_namespace,
-      topic_disabled_partitions_set,
-      model::topic_namespace_hash,
-      model::topic_namespace_eq>
-      disabled_partitions;
 
     friend bool operator==(const topics_t&, const topics_t&) = default;
 

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -74,6 +74,8 @@ enum class errc : int16_t {
     transform_invalid_source,
     transform_invalid_environment,
     trackable_keys_limit_exceeded,
+    topic_disabled,
+    partition_disabled,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -214,6 +216,10 @@ struct errc_category final : public std::error_category {
             return "Invalid transform environment";
         case errc::trackable_keys_limit_exceeded:
             return "Too many keys are currently tracked, no space for more.";
+        case errc::topic_disabled:
+            return "Topic disabled by user";
+        case errc::partition_disabled:
+            return "Partition disabled by user";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -76,6 +76,7 @@ enum class errc : int16_t {
     trackable_keys_limit_exceeded,
     topic_disabled,
     partition_disabled,
+    invalid_partition_operation,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -220,6 +221,8 @@ struct errc_category final : public std::error_category {
             return "Topic disabled by user";
         case errc::partition_disabled:
             return "Partition disabled by user";
+        case errc::invalid_partition_operation:
+            return "Invalid partition operation";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -362,4 +362,14 @@ bool metadata_cache::is_update_in_progress(const model::ntp& ntp) const {
     return _topics_state.local().is_update_in_progress(ntp);
 }
 
+bool metadata_cache::is_disabled(
+  model::topic_namespace_view ns_tp, model::partition_id p_id) const {
+    return _topics_state.local().is_disabled(ns_tp, p_id);
+}
+
+const topic_disabled_partitions_set* metadata_cache::get_topic_disabled_set(
+  model::topic_namespace_view ns_tp) const {
+    return _topics_state.local().get_topic_disabled_set(ns_tp);
+}
+
 } // namespace cluster

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -200,6 +200,10 @@ public:
     const topic_table::updates_t& updates_in_progress() const;
     bool is_update_in_progress(const model::ntp& ntp) const;
 
+    bool is_disabled(model::topic_namespace_view, model::partition_id) const;
+    const topic_disabled_partitions_set*
+      get_topic_disabled_set(model::topic_namespace_view) const;
+
 private:
     ss::sharded<topic_table>& _topics_state;
     ss::sharded<members_table>& _members_table;

--- a/src/v/cluster/plugin_frontend.cc
+++ b/src/v/cluster/plugin_frontend.cc
@@ -457,6 +457,14 @@ errc plugin_frontend::validator::validate_mutation(const transform_cmd& cmd) {
                 loggable_string(cmd.value.input_topic.tp()));
               return errc::transform_invalid_create;
           }
+          if (_topics->is_fully_disabled(cmd.value.input_topic)) {
+              vlog(
+                clusterlog.info,
+                "attempted to deploy transform {} to a disabled topic {}",
+                cmd.value.name,
+                loggable_string(cmd.value.input_topic.tp()));
+              return errc::transform_invalid_create;
+          }
           if (cmd.value.output_topics.empty()) {
               vlog(
                 clusterlog.info,
@@ -532,6 +540,15 @@ errc plugin_frontend::validator::validate_mutation(const transform_cmd& cmd) {
                     "{}",
                     cmd.value.name,
                     out_name.tp);
+                  return errc::transform_invalid_create;
+              }
+              if (_topics->is_fully_disabled(out_name)) {
+                  vlog(
+                    clusterlog.info,
+                    "attempted to deploy transform {} to write to a disabled "
+                    "topic {}",
+                    cmd.value.name,
+                    loggable_string(out_name.tp()));
                   return errc::transform_invalid_create;
               }
               if (would_cause_cycle(cmd.value.input_topic, out_name)) {

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -636,6 +636,7 @@ leader_balancer::index_type leader_balancer::build_index() {
 
     // for each ntp in the cluster
     for (const auto& topic : _topics.topics_map()) {
+        const auto* disabled_set = _topics.get_topic_disabled_set(topic.first);
         for (const auto& partition : topic.second.get_assignments()) {
             if (partition.replicas.empty()) {
                 vlog(
@@ -653,6 +654,12 @@ leader_balancer::index_type leader_balancer::build_index() {
             if (
               topic.first.ns == model::controller_ntp.ns
               && topic.first.tp == model::controller_ntp.tp.topic) {
+                continue;
+            }
+
+            if (disabled_set && disabled_set->is_disabled(partition.id)) {
+                // skip balancing disabled partitions, as they shouldn't have
+                // leaders anyway
                 continue;
             }
 

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -623,9 +623,9 @@ topic_table::apply(set_topic_partitions_disabled_cmd cmd, model::offset o) {
     if (topic_it == _topics.end()) {
         co_return errc::topic_not_exists;
     }
+    const auto& assignments = topic_it->second.get_assignments();
 
     if (cmd.value.partition_id) {
-        const auto& assignments = topic_it->second.get_assignments();
         if (!assignments.contains(*cmd.value.partition_id)) {
             co_return errc::partition_not_exists;
         }
@@ -643,13 +643,40 @@ topic_table::apply(set_topic_partitions_disabled_cmd cmd, model::offset o) {
         if (disabled_set.is_fully_enabled()) {
             _disabled_partitions.erase(disabled_it);
         }
+
+        _pending_deltas.emplace_back(
+          model::ntp{
+            cmd.value.ns_tp.ns, cmd.value.ns_tp.tp, *cmd.value.partition_id},
+          model::revision_id{o},
+          topic_table_delta_type::disabled_flag_updated);
     } else {
+        topic_disabled_partitions_set old_disabled_set;
         if (cmd.value.disabled) {
-            _disabled_partitions[cmd.value.ns_tp].set_fully_disabled();
+            auto& disabled_set = _disabled_partitions[cmd.value.ns_tp];
+            old_disabled_set = std::exchange(
+              disabled_set, topic_disabled_partitions_set{});
+            disabled_set.set_fully_disabled();
         } else {
-            _disabled_partitions.erase(cmd.value.ns_tp);
+            auto it = _disabled_partitions.find(cmd.value.ns_tp);
+            if (it != _disabled_partitions.end()) {
+                old_disabled_set = std::move(it->second);
+                _disabled_partitions.erase(it);
+            }
+        }
+
+        for (const auto& p_as : assignments) {
+            if (old_disabled_set.is_disabled(p_as.id) == cmd.value.disabled) {
+                continue;
+            }
+
+            _pending_deltas.emplace_back(
+              model::ntp{cmd.value.ns_tp.ns, cmd.value.ns_tp.tp, p_as.id},
+              model::revision_id{o},
+              topic_table_delta_type::disabled_flag_updated);
         }
     }
+
+    notify_waiters();
 
     co_return errc::success;
 }
@@ -879,22 +906,24 @@ topic_table::fill_snapshot(controller_snapshot& controller_snap) const {
             co_await ss::coroutine::maybe_yield();
         }
 
+        std::optional<topic_disabled_partitions_set> disabled_set;
+        if (auto it = _disabled_partitions.find(ns_tp);
+            it != _disabled_partitions.end()) {
+            disabled_set = it->second;
+        }
+
         snap.topics.emplace(
           ns_tp,
           controller_snapshot_parts::topics_t::topic_t{
             .metadata = md_item.metadata.get_fields(),
             .partitions = std::move(partitions),
             .updates = std::move(updates),
+            .disabled_set = std::move(disabled_set),
           });
     }
 
     for (const auto& [ntr, lm] : _lifecycle_markers) {
         snap.lifecycle_markers.emplace(ntr, lm);
-    }
-
-    for (const auto& [ns_tp, dps] : _disabled_partitions) {
-        snap.disabled_partitions.emplace(ns_tp, dps);
-        co_await ss::coroutine::maybe_yield();
     }
 }
 
@@ -902,6 +931,7 @@ topic_table::fill_snapshot(controller_snapshot& controller_snap) const {
 // controller snapshot
 class topic_table::snapshot_applier {
     updates_t& _updates_in_progress;
+    disabled_partitions_t& _disabled_partitions;
     fragmented_vector<delta>& _pending_deltas;
     topic_table_probe& _probe;
     model::revision_id _snap_revision;
@@ -909,6 +939,7 @@ class topic_table::snapshot_applier {
 public:
     snapshot_applier(topic_table& parent, model::revision_id snap_revision)
       : _updates_in_progress(parent._updates_in_progress)
+      , _disabled_partitions(parent._disabled_partitions)
       , _pending_deltas(parent._pending_deltas)
       , _probe(parent._probe)
       , _snap_revision(snap_revision) {}
@@ -937,6 +968,7 @@ public:
             delete_ntp(ns_tp, p_as);
             co_await ss::coroutine::maybe_yield();
         }
+        _disabled_partitions.erase(ns_tp);
         _probe.handle_topic_deletion(ns_tp);
         // topic_metadata_item object is supposed to be removed from _topics by
         // the caller
@@ -1081,6 +1113,9 @@ public:
       const model::topic_namespace& ns_tp,
       const controller_snapshot_parts::topics_t::topic_t& topic) {
         topic_metadata_item ret{topic_metadata{topic.metadata, {}}};
+        if (topic.disabled_set) {
+            _disabled_partitions[ns_tp] = *topic.disabled_set;
+        }
         for (const auto& [p_id, partition] : topic.partitions) {
             auto ntp = model::ntp(ns_tp.ns, ns_tp.tp, p_id);
             add_ntp(ntp, topic, partition, ret, false);
@@ -1131,6 +1166,17 @@ ss::future<> topic_table::apply_snapshot(
 
                 md_item.metadata.get_fields() = topic_snapshot.metadata;
 
+                topic_disabled_partitions_set old_disabled_set;
+                if (topic_snapshot.disabled_set) {
+                    old_disabled_set = std::exchange(
+                      _disabled_partitions[ns_tp],
+                      *topic_snapshot.disabled_set);
+                } else if (auto it = _disabled_partitions.find(ns_tp);
+                           it != _disabled_partitions.end()) {
+                    old_disabled_set = std::move(it->second);
+                    _disabled_partitions.erase(it);
+                }
+
                 // 2. For each partition in the new set, reconcile assignments
                 // and add corresponding deltas
                 for (const auto& [p_id, partition] :
@@ -1142,6 +1188,17 @@ ss::future<> topic_table::apply_snapshot(
                       partition,
                       md_item,
                       must_update_properties);
+
+                    const bool new_is_disabled
+                      = topic_snapshot.disabled_set
+                        && topic_snapshot.disabled_set->is_disabled(p_id);
+                    if (old_disabled_set.is_disabled(p_id) != new_is_disabled) {
+                        _pending_deltas.emplace_back(
+                          ntp,
+                          snap_revision,
+                          topic_table_delta_type::disabled_flag_updated);
+                    }
+
                     co_await ss::coroutine::maybe_yield();
                 }
 
@@ -1181,9 +1238,6 @@ ss::future<> topic_table::apply_snapshot(
     // Lifecycle markers is a simple static collection without notifications
     // etc, so we can just copy directly into place.
     _lifecycle_markers = controller_snap.topics.lifecycle_markers;
-
-    // Same for disabled partitions.
-    _disabled_partitions = controller_snap.topics.disabled_partitions;
 
     // 2. re-calculate derived state
 

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1037,6 +1037,10 @@ ss::future<std::error_code> topics_frontend::set_topic_partitions_disabled(
         co_return errc::feature_disabled;
     }
 
+    if (!model::is_user_topic(ns_tp)) {
+        co_return errc::invalid_partition_operation;
+    }
+
     auto r = co_await stm_linearizable_barrier(timeout);
     if (!r) {
         co_return r.error();

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -269,6 +269,10 @@ ss::future<std::error_code> topics_frontend::do_update_replication_factor(
             co_return cluster::errc::feature_disabled;
         }
 
+        if (_topics.local().is_fully_disabled(update.tp_ns)) {
+            co_return errc::topic_disabled;
+        }
+
         auto value = update.custom_properties.replication_factor.value;
         if (
           !value.has_value()
@@ -802,6 +806,9 @@ ss::future<std::error_code> topics_frontend::move_partition_replicas(
         co_return result.error();
     }
 
+    if (_topics.local().is_disabled(ntp)) {
+        co_return errc::partition_disabled;
+    }
     if (_topics.local().is_update_in_progress(ntp)) {
         co_return errc::update_in_progress;
     }
@@ -845,6 +852,9 @@ ss::future<std::error_code> topics_frontend::force_update_partition_replicas(
     if (!result) {
         co_return result.error();
     }
+    if (_topics.local().is_disabled(ntp)) {
+        co_return errc::partition_disabled;
+    }
     force_partition_reconfiguration_cmd cmd{
       std::move(ntp),
       force_partition_reconfiguration_cmd_data{std::move(new_replica_set)}};
@@ -860,6 +870,9 @@ ss::future<std::error_code> topics_frontend::cancel_moving_partition_replicas(
     auto result = co_await stm_linearizable_barrier(timeout);
     if (!result) {
         co_return result.error();
+    }
+    if (_topics.local().is_disabled(ntp)) {
+        co_return errc::partition_disabled;
     }
     if (!_topics.local().is_update_in_progress(ntp)) {
         co_return errc::no_update_in_progress;
@@ -882,6 +895,9 @@ ss::future<std::error_code> topics_frontend::abort_moving_partition_replicas(
         co_return result.error();
     }
 
+    if (_topics.local().is_disabled(ntp)) {
+        co_return errc::partition_disabled;
+    }
     if (!_topics.local().is_update_in_progress(ntp)) {
         co_return errc::no_update_in_progress;
     }
@@ -1099,6 +1115,9 @@ ss::future<topic_result> topics_frontend::do_create_partition(
         co_return make_error_result(
           p_cfg.tp_ns, errc::topic_invalid_partitions);
     }
+    if (_topics.local().is_fully_disabled(p_cfg.tp_ns)) {
+        co_return make_error_result(p_cfg.tp_ns, errc::topic_disabled);
+    }
 
     auto units = co_await _allocator.invoke_on(
       partition_allocator::shard,
@@ -1247,6 +1266,10 @@ ss::future<std::error_code> topics_frontend::change_replication_factor(
         co_return errc::success;
     }
 
+    if (_topics.local().is_fully_disabled(topic)) {
+        co_return errc::topic_disabled;
+    }
+
     if (new_replication_factor < current_replication_factor) {
         co_return co_await decrease_replication_factor(
           topic, new_replication_factor, timeout);
@@ -1360,6 +1383,10 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
         co_return errc::topic_not_exists;
     }
 
+    if (_topics.local().is_fully_disabled(topic)) {
+        co_return errc::topic_disabled;
+    }
+
     auto partition_count = tp_metadata->get_configuration().partition_count;
 
     // units shold exist during replicate_and_wait call
@@ -1465,6 +1492,10 @@ ss::future<std::error_code> topics_frontend::decrease_replication_factor(
         co_return errc::topic_not_exists;
     }
 
+    if (_topics.local().is_fully_disabled(topic)) {
+        co_return errc::topic_disabled;
+    }
+
     std::optional<std::error_code> error;
 
     auto metadata_ref = tp_metadata.value().get();
@@ -1522,6 +1553,10 @@ topics_frontend::generate_reassignments(
       model::topic_namespace{ntp.ns, ntp.tp.topic});
     if (!tp_metadata.has_value()) {
         co_return errc::topic_not_exists;
+    }
+
+    if (_topics.local().is_disabled(ntp)) {
+        co_return errc::partition_disabled;
     }
 
     auto tp_replication_factor

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -1569,6 +1569,10 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
 
         model::topic topic(req_topic.name);
 
+        const auto* disabled_set
+          = _metadata_cache.local().get_topic_disabled_set(
+            model::topic_namespace_view{model::kafka_namespace, topic});
+
         res_topic.results.reserve(req_topic.partitions.size());
         for (model::partition_id req_partition : req_topic.partitions) {
             model::ntp ntp(model::kafka_namespace, topic, req_partition);
@@ -1580,6 +1584,12 @@ ss::future<add_paritions_tx_reply> tx_gateway_frontend::do_add_partition_to_tx(
                 add_paritions_tx_reply::partition_result res_partition;
                 res_partition.partition_index = req_partition;
                 res_partition.error_code = tx_errc::none;
+                res_topic.results.push_back(res_partition);
+            } else if (
+              disabled_set && disabled_set->is_disabled(req_partition)) {
+                add_paritions_tx_reply::partition_result res_partition;
+                res_partition.partition_index = req_partition;
+                res_partition.error_code = tx_errc::partition_disabled;
                 res_topic.results.push_back(res_partition);
             } else {
                 new_partitions.push_back(ntp);

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -149,6 +149,9 @@ std::ostream& operator<<(std::ostream& o, const tx_errc& err) {
     case tx_errc::tx_id_not_found:
         o << "tx_errc::tx_id_not_found";
         break;
+    case tx_errc::partition_disabled:
+        o << "tx_errc::partition_disabled";
+        break;
     }
     return o;
 }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -460,6 +460,8 @@ std::ostream& operator<<(std::ostream& o, const topic_table_delta_type& tp) {
         return o << "replicas_updated";
     case topic_table_delta_type::properties_updated:
         return o << "properties_updated";
+    case topic_table_delta_type::disabled_flag_updated:
+        return o << "disabled_flag_updated";
     }
     __builtin_unreachable();
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2426,6 +2426,7 @@ enum class topic_table_delta_type {
     removed,
     replicas_updated,
     properties_updated,
+    disabled_flag_updated,
 };
 std::ostream& operator<<(std::ostream&, const topic_table_delta_type&);
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -200,7 +200,8 @@ enum class tx_errc {
     invalid_txn_state,
     invalid_producer_epoch,
     tx_not_found,
-    tx_id_not_found
+    tx_id_not_found,
+    partition_disabled,
 };
 
 std::ostream& operator<<(std::ostream&, const tx_errc&);

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -49,6 +49,9 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
         return error_code::throttling_quota_exceeded;
     case cluster::errc::no_update_in_progress:
         return error_code::no_reassignment_in_progress;
+    case cluster::errc::topic_disabled:
+    case cluster::errc::partition_disabled:
+        return error_code::policy_violation;
     case cluster::errc::replication_error:
     case cluster::errc::shutting_down:
     case cluster::errc::join_request_dispatch_error:

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -94,6 +94,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::transform_invalid_update:
     case cluster::errc::transform_invalid_source:
     case cluster::errc::trackable_keys_limit_exceeded:
+    case cluster::errc::invalid_partition_operation:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -766,6 +766,15 @@ class simple_fetch_planner final : public fetch_planner::impl {
 
             auto& tp = fp.topic_partition;
 
+            if (unlikely(octx.rctx.metadata_cache().is_disabled(
+                  tp.as_tn_view(), tp.get_partition()))) {
+                resp_it->set(make_partition_response_error(
+                  fp.topic_partition.get_partition(),
+                  error_code::replica_not_available));
+                ++resp_it;
+                return;
+            }
+
             auto shard = octx.rctx.shards().shard_for(tp);
             if (unlikely(!shard)) {
                 // there is given partition in topic metadata, return

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -116,6 +116,7 @@ metadata_response::topic make_topic_response_from_topic_metadata(
     tp.is_internal = is_internal(tp_ns);
 
     const bool is_user_topic = model::is_user_topic(tp_ns);
+    const auto* disabled_set = md_cache.get_topic_disabled_set(tp_ns);
 
     for (const auto& p_as : tp_md.get_assignments()) {
         std::vector<model::node_id> replicas{};
@@ -130,6 +131,8 @@ metadata_response::topic make_topic_response_from_topic_metadata(
         p.error_code = error_code::none;
         if (recovery_mode_enabled && is_user_topic) {
             p.error_code = error_code::policy_violation;
+        } else if (disabled_set && disabled_set->is_disabled(p_as.id)) {
+            p.error_code = error_code::replica_not_available;
         }
         p.partition_index = p_as.id;
         p.leader_id = no_leader;

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1050,6 +1050,10 @@ ss::future<response_ptr> add_partitions_to_txn_handler::handle(
                       case cluster::tx_errc::timeout:
                           partition.error_code = error_code::request_timed_out;
                           break;
+                      case cluster::tx_errc::partition_disabled:
+                          partition.error_code
+                            = error_code::replica_not_available;
+                          break;
                       default:
                           partition.error_code
                             = error_code::unknown_server_error;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1169,6 +1169,7 @@ ss::future<> admin_server::throw_on_error(
         case cluster::errc::transform_invalid_environment:
         case cluster::errc::source_topic_not_exists:
         case cluster::errc::source_topic_still_in_use:
+        case cluster::errc::invalid_partition_operation:
             throw ss::httpd::bad_request_exception(
               fmt::format("{}", ec.message()));
         default:

--- a/tests/rptest/tests/recovery_mode_test.py
+++ b/tests/rptest/tests/recovery_mode_test.py
@@ -21,6 +21,28 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.util import wait_until_result
 
 
+def _produce(test, topic, msg_count=1000, partition=None):
+    producer = RpkProducer(context=test.test_context,
+                           redpanda=test.redpanda,
+                           topic=topic,
+                           msg_size=4096,
+                           msg_count=msg_count,
+                           partition=partition)
+    try:
+        producer.run()
+    finally:
+        producer.free()
+
+
+def assert_rpk_fails(cmd, error_msg):
+    try:
+        cmd()
+    except RpkException:
+        pass
+    else:
+        assert False, error_msg
+
+
 class RecoveryModeTest(RedpandaTest):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, num_brokers=4, **kwargs)
@@ -28,17 +50,6 @@ class RecoveryModeTest(RedpandaTest):
     def setUp(self):
         # start the nodes manually
         pass
-
-    def _produce(self, topic):
-        producer = RpkProducer(context=self.test_context,
-                               redpanda=self.redpanda,
-                               topic=topic,
-                               msg_size=4096,
-                               msg_count=1000)
-        try:
-            producer.run()
-        finally:
-            producer.free()
 
     @cluster(num_nodes=5)
     def test_recovery_mode(self):
@@ -62,7 +73,7 @@ class RecoveryModeTest(RedpandaTest):
         rpk.create_topic("mytopic1", partitions=5, replicas=3)
         rpk.create_topic("mytopic2", partitions=5, replicas=3)
 
-        self._produce("mytopic1")
+        _produce(self, "mytopic1")
 
         partitions = list(rpk.describe_topic("mytopic1", tolerant=False))
         assert len(partitions) == 5
@@ -91,32 +102,19 @@ class RecoveryModeTest(RedpandaTest):
         assert len(partitions) == 5
         assert all(p.load_error is not None for p in partitions)
 
-        try:
-            rpk.produce('mytopic1', 'key', 'msg')
-        except RpkException:
-            pass
-        else:
-            assert False, "producing should fail"
+        assert_rpk_fails(lambda: rpk.produce('mytopic1', 'key', 'msg'),
+                         "producing should fail")
 
-        try:
-            rpk.consume('mytopic1', n=1000, quiet=True, timeout=10)
-            # rpk will retry indefinitely even in the presence of non-retryable errors,
-            # so just wait for the timeout to occur.
-        except RpkException:
-            pass
-        else:
-            assert False, "consuming should fail"
+        # rpk will retry indefinitely even in the presence of non-retryable errors,
+        # so just wait for the timeout to occur.
+        assert_rpk_fails(
+            lambda: rpk.consume('mytopic1', n=1000, quiet=True, timeout=10),
+            "consuming should fail")
 
-        try:
-            rpk.consume('mytopic1',
-                        n=1000,
-                        group='mygroup3',
-                        quiet=True,
-                        timeout=10)
-        except RpkException:
-            pass
-        else:
-            assert False, "group consuming should fail"
+        assert_rpk_fails(
+            lambda: rpk.consume(
+                'mytopic1', n=1000, group='mygroup3', quiet=True, timeout=10),
+            "group consuming should fail")
 
         # check consumer group ops
 
@@ -177,7 +175,7 @@ class RecoveryModeTest(RedpandaTest):
 
         # check that produce and consume work
 
-        self._produce("mytopic1")
+        _produce(self, "mytopic1")
 
         def partitions_ready():
             partitions = list(rpk.describe_topic("mytopic1", tolerant=False))
@@ -200,7 +198,7 @@ class RecoveryModeTest(RedpandaTest):
         assert len(consumed) == 2000
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True)
 class PartitionInfo:
     ns: str
     topic: str
@@ -352,3 +350,162 @@ class DisablingPartitionsTest(RedpandaTest):
         self.redpanda.wait_for_membership(first_start=False)
 
         check_everything()
+
+    @cluster(num_nodes=5)
+    def test_disable(self):
+        """
+        Test that disabled partitions are shut down and that producing/consuming
+        to them errors out, while producing/consuming to other partitions is
+        still possible.
+        """
+
+        rpk = RpkTool(self.redpanda)
+        admin = Admin(self.redpanda)
+
+        topics = ["mytopic1", "mytopic2"]
+        for topic in topics:
+            rpk.create_topic(topic, partitions=2, replicas=3)
+
+        def get_node_partitions(node):
+            return [
+                f'{p["topic"]}/{p["partition_id"]}'
+                for p in admin.get_partitions(node=node)
+                if p["topic"].startswith("mytopic")
+            ]
+
+        def get_partition_counts():
+            ret = dict()
+            for n in self.redpanda.nodes:
+                for p in get_node_partitions(n):
+                    ret[p] = ret.setdefault(p, 0) + 1
+            self.logger.debug(f"partition counts: {ret}")
+            return ret
+
+        def all_created():
+            pc = get_partition_counts()
+            return len(pc) == 4 and all(c == 3 for c in pc.values())
+
+        wait_until(all_created,
+                   timeout_sec=30,
+                   backoff_sec=1,
+                   err_msg="failed to wait until all partitions are created")
+
+        _produce(self, "mytopic1")
+        _produce(self, "mytopic2")
+
+        def get_hwms(topic=None):
+            ts = topics if topic is None else [topic]
+            ret = dict()
+            for topic in ts:
+                for p in rpk.describe_topic(topic):
+                    ret[f"{topic}/{p.id}"] = p.high_watermark
+            return ret
+
+        orig_hwms = get_hwms()
+        assert len(orig_hwms) == 4
+        for topic in topics:
+            assert sum(hwm for ntp, hwm in orig_hwms.items()
+                       if ntp.startswith(topic)) == 1000
+
+        self.logger.info("disabling partitions")
+
+        admin.set_partitions_disabled(ns="kafka",
+                                      topic="mytopic1",
+                                      partition=1)
+        admin.set_partitions_disabled(ns="kafka", topic="mytopic2")
+
+        def all_disabled_shut_down():
+            pc = get_partition_counts()
+            return set(pc.keys()) == {"mytopic1/0"} and all(
+                c == 3 for c in pc.values())
+
+        wait_until(
+            all_disabled_shut_down,
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="failed to wait until all disabled partitions are shut down"
+        )
+
+        hwms2 = get_hwms()
+        assert len(hwms2) == 1
+        assert hwms2["mytopic1/0"] == orig_hwms["mytopic1/0"]
+
+        # test that producing to disabled partitions fails, while producing to
+        # the remaining partition is still possible
+
+        _produce(self, "mytopic1", partition=0)
+
+        assert_rpk_fails(
+            lambda: rpk.produce('mytopic1', 'key', 'msg', partition=1),
+            "producing should fail")
+
+        assert_rpk_fails(lambda: rpk.produce('mytopic2', 'key', 'msg'),
+                         "producing should fail")
+
+        hwms3 = get_hwms()
+        assert len(hwms2) == 1
+        assert hwms3["mytopic1/0"] == hwms2["mytopic1/0"] + 1000
+
+        # the same with consuming
+
+        assert len(
+            rpk.consume(
+                'mytopic1', n=hwms3["mytopic1/0"],
+                quiet=True).rstrip().split('\n')) == hwms3["mytopic1/0"]
+
+        assert_rpk_fails(
+            lambda: rpk.consume(
+                'mytopic1', n=hwms3["mytopic1/0"] + 1, timeout=10),
+            "consuming should fail")
+
+        assert_rpk_fails(lambda: rpk.consume('mytopic2', n=1, timeout=10),
+                         "consuming should fail")
+
+        self.logger.info("restarting cluster")
+
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.wait_for_membership(first_start=False)
+
+        # test that partitions are still disabled after restart
+
+        assert all_disabled_shut_down()
+
+        assert get_hwms() == hwms3
+
+        self.logger.info("enabling partitions back")
+
+        admin.set_partitions_disabled(ns="kafka",
+                                      topic="mytopic1",
+                                      value=False)
+        admin.set_partitions_disabled(ns="kafka",
+                                      topic="mytopic2",
+                                      value=False)
+
+        wait_until(all_created,
+                   timeout_sec=30,
+                   backoff_sec=1,
+                   err_msg="failed to wait until all partitions are created")
+
+        wait_until(lambda: set(get_hwms().keys()) == set(orig_hwms.keys()),
+                   timeout_sec=30,
+                   backoff_sec=1,
+                   err_msg="failed to wait until all leaders elected")
+
+        # test that producing and consuming works after re-enabling all partitions
+
+        hwms4 = get_hwms()
+        assert set(hwms4.keys()) == set(orig_hwms.keys())
+        for ntp, hwm in hwms4.items():
+            if ntp == "mytopic1/0":
+                assert hwm == orig_hwms[ntp] + 1000
+            else:
+                assert hwm == orig_hwms[ntp]
+
+        _produce(self, "mytopic1")
+        _produce(self, "mytopic2")
+
+        assert sum(hwm for hwm in get_hwms("mytopic1").values()) == 3000
+        assert sum(hwm for hwm in get_hwms("mytopic2").values()) == 2000
+
+        rpk.consume('mytopic1', n=3000, quiet=True)
+        rpk.consume('mytopic2', n=2000, quiet=True)

--- a/tests/rptest/tests/recovery_mode_test.py
+++ b/tests/rptest/tests/recovery_mode_test.py
@@ -11,6 +11,7 @@ import tempfile
 import dataclasses
 
 from ducktape.utils.util import wait_until
+from requests.exceptions import HTTPError
 
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
@@ -239,6 +240,13 @@ class DisablingPartitionsTest(RedpandaTest):
     def test_apis(self):
         rpk = RpkTool(self.redpanda)
         admin = Admin(self.redpanda)
+
+        try:
+            admin.set_partitions_disabled(ns="redpanda", topic="controller")
+        except HTTPError as e:
+            assert e.response.status_code == 400
+        else:
+            assert False, "disabling internal topics should fail"
 
         topics = ["mytopic1", "mytopic2", "mytopic3", "mytopic4"]
         for topic in topics:


### PR DESCRIPTION
* Shut down disabled partitions in `controller_backend`
* Skip disabled partitions in balancers
* Forbid partition replica reconfiguration commands for disabled topics/partitions
* Return appropriate error codes for kafka requests related to disabled partitions

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Features
* Added the ability do *disable* whole topics and specific topic partitions. Disabled partitions are ignored by Redpanda and producing/consuming to them is impossible. This is useful when only a handful of partitions prevent the cluster from becoming healthy (e.g. if the data in them is corrupted in a way that causes Redpanda to crash).
