### PR TITLE
cloud_storage_fuzzy_rpfixture.test_scan_while_shutting_down

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -372,13 +372,13 @@ FIXTURE_TEST(
 namespace {
 
 ss::future<> scan_until_close(
-  remote_partition& partition,
-  const storage::log_reader_config& reader_config,
+  ss::shared_ptr<remote_partition> partition,
+  storage::log_reader_config reader_config,
   ss::gate& g) {
     auto guard = g.hold();
     while (!g.is_closed()) {
         try {
-            auto translating_reader = co_await partition.make_reader(
+            auto translating_reader = co_await partition->make_reader(
               reader_config);
             auto reader = std::move(translating_reader.reader);
             auto headers_read = co_await reader.consume(
@@ -404,8 +404,6 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);
 
-    storage::log_reader_config reader_config(
-      base, model::offset::max(), ss::default_priority_class());
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
 
     auto manifest = hydrate_manifest(api.local(), bucket);
@@ -418,22 +416,35 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 
     ss::gate g;
-    ssx::background = scan_until_close(*partition, reader_config, g);
+    auto scan_future = scan_until_close(
+      partition,
+      storage::log_reader_config(
+        base, model::offset::max(), ss::default_priority_class()),
+      g);
     auto close_fut = ss::maybe_yield()
                        .then([] { return ss::maybe_yield(); })
                        .then([] { return ss::maybe_yield(); })
-                       .then([] {
-                           return ss::sleep(std::chrono::milliseconds(10));
-                       })
+                       .then([] { return ss::sleep(10ms); })
                        .then([this, &g]() mutable {
                            pool.local().shutdown_connections();
                            return g.close();
                        });
 
     // NOTE: see issues/11271
-    BOOST_TEST_INFO("scan_unit_close should terminate in a finite amount of "
-                    "time at shutdown");
-    auto timeout_fut = ss::with_timeout(
-      model::timeout_clock::now() + 60s, std::move(close_fut));
-    BOOST_REQUIRE_NO_THROW(timeout_fut.get());
+    BOOST_TEST_CONTEXT("scan_unit_close should terminate in a finite amount of "
+                       "time at shutdown") {
+        auto timeout_fut = ss::with_timeout(
+          model::timeout_clock::now() + 60s, std::move(close_fut));
+        try {
+            timeout_fut.get();
+            BOOST_CHECK(scan_future.available());
+            scan_future.get();
+        } catch (...) {
+            // BOOST_REQUIRE_NOTHROW can't print std::current_exception, sadly
+            BOOST_CHECK_MESSAGE(
+              false,
+              fmt::format(
+                "failed with exception {}", std::current_exception()));
+        }
+    }
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Add logging around the steps of test_scan_while_shutting_down. 99% of the log is just data preparation; the last 10 log lines contain the active part of the test.

This increase in logging should help discover what steps are hanging. 

Related to #11271 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
