### PR TITLE
rpk/transform/deploy: fix nil map assignment

### DIFF
--- a/src/go/rpk/pkg/cli/transform/deploy.go
+++ b/src/go/rpk/pkg/cli/transform/deploy.go
@@ -138,6 +138,9 @@ func (e *environment) Set(s string) error {
 	if v == "" {
 		return errors.New("missing value")
 	}
+	if e.vars == nil {
+		e.vars = make(map[string]string)
+	}
 	e.vars[k] = v
 	return nil
 }


### PR DESCRIPTION
Fixes an error where we assign to a nil map when specifying environment
variables.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixes an issue assigning environment variables to data transforms during deploys

