### PR TITLE
[v22.3.x] archival: always move reupload start forward

### DIFF
--- a/src/v/archival/segment_reupload.cc
+++ b/src/v/archival/segment_reupload.cc
@@ -90,7 +90,13 @@ void segment_collector::do_collect() {
         // For the first compacted segment found, begin offset needs to be
         // re-aligned if it falls inside manifest segment.
         if (_segments.empty()) {
-            _begin_inclusive = result.segment->offsets().base_offset;
+            // We may have found our first segment, but we can't always use its
+            // base offset:
+            // - it's possible the segment we found is below our reupload
+            //   target start offset (_begin_inclusive), e.g. if the target
+            //   start offset is in the middle of a segment.
+            _begin_inclusive = std::max(
+              {_begin_inclusive, result.segment->offsets().base_offset});
             align_begin_offset_to_manifest();
         }
         _segments.push_back(result.segment);

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -911,3 +911,80 @@ SEASTAR_THREAD_TEST_CASE(test_same_size_reupload_skipped) {
         BOOST_REQUIRE(collector.should_replace_manifest_segment());
     }
 }
+
+SEASTAR_THREAD_TEST_CASE(test_bump_start_when_not_aligned) {
+    auto ntp = model::ntp{"test_ns", "test_tpc", 0};
+    temporary_dir tmp_dir("concat_segment_read");
+    auto data_path = tmp_dir.get_path();
+    using namespace storage;
+
+    auto b = make_log_builder(data_path.string());
+
+    auto o = std::make_unique<ntp_config::default_overrides>();
+    o->cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    b | start(ntp_config{ntp, {data_path}, std::move(o)});
+    auto defer = ss::defer([&b] { b.stop().get(); });
+
+    b | storage::add_segment(0) | storage::add_random_batch(0, 1000)
+      | storage::add_segment(1000) | storage::add_random_batch(1000, 1000)
+      | storage::add_segment(2000) | storage::add_random_batch(2000, 1000);
+
+    // Set up our manifest to look as if our local data is a compacted version
+    // of what's in the cloud.
+    auto seg_size = b.get_segment(0).size_bytes();
+    cloud_storage::partition_manifest m(ntp, model::initial_revision_id{1});
+    m.add(
+      cloud_storage::segment_name("0-499-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = seg_size,
+        .base_offset = model::offset(0),
+        .committed_offset = model::offset(499),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+    m.add(
+      cloud_storage::segment_name("500-999-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = seg_size,
+        .base_offset = model::offset(500),
+        .committed_offset = model::offset(999),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+    m.add(
+      cloud_storage::segment_name("1000-1999-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = seg_size,
+        .base_offset = model::offset(1000),
+        .committed_offset = model::offset(1999),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+    m.add(
+      cloud_storage::segment_name("2000-2999-v1.log"),
+      cloud_storage::segment_meta{
+        .is_compacted = false,
+        .size_bytes = seg_size,
+        .base_offset = model::offset(2000),
+        .committed_offset = model::offset(2999),
+        .delta_offset = model::offset_delta(0),
+        .delta_offset_end = model::offset_delta(0)});
+
+    // Mark our local segments compacted, making them eligible for reupload.
+    for (int i = 0; i < 3; i++) {
+        b.get_segment(i).mark_as_compacted_segment();
+        b.get_segment(i).mark_as_finished_self_compaction();
+    }
+
+    // Try collecting from the middle of a local segment that hapens to align
+    // with our manifest. The containing segment should be included, and the
+    // start offset of the upload candidate should be aligned with our
+    // manifest.
+    archival::segment_collector collector{
+      model::offset{500}, m, b.get_disk_log_impl(), seg_size * 10};
+    collector.collect_segments();
+    BOOST_REQUIRE_EQUAL(collector.begin_inclusive()(), 500);
+    BOOST_REQUIRE_EQUAL(collector.segments().size(), 3);
+    BOOST_REQUIRE_EQUAL(collector.segments()[0]->offsets().base_offset(), 0);
+    BOOST_REQUIRE(collector.should_replace_manifest_segment());
+}


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/14911

CONFLICT:
- removes the piece of the max() equation that was added for delete-records, since that was added after 23.1.

This updates the segment_collector collection to only move its collection start offset forward. Previously we were susceptible to the following issue:

- Say our manifest has [0, 10)[10,20)[20,25)[25,30), and we do one compacted upload [0, 25).
- Before we move onto persisting that fact into our manifest, we schedule our next upload, starting at 25.
- Schedule and compacted reupload starting from range 25.
- Locally, merge compact data such that we end up with local segment [20, 30).
- Locally, we only have a segment with [20, 30) that also happens to align with a remote segment in our manifest.
- We try to align the segment’s base offset 20, and get 20
- The new upload candidate is [20, 30).
- Total, we upload [0,25) [20,30).

(cherry picked from commit a2765cbe24bab2e9a78fae6b27da9228ad070e58)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixes a bug in compacted segment reuploads that could result in overlapping remote segments in the cloud manifest.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
