### PR TITLE
io: use config to avoid swappable params warning

### DIFF
--- a/src/v/io/persistence.cc
+++ b/src/v/io/persistence.cc
@@ -116,16 +116,12 @@ disk_persistence::open(std::filesystem::path path) noexcept {
 
 memory_persistence::memory_persistence()
   : memory_persistence(
-    default_alignment, default_alignment, default_alignment) {}
+    {default_alignment, default_alignment, default_alignment}) {}
 
-memory_persistence::memory_persistence(
-  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
-  uint64_t disk_read_dma_alignment,
-  uint64_t disk_write_dma_alignment,
-  uint64_t memory_dma_alignment)
-  : disk_read_dma_alignment_(disk_read_dma_alignment)
-  , disk_write_dma_alignment_(disk_write_dma_alignment)
-  , memory_dma_alignment_(memory_dma_alignment) {}
+memory_persistence::memory_persistence(config config)
+  : disk_read_dma_alignment_(config.disk_read_dma_alignment)
+  , disk_write_dma_alignment_(config.disk_write_dma_alignment)
+  , memory_dma_alignment_(config.memory_dma_alignment) {}
 
 /*
  * The temporary buffer alignment helper used here is based on posix_memalign,

--- a/src/v/io/persistence.h
+++ b/src/v/io/persistence.h
@@ -173,12 +173,21 @@ public:
     memory_persistence();
 
     /**
+     * Memory persistence parameters.
+     */
+    struct config {
+        /// Required alignment for DMA read operations.
+        uint64_t disk_read_dma_alignment;
+        /// Required alignment for DMA write operations.
+        uint64_t disk_write_dma_alignment;
+        /// Required memory alignment for DMA operations.
+        uint64_t memory_dma_alignment;
+    };
+
+    /**
      * Create a memory_persistence with specific alignment requirements.
      */
-    memory_persistence(
-      uint64_t disk_read_dma_alignment,
-      uint64_t disk_write_dma_alignment,
-      uint64_t memory_dma_alignment);
+    explicit memory_persistence(config config);
 
     /**
      * An implementation of \ref persistence::file that stores all data in

--- a/src/v/io/tests/persistence_test.cc
+++ b/src/v/io/tests/persistence_test.cc
@@ -67,7 +67,7 @@ template<uint64_t read, uint64_t write, uint64_t memory>
 class memfs_align : public io::memory_persistence {
 public:
     memfs_align()
-      : memory_persistence(read, write, memory) {}
+      : memory_persistence({read, write, memory}) {}
 };
 
 using PersistenceTypes = ::testing::Types<
@@ -288,7 +288,7 @@ TEST(MemoryPersistenceTest, CustomAlignment) {
     open_files.push_back(df);
 
     // custom alignments
-    io::memory_persistence cfs(1, 2, 3);
+    io::memory_persistence cfs({1, 2, 3});
     auto cf = cfs.create("file").get();
     open_files.push_back(cf);
 


### PR DESCRIPTION
io: use config to avoid swappable params warning

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
