### PR TITLE
transform: don't start transform in recovery mode

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2305,7 +2305,8 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
     start_kafka(node_id, app_signal);
     controller->set_ready().get();
 
-    if (wasm_data_transforms_enabled()) {
+    if (
+      wasm_data_transforms_enabled() && !config::node().recovery_mode_enabled) {
         const auto& cluster = config::shard_local_cfg();
         wasm::runtime::config config = {
           .heap_memory = {


### PR DESCRIPTION
If we're in recovery mode, don't start the transform or wasm subsystem up.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
