### PR TITLE
transform/processor: fix off by one lag error

### DIFF
--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -115,7 +115,7 @@ public:
             throw std::runtime_error(
               kafka::make_error_code(result.error()).message());
         }
-        return model::offset_cast(result.value());
+        return model::offset_cast(model::prev_offset(result.value()));
     }
 
     ss::future<model::record_batch_reader>

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -47,8 +47,9 @@ public:
     virtual ss::future<> start() = 0;
     virtual ss::future<> stop() = 0;
 
-    /*
-     * Get the latest offset in the log to read from.
+    /**
+     * The last offset of a record the log - if the log is empty then
+     * `kafka::offset::min()` is returned.
      */
     virtual kafka::offset latest_offset() = 0;
 

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -46,9 +46,9 @@ ss::future<> fake_source::stop() { co_return; }
 
 kafka::offset fake_source::latest_offset() {
     if (_batches.empty()) {
-        return kafka::offset(0);
+        return {};
     }
-    return kafka::next_offset(_batches.rbegin()->first);
+    return _batches.rbegin()->first;
 }
 
 ss::future<model::record_batch_reader>

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -83,6 +83,7 @@ public:
     }
     model::record_batch read_batch() { return _sinks[0]->read().get(); }
     uint64_t error_count() const { return _error_count; }
+    int64_t lag() const { return _p->current_lag(); }
 
     void restart() {
         stop();
@@ -181,6 +182,15 @@ TEST_F(ProcessorTestFixture, HandlesEmptyBatches) {
     push_batch(batch_three.copy());
     wait_for_committed_offset(batch_three.last_offset());
     EXPECT_EQ(read_batch(), batch_three);
+}
+
+TEST_F(ProcessorTestFixture, LagOffByOne) {
+    EXPECT_EQ(lag(), 0);
+    auto batch_one = make_tiny_batch();
+    push_batch(batch_one.copy());
+    wait_for_committed_offset(batch_one.last_offset());
+    EXPECT_EQ(read_batch(), batch_one);
+    EXPECT_EQ(lag(), 0);
 }
 
 } // namespace transform

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -225,7 +225,8 @@ ss::future<> processor::run_producer_loop() {
         auto drained = co_await drain_queue(&_transform_producer_pipe, _probe);
         co_await _sinks[0]->write(std::move(drained.batches));
         co_await _offset_tracker->commit_offset(drained.latest_offset);
-        report_lag(_source->latest_offset() - drained.latest_offset);
+        report_lag(
+          kafka::prev_offset(_source->latest_offset()) - drained.latest_offset);
     }
 }
 

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -179,14 +179,17 @@ ss::future<kafka::offset> processor::load_start_offset() {
     co_await _offset_tracker->wait_for_previous_flushes(&_as);
     auto latest_committed = co_await _offset_tracker->load_committed_offset();
     auto latest = _source->latest_offset();
-    if (latest_committed) {
-        auto start_offset = kafka::next_offset(latest_committed.value());
-        report_lag(latest - start_offset);
-        co_return start_offset;
+    if (!latest_committed) {
+        // If we have never committed, mark the end of the log as our starting
+        // place, and start processing from the next record that is produced.
+        co_await _offset_tracker->commit_offset(latest);
+        co_return kafka::next_offset(latest);
     }
-    // We "commit" at the previous offset so that we resume at the latest.
-    co_await _offset_tracker->commit_offset(kafka::prev_offset(latest));
-    co_return latest;
+    // The latest record is inclusive of the last record, so we want to start
+    // reading from the following record.
+    auto last_processed_offset = latest_committed.value_or(latest);
+    report_lag(latest - last_processed_offset);
+    co_return kafka::next_offset(last_processed_offset);
 }
 
 ss::future<> processor::run_consumer_loop() {
@@ -225,8 +228,7 @@ ss::future<> processor::run_producer_loop() {
         auto drained = co_await drain_queue(&_transform_producer_pipe, _probe);
         co_await _sinks[0]->write(std::move(drained.batches));
         co_await _offset_tracker->commit_offset(drained.latest_offset);
-        report_lag(
-          kafka::prev_offset(_source->latest_offset()) - drained.latest_offset);
+        report_lag(_source->latest_offset() - drained.latest_offset);
     }
 }
 


### PR DESCRIPTION
This fixes an off by one error with lag. _source->latest_offset() is LSO
which is last_produced_offset + 1, we want to compare this with the last
produced offset.

NOTE: that latest_offset can return 0 if there is an empty log, but we
don't have to worry about that here because if the transform read
something the log isn't empty :)

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixes off by one issue with reported transform lag
