### PR TITLE
transform: report unknown transforms as unknown

### DIFF
--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -576,7 +576,13 @@ ss::future<model::cluster_transform_report> service::list_transforms() {
         co_return model::cluster_transform_report{};
     }
     auto _ = _gate.hold();
-    co_return co_await _rpc_client->local().generate_report();
+    // The default report marks all transform's partitions in the unknown state,
+    // then update the report with the information that we gather from all the
+    // nodes in the cluster's in memory state. This allows us to report on
+    // partitions that may not be actively in memory on a node somewhere.
+    auto report = compute_default_report();
+    report.merge(co_await _rpc_client->local().generate_report());
+    co_return report;
 }
 
 ss::future<> service::cleanup_wasm_binary(uuid_t key) {
@@ -654,6 +660,30 @@ service::compute_node_local_report() {
           agg.merge(local);
           return agg;
       });
+}
+
+model::cluster_transform_report service::compute_default_report() {
+    using state = model::transform_report::processor::state;
+    model::cluster_transform_report report;
+    // Mark all transforms in an unknown state if they don't get an update
+    for (auto [id, transform] : _plugin_frontend->local().all_transforms()) {
+        auto cfg = _topic_table->local().get_topic_cfg(transform.input_topic);
+        if (!cfg) {
+            continue;
+        }
+        for (int32_t i = 0; i < cfg->partition_count; ++i) {
+            report.add(
+              id,
+              transform,
+              {
+                .id = model::partition_id(i),
+                .status = state::unknown,
+                .node = _self,
+                .lag = 0,
+              });
+        }
+    }
+    return report;
 }
 
 std::unique_ptr<rpc::reporter>

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -91,6 +91,7 @@ private:
 
     friend class wrapped_service_reporter;
     ss::future<model::cluster_transform_report> compute_node_local_report();
+    model::cluster_transform_report compute_default_report();
 
     ss::gate _gate;
 


### PR DESCRIPTION
It's possible to get empty reports often for transforms, which is very
confusing because there is a deploy ongoing or leadership transfers.
Fix that by reporting the transform as being in an unknown state.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Report pending transforms in an unknown state when generating reports via `rpk transform list`.

