### PR TITLE
rpk/transform/build: support old tinygo lang opt

### DIFF
--- a/src/go/rpk/pkg/cli/transform/project/project.go
+++ b/src/go/rpk/pkg/cli/transform/project/project.go
@@ -39,6 +39,12 @@ var AllWasmLangsWithDescriptions = []string{
 
 func (l *WasmLang) Set(str string) error {
 	lower := strings.ToLower(str)
+	// For compatibility with old projects, we map bare `tinygo` to the version
+	// without goroutines.
+	if lower == "tinygo" {
+		*l = WasmLangTinygoNoGoroutines
+		return nil
+	}
 	for _, s := range AllWasmLangs {
 		if lower == s {
 			*l = WasmLang(s)


### PR DESCRIPTION
Previously one could just use `tinygo`, instead of updating anything
someone wrote during the sandbox period, just translate that option to
the no goroutines version.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
