### PR TITLE
Remove local_monitor::_min_free_bytes

### DIFF
--- a/src/v/cluster/node/local_monitor.cc
+++ b/src/v/cluster/node/local_monitor.cc
@@ -46,11 +46,9 @@ constexpr ss::lowres_clock::duration tick_period = 1s;
 local_monitor::local_monitor(
   config::binding<size_t> alert_bytes,
   config::binding<unsigned> alert_percent,
-  config::binding<size_t> min_bytes,
   ss::sharded<storage::node>& node_api)
   : _free_bytes_alert_threshold(std::move(alert_bytes))
   , _free_percent_alert_threshold(std::move(alert_percent))
-  , _min_free_bytes(std::move(min_bytes))
   , _storage_node_api(node_api) {}
 
 ss::future<> local_monitor::_update_loop() {

--- a/src/v/cluster/node/local_monitor.h
+++ b/src/v/cluster/node/local_monitor.h
@@ -34,7 +34,6 @@ public:
     local_monitor(
       config::binding<size_t> min_bytes_alert,
       config::binding<unsigned> min_percent_alert,
-      config::binding<size_t> min_bytes,
       ss::sharded<storage::node>&);
 
     local_monitor(const local_monitor&) = delete;
@@ -83,7 +82,6 @@ private:
       std::chrono::hours(1));
     config::binding<size_t> _free_bytes_alert_threshold;
     config::binding<unsigned> _free_percent_alert_threshold;
-    config::binding<size_t> _min_free_bytes;
 
     ss::sharded<storage::node>& _storage_node_api; // single instance
 

--- a/src/v/cluster/tests/local_monitor_test.cc
+++ b/src/v/cluster/tests/local_monitor_test.cc
@@ -79,9 +79,6 @@ local_monitor_fixture::local_monitor_fixture() {
             return config::shard_local_cfg()
               .storage_space_alert_free_threshold_percent.bind();
         }),
-        ss::sharded_parameter([] {
-            return config::shard_local_cfg().storage_min_free_bytes.bind();
-        }),
         std::ref(_storage_node_api))
       .get();
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1941,7 +1941,6 @@ void application::wire_up_bootstrap_services() {
       config::shard_local_cfg().storage_space_alert_free_threshold_bytes.bind(),
       config::shard_local_cfg()
         .storage_space_alert_free_threshold_percent.bind(),
-      config::shard_local_cfg().storage_min_free_bytes.bind(),
       std::ref(storage_node))
       .get();
 


### PR DESCRIPTION
It was never used.

## Release Notes

* none
