### PR TITLE
archival/test: Ensure archiver is stopped

### DIFF
--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -1732,6 +1732,8 @@ static void test_manifest_spillover_impl(
       *part,
       amv);
 
+    auto stop_archiver = ss::defer([&archiver] { archiver.stop().get(); });
+
     // Do not start archiver and run spillover manually.
     vlog(
       test_log.debug,


### PR DESCRIPTION
If `test_manifest_spillover` fails, its archiver is destroyed without stopping. This also destroys the scrubber, which may have requests active keeping its gate open.

This triggers an assertion from seastar related to gate destroyed while requests active. Usually this is prominently visible but when running multiple tests the SIGABRT results in the ctest invocation hanging in CI. This causes the build to hang and timeout. 

NOTE: The root cause is the `test_manifest_spillover` sometimes not being able to add segments to the archival meta STM, which can be investigated separately. This change should enable that test to fail in a visible manner with logs seen in CI instead of hanging.

FIXES #14254 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
