### PR TITLE
named_type: forbid arithmetic operations between unrelated named_types

### DIFF
--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -124,8 +124,7 @@ segment_layout write_random_batches(
       model::test::record_batch_spec{
         .offset = seg->offsets().committed_offset == model::offset{}
                     ? seg->offsets().base_offset
-                    : (
-                      seg->offsets().committed_offset + model::offset_delta{1}),
+                    : (seg->offsets().committed_offset + model::offset{1}),
         .allow_compression = true,
         .count = full_batches_count,
         .records = records_per_batch,

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1164,7 +1164,7 @@ public:
         _parent._cur_rp_offset = header.last_offset() + model::offset{1};
 
         if (header.type == model::record_batch_type::raft_data) {
-            auto next = rp_to_kafka(header.last_offset()) + model::offset(1);
+            auto next = rp_to_kafka(header.last_offset()) + kafka::offset(1);
             if (kafka::offset_cast(next) > _config.start_offset) {
                 _config.start_offset = kafka::offset_cast(next);
             }

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -280,7 +280,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
                      .get();
         vlog(e2e_test_log.debug, "{} records consumed", tmp.size());
         std::copy(tmp.begin(), tmp.end(), std::back_inserter(consumed_records));
-        next_offset += model::offset((int64_t)tmp.size());
+        next_offset += kafka::offset((int64_t)tmp.size());
     }
 
     BOOST_REQUIRE_EQUAL(total_records, consumed_records.size());
@@ -310,7 +310,7 @@ FIXTURE_TEST(test_produce_consume_from_cloud_with_spillover, e2e_fixture) {
     }
 
     consumed_records.clear();
-    auto last_offset = next_offset - model::offset(1);
+    auto last_offset = next_offset - kafka::offset(1);
     next_offset = kafka::offset(new_so);
     while (next_offset < last_offset) {
         auto tmp = consumer

--- a/src/v/cloud_storage/tests/remote_segment_index_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_index_test.cc
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(remote_segment_index_search_test) {
         BOOST_REQUIRE_EQUAL(kaf, kaf_offsets[ix]);
         BOOST_REQUIRE_EQUAL(fpos, file_offsets[ix]);
 
-        auto kopt = index.find_kaf_offset(kaf_offsets[ix] + model::offset(1));
+        auto kopt = index.find_kaf_offset(kaf_offsets[ix] + kafka::offset(1));
         BOOST_REQUIRE_EQUAL(kopt->rp_offset, rp_offsets[ix]);
         BOOST_REQUIRE_EQUAL(kopt->kaf_offset, kaf_offsets[ix]);
         BOOST_REQUIRE_EQUAL(kopt->file_pos, file_offsets[ix]);

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -485,8 +485,8 @@ std::vector<cloud_storage_fixture::expectation> make_imposter_expectations(
           .sname_format = sname_format};
 
         m.add(s.sname, meta);
-        delta = delta
-                + model::offset(s.num_config_records - s.delta_offset_overlap);
+        delta += model::offset_delta(
+          s.num_config_records - s.delta_offset_overlap);
         auto url = m.generate_segment_path(*m.get(meta.base_offset));
         results.push_back(cloud_storage_fixture::expectation{
           .url = "/" + url().string(), .body = body});

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -29,7 +29,7 @@ ss::future<ss::stop_iteration> put_entry(
   key_offset_map& map,
   const compacted_index::entry& idx_entry,
   bool& fully_indexed) {
-    auto offset = idx_entry.offset + model::offset_delta(idx_entry.delta);
+    auto offset = idx_entry.offset + model::offset(idx_entry.delta);
     bool success = co_await map.put(idx_entry.key, offset);
     if (success) {
         co_return ss::stop_iteration::no;
@@ -42,7 +42,7 @@ ss::future<bool> should_keep(
   const key_offset_map& map,
   const model::record_batch& b,
   const model::record& r) {
-    const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
+    const auto o = b.base_offset() + model::offset(r.offset_delta());
     auto key_view = compaction_key{iobuf_to_bytes(r.key())};
     auto key = enhance_key(
       b.header().type, b.header().attrs.is_control(), key_view);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -410,13 +410,12 @@ ss::future<storage::index_state> do_copy_segment_data(
       seg->reader().filename(),
       tmpname);
 
-    auto should_keep = [compacted_list = std::move(compacted_offsets)](
-                         const model::record_batch& b,
-                         const model::record& r,
-                         bool) {
-        const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
-        return ss::make_ready_future<bool>(compacted_list.contains(o));
-    };
+    auto should_keep =
+      [compacted_list = std::move(compacted_offsets)](
+        const model::record_batch& b, const model::record& r, bool) {
+          const auto o = b.base_offset() + model::offset(r.offset_delta());
+          return ss::make_ready_future<bool>(compacted_list.contains(o));
+      };
 
     model::offset segment_last_offset{};
     if (likely(feature_table.local().is_active(

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -61,18 +61,34 @@ public:
         --_value;
         return cp;
     }
-    constexpr base_named_type operator+(const base_named_type& val) const {
+    template<typename X, typename Y, typename Z>
+    constexpr base_named_type operator+(const base_named_type<X, Y, Z>&) const
+      = delete;
+    constexpr base_named_type
+    operator+(const base_named_type& val) const noexcept {
         return base_named_type(_value + val()); // not mutable
     }
-    constexpr base_named_type operator+(const type& val) const {
+
+    constexpr base_named_type operator+(const type& val) const noexcept {
         return base_named_type(_value + val); // not mutable
     }
 
-    constexpr base_named_type operator-(const base_named_type& val) const {
+    template<typename X, typename Y, typename Z>
+    constexpr base_named_type operator-(const base_named_type<X, Y, Z>&) const
+      = delete;
+    constexpr base_named_type
+    operator-(const base_named_type& val) const noexcept {
         return base_named_type(_value - val()); // not mutable
     }
 
-    base_named_type& operator+=(const type& val) {
+    template<typename X, typename Y, typename Z>
+    constexpr base_named_type& operator+=(const base_named_type<X, Y, Z>&)
+      = delete;
+    constexpr base_named_type& operator+=(const base_named_type& val) noexcept {
+        _value += val();
+        return *this;
+    }
+    constexpr base_named_type& operator+=(const type& val) noexcept {
         _value += val;
         return *this;
     }

--- a/src/v/utils/tests/named_type_tests.cc
+++ b/src/v/utils/tests/named_type_tests.cc
@@ -117,3 +117,15 @@ static_assert(std::equality_comparable_with<
               std::reference_wrapper<named_int>>);
 static_assert(
   std::equality_comparable_with<named_int, std::reference_wrapper<named_int>>);
+
+template<typename Lhs, typename Rhs>
+concept arithmetic_ready = requires(Lhs l, Rhs r) {
+    l + r;
+    l - r;
+    l += r;
+};
+
+static_assert(arithmetic_ready<named_int, named_int>);
+static_assert(arithmetic_ready<named_int, int>);
+static_assert(
+  !arithmetic_ready<named_int, named_type<int, struct another_tag_t>>);


### PR DESCRIPTION
explicitly forbids operations like
```cpp
named_type<int, struct tag_a>(1) + named_type<int, struct tag_b>(1)
```
The expression worked because there is an implicit conversion possible from named_type<int, tag> to int, and an operator+(int).

this pr deletes the generic base_named_type from the arithmetic operators overload set and implicitly forbids the above case
to compile.

operations like 
```cpp
named_type<int>(1) + 1
```
are still allowed. see named_type_test.cc

```cpp
template<typename Lhs, typename Rhs>
concept arithmetic_ready = requires(Lhs l, Rhs r) {
    l + r;
    l - r;
    l += r;
};

static_assert(arithmetic_ready<named_int, named_int>);
static_assert(arithmetic_ready<named_int, int>);
static_assert(
  !arithmetic_ready<named_int, named_type<int, struct another_tag_t>>);
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none