### PR TITLE
model: store wasm binaries in kafka_internal namespace

### DIFF
--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -68,7 +68,9 @@ inline const model::topic_partition schema_registry_internal_tp{
   model::topic{"_schemas"}, model::partition_id{0}};
 
 inline const model::ntp wasm_binaries_internal_ntp(
-  model::redpanda_ns, model::topic("wasm_binaries"), model::partition_id(0));
+  model::kafka_internal_namespace,
+  model::topic("wasm_binaries"),
+  model::partition_id(0));
 
 inline bool is_user_topic(topic_namespace_view tp_ns) {
     return tp_ns.ns == kafka_namespace


### PR DESCRIPTION
There seems to be some issues using the `redpanda` namespace that I'm
still chasing, but while I'm tracking that down, switching to
`kafka_internal` seems to fix the errors I'm seeing, so I am going to move
to that in the meantime.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
