### PR TITLE
ducktape: add transaction tests for transforms

### DIFF
--- a/tests/go/transform-verifier/consume/consumer.go
+++ b/tests/go/transform-verifier/consume/consumer.go
@@ -100,7 +100,7 @@ func createRecordValidator() recordValidator {
 		// The real thing we can guarantee is that once we get a new seqno, there are no
 		// gaps we've seen.
 		if seqno > latestSeqno && latestSeqno+1 != seqno {
-			return latestSeqno, fmt.Errorf("detected missing seqno: seqno=%d latest=%d", seqno, latestSeqno)
+			return latestSeqno, fmt.Errorf("detected missing seqno: partition=%d seqno=%d latest=%d", r.Partition, seqno, latestSeqno)
 		}
 		latestSeqno = max(seqno, latestSeqno)
 		return latestSeqno, nil

--- a/tests/rptest/services/transform_verifier_service.py
+++ b/tests/rptest/services/transform_verifier_service.py
@@ -67,16 +67,20 @@ class TransformVerifierProduceConfig(typing.NamedTuple):
     # Maximum size to batch records on the client
     # i.e. 1MB
     max_batch_size: str
+    transactional: bool = False
 
     def serialize_cmd(self) -> str:
-        return " ".join([
+        cmd = [
             "produce",
             f"--topic={self.topic}",
             f"--max-bytes={self.max_bytes}",
             f"--bytes-per-second={self.bytes_per_second}",
             f"--message-size={self.message_size}",
             f"--max-batch-size={self.max_batch_size}",
-        ])
+        ]
+        if self.transactional:
+            cmd.append("--transactional")
+        return " ".join(cmd)
 
     def deserialize_status(self, buf: str | bytes | bytearray):
         return TransformVerifierProduceStatus.deserialize(buf)
@@ -135,6 +139,8 @@ class TransformVerifierConsumeConfig(typing.NamedTuple):
         return TransformVerifierConsumeStatus.deserialize(buf)
 
     def is_done(self, status: TransformVerifierConsumeStatus) -> bool:
+        if status.invalid_records > 0:
+            return True
         for partition, amt in self.validate.latest_seqnos.items():
             if status.latest_seqnos.get(partition, 0) < amt:
                 return False
@@ -170,16 +176,19 @@ class TransformVerifierService(Service):
     _pid: typing.Optional[int]
 
     @classmethod
-    def oneshot(cls, context: TestContext, redpanda: RedpandaService,
+    def oneshot(cls,
+                context: TestContext,
+                redpanda: RedpandaService,
                 config: TransformVerifierConsumeConfig
-                | TransformVerifierProduceConfig):
+                | TransformVerifierProduceConfig,
+                timeout_sec=300):
         """
         Common pattern to use the service
         """
         service = cls(context, redpanda, config)
         service.start()
         try:
-            service.wait()
+            service.wait(timeout_sec=timeout_sec)
             final_status = service.get_status()
             service.stop()
             service.free()


### PR DESCRIPTION
Add automated tests that transforms only process read committed records.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
