### PR TITLE
io: add page set index

### DIFF
--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -2,6 +2,7 @@ v_cc_library(
   NAME io
   SRCS
     persistence.cc
+    page.cc
   DEPS
     Seastar::seastar
     absl::btree

--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   SRCS
     persistence.cc
     page.cc
+    page_set.cc
   DEPS
     Seastar::seastar
     absl::btree

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/page.h"
+
+namespace experimental::io {
+
+page::page(uint64_t offset, seastar::temporary_buffer<char> data)
+  : offset_(offset)
+  , size_(data.size())
+  , data_(std::move(data)) {}
+
+uint64_t page::offset() const noexcept { return offset_; }
+
+uint64_t page::size() const noexcept { return size_; }
+
+const seastar::temporary_buffer<char>& page::data() const noexcept {
+    return data_;
+}
+
+} // namespace experimental::io

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <seastar/core/temporary_buffer.hh>
+
+#include <cstdint>
+
+namespace experimental::io {
+
+/**
+ * A page represents a contiguous region of data in a file.
+ */
+class page {
+public:
+    /**
+     * Construct a page with the given \p offset and \p data.
+     */
+    page(uint64_t offset, seastar::temporary_buffer<char> data);
+
+    page(const page&) = delete;
+    page& operator=(const page&) = delete;
+    page(page&&) = delete;
+    page& operator=(page&&) = delete;
+    ~page() = default;
+
+    /**
+     * Offset of this page in the underlying file.
+     *
+     * The offset is fixed for the lifetime of the page.
+     */
+    [[nodiscard]] uint64_t offset() const noexcept;
+
+    /**
+     * Size of the this page.
+     *
+     * The size is fixed, even if the page data is removed.
+     */
+    [[nodiscard]] uint64_t size() const noexcept;
+
+    /**
+     * Data stored in this page.
+     */
+    [[nodiscard]] const seastar::temporary_buffer<char>& data() const noexcept;
+
+private:
+    uint64_t offset_;
+    uint64_t size_;
+    seastar::temporary_buffer<char> data_;
+};
+
+} // namespace experimental::io

--- a/src/v/io/page_set.cc
+++ b/src/v/io/page_set.cc
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/page_set.h"
+
+namespace experimental::io {
+
+page_set::const_iterator::const_iterator(map_type::const_iterator it)
+  : const_iterator::iterator_adaptor(it) {}
+
+page_set::const_iterator::reference
+page_set::const_iterator::dereference() const {
+    return base_reference()->second;
+}
+
+page_set::const_iterator page_set::find(uint64_t offset) const {
+    return const_iterator(pages_.find(offset));
+}
+
+void page_set::erase(page_set::const_iterator it) {
+    pages_.erase(it.base_reference());
+}
+
+page_set::const_iterator page_set::begin() const {
+    return const_iterator(pages_.begin());
+}
+
+page_set::const_iterator page_set::end() const {
+    return const_iterator(pages_.end());
+}
+
+std::pair<page_set::const_iterator, bool>
+page_set::insert(seastar::lw_shared_ptr<page> page) {
+    auto offset = page->offset();
+    auto size = page->size();
+    auto res = pages_.insert({offset, size}, std::move(page));
+    return {const_iterator(res.first), res.second};
+}
+
+} // namespace experimental::io

--- a/src/v/io/page_set.h
+++ b/src/v/io/page_set.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "io/interval_map.h"
+#include "io/page.h"
+
+#include <seastar/core/shared_ptr.hh>
+
+#include <boost/iterator/iterator_adaptor.hpp>
+
+namespace experimental::io {
+
+/**
+ * A container holding non-overlapping pages.
+ */
+class page_set {
+    using map_type = io::interval_map<uint64_t, seastar::lw_shared_ptr<page>>;
+
+public:
+    /**
+     * Container value iterator.
+     */
+    class const_iterator
+      : public boost::iterator_adaptor<
+          const_iterator,
+          map_type::const_iterator,
+          const seastar::lw_shared_ptr<page>,
+          boost::iterators::forward_traversal_tag> {
+    private:
+        friend class boost::iterator_core_access;
+        friend class page_set;
+        explicit const_iterator(map_type::const_iterator);
+        reference dereference() const;
+    };
+
+    /**
+     * Find the page containing \p offset. If no such page exists, then the
+     * returned iterator will compare equal to end().
+     */
+    [[nodiscard]] const_iterator find(uint64_t offset) const;
+
+    /**
+     * Add \p page to the container. The return value will contain true if
+     * insertion succeeded, and the iterator will point to the newly inserted
+     * page.
+     *
+     * If the page is empty or it overlaps an existing page then no insertion
+     * will occur, and false will be returned. When the page is empty the
+     * iterator will compare equal to end(), and when an overlap occurs the
+     * iterator will point at some existing page that overlaps.
+     */
+    [[nodiscard]] std::pair<const_iterator, bool>
+    insert(seastar::lw_shared_ptr<page> page);
+
+    /**
+     * Remove the page pointed to be \p it.
+     */
+    void erase(const_iterator it);
+
+    /**
+     * Return an iterator to the first page in the set.
+     */
+    [[nodiscard]] const_iterator begin() const;
+
+    /**
+     * Return an iterator to the end of the page set.
+     */
+    [[nodiscard]] const_iterator end() const;
+
+private:
+    map_type pages_;
+};
+
+} // namespace experimental::io

--- a/src/v/io/tests/CMakeLists.txt
+++ b/src/v/io/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ rp_test(
     cache_test.cc
     interval_map_test.cc
     persistence_test.cc
+    page_test.cc
   LIBRARIES
     v::gtest_main
     v::io

--- a/src/v/io/tests/CMakeLists.txt
+++ b/src/v/io/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ rp_test(
     interval_map_test.cc
     persistence_test.cc
     page_test.cc
+    page_set_test.cc
   LIBRARIES
     v::gtest_main
     v::io

--- a/src/v/io/tests/page_set_test.cc
+++ b/src/v/io/tests/page_set_test.cc
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/page_set.h"
+
+#include <seastar/util/later.hh>
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+namespace io = experimental::io;
+
+namespace {
+auto make_page(uint64_t offset, uint64_t size) {
+    return seastar::make_lw_shared<io::page>(
+      offset, seastar::temporary_buffer<char>(size));
+}
+} // namespace
+
+TEST(PageSet, EmptyBeginEnd) {
+    io::page_set set;
+    EXPECT_EQ(set.begin(), set.end());
+}
+
+TEST(PageSet, EmptyFind) {
+    io::page_set set;
+    EXPECT_EQ(set.find(0), set.end());
+}
+
+TEST(PageSet, InsertOne) {
+    io::page_set set;
+
+    auto res = set.insert(make_page(0, 10));
+    EXPECT_TRUE(res.second);
+    EXPECT_EQ(set.find(0), res.first);
+
+    EXPECT_NE(set.begin(), set.end());
+    for (int i = 0; i < 10; ++i) {
+        auto it = set.find(i);
+        EXPECT_EQ((*it)->offset(), 0);
+        EXPECT_EQ((*it)->size(), 10);
+        EXPECT_EQ((*it)->data().size(), 10);
+    }
+    EXPECT_EQ(set.find(10), set.end());
+}
+
+TEST(PageSet, InsertOverlap) {
+    io::page_set set;
+
+    auto res = set.insert(make_page(0, 10));
+    EXPECT_TRUE(res.second);
+    EXPECT_EQ(set.find(0), res.first);
+
+    auto res2 = set.insert(make_page(9, 10));
+    EXPECT_FALSE(res2.second);
+    EXPECT_EQ(res2.first, res.first);
+}
+
+TEST(PageSet, InsertEmpty) {
+    io::page_set set;
+
+    auto res = set.insert(make_page(0, 0));
+    EXPECT_FALSE(res.second);
+    EXPECT_EQ(res.first, set.end());
+    EXPECT_EQ(set.begin(), set.end());
+
+    res = set.insert(make_page(0, 10));
+    EXPECT_TRUE(res.second);
+    EXPECT_EQ(set.find(0), res.first);
+
+    res = set.insert(make_page(0, 0));
+    EXPECT_FALSE(res.second);
+    EXPECT_EQ(res.first, set.end());
+}
+
+TEST(PageSet, Erase) {
+    io::page_set set;
+
+    // add two pages
+    auto res = set.insert(make_page(0, 10));
+    EXPECT_TRUE(res.second);
+    res = set.insert(make_page(20, 10));
+    EXPECT_TRUE(res.second);
+    EXPECT_NE(set.begin(), set.end());
+
+    // remove one
+    set.erase(set.find(5));
+    EXPECT_NE(set.begin(), set.end());
+
+    // remove the other
+    set.erase(set.find(25));
+
+    // now its empty
+    EXPECT_EQ(set.begin(), set.end());
+}

--- a/src/v/io/tests/page_test.cc
+++ b/src/v/io/tests/page_test.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/page.h"
+#include "test_utils/test.h"
+
+namespace io = experimental::io;
+
+TEST(Page, Empty) {
+    io::page p(1, {});
+    EXPECT_EQ(p.offset(), 1);
+    EXPECT_EQ(p.size(), 0);
+    EXPECT_EQ(p.data().size(), 0);
+}
+
+TEST(Page, NonEmpty) {
+    constexpr auto size = 10;
+    seastar::temporary_buffer<char> data(size);
+    io::page p(1, std::move(data));
+    EXPECT_EQ(p.offset(), 1);
+    EXPECT_EQ(p.size(), size);
+    EXPECT_EQ(p.data().size(), size);
+}


### PR DESCRIPTION
Add page and page set.

```
[nwatkins@fedora coverage]$ ../../tools/gcovr src/v/io
------------------------------------------------------------------------------
                           GCC Code Coverage Report
Directory: ../..
------------------------------------------------------------------------------
File                                       Lines    Exec  Cover   Missing
------------------------------------------------------------------------------
src/v/io/cache.h                             116     116   100%
src/v/io/interval_map.h                       50      50   100%
src/v/io/page.cc                               8       8   100%
src/v/io/page.h                                1       1   100%
src/v/io/page_set.cc                          17      16    94%   43
src/v/io/page_set.h                            0       0    --%
src/v/io/persistence.cc                      165     165   100%
src/v/io/persistence.h                         6       6   100%
src/v/io/tests/cache_test.cc                 504     504   100%
src/v/io/tests/common.cc                      23      21    91%   32-33
src/v/io/tests/interval_map_test.cc          223     223   100%
src/v/io/tests/page_set_test.cc               60      59    98%   25
src/v/io/tests/page_test.cc                   14      14   100%
src/v/io/tests/persistence_test.cc           148     147    99%   39
------------------------------------------------------------------------------
TOTAL                                       1335    1330    99%
------------------------------------------------------------------------------
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
