### PR TITLE
rpk: rename storage recovery to restore.

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/recovery.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/recovery.go
@@ -17,19 +17,20 @@ import (
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "recovery",
-		Short: "Interact with the topic recovery process",
-		Long: `Interact with the topic recovery process.
+		Use:     "restore",
+		Aliases: []string{"recovery"},
+		Short:   "Interact with the topic restoration process",
+		Long: `Interact with the topic restoration process.
 		
 This command is used to restore topics from the archival bucket, which can be 
 useful for disaster recovery or if a topic was accidentally deleted.
 
-To begin the recovery process, use the "recovery start" command. Note that this 
+To begin the recovery process, use the "restore start" command. Note that this 
 process can take a while to complete, so the command will exit after starting 
 it. If you want the command to wait for the process to finish, use the "--wait"
 or "-w" flag.
 
-You can check the status of the recovery process with the "recovery status" 
+You can check the status of the recovery process with the "restore status" 
 command after it has been started.
 `,
 	}

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
@@ -30,8 +30,8 @@ func newStartCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "Start the topic recovery process",
-		Long: `Start the topic recovery process.
+		Short: "Start the topic restoration process",
+		Long: `Start the topic restoration process.
 		
 This command starts the process of restoring topics from the archival bucket.
 If the wait flag (--wait/-w) is set, the command will poll the status of the
@@ -66,7 +66,7 @@ recovery process until it's finished.`,
 			fmt.Println("Successfully started topic recovery")
 
 			if !wait {
-				fmt.Println("To check the recovery status, run 'rpk cluster storage recovery status'")
+				fmt.Println("To check the recovery status, run 'rpk cluster storage restore status'")
 				return
 			}
 

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/status.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/status.go
@@ -22,8 +22,8 @@ import (
 func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Fetch the status of the topic recovery process",
-		Long: `Fetch the status of the topic recovery process.
+		Short: "Fetch the status of the topic restoration process",
+		Long: `Fetch the status of the topic restoration process.
 		
 This command fetches the status of the process of restoring topics from the 
 archival bucket.`,


### PR DESCRIPTION
We are introducing a new recovery mode and this can lead to confusion.

Fixes https://github.com/redpanda-data/core-internal/issues/842
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes


### Improvements

* rpk: rename `rpk cloud storage recovery` to `rpk cloud storage restore`, but kept recovery as an alias.
