### PR TITLE
rptest: Fix delete-records test incorrect conditional

### DIFF
--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -170,8 +170,8 @@ class DeleteRecordsTest(RedpandaTest, PartitionMovementMixin):
                 if fn():
                     return value_on_read
             except Exception as e:
-                # Transient failure, desired to retry
-                if 'unknown broker' in str(e):
+                # Not transient failure, no need to retry
+                if 'unknown broker' not in str(e):
                     raise e
             return not value_on_read
 


### PR DESCRIPTION
- Shortly ago the test was patched to retry if rpk contained `unknown broker` in stderr after executing a list offsets request

- A retry loop was made to retry on this condition. Unfortunately the condition was wrong and the code throws when it sees `unknown broker` instead of retrying.

- Fixes: #14641

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
