### PR TITLE
rpk/transform/init: clarify the transform package name

### DIFF
--- a/src/go/rpk/pkg/cli/transform/template/golang/transform.gosrc
+++ b/src/go/rpk/pkg/cli/transform/template/golang/transform.gosrc
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/redpanda-data/redpanda/src/transform-sdk/go"
+	redpanda "github.com/redpanda-data/redpanda/src/transform-sdk/go"
 )
 
 func main() {


### PR DESCRIPTION
It's a go convention that the package comes from the last package
element, which we break in the transform-sdk so I think it's helpful to
show where `redpanda` comes from. I've also seen examples from users
that manually did this.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
