### PR TITLE
rpk debug bundle: k8s bundle improvements

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -181,13 +181,14 @@ type stepParams struct {
 }
 
 type fileInfo struct {
-	Size     string `json:"size"`
-	Mode     string `json:"mode"`
-	Symlink  string `json:"symlink,omitempty"`
-	Error    string `json:"error,omitempty"`
-	Modified string `json:"modified"`
-	User     string `json:"user"`
-	Group    string `json:"group"`
+	Size      string `json:"size"`
+	Mode      string `json:"mode"`
+	Symlink   string `json:"symlink,omitempty"`
+	Error     string `json:"error,omitempty"`
+	Modified  string `json:"modified"`
+	User      string `json:"user"`
+	Group     string `json:"group"`
+	SizeBytes int64  `json:"size_bytes"`
 }
 
 type limitedWriter struct {
@@ -994,7 +995,9 @@ func walkDir(root string, files map[string]*fileInfo) error {
 				return nil
 			}
 
-			i.Size = units.HumanSize(float64(info.Size()))
+			bSize := info.Size()
+			i.SizeBytes = bSize
+			i.Size = units.HumanSize(float64(bSize))
 			i.Mode = info.Mode().String()
 			i.Modified = info.ModTime().String()
 


### PR DESCRIPTION
- a63bf66185bccdc6670a9e2510589baec3fd56d4 adds a new flag `--label-selector` to `rpk debug bundle` and have a way to filter the bundled resources by label, by default this is the label `app.kubernetes.io/name: redpanda`. Fixes #14362

- 444f2dc62f5c441ece91e7cd687687aa558cf3ed makes rpk fall back to localhost in the case that we are not able to get the admin API addresses by calling the k8s API. Fixes https://github.com/redpanda-data/core-internal/issues/925

- 6ed92b5000637f176f98c5da815903318361f70a adds a new field `size_bytes` to the generated `data_dir.txt` file.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* rpk: Introduce a new flag `--label-selector` to `rpk debug bundle` and have a way to filter the bundled resources by label.