### PR TITLE
cluster: fix tx_gateway_frontend log statement

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -994,6 +994,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
               txlog.trace,
               "[tx_id: {}] waiting for {} topic to apper in metadata cache, "
               "retries left: {}",
+              tx_id,
               model::tx_manager_nt,
               retries);
             if (_metadata_cache.local().contains(model::tx_manager_nt)) {


### PR DESCRIPTION
This was missing an arg - causing error logs in a transaction test I'm
writing for Data Transforms.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
