### PR TITLE
DNM: testing triggering from GHA

### DIFF
--- a/.github/workflows/trigger-redpanda-bk.yml
+++ b/.github/workflows/trigger-redpanda-bk.yml
@@ -1,0 +1,39 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+name: trigger-redpanda-bk
+on:
+  push:
+    branches:
+      - dev
+      - 'v[0-9][0-9].[0-9].[0-9]+'
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    paths:
+      - 'src/v/**'
+      - 'cmake/**'
+      - 'CMakeLists.txt'
+      - 'CMakePresets.json'
+      - 'install-dependencies.sh'
+      - '.github/workflows/trigger-redpanda-bk.yml'
+
+jobs:
+  trigger-buildkite:
+    if: github.event.pull_request.draft == false
+    name: Trigger redpanda pipeline on buildkite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: "buildkite/trigger-pipeline-action@v2.0.0"
+        with:
+          buildkite_api_access_token: ${{ secrets.BUILDKITE_TOKEN }}
+          pipeline: "redpanda/redpanda-dev"


### PR DESCRIPTION
Testing to see if we can skip running buildkite builds by using GHA instead of buildkite-github integration

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
