### PR TITLE
format exception fixes 

### DIFF
--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -994,6 +994,7 @@ ss::future<cluster::init_tm_tx_reply> tx_gateway_frontend::init_tm_tx(
               txlog.trace,
               "[tx_id: {}] waiting for {} topic to apper in metadata cache, "
               "retries left: {}",
+              tx_id,
               model::tx_manager_nt,
               retries);
             if (_metadata_cache.local().contains(model::tx_manager_nt)) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -1021,7 +1021,8 @@ consensus::update_group_member(model::broker broker) {
           if (!cfg.contains_broker(broker.id())) {
               vlog(
                 _ctxlog.warn,
-                "Node with id {} does not exists in current configuration");
+                "Node with id {} does not exists in current configuration",
+                broker.id());
               return ss::make_ready_future<std::error_code>(
                 errc::node_does_not_exists);
           }

--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -115,6 +115,7 @@ model::offset offset_translator_state::to_log_offset(
     vassert(
       interval_end_it != _last_offset2batch.begin(),
       "ntp {}: log offset search start too small: {}",
+      _ntp,
       search_start);
     auto delta = std::prev(interval_end_it)->second.next_delta;
 

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -295,6 +295,7 @@ ss::future<> segment_appender::truncate(size_t n) {
       n <= file_byte_offset(),
       "Cannot ask to truncate at:{} which is more bytes than we have:{} - {}",
       file_byte_offset(),
+      n,
       *this);
     return hard_flush()
       .then([this, n] { return do_truncation(n); })
@@ -664,7 +665,10 @@ bool segment_appender::inflight_write::try_merge(
         // writes should form a contiguous series of writes and we only check
         // the last write for merging.
         vassert(
-          committed_offset == pco, "in try_merge writes didn't touch: {} {}");
+          committed_offset == pco,
+          "in try_merge writes didn't touch: {} {}",
+          committed_offset,
+          pco);
 
         // the lhs write cannot be full since then how could the next write
         // share its chunk: it must use a new chunk


### PR DESCRIPTION
Fixes some log command missing parameters; these would cause an exception at runtime if hit, but the codepaths are likely cold.

They could be a compile-time error with an update to seastar/util/log.hh to use fmt::format_string

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none