### PR TITLE
define `/dt` slash command for triggering PR tests

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -8,6 +8,7 @@ on:
       - cdt-command
       - test-release-pipeline-command
       - test-arm64-command
+      - dt-command
 
 jobs:
   run-build:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -19,6 +19,7 @@ jobs:
             cdt
             test-release-pipeline
             test-arm64
+            dt
           static-args: |
             org=redpanda-data
             repo=redpanda


### PR DESCRIPTION
logic for this command is added in redpanda-data/vtools#2360

ref redpanda-data/devprod#941


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
