### PR TITLE
remote_partition_fuzz_test: measure shutdown time directly

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -17,6 +17,8 @@
 
 #include <seastar/core/lowres_clock.hh>
 
+#include <fmt/chrono.h>
+
 #include <random>
 
 using namespace cloud_storage;
@@ -428,28 +430,30 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
       storage::log_reader_config(
         base, model::offset::max(), ss::default_priority_class()),
       g);
-    auto close_fut = ss::maybe_yield()
-                       .then([] { return ss::maybe_yield(); })
-                       .then([] { return ss::maybe_yield(); })
-                       .then([] { return ss::sleep(10ms); })
-                       .then([this, &g]() mutable {
-                           test_log.info("shutting down connections");
-                           pool.local().shutdown_connections();
-                           test_log.info("closing gate");
-                           return g.close();
-                       })
-                       .then([] { test_log.info("gate closed"); });
-
+    auto close_fut
+      = ss::maybe_yield()
+          .then([] { return ss::maybe_yield(); })
+          .then([] { return ss::maybe_yield(); })
+          .then([] { return ss::sleep(10ms); })
+          .then([this, &g]() mutable {
+              auto begin_shutdown = std::chrono::steady_clock::now();
+              test_log.info("shutting down connections");
+              pool.local().shutdown_connections();
+              test_log.info("closing gate");
+              return g.close().then([begin_shutdown] {
+                  auto end_shutdown = std::chrono::steady_clock::now();
+                  test_log.info("gate closed");
+                  return end_shutdown - begin_shutdown;
+              });
+          });
     // NOTE: see issues/11271
     BOOST_TEST_CONTEXT("scan_unit_close should terminate in a finite amount of "
                        "time at shutdown") {
-        auto timeout_fut = ss::with_timeout(
-          model::timeout_clock::now() + 60s, std::move(close_fut));
         try {
             test_log.info("waiting on close future with timeout");
-            timeout_fut.get();
+            BOOST_CHECK_LE(close_fut.get(), 60s);
             test_log.info(
-              "waiting on scan_future, this should be immediatly available");
+              "waiting on scan_future, this should be immediately available");
             BOOST_CHECK(scan_future.available());
             scan_future.get();
         } catch (...) {

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -449,19 +449,11 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
     // NOTE: see issues/11271
     BOOST_TEST_CONTEXT("scan_unit_close should terminate in a finite amount of "
                        "time at shutdown") {
-        try {
-            test_log.info("waiting on close future with timeout");
-            BOOST_CHECK_LE(close_fut.get(), 60s);
-            test_log.info(
-              "waiting on scan_future, this should be immediately available");
-            BOOST_CHECK(scan_future.available());
-            scan_future.get();
-        } catch (...) {
-            // BOOST_REQUIRE_NOTHROW can't print std::current_exception, sadly
-            BOOST_CHECK_MESSAGE(
-              false,
-              fmt::format(
-                "failed with exception {}", std::current_exception()));
-        }
+        test_log.info("waiting on close future with timeout");
+        BOOST_CHECK_LE(close_fut.get(), 60s);
+        test_log.info(
+          "waiting on scan_future, this should be immediately available");
+        BOOST_CHECK(scan_future.available());
+        scan_future.get();
     }
 }


### PR DESCRIPTION
logging shows that test_scan_while_shutting_down completes in a few seconds, 
but the shutdow_connections() call starts way after the 10ms sleep interval.

In this log, `test - waiting on close future with timeout` is called in the same fiber as ss::with_timeout, just before starting the timer, and `test - shutting down connections` is called in the same fiber as shutdown_connections(). The call happens more than 1 minute later, even though it should be ~10ms apart. 

```
INFO  2023-11-29 07:23:28,121 [shard 0:main] test - waiting on close future with timeout
INFO  2023-11-29 07:24:30,321 [shard 0:main] test - shutting down connections
INFO  2023-11-29 07:24:30,321 [shard 0:main] test - closing gate
INFO  2023-11-29 07:24:30,329 [shard 0:main] test - done scan loop 0
INFO  2023-11-29 07:24:30,329 [shard 0:main] test - exiting scan_until_close
INFO  2023-11-29 07:24:30,329 [shard 0:main] test - gate closed
```

And the test is marked as failed with a timeout. 

It seems that the test preparation, in combination with underprovisioned hardware, makes the test runner suspend execution because in the log there is no dependency between the timeout fiber and the shutdown fiber, and there are no `Reactor stalled` messages.

This pr removes ss::with_timeout and uses std::chrono::steady_clock to measure the actual shutdown duration, starting from the shutdown_connections() call and ending after the gate held by the scan fiber is closed.

Fixes #11271 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none