### PR TITLE
kafka/client: Introduce automatic partition strategy on failure mode

### DIFF
--- a/src/v/kafka/client/client.cc
+++ b/src/v/kafka/client/client.cc
@@ -243,6 +243,9 @@ ss::future<produce_response> client::produce_records(
       partition_builders;
 
     // Assign records to batches per topic_partition
+    //
+    // If the \ref produce_partition_agnostic config option is enabled the
+    // initially selected partition_id may change if failures occur
     for (auto& record : records) {
         auto p_id = record.partition_id;
         if (!p_id) {

--- a/src/v/kafka/client/configuration.cc
+++ b/src/v/kafka/client/configuration.cc
@@ -99,6 +99,14 @@ configuration::configuration()
           }
           return std::nullopt;
       })
+  , produce_partition_agnostic_retries(
+      *this,
+      "produce_partition_agnostic_retries",
+      "Allow automatic error handling mechanism in the produce_records() API "
+      "which will automatically select a different partition to produce to if "
+      "failures occur, after this configured number of attempts",
+      {},
+      0)
   , consumer_request_timeout(
       *this,
       "consumer_request_timeout_ms",

--- a/src/v/kafka/client/configuration.h
+++ b/src/v/kafka/client/configuration.h
@@ -37,6 +37,7 @@ struct configuration final : public config::config_store {
     config::property<ss::sstring> produce_compression_type;
     config::property<std::chrono::milliseconds> produce_shutdown_delay;
     config::property<int16_t> produce_ack_level;
+    config::property<size_t> produce_partition_agnostic_retries;
     config::property<std::chrono::milliseconds> consumer_request_timeout;
     config::bounded_property<int32_t> consumer_request_min_bytes;
     config::bounded_property<int32_t> consumer_request_max_bytes;

--- a/src/v/kafka/client/produce_partition.h
+++ b/src/v/kafka/client/produce_partition.h
@@ -58,6 +58,10 @@ public:
         return ss::now();
     }
 
+    void take_batch(model::record_batch&& batch, produce_partition& partition) {
+        _batcher.take_batch(std::move(batch), partition._batcher);
+    }
+
 private:
     model::record_batch do_consume() {
         vassert(!_in_flight, "do_consume should not run concurrently");

--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -56,6 +56,9 @@ private:
     ss::future<produce_response::partition>
     do_send(model::topic_partition tp, model::record_batch batch);
 
+    ss::future<model::topic_partition>
+    move_batch(model::topic_partition tp, model::record_batch batch);
+
     auto make_consumer(model::topic_partition tp) {
         return [this, tp](model::record_batch&& batch) {
             (void)send(tp, std::move(batch));

--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -71,4 +71,13 @@ topic_cache::partition_for(model::topic_view tv, const record_essence& rec) {
       topic_error(tv, error_code::unknown_topic_or_partition));
 }
 
+ss::future<size_t> topic_cache::number_of_partitions_for(model::topic_view tv) {
+    if (auto topic_it = _topics.find(tv); topic_it != _topics.end()) {
+        return ss::make_ready_future<size_t>(
+          topic_it->second.partitions.size());
+    }
+    return ss::make_exception_future<size_t>(
+      topic_error(tv, error_code::unknown_topic_or_partition));
+}
+
 } // namespace kafka::client

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -55,6 +55,9 @@ public:
     ss::future<model::partition_id>
     partition_for(model::topic_view tv, const record_essence& rec);
 
+    /// \brief Obtain the total number of partitions for a topic
+    ss::future<size_t> number_of_partitions_for(model::topic_view tv);
+
 private:
     /// \brief Cache of topic information.
     topics_t _topics;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -222,6 +222,9 @@ static void set_auditing_kafka_client_defaults(
     if (!client_config.produce_shutdown_delay.is_overriden()) {
         client_config.produce_shutdown_delay.set_value(3000ms);
     }
+    if (!client_config.produce_partition_agnostic_retries.is_overriden()) {
+        client_config.produce_partition_agnostic_retries.set_value(size_t(3));
+    }
     /// explicity override the scram details as the client will need to use
     /// broker generated ephemeral credentials
     client_config.scram_password.reset();

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -339,6 +339,12 @@ class KgoRepeaterService(Service):
             for worker_status in node_status:
                 yield worker_status
 
+    def total_errors(self):
+        """
+        :return integer total number of observed errors
+        """
+        return sum([int(wst['errors']) for wst in self._get_status_reports()])
+
     def total_messages(self):
         """
         :return: 2-tuple of produced, consumed

--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -189,6 +189,7 @@ class AuditLogConfig:
     def __init__(self,
                  enabled: bool = True,
                  num_partitions: int = 8,
+                 replication_factor: int = 3,
                  event_types=['management', 'admin']):
         """Initializes the config
 
@@ -200,11 +201,15 @@ class AuditLogConfig:
         num_partitions: int, default=8
             Number of partitions to create
 
+        replication_factor: int, default 3
+            Number of replicas for the audit log topic
+
         event_types: [str], default=['management']
             The event types to start with enabled
         """
         self.enabled = enabled
         self.num_partitions = num_partitions
+        self.replication_factor = replication_factor
         self.event_types = event_types
 
     def to_conf(self) -> {str, str}:
@@ -218,6 +223,7 @@ class AuditLogConfig:
         return {
             'audit_enabled': self.enabled,
             'audit_log_num_partitions': self.num_partitions,
+            'audit_log_replication_factor': self.replication_factor,
             'audit_enabled_event_types': self.event_types
         }
 


### PR DESCRIPTION
This PR adds the ability to the `kafka/client` to automatically push records to another topic, when `topic_or_partition_not_found` errors are observed. This is only for applications that don't care about which partition a record in a topic is sent to. 

This patch was necessitated by auditing which may be stuck in a forever retry loop if a partition is unavailable, but was initially designated to have some data sent there. Instead of retrying forever the client may just send the data to another partition.  

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Adds the automatic partition id selection configuration option to the internal kafka/client
