### PR TITLE
rptest: Basic flink service, workload and test

### DIFF
--- a/tests/rptest/e2e_tests/workloads/flink_produce_workload.py
+++ b/tests/rptest/e2e_tests/workloads/flink_produce_workload.py
@@ -1,0 +1,165 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import json
+import logging
+import os
+import random
+import string
+import sys
+
+from copy import deepcopy
+from dataclasses import dataclass
+
+from pyflink.common import Types, Configuration
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.datastream.connectors.kafka import FlinkKafkaProducer
+from pyflink.datastream.formats.json import JsonRowSerializationSchema
+
+
+@dataclass(kw_only=True)
+class WorkloadConfig:
+    # Default values are set for CDT run inside EC2 instance
+    connector_path: str = "file:///opt/flink/connectors/flink-sql-connector-kafka-3.0.1-1.18.jar"
+    logger_path: str = "/workloads"
+    log_level: str = "DEBUG"
+    producer_group: str = "flink_group"
+    consumer_group: str = "flink_group"
+    topic_name: str = "flink_workload_topic"
+    msg_size: int = 4096
+    count: int = 1000
+    # This should be updated to value from self.redpanda.brokers()
+    brokers: str = "localhost:9092"
+
+
+def setup_logger(logfilepath, level):
+    # Simple file logger
+    handler = logging.FileHandler(logfilepath)
+    handler.setFormatter(
+        logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    level = logging.getLevelName(level.upper())
+    handler.setLevel(level)
+    logger = logging.getLogger(__name__)
+    logger.addHandler(handler)
+
+    return logger
+
+
+class FlinkWorkloadProduce:
+    def __init__(self, config_override):
+        # Serialize config
+        self.config = WorkloadConfig(**config_override)
+        # Create logger
+        filename = f"{os.path.basename(__file__).split('.')[0]}.log"
+        logfile = os.path.join(self.config.logger_path, filename)
+        self.logger = setup_logger(logfile, self.config.log_level)
+
+    def setup(self):
+        self.logger.info("Initializing Produce workload")
+        # Initialize
+        config = Configuration()
+        # This is required for ducktape EC2 run
+        config.set_string("python.client.executable", "python3")
+        config.set_string("python.executable", "python3")
+        # Create flink env
+        self.env = StreamExecutionEnvironment.get_execution_environment(config)
+        # Add Kafka connector to Flink
+        self.env.add_jars(self.config.connector_path)
+        # Set the broker addresses
+        self._basic_properties = {
+            'bootstrap.servers': self.config.brokers,
+        }
+        self.logger.info(f"Brokers set to '{self.config.brokers}'")
+        # Announce message holder array
+        # This is suitable onlt for simple low-memory workloads
+        self.messages = []
+
+    def _generate_message(self):
+        return ''.join(
+            random.choices(string.ascii_letters + string.digits,
+                           k=self.config.msg_size))
+
+    def run(self):
+        """
+            Example of a produce task
+
+            Steps:
+            - generate messages using configured size and random.choices() func
+            - create simple serializer
+            - create Producer with topic name and group
+            - execute producer
+        """
+        # Prepare data to be sent
+        self.logger.info(f"Generating {self.config.count} messages")
+        _messages = [(self._generate_message(), )
+                     for i in range(self.config.count)]
+
+        type_info = Types.ROW([Types.STRING()])
+        ds = self.env.from_collection(_messages, type_info=type_info)
+
+        # Serializer
+        serialization_schema = JsonRowSerializationSchema.Builder() \
+            .with_type_info(type_info) \
+            .build()
+
+        # Producer creation
+        _properties = deepcopy(self._basic_properties)
+        _properties['group.id'] = self.config.producer_group
+
+        self.logger.info("Creating producer with target topic of "
+                         f"'{self.config.topic_name}'")
+        kafka_producer = FlinkKafkaProducer(
+            topic=self.config.topic_name,
+            serialization_schema=serialization_schema,
+            producer_config=_properties)
+
+        # Output type of ds must be RowTypeInfo
+        ds.add_sink(kafka_producer)
+        self.logger.info("About to produce messages")
+        self.env.execute()
+        self.logger.info("Done")
+
+    def cleanup(self):
+        """
+            Cleanup placeholder
+        """
+        pass
+
+
+if __name__ == '__main__':
+    # Load config if specified
+    if len(sys.argv) > 1:
+        # Validate arguments in a quick and dirty way.
+        # This will assign one argument to filename and generate exception if
+        # there is more than one argument
+        try:
+            [filename] = sys.argv[1:]
+        except Exception as e:
+            raise RuntimeError("Wrong number of arguments."
+                               "Should be one with path to "
+                               "flink_workload_conf.json") from e
+    else:
+        # No config path provided, just use defaults
+        filename = "/workloads/flink_workload_config.json"
+
+    # Load configuration
+    with open(filename, 'r+t') as f:
+        input_config = json.load(f)
+
+    # All messages past this point is intercepted by task manager
+    # and will be seen in its log
+    workload = FlinkWorkloadProduce(input_config)
+    try:
+        workload.setup()
+        workload.run()
+    except Exception as e:
+        # Do not re-throw not to cause a commoution
+        raise RuntimeError("Workload run failed") from e
+    finally:
+        workload.cleanup()

--- a/tests/rptest/e2e_tests/workloads/flink_simple_workload.py
+++ b/tests/rptest/e2e_tests/workloads/flink_simple_workload.py
@@ -1,0 +1,329 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import json
+import logging
+import os
+import random
+import string
+import sys
+import threading
+import time
+
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Dict, Union, List
+
+from pyflink.common import Types, Time
+from pyflink.datastream import StreamExecutionEnvironment
+from pyflink.datastream.connectors.kafka import FlinkKafkaProducer, \
+    FlinkKafkaConsumer, DeserializationSchema
+from pyflink.datastream.formats.json import JsonRowSerializationSchema, \
+    JsonRowDeserializationSchema
+from pyflink.datastream.functions import KeyedProcessFunction, RuntimeContext
+from pyflink.datastream.state import ValueStateDescriptor, StateTtlConfig
+
+
+@ dataclass(kw_only=True)
+class WorkloadConfig:
+    # Default values are set for CDT run inside EC2 instance
+    connector_path: str = "file:///opt/flink/connectors/flink-sql-connector-kafka-3.0.1-1.18.jar",
+    logger_path: str = "/opt/flink/log",
+    log_level: str = "DEBUG",
+    producer_group: str = "flink_produce_group",
+    consumer_group: str = "flink_consume_group",
+    topic_name: str = "flink_workload_topic",
+    msg_size: int = 4096,
+    count: int = 1000
+    # This should be updated to value from self.redpanda.brokers()
+    brokers: str = "localhost:9092",
+
+
+def setup_logger(path, level):
+    # Simple file logger
+    filename = f"{os.path.basename(__file__).split('.')[0]}.log"
+    handler = logging.FileHandler(os.path.join(path, filename))
+    handler.setFormatter(
+        logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    level = logging.getLevelName(level.upper())
+    handler.setLevel(level)
+    logger = logging.getLogger(__name__)
+    logger.addHandler(handler)
+
+    return logger
+
+
+class MessageConsumer(KeyedProcessFunction):
+    """
+        Simple consumer based on Apache example.
+        Receives a message and counts characters
+    """
+    def __init__(self, logger):
+        self.logger = logger
+        self.state = None
+        self._message_count = 0
+        self.last_message_time = time.time()
+
+    def open(self, runtime_context: RuntimeContext):
+        self.logger.info("MessageConsumer process started")
+        # Create descriptor for the saved state
+        state_descriptor = ValueStateDescriptor("character_count", Types.INT())
+        state_ttl_config = StateTtlConfig \
+            .new_builder(Time.seconds(1)) \
+            .set_update_type(StateTtlConfig.UpdateType.OnReadAndWrite) \
+            .disable_cleanup_in_background() \
+            .build()
+        state_descriptor.enable_time_to_live(state_ttl_config)
+        self.state = runtime_context.get_state(state_descriptor)
+
+    def process_element(self, value, ctx: 'KeyedProcessFunction.Context'):
+        # retrieve the current character count
+        current = self.state.value()
+        if current is None:
+            current = 0
+
+        # update and save
+        # Count chars and add it to total
+        chars = len(value[1])
+        current += chars
+        # save it
+        self.state.update(current)
+        # Log and save time received
+        self.logger.debug(f"...received {chars} chars, total: {current}")
+        self.time = time.time()
+
+        # increment message count
+        self._message_count += 1
+
+        # return
+        yield value[0], current
+
+    def get_message_count(self):
+        return self._message_count
+
+
+class MyKafkaConsumer(FlinkKafkaConsumer):
+    """
+        Wrapper class for FlinkKafkaConsumer.
+        Has additional methods to hold message consumer
+        and a wrapped 'run' method
+    """
+    def __init__(self,
+                 logger,
+                 topics: Union[str, List[str]] = "test_topic",
+                 deserialization_schema: DeserializationSchema = None,
+                 properties: Dict = {},
+                 message_count: int = 0,
+                 timeout: int = 120):
+        super(MyKafkaConsumer, self).__init__(
+            topics=topics,
+            deserialization_schema=deserialization_schema,
+            properties=properties)
+        self.message_count = message_count
+        self.timeout = timeout
+        self.logger = logger
+        # Initialize MessageConsumer internally
+        self.consumer = MessageConsumer(logger)
+        # Do some initialization
+        self.set_start_from_earliest()
+        self.run_thread = None
+
+    def get_message_consumer(self):
+        return self.consumer
+
+    def run(self):
+        # Instead of calling base function 'run', wrap it
+        if self.run_thread is not None:
+            self.run_thread = threading.Thread(target=self.run,
+                                               args=None,
+                                               kwargs=None)
+            self.run_thread.start()
+
+        # check if message count or timeout in consumer is reached
+        _now = time.time()
+        if self.message_count <= self.consumer.get_message_count() or \
+                _now - self.consumer.last_message_time > self.timeout:
+            self.run_thread.get_java_function().cancel()
+            self.run_thread.join()
+
+        return
+
+
+class FlinkWorkload:
+    def __init__(self, config_override):
+        self.config = WorkloadConfig(**config_override)
+        self.logger = setup_logger(self.config.logger_path,
+                                   self.config.log_level)
+
+    def setup(self):
+        # Initialize
+        self.env = StreamExecutionEnvironment.get_execution_environment()
+        self.env.add_jars(self.config.connector_path)
+        self._basic_properties = {
+            'bootstrap.servers': self.config.brokers,
+        }
+        self.type_info = Types.ROW([Types.STRING()])
+
+        self.messages = []
+
+    def _generate_message(self):
+        return ''.join(random.choices(
+            string.ascii_letters + string.digits, k=self.config.msg_size))
+
+    def task_produce(self):
+        """
+            Example of a produce task
+
+            Steps:
+            - generate messages using configured size and random.choices() func
+            - create simple serializer
+            - create Producer with topic name and group
+            - execute producer
+        """
+        # Prepare data to be sent
+        _messages = [(self._generate_message(),)
+                     for i in range(self.config.count)]
+        ds = self.env.from_collection(_messages, type_info=self.type_info)
+
+        # Serializer
+        serialization_schema = JsonRowSerializationSchema.Builder() \
+            .with_type_info(self.type_info) \
+            .build()
+
+        # Producer creation
+        _properties = deepcopy(self._basic_properties)
+        _properties['group.id'] = self.config.producer_group
+
+        kafka_producer = FlinkKafkaProducer(
+            topic=self.config.topic_name,
+            serialization_schema=serialization_schema,
+            producer_config=_properties
+        )
+
+        # Output type of ds must be RowTypeInfo
+        ds.add_sink(kafka_producer)
+        self.env.execute()
+
+    def task_consume(self):
+        """
+            Example consume task
+
+            Steps:
+            - create deserializer and configured properties
+            - create consumer
+            - set offset to earliest
+            - assign source and add callback class
+            - execute
+        """
+        # Deserialization schema
+        deserialization_schema = JsonRowDeserializationSchema.Builder() \
+            .type_info(self.type_info) \
+            .build()
+        # Consumer creation
+        properties = deepcopy(self._basic_properties)
+        properties['group.id'] = self.config.consumer_group
+
+        # Create my consumer
+        my_consumer = MyKafkaConsumer(
+            self.config.topic_name,
+            deserialization_schema=deserialization_schema,
+            properties=properties
+        )
+        # Add source and link message consumer
+        self.env.add_source(my_consumer).process(
+            my_consumer.get_message_consumer(), self.type_info)
+        # Run
+        self.env.execute()
+
+    def run_tasks(self, tasks):
+        # No tag or keyword checking as in run_all_tasks
+        # Validation is ommitted at this point in time
+        for task in tasks:
+            self.logger.info(f"Running task '{task}'")
+            try:
+                task()
+            except Exception as e:
+                # Just log error and return
+                self.logger.error(f"Task '{task}' failed: {e}")
+
+        return
+
+    def run_all_tasks(self):
+        # Prepare tasks
+        _producing = []
+        _consuming = []
+        _other = []
+        # Dynamic method loading
+        for method in dir(self):
+            if method.startswith("task_"):
+                if "produce" in method:
+                    _producing.append(getattr(self, method))
+                elif "consume" in method:
+                    _consuming.append(getattr(self, method))
+                else:
+                    _other.append(getattr(self, method))
+
+        # methods with keyword 'produce' goes first
+        self.run_tasks(_producing)
+        # all other goes in between
+        self.run_tasks(_other)
+        # keyword 'consume' goes last
+        self.run_tasks(_consuming)
+
+    def cleanup(self):
+        # Nothing to cleanup as of right now
+        pass
+
+
+if __name__ == '__main__':
+    # Temp log that prints to stdout
+    log = logging.basicConfig(stream=sys.stdout,
+                              level=logging.INFO,
+                              format="%(message)s")
+    # Load config if specified
+    if len(sys.argv) > 1:
+        # Validate arguments in a quick and dirty way.
+        # This will assign one argument to filename and generate exception if
+        # there is more than one argument
+        try:
+            [filename] = sys.argv[1:]
+        except Exception:
+            log.error("Wrong number of arguments."
+                      "Should be one with path to flink_workload_conf.json")
+            sys.exit(1)
+    else:
+        # No config path provided, just use defaults
+        filename = "/workloads/flink_workload_config.json"
+
+    # Load configuration
+    with open(filename, 'r+t') as f:
+        input_config = json.load(f)
+
+    # No stdout messages from this point forward. Only errors.
+    # Main reason, stdout should stay as clean as possible as this is to be
+    # caught by ducktape and parsed for JobIds
+    workload = FlinkWorkload(input_config)
+    try:
+        workload.setup()
+        # Specific scenario run example
+        # tasks = [
+        #     workload.task_produce,
+        #     workload.task_consume
+        # ]
+        # workload.run(tasks)
+
+        # Or just all of the tasks
+        workload.run_all_tasks()
+
+    except Exception:
+        # Do not re-throw not to cause a commoution
+        log.error("Workload run failed")
+        sys.exit(1)
+    finally:
+        workload.cleanup()

--- a/tests/rptest/e2e_tests/workloads/flink_workload_config.json
+++ b/tests/rptest/e2e_tests/workloads/flink_workload_config.json
@@ -1,0 +1,11 @@
+{
+    "connector_path": "file:///opt/flink/connectors/flink-sql-connector-kafka-3.0.1-1.18.jar",
+    "logger_path": "/opt/flink/log",
+    "log_level": "DEBUG",
+    "brokers": "localhost:9092",
+    "producer_group": "flink_produce_group",
+    "consumer_group": "flink_consume_group",
+    "topic_name": "flink_workload_topic",
+    "msg_size": 4096,
+    "count": 10
+}

--- a/tests/rptest/e2e_tests/workloads/flink_workload_config.json
+++ b/tests/rptest/e2e_tests/workloads/flink_workload_config.json
@@ -1,6 +1,6 @@
 {
     "connector_path": "file:///opt/flink/connectors/flink-sql-connector-kafka-3.0.1-1.18.jar",
-    "logger_path": "/workload",
+    "logger_path": "/workloads",
     "log_level": "DEBUG",
     "brokers": "localhost:9092",
     "producer_group": "flink_produce_group",

--- a/tests/rptest/e2e_tests/workloads/flink_workload_config.json
+++ b/tests/rptest/e2e_tests/workloads/flink_workload_config.json
@@ -1,6 +1,6 @@
 {
     "connector_path": "file:///opt/flink/connectors/flink-sql-connector-kafka-3.0.1-1.18.jar",
-    "logger_path": "/opt/flink/log",
+    "logger_path": "/workload",
     "log_level": "DEBUG",
     "brokers": "localhost:9092",
     "producer_group": "flink_produce_group",

--- a/tests/rptest/services/flink.py
+++ b/tests/rptest/services/flink.py
@@ -1,0 +1,364 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import requests
+import os
+import yaml
+import json
+
+from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.services.service import Service
+from ducktape.utils.util import wait_until
+
+# Used to generate flink-conf.yaml
+# Only at-hand parameters listed.
+# Refer to original file for additional parameters.
+flink_config = {
+    # These parameters are required for Java 17 support.
+    # They can be safely removed when using Java 8/11.
+    "env.java.opts.all":
+    "--add-exports=java.base/sun.net.util=ALL-UNNAMED "
+    "--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED "
+    "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED "
+    "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED "
+    "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED "
+    "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED "
+    "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED "
+    "--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED "
+    "--add-opens=java.base/java.lang=ALL-UNNAMED "
+    "--add-opens=java.base/java.net=ALL-UNNAMED "
+    "--add-opens=java.base/java.io=ALL-UNNAMED "
+    "--add-opens=java.base/java.nio=ALL-UNNAMED "
+    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED "
+    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED "
+    "--add-opens=java.base/java.text=ALL-UNNAMED "
+    "--add-opens=java.base/java.time=ALL-UNNAMED "
+    "--add-opens=java.base/java.util=ALL-UNNAMED "
+    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED "
+    "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED "
+    "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+
+    # The external address of the host on which the JobManager runs and can be
+    # reached by the TaskManagers and any clients which want to connect. This setting
+    # is only used in Standalone mode and may be overwritten on the JobManager side
+    # by specifying the --host <hostname> parameter of the bin/jobmanager.sh executable.
+    # In high availability mode, if you use the bin/start-cluster.sh script and setup
+    # the conf/masters file, this will be taken care of automatically. Yarn
+    # automatically configure the host name based on the hostname of the node where the
+    # JobManager runs.
+    "jobmanager.rpc.address":
+    "localhost",
+
+    # The RPC port where the JobManager is reachable.
+    "jobmanager.rpc.port":
+    6123,
+
+    # The host interface the JobManager will bind to. By default, this is localhost, and will prevent
+    # the JobManager from communicating outside the machine/container it is running on.
+    # On YARN this setting will be ignored if it is set to 'localhost', defaulting to 0.0.0.0.
+    # On Kubernetes this setting will be ignored, defaulting to 0.0.0.0.
+    #
+    # To enable this, set the bind-host address to one that has access to an outside facing network
+    # interface, such as 0.0.0.0.
+    "jobmanager.bind-host":
+    "localhost",
+
+    # The total process memory size for the JobManager.
+    # Note this accounts for all memory usage within the JobManager process, including JVM metaspace and other overhead.
+    "jobmanager.memory.process.size":
+    "1600m",
+
+    # The host interface the TaskManager will bind to. By default, this is localhost, and will prevent
+    # the TaskManager from communicating outside the machine/container it is running on.
+    # On YARN this setting will be ignored if it is set to 'localhost', defaulting to 0.0.0.0.
+    # On Kubernetes this setting will be ignored, defaulting to 0.0.0.0.
+    #
+    # To enable this, set the bind-host address to one that has access to an outside facing network
+    # interface, such as 0.0.0.0.
+    "taskmanager.bind-host":
+    "localhost",
+
+    # The address of the host on which the TaskManager runs and can be reached by the JobManager and
+    # other TaskManagers. If not specified, the TaskManager will try different strategies to identify
+    # the address.
+    #
+    # Note this address needs to be reachable by the JobManager and forward traffic to one of
+    # the interfaces the TaskManager is bound to (see 'taskmanager.bind-host').
+    #
+    # Note also that unless all TaskManagers are running on the same machine, this address needs to be
+    # configured separately for each TaskManager.
+    "taskmanager.host":
+    "localhost",
+
+    # The total process memory size for the TaskManager.
+    #
+    # Note this accounts for all memory usage within the TaskManager process, including JVM metaspace and other overhead.
+    "taskmanager.memory.process.size":
+    "1728m",
+
+    # To exclude JVM metaspace and overhead, please, use total Flink memory size instead of 'taskmanager.memory.process.size'.
+    # It is not recommended to set both 'taskmanager.memory.process.size' and Flink memory.
+    #
+    "taskmanager.memory.flink.size":
+    "1280m",
+
+    # The number of task slots that each TaskManager offers. Each slot runs one parallel pipeline.
+    "taskmanager.numberOfTaskSlots":
+    1,
+
+    # The parallelism used for programs that did not specify and other parallelism.
+    "parallelism.default":
+    1,
+
+    #==============================================================================
+    # Rest & web frontend
+    #==============================================================================
+
+    # The port to which the REST client connects to. If rest.bind-port has
+    # not been specified, then the server will bind to this port as well.
+    #
+    "rest.port":
+    8090,
+
+    # The address to which the REST client will connect to
+    "rest.address":
+    "localhost",
+
+    # Port range for the REST and web server to bind to.
+    #rest.bind-port: 8080-8090
+
+    # The address that the REST & web server binds to
+    # By default, this is localhost, which prevents the REST & web server from
+    # being able to communicate outside of the machine/container it is running on.
+    #
+    # To enable this, set the bind address to one that has access to outside-facing
+    # network interface, such as 0.0.0.0.
+    "rest.bind-address":
+    "0.0.0.0",
+
+    # Flag to specify whether job submission is enabled from the web-based
+    # runtime monitor. Uncomment to disable.
+    "web.submit.enable":
+    False,
+
+    # Flag to specify whether job cancellation is enabled from the web-based
+    # runtime monitor. Uncomment to disable.
+    "web.cancel.enable":
+    False,
+}
+
+
+class FlinkService(Service):
+    """
+    Service that runs Job and Task managers on single node
+    Jobs are separate python scripts at this point.
+    """
+    FLINK_HOME = "/opt/flink/"
+    FLINK_BIN = FLINK_HOME + "bin/"
+    FLINK_CONFIG_FILE_PATH = FLINK_HOME + "conf/flink-conf.yaml"
+    FLINK_START = FLINK_BIN + "start-cluster.sh"
+    FLINK_STOP = FLINK_BIN + "stop-cluster.sh"
+    FLINK_WORKLOADS_FOLDER = "/workloads"
+    FLINK_WORKLOAD_CONFIG_FILENAME = "flink_workload_config.json"
+
+    STATE_INIT = 'INITIALIZING'
+    STATE_RECONCILING = 'RECONCILING'
+    STATE_RUNNING = 'RUNNING'
+    STATE_CANCELING = 'CANCELING'
+    STATE_DEPLOYING = 'DEPLOYING'
+
+    STATE_CREATED = 'CREATED'
+    STATE_SCHEDULED = 'SCHEDULED'
+    STATE_FAILED = 'FAILED'
+    STATE_FINISHED = 'FINISHED'
+    STATE_CANCELED = 'CANCELED'
+
+    def __init__(self, context, redpanda, topic, *args, **kwargs):
+        # No custom node support at this time
+        nodes_for_allocate = 1
+        # Init service
+        super(FlinkService, self).__init__(context,
+                                           num_nodes=nodes_for_allocate,
+                                           *args,
+                                           **kwargs)
+
+        self._port = flink_config["rest.port"]
+        self._baseurl = \
+            f"http://{self.nodes[0].account.hostname}:{self._port}"
+        # Map statuses
+        self._active_statuses = [
+            self.STATE_INIT, self.STATE_RECONCILING, self.STATE_RUNNING,
+            self.STATE_CANCELING, self.STATE_DEPLOYING
+        ]
+        self._inactive_statuses = [
+            self.STATE_CREATED, self.STATE_SCHEDULED, self.STATE_FAILED,
+            self.STATE_FINISHED, self.STATE_CANCELED
+        ]
+
+    def run_flink_job(self, workload_path, workload_config, detached=True):
+        """
+            Runs a job on flink using current redpanda broker address.
+            Not using REST for this to eliminate expensive and
+            complex file upload routine via milti-part MIME
+
+            workload_path: path to jar or py file
+            detach: detaches after adding the job
+        """
+        # Check that supplied path exists
+        if not os.path.exists(workload_path):
+            raise RuntimeError("Workload not found in path "
+                               f"'{workload_path}'")
+
+        # Check for the folder and create
+        n = self.nodes[0]
+        self.logger.debug("Checking and creating folder on target node "
+                          f"'{self.FLINK_WORKLOADS_FOLDER}'")
+        if not n.account.exists(self.FLINK_WORKLOADS_FOLDER):
+            n.account.mkdir(self.FLINK_WORKLOADS_FOLDER)
+
+        # Copy workload to node
+        self.logger.debug(f"Copy workload to flink node: {workload_path}")
+        n.account.copy_to(workload_path, self.FLINK_WORKLOADS_FOLDER)
+
+        # Create workload config
+        config_path = os.path.join(
+            self.FLINK_WORKLOADS_FOLDER,
+            self.FLINK_WORKLOAD_CONFIG_FILENAME
+        )
+        n.account.create_file(config_path, json.dumps(workload_config))
+
+        # Start job
+        _script = os.path.split(workload_path)[-1]
+        _run_path = os.path.join(self.FLINK_WORKLOADS_FOLDER, _script)
+
+        _cmd = f"sudo {self.FLINK_BIN}flink run"
+        if _script.endswith(".jar"):
+            _cmd += f" {_run_path}"
+        elif _script.endswith(".py"):
+            _cmd += " -pyclientexec /usr/bin/python3"
+            _cmd += f" -py {_run_path}"
+
+        if detached:
+            _cmd += " -d"
+
+        self.logger.debug(f"Running flink job: {_cmd}")
+        try:
+            _out = n.account.ssh_output(_cmd)
+            _out = _out.decode()
+        except RemoteCommandError as re:
+            self.logger.error(f"Failed to run job for {workload_path}:\n{re}")
+            return None
+
+        self.logger.debug(f"Run job returned:\n{_out}")
+        _generated_ids = []
+        for line in _out.splitlines():
+            # Example of what needs to be parsed
+            # Job has been submitted with JobID 8d29c8ab8e6e6634875a1cd16e879802
+            _idx = line.find("JobID")
+            if _idx > 0:
+                _id = line[_idx + 6:]
+                self.logger.debug(f"Found JobID:\n{_id}")
+                _generated_ids.append(_id)
+
+        return _generated_ids
+
+    def _get(self, rest_handle):
+        """
+            Perform a GET to Flink REST API
+            More here:
+            https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/ops/rest_api/
+        """
+        _url = f"{self._baseurl}{rest_handle}"
+        try:
+            _r = requests.get(_url)
+        except Exception as e:
+            raise RuntimeError(f"Failed to get data from '{_url}'") from e
+        return _r.json()
+
+    def list_jobs(self):
+        """
+            List all jobs
+        """
+        _handle = "/jobs"
+        return self._get(_handle)
+
+    def get_job_by_id(self, jobid):
+        """
+            Gets job specs
+        """
+        _handle = f"/jobs/{jobid}"
+        return self._get(_handle)
+
+    def start_node(self, node):
+        # Prepare config
+        conf = yaml.dump(flink_config)
+        self.logger.info("Creating flink configuration file")
+        node.account.create_file(self.FLINK_CONFIG_FILE_PATH, conf)
+
+        # Start
+        self.logger.info("Starting Flink standalone cluster")
+        _out = node.account.ssh_output(self.FLINK_START)
+        self.logger.info(f"Response:\n{_out.decode()}")
+
+        return
+
+    def stop_node(self, node):
+        # Stop cluster
+        self.logger.info("Stopping flink standalone cluster")
+        _out = node.account.ssh_output(self.FLINK_STOP)
+        self.logger.info(f"Response:\n{_out.decode()}")
+
+        return
+
+    def get_active_jobs(self):
+        """
+            Get all active jobs from flink REST API
+        """
+        _jobs = self.list_jobs()
+        _active = [
+            _job for _job in _jobs['jobs']
+            if _job['status'] in self._active_statuses
+        ]
+        return _active
+
+    def _has_active_jobs(self):
+        """
+            Get active job list, log aggregated status count
+            Return Bool valus if active jobs >0
+        """
+        _jobs = self.get_active_jobs()
+        _map = {}
+        for _j in _jobs:
+            _s = _j['status']
+            if _s not in _map:
+                _map[_s] = 1
+            else:
+                _map[_s] += 1
+        _out = [f"{k}: {v}" for k, v in _map.items()]
+        if len(_out) > 0:
+            self.logger.debug(f"Flink active jobs status: {', '.join(_out)}")
+        else:
+            self.logger.debug("Flink has no active jobs")
+
+        return len(_jobs) > 0
+
+    def wait_node(self, node, timeout_sec=1800):
+        """
+            Wait for all jobs to finish, default timeout is half an hour
+        """
+        wait_until(lambda: not self._has_active_jobs(),
+                   timeout_sec=timeout_sec,
+                   backoff_sec=5)
+
+        return True
+
+    def clean_node(self, node):
+        # TODO: Remove logs and tmp folders
+
+        return

--- a/tests/rptest/services/flink.py
+++ b/tests/rptest/services/flink.py
@@ -16,33 +16,36 @@ from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
 
+java_opts = [
+    "--add-exports=java.base/sun.net.util=ALL-UNNAMED",
+    "--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
+    "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
+    "--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+    "--add-opens=java.base/java.net=ALL-UNNAMED",
+    "--add-opens=java.base/java.io=ALL-UNNAMED",
+    "--add-opens=java.base/java.nio=ALL-UNNAMED",
+    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+    "--add-opens=java.base/java.text=ALL-UNNAMED",
+    "--add-opens=java.base/java.time=ALL-UNNAMED",
+    "--add-opens=java.base/java.util=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+    "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+]
+
 # Used to generate flink-conf.yaml
 # Only at-hand parameters listed.
 # Refer to original file for additional parameters.
 flink_config = {
     # These parameters are required for Java 17 support.
     # They can be safely removed when using Java 8/11.
-    "env.java.opts.all":
-    "--add-exports=java.base/sun.net.util=ALL-UNNAMED "
-    "--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED "
-    "--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED "
-    "--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED "
-    "--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED "
-    "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED "
-    "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED "
-    "--add-exports=java.security.jgss/sun.security.krb5=ALL-UNNAMED "
-    "--add-opens=java.base/java.lang=ALL-UNNAMED "
-    "--add-opens=java.base/java.net=ALL-UNNAMED "
-    "--add-opens=java.base/java.io=ALL-UNNAMED "
-    "--add-opens=java.base/java.nio=ALL-UNNAMED "
-    "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED "
-    "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED "
-    "--add-opens=java.base/java.text=ALL-UNNAMED "
-    "--add-opens=java.base/java.time=ALL-UNNAMED "
-    "--add-opens=java.base/java.util=ALL-UNNAMED "
-    "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED "
-    "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED "
-    "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+    "env.java.opts.all": " ".join(java_opts),
 
     # The external address of the host on which the JobManager runs and can be
     # reached by the TaskManagers and any clients which want to connect. This setting
@@ -52,12 +55,13 @@ flink_config = {
     # the conf/masters file, this will be taken care of automatically. Yarn
     # automatically configure the host name based on the hostname of the node where the
     # JobManager runs.
-    "jobmanager.rpc.address":
-    "localhost",
+    "jobmanager.rpc.address": "localhost",
+
+    # Python client executable
+    "python.client.executable": "python3",
 
     # The RPC port where the JobManager is reachable.
-    "jobmanager.rpc.port":
-    6123,
+    "jobmanager.rpc.port": 6123,
 
     # The host interface the JobManager will bind to. By default, this is localhost, and will prevent
     # the JobManager from communicating outside the machine/container it is running on.
@@ -66,13 +70,11 @@ flink_config = {
     #
     # To enable this, set the bind-host address to one that has access to an outside facing network
     # interface, such as 0.0.0.0.
-    "jobmanager.bind-host":
-    "localhost",
+    "jobmanager.bind-host": "localhost",
 
     # The total process memory size for the JobManager.
     # Note this accounts for all memory usage within the JobManager process, including JVM metaspace and other overhead.
-    "jobmanager.memory.process.size":
-    "1600m",
+    "jobmanager.memory.process.size": "1600m",
 
     # The host interface the TaskManager will bind to. By default, this is localhost, and will prevent
     # the TaskManager from communicating outside the machine/container it is running on.
@@ -81,8 +83,7 @@ flink_config = {
     #
     # To enable this, set the bind-host address to one that has access to an outside facing network
     # interface, such as 0.0.0.0.
-    "taskmanager.bind-host":
-    "localhost",
+    "taskmanager.bind-host": "localhost",
 
     # The address of the host on which the TaskManager runs and can be reached by the JobManager and
     # other TaskManagers. If not specified, the TaskManager will try different strategies to identify
@@ -93,28 +94,23 @@ flink_config = {
     #
     # Note also that unless all TaskManagers are running on the same machine, this address needs to be
     # configured separately for each TaskManager.
-    "taskmanager.host":
-    "localhost",
+    "taskmanager.host": "localhost",
 
     # The total process memory size for the TaskManager.
     #
     # Note this accounts for all memory usage within the TaskManager process, including JVM metaspace and other overhead.
-    "taskmanager.memory.process.size":
-    "1728m",
+    "taskmanager.memory.process.size": "1728m",
 
     # To exclude JVM metaspace and overhead, please, use total Flink memory size instead of 'taskmanager.memory.process.size'.
     # It is not recommended to set both 'taskmanager.memory.process.size' and Flink memory.
     #
-    "taskmanager.memory.flink.size":
-    "1280m",
+    "taskmanager.memory.flink.size": "1280m",
 
     # The number of task slots that each TaskManager offers. Each slot runs one parallel pipeline.
-    "taskmanager.numberOfTaskSlots":
-    1,
+    "taskmanager.numberOfTaskSlots": 1,
 
     # The parallelism used for programs that did not specify and other parallelism.
-    "parallelism.default":
-    1,
+    "parallelism.default": 1,
 
     #==============================================================================
     # Rest & web frontend
@@ -123,15 +119,13 @@ flink_config = {
     # The port to which the REST client connects to. If rest.bind-port has
     # not been specified, then the server will bind to this port as well.
     #
-    "rest.port":
-    8090,
+    "rest.port": 8090,
 
     # The address to which the REST client will connect to
-    "rest.address":
-    "localhost",
+    "rest.address": "localhost",
 
     # Port range for the REST and web server to bind to.
-    #rest.bind-port: 8080-8090
+    # rest.bind-port: 8080-8090
 
     # The address that the REST & web server binds to
     # By default, this is localhost, which prevents the REST & web server from
@@ -139,18 +133,15 @@ flink_config = {
     #
     # To enable this, set the bind address to one that has access to outside-facing
     # network interface, such as 0.0.0.0.
-    "rest.bind-address":
-    "0.0.0.0",
+    "rest.bind-address": "0.0.0.0",
 
     # Flag to specify whether job submission is enabled from the web-based
     # runtime monitor. Uncomment to disable.
-    "web.submit.enable":
-    False,
+    "web.submit.enable": False,
 
     # Flag to specify whether job cancellation is enabled from the web-based
     # runtime monitor. Uncomment to disable.
-    "web.cancel.enable":
-    False,
+    "web.cancel.enable": False,
 }
 
 
@@ -160,6 +151,7 @@ class FlinkService(Service):
     Jobs are separate python scripts at this point.
     """
     FLINK_HOME = "/opt/flink/"
+    FLINK_LOGS = FLINK_HOME + "log"
     FLINK_BIN = FLINK_HOME + "bin/"
     FLINK_CONFIG_FILE_PATH = FLINK_HOME + "conf/flink-conf.yaml"
     FLINK_START = FLINK_BIN + "start-cluster.sh"
@@ -201,6 +193,10 @@ class FlinkService(Service):
             self.STATE_FINISHED, self.STATE_CANCELED
         ]
 
+        # Safe var announce for log handling
+        self.node = None
+        self.hostname = None
+
     def run_flink_job(self, workload_path, workload_config, detached=True):
         """
             Runs a job on flink using current redpanda broker address.
@@ -227,46 +223,44 @@ class FlinkService(Service):
         n.account.copy_to(workload_path, self.FLINK_WORKLOADS_FOLDER)
 
         # Create workload config
-        config_path = os.path.join(
-            self.FLINK_WORKLOADS_FOLDER,
-            self.FLINK_WORKLOAD_CONFIG_FILENAME
-        )
+        config_path = os.path.join(self.FLINK_WORKLOADS_FOLDER,
+                                   self.FLINK_WORKLOAD_CONFIG_FILENAME)
         n.account.create_file(config_path, json.dumps(workload_config))
 
         # Start job
-        _script = os.path.split(workload_path)[-1]
-        _run_path = os.path.join(self.FLINK_WORKLOADS_FOLDER, _script)
+        script = os.path.split(workload_path)[-1]
+        run_path = os.path.join(self.FLINK_WORKLOADS_FOLDER, script)
 
-        _cmd = f"sudo {self.FLINK_BIN}flink run"
-        if _script.endswith(".jar"):
-            _cmd += f" {_run_path}"
-        elif _script.endswith(".py"):
-            _cmd += " -pyclientexec /usr/bin/python3"
-            _cmd += f" -py {_run_path}"
+        cmd = f"sudo {self.FLINK_BIN}flink run"
+        if script.endswith(".jar"):
+            cmd += f" {run_path}"
+        elif script.endswith(".py"):
+            cmd += " -pyclientexec /usr/bin/python3"
+            cmd += f" -py {run_path}"
 
         if detached:
-            _cmd += " -d"
+            cmd += " -d"
 
-        self.logger.debug(f"Running flink job: {_cmd}")
+        self.logger.debug(f"Running flink job: {cmd}")
         try:
-            _out = n.account.ssh_output(_cmd)
-            _out = _out.decode()
+            out = n.account.ssh_output(cmd)
+            out = out.decode()
         except RemoteCommandError as re:
             self.logger.error(f"Failed to run job for {workload_path}:\n{re}")
             return None
 
-        self.logger.debug(f"Run job returned:\n{_out}")
-        _generated_ids = []
-        for line in _out.splitlines():
+        self.logger.debug(f"Run job returned:\n{out}")
+        generated_ids = []
+        for line in out.splitlines():
             # Example of what needs to be parsed
             # Job has been submitted with JobID 8d29c8ab8e6e6634875a1cd16e879802
-            _idx = line.find("JobID")
-            if _idx > 0:
-                _id = line[_idx + 6:]
-                self.logger.debug(f"Found JobID:\n{_id}")
-                _generated_ids.append(_id)
+            idx = line.find("JobID")
+            if idx > 0:
+                id = line[idx + 6:]
+                self.logger.debug(f"Found JobID:\n{id}")
+                generated_ids.append(id)
 
-        return _generated_ids
+        return generated_ids
 
     def _get(self, rest_handle):
         """
@@ -274,79 +268,84 @@ class FlinkService(Service):
             More here:
             https://nightlies.apache.org/flink/flink-docs-release-1.18/docs/ops/rest_api/
         """
-        _url = f"{self._baseurl}{rest_handle}"
+        url = f"{self._baseurl}{rest_handle}"
         try:
-            _r = requests.get(_url)
+            r = requests.get(url)
         except Exception as e:
-            raise RuntimeError(f"Failed to get data from '{_url}'") from e
-        return _r.json()
+            raise RuntimeError(f"Failed to get data from '{url}'") from e
+        return r.json()
 
     def list_jobs(self):
         """
             List all jobs
         """
-        _handle = "/jobs"
-        return self._get(_handle)
+        handle = "/jobs"
+        return self._get(handle)
 
     def get_job_by_id(self, jobid):
         """
             Gets job specs
         """
-        _handle = f"/jobs/{jobid}"
-        return self._get(_handle)
+        handle = f"/jobs/{jobid}"
+        return self._get(handle)
 
     def start_node(self, node):
         # Prepare config
-        conf = yaml.dump(flink_config)
+        # Dump yaml and prevent java options to be divided
+        conf = yaml.dump(flink_config, width=float("inf"))
         self.logger.info("Creating flink configuration file")
         node.account.create_file(self.FLINK_CONFIG_FILE_PATH, conf)
 
         # Start
         self.logger.info("Starting Flink standalone cluster")
-        _out = node.account.ssh_output(self.FLINK_START)
-        self.logger.info(f"Response:\n{_out.decode()}")
+        out = node.account.ssh_output(self.FLINK_START)
+        self.logger.info(f"Response:\n{out.decode()}")
 
+        # Save node data for future log handling
+        self.node = node
+        self.hostname = node.account.hostname
         return
 
     def stop_node(self, node):
         # Stop cluster
         self.logger.info("Stopping flink standalone cluster")
-        _out = node.account.ssh_output(self.FLINK_STOP)
-        self.logger.info(f"Response:\n{_out.decode()}")
+        out = node.account.ssh_output(self.FLINK_STOP)
+        self.logger.info(f"Response:\n{out.decode()}")
 
+        # No local node or hostname removing as they needed for log extraction
         return
 
     def get_active_jobs(self):
         """
             Get all active jobs from flink REST API
         """
-        _jobs = self.list_jobs()
-        _active = [
-            _job for _job in _jobs['jobs']
-            if _job['status'] in self._active_statuses
+        jobs = self.list_jobs()
+        active = [
+            job for job in jobs['jobs']
+            if job['status'] in self._active_statuses
         ]
-        return _active
+        return active
 
     def _has_active_jobs(self):
         """
             Get active job list, log aggregated status count
             Return Bool valus if active jobs >0
         """
-        _jobs = self.get_active_jobs()
-        _map = {}
-        for _j in _jobs:
-            _s = _j['status']
-            if _s not in _map:
-                _map[_s] = 1
+        jobs = self.get_active_jobs()
+        map = {}
+        for j in jobs:
+            s = j['status']
+            if s not in map:
+                map[s] = 1
             else:
-                _map[_s] += 1
-        _out = [f"{k}: {v}" for k, v in _map.items()]
-        if len(_out) > 0:
-            self.logger.debug(f"Flink active jobs status: {', '.join(_out)}")
+                map[s] += 1
+        out = [f"{k}: {v}" for k, v in map.items()]
+        if len(out) > 0:
+            self.logger.debug(f"Flink active jobs status: {', '.join(out)}")
         else:
             self.logger.debug("Flink has no active jobs")
 
-        return len(_jobs) > 0
+        return len(jobs) > 0
 
     def wait_node(self, node, timeout_sec=1800):
         """
@@ -359,6 +358,48 @@ class FlinkService(Service):
         return True
 
     def clean_node(self, node):
-        # TODO: Remove logs and tmp folders
+        # Cleanup any redundant logs only if there is no service running.
+        # I.e. if self.node if None, it means that this is called from 'start'
+        # method and cleaning is relevant
+        if self.node is None:
+            node.account.ssh_output(f"sudo rm -f {self.FLINK_LOGS}/*")
+        else:
+            # Clear local vars
+            self.node = None
+            self.hostname = None
 
         return
+
+    @property
+    def logs(self):
+        # Safeguard if service not created
+        if self.node is None or self.hostname is None:
+            return {}
+        # This will be run for all calls to logs property
+        # Caching is not used for simplicity
+        # Load all logs in folder
+        files = self.nodes[0].account.ssh_output(
+            f"ls -1 {self.FLINK_LOGS}").decode()
+        # Filter out only ones from this node
+        logfiles = [fn for fn in files.splitlines() if self.hostname in fn]
+        # Build log map for ducktape copy
+        # There might be multiple log files for the same keyword and this is
+        # the reason index is used. Goal is to enumerate all that is generated
+        keywords = ["client", "standalonesession", "taskexecutor"]
+        log_map = {}
+        for keyword in keywords:
+            targetfiles = [
+                logfile for logfile in logfiles if keyword in logfile
+            ]
+            for idx in range(len(targetfiles)):
+                targetfile = targetfiles[idx]
+                # Extract extension
+                ext = targetfile[targetfile.rindex('.') + 1:]
+                # Add log item
+                log_map.update({
+                    f"{self.who_am_i().lower()}_{keyword}_{idx}_{ext}": {
+                        "path": f"{self.FLINK_LOGS}/{targetfile}",
+                        "collect_default": True
+                    }
+                })
+        return log_map

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -38,7 +38,6 @@ class FlinkBasicTests(RedpandaTest):
         self.kafkacli.delete_topic(self.topic)
         return super().tearDown()
 
-    @ignore
     def test_basic_workload(self):
         # Currently test is failed on data processing
 

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -49,7 +49,7 @@ class FlinkBasicTests(RedpandaTest):
         # Hardcoded file
         # TODO: Workload manager with workload config management
         _workload = "/home/ubuntu/tests/rptest/e2e_tests/workloads/" \
-                    "flink_simple_workload.py"
+                    "flink_produce_workload.py"
         _workload_config = {
             "log_level": "DEBUG",
             "brokers": self.redpanda.brokers(),

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -6,12 +6,18 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
-from ducktape.mark import ignore
+import os
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.services.cluster import cluster
 from rptest.services.flink import FlinkService
 from rptest.tests.redpanda_test import RedpandaTest
+
+# Temporary solution before workload manager is built
+workloads_path = os.path.abspath('.')
+workloads_path = os.path.join(os.path.abspath('.'),
+                              "tests/rptest/e2e_tests/workloads/")
 
 
 class FlinkBasicTests(RedpandaTest):
@@ -38,6 +44,7 @@ class FlinkBasicTests(RedpandaTest):
         self.kafkacli.delete_topic(self.topic)
         return super().tearDown()
 
+    @cluster(num_nodes=4)
     def test_basic_workload(self):
         # Currently test is failed on data processing
 
@@ -47,8 +54,9 @@ class FlinkBasicTests(RedpandaTest):
         # Load python workload to target node
         # Hardcoded file
         # TODO: Workload manager with workload config management
-        _workload = "/home/ubuntu/tests/rptest/e2e_tests/workloads/" \
-                    "flink_produce_workload.py"
+        self.logger.debug(f"Current path is: {os.path.abspath('.')}")
+        self.logger.debug(f"Workload folder set as: '{workloads_path}'")
+        _workload = os.path.join(workloads_path, "flink_produce_workload.py")
         _workload_config = {
             "log_level": "DEBUG",
             "brokers": self.redpanda.brokers(),

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -1,0 +1,73 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from ducktape.mark import ignore
+
+from rptest.clients.types import TopicSpec
+from rptest.services.flink import FlinkService
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class FlinkBasicTests(RedpandaTest):
+    def __init__(self, test_context, *args, **kwargs):
+        # Init parent
+        super(FlinkBasicTests, self).__init__(test_context, log_level="trace")
+
+        # Prepare FlinkService
+        self.topics = [TopicSpec()]
+        self.flink = FlinkService(test_context, self.redpanda, self.topic)
+
+        return
+
+    @ignore
+    def test_basic_workload(self):
+        # Start Flink
+        self.flink.start()
+
+        # Load python workload to target node
+        # Hardcoded file
+        # TODO: Implement simple workload
+        _workload = "/home/ubuntu/tests/rptests/e2e_tests/workloads/" \
+                    "flink_simple_workload.py"
+        _workload_config = {
+            "log_level": "DEBUG",
+            "brokers": self.redpanda.brokers(),
+            "producer_group": "flink_produce_group",
+            "consumer_group": "flink_consume_group",
+            "topic_name": "flink_workload_topic",
+            "msg_size": 4096,
+            "count": 10
+        }
+
+        # Add script as a job
+        _ids = self.flink.run_flink_job(_workload, _workload_config)
+        if _ids is None:
+            raise RuntimeError(f"Failed to run job on flink: {_workload}")
+
+        self.logger.debug(f"Workload '{_workload}' generated {len(_ids)} "
+                          f"jobs: {', '.join(_ids)}")
+
+        # Wait for jobs to finish
+        self.flink.wait(timeout_sec=3600)
+
+        # Collect failed jobs
+        _failed = []
+        for _id in _ids:
+            _job = self.flink.get_job_by_id(_id)
+            if _job['state'] == self.flink.STATE_FAILED:
+                self.logger.warning(f"Job '{_id}' has failed")
+                _failed.append(_job)
+
+        # Stop flink
+        self.flink.stop()
+
+        # Assert failed jobs
+        assert len(_failed) == 0, \
+            f"Flink reports failed jobs for the workload {_workload}"
+
+        return


### PR DESCRIPTION
This PR creates Flink service, basic workloads and a simple produce test
- Flink Service uses similar structure to other services, for example kgo_verifier
- Standalone mode is used when starting a cluster. I.e. no HA or connections to/from Flink services on other nodes
- Support for flink/java embedded Python environments is not yet implemented. I.e. workloads that generates python subtasks are not currently supported

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none