### PR TITLE
Fix some clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,5 +23,13 @@ CheckOptions:
     value:           llvm
   - key:             modernize-use-nullptr.NullMacros
     value:           NULL
+  - key:             readability-identifier-length.IgnoredVariableNames
+    value:           ^it$
+  - key:             readability-identifier-length.IgnoredParameterNames
+    value:           ^(it|a|b)$
+  - key:             readability-uppercase-literal-suffix.NewSuffixes
+    value:           KiB;MiB;GiB;TiB
+  - key:             hicpp-uppercase-literal-suffix.NewSuffixes
+    value:           KiB;MiB;GiB;TiB
 ...
 

--- a/src/v/io/cache.h
+++ b/src/v/io/cache.h
@@ -439,15 +439,17 @@ private:
             return &((value.*Hook).hook_);
         }
 
-        static pointer to_value_ptr(hook_ptr n) {
+        static pointer to_value_ptr(hook_ptr hook) {
             return boost::intrusive::get_parent_from_member(
-              boost::intrusive::get_parent_from_member(n, &cache_hook::hook_),
+              boost::intrusive::get_parent_from_member(
+                hook, &cache_hook::hook_),
               Hook);
         }
 
-        static const_pointer to_value_ptr(const_hook_ptr n) {
+        static const_pointer to_value_ptr(const_hook_ptr hook) {
             return boost::intrusive::get_parent_from_member(
-              boost::intrusive::get_parent_from_member(n, &cache_hook::hook_),
+              boost::intrusive::get_parent_from_member(
+                hook, &cache_hook::hook_),
               Hook);
         }
     };

--- a/src/v/io/page_set.h
+++ b/src/v/io/page_set.h
@@ -39,7 +39,7 @@ public:
         friend class boost::iterator_core_access;
         friend class page_set;
         explicit const_iterator(map_type::const_iterator it);
-        reference dereference() const;
+        [[nodiscard]] reference dereference() const;
     };
 
     /**

--- a/src/v/io/page_set.h
+++ b/src/v/io/page_set.h
@@ -38,7 +38,7 @@ public:
     private:
         friend class boost::iterator_core_access;
         friend class page_set;
-        explicit const_iterator(map_type::const_iterator);
+        explicit const_iterator(map_type::const_iterator it);
         reference dereference() const;
     };
 

--- a/src/v/io/persistence.cc
+++ b/src/v/io/persistence.cc
@@ -44,7 +44,7 @@ std::optional<seastar::future<size_t>> check_alignment(
   std::span<const char> data,
   uint64_t memory_alignment,
   uint64_t disk_alignment) {
-    if (pos % disk_alignment) {
+    if ((pos % disk_alignment) != 0) {
         return make_alignment_error(name, "pos", pos, disk_alignment);
     }
 
@@ -54,7 +54,7 @@ std::optional<seastar::future<size_t>> check_alignment(
         return make_alignment_error(name, "buf", ptr, memory_alignment);
     }
 
-    if (data.size() % disk_alignment) {
+    if ((data.size() % disk_alignment) != 0) {
         return make_alignment_error(name, "len", data.size(), disk_alignment);
     }
 
@@ -256,7 +256,7 @@ memory_persistence::memory_file::read(uint64_t pos, char* buffer, size_t len) {
 
     size_t bytes_read = 0;
     len = std::min(len, size_ - pos);
-    while (len) {
+    while (len != 0) {
         assert(it != data_.end());
 
         auto chunk_pos = pos - it->first;
@@ -294,7 +294,7 @@ seastar::future<size_t> memory_persistence::memory_file::write(
 
     size_t written = 0;
     std::span input(buf, len);
-    while (len) {
+    while (len != 0) {
         assert(it != data_.end());
 
         auto chunk_pos = pos - it->first;

--- a/src/v/io/persistence.cc
+++ b/src/v/io/persistence.cc
@@ -24,10 +24,13 @@ namespace {
  * build an alignment error to return from read/write
  */
 seastar::future<size_t> make_alignment_error(
-  std::string_view op, std::string_view arg, auto val, uint64_t alignment) {
+  std::string_view op_name,
+  std::string_view arg,
+  auto val,
+  uint64_t alignment) {
     auto msg = fmt::format(
       R"(Op "{}" arg "{}" with value {} expects alignment {})",
-      op,
+      op_name,
       arg,
       val,
       alignment);
@@ -64,8 +67,8 @@ std::optional<seastar::future<size_t>> check_alignment(
 
 namespace experimental::io {
 
-disk_persistence::disk_file::disk_file(seastar::file f)
-  : file_(std::move(f)) {}
+disk_persistence::disk_file::disk_file(seastar::file file)
+  : file_(std::move(file)) {}
 
 seastar::future<size_t> disk_persistence::disk_file::dma_read(
   uint64_t pos, char* buf, size_t len) noexcept {

--- a/src/v/io/persistence.h
+++ b/src/v/io/persistence.h
@@ -134,9 +134,11 @@ public:
 
         seastar::future<> close() noexcept override;
 
-        uint64_t disk_read_dma_alignment() const noexcept override;
-        uint64_t disk_write_dma_alignment() const noexcept override;
-        uint64_t memory_dma_alignment() const noexcept override;
+        [[nodiscard]] uint64_t
+        disk_read_dma_alignment() const noexcept override;
+        [[nodiscard]] uint64_t
+        disk_write_dma_alignment() const noexcept override;
+        [[nodiscard]] uint64_t memory_dma_alignment() const noexcept override;
 
     private:
         seastar::file file_;
@@ -210,9 +212,11 @@ public:
 
         seastar::future<> close() noexcept override;
 
-        uint64_t disk_read_dma_alignment() const noexcept override;
-        uint64_t disk_write_dma_alignment() const noexcept override;
-        uint64_t memory_dma_alignment() const noexcept override;
+        [[nodiscard]] uint64_t
+        disk_read_dma_alignment() const noexcept override;
+        [[nodiscard]] uint64_t
+        disk_write_dma_alignment() const noexcept override;
+        [[nodiscard]] uint64_t memory_dma_alignment() const noexcept override;
 
     private:
         seastar::future<> ensure_capacity(size_t);

--- a/src/v/io/persistence.h
+++ b/src/v/io/persistence.h
@@ -127,10 +127,10 @@ public:
         explicit disk_file(seastar::file file);
 
         seastar::future<size_t>
-        dma_read(uint64_t, char*, size_t) noexcept override;
+        dma_read(uint64_t pos, char* buf, size_t len) noexcept override;
 
         seastar::future<size_t>
-        dma_write(uint64_t, const char*, size_t) noexcept override;
+        dma_write(uint64_t pos, const char* buf, size_t len) noexcept override;
 
         seastar::future<> close() noexcept override;
 
@@ -219,9 +219,10 @@ public:
         [[nodiscard]] uint64_t memory_dma_alignment() const noexcept override;
 
     private:
-        seastar::future<> ensure_capacity(size_t);
-        seastar::future<size_t> read(uint64_t, char*, size_t);
-        seastar::future<size_t> write(uint64_t, const char*, size_t);
+        seastar::future<> ensure_capacity(size_t size);
+        seastar::future<size_t> read(uint64_t pos, char* buf, size_t len);
+        seastar::future<size_t>
+        write(uint64_t pos, const char* buf, size_t len);
 
         size_t size_{0};
         size_t capacity_{0};

--- a/src/v/io/tests/common.cc
+++ b/src/v/io/tests/common.cc
@@ -31,9 +31,8 @@ make_random_data(size_t size, std::optional<uint64_t> alignment) {
         if (alignment.has_value()) {
             return seastar::temporary_buffer<char>::aligned(
               alignment.value(), size);
-        } else {
-            return seastar::temporary_buffer<char>(size);
         }
+        return seastar::temporary_buffer<char>(size);
     }();
 
     uint64_t offset = 0;

--- a/src/v/io/tests/page_set_test.cc
+++ b/src/v/io/tests/page_set_test.cc
@@ -26,12 +26,12 @@ auto make_page(uint64_t offset, uint64_t size) {
 } // namespace
 
 TEST(PageSet, EmptyBeginEnd) {
-    io::page_set set;
+    const io::page_set set;
     EXPECT_EQ(set.begin(), set.end());
 }
 
 TEST(PageSet, EmptyFind) {
-    io::page_set set;
+    const io::page_set set;
     EXPECT_EQ(set.find(0), set.end());
 }
 

--- a/src/v/io/tests/page_test.cc
+++ b/src/v/io/tests/page_test.cc
@@ -14,7 +14,7 @@
 namespace io = experimental::io;
 
 TEST(Page, Empty) {
-    io::page p(1, {});
+    const io::page p(1, {});
     EXPECT_EQ(p.offset(), 1);
     EXPECT_EQ(p.size(), 0);
     EXPECT_EQ(p.data().size(), 0);
@@ -23,7 +23,7 @@ TEST(Page, Empty) {
 TEST(Page, NonEmpty) {
     constexpr auto size = 10;
     seastar::temporary_buffer<char> data(size);
-    io::page p(1, std::move(data));
+    const io::page p(1, std::move(data));
     EXPECT_EQ(p.offset(), 1);
     EXPECT_EQ(p.size(), size);
     EXPECT_EQ(p.data().size(), size);

--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -30,7 +30,7 @@ private:
     void TearDown() override { TearDownAsync().get(); }
 };
 
-// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+// NOLINTBEGIN(cppcoreguidelines-macro-usage,bugprone-macro-parentheses)
 #define GTEST_TEST_SEASTAR_(                                                   \
   test_suite_name, test_name, parent_class, parent_id)                         \
     static_assert(                                                             \
@@ -173,4 +173,4 @@ private:
 #define ASSERT_LT_CORO(val1, val2) GTEST_ASSERT_LT_CORO(val1, val2)
 #define ASSERT_LE_CORO(val1, val2) GTEST_ASSERT_LE_CORO(val1, val2)
 #define ASSERT_NE_CORO(val1, val2) GTEST_ASSERT_NE_CORO(val1, val2)
-// NOLINTEND(cppcoreguidelines-macro-usage)
+// NOLINTEND(cppcoreguidelines-macro-usage,bugprone-macro-parentheses)

--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -30,6 +30,7 @@ private:
     void TearDown() override { TearDownAsync().get(); }
 };
 
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define GTEST_TEST_SEASTAR_(                                                   \
   test_suite_name, test_name, parent_class, parent_id)                         \
     static_assert(                                                             \
@@ -172,3 +173,4 @@ private:
 #define ASSERT_LT_CORO(val1, val2) GTEST_ASSERT_LT_CORO(val1, val2)
 #define ASSERT_LE_CORO(val1, val2) GTEST_ASSERT_LE_CORO(val1, val2)
 #define ASSERT_NE_CORO(val1, val2) GTEST_ASSERT_NE_CORO(val1, val2)
+// NOLINTEND(cppcoreguidelines-macro-usage)

--- a/src/v/units.h
+++ b/src/v/units.h
@@ -20,7 +20,9 @@ constexpr size_t MiB = 1024 * KiB;
 constexpr size_t GiB = 1024 * MiB;
 constexpr size_t TiB = 1024 * GiB;
 
+// NOLINTBEGIN(google-runtime-int)
 constexpr size_t operator"" _KiB(unsigned long long val) { return val * KiB; }
 constexpr size_t operator"" _MiB(unsigned long long val) { return val * MiB; }
 constexpr size_t operator"" _GiB(unsigned long long val) { return val * GiB; }
 constexpr size_t operator"" _TiB(unsigned long long val) { return val * TiB; }
+// NOLINTEND(google-runtime-int)


### PR DESCRIPTION
Fix some clang tidy warnings.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

