### PR TITLE
rptest: update `test_decommission_and_add` to decomm and add on cloudv2

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -149,27 +149,25 @@ class KubectlTool:
 
     def _run(self, cmd):
         # Log and run
-        self._redpanda.logger.info(cmd)
-        res = subprocess.check_output(cmd)
-        return res
+        ssh_prefix = self._ssh_prefix()
+        remote_cmd = ssh_prefix + cmd
+        self._redpanda.logger.info(remote_cmd)
+        return subprocess.check_output(remote_cmd)
 
     def run_kube_command(self, kcmd):
         # prepare
         self._install()
-        _ssh_prefix = self._ssh_prefix()
         _kubectl = ["kubectl", '-n', self._namespace]
 
         # Make it universal for str/list
         _kcmd = kcmd if isinstance(kcmd, list) else kcmd.split()
         # Format command
-        cmd = _ssh_prefix + _kubectl + _kcmd
-        # Log and run
+        cmd = _kubectl + _kcmd
         return self._run(cmd)
 
     def exec(self, remote_cmd):
         self._install()
-        ssh_prefix = self._ssh_prefix()
-        cmd = ssh_prefix + [
+        cmd = [
             'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
             f'rp-{self._cluster_id}-0', '--', 'bash', '-c'
         ] + ['"' + remote_cmd + '"']

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -18,7 +18,6 @@ class KubectlTool:
     Wrapper around kubectl for operating on a redpanda cluster.
     """
 
-    KUBECTL_VERSION = '1.24.10'
     TELEPORT_DEST_DIR = '/tmp/machine-id'
     TELEPORT_IDENT_FILE = f'{TELEPORT_DEST_DIR}/identity'
 
@@ -120,28 +119,15 @@ class KubectlTool:
         '''
         if not self._kubectl_installed and self._remote_uri is not None:
             ssh_prefix = self._ssh_prefix()
-            download_cmd = ssh_prefix + [
-                'wget', '-q',
-                f'https://dl.k8s.io/release/v{self.KUBECTL_VERSION}/bin/linux/amd64/kubectl',
-                '-O', '/tmp/kubectl'
-            ]
-            install_cmd = ssh_prefix + [
-                'sudo', 'install', '-m', '0755', '/tmp/kubectl',
-                '/usr/local/bin/kubectl'
-            ]
-            cleanup_cmd = ssh_prefix + ['rm', '-f', '/tmp/kubectl']
+            bg_cmd = ssh_prefix + ['./breakglass-tools.sh']
 
             if self._provider == 'aws':
                 config_cmd = ssh_prefix + self._aws_config_cmd()
             elif self._provider == 'gcp':
                 config_cmd = ssh_prefix + self._gcp_config_cmd()
 
-            self._redpanda.logger.info(download_cmd)
-            res = subprocess.check_output(download_cmd)
-            self._redpanda.logger.info(install_cmd)
-            res = subprocess.check_output(install_cmd)
-            self._redpanda.logger.info(cleanup_cmd)
-            res = subprocess.check_output(cleanup_cmd)
+            self._redpanda.logger.info(bg_cmd)
+            res = subprocess.check_output(bg_cmd)
             self._redpanda.logger.info(config_cmd)
             res = subprocess.check_output(config_cmd)
             self._kubectl_installed = True

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -147,23 +147,25 @@ class KubectlTool:
             self._kubectl_installed = True
         return
 
-    def _run(self, cmd):
+    def _cmd(self, cmd):
         # Log and run
         ssh_prefix = self._ssh_prefix()
         remote_cmd = ssh_prefix + cmd
         self._redpanda.logger.info(remote_cmd)
         return subprocess.check_output(remote_cmd)
 
-    def run_kube_command(self, kcmd):
+    def cmd(self, kcmd):
+        """Execute a kubectl command on the agent node.
+        """
         # prepare
         self._install()
-        _kubectl = ["kubectl", '-n', self._namespace]
+        _kubectl = ['kubectl']
 
         # Make it universal for str/list
         _kcmd = kcmd if isinstance(kcmd, list) else kcmd.split()
         # Format command
         cmd = _kubectl + _kcmd
-        return self._run(cmd)
+        return self._cmd(cmd)
 
     def exec(self, remote_cmd):
         self._install()
@@ -171,7 +173,7 @@ class KubectlTool:
             'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
             f'rp-{self._cluster_id}-0', '--', 'bash', '-c'
         ] + ['"' + remote_cmd + '"']
-        return self._run(cmd)
+        return self._cmd(cmd)
 
     def exists(self, remote_path):
         self._install()

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -34,7 +34,7 @@ from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import \
     OMBSampleConfigurations
 from rptest.services.producer_swarm import ProducerSwarm
-from rptest.services.redpanda_cloud import CloudTierName, get_config_profile_name
+from rptest.services.redpanda_cloud import CloudTierName, get_config_profile_name, PROVIDER_AWS
 from rptest.services.redpanda import (RESTART_LOG_ALLOW_LIST, MetricsEndpoint,
                                       SISettings, RedpandaServiceCloud)
 from rptest.services.rpk_consumer import RpkConsumer
@@ -862,21 +862,36 @@ class HighThroughputTest(PreallocNodesTest):
     @ignore
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_and_add(self):
-        """
+        """Decommission and add while under load.
+
         Preloads cluster with large number of messages/segments that are also
-        replicated to the cloud, and then runs the decommission-and-add a node
-        stage. This could have been a part of 'test_combo_preloaded' but
-        this stage alone is too heavy and long-lasting, so it's put into a
-        separate test.
+        replicated to the cloud. Then runs the decommission-and-add a node
+        stage.
         """
+
+        self.logger.info(f'verify cluster > 3 nodes')
+        if self._num_brokers <= 3:
+            self.logger.warn('need more than 3 nodes to run test')
+            return
+
+        self.logger.info('verify operator-v2 is not activated')
+        # kubectl get redpanda -n=redpanda
+        get_redpanda = self.redpanda.kubectl.cmd(
+            ['get', 'redpanda', '-n=redpanda'])
+        if len(get_redpanda) > 0:
+            self.logger.warn('cannot run test with operator-v2')
+            return
+
         # create default topics
         self._create_default_topics()
 
         self.adjust_topic_segment_properties(
             segment_bytes=self.min_segment_size,
             retention_local_bytes=2 * self.min_segment_size)
+
         # Generate a realistic number of segments per partition.
         self.load_many_segments()
+        producer = None
         try:
             producer = KgoVerifierProducer(
                 self.test_context,
@@ -891,75 +906,156 @@ class HighThroughputTest(PreallocNodesTest):
             self._wait_for_traffic(producer,
                                    self.msg_count,
                                    timeout=self.msg_timeout)
-
-            # Decommission.
-            # Add node (after stage_decommission has freed up a node)
-            # and wait for partitions to move in.
             self.stage_decommission_and_add()
 
         finally:
             producer.stop()
             producer.wait(timeout_sec=600)
-            self.free_preallocated_nodes()
 
     def stage_decommission_and_add(self):
-        pod = self.get_broker_pod()
-        pod_id = pod.slot_id
-        pod_str = pod.name
+        def cluster_ready_replicas(cluster_name):
+            # kubectl get cluster rp-clkd0n22nfn1jf7vd9t0 -n=redpanda -o=jsonpath='{.status.readyReplicas}'
+            return int(
+                self.redpanda.kubectl.cmd([
+                    'get', 'cluster', cluster_name, '-n=redpanda',
+                    "-o=jsonpath='{.status.readyReplicas}'"
+                ]).decode())
 
-        def topic_partitions_on_pod():
-            try:
-                parts = self.redpanda.partitions(self.topic)
-            except StopIteration:
-                return 0
-            n = sum([
-                1 if r.account == pod.account else 0 for p in parts
-                for r in p.replicas
-            ])
-            self.logger.debug(f"Partitions in the node-topic: {n}")
-            return n
+        def deployment_ready_replicas():
+            # kubectl get deployment redpanda-controller-manager -n=redpanda-system -o=jsonpath='{.status.readyReplicas}'
+            return int(
+                self.redpanda.kubectl.cmd([
+                    'get', 'deployment', 'redpanda-controller-manager',
+                    '-n=redpanda-system',
+                    "-o=jsonpath='{.status.readyReplicas}'"
+                ]).decode())
 
-        # create default topics
-        self._create_default_topics()
+        agent_services = [
+            'redpanda-agent.service', 'redpanda-agent-boot.service'
+        ]
+        if self.redpanda._cloud_cluster.config.provider == PROVIDER_AWS:
+            agent_services.append('redpanda-agent-init.service')
 
-        nt_partitions_before = topic_partitions_on_pod()
+        self.logger.info('disabling agent services')
+        # sudo systemctl disable --now redpanda-agent.service redpanda-agent-boot.service redpanda-agent-init.service
+        self.redpanda.cloud_agent_ssh(
+            ['sudo', 'systemctl', 'disable', '--now'] + agent_services)
 
+        self.logger.info('getting list of args from deployment')
+        # kubectl get deployment redpanda-controller-manager -n=redpanda-system -o=jsonpath='{.spec.template.spec.containers[0].args}'
+        deployment_args = self.redpanda.kubectl.cmd([
+            'get', 'deployment', 'redpanda-controller-manager',
+            '-n=redpanda-system',
+            "-o=jsonpath='{.spec.template.spec.containers[0].args}'"
+        ])
+
+        self.logger.info('patching deployment to allow downscaling')
+        deployment_args = deployment_args.decode().replace(
+            '--allow-downscaling=false', '--allow-downscaling=true', 1)
+        patch = [{
+            'op': 'replace',
+            'path': '/spec/template/spec/containers/0/args',
+            'value': json.loads(deployment_args)
+        }]
+        patch_str = json.dumps(patch)
+        # kubectl patch deployment redpanda-controller-manager -n=redpanda-system --type=json \
+        #         --patch='[{"op":"replace","path":"/spec/template/spec/containers/0/args","value":["arg1","arg2","etc..."]}]'
+        self.redpanda.kubectl.cmd([
+            'patch', 'deployment', 'redpanda-controller-manager',
+            '-n=redpanda-system', '--type=json', f"-p='{patch_str}'"
+        ])
+
+        self.logger.info('waiting for deployment to become ready after patch')
+        wait_until(lambda: deployment_ready_replicas() == 1,
+                   timeout_sec=600,
+                   backoff_sec=1)
+
+        cluster_name = f'rp-{self.redpanda._cloud_cluster.cluster_id}'
+        self.logger.info(f'getting replicas from cluster {cluster_name}')
+        orig_replicas = cluster_ready_replicas(cluster_name)
+        new_replicas = orig_replicas - 1
         self.logger.info(
-            f"Decommissioning node {pod_str}, partitions: {nt_partitions_before}"
+            f'decomm by patching cluster {cluster_name} with replicas {new_replicas}'
         )
-        decomm_time = time.monotonic()
-        admin = self.redpanda._admin
-        admin.decommission_broker(pod_id)
-        waiter = NodeDecommissionWaiter(self.redpanda,
-                                        pod_id,
-                                        self.logger,
-                                        progress_timeout=120)
-        waiter.wait_for_removal()
-        self.redpanda.stop_node(pod)
-        assert topic_partitions_on_pod() == 0
-        decomm_time = time.monotonic() - decomm_time
-
-        self.logger.info(f"Adding a node")
-        self.redpanda.clean_node(pod,
-                                 preserve_logs=True,
-                                 preserve_current_install=True)
-        self.redpanda.start_node(pod,
-                                 auto_assign_node_id=False,
-                                 omit_seeds_on_idx_one=False)
-        wait_until(self.redpanda.healthy, timeout_sec=600, backoff_sec=1)
-        new_node_id = self.redpanda.node_id(pod, force_refresh=True)
+        patch = [{
+            'op': 'replace',
+            'path': '/spec/replicas',
+            'value': new_replicas
+        }]
+        patch_str = json.dumps(patch)
+        # kubectl patch cluster rp-clkd0n22nfn1jf7vd9t0 -n=redpanda --type=json -p='[{"op":"replace","path":"/spec/replicas","value":4}]'
+        self.redpanda.kubectl.cmd([
+            'patch', 'cluster', cluster_name, '-n=redpanda', '--type=json',
+            f"-p='{patch_str}'"
+        ])
 
         self.logger.info(
-            f"Node added, new node_id: {new_node_id}, waiting for {int(nt_partitions_before/2)} partitions to move there in {int(decomm_time*2)} s"
+            f'waiting for decommissioning of {cluster_name} to arrive at {new_replicas}'
         )
         wait_until(
-            lambda: topic_partitions_on_pod() > nt_partitions_before / 2,
-            timeout_sec=max(120, decomm_time * 2),
-            backoff_sec=2,
-            err_msg=
-            f"{int(nt_partitions_before/2)} partitions failed to move to node {new_node_id} in {max(60, decomm_time*2)} s"
+            lambda: cluster_ready_replicas(cluster_name) == new_replicas,
+            timeout_sec=600,
+            backoff_sec=1)
+
+        pvc_name = f'datadir-rp-{self.redpanda._cloud_cluster.cluster_id}-{new_replicas}'
+        self.logger.info(f'deleting pvc {pvc_name}')
+        # kubectl delete pvc datadir-rp-clkd0n22nfn1jf7vd9t0-4 -n=redpanda
+        self.redpanda.kubectl.cmd(['delete', 'pvc', pvc_name, '-n=redpanda'])
+
+        pvc_name = f'shadow-index-cache-rp-{self.redpanda._cloud_cluster.cluster_id}-{new_replicas}'
+        self.logger.info(f'deleting pvc {pvc_name}')
+        # kubectl delete pvc shadow-index-cache-rp-clkd0n22nfn1jf7vd9t0-4 -n=redpanda
+        self.redpanda.kubectl.cmd(['delete', 'pvc', pvc_name, '-n=redpanda'])
+
+        self.logger.info(
+            f'ensuring decommission of {cluster_name} reduced replicas to {new_replicas}'
         )
-        self.logger.info(f"{topic_partitions_on_pod()} partitions moved")
+        assert cluster_ready_replicas(cluster_name) == new_replicas
+
+        # skip decomm via broker admin api so it does not conflict with decomm via kubectl
+        #admin = self.redpanda._admin
+        #admin.decommission_broker(pod_id)
+        #waiter = NodeDecommissionWaiter(self.redpanda, pod_id, self.logger, progress_timeout=120)
+        #waiter.wait_for_removal()
+        #self.redpanda.stop_node(pod)
+
+        self.logger.info(
+            f'adding new broker by patching cluster {cluster_name} with replicas {orig_replicas}'
+        )
+        patch = [{
+            'op': 'replace',
+            'path': '/spec/replicas',
+            'value': orig_replicas
+        }]
+        patch_str = json.dumps(patch)
+        # kubectl patch cluster rp-clkd0n22nfn1jf7vd9t0 -n=redpanda --type=json -p='[{"op":"replace","path":"/spec/replicas","value":5}]'
+        self.redpanda.kubectl.cmd([
+            'patch', 'cluster', cluster_name, '-n=redpanda', '--type=json',
+            f"-p='{patch_str}'"
+        ])
+
+        self.logger.info(
+            f'waiting for commissioning of {cluster_name} to arrive at replicas {orig_replicas}'
+        )
+        wait_until(
+            lambda: cluster_ready_replicas(cluster_name) == orig_replicas,
+            timeout_sec=600,
+            backoff_sec=1)
+
+        self.logger.info('reenabling agent services')
+        self.redpanda.cloud_agent_ssh(
+            ['sudo', 'systemctl', 'enable', '--now'] + agent_services)
+
+        self.logger.info(
+            f'ensuring commission of {cluster_name} restored replicas to {orig_replicas}'
+        )
+        assert cluster_ready_replicas(cluster_name) == orig_replicas
+
+        # skip new node creation so it does not conflict with add via kubectl
+        #self.redpanda.clean_node(pod, preserve_logs=True, preserve_current_install=True)
+        #self.redpanda.start_node(pod, auto_assign_node_id=False, omit_seeds_on_idx_one=False)
+        #wait_until(self.redpanda.healthy, timeout_sec=600, backoff_sec=1)
+        #new_node_id = self.redpanda.node_id(pod, force_refresh=True)
 
     @cluster(num_nodes=3, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_cloud_cache_thrash(self):

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -859,7 +859,6 @@ class HighThroughputTest(PreallocNodesTest):
                 f"Low throughput while preparing for the test: {_throughput}: {e}"
             )
 
-    @ignore
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_and_add(self):
         """Decommission and add while under load.

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1647,6 +1647,13 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
         # Load install pack and check profile
         return install_pack_client.getInstallPack(install_pack_version)
 
+    def cloud_agent_ssh(self, remote_cmd):
+        """Run the given command on the redpanda agent node of the cluster.
+
+        :param remote_cmd: The command to run on the agent node.
+        """
+        return self._kubectl._cmd(remote_cmd)
+
 
 class RedpandaService(RedpandaServiceBase):
     def __init__(self,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1515,6 +1515,10 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
             'ResourceSettings: setting dedicated_nodes=True because serving from redpanda cloud'
         )
 
+    @property
+    def kubectl(self):
+        return self._kubectl
+
     def start_node(self, node, **kwargs):
         pass
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1543,7 +1543,7 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
         # Get pods and form node list
         self.pods = []
-        _r = self._kubectl.run_kube_command("get pods -o json")
+        _r = self._kubectl.cmd('get pods -n redpanda -o json')
         _pods = json.loads(_r.decode())
         for p in _pods['items']:
             if not p['metadata']['name'].startswith(


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/cloudv2/issues/10373

Updated the `test_decommission_and_add` test to decommissions a node and then adds a node back to the cluster using `kubectl` commands.

Restrictions (test will exit with warning if not satisified):
* only works with operator-v1 because the kubectl cmds will be different with operator-v2
* requires more than 3 nodes in the config profile of the tier being tested because the first operation will be a decomm and can't have less than 3 nodes in the k8s cluster

example of test run:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  --test-runner-timeout=3600000 \
  tests/rptest/redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_decommission_and_add
```
output:
```
...
[INFO  - 2023-12-05 03:34:22,604 - high_throughput_test - __init__ - lineno:249]: Loaded install pack '23.2.20231124095407': Redpanda v23.2.16, created at '2023-11-24T09:57:36.209549049Z'
[INFO  - 2023-12-05 03:34:24,342 - high_throughput_test - __init__ - lineno:298]: config profile tier-4-aws: {'cloud_provider': 'aws', 'machine_type': 'i3en.3xlarge', 'nodes_count': 6, 'storage_type': '}
...
[INFO:2023-12-05 03:34:43,579]: RunnerClient: rptest.redpanda_cloud_tests.high_throughput_test.HighThroughputTest.test_decommission_and_add: Running...
[INFO  - 2023-12-05 03:34:43,579 - high_throughput_test - test_decommission_and_add - lineno:871]: verify cluster > 3 nodes
[INFO  - 2023-12-05 03:34:43,579 - high_throughput_test - test_decommission_and_add - lineno:876]: verify operator-v2 is not activated
[INFO  - 2023-12-05 03:34:43,579 - kubectl - _cmd - lineno:140]: ['tsh', 'ssh', '--proxy=proxy.tp.redpanda.com:443', '--identity=/tmp/machine-id/identity', 'redpanda@cln58mqcn3kaj5t5icf0-agent', 'kubect]
No resources found in redpanda namespace.
[DEBUG - 2023-12-05 03:34:46,783 - redpanda_test - _create_initial_topics - lineno:127]: Creating initial topic topic-qwttttekmx
...
test_id:    rptest.redpanda_cloud_tests.high_throughput_test.HighThroughputTest.test_decommission_and_add
status:     PASS
run time:   16 minutes 48.926 seconds
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
===========================================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2023-12-05--018
run time:         16 minutes 48.947 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
=======================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
