### PR TITLE
audit: Disable auditing in recovery mode

### DIFF
--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -18,6 +18,7 @@
 #include "kafka/protocol/produce.h"
 #include "kafka/protocol/schemata/produce_response.h"
 #include "kafka/server/handlers/topics/types.h"
+#include "model/namespace.h"
 #include "security/acl.h"
 #include "security/audit/client_probe.h"
 #include "security/audit/logger.h"
@@ -926,8 +927,11 @@ audit_log_manager::should_enqueue_audit_event() const {
 }
 
 std::optional<audit_log_manager::audit_event_passthrough>
-audit_log_manager::should_enqueue_audit_event(event_type type) const {
-    if (!is_audit_event_enabled(type)) {
+audit_log_manager::should_enqueue_audit_event(
+  event_type type, ignore_enabled_events ignore_events) const {
+    if (
+      ignore_events == ignore_enabled_events::no
+      && !is_audit_event_enabled(type)) {
         return std::make_optional(audit_event_passthrough::yes);
     }
     return should_enqueue_audit_event();
@@ -935,18 +939,23 @@ audit_log_manager::should_enqueue_audit_event(event_type type) const {
 
 std::optional<audit_log_manager::audit_event_passthrough>
 audit_log_manager::should_enqueue_audit_event(
-  event_type type, const security::acl_principal& principal) const {
+  event_type type,
+  const security::acl_principal& principal,
+  ignore_enabled_events ignore_events) const {
     if (_audit_excluded_principals.contains(principal)) {
         return std::make_optional(audit_event_passthrough::yes);
     }
 
-    return should_enqueue_audit_event(type);
+    return should_enqueue_audit_event(type, ignore_events);
 }
 
 std::optional<audit_log_manager::audit_event_passthrough>
 audit_log_manager::should_enqueue_audit_event(
-  kafka::api_key key, const security::acl_principal& principal) const {
-    return should_enqueue_audit_event(kafka_api_to_event_type(key), principal);
+  kafka::api_key key,
+  const security::acl_principal& principal,
+  ignore_enabled_events ignore_events) const {
+    return should_enqueue_audit_event(
+      kafka_api_to_event_type(key), principal, ignore_events);
 }
 
 std::optional<audit_log_manager::audit_event_passthrough>
@@ -968,11 +977,14 @@ audit_log_manager::should_enqueue_audit_event(
   kafka::api_key key,
   const security::acl_principal& principal,
   const model::topic& t) const {
+    auto ignore_events = ignore_enabled_events::no;
     if (_audit_excluded_topics.contains(t)) {
         return std::make_optional(audit_event_passthrough::yes);
+    } else if (t == model::kafka_audit_logging_topic) {
+        ignore_events = ignore_enabled_events::yes;
     }
 
-    return should_enqueue_audit_event(key, principal);
+    return should_enqueue_audit_event(key, principal, ignore_events);
 }
 
 } // namespace security::audit

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -104,8 +104,7 @@ public:
         if constexpr (std::is_same_v<T, model::topic>) {
             if (auto val = should_enqueue_audit_event(
                   api, result.principal, resource_name);
-                val.has_value()
-                && resource_name != model::kafka_audit_logging_topic) {
+                val.has_value()) {
                 return (bool)*val;
             }
         } else {
@@ -133,8 +132,7 @@ public:
         if constexpr (std::is_same_v<T, model::topic>) {
             if (auto val = should_enqueue_audit_event(
                   api, result.principal, resource_name);
-                val.has_value()
-                && resource_name != model::kafka_audit_logging_topic) {
+                val.has_value()) {
                 return (bool)*val;
             }
         } else {
@@ -220,17 +218,24 @@ public:
     bool report_redpanda_app_event(is_started);
 
 private:
+    using ignore_enabled_events
+      = ss::bool_class<struct ignore_enabled_events_tag>;
     /// The following methods return nullopt in the case the event should
     /// be audited, otherwise the optional is filled with the value representing
     /// whether it could not be enqueued due to error or due to the event
     /// not having attributes of desired trackable events
     std::optional<audit_event_passthrough> should_enqueue_audit_event() const;
-    std::optional<audit_event_passthrough>
-      should_enqueue_audit_event(event_type) const;
     std::optional<audit_event_passthrough> should_enqueue_audit_event(
-      event_type, const security::acl_principal&) const;
+      event_type,
+      ignore_enabled_events ignore_events = ignore_enabled_events::no) const;
     std::optional<audit_event_passthrough> should_enqueue_audit_event(
-      kafka::api_key, const security::acl_principal&) const;
+      event_type,
+      const security::acl_principal&,
+      ignore_enabled_events ignore_events = ignore_enabled_events::no) const;
+    std::optional<audit_event_passthrough> should_enqueue_audit_event(
+      kafka::api_key,
+      const security::acl_principal&,
+      ignore_enabled_events ignore_events = ignore_enabled_events::no) const;
     std::optional<audit_event_passthrough>
     should_enqueue_audit_event(event_type, const security::audit::user&) const;
     std::optional<audit_event_passthrough>

--- a/src/v/security/audit/audit_log_manager.h
+++ b/src/v/security/audit/audit_log_manager.h
@@ -270,6 +270,8 @@ private:
         return result;
     }
 
+    static bool recovery_mode_enabled() noexcept;
+
 private:
     class audit_msg {
     public:


### PR DESCRIPTION
Fixes: #15226

Audit logging is not able to function in recovery mode as produce messages are rejected.  In this situation, it's possible the cluster may become unusable if audit messages are generated and the queues are unable to drain.

Also fixed a logic error in the ducktape tests.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none