### PR TITLE
storage: track intermediary files and clear them if compaction fails

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -618,7 +618,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         // TODO: implement a segment replacement strategy such that each term
         // tries to write only one segment (or more if the term had a large
         // amount of data), rather than replacing N segments with N segments.
-        auto tmpname = seg->reader().path().to_staging();
+        const auto tmpname = seg->reader().path().to_compaction_staging();
         auto appender = co_await internal::make_segment_appender(
           tmpname,
           segment_appender::write_behind_memory
@@ -628,7 +628,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
           resources(),
           cfg.sanitizer_config);
 
-        auto cmp_idx_tmpname = seg->path().to_compaction_staging();
+        const auto cmp_idx_tmpname = tmpname.to_compacted_index();
         auto cmp_idx_name = seg->path().to_compacted_index();
         auto compacted_idx_writer = make_file_backed_compacted_index(
           cmp_idx_tmpname, cfg.iopc, true, resources(), cfg.sanitizer_config);

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -189,6 +189,8 @@ private:
     find_compaction_range(const compaction_config&);
 
     ss::future<std::optional<model::offset>> do_gc(gc_config);
+    ss::future<> do_compact(
+      compaction_config, std::optional<model::offset> new_start_offset);
 
     ss::future<> remove_empty_segments();
 

--- a/src/v/storage/scoped_file_tracker.h
+++ b/src/v/storage/scoped_file_tracker.h
@@ -1,0 +1,63 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include <absl/container/btree_set.h>
+
+#include <filesystem>
+#include <vector>
+
+namespace storage {
+
+// RAII class used to keep track of files in case of an early return (e.g.
+// keeping track of staging files during compaction, so they may be cleaned up
+// if compaction is aborted).
+//
+// NOTE: scoped_file_tracker is additive to the input set_t -- calling clear()
+// on a value will not remove that value from the tracked files if it already
+// exists.
+class scoped_file_tracker {
+public:
+    using set_t = absl::btree_set<std::filesystem::path>;
+    scoped_file_tracker(
+      set_t* tracked_files,
+      std::vector<std::filesystem::path> may_need_tracking)
+      : tracked_files_(tracked_files)
+      , may_need_tracking_(std::move(may_need_tracking)) {}
+
+    scoped_file_tracker(scoped_file_tracker&& other) noexcept
+      : tracked_files_(std::exchange(other.tracked_files_, nullptr))
+      , may_need_tracking_(std::move(other.may_need_tracking_)) {}
+
+    scoped_file_tracker& operator=(scoped_file_tracker&& other) = delete;
+    scoped_file_tracker(const scoped_file_tracker&) = delete;
+    scoped_file_tracker& operator=(const scoped_file_tracker&) = delete;
+
+    ~scoped_file_tracker() {
+        if (!tracked_files_) {
+            return;
+        }
+        // If we didn't clear(), add them to the tracked set.
+        for (const auto& file : may_need_tracking_) {
+            tracked_files_->emplace(file);
+        }
+    }
+
+    // Once called, will not add to `tracked_files_` upon destruction.
+    void clear() { may_need_tracking_.clear(); }
+
+private:
+    set_t* tracked_files_{nullptr};
+
+    // Files that may end up being left in `_tracked_files` if the tracking
+    // isn't canceled.
+    std::vector<std::filesystem::path> may_need_tracking_{};
+};
+
+} // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -31,6 +31,7 @@
 #include "storage/logger.h"
 #include "storage/ntp_config.h"
 #include "storage/parser_utils.h"
+#include "storage/scoped_file_tracker.h"
 #include "storage/segment.h"
 #include "storage/types.h"
 #include "units.h"
@@ -276,11 +277,14 @@ static ss::future<> do_write_clean_compacted_index(
     const auto tmpname = std::filesystem::path(
       fmt::format("{}.staging", reader.path()));
     auto bitmap = co_await natural_index_of_entries_to_keep(reader);
+    auto staging_to_clean = scoped_file_tracker{
+      cfg.files_to_cleanup, {tmpname}};
     auto truncating_writer = make_file_backed_compacted_index(
       tmpname.string(), cfg.iopc, true, resources, cfg.sanitizer_config);
     co_await copy_filtered_entries(
       reader, std::move(bitmap), std::move(truncating_writer));
     co_await ss::rename_file(std::string(tmpname), ss::sstring(reader.path()));
+    staging_to_clean.clear();
 };
 
 ss::future<> write_clean_compacted_index(
@@ -508,6 +512,9 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
     co_await do_compact_segment_index(s, cfg, resources);
     // copy the bytes after segment is good - note that we
     // need to do it with the READ-lock, not the write lock
+    auto staging_file = s->reader().path().to_staging();
+    auto staging_to_clean = scoped_file_tracker{
+      cfg.files_to_cleanup, {staging_file}};
     auto idx = co_await do_copy_segment_data(
       s, cfg, pb, std::move(read_holder), resources, apply_offset);
 
@@ -521,10 +528,6 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
           "generation: {}, skipping compaction",
           s->get_generation_id(),
           segment_generation);
-        const ss::sstring staging_file = s->reader().path().to_staging();
-        if (co_await ss::file_exists(staging_file)) {
-            co_await ss::remove_file(staging_file);
-        }
         co_return std::nullopt;
     }
 
@@ -536,6 +539,7 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
 
     auto compacted_file = s->reader().path().to_staging();
     co_await do_swap_data_file_handles(compacted_file, s, cfg, pb);
+    staging_to_clean.clear();
 
     s->index().swap_index_state(std::move(idx));
     s->force_set_commit_offset_from_index();
@@ -617,6 +621,9 @@ ss::future<> rebuild_compaction_index(
     vlog(gclog.info, "Rebuilding index file... ({})", idx_path);
     pb.corrupted_compaction_index();
     auto h = co_await s->read_lock();
+    if (s->is_closed()) {
+        throw segment_closed_exception();
+    }
     // TODO: Improve memory management here, eg: ton of aborted txs?
     auto aborted_txs = co_await stm_manager->aborted_tx_ranges(
       s->offsets().base_offset, s->offsets().stable_offset);
@@ -652,6 +659,7 @@ ss::future<compaction_result> self_compact_segment(
 
     auto read_holder = co_await s->read_lock();
     compacted_index::recovery_state state;
+    std::optional<scoped_file_tracker> to_clean;
     while (true) {
         if (s->is_closed()) {
             throw segment_closed_exception();
@@ -665,11 +673,24 @@ ss::future<compaction_result> self_compact_segment(
         // Rebuilding the compaction index will take the read lock again,
         // so release here.
         read_holder.return_all();
+
+        // It's possible that while the lock isn't held, the segment is closed
+        // and removed. In case that happens, track the new compacted index for
+        // removal until we check under lock that the segment is still alive.
+        // Otherwise, we may end up with a stray compacted index.
+        if (!to_clean.has_value()) {
+            to_clean.emplace(
+              scoped_file_tracker{cfg.files_to_cleanup, {idx_path}});
+        }
+
         co_await rebuild_compaction_index(s, stm_manager, cfg, pb, resources);
 
         // Take the lock again before proceeding so we're guaranteed the index
         // will survive until it's used in self compaction below.
         read_holder = co_await s->read_lock();
+    }
+    if (to_clean.has_value()) {
+        to_clean->clear();
     }
     if (state == compacted_index::recovery_state::already_compacted) {
         vlog(gclog.debug, "detected {} is already compacted", idx_path);

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -275,28 +275,12 @@ static ss::future<> do_write_clean_compacted_index(
   storage_resources& resources) {
     const auto tmpname = std::filesystem::path(
       fmt::format("{}.staging", reader.path()));
-    return natural_index_of_entries_to_keep(reader)
-      .then(
-        [reader, cfg, tmpname, &resources](
-          roaring::Roaring bitmap) -> ss::future<> {
-            auto truncating_writer = make_file_backed_compacted_index(
-              tmpname.string(),
-              cfg.iopc,
-              true,
-              resources,
-              cfg.sanitizer_config);
-
-            return copy_filtered_entries(
-              reader, std::move(bitmap), std::move(truncating_writer));
-        })
-      .then(
-        [old_name = tmpname,
-         new_name = ss::sstring(reader.path())]() -> ss::future<> {
-            // from glibc: If oldname is not a directory, then any
-            // existing file named newname is removed during the
-            // renaming operation
-            return ss::rename_file(std::string(old_name), new_name);
-        });
+    auto bitmap = co_await natural_index_of_entries_to_keep(reader);
+    auto truncating_writer = make_file_backed_compacted_index(
+      tmpname.string(), cfg.iopc, true, resources, cfg.sanitizer_config);
+    co_await copy_filtered_entries(
+      reader, std::move(bitmap), std::move(truncating_writer));
+    co_await ss::rename_file(std::string(tmpname), ss::sstring(reader.path()));
 };
 
 ss::future<> write_clean_compacted_index(

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -138,7 +138,9 @@ rp_test(
   UNIT_TEST
   GTEST
   BINARY_NAME gtest_storage
-  SOURCES segment_deduplication_test.cc
+  SOURCES
+    scoped_file_tracker_test.cc
+    segment_deduplication_test.cc
   LIBRARIES  v::storage v::storage_test_utils v::gtest_main
   LABELS storage
   ARGS "-- -c 1"

--- a/src/v/storage/tests/scoped_file_tracker_test.cc
+++ b/src/v/storage/tests/scoped_file_tracker_test.cc
@@ -1,0 +1,89 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "storage/scoped_file_tracker.h"
+
+#include <absl/container/btree_set.h>
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+using namespace storage;
+
+TEST(ScopedFileTrackerTest, TestBasic) {
+    scoped_file_tracker::set_t tracked;
+
+    // Clearing the tracker will leave nothing tracked.
+    {
+        scoped_file_tracker t(&tracked, {"foo"});
+        t.clear();
+    }
+    ASSERT_EQ(0, tracked.size());
+
+    // If we leave scope without clearing, we leave behind some files.
+    { scoped_file_tracker t(&tracked, {"foo"}); }
+    ASSERT_EQ(1, tracked.size());
+
+    // Even if we clear from a new tracker, we don't affect the already tracked
+    // files.
+    {
+        scoped_file_tracker t(&tracked, {"foo"});
+        t.clear();
+    }
+    ASSERT_EQ(1, tracked.size());
+}
+
+TEST(ScopedFileTrackerTest, TestMoveConstruct) {
+    scoped_file_tracker::set_t tracked;
+    {
+        scoped_file_tracker t(&tracked, {"foo"});
+        {
+            // Move the tracker and clear it.
+            scoped_file_tracker t2(std::move(t));
+            t2.clear();
+        }
+        ASSERT_EQ(0, tracked.size());
+    }
+    ASSERT_EQ(0, tracked.size());
+    {
+        scoped_file_tracker t(&tracked, {"foo"});
+        {
+            // This time don't clear it. This will leave behind some files.
+            scoped_file_tracker t2(std::move(t));
+        }
+        ASSERT_EQ(1, tracked.size());
+    }
+    ASSERT_EQ(1, tracked.size());
+}
+
+TEST(ScopedFileTrackerTest, TestOptional) {
+    scoped_file_tracker::set_t tracked;
+    std::optional<scoped_file_tracker> cleanup;
+    {
+        // Move construct and clear a tracker. Note that this creates a
+        // temporary.
+        cleanup.emplace(scoped_file_tracker{&tracked, {"foo"}});
+        cleanup->clear();
+    }
+    // Upon destructing the tracker, this should leave nothing behind.
+    ASSERT_EQ(0, tracked.size());
+    cleanup.reset();
+    ASSERT_EQ(0, tracked.size());
+
+    {
+        // Now exit without calling clear().
+        cleanup.emplace(scoped_file_tracker{&tracked, {"foo"}});
+    }
+    // We haven't destructed yet, so nothing should be tracked.
+    ASSERT_EQ(0, tracked.size());
+
+    // But once we do, we should see a file.
+    cleanup.reset();
+    ASSERT_EQ(1, tracked.size());
+}

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -37,6 +37,7 @@
 #include "vassert.h"
 
 #include <seastar/core/io_priority_class.hh>
+#include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/when_all.hh>
 #include <seastar/util/defer.hh>
@@ -2686,11 +2687,8 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                 return ss::make_ready_future<>();
             })
           .get();
-        // TODO: re-enable. See:
-        // https://github.com/redpanda-data/redpanda/issues/8153
-        // throw;
     }
-    // BOOST_REQUIRE_EQUAL(false, ss::file_exists(dir_path).get());
+    BOOST_REQUIRE_EQUAL(false, ss::file_exists(dir_path).get());
 };
 
 FIXTURE_TEST(compaction_truncation_corner_cases, storage_test_fixture) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR attempts to unify the cleaning up of intermediary files (mostly "staging" files) left behind by aborted compactions. We were already going this to a degree by manually cleaning up files in a couple of specific places. This is an attempt to iron out all remaining cases.

A new scoped class is added to be able to track files left behind by early exits. This is used at the key places in which staging files (and in one case, regular compacted index) are created. The scoped class spans the point in time before the intermediary files are created and is cleared when these files are removed, typically by renaming them to the base segment names.

Each instance of housekeeping will now track a set of files to be erased once the compaction completes.

Along the way there were a couple tweaks:
- the intermediary files during sliding window compaction are renamed to be less surprising (previously the compacted index naming wasn't using a compacted_index suffix)
- added a couple missing checks for the "segment closed" condition while the segment lock is held, which was causing compaction to proceed with a removed compacted index

Fixes https://github.com/redpanda-data/redpanda/issues/15143
Fixes https://github.com/redpanda-data/redpanda/issues/15043

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
