### PR TITLE
[v22.3.x] cloud_storage_clients: handle both gcp and s3 request ids

### DIFF
--- a/src/v/s3/client.cc
+++ b/src/v/s3/client.cc
@@ -62,6 +62,9 @@ struct aws_header_names {
     static constexpr boost::beast::string_view x_amz_tagging = "x-amz-tagging";
     static constexpr boost::beast::string_view x_amz_request_id
       = "x-amz-request-id";
+    // https://cloud.google.com/storage/docs/xml-api/reference-headers#xguploaderuploadid
+    static constexpr boost::beast::string_view x_guploader_uploadid
+      = "x-guploader-uploadid";
 };
 
 struct aws_header_values {
@@ -446,7 +449,13 @@ ss::future<ResultT> parse_head_error_response(
             code = "Unknown";
             msg = ss::sstring(hdr.reason().data(), hdr.reason().size());
         }
-        auto rid = hdr.at(aws_header_names::x_amz_request_id);
+        boost::string_view rid;
+        if (hdr.find(aws_header_names::x_amz_request_id) != hdr.end()) {
+            rid = hdr.at(aws_header_names::x_amz_request_id);
+        } else if (
+          hdr.find(aws_header_names::x_guploader_uploadid) != hdr.end()) {
+            rid = hdr.at(aws_header_names::x_guploader_uploadid);
+        }
         rest_error_response err(
           code, msg, ss::sstring(rid.data(), rid.size()), key().native());
         return ss::make_exception_future<ResultT>(err);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15220 