### PR TITLE
cmake: upgrade wasmtime

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -104,7 +104,7 @@ list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=addr2line)
 FetchContent_Declare(
   wasmtime
   GIT_REPOSITORY https://github.com/bytecodealliance/wasmtime
-  GIT_TAG 282edac149c0883a7d064132f93ce0a20a50d0d7
+  GIT_TAG v15.0.0
   GIT_PROGRESS TRUE
   USES_TERMINAL_DOWNLOAD TRUE
   OVERRIDE_FIND_PACKAGE


### PR DESCRIPTION
No real changes, just switches us to a stable version instead of a
commit from main.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
