### PR TITLE
[v23.2.x] remote_partition_fuzz_test: measure shutdown time directly

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -448,19 +448,11 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
     // NOTE: see issues/11271
     BOOST_TEST_CONTEXT("scan_unit_close should terminate in a finite amount of "
                        "time at shutdown") {
-        try {
-            test_log.info("waiting on close future with timeout");
-            BOOST_CHECK_LE(close_fut.get(), 60s);
-            test_log.info(
-              "waiting on scan_future, this should be immediately available");
-            BOOST_CHECK(scan_future.available());
-            scan_future.get();
-        } catch (...) {
-            // BOOST_REQUIRE_NOTHROW can't print std::current_exception, sadly
-            BOOST_CHECK_MESSAGE(
-              false,
-              fmt::format(
-                "failed with exception {}", std::current_exception()));
-        }
+        test_log.info("waiting on close future with timeout");
+        BOOST_CHECK_LE(close_fut.get(), 60s);
+        test_log.info(
+          "waiting on scan_future, this should be immediately available");
+        BOOST_CHECK(scan_future.available());
+        scan_future.get();
     }
 }

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -16,6 +16,8 @@
 
 #include <seastar/core/lowres_clock.hh>
 
+#include <fmt/chrono.h>
+
 #include <random>
 
 using namespace cloud_storage;
@@ -427,28 +429,30 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
       storage::log_reader_config(
         base, model::offset::max(), ss::default_priority_class()),
       g);
-    auto close_fut = ss::maybe_yield()
-                       .then([] { return ss::maybe_yield(); })
-                       .then([] { return ss::maybe_yield(); })
-                       .then([] { return ss::sleep(10ms); })
-                       .then([this, &g]() mutable {
-                           test_log.info("shutting down connections");
-                           pool.local().shutdown_connections();
-                           test_log.info("closing gate");
-                           return g.close();
-                       })
-                       .then([] { test_log.info("gate closed"); });
-
+    auto close_fut
+      = ss::maybe_yield()
+          .then([] { return ss::maybe_yield(); })
+          .then([] { return ss::maybe_yield(); })
+          .then([] { return ss::sleep(10ms); })
+          .then([this, &g]() mutable {
+              auto begin_shutdown = std::chrono::steady_clock::now();
+              test_log.info("shutting down connections");
+              pool.local().shutdown_connections();
+              test_log.info("closing gate");
+              return g.close().then([begin_shutdown] {
+                  auto end_shutdown = std::chrono::steady_clock::now();
+                  test_log.info("gate closed");
+                  return end_shutdown - begin_shutdown;
+              });
+          });
     // NOTE: see issues/11271
     BOOST_TEST_CONTEXT("scan_unit_close should terminate in a finite amount of "
                        "time at shutdown") {
-        auto timeout_fut = ss::with_timeout(
-          model::timeout_clock::now() + 60s, std::move(close_fut));
         try {
             test_log.info("waiting on close future with timeout");
-            timeout_fut.get();
+            BOOST_CHECK_LE(close_fut.get(), 60s);
             test_log.info(
-              "waiting on scan_future, this should be immediatly available");
+              "waiting on scan_future, this should be immediately available");
             BOOST_CHECK(scan_future.available());
             scan_future.get();
         } catch (...) {

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -371,13 +371,13 @@ FIXTURE_TEST(
 namespace {
 
 ss::future<> scan_until_close(
-  remote_partition& partition,
-  const storage::log_reader_config& reader_config,
+  ss::shared_ptr<remote_partition> partition,
+  storage::log_reader_config reader_config,
   ss::gate& g) {
     gate_guard guard{g};
     while (!g.is_closed()) {
         try {
-            auto translating_reader = co_await partition.make_reader(
+            auto translating_reader = co_await partition->make_reader(
               reader_config);
             auto reader = std::move(translating_reader.reader);
             auto headers_read = co_await reader.consume(
@@ -403,8 +403,6 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);
 
-    storage::log_reader_config reader_config(
-      base, model::offset::max(), ss::default_priority_class());
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
 
     auto manifest = hydrate_manifest(api.local(), bucket);
@@ -417,17 +415,35 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 
     ss::gate g;
-    ssx::background = scan_until_close(*partition, reader_config, g);
+    auto scan_future = scan_until_close(
+      partition,
+      storage::log_reader_config(
+        base, model::offset::max(), ss::default_priority_class()),
+      g);
     auto close_fut = ss::maybe_yield()
                        .then([] { return ss::maybe_yield(); })
                        .then([] { return ss::maybe_yield(); })
-                       .then([] {
-                           return ss::sleep(std::chrono::milliseconds(10));
-                       })
+                       .then([] { return ss::sleep(10ms); })
                        .then([this, &g]() mutable {
                            pool.local().shutdown_connections();
                            return g.close();
                        });
-    ss::with_timeout(model::timeout_clock::now() + 60s, std::move(close_fut))
-      .get();
+
+    // NOTE: see issues/11271
+    BOOST_TEST_CONTEXT("scan_unit_close should terminate in a finite amount of "
+                       "time at shutdown") {
+        auto timeout_fut = ss::with_timeout(
+          model::timeout_clock::now() + 60s, std::move(close_fut));
+        try {
+            timeout_fut.get();
+            BOOST_CHECK(scan_future.available());
+            scan_future.get();
+        } catch (...) {
+            // BOOST_REQUIRE_NOTHROW can't print std::current_exception, sadly
+            BOOST_CHECK_MESSAGE(
+              false,
+              fmt::format(
+                "failed with exception {}", std::current_exception()));
+        }
+    }
 }

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -374,16 +374,22 @@ ss::future<> scan_until_close(
   ss::shared_ptr<remote_partition> partition,
   storage::log_reader_config reader_config,
   ss::gate& g) {
-    gate_guard guard{g};
+    test_log.info("starting scan_until_close");
+    auto _ = ss::defer([] { test_log.info("exiting scan_until_close"); });
+    auto guard = g.hold();
+    auto counter = size_t{0};
     while (!g.is_closed()) {
         try {
+            test_log.info("running scan loop nr {}", counter);
             auto translating_reader = co_await partition->make_reader(
               reader_config);
             auto reader = std::move(translating_reader.reader);
             auto headers_read = co_await reader.consume(
               test_consumer(), model::no_timeout);
+            test_log.info("done scan loop {}", counter);
+            ++counter;
         } catch (...) {
-            test_log.info("Error scanning: {}", std::current_exception());
+            test_log.warn("Error scanning: {}", std::current_exception());
         }
     }
 }
@@ -414,6 +420,7 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
     partition->start().get();
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 
+    test_log.info("starting scan op");
     ss::gate g;
     auto scan_future = scan_until_close(
       partition,
@@ -425,9 +432,12 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
                        .then([] { return ss::maybe_yield(); })
                        .then([] { return ss::sleep(10ms); })
                        .then([this, &g]() mutable {
+                           test_log.info("shutting down connections");
                            pool.local().shutdown_connections();
+                           test_log.info("closing gate");
                            return g.close();
-                       });
+                       })
+                       .then([] { test_log.info("gate closed"); });
 
     // NOTE: see issues/11271
     BOOST_TEST_CONTEXT("scan_unit_close should terminate in a finite amount of "
@@ -435,7 +445,10 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
         auto timeout_fut = ss::with_timeout(
           model::timeout_clock::now() + 60s, std::move(close_fut));
         try {
+            test_log.info("waiting on close future with timeout");
             timeout_fut.get();
+            test_log.info(
+              "waiting on scan_future, this should be immediatly available");
             BOOST_CHECK(scan_future.available());
             scan_future.get();
         } catch (...) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15142
Backport of PR https://github.com/redpanda-data/redpanda/pull/15200

Fixes https://github.com/redpanda-data/redpanda/issues/15234