### PR TITLE
gha: add release workflow for transform-sdks

### DIFF
--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-name: transform-sdk
+name: transform-sdk-build
 on:
   push:
     tags:

--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -1,0 +1,48 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+name: transform-sdk-release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  list-golang:
+    name: List Golang Transform SDK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.6
+
+      - name: List module
+        working-directory: src/transform-sdk/go
+        # https://go.dev/doc/modules/publishing
+        run: go list -m github.com/redpanda-data/redpanda/src/transform-sdk/go/transform@${{github.ref_name}}
+
+  publish-rust:
+    name: Publish Rust Transform SDK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust
+        run: rustup update stable --no-self-update && rustup default stable
+
+      - name: Publish
+        working-directory: src/transform-sdk/rust
+        run: ./scripts/publish.py --version ${{github.ref_name}}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Add a workflow to automatically publish the transform SDKs when a release is tagged.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
