### PR TITLE
build: enable strict clang-tidy for sub-directory

### DIFF
--- a/.clang-tidy-strict
+++ b/.clang-tidy-strict
@@ -1,0 +1,16 @@
+# altera-*, fuschia-*, llvmlibc-*: project specific checks
+# llvm-header-guard: in redpanda we normally to use `#pragma once`
+# modernize-use-trailing-return-type: arbitrary style choice
+---
+Checks: '*,-altera-*,-fuchsia-*,-llvmlibc-*,-llvm-header-guard,-modernize-use-trailing-return-type'
+WarningsAsErrors: false
+CheckOptions:
+  - key:             readability-identifier-length.IgnoredVariableNames
+    value:           ^it$
+  - key:             readability-identifier-length.IgnoredParameterNames
+    value:           ^(it|a|b)$
+  - key:             readability-uppercase-literal-suffix.NewSuffixes
+    value:           KiB;MiB;GiB;TiB
+  - key:             hicpp-uppercase-literal-suffix.NewSuffixes
+    value:           KiB;MiB;GiB;TiB
+...

--- a/.clang-tidy-strict-tests
+++ b/.clang-tidy-strict-tests
@@ -1,0 +1,11 @@
+# readability-function-cognitive-complexity: triggers for TEST_F macro
+# readability-identifier-length: quality of life improvement
+# cppcoreguidelines-avoid-magic-numbers: qualifty of life improvement
+# readability-magic-numbers: duplicate
+# cppcoreguidelines-pointer-arithmetic: quality of life improvement
+# misc-non-private-member-variables-in-classes: quality of life improvement
+---
+Checks:
+'-readability-function-cognitive-complexity,-readability-identifier-length,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-misc-non-private-member-variables-in-classes'
+InheritParentConfig: true
+...

--- a/.github/workflows/build-redpanda.yml
+++ b/.github/workflows/build-redpanda.yml
@@ -62,12 +62,12 @@ jobs:
         - name: configure
           env:
             CCACHE_DIR: /mnt/ccache
-          run: cmake --preset release
+          run: cmake --preset release-ci
         - name: build
           env:
             CCACHE_DIR: /mnt/ccache
             CCACHE_COMPRESSLEVEL: 6
-          run: ninja -C build/release
+          run: cmake --build --preset release-ci
         - name: trim cache
           env:
             CCACHE_DIR: /mnt/ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,4 +46,29 @@ if(Redpanda_ENABLE_COVERAGE)
   add_link_options(--coverage)
 endif()
 
+#
+# Configure clang-tidy checks. By default checks will be enabled if the
+# clang-tidy tool is found. Otherwise, it can be explicitly disabled. It's
+# recommended to use FORCE_ON in contexts such as CI where we want to fail
+# configuration if clang-tidy is not available.
+#
+set(Redpanda_ENABLE_CLANG_TIDY "ON" CACHE STRING
+  "Enable clang-tidy checks if available. Can be ON, OFF, or FORCE_ON")
+
+if(NOT Redpanda_ENABLE_CLANG_TIDY STREQUAL OFF)
+  if(Redpanda_ENABLE_CLANG_TIDY STREQUAL FORCE_ON)
+    find_program(CLANG_TIDY_COMMAND clang-tidy
+      PATHS ${PROJECT_SOURCE_DIR}/vbuild/llvm/install/bin
+      REQUIRED)
+  else()
+    find_program(CLANG_TIDY_COMMAND clang-tidy
+      PATHS ${PROJECT_SOURCE_DIR}/vbuild/llvm/install/bin)
+  endif()
+  if(CLANG_TIDY_COMMAND)
+    set(Redpanda_ENABLE_CLANG_TIDY ON)
+  else()
+    set(Redpanda_ENABLE_CLANG_TIDY OFF)
+  endif()
+endif()
+
 add_subdirectory(src)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -54,12 +54,23 @@
       }
     },
     {
+      "name": "ci",
+      "hidden": true,
+      "cacheVariables": {
+        "Redpanda_ENABLE_CLANG_TIDY": "FORCE_ON"
+      }
+    },
+    {
       "name": "release",
       "inherits": ["base", "release-type", "shared"]
     },
     {
       "name": "release-static",
       "inherits": ["base", "release-type", "static"]
+    },
+    {
+      "name": "release-ci",
+      "inherits": ["release", "ci"]
     },
     {
       "name": "debug",
@@ -82,6 +93,10 @@
     {
       "name": "release-static",
       "configurePreset": "release-static"
+    },
+    {
+      "name": "release-ci",
+      "configurePreset": "release-ci"
     },
     {
       "name": "debug",

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -28,6 +28,7 @@ deb_deps=(
   cargo
   ccache
   clang
+  clang-tidy
   cmake
   git
   gnutls-dev
@@ -63,6 +64,7 @@ fedora_deps=(
   cargo
   ccache
   clang
+  clang-tools-extra
   cmake
   compiler-rt
   cryptopp-devel

--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -38,6 +38,21 @@ if(REDPANDA_RUN_CLANG_TIDY)
     unset(clang_tidy_checks)
 endif()
 
+#
+# The `enable_clang_tidy` macro should be used to turn on clang-tidy checks in
+# sub-directories that are clang-tidy clean according to .clang-tidy-strict and
+# .clang-tidy-strict-tests. These two files should also be symlinked with the
+# standard name .clang-tidy into the compliant sub-directories.
+#
+# The clang-tidy checks above are being phased out and are currently only used
+# in the buildkite private build.
+#
+macro(enable_clang_tidy)
+  if(Redpanda_ENABLE_CLANG_TIDY)
+    set(CMAKE_CXX_CLANG_TIDY ${CLANG_TIDY_COMMAND} -warnings-as-errors=*)
+  endif()
+endmacro()
+
 # Redpanda's internal build system constructs a Python virtual environment
 # executable using pex that contains all of the Python build dependencies. If
 # this isn't found, then fall back to the system Python3 interpreter.

--- a/src/v/io/.clang-tidy
+++ b/src/v/io/.clang-tidy
@@ -1,0 +1,1 @@
+../../../.clang-tidy-strict

--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     persistence.cc
     page.cc
     page_set.cc
+    clang-tidy-helper.cc
   DEPS
     Seastar::seastar
     absl::btree

--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -1,3 +1,5 @@
+enable_clang_tidy()
+
 v_cc_library(
   NAME io
   SRCS

--- a/src/v/io/clang-tidy-helper.cc
+++ b/src/v/io/clang-tidy-helper.cc
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/cache.h"
+#include "io/interval_map.h"
+#include "io/page.h"
+#include "io/page_set.h"
+#include "io/persistence.h"

--- a/src/v/io/tests/.clang-tidy
+++ b/src/v/io/tests/.clang-tidy
@@ -1,0 +1,1 @@
+../../../../.clang-tidy-strict-tests


### PR DESCRIPTION
Adds macros for selectively enabling a strict set of clang-tidy checks. Then enables this for the io subsystem which passes all the checks. Exact set of checks expected to be a topic of much debate as folks work towards getting sub-directories to pass checks.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.
Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none

