### PR TITLE
tests: made progress timeout dependent on failure injection

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -410,7 +410,11 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             fi.start()
 
         # main workload loop
-        executor = NodeOpsExecutor(self.redpanda, self.logger, lock)
+        executor = NodeOpsExecutor(
+            self.redpanda,
+            self.logger,
+            lock,
+            progress_timeout=120 if enable_failures else 60)
         for i, op in enumerate(
                 generate_random_workload(
                     available_nodes=self.active_node_idxs)):

--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -223,12 +223,16 @@ class NodeDecommissionWaiter():
 
 
 class NodeOpsExecutor():
-    def __init__(self, redpanda: RedpandaService, logger,
-                 lock: threading.Lock):
+    def __init__(self,
+                 redpanda: RedpandaService,
+                 logger,
+                 lock: threading.Lock,
+                 progress_timeout=60):
         self.redpanda = redpanda
         self.logger = logger
         self.timeout = 360
         self.lock = lock
+        self.progress_timeout = progress_timeout
 
     def node_id(self, idx):
         return self.redpanda.node_id(self.redpanda.get_node(idx),
@@ -324,7 +328,7 @@ class NodeOpsExecutor():
         waiter = NodeDecommissionWaiter(self.redpanda,
                                         node_id=node_id,
                                         logger=self.logger,
-                                        progress_timeout=60)
+                                        progress_timeout=self.progress_timeout)
 
         waiter.wait_for_removal()
         wait_until(lambda: self.node_removed(node_id),


### PR DESCRIPTION
Made progress timeout longer in the tests that enables failure injection. With random failure injection it may be the case that the node which is currently controller leader will be restarted/suspended multiple times before being able to finish balancing operation. In this pessimistic case it may happen that the tick will not be scheduled frequent enough for the decommission to make progress.

Fixes: #8657

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none