### PR TITLE
Fixed describe producers to include all data

### DIFF
--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -212,6 +212,18 @@ public:
 
     producer_state_snapshot snapshot(kafka::offset log_start_offset) const;
 
+    model::timestamp last_update_timestamp() const {
+        return model::timestamp(_last_updated_ts.time_since_epoch() / 1ms);
+    }
+
+    std::optional<kafka::offset> current_txn_start_offset() const {
+        return _current_txn_start_offset;
+    }
+
+    void update_current_txn_start_offset(std::optional<kafka::offset> offset) {
+        _current_txn_start_offset = offset;
+    }
+
 private:
     // Register/deregister with manager.
     void register_self();
@@ -244,6 +256,7 @@ private:
     bool _evicted = false;
     size_t _ops_in_progress = 0;
     ss::noncopyable_function<void()> _post_eviction_hook;
+    std::optional<kafka::offset> _current_txn_start_offset;
     friend class producer_state_manager;
     friend struct ::test_fixture;
 };

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1839,6 +1839,8 @@ void rm_stm::apply_prepare(rm_stm::prepare_marker prepare) {
 
 void rm_stm::apply_control(
   model::producer_identity pid, model::control_record_type crt) {
+    vlog(
+      _ctx_log.trace, "applying control batch of type {}, pid: {}", crt, pid);
     // either epoch is the same as fencing or it's lesser in the latter
     // case we don't fence off aborts and commits because transactional
     // manager already decided a tx's outcome and acked it to the client

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1806,8 +1806,6 @@ void rm_stm::apply_fence(model::record_batch&& b) {
 }
 
 ss::future<> rm_stm::apply(const model::record_batch& b) {
-    auto last_offset = b.last_offset();
-
     const auto& hdr = b.header();
 
     if (hdr.type == model::record_batch_type::tx_fence) {
@@ -1819,7 +1817,7 @@ ss::future<> rm_stm::apply(const model::record_batch& b) {
         if (hdr.attrs.is_control()) {
             apply_control(bid.pid, parse_control_batch(b));
         } else {
-            apply_data(bid, last_offset);
+            apply_data(bid, hdr);
         }
     }
 
@@ -1844,7 +1842,18 @@ void rm_stm::apply_control(
     // either epoch is the same as fencing or it's lesser in the latter
     // case we don't fence off aborts and commits because transactional
     // manager already decided a tx's outcome and acked it to the client
+    auto producer = maybe_create_producer(pid);
 
+    if (likely(
+          crt == model::control_record_type::tx_abort
+          || crt == model::control_record_type::tx_commit)) {
+        /**
+         * Transaction is finished, update producer tx start offset
+         */
+        producer->update_current_txn_start_offset(std::nullopt);
+    }
+
+    // there are only two types of control batches
     if (crt == model::control_record_type::tx_abort) {
         _highest_producer_id = std::max(_highest_producer_id, pid.get_id());
         _log_state.prepared.erase(pid);
@@ -1893,39 +1902,51 @@ ss::future<> rm_stm::reduce_aborted_list() {
       [this] { _is_abort_idx_reduction_requested = false; });
 }
 
-void rm_stm::apply_data(model::batch_identity bid, model::offset last_offset) {
+void rm_stm::apply_data(
+  model::batch_identity bid, const model::record_batch_header& header) {
     if (bid.has_idempotent()) {
         _highest_producer_id = std::max(_highest_producer_id, bid.pid.get_id());
-        auto kafka_offset = from_log_offset(last_offset);
+        const auto last_offset = header.last_offset();
+        const auto last_kafka_offset = from_log_offset(header.last_offset());
         auto producer = maybe_create_producer(bid.pid);
-        producer->update(bid, kafka_offset);
-    }
+        producer->update(bid, last_kafka_offset);
 
-    if (bid.is_transactional) {
-        if (_log_state.prepared.contains(bid.pid)) {
+        if (bid.is_transactional) {
             vlog(
-              _ctx_log.error,
-              "Adding a record with pid:{} to a tx after it was prepared",
-              bid.pid);
-            return;
-        }
-
-        auto ongoing_it = _log_state.ongoing_map.find(bid.pid);
-        if (ongoing_it != _log_state.ongoing_map.end()) {
-            if (ongoing_it->second.last < last_offset) {
-                ongoing_it->second.last = last_offset;
+              _ctx_log.trace,
+              "Applying tx data batch with identity: {} and offset range: "
+              "[{},{}]",
+              bid,
+              header.base_offset,
+              last_offset);
+            if (_log_state.prepared.contains(bid.pid)) {
+                vlog(
+                  _ctx_log.error,
+                  "Adding a record with pid:{} to a tx after it was prepared",
+                  bid.pid);
+                return;
             }
-        } else {
-            auto base_offset = model::offset(
-              last_offset() - (bid.record_count - 1));
-            _log_state.ongoing_map.emplace(
-              bid.pid,
-              tx_range{
-                .pid = bid.pid,
-                .first = base_offset,
-                .last = model::offset(last_offset)});
-            _log_state.ongoing_set.insert(base_offset);
-            _mem_state.estimated.erase(bid.pid);
+
+            auto ongoing_it = _log_state.ongoing_map.find(bid.pid);
+            if (ongoing_it != _log_state.ongoing_map.end()) {
+                if (ongoing_it->second.last < last_offset) {
+                    ongoing_it->second.last = last_offset;
+                }
+            } else {
+                // we do no have to check if the value is empty as it is already
+                // done with ongoing map
+                producer->update_current_txn_start_offset(
+                  from_log_offset(header.base_offset));
+
+                _log_state.ongoing_map.emplace(
+                  bid.pid,
+                  tx_range{
+                    .pid = bid.pid,
+                    .first = header.base_offset,
+                    .last = last_offset});
+                _log_state.ongoing_set.insert(header.base_offset);
+                _mem_state.estimated.erase(bid.pid);
+            }
         }
     }
 }

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -371,8 +371,7 @@ private:
     ss::future<> apply(const model::record_batch&) override;
     void apply_fence(model::record_batch&&);
     void apply_prepare(rm_stm::prepare_marker);
-    ss::future<>
-      apply_control(model::producer_identity, model::control_record_type);
+    void apply_control(model::producer_identity, model::control_record_type);
     void apply_data(model::batch_identity, model::offset);
 
     ss::future<> reduce_aborted_list();

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -68,6 +68,9 @@ public:
     using time_point_type = clock_type::time_point;
     using duration_type = clock_type::duration;
 
+    using producers_t = mt::
+      map_t<absl::btree_map, model::producer_identity, cluster::producer_ptr>;
+
     static constexpr const int8_t abort_snapshot_version = 0;
     using tx_range = model::tx_range;
 
@@ -261,6 +264,8 @@ public:
     std::string_view get_name() const final { return "rm_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
+    const producers_t& get_producers() const { return _producers; }
+
 protected:
     ss::future<> apply_raft_snapshot(const iobuf&) final;
 
@@ -372,7 +377,7 @@ private:
     void apply_fence(model::record_batch&&);
     void apply_prepare(rm_stm::prepare_marker);
     void apply_control(model::producer_identity, model::control_record_type);
-    void apply_data(model::batch_identity, model::offset);
+    void apply_data(model::batch_identity, const model::record_batch_header&);
 
     ss::future<> reduce_aborted_list();
     ss::future<> offload_aborted_txns();
@@ -639,8 +644,7 @@ private:
     ss::timer<clock_type> _log_stats_timer;
     prefix_logger _ctx_log;
     ss::sharded<producer_state_manager>& _producer_state_manager;
-    using producers_t = mt::
-      map_t<absl::btree_map, model::producer_identity, cluster::producer_ptr>;
+
     producers_t _producers;
     metrics::internal_metric_groups _metrics;
     ss::abort_source _as;

--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -344,6 +344,7 @@ enum class control_record_type : int16_t {
     tx_commit = 1,
     unknown = -1
 };
+std::ostream& operator<<(std::ostream&, const control_record_type&);
 
 using control_record_version
   = named_type<int16_t, struct control_record_version_tag>;

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -463,4 +463,15 @@ std::istream& operator>>(std::istream& i, leader_balancer_mode& lbt) {
     return i;
 }
 
+std::ostream& operator<<(std::ostream& o, const control_record_type& crt) {
+    switch (crt) {
+    case control_record_type::tx_abort:
+        return o << "tx_abort";
+    case control_record_type::tx_commit:
+        return o << "tx_commit";
+    case control_record_type::unknown:
+        return o << "unknown";
+    }
+}
+
 } // namespace model

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -474,4 +474,17 @@ std::ostream& operator<<(std::ostream& o, const control_record_type& crt) {
     }
 }
 
+std::ostream& operator<<(std::ostream& o, const batch_identity& bid) {
+    fmt::print(
+      o,
+      "{{pid: {}, first_seq: {}, is_transactional: {}, record_count: {}, "
+      "last_seq: {}}}",
+      bid.pid,
+      bid.first_seq,
+      bid.is_transactional,
+      bid.record_count,
+      bid.last_seq);
+    return o;
+}
+
 } // namespace model

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -575,6 +575,8 @@ struct batch_identity {
     bool is_transactional{false};
 
     bool has_idempotent() { return pid.id >= 0; }
+
+    friend std::ostream& operator<<(std::ostream&, const batch_identity&);
 };
 
 // A simple iterator for model::record_batch

--- a/tests/rptest/tests/describe_producers_test.py
+++ b/tests/rptest/tests/describe_producers_test.py
@@ -1,0 +1,131 @@
+# Copyright 2022 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import time
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+from ducktape.utils.util import wait_until
+import confluent_kafka as ck
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
+from rptest.clients.rpk import parse_rpk_table
+from rptest.util import wait_until_result
+
+
+class DescribeProducersTest(RedpandaTest):
+    partition_count = 3
+    topics = (TopicSpec(partition_count=partition_count, replication_factor=3),
+              TopicSpec(partition_count=partition_count, replication_factor=3))
+
+    def __init__(self, test_context):
+        super(DescribeProducersTest, self).__init__(test_context=test_context,
+                                                    num_brokers=3)
+
+        self.kafka_cli = KafkaCliTools(self.redpanda, "3.0.0")
+
+    def _describe_all_producers(self):
+        all_producers = []
+        for topic in self.topics:
+            for partition in range(topic.partition_count):
+                producers = self.kafka_cli.describe_producers(
+                    topic.name, partition)
+                all_producers += producers
+        return all_producers
+
+    def _check_timestamp(self, producer_desc, range_start, range_end):
+        # convert to python representation of epoch
+        ts = int(producer_desc['LastTimestamp']) / 1000.0
+        assert ts >= range_start and ts <= range_end, \
+            f"Producer timestamp must correspond to system clock. Returned timestamp: {ts}, range: [{range_start}, {range_end}]"
+
+    @cluster(num_nodes=3)
+    def test_describe_producer_with_tx(self):
+        before = time.time()
+        producer_count = 20
+        producers = []
+        for idx in range(producer_count):
+            producer = ck.Producer({
+                'bootstrap.servers': self.redpanda.brokers(),
+                'transactional.id': f'tx-producer-{idx}',
+            })
+            producer.init_transactions()
+            producers.append(producer)
+
+        all_producers_desc = self._describe_all_producers()
+
+        assert len(all_producers_desc
+                   ) == 0, "Before producing data producers should be empty"
+
+        for idx, producer in enumerate(producers):
+            producer.begin_transaction()
+            producer.produce(self.topics[idx % len(self.topics)].name,
+                             f'key-{idx}', f'value-{idx}',
+                             idx % self.partition_count)
+            producer.flush()
+
+        def _all_producers():
+            all = self._describe_all_producers()
+            if len(all) == producer_count:
+                return (True, all)
+            return (False, None)
+
+        all_producers_desc = wait_until_result(_all_producers, 30, 1)
+
+        after = time.time()
+        assert len(
+            all_producers_desc
+        ) == producer_count, f"Unexpected size of producers list, expected: {producer_count}, current: {len(all_producers_desc)}"
+        for p in all_producers_desc:
+            self.logger.info(f"producer state with transaction ongoing: {p}")
+            self._check_timestamp(p, before, after)
+            # for every partition transaction is the first batch, validate initial offset
+            so = int(p['CurrentTransactionStartOffset'])
+            assert so >= 0, "Transaction start offset should be a part of producer state"
+
+        # commit transactions
+        for producer in producers:
+            producer.commit_transaction()
+            producer.flush()
+
+        all_producers_desc = self._describe_all_producers()
+        after = time.time()
+        assert len(
+            all_producers_desc
+        ) == producer_count, f"Unexpected size of producers list, expected: {producer_count}, current: {len(all_producers_desc)}"
+        for p in all_producers_desc:
+            self.logger.info(f"producer state with transaction committed: {p}")
+            self._check_timestamp(p, before, after)
+            # for every partition transaction is the first batch, validate initial offset
+            assert p[
+                'CurrentTransactionStartOffset'] == 'None', "Transaction start offset should be a part of producer state"
+
+    @cluster(num_nodes=3)
+    def test_describe_idempotent_producers(self):
+        before = time.time()
+        rpk = RpkTool(self.redpanda)
+        producer_count = 20
+        for i in range(producer_count):
+            rpk.produce(self.topics[i % len(self.topics)].name,
+                        "test-key",
+                        "test-msg",
+                        partition=i % self.partition_count)
+
+        all_producers = self._describe_all_producers()
+
+        after = time.time()
+        assert len(
+            all_producers
+        ) == producer_count, f"Unexpected size of producers list, expected: {producer_count}, current: {len(all_producers)}"
+        for p in all_producers:
+            self.logger.info(f"producer state: {p}")
+            self._check_timestamp(p, before, after)
+            assert p[
+                'CurrentTransactionStartOffset'] == 'None', "Idempotent producers should not have first transaction offset"


### PR DESCRIPTION
Change the way how describe producers request handler list active
producers. Before it was deriving producer state from the ongoing
transaction list. This is incorrect as it didn't include the idempotent
producers and the one with finished transactions.

Now the handler uses producer state directly.

Fixes: #15247
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixed `DescribeProducers` API output