### PR TITLE
raft/state_machine: sleep after apply error

### DIFF
--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -183,6 +183,9 @@ ss::future<> state_machine::apply() {
             "State machine for ntp={} caught exception {}",
             _raft->ntp(),
             e);
+
+          return ss::sleep_abortable(1s, _as).handle_exception_type(
+            [](const ss::sleep_aborted&) {});
       });
 }
 


### PR DESCRIPTION
Sleeping in case of apply error helps avoiding busy-looping that leads to 100% reactor util and hard-to-investigate incidents.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
* Avoid 100% reactor utilization in case of state machine errors.
