### PR TITLE
ducktape/transform: add more transform tests

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1075,9 +1075,6 @@ class RedpandaServiceBase(Service):
                         counts[idx] += int(sample.value)
         return all(map(lambda count: count == 0, counts.values()))
 
-    def node_id(self, node, force_refresh=False, timeout_sec=30):
-        pass
-
     def partitions(self, topic_name=None):
         """
         Return partition metadata for the topic.

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -225,15 +225,23 @@ class Move(typing.NamedTuple):
 
 class DataTransformsLeadershipChangingTest(BaseDataTransformsTest):
     """
-    Tests related to WebAssembly powered data transforms that are chained together, it is possible to create a full DAG.
+    Tests related to WebAssembly powered data transforms leadership changing.
+    On the input topic moves requires shutdown and spinning up processors, and
+    for the output topic it requires produce retries.
     """
     def __init__(self, *args, **kwargs):
         super(DataTransformsLeadershipChangingTest, self).__init__(
             *args,
             extra_rp_conf={
                 # Disable leader balancer, as this test is doing its own
-                # partition movement and the balancer would interfere
-                'enable_leader_balancer': False
+                # leadership transfers and the balancer would interfere
+                'enable_leader_balancer': False,
+                # Lower the delay before we start processing.
+                # In slow debug mode tests the default here is
+                # three seconds, and we have to wait on leadership
+                # transfer this long for commits to be flushed, so
+                # we can more easily timeout with the long wait.
+                'data_transforms_commit_interval_ms': 500,
             },
             **kwargs)
         self._admin = Admin(self.redpanda)


### PR DESCRIPTION
Split out the base test so that it can be reused for other scenarios. 
Add a scenario where multiple topics are chained together.
Add a scenario where leadership changes while producing.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
