### PR TITLE
rpk/serde: use fullName for proto decoding.

### DIFF
--- a/src/go/rpk/pkg/serde/serde.go
+++ b/src/go/rpk/pkg/serde/serde.go
@@ -55,7 +55,7 @@ func NewSerde(ctx context.Context, cl *sr.Client, schema *sr.Schema, schemaID in
 		// If the proto FQN is not provided, but we only have one message, we
 		// use that.
 		if protoFQN == "" && compiled.FindFileByPath(inMemFileName).Messages().Len() == 1 {
-			protoFQN = string(compiled.FindFileByPath(inMemFileName).Messages().Get(0).Name())
+			protoFQN = string(compiled.FindFileByPath(inMemFileName).Messages().Get(0).FullName())
 		}
 		var encFn serdeFunc
 		// If there is no FQN, most likely we are trying to decode only.


### PR DESCRIPTION
When guessing the proto message name (i.e, just
1 message in a schema), we need to use the
fullName, the difference between this and Name is
that the fullName includes the package name as
well.

Person = Name
foo.bar.Person = FullName



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
