### PR TITLE
c/partition_balancer: prioritize full-disk constraint over rack repair

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -1461,7 +1461,7 @@ ss::future<> partition_balancer_planner::get_rack_constraint_repair_actions(
                           // other reasons
                           (void)part.move_replica(
                             replica,
-                            ctx.config().hard_max_disk_usage_ratio,
+                            ctx.config().soft_max_disk_usage_ratio,
                             change_reason::rack_constraint_repair);
                       }
                   }
@@ -1926,8 +1926,8 @@ partition_balancer_planner::plan_actions(
         }
         co_await get_node_drain_actions(
           ctx, unavailable_nodes, change_reason::node_unavailable);
-        co_await get_rack_constraint_repair_actions(ctx);
         co_await get_full_node_actions(ctx);
+        co_await get_rack_constraint_repair_actions(ctx);
     }
     co_await get_counts_rebalancing_actions(ctx);
     co_await get_force_repair_actions(ctx);

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -118,6 +118,31 @@ public:
 
     size_t cur_tick() const { return _cur_tick; }
 
+    // returns true if all partition movements stopped
+    bool run_to_completion(
+      size_t max_balancer_actions, std::function<void()> tick_cb = [] {}) {
+        print_state();
+
+        size_t num_actions = 0;
+        while (num_actions < max_balancer_actions) {
+            tick();
+            tick_cb();
+
+            if (should_schedule_balancer_run()) {
+                num_actions += run_balancer();
+                print_state();
+
+                if (last_run_in_progress_updates() == 0) {
+                    logger.info("finished after {} ticks", cur_tick());
+                    return true;
+                }
+            }
+        }
+
+        print_state();
+        return false;
+    }
+
     void tick() {
         // refill the bandwidth
         for (auto& [id, node] : _nodes) {
@@ -181,7 +206,8 @@ public:
         _cur_tick += 1;
     }
 
-    void run_balancer() {
+    // return the number of scheduled actions
+    size_t run_balancer() {
         auto hr = create_health_report();
         populate_node_status_table();
 
@@ -198,10 +224,12 @@ public:
               plan_data.cancellations.size(),
               plan_data.failed_actions_count);
 
+            size_t actions_count = plan_data.reassignments.size()
+                                   + plan_data.cancellations.size();
+
             _last_run_in_progress_updates
               = _workers.table.local().updates_in_progress().size()
-                + plan_data.reassignments.size()
-                + plan_data.cancellations.size();
+                + actions_count;
 
             for (const auto& reassignment : plan_data.reassignments) {
                 dispatch_move(
@@ -210,6 +238,8 @@ public:
             for (const auto& ntp : plan_data.cancellations) {
                 dispatch_cancel(ntp);
             }
+
+            return actions_count;
         }
     }
 
@@ -606,23 +636,7 @@ FIXTURE_TEST(test_decommission, partition_balancer_sim_fixture) {
     add_topic("mytopic", 100, 3, 100_MiB);
     set_decommissioning(model::node_id{0});
 
-    print_state();
-    for (size_t i = 0; i < 10000; ++i) {
-        if (nodes().at(model::node_id{0}).replicas.empty()) {
-            logger.info("finished in {} ticks", i);
-            break;
-        }
-
-        tick();
-        if (should_schedule_balancer_run()) {
-            print_state();
-            run_balancer();
-        }
-    }
-
-    logger.info("finished after {} ticks", cur_tick());
-    print_state();
-
+    BOOST_REQUIRE(run_to_completion(100));
     BOOST_REQUIRE_EQUAL(
       allocation_nodes().at(model::node_id{0})->allocated_partitions()(), 0);
 }
@@ -636,15 +650,7 @@ FIXTURE_TEST(test_two_decommissions, partition_balancer_sim_fixture) {
 
     size_t start_node_0_replicas
       = nodes().at(model::node_id{0}).replicas.size();
-
-    print_state();
-    for (size_t i = 0; i < 20000; ++i) {
-        if (
-          nodes().at(model::node_id{0}).replicas.empty()
-          && nodes().at(model::node_id{1}).replicas.empty()) {
-            break;
-        }
-
+    auto tick_cb = [&] {
         if (
           !allocation_nodes().at(model::node_id{1})->is_decommissioned()
           && allocation_nodes().at(model::node_id{0})->final_partitions()()
@@ -654,17 +660,9 @@ FIXTURE_TEST(test_two_decommissions, partition_balancer_sim_fixture) {
             set_decommissioning(model::node_id{1});
             print_state();
         }
+    };
 
-        tick();
-        if (should_schedule_balancer_run()) {
-            print_state();
-            run_balancer();
-        }
-    }
-
-    logger.info("finished after {} ticks", cur_tick());
-    print_state();
-
+    BOOST_REQUIRE(run_to_completion(500, tick_cb));
     BOOST_REQUIRE_EQUAL(
       allocation_nodes().at(model::node_id{0})->allocated_partitions()(), 0);
     BOOST_REQUIRE_EQUAL(
@@ -689,21 +687,7 @@ FIXTURE_TEST(test_counts_rebalancing, partition_balancer_sim_fixture) {
     add_node(model::node_id{4}, 1000_GiB, 8);
     add_node_to_rebalance(model::node_id{4});
 
-    print_state();
-
-    for (size_t i = 0; i < 100000; ++i) {
-        tick();
-        if (should_schedule_balancer_run()) {
-            print_state();
-            run_balancer();
-
-            if (last_run_in_progress_updates() == 0) {
-                break;
-            }
-        }
-    }
-
-    print_state();
+    BOOST_REQUIRE(run_to_completion(1000));
     validate_even_replica_distribution();
     validate_even_topic_distribution();
 }


### PR DESCRIPTION
To avoid flip-flop partition movements (replica moved from over-disk-limit node to a rack that already hosts another replica and then back to original node to repair the rack constraint), prioritize full-disk constraint over rack repair by essentially making full-disk threshold a hard constraint when calculating movements for rack constraint repair.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Bug Fixes
* Prevent data balancing from scheduling partition moves back and forth when rack awareness and preventing full disk are in conflict (the latter gets a priority).