### PR TITLE
c/cluster_discovery: log an error when join request failed

### DIFF
--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -165,7 +165,7 @@ cluster_discovery::dispatch_node_uuid_registration_to_seeds() {
               });
         } catch (...) {
             vlog(
-              clusterlog.debug,
+              clusterlog.warn,
               "Error registering node UUID {}, retrying: {}",
               _node_uuid,
               std::current_exception());
@@ -173,7 +173,7 @@ cluster_discovery::dispatch_node_uuid_registration_to_seeds() {
         }
         if (r.has_error()) {
             vlog(
-              clusterlog.debug,
+              clusterlog.warn,
               "Error registering UUID {}: {}, retrying",
               _node_uuid,
               r.error().message());
@@ -181,7 +181,7 @@ cluster_discovery::dispatch_node_uuid_registration_to_seeds() {
         }
         if (!r.has_value()) {
             vlog(
-              clusterlog.debug,
+              clusterlog.warn,
               "Error registering node UUID {} - {}, retrying",
               _node_uuid,
               r.error().message());
@@ -190,7 +190,7 @@ cluster_discovery::dispatch_node_uuid_registration_to_seeds() {
         auto& reply = r.value();
         if (!reply.success) {
             vlog(
-              clusterlog.debug,
+              clusterlog.warn,
               "Error registering node UUID {} received failure response, "
               "retrying",
               _node_uuid);
@@ -250,7 +250,7 @@ cluster_discovery::request_cluster_bootstrap_info_single(
                 co_return std::move(reply_result.value());
             }
             vlog(
-              clusterlog.debug,
+              clusterlog.warn,
               "Cluster bootstrap info failed from {} with {}",
               addr,
               reply_result.error());

--- a/src/v/cluster/cluster_discovery.cc
+++ b/src/v/cluster/cluster_discovery.cc
@@ -179,14 +179,23 @@ cluster_discovery::dispatch_node_uuid_registration_to_seeds() {
               r.error().message());
             continue;
         }
-        if (!r.has_value() || !r.value().success) {
+        if (!r.has_value()) {
             vlog(
               clusterlog.debug,
-              "Error registering node UUID {}, retrying",
-              _node_uuid);
+              "Error registering node UUID {} - {}, retrying",
+              _node_uuid,
+              r.error().message());
             continue;
         }
         auto& reply = r.value();
+        if (!reply.success) {
+            vlog(
+              clusterlog.debug,
+              "Error registering node UUID {} received failure response, "
+              "retrying",
+              _node_uuid);
+            continue;
+        }
         if (reply.id < 0) {
             // Something else went wrong. Maybe duplicate UUID?
             vlog(clusterlog.debug, "Negative node ID {}", reply.id);


### PR DESCRIPTION
When Join request fails the node is unable to become a cluster member. Added logging Join request failure. This will enable debugging the underlying problem.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none