### PR TITLE
rptest: include omb_validation_test.py tests in cloud test suite

### DIFF
--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -14,5 +14,3 @@ cloud:
     - tests/rpk_topic_test.py::RpkToolTest.test_consume_from_partition
     - tests/services_self_test.py::SimpleSelfTest
     - tests/services_self_test.py::OpenBenchmarkSelfTest
-  excluded:
-    - redpanda_cloud_tests/omb_validation_test.py


### PR DESCRIPTION
Following on from PR #13655, this PR includes the 4 tests in `omb_validation_test.py` to run on the scheduled jobs against cloud.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none