### PR TITLE
rpk: add 'rpk cluster partitions unsafe-recover'

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_cluster.go
+++ b/src/go/rpk/pkg/adminapi/api_cluster.go
@@ -47,6 +47,13 @@ type PartitionBalancerStatus struct {
 	// CurrentReassignmentsCount is the current number of partition
 	// reassignments in progress.
 	CurrentReassignmentsCount int `json:"current_reassignments_count,omitempty"`
+	// PartitionsPendingForceRecovery Specifies the number of partitions that
+	// are yet to be force recovered. This is a pointer because not all Redpanda
+	// versions include this parameter.
+	PartitionsPendingForceRecovery *int `json:"partitions_pending_force_recovery_count"`
+	// PartitionsPendingRecoveryList Is a sample list of partitions pending
+	// force recovery (limit capped to 10).
+	PartitionsPendingRecoveryList []string `json:"partitions_pending_force_recovery_sample"`
 }
 
 // PartitionBalancerViolations describe the violations of the partition

--- a/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
@@ -32,6 +32,7 @@ func NewPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newPartitionDisableCommand(fs, p),
 		newPartitionEnableCommand(fs, p),
 		newPartitionMovementsStatusCommand(fs, p),
+		newUnsafeRecoveryCommand(fs, p),
 	)
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/cluster/partitions/status.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/status.go
@@ -95,17 +95,17 @@ investigation. A few areas to investigate:
 }
 
 func printBalancerStatus(pbs adminapi.PartitionBalancerStatus) {
-	const format = `Status:                       %v
-Seconds Since Last Tick:      %v
-Current Reassignment Count:   %v
-`
-	fmt.Printf(format, pbs.Status, pbs.SecondsSinceLastTick, pbs.CurrentReassignmentsCount)
-
+	tw := out.NewTable()
+	defer tw.Flush()
+	tw.Print("Status:", pbs.Status)
+	tw.Print("Seconds Since Last Tick:", pbs.SecondsSinceLastTick)
+	tw.Print("Current Reassignment Count:", pbs.CurrentReassignmentsCount)
+	if pbs.PartitionsPendingForceRecovery != nil && pbs.PartitionsPendingRecoveryList != nil {
+		tw.Print(fmt.Sprintf("Partitions Pending Recovery (%v):", *pbs.PartitionsPendingForceRecovery), pbs.PartitionsPendingRecoveryList)
+	}
 	v := pbs.Violations
 	if len(v.OverDiskLimitNodes) > 0 || len(v.UnavailableNodes) > 0 {
-		const vFormat = `Unavailable Nodes:            %v
-Over Disk Limit Nodes:        %v
-`
-		fmt.Printf(vFormat, v.UnavailableNodes, v.OverDiskLimitNodes)
+		tw.Print("Unavailable Nodes:", v.UnavailableNodes)
+		tw.Print("Over Disk Limit Nodes:", v.OverDiskLimitNodes)
 	}
 }

--- a/src/go/rpk/pkg/cli/cluster/partitions/unsafe_recover.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/unsafe_recover.go
@@ -1,0 +1,109 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package partitions
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newUnsafeRecoveryCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		dry       bool
+		noConfirm bool
+		nodes     []int
+	)
+	cmd := &cobra.Command{
+		Use:   "unsafe-recover",
+		Short: "Recover unsafely from partitions that have lost majority",
+		Long: `Recover unsafely from partitions that have lost majority.
+
+This command allows you to unsafely recover all data adversely affected by the
+loss of the nodes specified in the '--from-nodes' flag. This operation is unsafe 
+because it allows you to bulk move all partitions that have lost majority when 
+nodes are gone and irrecoverable; this may result in data loss.
+
+You can perform a dry run and verify the partitions that will be recovered by 
+using the '--dry' flag.
+`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			f := p.Formatter
+			if f.Kind != "text" && f.Kind != "help" && !dry {
+				out.Die("Format type %q is only valid for dry runs (--dry)", f.Kind)
+			}
+			if h, ok := f.Help([]adminapi.MajorityLostPartitions{}); ok {
+				out.Exit(h)
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "unable to load config: %v", err)
+			out.CheckExitCloudAdmin(p)
+
+			cl, err := adminapi.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			plan, err := cl.MajorityLostPartitions(cmd.Context(), nodes)
+			out.MaybeDie(err, "unable to get recovery plan: %v", err)
+			if len(plan) == 0 {
+				out.Exit("There are no partitions to recover from node(s): %v", nodes)
+			}
+			err = printPlan(f, plan)
+			out.MaybeDieErr(err)
+			if dry {
+				return
+			}
+			if !noConfirm {
+				confirmed, err := out.Confirm("Confirm recovery from these nodes? This may result in data loss")
+				out.MaybeDie(err, "unable to confirm recovery plan: %v", err)
+				if !confirmed {
+					out.Exit("Command execution canceled")
+				}
+			}
+			fmt.Println("Executing recovery plan...")
+			err = cl.ForceRecoverFromNode(cmd.Context(), plan, nodes)
+			out.MaybeDie(err, "unable to execute recovery plan: %v", err)
+			fmt.Println("Successfully queued the recovery plan, you can check the status by running 'rpk cluster partitions balancer-status'")
+		},
+	}
+	p.InstallFormatFlag(cmd)
+
+	cmd.Flags().IntSliceVar(&nodes, "from-nodes", nil, "Comma-separated list of node IDs from which to recover the partitions")
+	cmd.Flags().BoolVar(&dry, "dry", false, "Dry run: print the partition movement plan. Does not execute it")
+	cmd.Flags().BoolVar(&noConfirm, "no-confirm", false, "Disable confirmation prompt")
+
+	cmd.MarkFlagRequired("from-nodes")
+	cmd.MarkFlagsMutuallyExclusive("dry", "no-confirm")
+
+	return cmd
+}
+
+func printPlan(f config.OutFormatter, plan []adminapi.MajorityLostPartitions) error {
+	if isText, _, s, err := f.Format(plan); !isText {
+		if err != nil {
+			return fmt.Errorf("unable to print in the required format %q: %v", f.Kind, err)
+		}
+		fmt.Println(s)
+		return nil
+	}
+	tw := out.NewTable("namespace", "topic", "partition", "replica-core", "dead-nodes")
+	defer tw.Flush()
+	for _, p := range plan {
+		var replicas []string
+		for _, r := range p.Replicas {
+			replicas = append(replicas, fmt.Sprintf("%v-%v", r.NodeID, r.Core))
+		}
+		tw.Print(p.NTP.Ns, p.NTP.Topic, p.NTP.PartitionID, replicas, p.DeadNodes)
+	}
+	return nil
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1694,3 +1694,20 @@ class RpkTool:
         out = self._execute(cmd, stdin=stdin, timeout=timeout)
 
         return json.loads(out) if output_format == "json" else out
+
+    def force_partition_recovery(self, from_nodes, to_node=None):
+        cmd = [
+            self._rpk_binary(),
+            "cluster",
+            "partitions",
+            "unsafe-recover",
+            "--no-confirm",
+            "--from-nodes",
+            ",".join([str(x) for x in from_nodes]),
+        ]
+
+        if to_node is not None:
+            cmd += ["-X", "admin.hosts=" + f"{to_node.account.hostname}:9644"]
+        else:
+            cmd += ["-X", "admin.hosts=" + self._admin_host()]
+        return self._execute(cmd)

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -417,11 +417,12 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
             n for n in self.redpanda.started_nodes()
             if self.redpanda.node_id(n) not in to_kill_node_ids
         ])
-        payload = make_recovery_payload(to_kill_node_ids,
-                                        partitions_lost_majority)
+
+        self.logger.debug(f"recovering from: {to_kill_node_ids}")
+        self._rpk = RpkTool(self.redpanda)
         # issue a node wise recovery
-        self.redpanda._admin.force_recover_partitions_from_nodes(
-            payload, surviving_node)
+        self._rpk.force_partition_recovery(from_nodes=to_kill_node_ids,
+                                           to_node=surviving_node)
 
         with ControllerLeadershipTransferInjector(self.redpanda) as transfers:
 


### PR DESCRIPTION
Adding `rpk cluster partitions unsafe-recover`:  This command will let the user forcefully recover data adversely affected by irrecoverable nodes.

Core's PRs: 
- https://github.com/redpanda-data/redpanda/pull/15394
- https://github.com/redpanda-data/redpanda/pull/13943

Changes introduced in this PR:
- New `rpk cluster partitions unsafe-recover` command. (Usage below)
- A new field: `Partitions Pending Recovery (<Number of partitions>)` in `rpk cluster partitions balancer-status` response.

### Usage

You must pass the dead-nodes list to execute the command, the command will print the "plan" (i.e the partitions that lost majority) and has and interactive prompt to confirm you want to perform the unsafe recovery:

```
$ rpk cluster partitions unsafe-recover --from-nodes 1
NAMESPACE  TOPIC  PARTITION  REPLICA-CORE  DEAD-NODES
kafka      bar    0          [1-1]         [1]
? Confirm recovery from these nodes? Yes
Executing recovery plan...
Successfully queued the recovery plan, you may check the status by running 'rpk cluster partitions balancer-status'

$ rpk cluster partitions balancer-status 
Status:                               ready
Seconds Since Last Tick:              26
Current Reassignment Count:           0
Partitions Pending Recovery (1):      [kafka/bar/0]
```

You may skip the confirmation prompt using the `--no-confirm` flag or just get the plan (dry run) using the `--dry` flag.

### How to reproduce:

1. Create a 3 or 5 nodes cluster using the nightly build of redpanda (you may use `rpk container`: `rpk container start -n 3 --image redpandadata/redpanda-nightly:latest`
2. Create a topic with RF=1 and produce: `rpk topic create bar -r 1` && `rpk topic produce bar...`
3. Check which node is the leader with `rpk topic describe bar -p` and stop the node (`docker stop rp-node-<id>`)
Fixes #14744

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [x] v22.3.x

## Release Notes

### Features

* rpk: add `rpk cluster partitions unsafe-recover`: This command will let the user forcefully recover data adversely affected by irrecoverable nodes.
