### PR TITLE
net: Expose total sent/recv bytes on public_metrics

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -144,7 +144,8 @@ void replicated_partition_probe::setup_internal_metrics(const model::ntp& ntp) {
         sm::make_total_bytes(
           "bytes_fetched_total",
           [this] { return _bytes_fetched; },
-          sm::description("Total number of bytes fetched"),
+          sm::description("Total number of bytes fetched (not all might be "
+                          "returned to the client)"),
           labels)
           .aggregate(aggregate_labels),
         sm::make_total_bytes(
@@ -248,7 +249,8 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
         sm::make_total_bytes(
           "request_bytes_total",
           [this] { return _bytes_fetched; },
-          sm::description("Total number of bytes consumed per topic"),
+          sm::description("Total number of bytes fetched (not all "
+                          "might be returned to the client)"),
           {request_label("consume"),
            ns_label(ntp.ns()),
            topic_label(ntp.tp.topic()),

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -136,6 +136,21 @@ void server_probe::setup_public_metrics(
           sm::description("Count of currently active connections"),
           {server_label(proto)})
           .aggregate({sm::shard_label}),
+        sm::make_total_bytes(
+          "received_bytes",
+          [this] { return _in_bytes; },
+          sm::description(ssx::sformat(
+            "{}: Number of bytes received from the clients in valid requests",
+            proto)),
+          {server_label(proto)})
+          .aggregate({sm::shard_label}),
+        sm::make_total_bytes(
+          "sent_bytes",
+          [this] { return _out_bytes; },
+          sm::description(
+            ssx::sformat("{}: Number of bytes sent to clients", proto)),
+          {server_label(proto)})
+          .aggregate({sm::shard_label}),
       });
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/14836

Fixes https://github.com/redpanda-data/redpanda/pull/14836