### PR TITLE
k/client: Move gate in producer::send

### DIFF
--- a/src/v/kafka/client/producer.h
+++ b/src/v/kafka/client/producer.h
@@ -58,10 +58,7 @@ private:
 
     auto make_consumer(model::topic_partition tp) {
         return [this, tp](model::record_batch&& batch) {
-            (void)send(tp, std::move(batch))
-              .handle_exception_type([](const ss::gate_closed_exception&) {
-                  vlog(kclog.debug, "Failed to call send() shutting down");
-              });
+            (void)send(tp, std::move(batch));
         };
     }
 


### PR DESCRIPTION
CI issue was caused due to gate close exception not being properly handled in producer::send.  When gate was closed, the proper response future was never generated.  Now gate will be held by a ss::with_gate and the exception properly caught and handled.

Fixes: #15314

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
