### PR TITLE
Add truncating_logger and formatter specializations for `metadata_*` API types

### DIFF
--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -62,7 +62,7 @@ public:
         return _gated_mutex
           .with([this, r{std::move(r)}]() mutable {
               vlog(
-                kclog.debug,
+                kcwire.debug,
                 "{}Dispatch to node {}: {} req: {}",
                 *this,
                 _node_id,
@@ -70,7 +70,7 @@ public:
                 r);
               return _client.dispatch(std::move(r)).then([this](Ret res) {
                   vlog(
-                    kclog.debug,
+                    kcwire.debug,
                     "{}Dispatch from node {}: {} res: {}",
                     *this,
                     _node_id,

--- a/src/v/kafka/client/logger.h
+++ b/src/v/kafka/client/logger.h
@@ -15,6 +15,9 @@
 
 #include <seastar/util/log.hh>
 
+#include <utils/truncating_logger.h>
+
 namespace kafka::client {
 inline ss::logger kclog("kafka/client");
+inline truncating_logger kcwire(kclog, 1048576);
 } // namespace kafka::client

--- a/src/v/kafka/protocol/logger.cc
+++ b/src/v/kafka/protocol/logger.cc
@@ -11,4 +11,5 @@
 
 namespace kafka {
 ss::logger klog("kafka");
+truncating_logger kwire(klog, 1048576);
 } // namespace kafka

--- a/src/v/kafka/protocol/metadata.h
+++ b/src/v/kafka/protocol/metadata.h
@@ -69,11 +69,21 @@ struct metadata_response {
     void decode(iobuf buf, api_version version) {
         data.decode(std::move(buf), version);
     }
-
-    friend std::ostream&
-    operator<<(std::ostream& os, const metadata_response& r) {
-        return os << r.data;
-    }
 };
 
 } // namespace kafka
+
+template<>
+struct fmt::formatter<kafka::metadata_response> {
+    template<typename ParseContext>
+    constexpr auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+        return ctx.begin();
+    }
+
+    template<typename FormatContext>
+    auto format(
+      [[maybe_unused]] const kafka::metadata_response& v,
+      FormatContext& ctx) const -> decltype(ctx.out()) {
+        return fmt::format_to(ctx.out(), "{}", v.data);
+    }
+};

--- a/src/v/kafka/server/logger.h
+++ b/src/v/kafka/server/logger.h
@@ -15,6 +15,9 @@
 
 #include <seastar/util/log.hh>
 
+#include <utils/truncating_logger.h>
+
 namespace kafka {
 extern ss::logger klog;
+extern truncating_logger kwire;
 } // namespace kafka

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -212,7 +212,7 @@ public:
 
         if (r.data.errored()) {
             vlog(
-              klog.debug,
+              kwire.debug,
               "[{}:{}] sending {}:{} for {}, response {}",
               _conn->client_host(),
               _conn->client_port(),
@@ -222,7 +222,7 @@ public:
               r);
         } else {
             vlog(
-              klog.trace,
+              kwire.trace,
               "[{}:{}] sending {}:{} for {}, response {}",
               _conn->client_host(),
               _conn->client_port(),

--- a/src/v/kafka/server/requests.cc
+++ b/src/v/kafka/server/requests.cc
@@ -47,7 +47,7 @@ requires(KafkaApiHandler<Request> || KafkaApiTwoPhaseHandler<Request>)
 process_result_stages
 do_process(request_context&& ctx, ss::smp_service_group g) {
     vlog(
-      klog.trace,
+      kwire.trace,
       "[{}:{}] processing name:{}, key:{}, version:{} for {}",
       ctx.connection()->client_host(),
       ctx.connection()->client_port(),
@@ -83,7 +83,7 @@ process_result_stages process_generic(
   ss::smp_service_group g,
   const session_resources& sres) {
     vlog(
-      klog.trace,
+      kwire.trace,
       "[{}:{}] processing name:{}, key:{}, version:{} for {}, mem_units: {}, "
       "ctx_size: {}",
       ctx.connection()->client_host(),

--- a/src/v/utils/truncating_logger.h
+++ b/src/v/utils/truncating_logger.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+#include "ssx/sformat.h"
+#include "vassert.h"
+
+#include <seastar/util/log-impl.hh>
+#include <seastar/util/log.hh>
+
+#include <iostream>
+
+/// Logger that supports proactive truncation of formatted output at the level
+/// of seastar::logger::log_writer
+class truncating_logger {
+    static constexpr std::string_view trunc_msg_fmt
+      = "... log line too large; dropped {}B";
+    static constexpr size_t max_max_line_bytes = 1048576;
+    static constexpr size_t max_trunc_msg_len = trunc_msg_fmt.size() + (20 - 2);
+
+public:
+    truncating_logger(ss::logger& logger, size_t max_line_bytes)
+      : _logger(logger) {
+        vassert(
+          max_line_bytes <= max_max_line_bytes,
+          "max_line_bytes {} too large; should be <= {}",
+          max_line_bytes,
+          max_max_line_bytes);
+        vassert(
+          max_line_bytes > max_trunc_msg_len,
+          "max_line_bytes {} too small; should be > {}",
+          max_line_bytes,
+          max_trunc_msg_len);
+
+        _max_line_bytes = max_line_bytes - max_trunc_msg_len;
+    }
+
+    template<typename... Args>
+    void
+    log(ss::log_level lvl, fmt::format_string<Args...> format, Args&&... args)
+      const {
+        if (_logger.is_enabled(lvl)) {
+            ss::logger::lambda_log_writer writer(
+              [&](ss::internal::log_buf::inserter_iterator it) {
+                  auto res = fmt::format_to_n(
+                    it, _max_line_bytes, format, std::forward<Args>(args)...);
+                  if (res.size > _max_line_bytes) {
+                      return fmt::format_to(
+                        res.out, trunc_msg_fmt, res.size - _max_line_bytes);
+                  }
+                  return res.out;
+              });
+            _logger.log(lvl, writer);
+        }
+    }
+
+    template<typename... Args>
+    void error(fmt::format_string<Args...> format, Args&&... args) const {
+        log(ss::log_level::error, format, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void warn(fmt::format_string<Args...> format, Args&&... args) const {
+        log(ss::log_level::warn, format, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void info(fmt::format_string<Args...> format, Args&&... args) const {
+        log(ss::log_level::info, format, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void debug(fmt::format_string<Args...> format, Args&&... args) const {
+        log(ss::log_level::debug, format, std::forward<Args>(args)...);
+    }
+
+    template<typename... Args>
+    void trace(fmt::format_string<Args...> format, Args&&... args) const {
+        log(ss::log_level::trace, format, std::forward<Args>(args)...);
+    }
+
+private:
+    ss::logger& _logger;
+    size_t _max_line_bytes;
+};


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Introduces a specialized logger for situations where `fmt` output might be extremely large and wires it into Kafka API request and response logging.

Also adds code gen for custom `fmt::formatter` specializations for `metadata_response_data` and associated types.

Usually formatters for generated kafka API types are defined as `operator<<` overloads. When fmtlib encounters a format arg of "custom" type `T`, it first looks for a matching `fmt::formatter<T>` specialization. Failing that, it constructs a `fallback_formatter<T>`, which, in our case (assuming `operator<<(os, const T&)` exists), constructs an ostream backed by an expandable buffer and streams the arg value into it.

The purpose of this PR is to limit the memory footprint of logging large (i.e. >1MiB formatted)  `metadata_response`s. `truncating_logger` explicitly imposes this limit at the highest level (iterator into `ss::internal::log_buf`), but formatter lookup proceeds irrespective of this limit, allocating a stream buffer each time it encounters an argument of some type `T` such that no `fmt::formatter<T>` specialization exists, subsequently expanding that buffer to fit the fully formatted representation of `T`. 

By providing `fmt::formatter` specializations for `metadata_response_data` and its various sub-fields, we can carry a consistent `format_context` throughout format arg visitation, which should in turn preserve the `format_to_n` (i.e. fixed buffer) semantics of `truncating_logger`.

TODO:
- [x] After much head scratching, I'm not really convinced that this avoids the large allocation. Need to collect a heap profile.
- [ ] Probably needs a test of some kind, but I'm not sure what form that would take, exactly.
   - TO REVIEWERS: Any ideas or suggestions here?

Fixes https://github.com/redpanda-data/core-internal/issues/932

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [x] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixed-limit truncation for request/response logging in the Kafka API

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
