### PR TITLE
Non-polling fetch implementation

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -587,6 +587,19 @@ configuration::configuration()
       "wasn't reached",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1ms)
+  , fetch_read_strategy(
+      *this,
+      "fetch_read_strategy",
+      "The strategy used to fulfill fetch requests",
+      {.needs_restart = needs_restart::no,
+       .example = model::fetch_read_strategy_to_string(
+         model::fetch_read_strategy::non_polling),
+       .visibility = visibility::tunable},
+      model::fetch_read_strategy::non_polling,
+      {
+        model::fetch_read_strategy::polling,
+        model::fetch_read_strategy::non_polling,
+      })
   , alter_topic_cfg_timeout_ms(
       *this,
       "alter_topic_cfg_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -139,6 +139,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> tx_timeout_delay_ms;
     deprecated_property rm_violation_recovery_policy;
     property<std::chrono::milliseconds> fetch_reads_debounce_timeout;
+    enum_property<model::fetch_read_strategy> fetch_read_strategy;
     property<std::chrono::milliseconds> alter_topic_cfg_timeout_ms;
     property<model::cleanup_policy_bitflags> log_cleanup_policy;
     enum_property<model::timestamp_type> log_message_timestamp_type;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -500,4 +500,35 @@ struct convert<pandaproxy::schema_registry::schema_id_validation_mode> {
     }
 };
 
+template<>
+struct convert<model::fetch_read_strategy> {
+    using type = model::fetch_read_strategy;
+
+    static constexpr auto acceptable_values = std::to_array(
+      {model::fetch_read_strategy_to_string(type::polling),
+       model::fetch_read_strategy_to_string(type::non_polling)});
+
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+
+        if (
+          std::find(acceptable_values.begin(), acceptable_values.end(), value)
+          == acceptable_values.end()) {
+            return false;
+        }
+
+        rhs = string_switch<type>(std::string_view{value})
+                .match(
+                  model::fetch_read_strategy_to_string(type::polling),
+                  type::polling)
+                .match(
+                  model::fetch_read_strategy_to_string(type::non_polling),
+                  type::non_polling);
+
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -640,6 +640,8 @@ consteval std::string_view property_type_name() {
                            pandaproxy::schema_registry::
                              schema_id_validation_mode>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, model::fetch_read_strategy>) {
+        return "string";
     } else {
         static_assert(
           utils::unsupported_type<T>::value, "Type name not defined");

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -161,6 +161,11 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::fetch_read_strategy& v) {
+    stringize(w, v);
+}
+
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const model::cloud_storage_chunk_eviction_strategy& v) {
     stringize(w, v);

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -77,6 +77,9 @@ void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::leader_balancer_mode& v);
 
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::fetch_read_strategy& v);
+
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const model::cloud_storage_chunk_eviction_strategy& v);
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -418,7 +418,7 @@ read_result::memory_units_t reserve_memory_units(
 static void fill_fetch_responses(
   op_context& octx,
   std::vector<read_result> results,
-  std::vector<op_context::response_placeholder_ptr> responses,
+  const std::vector<op_context::response_placeholder_ptr>& responses,
   op_context::latency_point start_time) {
     auto range = boost::irange<size_t>(0, results.size());
     if (unlikely(results.size() != responses.size())) {
@@ -439,7 +439,7 @@ static void fill_fetch_responses(
 
     for (auto idx : range) {
         auto& res = results[idx];
-        auto& resp_it = responses[idx];
+        const auto& resp_it = responses[idx];
 
         // error case
         if (unlikely(res.error != error_code::none)) {
@@ -647,8 +647,7 @@ handle_shard_fetch(ss::shard_id shard, op_context& octx, shard_fetch fetch) {
       .then([responses = std::move(fetch.responses),
              start_time = fetch.start_time,
              &octx](std::vector<read_result> results) mutable {
-          fill_fetch_responses(
-            octx, std::move(results), std::move(responses), start_time);
+          fill_fetch_responses(octx, std::move(results), responses, start_time);
       });
 }
 

--- a/src/v/kafka/server/handlers/fetch.h
+++ b/src/v/kafka/server/handlers/fetch.h
@@ -361,7 +361,11 @@ struct fetch_plan {
     explicit fetch_plan(
       size_t shards,
       op_context::latency_point start_time = op_context::latency_clock::now())
-      : fetches_per_shard(shards, shard_fetch(start_time)) {}
+      : fetches_per_shard(shards, shard_fetch(start_time)) {
+        for (size_t i = 0; i < fetches_per_shard.size(); i++) {
+            fetches_per_shard[i].shard = i;
+        }
+    }
 
     std::vector<shard_fetch> fetches_per_shard;
 

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -539,6 +539,25 @@ operator<<(std::ostream& os, cloud_storage_chunk_eviction_strategy st) {
     }
 }
 
+enum class fetch_read_strategy : uint8_t {
+    polling = 0,
+    non_polling = 1,
+};
+
+constexpr const char* fetch_read_strategy_to_string(fetch_read_strategy s) {
+    switch (s) {
+    case fetch_read_strategy::polling:
+        return "polling";
+    case fetch_read_strategy::non_polling:
+        return "non_polling";
+    default:
+        throw std::invalid_argument("unknown fetch_read_strategy");
+    }
+}
+
+std::ostream& operator<<(std::ostream&, fetch_read_strategy);
+std::istream& operator>>(std::istream&, fetch_read_strategy&);
+
 namespace internal {
 /*
  * Old version for use in backwards compatibility serialization /

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -477,4 +477,22 @@ std::ostream& operator<<(std::ostream& o, const batch_identity& bid) {
     return o;
 }
 
+std::ostream& operator<<(std::ostream& o, fetch_read_strategy s) {
+    o << fetch_read_strategy_to_string(s);
+    return o;
+}
+
+std::istream& operator>>(std::istream& i, fetch_read_strategy& strat) {
+    ss::sstring s;
+    i >> s;
+    strat = string_switch<fetch_read_strategy>(s)
+              .match(
+                fetch_read_strategy_to_string(fetch_read_strategy::polling),
+                fetch_read_strategy::polling)
+              .match(
+                fetch_read_strategy_to_string(fetch_read_strategy::non_polling),
+                fetch_read_strategy::non_polling);
+    return i;
+}
+
 } // namespace model

--- a/src/v/ssx/abort_source.h
+++ b/src/v/ssx/abort_source.h
@@ -68,6 +68,10 @@ public:
     auto abort_requested() const noexcept { return local().abort_requested(); }
     auto check() const { return local().check(); }
 
+    bool local_is_initialized() const noexcept {
+        return _as.local_is_initialized();
+    }
+
 private:
     ss::sharded<ss::abort_source> _as;
     std::optional<ss::abort_source::subscription> _sub;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR implements a new `fetch_plan_executor` that doesn't repeatedly poll every partition in the fetch for new data. Instead it relies on registering callbacks with `raft:consensus::visible_offset_monitor` to know when a partition has new data and therefore would be worth querying once again.

The gist of how this is implemented is as follows;
- A fetch "coordinator"(see `kafka::nonpolling_fetch_plan_executor::execute_plan`) is created on the shard that received the fetch request. This coordinator is responsible for creating fetch workers and determining when a fetch request is completed.
- A fetch "worker"(see `kafka::nonpolling_fetch_plan_executor::shard_fetch_worker`) is created on every shard that has a partition from the request. It's responsible for querying partitions for data. And if no partitions have data it'll register with the `raft:consensus::visible_offset_monitor` for those partitions and wait until it increases for one or more of them. The worker only returns on errors, aborts from the worker, or when it has queried enough data to meet or exceed the lower limit the coordinator specified.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements
- Introduces a new non-polling fetch execution strategy that decreases CPU utilization of fetch requests and fetch request latency. 
- Adds a new cluster configuration property `fetch_read_strategy`. This property determines which fetch execution strategy Redpanda will use to fulfill a fetch request. The newly introduced `non_polling` execution strategy is the default for this property with the `polling` strategy being included to make backporting possible.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
