### PR TITLE
 dnm: assert failure tester tx+time-based-rolling

### DIFF
--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -12,7 +12,9 @@ static ss::logger test_logger{"tx_compaction_tests"};
 using cluster::random_tx_generator;
 
 #define STM_BOOTSTRAP()                                                        \
-    storage::ntp_config::default_overrides o;                                  \
+    storage::ntp_config::default_overrides o{                                  \
+      .retention_time = tristate<std::chrono::milliseconds>(10s),              \
+      .segment_ms = tristate<std::chrono::milliseconds>(1s)};                  \
     o.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;    \
                                                                                \
     create_stm_and_start_raft(o);                                              \
@@ -36,6 +38,7 @@ FIXTURE_TEST(test_tx_compaction_combinations, rm_stm_test_fixture) {
     // batches and tx control batches removed.
     // Each workload execution can fully be backtracked from the test log
     // (in case of failures) and re-executed manually.
+    config::shard_local_cfg().log_segment_ms_min.set_value(1ms);
     for (auto num_tx : {10, 20, 30}) {
         for (auto num_rolls : {0, 1, 2, 3, 5}) {
             for (auto type :


### PR DESCRIPTION
try with
```sh
export BUILD_TYPE=Debug
TARGETS=tx_compaction_tests_rpunit task rp:build && vbuild/$BUILD_TYPE/clang/bin/tx_compaction_tests_rpunit -- -c 1 --default-log-level=debug
```

this test combines transactions and time based segment rolling. on my machine, it ends with this assertion:

```
INFO  2023-12-06 16:57:28,771 [shard 0:main] cluster - tx_compaction_utils.h:134 - Executed op: roll log
DEBUG 2023-12-06 16:57:28,771 [shard 0:main] tx - [{default/test/0}] - rm_stm.cc:2181 - Removing abort indexes 0 with offset < 0
DEBUG 2023-12-06 16:57:28,785 [shard 0:main] storage-gc - segment_utils.cc:881 - concatenating 2 indicies
DEBUG 2023-12-06 16:57:28,802 [shard 0:main] storage - segment_reader.cc:99 - Opening segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log
DEBUG 2023-12-06 16:57:28,803 [shard 0:main] storage - segment_reader.cc:126 - Closing segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log
DEBUG 2023-12-06 16:57:28,803 [shard 0:main] storage - segment_reader.cc:99 - Opening segment file test_dir_hqTXUJ/default/test/0_0/14-1-v1.log
DEBUG 2023-12-06 16:57:28,804 [shard 0:main] storage - segment_reader.cc:126 - Closing segment file test_dir_hqTXUJ/default/test/0_0/14-1-v1.log
DEBUG 2023-12-06 16:57:28,811 [shard 0:main] storage - segment_reader.cc:99 - Opening segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.staging
DEBUG 2023-12-06 16:57:28,811 [shard 0:main] storage - segment_reader.cc:126 - Closing segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.staging
DEBUG 2023-12-06 16:57:28,832 [shard 0:main] storage - segment_reader.cc:99 - Opening segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.staging
DEBUG 2023-12-06 16:57:28,838 [shard 0:main] storage - segment_reader.cc:126 - Closing segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.staging
DEBUG 2023-12-06 16:57:28,852 [shard 0:main] storage - readers_cache.cc:188 - {default/test/0} - evicting reader from cache, segment [0,49] removal
DEBUG 2023-12-06 16:57:28,852 [shard 0:main] storage - readers_cache.cc:224 - {default/test/0} - evicting reader from cache, range [0,49]
DEBUG 2023-12-06 16:57:28,853 [shard 0:main] storage - segment_reader.cc:99 - Opening segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.staging
DEBUG 2023-12-06 16:57:28,854 [shard 0:main] storage - segment_reader.cc:126 - Closing segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.staging
DEBUG 2023-12-06 16:57:28,861 [shard 0:main] storage-gc - disk_log_impl.cc:853 - Final compacted segment {offset_tracker:{term:1, base_offset:0, committed_offset:8, dirty_offset:8}, compacted_segment=1, finished_self_compaction=1, finished_windowed_compaction=0, generation={17}, reader={test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.staging, (390 bytes)}, writer=nullptr, cache=nullptr, compaction_index:nullopt, closed=0, tombstone=0, index={file:test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.base_index, offsets:{0}, index:{header_bitflags:0, base_offset:{0}, max_offset:{8}, base_timestamp:{timestamp: 1701878248402}, max_timestamp:{timestamp: 1701878248515}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:0, broker_timestamp:{{timestamp: 1701878248764}}, index(1,1,1)}, step:32768, needs_persistence:0}}
DEBUG 2023-12-06 16:57:28,862 [shard 0:main] storage - segment_reader.cc:99 - Opening segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log
DEBUG 2023-12-06 16:57:28,863 [shard 0:main] storage - segment_reader.cc:126 - Closing segment file test_dir_hqTXUJ/default/test/0_0/0-1-v1.log
DEBUG 2023-12-06 16:57:28,871 [shard 0:main] storage - segment.cc:167 - removed: "test_dir_hqTXUJ/default/test/0_0/0-1-v1.log.compaction.base_index" size 90
INFO  2023-12-06 16:57:28,871 [shard 0:main] storage - disk_log_impl.cc:1821 - Removing "test_dir_hqTXUJ/default/test/0_0/14-1-v1.log" (compact_adjacent_segments, {offset_tracker:{term:1, base_offset:14, committed_offset:49, dirty_offset:49}, compacted_segment=1, finished_self_compaction=0, finished_windowed_compaction=0, generation={33}, reader={test_dir_hqTXUJ/default/test/0_0/14-1-v1.log, (4973 bytes)}, writer=nullptr, cache={cache_size=16}, compaction_index:nullopt, closed=0, tombstone=0, index={file:test_dir_hqTXUJ/default/test/0_0/14-1-v1.base_index, offsets:{14}, index:{header_bitflags:0, base_offset:{14}, max_offset:{49}, base_timestamp:{timestamp: 1701878248544}, max_timestamp:{timestamp: 1701878248763}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:0, broker_timestamp:{{timestamp: 1701878248764}}, index(1,1,1)}, step:32768, needs_persistence:0}})
DEBUG 2023-12-06 16:57:28,871 [shard 0:main] storage - readers_cache.cc:188 - {default/test/0} - evicting reader from cache, segment [14,49] removal
DEBUG 2023-12-06 16:57:28,871 [shard 0:main] storage - readers_cache.cc:224 - {default/test/0} - evicting reader from cache, range [14,49]
DEBUG 2023-12-06 16:57:28,872 [shard 0:main] storage - segment.cc:167 - removed: "test_dir_hqTXUJ/default/test/0_0/14-1-v1.compaction_index" size 33
DEBUG 2023-12-06 16:57:28,872 [shard 0:main] storage - segment.cc:167 - removed: "test_dir_hqTXUJ/default/test/0_0/14-1-v1.log" size 4973
DEBUG 2023-12-06 16:57:28,872 [shard 0:main] storage - segment.cc:167 - removed: "test_dir_hqTXUJ/default/test/0_0/14-1-v1.base_index" size 90
DEBUG 2023-12-06 16:57:28,872 [shard 0:main] storage - segment.cc:105 - Removed 5096 bytes for tombstone segment {offset_tracker:{term:1, base_offset:14, committed_offset:49, dirty_offset:49}, compacted_segment=1, finished_self_compaction=0, finished_windowed_compaction=0, generation={34}, reader={test_dir_hqTXUJ/default/test/0_0/14-1-v1.log, (4973 bytes)}, writer=nullptr, cache={cache_size=16}, compaction_index:nullopt, closed=1, tombstone=1, index={file:test_dir_hqTXUJ/default/test/0_0/14-1-v1.base_index, offsets:{14}, index:{header_bitflags:0, base_offset:{14}, max_offset:{49}, base_timestamp:{timestamp: 1701878248544}, max_timestamp:{timestamp: 1701878248763}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:0, broker_timestamp:{{timestamp: 1701878248764}}, index(1,1,1)}, step:32768, needs_persistence:0}}
DEBUG 2023-12-06 16:57:28,873 [shard 0:main] storage-gc - disk_log_impl.cc:1145 - Adjacent segments of {default/test/0}, compaction result: {executed_compaction: true, size_before: 5363, size_after: 390}
DEBUG 2023-12-06 16:57:28,873 [shard 0:main] storage-gc - disk_log_impl.cc:527 - [{default/test/0}] running sliding window compaction
DEBUG 2023-12-06 16:57:28,873 [shard 0:main] storage-gc - disk_log_impl.cc:530 - [{default/test/0}] no more segments to compact
DEBUG 2023-12-06 16:57:28,873 [shard 0:main] storage-gc - disk_log_impl.cc:1153 - Adjacent segments of {default/test/0}, no adjacent pair
ERROR 2023-12-06 16:57:28,874 [shard 0:main] assert - Assert failure: (/home/andrea/redpanda/redpanda/src/v/storage/segment.cc:504) 'b.base_offset() >= _tracker.base_offset' Invalid state. Attempted to append a batch with base_offset:9, but would invalidate our initial state base offset of:50. Actual batch header:{header_crc:2401767366, size_bytes:98, base_offset:{9}, type:batch_type::tx_fence, crc:984829958, attrs:{compression:none, type:CreateTime, transactional: 0, control: 1}, last_offset_delta:0, first_timestamp:{timestamp: 1701878248873}, max_timestamp:{timestamp: 1701878248873}, producer_id:7, producer_epoch:0, base_sequence:-1, record_count:1, ctx:{term:{1}, owner_shard:{0}}}, self:{offset_tracker:{term:1, base_offset:50, committed_offset:49, dirty_offset:49}, compacted_segment=1, finished_self_compaction=0, finished_windowed_compaction=0, generation={0}, reader={test_dir_hqTXUJ/default/test/0_0/50-1-v1.log, (0 bytes)}, writer={no_of_chunks:64, closed:0, fallocation_offset:0, committed_offset:0, inflight_writes:0, dispatched_writes:0, bytes_flush_pending:0}, cache={cache_size=0}, compaction_index:{name:test_dir_hqTXUJ/default/test/0_0/50-1-v1.compaction_index, key_mem_usage:0, persisted_entries:0, in_memory_entries:0, file_appender:{nullopt}}, closed=0, tombstone=0, index={file:test_dir_hqTXUJ/default/test/0_0/50-1-v1.base_index, offsets:{50}, index:{header_bitflags:0, base_offset:{50}, max_offset:{0}, base_timestamp:{timestamp: 0}, max_timestamp:{timestamp: 0}, batch_timestamps_are_monotonic:1, with_offset:true, non_data_timestamps:0, broker_timestamp:{nullopt}, index(0,0,0)}, step:32768, needs_persistence:0}}
ERROR 2023-12-06 16:57:28,874 [shard 0:main] assert - Backtrace below:
0x8b0cb6 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x5aaf0d2 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x5aaecb5 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x5ab32ee /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x5ab5ccf /home/andrea/redpanda/redpanda/vbuild/Debug/clang/lib/libv_v_storage.so+0x3ab1518 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/lib/libv_v_storage.so+0x3ab42d5 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/lib/libv_v_storage.so+0x3678476 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/lib/libv_v_storage.so+0x367d8c3 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/lib/libv_v_transform.so+0x1083d3b /home/andrea/redpanda/redpanda/vbuild/Debug/clang/lib/libv_v_transform.so+0x108377c /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x47e9c94 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x47f6f11 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x47fd17b /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x47fab55 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x426446c /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x4261e66 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar_testing.so+0x14d228 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar_testing.so+0x14cb20 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar_testing.so+0x14c9e0 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar_testing.so+0x14c984 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar_testing.so+0x148610 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/lib/libv_v_application.so+0x8625d21 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/lib/libv_v_application.so+0x8621888 /home/andrea/redpanda/redpanda/vbuild/Debug/clang/rp_deps_install/lib/libseastar.so+0x45ce4fc /lib/x86_64-linux-gnu/libc.so.6+0x94ac2 /lib/x86_64-linux-gnu/libc.so.6+0x126a3f
   --------
   seastar::internal::coroutine_traits_base<seastar::bool_class<seastar::stop_iteration_tag>>::promise_type
   --------
   seastar::internal::coroutine_traits_base<seastar::bool_class<seastar::stop_iteration_tag>>::promise_type
   --------
   seastar::internal::repeater<auto model::record_batch_reader::impl::do_action<raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer, auto model::record_batch_reader::impl::do_for_each_ref<raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer>(raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer&, std::__1::chrono::time_point<seastar::lowres_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l>>>)::'lambda'(raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer&)>(raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer&, std::__1::chrono::time_point<seastar::lowres_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l>>>, auto model::record_batch_reader::impl::do_for_each_ref<raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer>(raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer&, std::__1::chrono::time_point<seastar::lowres_clock, std::__1::chrono::duration<long long, std::__1::ratio<1l, 1000000000l>>>)::'lambda'(raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer&)&&)::'lambda'()>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<storage::append_result>, seastar::noncopyable_function<seastar::future<storage::append_result> ()>, seastar::future<storage::append_result> seastar::future<void>::then_impl_nrvo<seastar::noncopyable_function<seastar::future<storage::append_result> ()>, seastar::future<storage::append_result>>(seastar::noncopyable_function<seastar::future<storage::append_result> ()>&&)::'lambda'(seastar::internal::promise_base_with_type<storage::append_result>&&, seastar::noncopyable_function<seastar::future<storage::append_result> ()>&, seastar::future_state<seastar::internal::monostate>&&), void>
   --------
   seastar::internal::do_with_state<std::__1::tuple<raft::consensus::disk_append(model::record_batch_reader&&, seastar::bool_class<raft::update_last_quorum_index>)::consumer>, seastar::future<storage::append_result>>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<storage::append_result>, seastar::noncopyable_function<seastar::future<storage::append_result> (seastar::future<storage::append_result>&&)>, seastar::futurize<seastar::future<storage::append_result>>::type seastar::future<storage::append_result>::then_wrapped_nrvo<seastar::future<storage::append_result>, seastar::noncopyable_function<seastar::future<storage::append_result> (seastar::future<storage::append_result>&&)>>(seastar::noncopyable_function<seastar::future<storage::append_result> (seastar::future<storage::append_result>&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<storage::append_result>&&, seastar::noncopyable_function<seastar::future<storage::append_result> (seastar::future<storage::append_result>&&)>&, seastar::future_state<storage::append_result>&&), storage::append_result>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>>, seastar::noncopyable_function<seastar::future<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>> (storage::append_result&&)>, seastar::future<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>> seastar::future<storage::append_result>::then_impl_nrvo<seastar::noncopyable_function<seastar::future<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>> (storage::append_result&&)>, seastar::future<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>>>(seastar::noncopyable_function<seastar::future<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>> (storage::append_result&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>>&&, seastar::noncopyable_function<seastar::future<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>> (storage::append_result&&)>&, seastar::future_state<storage::append_result>&&), storage::append_result>
   --------
   seastar::internal::do_with_state<std::__1::tuple<std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>, seastar::future<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>>>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<storage::append_result>, seastar::noncopyable_function<seastar::future<storage::append_result> (std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>&&)>, seastar::future<storage::append_result> seastar::future<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>>::then_impl_nrvo<seastar::noncopyable_function<seastar::future<storage::append_result> (std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>&&)>, seastar::future<storage::append_result>>(seastar::noncopyable_function<seastar::future<storage::append_result> (std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<storage::append_result>&&, seastar::noncopyable_function<seastar::future<storage::append_result> (std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>&&)>&, seastar::future_state<std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>>&&), std::__1::tuple<storage::append_result, std::__1::vector<raft::offset_configuration, std::__1::allocator<raft::offset_configuration>>>>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>, seastar::noncopyable_function<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> (storage::append_result&&)>, seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> seastar::future<storage::append_result>::then_impl_nrvo<seastar::noncopyable_function<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> (storage::append_result&&)>, seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>>(seastar::noncopyable_function<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> (storage::append_result&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>&&, seastar::noncopyable_function<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> (storage::append_result&&)>&, seastar::future_state<storage::append_result>&&), storage::append_result>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>, seastar::noncopyable_function<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> (seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>&&)>, seastar::futurize<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>>::type seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>::then_wrapped_nrvo<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>, seastar::noncopyable_function<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> (seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>&&)>>(seastar::noncopyable_function<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> (seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>&&, seastar::noncopyable_function<seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>> (seastar::future<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>&&)>&, seastar::future_state<boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>&&), boost::outcome_v2::basic_result<storage::append_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<storage::append_result, std::__1::error_code, void>>>
   --------
   seastar::internal::coroutine_traits_base<boost::outcome_v2::basic_result<raft::replicate_result, std::__1::error_code, boost::outcome_v2::policy::error_code_throw_as_system_error<raft::replicate_result, std::__1::error_code, void>>>::promise_type
   --------
   seastar::internal::coroutine_traits_base<void>::promise_type
   --------
   seastar::internal::coroutine_traits_base<void>::promise_type
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::noncopyable_function<seastar::future<void> (seastar::future<void>&&)>, seastar::futurize<seastar::future<void>>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::noncopyable_function<seastar::future<void> (seastar::future<void>&&)>>(seastar::noncopyable_function<seastar::future<void> (seastar::future<void>&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::noncopyable_function<seastar::future<void> (seastar::future<void>&&)>&, seastar::future_state<seastar::internal::monostate>&&), void>
   --------
   seastar::continuation<seastar::internal::promise_base_with_type<void>, seastar::noncopyable_function<seastar::future<void> (seastar::future<void>&&)>, seastar::futurize<seastar::future<void>>::type seastar::future<void>::then_wrapped_nrvo<seastar::future<void>, seastar::noncopyable_function<seastar::future<void> (seastar::future<void>&&)>>(seastar::noncopyable_function<seastar::future<void> (seastar::future<void>&&)>&&)::'lambda'(seastar::internal::promise_base_with_type<void>&&, seastar::noncopyable_function<seastar::future<void> (seastar::future<void>&&)>&, seastar::future_state<seastar::internal::monostate>&&), void>
Illegal instruction (core dumped)
```

[last_log_single_core.zip](https://github.com/redpanda-data/redpanda/files/13588361/last_log_single_core.zip)


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

a crash log and data dir:
[test_dir_oIYzDZ.crash_log.zip](https://github.com/redpanda-data/redpanda/files/13602163/test_dir_oIYzDZ.crash_log.zip)
[test_dir_oIYzDZ.tar.gz](https://github.com/redpanda-data/redpanda/files/13602166/test_dir_oIYzDZ.tar.gz)
