### PR TITLE
clang-tidy: tweak find_program hints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,12 +57,9 @@ set(Redpanda_ENABLE_CLANG_TIDY "ON" CACHE STRING
 
 if(NOT Redpanda_ENABLE_CLANG_TIDY STREQUAL OFF)
   if(Redpanda_ENABLE_CLANG_TIDY STREQUAL FORCE_ON)
-    find_program(CLANG_TIDY_COMMAND clang-tidy
-      PATHS ${PROJECT_SOURCE_DIR}/vbuild/llvm/install/bin
-      REQUIRED)
+    find_program(CLANG_TIDY_COMMAND clang-tidy REQUIRED)
   else()
-    find_program(CLANG_TIDY_COMMAND clang-tidy
-      PATHS ${PROJECT_SOURCE_DIR}/vbuild/llvm/install/bin)
+    find_program(CLANG_TIDY_COMMAND clang-tidy)
   endif()
   if(CLANG_TIDY_COMMAND)
     set(Redpanda_ENABLE_CLANG_TIDY ON)

--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -10,7 +10,7 @@ add_compile_options(-Wall)
 option(REDPANDA_RUN_CLANG_TIDY "Enable clang-tidy checks" OFF)
 if(REDPANDA_RUN_CLANG_TIDY)
     find_program(CLANG_TIDY_COMMAND clang-tidy
-        PATHS ${PROJECT_SOURCE_DIR}/vbuild/llvm/install/bin)
+        HINTS ${PROJECT_SOURCE_DIR}/vbuild/llvm/install/bin)
     if(NOT CLANG_TIDY_COMMAND)
         message(FATAL_ERROR "Could not find clang-tidy program")
     endif()


### PR DESCRIPTION
Tweak the find_program path hints for clang-tidy in the context of the open-source build and the private build.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

