### PR TITLE
storage: don't recompact segments with no compactible data

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -591,11 +591,12 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     }
     vlog(
       gclog.debug,
-      "[{}] built offset map with {} keys (max allowed {}), max indexed "
-      "key offset: {}",
+      "[{}] built offset map with {} keys (max allowed {}), min segment fully "
+      "indexed base offset: {}, max indexed key offset: {}",
       config().ntp(),
       map.size(),
       map.capacity(),
+      idx_start_offset,
       map.max_offset());
 
     auto segment_modify_lock = co_await _segment_rewrite_lock.get_units();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -541,6 +541,9 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         if (cfg.asrc) {
             cfg.asrc->check();
         }
+        if (seg->finished_self_compaction()) {
+            continue;
+        }
         auto result = co_await storage::internal::self_compact_segment(
           seg,
           _stm_manager,

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -165,6 +165,8 @@ public:
       const compaction_config& cfg,
       std::optional<model::offset> new_start_offset = std::nullopt);
 
+    const auto& compaction_ratio() const { return _compaction_ratio; }
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -109,7 +109,7 @@ ss::future<model::offset> build_offset_map(
             cfg.asrc->check();
         }
         const auto& seg = iter->get();
-        vlog(gclog.debug, "Adding segment to offset map: {}", seg->filename());
+        vlog(gclog.trace, "Adding segment to offset map: {}", seg->filename());
         auto read_lock = co_await seg->read_lock();
         segment_full_path idx_path = seg->path().to_compacted_index();
         std::optional<scoped_file_tracker> to_clean;

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -159,6 +159,7 @@ public:
     std::optional<model::timestamp>
       find_highest_timestamp_before(model::timestamp) const;
 
+    auto first_data_offset() const { return _state.first_data_offset; }
     model::offset base_offset() const { return _state.base_offset; }
     model::offset max_offset() const { return _state.max_offset; }
     model::timestamp max_timestamp() const { return _state.max_timestamp; }

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -281,11 +281,14 @@ TEST_F(CompactionFixtureTest, TestRecompactWithNewData) {
       cardinality);
     disk_log.sliding_window_compact(cfg).get();
     auto segments_compacted = disk_log.get_probe().get_segments_compacted();
+    auto compaction_ratio = disk_log.compaction_ratio().get();
 
     // Subsequent compaction doesn't do anything.
     disk_log.sliding_window_compact(cfg).get();
     auto segments_compacted_2 = disk_log.get_probe().get_segments_compacted();
+    auto compaction_ratio_2 = disk_log.compaction_ratio().get();
     ASSERT_EQ(segments_compacted, segments_compacted_2);
+    ASSERT_EQ(compaction_ratio, compaction_ratio_2);
 
     // But once we add more data, we become eligible for compaction again.
     generate_data(1, cardinality, records_per_segment).get();
@@ -303,7 +306,16 @@ TEST_F(CompactionFixtureTest, TestRecompactWithNewData) {
     // - the new segment is compacted twice (self + windowed)
     // - the segment that previously had the latest keys should be compacted
     auto segments_compacted_3 = disk_log.get_probe().get_segments_compacted();
+    auto compaction_ratio_3 = disk_log.compaction_ratio().get();
     ASSERT_EQ(segments_compacted + 3, segments_compacted_3);
+
+    // Check for a reasonable compaction ratio.
+    ASSERT_LT(compaction_ratio_3, 0.5);
+
+    // Compared to our first compaction ratio that windowed compacted many
+    // segments in a row, one self-compaction + windowed compaction will have a
+    // worse compaction ratio.
+    ASSERT_LT(compaction_ratio, compaction_ratio_3);
 }
 
 // Regression test for a bug when compacting when the last segment is all

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -296,8 +296,14 @@ TEST_F(CompactionFixtureTest, TestRecompactWithNewData) {
       std::nullopt,
       cardinality);
     disk_log.sliding_window_compact(new_cfg).get();
+
+    // Most segments have already compacted their segments away entirely,
+    // except their last record. Such segments shouldn't be compacted. Three
+    // segments should be compacted:
+    // - the new segment is compacted twice (self + windowed)
+    // - the segment that previously had the latest keys should be compacted
     auto segments_compacted_3 = disk_log.get_probe().get_segments_compacted();
-    ASSERT_LT(segments_compacted, segments_compacted_3);
+    ASSERT_EQ(segments_compacted + 3, segments_compacted_3);
 }
 
 // Regression test for a bug when compacting when the last segment is all


### PR DESCRIPTION
Segments may contain records that won't be compacted:
- when all batches are non-data batches, or
- when the only data record is the last record

In either of the above cases, a windowed compaction will repeatedly
result in the same resulting segment, since we only remove non-data
batches and we do not remove the last record.

This commit introduces a new field to the index_state to keep track of
the first data batch in the segment. This is used to determine whether
either of the conditions are true before compacting them. If so, the
segment is skipped for compaction.

Along the way in debugging this issue, I noticed a couple things:
- The compaction ratios weren't being reported by the windowed compaction implementation. This PR includes a fix for this.
- Some logging can be particularly verbose, especially when every segment in the partition is involved. This PR reduces log level, and avoids certain statements entirely.

Fixes #15347
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
