### PR TITLE
cloud_storage: Make wait for hydration abortable

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -278,10 +278,12 @@ remote_segment::offset_data_stream(
   kafka::offset start,
   kafka::offset end,
   std::optional<model::timestamp> first_timestamp,
-  ss::io_priority_class io_priority) {
+  ss::io_priority_class io_priority,
+  storage::opt_abort_source_t as) {
     vlog(_ctxlog.debug, "remote segment file input stream at offset {}", start);
     ss::gate::holder g(_gate);
-    co_await hydrate();
+
+    co_await hydrate(as);
 
     std::optional<offset_index::find_result> indexed_pos;
     std::optional<uint16_t> prefetch_override = std::nullopt;
@@ -872,7 +874,73 @@ ss::future<> remote_segment::run_hydrate_bg() {
     _hydration_loop_running = false;
 }
 
-ss::future<> remote_segment::hydrate() {
+namespace {
+
+void log_hydration_abort_cause(
+  const retry_chain_logger& logger,
+  const ss::lowres_clock::time_point& deadline,
+  storage::opt_abort_source_t as) {
+    if (ss::lowres_clock::now() > deadline) {
+        vlog(logger.warn, "timed out while waiting for hydration");
+    } else if (as.has_value() && as->get().abort_requested()) {
+        // TODO it might be useful to be able to log the client info here from
+        // log reader config.
+        vlog(logger.debug, "consumer disconnected during hydration");
+    }
+}
+
+} // namespace
+
+ss::future<> remote_segment::do_hydrate(
+  ss::abort_source& as, ss::lowres_clock::time_point deadline) {
+    ss::promise<ss::file> p;
+    auto fut = ssx::with_timeout_abortable(p.get_future(), deadline, as);
+
+    _wait_list.push_back(std::move(p), ss::lowres_clock::time_point::max());
+    _bg_cvar.signal();
+
+    return fut
+      .handle_exception_type(
+        [this, deadline, &as](const ss::timed_out_error& ex) {
+            log_hydration_abort_cause(_ctxlog, deadline, as);
+            return ss::make_exception_future<ss::file>(ex);
+        })
+      .handle_exception_type(
+        [this, deadline, &as](const ss::abort_requested_exception& ex) {
+            log_hydration_abort_cause(_ctxlog, deadline, as);
+            return ss::make_exception_future<ss::file>(ex);
+        })
+      .handle_exception_type(
+        [this, deadline, &as](const download_exception& ex) {
+            // If we are working with an index-only format, and index
+            // download failed, we may not be able to progress. So we
+            // fallback to old format where the full segment was downloaded,
+            // and try to hydrate again.
+            if (ex.path == _index_path && !_fallback_mode) {
+                vlog(
+                  _ctxlog.info,
+                  "failed to download index with error [{}], switching to "
+                  "fallback mode and retrying hydration.",
+                  ex);
+                _fallback_mode = fallback_mode::yes;
+                return do_hydrate(as, deadline).then([] {
+                    // This is an empty file to match the type returned by
+                    // `fut`. The result is discarded immediately so it is
+                    // unused.
+                    return ss::file{};
+                });
+            }
+
+            // If the download failure was something other than the index,
+            // OR if we are in the fallback mode already or if we are
+            // working with old format, rethrow the exception and let the
+            // upper layer handle it.
+            return ss::make_exception_future<ss::file>(ex);
+        })
+      .discard_result();
+}
+
+ss::future<> remote_segment::hydrate(storage::opt_abort_source_t as) {
     if (!_hydration_loop_running) {
         vlog(
           _ctxlog.error,
@@ -886,37 +954,15 @@ ss::future<> remote_segment::hydrate() {
 
     auto g = _gate.hold();
     vlog(_ctxlog.debug, "segment {} hydration requested", _path);
-    ss::promise<ss::file> p;
-    auto fut = p.get_future();
-    _wait_list.push_back(std::move(p), ss::lowres_clock::time_point::max());
-    _bg_cvar.signal();
-    return fut
-      .handle_exception_type([this](const download_exception& ex) {
-          // If we are working with an index-only format, and index download
-          // failed, we may not be able to progress. So we fallback to old
-          // format where the full segment was downloaded, and try to hydrate
-          // again.
-          if (ex.path == _index_path && !_fallback_mode) {
-              vlog(
-                _ctxlog.info,
-                "failed to download index with error [{}], switching to "
-                "fallback mode and retrying hydration.",
-                ex);
-              _fallback_mode = fallback_mode::yes;
-              return hydrate().then([] {
-                  // This is an empty file to match the type returned by `fut`.
-                  // The result is discarded immediately so it is unused.
-                  return ss::file{};
-              });
-          }
 
-          // If the download failure was something other than the index, OR
-          // if we are in the fallback mode already or if we are working
-          // with old format, rethrow the exception and let the upper layer
-          // handle it.
-          throw;
-      })
-      .discard_result();
+    // A no-op abort source is created on heap so that `do_hydrate` can call
+    // `with_timeout_abortable` if we do not have an input abort source.
+    return ss::do_with(ss::abort_source{}, [this, as](ss::abort_source& noop) {
+        return do_hydrate(
+          as.value_or(noop),
+          ss::lowres_clock::now()
+            + config::shard_local_cfg().cloud_storage_hydration_timeout_ms());
+    });
 }
 
 ss::future<> remote_segment::hydrate_chunk(segment_chunk_range range) {
@@ -1371,7 +1417,8 @@ remote_segment_batch_reader::init_parser() {
       model::offset_cast(_config.start_offset),
       model::offset_cast(_config.max_offset),
       _config.first_timestamp,
-      priority_manager::local().shadow_indexing_priority());
+      priority_manager::local().shadow_indexing_priority(),
+      _config.abort_source);
 
     vlog(
       _ctxlog.debug,

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -31,6 +31,7 @@
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/expiring_fifo.hh>
 #include <seastar/core/io_priority_class.hh>
+#include <seastar/core/shared_future.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
 
@@ -114,14 +115,22 @@ public:
       kafka::offset start,
       kafka::offset end,
       std::optional<model::timestamp>,
-      ss::io_priority_class);
+      ss::io_priority_class,
+      storage::opt_abort_source_t as);
+
+    /// Hydrates the segment, index or tx-range depending on segment meta
+    /// version, returning a future that the caller can use to wait for the
+    /// download to finish. If the abort source is triggered or the deadline is
+    /// reached before the download finishes, the wait is aborted. The download
+    /// will still complete but the caller will need to handle the exception.
+    ss::future<> do_hydrate(ss::abort_source&, ss::lowres_clock::time_point);
 
     /// Hydrate the segment for segment meta version v2 or lower. For v3 or
     /// higher, only hydrate the index. If the index hydration fails, fall back
     /// to old mode where the full segment is hydrated. For v3 or higher
     /// versions, the actual segment data is hydrated by the data source
     /// implementation, but the index is still required to be present first.
-    ss::future<> hydrate();
+    ss::future<> hydrate(storage::opt_abort_source_t as = std::nullopt);
 
     /// Hydrate a part of a segment, identified by the given range. The range
     /// can contain data for multiple contiguous chunks, in which case multiple

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1922,6 +1922,14 @@ configuration::configuration()
       "option should be disabled.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       true)
+  , cloud_storage_hydration_timeout_ms(
+      *this,
+      "cloud_storage_hydration_timeout_ms",
+      "Duration to wait for a hydration request to be fulfilled, if hydration "
+      "is not completed within this time, the consumer will be notified with a "
+      "timeout error.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      600s)
   , cloud_storage_azure_storage_account(
       *this,
       "cloud_storage_azure_storage_account",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -359,6 +359,7 @@ struct configuration final : public config_store {
       cloud_storage_topic_purge_grace_period_ms;
     property<bool> cloud_storage_disable_upload_consistency_checks;
     property<bool> cloud_storage_disable_metadata_consistency_checks;
+    property<std::chrono::milliseconds> cloud_storage_hydration_timeout_ms;
 
     // Azure Blob Storage
     property<std::optional<ss::sstring>> cloud_storage_azure_storage_account;


### PR DESCRIPTION
When a consumer is waiting for hydration, the underlying kafka connection may disconnect. The read path will still wait for the hydration to finish.

This change adds a subscription to the abort source wired in with the kafka connection - if that abort source is triggered, which happens when the consumer disconnects, the read path fiber waiting for the hydration is notified by setting the promise to aborted exception.

A new setting `cloud_storage_hydration_timeout_ms` is added which defaults to 10 minutes, to control the time the fiber will wait for hydration.

* If the consumer disconnects before `cloud_storage_hydration_timeout_ms` passes, the wait for hydration is aborted. 
* If the timeout equal to `cloud_storage_hydration_timeout_ms` passes, and the consumer has not yet disconnected, the wait for hydration is aborted. 
* For code paths where the consumer abort source is not available yet (chunk read path, transactions), the `cloud_storage_hydration_timeout_ms` setting alone is used to abort the wait for hydration when this time limit passes.

When the wait is aborted during hydrate, the remote partition reader logs a message at debug level and the read is finished and the control returns to the kafka fetch handler. 

If the consumer has disconnected, in a future PR it may be useful to throw a special client disconnected error which will allow the read path not to return data to the client.

The download will still progress, so if there are multiple waiters for a segment, and one of them disconnects, the others will still get access to the file.

Chunk read path is not covered by these changes, as hydration for chunks does not run in background like full segment downloads, and will require more work to be able to abort on consumer disconnect.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
