### PR TITLE
tests: increased number of admin operation retries

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -398,7 +398,9 @@ class RandomNodeOperationsTest(PreallocNodesTest):
         # admin day 2 operations executed during the test
         self.admin_fuzz = AdminOperationsFuzzer(self.redpanda,
                                                 min_replication=3,
-                                                operations_interval=3)
+                                                operations_interval=3,
+                                                retries_interval=10,
+                                                retries=10)
 
         self.admin_fuzz.start()
         self.active_node_idxs = set(


### PR DESCRIPTION
Increased number of admin operation retires in RandomNodeOperations test. Since the test is executed in highly unstable environment connection resets and unavailable nodes are the first class citizens. Made admin operations fuzzer more permissive by increasing number of retries to reduce false positive test failures.

Fixes: #15339

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none