### PR TITLE
r/consensus: update _last_leader_visible_offset on leader as well

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -331,18 +331,6 @@ static ss::future<read_result> do_read_from_ntp(
     }
 
     if (offset_ec != error_code::none) {
-        vlog(
-          klog.warn,
-          "fetch offset out of range for {}, requested offset: {}, "
-          "partition start offset: {}, high watermark: {}, log end offset: {} "
-          "ec: {}",
-          ntp_config.ktp(),
-          ntp_config.cfg.start_offset,
-          kafka_partition->start_offset(),
-          kafka_partition->high_watermark(),
-          kafka_partition->log_end_offset(),
-          offset_ec);
-
         co_return read_result(
           offset_ec,
           kafka_partition->start_offset(),

--- a/src/v/kafka/server/partition_proxy.h
+++ b/src/v/kafka/server/partition_proxy.h
@@ -37,7 +37,6 @@ public:
           sync_effective_start(model::timeout_clock::duration) = 0;
         virtual model::offset start_offset() const = 0;
         virtual model::offset high_watermark() const = 0;
-        virtual model::offset log_end_offset() const = 0;
         virtual checked<model::offset, error_code>
         last_stable_offset() const = 0;
         virtual kafka::leader_epoch leader_epoch() const = 0;
@@ -89,7 +88,6 @@ public:
     model::offset start_offset() const { return _impl->start_offset(); }
 
     model::offset high_watermark() const { return _impl->high_watermark(); }
-    model::offset log_end_offset() const { return _impl->log_end_offset(); }
 
     checked<model::offset, error_code> last_stable_offset() const {
         return _impl->last_stable_offset();

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -89,7 +89,7 @@ public:
      * According to Kafka protocol semantics a log_end_offset is an offset that
      * is assigned to the next record produced to a log
      */
-    model::offset log_end_offset() const final {
+    model::offset log_end_offset() const {
         if (_partition->is_read_replica_mode_enabled()) {
             if (_partition->cloud_data_available()) {
                 return model::next_offset(_partition->next_cloud_offset());

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -441,9 +441,6 @@ private:
         model::offset high_watermark() const final {
             throw std::runtime_error("unimplemented");
         }
-        model::offset log_end_offset() const final {
-            throw std::runtime_error("unimplemented");
-        }
         checked<model::offset, kafka::error_code>
         last_stable_offset() const final {
             throw std::runtime_error("unimplemented");

--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -94,8 +94,12 @@ class KafkaCliConsumer(BackgroundThreadService):
         finally:
             self._done = True
 
+    def message_cnt(self):
+        with self._lock:
+            return self._message_cnt
+
     def wait_for_messages(self, messages, timeout=30):
-        wait_until(lambda: self._message_cnt >= messages,
+        wait_until(lambda: self.message_cnt() >= messages,
                    timeout,
                    backoff_sec=2)
 


### PR DESCRIPTION
Previously _last_leader_visible_offset was updated only from info in append_entries requests. This meant that on a leader that was stepping down there was a small window between stepping down and receiving the first append_entries from the new leader, where _last_leader_visible_offset value was bogus. This led offset_out_of_range errors when serving valid fetch requests as a follower. Fix this by updating _last_leader_visible_offset value while we are the leader as well.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Bug Fixes
* Fix a bug that resulted in `offset_out_of_range` errors for valid fetch offsets when fetching from followers that had recently lost leadership.