### PR TITLE
[v23.2.x] rpk: manually update golangci-lint version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.52.2
+        version: v1.55.0
         args: --timeout 5m
         working-directory: src/go/rpk/
 

--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -248,7 +248,7 @@ func CreateNode(
 	if err != nil {
 		return nil, err
 	}
-	kPort, err := nat.NewPort( //nolint:revive // var-naming diff here is intended kPort = kafkaPort.
+	kPort, err := nat.NewPort(
 		"tcp",
 		strconv.Itoa(int(externalKafkaPort)),
 	)


### PR DESCRIPTION
We use `latest` in dev, but v22.3 was using an old
version that was causing errors in CI

**Why?**
Our GH actions:
- Download Go's `stable` version.
- Download the pinned version of golangci-lint. (Previously 1.52)

From the GH Actions [Doc](https://github.com/actions/setup-go#using-stableoldstable-aliases), Go's `stable` version comes from the go-version [repository manifest](https://github.com/actions/go-versions/blob/main/versions-manifest.json) and this was updated yesterday to 1.21.5, and `golangci-lint@1.52` is incompatible with this new version.

 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
