### PR TITLE
goreleaser: add completion to brew formulas

### DIFF
--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -78,6 +78,8 @@ brews:
     skip_upload: auto
     ids:
       - rpk
+    extra_install: |
+      generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
     caveats: |
         Redpanda Keeper (rpk) is Redpanda's command line interface (CLI)
         utility. The rpk commands let you configure, manage, and tune


### PR DESCRIPTION
This will make users that install 'rpk' via brew
to have auto-completion by default.

Fixes #12488


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
