### PR TITLE
New scale test for audit logging

### DIFF
--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -844,7 +844,8 @@ bool audit_log_manager::do_enqueue_audit_event(
         if (!units) {
             vlog(
               adtlog.warn,
-              "Unable to enqueue audit message, msg size: {}, avail units: {}",
+              "Unable to enqueue audit event {}, msg size: {}, avail units: {}",
+              *msg,
               msg_size,
               _queue_bytes_sem.available_units());
             probe().audit_error();

--- a/src/v/security/audit/schemas/application_activity.h
+++ b/src/v/security/audit/schemas/application_activity.h
@@ -89,6 +89,13 @@ private:
     status_id _status_id;
     api_activity_unmapped _unmapped;
 
+    ss::sstring api_info() const final {
+        if (_http_request) {
+            return _http_request->url.path;
+        }
+        return _api.operation;
+    }
+
     size_t hash() const final { return std::hash<api_activity>()(*this); }
 
     friend inline void rjson_serialize(

--- a/src/v/security/audit/schemas/iam.h
+++ b/src/v/security/audit/schemas/iam.h
@@ -123,6 +123,8 @@ private:
     std::optional<ss::sstring> _status_detail;
     user _user;
 
+    ss::sstring api_info() const final { return _user.name; }
+
     size_t hash() const final { return std::hash<authentication>()(*this); }
 
     friend inline void rjson_serialize(

--- a/src/v/security/audit/schemas/schemas.h
+++ b/src/v/security/audit/schemas/schemas.h
@@ -46,6 +46,7 @@ public:
     ocsf_base_impl& operator=(const ocsf_base_impl&) = delete;
     virtual ~ocsf_base_impl() = default;
 
+    virtual ss::sstring api_info() const = 0;
     virtual ss::sstring to_json() const = 0;
     virtual size_t key() const noexcept = 0;
     virtual size_t estimated_size() const noexcept = 0;
@@ -70,6 +71,8 @@ public:
         return sizeof(*this)
                + estimated_ocsf_size(*static_cast<const Derived*>(this));
     }
+
+    ss::sstring api_info() const override { return ""; }
 
     size_t key() const noexcept final {
         size_t h = 0;

--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -429,7 +429,8 @@ std::ostream& operator<<(std::ostream& os, const class_uid& uid) {
 std::ostream& operator<<(std::ostream& os, const ocsf_base_impl& impl) {
     return os << "{category: " << impl.get_category_uid()
               << ", class: " << impl.get_class_uid()
-              << ", type_uid: " << impl.get_type_uid()() << "}";
+              << ", type_uid: " << impl.get_type_uid()()
+              << ", detail: " << impl.api_info() << "}";
 }
 
 event_type kafka_api_to_event_type(kafka::api_key key) {

--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -9,6 +9,7 @@
 
 import time
 import threading
+from ducktape.mark import ok_to_fail
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
@@ -290,6 +291,10 @@ class AuditLogTest(RedpandaTest):
             # to me able to assert on other properties of the test run.
             return make_result_set(t1, repeater)
 
+    # Temporarily marking as ok_to_fail so we can observe in CI how full
+    # the audit queues are during the scale test so we can appropriately
+    # set the audit configuration parameters listed above
+    @ok_to_fail
     @cluster(num_nodes=5)
     def test_audit_log(self):
         """

--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -1,0 +1,403 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+import threading
+from rptest.clients.types import TopicSpec
+from rptest.clients.rpk import RpkTool
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import SaslCredentials
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.utils.scale_parameters import ScaleParameters
+from rptest.services.kgo_repeater_service import KgoRepeaterService, repeater_traffic
+from rptest.services.redpanda import SaslCredentials, SecurityConfig, MetricsEndpoint, MetricSample, LoggingConfig
+from rptest.tests.cluster_config_test import wait_for_version_sync
+from rptest.util import wait_until_result
+from ducktape.errors import TimeoutError
+
+# How much memory to assign to redpanda per partition. Redpanda will be started
+# with MIB_PER_PARTITION * PARTITIONS_PER_SHARD * CORE_COUNT memory
+DEFAULT_MIB_PER_PARTITION = 4
+
+# How many partitions we will create per shard: this is the primary scaling
+# factor that controls how many partitions a given cluster will get.
+PARTITIONS_PER_SHARD = 1000
+
+
+class AuditLogTestSecurityConfig(SecurityConfig):
+    """
+    Hardcoded security parameters for the audit scale tests. SASL will be
+    the authentication method of choice
+    """
+    sasl_credentials = SaslCredentials('rob', '123rob456', 'SCRAM-SHA-256')
+
+    def __init__(self):
+        super(AuditLogTestSecurityConfig, self).__init__()
+        self.enable_sasl = True
+        self.kafka_enable_authorization = True
+        self.endpoint_authn_method = 'sasl'
+        self.tls_provider = None
+
+
+class AuditBenchmarkResults():
+    def __init__(self, time_elapsed: float, final_totals: tuple[int, int],
+                 latencies: tuple[float, float, float], message_size: int):
+        self.time_elapsed = time_elapsed
+        self.messages_produced = final_totals[0]
+        self.messages_consumed = final_totals[1]
+        self.message_size = message_size
+        self.p50 = latencies[0]
+        self.p90 = latencies[1]
+        self.p99 = latencies[2]
+
+    def _mbps(self, b: float) -> float:
+        return (b / self.time_elapsed) / (1024.0 * 1024.0)
+
+    @property
+    def produce_mbps(self) -> float:
+        bytes_produced = self.messages_produced * self.message_size
+        return self._mbps(bytes_produced)
+
+    @property
+    def consume_mbps(self) -> float:
+        bytes_consumed = self.messages_consumed * self.message_size
+        return self._mbps(bytes_consumed)
+
+    @property
+    def total_mbps(self) -> float:
+        total_bytes_moved = (self.messages_produced +
+                             self.messages_consumed) * self.message_size
+        return self._mbps(total_bytes_moved)
+
+    def __repr__(self):
+        return str({
+            'time_elapsed': self.time_elapsed,
+            'total_produced': self.messages_produced,
+            'total_consumed': self.messages_consumed,
+            'p50': self.p50,
+            'p90': self.p90,
+            'p99': self.p99
+        })
+
+
+class AuditLogTest(RedpandaTest):
+    """
+    Test to ensure that enabling auditing does not create a discernable decrease
+    in performance.
+    """
+    topics = ()
+
+    def __init__(self, ctx, *args, **kwargs):
+        # Ensure redpanda is setup with sasl_enabled and endpoints are configured
+        # to work with SASL, otherwise audit client will not be able to connect
+        self.security = AuditLogTestSecurityConfig()
+
+        # We will send huge numbers of messages, so tune down the log verbosity
+        # as we will be comparing performance to a known good baseline
+        kwargs['log_config'] = LoggingConfig(
+            'info', logger_levels={'auditing': 'debug'})
+
+        kwargs['extra_rp_conf'] = {
+            # Authentication is mandatory for auditing
+            'enable_sasl':
+            True,
+
+            # No auditing will occur without the global feature flag set to True
+            'audit_enabled':
+            True,
+
+            # The default is 8, but for a scale test its desired to increase the
+            # number of partitions to handle the expected load
+            'audit_log_num_partitions':
+            12,
+
+            # RF factor for the audit log, the default is 3 however if there is
+            # only 1 node, the replication factor is 1 and will increase to this
+            # configured value if the number of nodes can support it
+            'audit_log_replication_factor':
+            3,
+
+            # Enable auditing for every supported event, there are currently 8
+            'audit_enabled_event_types': [
+                'management', 'produce', 'consume', 'describe', 'heartbeat',
+                'authenticate', 'admin', 'schema_registry'
+            ],
+
+            # Adjust this value to give the system a chance to buffer more data
+            # at the kafka client size
+            # default: 16MiB
+            'audit_client_max_buffer_size':
+            16000000,
+
+            # This is the frequency at which queues are drained for data to be
+            # buffered to the kafka client. Increase this value to buffer more
+            # data which increases the likelihood of compressing duplicate events
+            # and reducing the total amount of data sent to the audit topic
+            # default: 500ms
+            'audit_queue_drain_interval_ms':
+            2000,
+
+            # How large the per shard audit buffers are. The more unique events
+            # and the more time the data spends residing in the buffer, the
+            # larger this may have to become. If this queue is exhausted events
+            # for which audited is enabled for will fail is the event cannot be
+            # enqueued
+            # default: 1MiB
+            'audit_queue_max_buffer_size_per_shard':
+            1000000,
+        }
+
+        super().__init__(test_context=ctx,
+                         security=self.security,
+                         *args,
+                         **kwargs)
+
+        self.superuser = self.redpanda.SUPERUSER_CREDENTIALS
+        self.user_creds = AuditLogTestSecurityConfig.sasl_credentials
+
+        self._ctx = ctx
+        self.admin = Admin(self.redpanda,
+                           auth=(self.superuser.username,
+                                 self.superuser.password))
+        self._super_rpk = RpkTool(self.redpanda,
+                                  username=self.superuser.username,
+                                  password=self.superuser.password,
+                                  sasl_mechanism=self.superuser.algorithm)
+        self._user_rpk = RpkTool(self.redpanda,
+                                 username=self.user_creds.username,
+                                 password=self.user_creds.password,
+                                 sasl_mechanism=self.user_creds.algorithm)
+
+    def _create_audit_test_sasl_user(self):
+        self._super_rpk.sasl_create_user(self.user_creds.username,
+                                         self.user_creds.password)
+        self._super_rpk.sasl_allow_principal(
+            f'User:{self.user_creds.username}', ['all'], 'topic', '*')
+        self._super_rpk.sasl_allow_principal(
+            f'User:{self.user_creds.username}', ['all'], 'group', '*')
+        # Attempt to list topics to check if the above worked
+        self._user_rpk.list_topics()
+
+    def _repeater_worker_count(self, scale):
+        workers = 32 * scale.node_cpus
+        if self.redpanda.dedicated_nodes:
+            return workers
+        else:
+            return min(workers, 4)
+
+    def _get_audit_metrics(self):
+        def get_metrics_from_nodes():
+            patterns = [
+                "audit_buffer_usage_ratio",
+                "audit_client_buffer_usage_ratio",
+            ]
+            samples = self.redpanda.metrics_samples(patterns,
+                                                    self.redpanda.nodes,
+                                                    MetricsEndpoint.METRICS)
+            success = samples is not None and set(
+                samples.keys()) == set(patterns)
+            return success, samples
+
+        try:
+            results = wait_until_result(get_metrics_from_nodes,
+                                        timeout_sec=5,
+                                        backoff_sec=1)
+
+            def avg_metric(mss: list[MetricSample]):
+                values = [x.value for x in mss]
+                return sum(values) / len(values) if len(values) > 0 else -1
+
+            return {
+                name: avg_metric(mss.samples)
+                for name, mss in results.items()
+            }
+
+        except TimeoutError as _:
+            self.redpanda.logger.warn(f"Timed out getting audit metrics")
+
+        return {}
+
+    def _run_repeater(self, topics: list[str], scale: ScaleParameters):
+        repeater_kwargs = {'key_count': 2**32}
+        repeater_msg_size = 16384
+        rate_limit_bps = int(scale.expect_bandwidth)
+        max_buffered_records = 64
+
+        def make_result_set(initial_time: float, repeater: KgoRepeaterService):
+            t2 = time.time()
+            total_time_elapsed = t2 - initial_time
+            final_totals = repeater.total_messages()
+            latency = repeater.latency_reports()
+            if latency == ():
+                raise RuntimeError(
+                    "Couldn't fetch latency report from kgo-repeater")
+            return AuditBenchmarkResults(total_time_elapsed, final_totals,
+                                         latency, repeater_msg_size)
+
+        stop_thread = False
+
+        def periodically_log_metrics():
+            while stop_thread is not True:
+                self.redpanda.logger.info(
+                    f"Aggregated audit metrics: \n{self._get_audit_metrics()}")
+                time.sleep(3)
+
+        with repeater_traffic(context=self._ctx,
+                              redpanda=self.redpanda,
+                              sasl_options=self.user_creds,
+                              topics=topics,
+                              msg_size=repeater_msg_size,
+                              rate_limit_bps=rate_limit_bps,
+                              workers=self._repeater_worker_count(scale),
+                              max_buffered_records=max_buffered_records,
+                              **repeater_kwargs) as repeater:
+            # soak for two minutes
+            soak_time_seconds = 120
+            soak_await_bytes = soak_time_seconds * scale.expect_bandwidth
+            soak_await_msgs = soak_await_bytes / repeater_msg_size
+            # Add some leeway to avoid flakiness
+            soak_timeout = soak_time_seconds * 1.25
+            t1 = time.time()
+            repeater.reset()
+            metrics_log_thread = threading.Thread(
+                target=periodically_log_metrics, args=())
+            try:
+                metrics_log_thread.start()
+                repeater.await_progress(soak_await_msgs, soak_timeout)
+            except TimeoutError:
+                # Progress is determined by a certain number of total messages produces and
+                # consumed arriving after a predetermined amount of time, in this case 2 minutes.
+                # If that does not occur the TimeoutError is thrown by repeater.await_progress
+
+                result_set = make_result_set(t1, repeater)
+                expected_produce_mbps = scale.expect_bandwidth / (1024 *
+                                                                  1024.0)
+                raise TimeoutError(
+                    f"Expected throughput {expected_produce_mbps:.2f}, got throughput {result_set.produce_mbps:.2f}MB/s"
+                )
+            finally:
+                stop_thread = True
+                metrics_log_thread.join()
+
+            # If the estimated progress was made, the results are returned to the caller
+            # to me able to assert on other properties of the test run.
+            return make_result_set(t1, repeater)
+
+    @cluster(num_nodes=5)
+    def test_audit_log(self):
+        """
+        This test attempts to create a worst-case-scenario for audit logging -
+        what exactly would that be? It would be a case where many events are distinct
+        from eachother which would prevent the system from reducing the total amount
+        of messages that are needed to be produced onto the audit topic.
+
+        The best way to abuse this would be via the produce path, to produce messages
+        with a high cardinality. Messages are determined to be equivalent if they:
+
+        1. Have the same API type (so kafka::<produce>, or admin_api::<endpoint>)
+        2. Have the same authorization result (so user, ip, credentials, etc)
+        3. Have the same request parameters
+
+        For point (3) the detail of request parameters is usually not so exhaustive, for
+        example in a produce request only the topics not the partitions are part of the
+        audit payload. This means increasing the number of partitions will introduce more
+        traffic only up until a certain point. Only when partitions for the same topic
+        reside on different cores will they produce distinct auditable events.
+
+        Due to the above this test will use many clients with many topics (and a light
+        number of partitions, enough to have 1 per shard) to generate a many
+        unique auditable messages from the produce, consume and authentication
+        APIs.
+        """
+
+        # Scale tests are not run on debug builds
+        assert not self.debug_mode
+
+        # This user will be passed to the kgo-repeater program
+        self._create_audit_test_sasl_user()
+
+        # Message cardinality formula:
+        # distinct_events = number_of_workers * number_of_cores * number_of_topics
+        #
+        # Adding more partitions past the number of cores won't matter because
+        # the partition_id isn't part of the audit message payload. We will want only the
+        # number of partitions up until there is one per core in the entire cluster. To
+        # scale further then that we want to increase the number of topics.
+        scale = ScaleParameters(
+            self.redpanda,
+            replication_factor=3,
+            mib_per_partition=DEFAULT_MIB_PER_PARTITION,
+            topic_partitions_per_shard=PARTITIONS_PER_SHARD)
+        partitions_per_topic = self.redpanda.get_node_cpu_count() * len(
+            self.redpanda.nodes)
+        total_topics = scale.partition_limit // partitions_per_topic
+        assert total_topics >= 1
+
+        # Create the topics as configured with the scale definition above stopping when
+        # the partition limit has been exhausted. The partition limit must be spread across
+        # a number of topics so that no topic has more then partitions_per_topic partitions.
+        topics = [
+            TopicSpec(partition_count=partitions_per_topic)
+            for _ in range(0, total_topics)
+        ]
+        extra_partitions = scale.partition_limit % partitions_per_topic
+        if extra_partitions > 0:
+            # If partition_limit doesn't evenly divide into the total number of shards,
+            # create an extra topic with the number of partitions containing the diff
+            topics = topics + [TopicSpec(partition_count=extra_partitions)]
+        self.redpanda.logger.info(
+            f"Creating {len(topics)} topics almost all with {partitions_per_topic} partitions with options: segment.bytes {scale.segment_size} topic retention.bytes {scale.retention_bytes}"
+        )
+        for topic in topics:
+            self._user_rpk.create_topic(topic.name,
+                                        partitions=topic.partition_count,
+                                        replicas=3,
+                                        config={
+                                            "segment.bytes":
+                                            scale.segment_size,
+                                            "retention.bytes":
+                                            scale.retention_bytes
+                                        })
+
+        # Use the kgo-repeater to generate traffic for 2 minutes
+        # Then assert that the traffic is within an expected range
+        topic_names = [topic.name for topic in topics]
+        audit_enabled_results = self._run_repeater(topic_names, scale)
+
+        # Disable auditing
+        patch_result = self.admin.patch_cluster_config(
+            upsert={'audit_enabled': False})
+        wait_for_version_sync(self.admin, self.redpanda,
+                              patch_result['config_version'])
+
+        # Re-run the test and compare results
+        audit_disabled_results = self._run_repeater(topic_names, scale)
+
+        # Assert that there is no more then a x% difference in produce and consume throughput
+        allowable_threshold = 10.0
+
+        def pct_difference(a, b):
+            return (abs(a - b) / abs((a + b) / 2)) * 100
+
+        self.redpanda.logger.info(
+            f"audit_disabled_results: {audit_disabled_results}")
+        self.redpanda.logger.info(
+            f"audit_enabled_results: {audit_enabled_results}")
+
+        assert pct_difference(
+            audit_disabled_results.produce_mbps,
+            audit_enabled_results.produce_mbps) <= allowable_threshold
+        assert pct_difference(
+            audit_disabled_results.consume_mbps,
+            audit_enabled_results.consume_mbps) <= allowable_threshold
+        assert pct_difference(audit_disabled_results.p90,
+                              audit_enabled_results.p90) <= allowable_threshold
+        assert pct_difference(audit_disabled_results.p99,
+                              audit_enabled_results.p99) <= allowable_threshold

--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -20,11 +20,12 @@ from rptest.clients.rpk import RpkTool, RpkException
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.utils.si_utils import nodes_report_cloud_segments
 from rptest.services.rpk_consumer import RpkConsumer
-from rptest.services.redpanda import ResourceSettings, RESTART_LOG_ALLOW_LIST, SISettings, LoggingConfig, MetricsEndpoint
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, LoggingConfig, MetricsEndpoint
 from rptest.services.kgo_verifier_services import KgoVerifierProducer, KgoVerifierSeqConsumer, KgoVerifierRandomConsumer
 from rptest.services.kgo_repeater_service import KgoRepeaterService, repeater_traffic
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
+from rptest.utils.scale_parameters import ScaleParameters
 
 # An unreasonably large fetch request: we submit requests like this in the
 # expectation that the server will properly clamp the amount of data it
@@ -40,15 +41,6 @@ DEFAULT_MIB_PER_PARTITION = 4
 # factor that controls how many partitions a given cluster will get.
 DEFAULT_PARTITIONS_PER_SHARD = 1000
 
-# Number of partitions to create when running in docker (i.e.
-# when dedicated_nodes=false).  This is independent of the
-# amount of RAM or CPU that the nodes claim to have, because
-# we know they are liable to be oversubscribed.
-# This is _not_ for running on oversubscribed CI environments: it's for
-# running on a reasonably powerful developer machine while they work
-# on the test.
-DOCKER_PARTITION_LIMIT = 128
-
 # Large volume of data to write. If tiered storage is enabled this is the
 # amount of data to retain total. Otherwise, this can be used as a large volume
 # of data to write.
@@ -57,185 +49,6 @@ STRESS_DATA_SIZE = 1024 * 1024 * 1024 * 100
 # When running with tiered storage, it's been observed that shutdown can take
 # on the order of a few minutes.
 STOP_TIMEOUT = 60 * 5
-
-
-class ScaleParameters:
-    def __init__(self,
-                 redpanda,
-                 replication_factor,
-                 mib_per_partition,
-                 topic_partitions_per_shard,
-                 tiered_storage_enabled=False):
-        self.redpanda = redpanda
-        self.tiered_storage_enabled = tiered_storage_enabled
-
-        node_count = len(self.redpanda.nodes)
-
-        node_memory = self.redpanda.get_node_memory_mb()
-        self.node_cpus = self.redpanda.get_node_cpu_count()
-        node_disk_free = self.redpanda.get_node_disk_free()
-
-        self.logger.info(
-            f"Nodes have {self.node_cpus} cores, {node_memory}MB memory, {node_disk_free / (1024 * 1024)}MB free disk"
-        )
-
-        # On large nodes, reserve half of shard 0 to minimize interference
-        # between data and control plane, as control plane messages become
-        # very large.
-        shard0_reserve = None
-        if self.node_cpus >= 8:
-            shard0_reserve = topic_partitions_per_shard / 2
-
-        # Reserve a few slots for internal partitions. This is a count of
-        # partitions and we assume the replication factor is 'replication_factor'
-        # in order to calculate the associated number of partition replicas.
-        #
-        # The way we calculate internal partitions in practice is complicated
-        # and this value is an over-simplification. See generate-tiers.py for
-        # additional details on internal partition calculations.
-        internal_partition_slack = 32
-
-        # Calculate how many partitions we will aim to create, based
-        # on the size & count of nodes.  This enables running the
-        # test on various instance sizes without explicitly adjusting.
-        self.partition_limit = int(
-            (node_count * self.node_cpus * topic_partitions_per_shard) /
-            replication_factor - internal_partition_slack)
-        if shard0_reserve:
-            self.partition_limit -= node_count * shard0_reserve
-
-        if not self.redpanda.dedicated_nodes:
-            self.partition_limit = min(DOCKER_PARTITION_LIMIT,
-                                       self.partition_limit)
-
-        self.logger.info(f"Selected partition limit {self.partition_limit}")
-
-        # Emulate seastar's policy for default reserved memory
-        reserved_memory = max(1536, int(0.07 * node_memory) + 1)
-        effective_node_memory = node_memory - reserved_memory
-
-        partition_replicas_per_node = int(self.partition_limit *
-                                          replication_factor // node_count)
-
-        # Aim to use about half the disk space: set retention limits
-        # to enforce that.  This enables traffic tests to run as long
-        # as they like without risking filling the disk.
-        self.retention_bytes = int(
-            (node_disk_free / 2) / partition_replicas_per_node)
-        self.local_retention_bytes = None
-
-        # Choose an appropriate segment size to enable retention
-        # rules to kick in promptly.
-        # TODO: redpanda should figure this out automatically by
-        #       rolling segments pre-emptively if low on disk space
-        self.segment_size = int(self.retention_bytes / 4)
-
-        # Tiered storage will have a warmup period where it will set the
-        # segment size and local retention lower to ensure a large number of
-        # segments.
-        self.segment_size_after_warmup = self.segment_size
-
-        # NOTE: using retention_bytes that is aimed at occupying disk space.
-        self.local_retention_after_warmup = self.retention_bytes
-
-        if tiered_storage_enabled:
-            # When testing with tiered storage, the tuning goals of the test
-            # parameters are different: we want to stress the number of
-            # uploaded segments.
-
-            # Locally retain as many segments as a full day.
-            self.segment_size = 32 * 1024
-
-            # Retain as much data in cloud as one big batch of data.
-            # NOTE: we consider the existing `retention_bytes` (computed above)
-            # so the test doesn't take too much space on disk.
-            self.local_retention_bytes = min(self.retention_bytes,
-                                             self.segment_size * 24)
-
-            # One of the goals of this test with tiered storage enabled is to
-            # test with a large number of managed cloud segments.
-            # TODO: consider a variant of this test (or another test) that
-            # tests cloud retention.
-            self.retention_bytes = -1
-
-            # Set a max upload interval such that won't swamp S3 -- we should
-            # already be uploading somewhat frequently given the segment size.
-            cloud_storage_segment_max_upload_interval_sec = 300
-            cloud_storage_housekeeping_interval_ms = cloud_storage_segment_max_upload_interval_sec * 1000
-
-            self.si_settings = SISettings(
-                redpanda._context,
-                log_segment_size=self.segment_size,
-                cloud_storage_segment_max_upload_interval_sec=
-                cloud_storage_segment_max_upload_interval_sec,
-                cloud_storage_housekeeping_interval_ms=
-                cloud_storage_housekeeping_interval_ms,
-            )
-        else:
-            self.si_settings = None
-
-        # The expect_bandwidth is just for calculating sensible
-        # timeouts when waiting for traffic: it is not a scientific
-        # success condition for the tests.
-        if self.redpanda.dedicated_nodes:
-            # A 24 core i3en.6xlarge has about 1GB/s disk write
-            # bandwidth.  Divide by 2 to give comfortable room for variation.
-            # This is total bandwidth from a group of producers.
-            self.expect_bandwidth = (node_count / replication_factor) * (
-                self.node_cpus / 24.0) * 1E9 * 0.5
-
-            # Single-producer tests are slower, bottlenecked on the
-            # client side.
-            self.expect_single_bandwidth = 200E6
-        else:
-            # Docker environment: curb your expectations.  Not only is storage
-            # liable to be slow, we have many nodes sharing the same drive.
-            self.expect_bandwidth = 5 * 1024 * 1024
-            self.expect_single_bandwidth = 10E6
-
-        if tiered_storage_enabled:
-            self.expect_bandwidth /= 2
-            self.expect_single_bandwidth /= 2
-
-        # Clamp the node memory to exercise the partition limit.
-        # Not all internal partitions have rf=replication_factor so this
-        # over-allocates but making it more accurate would be complicated.
-        per_node_slack = internal_partition_slack * replication_factor / node_count
-        partition_mem_total_per_node = mib_per_partition * (
-            partition_replicas_per_node + per_node_slack)
-
-        resource_settings_args = {}
-        if not self.redpanda.dedicated_nodes:
-            # In docker, assume we're on a laptop drive and not doing
-            # real testing, so disable fsync to make test run faster.
-            resource_settings_args['bypass_fsync'] = True
-
-            partition_mem_total_per_node = max(partition_mem_total_per_node,
-                                               500)
-        else:
-            # On dedicated nodes we will use an explicit reactor stall threshold
-            # as a success condition.
-            resource_settings_args['reactor_stall_threshold'] = 100
-
-        resource_settings_args['memory_mb'] = int(partition_mem_total_per_node)
-
-        self.redpanda.set_resource_settings(
-            ResourceSettings(**resource_settings_args))
-
-        self.logger.info(
-            f"Selected retention.bytes={self.retention_bytes}, retention.local.target.bytes={self.local_retention_bytes}, segment.bytes={self.segment_size}"
-        )
-
-        # Should not happen on the expected EC2 instance types where
-        # the cores-RAM ratio is sufficient to meet our shards-per-core
-        if effective_node_memory < partition_mem_total_per_node:
-            raise RuntimeError(
-                f"Node memory is too small ({node_memory}MB - {reserved_memory}MB)"
-            )
-
-    @property
-    def logger(self):
-        return self.redpanda.logger
 
 
 class ManyPartitionsTest(PreallocNodesTest):

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -409,6 +409,12 @@ class KgoRepeaterService(Service):
                                  backoff_sec=1,
                                  err_msg=err_msg)
 
+    def reset(self):
+        """Internally resets the metrics accumulated within the kgo-repeater"""
+        for node in self.nodes:
+            r = requests.get(self._remote_url(node, "reset"), timeout=10)
+            r.raise_for_status()
+
 
 @contextmanager
 def repeater_traffic(context,

--- a/tests/rptest/services/kgo_repeater_service.py
+++ b/tests/rptest/services/kgo_repeater_service.py
@@ -37,7 +37,7 @@ class KgoRepeaterService(Service):
                  *,
                  nodes: Optional[list[ClusterNode]] = None,
                  num_nodes: Optional[int] = None,
-                 topic: str,
+                 topics: list[str],
                  msg_size: Optional[int],
                  workers: int,
                  key_count: Optional[int] = None,
@@ -64,7 +64,7 @@ class KgoRepeaterService(Service):
             self.nodes = nodes
 
         self.redpanda = redpanda
-        self.topic = topic
+        self.topics = topics
         self.msg_size = msg_size
         self.workers = workers
         self.group_name = group_name
@@ -104,9 +104,10 @@ class KgoRepeaterService(Service):
     def start_node(self, node, clean=None):
         initial_data_mb = self.mb_per_worker * self.workers
 
+        topics = ",".join(self.topics)
         cmd = (
             "/opt/kgo-verifier/kgo-repeater "
-            f"-topic {self.topic} -brokers {self.redpanda.brokers()} "
+            f"-topics {topics} -brokers {self.redpanda.brokers()} "
             f"-workers {self.workers} -initial-data-mb {initial_data_mb} "
             f"-group {self.group_name} -remote -remote-port {self.remote_port} "
         )

--- a/tests/rptest/tests/cpu_profiler_admin_api_test.py
+++ b/tests/rptest/tests/cpu_profiler_admin_api_test.py
@@ -37,7 +37,7 @@ class CPUProfilerAdminAPITest(RedpandaTest):
         # Provide traffic so there is something to sample.
         with repeater_traffic(context=self.test_context,
                               redpanda=self.redpanda,
-                              topic=self.topic,
+                              topics=[self.topic],
                               msg_size=4096,
                               workers=1) as repeater:
             repeater.await_group_ready()

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -68,7 +68,7 @@ class KgoRepeaterSelfTest(RedpandaTest):
         with repeater_traffic(context=self.test_context,
                               redpanda=self.redpanda,
                               num_nodes=2,
-                              topic=topic,
+                              topics=[topic],
                               msg_size=4096,
                               workers=1) as repeater:
             repeater.await_group_ready()
@@ -186,7 +186,7 @@ class BucketScrubSelfTest(RedpandaTest):
 
         with repeater_traffic(context=self.test_context,
                               redpanda=self.redpanda,
-                              topic=topic,
+                              topics=[topic],
                               msg_size=msg_size,
                               workers=1) as repeater:
             repeater.await_group_ready()

--- a/tests/rptest/utils/functional.py
+++ b/tests/rptest/utils/functional.py
@@ -26,4 +26,4 @@ def flatten(input_list):
 
     Returns all lists concatenated into one
     """
-    return reduce(lambda acc, x: acc + x, input_list)
+    return reduce(lambda acc, x: acc + x, input_list, [])

--- a/tests/rptest/utils/scale_parameters.py
+++ b/tests/rptest/utils/scale_parameters.py
@@ -1,0 +1,198 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.services.redpanda import ResourceSettings, SISettings
+
+
+class ScaleParameters:
+    # Number of partitions to create when running in docker (i.e.
+    # when dedicated_nodes=false).  This is independent of the
+    # amount of RAM or CPU that the nodes claim to have, because
+    # we know they are liable to be oversubscribed.
+    # This is _not_ for running on oversubscribed CI environments: it's for
+    # running on a reasonably powerful developer machine while they work
+    # on the test.
+    DOCKER_PARTITION_LIMIT = 128
+
+    def __init__(self,
+                 redpanda,
+                 replication_factor,
+                 mib_per_partition,
+                 topic_partitions_per_shard,
+                 tiered_storage_enabled=False):
+        self.redpanda = redpanda
+        self.tiered_storage_enabled = tiered_storage_enabled
+
+        node_count = len(self.redpanda.nodes)
+
+        node_memory = self.redpanda.get_node_memory_mb()
+        self.node_cpus = self.redpanda.get_node_cpu_count()
+        node_disk_free = self.redpanda.get_node_disk_free()
+
+        self.logger.info(
+            f"Nodes have {self.node_cpus} cores, {node_memory}MB memory, {node_disk_free / (1024 * 1024)}MB free disk"
+        )
+
+        # On large nodes, reserve half of shard 0 to minimize interference
+        # between data and control plane, as control plane messages become
+        # very large.
+        shard0_reserve = None
+        if self.node_cpus >= 8:
+            shard0_reserve = topic_partitions_per_shard / 2
+
+        # Reserve a few slots for internal partitions. This is a count of
+        # partitions and we assume the replication factor is 'replication_factor'
+        # in order to calculate the associated number of partition replicas.
+        #
+        # The way we calculate internal partitions in practice is complicated
+        # and this value is an over-simplification. See generate-tiers.py for
+        # additional details on internal partition calculations.
+        internal_partition_slack = 32
+
+        # Calculate how many partitions we will aim to create, based
+        # on the size & count of nodes.  This enables running the
+        # test on various instance sizes without explicitly adjusting.
+        self.partition_limit = int(
+            (node_count * self.node_cpus * topic_partitions_per_shard) /
+            replication_factor - internal_partition_slack)
+        if shard0_reserve:
+            self.partition_limit -= node_count * shard0_reserve
+
+        if not self.redpanda.dedicated_nodes:
+            self.partition_limit = min(ScaleParameters.DOCKER_PARTITION_LIMIT,
+                                       self.partition_limit)
+
+        self.logger.info(f"Selected partition limit {self.partition_limit}")
+
+        # Emulate seastar's policy for default reserved memory
+        reserved_memory = max(1536, int(0.07 * node_memory) + 1)
+        effective_node_memory = node_memory - reserved_memory
+
+        partition_replicas_per_node = int(self.partition_limit *
+                                          replication_factor // node_count)
+
+        # Aim to use about half the disk space: set retention limits
+        # to enforce that.  This enables traffic tests to run as long
+        # as they like without risking filling the disk.
+        self.retention_bytes = int(
+            (node_disk_free / 2) / partition_replicas_per_node)
+        self.local_retention_bytes = None
+
+        # Choose an appropriate segment size to enable retention
+        # rules to kick in promptly.
+        # TODO: redpanda should figure this out automatically by
+        #       rolling segments pre-emptively if low on disk space
+        self.segment_size = int(self.retention_bytes / 4)
+
+        # Tiered storage will have a warmup period where it will set the
+        # segment size and local retention lower to ensure a large number of
+        # segments.
+        self.segment_size_after_warmup = self.segment_size
+
+        # NOTE: using retention_bytes that is aimed at occupying disk space.
+        self.local_retention_after_warmup = self.retention_bytes
+
+        if tiered_storage_enabled:
+            # When testing with tiered storage, the tuning goals of the test
+            # parameters are different: we want to stress the number of
+            # uploaded segments.
+
+            # Locally retain as many segments as a full day.
+            self.segment_size = 32 * 1024
+
+            # Retain as much data in cloud as one big batch of data.
+            # NOTE: we consider the existing `retention_bytes` (computed above)
+            # so the test doesn't take too much space on disk.
+            self.local_retention_bytes = min(self.retention_bytes,
+                                             self.segment_size * 24)
+
+            # One of the goals of this test with tiered storage enabled is to
+            # test with a large number of managed cloud segments.
+            # TODO: consider a variant of this test (or another test) that
+            # tests cloud retention.
+            self.retention_bytes = -1
+
+            # Set a max upload interval such that won't swamp S3 -- we should
+            # already be uploading somewhat frequently given the segment size.
+            cloud_storage_segment_max_upload_interval_sec = 300
+            cloud_storage_housekeeping_interval_ms = cloud_storage_segment_max_upload_interval_sec * 1000
+
+            self.si_settings = SISettings(
+                redpanda._context,
+                log_segment_size=self.segment_size,
+                cloud_storage_segment_max_upload_interval_sec=
+                cloud_storage_segment_max_upload_interval_sec,
+                cloud_storage_housekeeping_interval_ms=
+                cloud_storage_housekeeping_interval_ms,
+            )
+        else:
+            self.si_settings = None
+
+        # The expect_bandwidth is just for calculating sensible
+        # timeouts when waiting for traffic: it is not a scientific
+        # success condition for the tests.
+        if self.redpanda.dedicated_nodes:
+            # A 24 core i3en.6xlarge has about 1GB/s disk write
+            # bandwidth.  Divide by 2 to give comfortable room for variation.
+            # This is total bandwidth from a group of producers.
+            self.expect_bandwidth = (node_count / replication_factor) * (
+                self.node_cpus / 24.0) * 1E9 * 0.5
+
+            # Single-producer tests are slower, bottlenecked on the
+            # client side.
+            self.expect_single_bandwidth = 200E6
+        else:
+            # Docker environment: curb your expectations.  Not only is storage
+            # liable to be slow, we have many nodes sharing the same drive.
+            self.expect_bandwidth = 5 * 1024 * 1024
+            self.expect_single_bandwidth = 10E6
+
+        if tiered_storage_enabled:
+            self.expect_bandwidth /= 2
+            self.expect_single_bandwidth /= 2
+
+        # Clamp the node memory to exercise the partition limit.
+        # Not all internal partitions have rf=replication_factor so this
+        # over-allocates but making it more accurate would be complicated.
+        per_node_slack = internal_partition_slack * replication_factor / node_count
+        partition_mem_total_per_node = mib_per_partition * (
+            partition_replicas_per_node + per_node_slack)
+
+        resource_settings_args = {}
+        if not self.redpanda.dedicated_nodes:
+            # In docker, assume we're on a laptop drive and not doing
+            # real testing, so disable fsync to make test run faster.
+            resource_settings_args['bypass_fsync'] = True
+
+            partition_mem_total_per_node = max(partition_mem_total_per_node,
+                                               500)
+        else:
+            # On dedicated nodes we will use an explicit reactor stall threshold
+            # as a success condition.
+            resource_settings_args['reactor_stall_threshold'] = 100
+
+        resource_settings_args['memory_mb'] = int(partition_mem_total_per_node)
+
+        self.redpanda.set_resource_settings(
+            ResourceSettings(**resource_settings_args))
+
+        self.logger.info(
+            f"Selected retention.bytes={self.retention_bytes}, retention.local.target.bytes={self.local_retention_bytes}, segment.bytes={self.segment_size}"
+        )
+
+        # Should not happen on the expected EC2 instance types where
+        # the cores-RAM ratio is sufficient to meet our shards-per-core
+        if effective_node_memory < partition_mem_total_per_node:
+            raise RuntimeError(
+                f"Node memory is too small ({node_memory}MB - {reserved_memory}MB)"
+            )
+
+    @property
+    def logger(self):
+        return self.redpanda.logger


### PR DESCRIPTION
Introduce a new scale test for audit logging. The test environment leverages the kgo-repeater to generate traffic over a set number of topics so that many unique audit messages are generated, making a sort of almost worst-case scenario event for the system.

This would be a case where auditing doesn't have the oppurtunity to combine like messages. These for example would be produce messages coming from the same topic on the same shard (since partition_id is not part of the audit message payload only topic name).  Therefore this test differes from other scale tests which typically use one topic and a large number of partitions. Instead the audit scale test ensures a topic can only have as many partitions as CPUs exist in the cluster, if more are desired, they must be spread across multiple topics.

This patch leverages a recent change in the kgo-repeater to make the program multi topic aware. https://github.com/redpanda-data/kgo-verifier/pull/47

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
