### PR TITLE
tests/docker: Bump kgo-verifier version

### DIFF
--- a/tests/docker/ducktape-deps/kgo-verifier
+++ b/tests/docker/ducktape-deps/kgo-verifier
@@ -2,6 +2,6 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
 cd /opt/kgo-verifier
-git reset --hard 0ce461399d3336cc825ff28a780582bab7bdefe4
+git reset --hard e3f1f87896194a607f468feb97dd3e66d720d771
 go mod tidy
 make


### PR DESCRIPTION
- Will include latest changes to make the kgo-repeater multi topic aware

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none