### PR TITLE
[v23.2.x] rpk produce: Adjust timeout and maxBytes options

### DIFF
--- a/src/go/rpk/pkg/cli/topic/produce.go
+++ b/src/go/rpk/pkg/cli/topic/produce.go
@@ -91,12 +91,14 @@ func newProduceCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				out.Die("invalid --delivery-timeout less than 1s")
 			default:
 				opts = append(opts, kgo.RecordDeliveryTimeout(timeout))
+				opts = append(opts, kgo.ProduceRequestTimeout(timeout+5*time.Second))
 			}
 			if partition >= 0 {
 				opts = append(opts, kgo.RecordPartitioner(kgo.ManualPartitioner()))
 			}
 			if maxMessageBytes >= 0 {
 				opts = append(opts, kgo.ProducerBatchMaxBytes(maxMessageBytes))
+				opts = append(opts, kgo.BrokerMaxWriteBytes(2*maxMessageBytes))
 			}
 			var defaultTopic string
 			if len(args) == 1 {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15371
Fixes: https://github.com/redpanda-data/redpanda/issues/15379,