### PR TITLE
admin: split out handlers for usage, transactions

### DIFF
--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -48,6 +48,7 @@ v_cc_library(
     admin/security.cc
     admin/recovery.cc
     admin/transaction.cc
+    admin/usage.cc
     cli_parser.cc
     application.cc
     monitor_unsafe_log_flag.cc

--- a/src/v/redpanda/CMakeLists.txt
+++ b/src/v/redpanda/CMakeLists.txt
@@ -47,6 +47,7 @@ v_cc_library(
     admin/transform.cc
     admin/security.cc
     admin/recovery.cc
+    admin/transaction.cc
     cli_parser.cc
     application.cc
     monitor_unsafe_log_flag.cc

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -83,7 +83,6 @@
 #include "redpanda/admin/api-doc/security.json.hh"
 #include "redpanda/admin/api-doc/shadow_indexing.json.hh"
 #include "redpanda/admin/api-doc/status.json.hh"
-#include "redpanda/admin/api-doc/transform.json.hh"
 #include "redpanda/cluster_config_schema_util.h"
 #include "resource_mgmt/memory_sampling.h"
 #include "rpc/errc.h"

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -45,7 +45,6 @@
 #include "cluster/topic_recovery_status_frontend.h"
 #include "cluster/topic_recovery_status_rpc_handler.h"
 #include "cluster/topics_frontend.h"
-#include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
@@ -85,7 +84,6 @@
 #include "redpanda/admin/api-doc/security.json.hh"
 #include "redpanda/admin/api-doc/shadow_indexing.json.hh"
 #include "redpanda/admin/api-doc/status.json.hh"
-#include "redpanda/admin/api-doc/transaction.json.hh"
 #include "redpanda/admin/api-doc/transform.json.hh"
 #include "redpanda/admin/api-doc/usage.json.hh"
 #include "redpanda/cluster_config_schema_util.h"
@@ -256,9 +254,8 @@ model::ntp admin_server::parse_ntp_from_request(ss::httpd::parameters& param) {
     return parse_ntp_from_request(param, model::ns(param["namespace"]));
 }
 
-namespace {
-model::ntp
-parse_ntp_from_query_param(const std::unique_ptr<ss::http::request>& req) {
+model::ntp admin_server::parse_ntp_from_query_param(
+  const std::unique_ptr<ss::http::request>& req) {
     auto ns = req->get_query_param("namespace");
     auto topic = req->get_query_param("topic");
     auto partition_str = req->get_query_param("partition_id");
@@ -277,8 +274,6 @@ parse_ntp_from_query_param(const std::unique_ptr<ss::http::request>& req) {
 
     return {std::move(ns), std::move(topic), partition};
 }
-
-} // namespace
 
 admin_server::admin_server(
   admin_server_cfg cfg,
@@ -3819,201 +3814,6 @@ void admin_server::register_hbadger_routes() {
                    [m, p] { finjector::shard_local_badger().unset(m, p); })
             .then(
               [] { return ss::json::json_return_type(ss::json::json_void()); });
-      });
-}
-
-ss::future<ss::json::json_return_type>
-admin_server::get_all_transactions_handler(
-  std::unique_ptr<ss::http::request> req) {
-    if (!config::shard_local_cfg().enable_transactions) {
-        throw ss::httpd::bad_request_exception("Transaction are disabled");
-    }
-
-    auto coordinator_partition_str = req->get_query_param(
-      "coordinator_partition_id");
-    int64_t coordinator_partition;
-    try {
-        coordinator_partition = std::stoi(coordinator_partition_str);
-    } catch (...) {
-        throw ss::httpd::bad_param_exception(fmt::format(
-          "Partition must be an integer: {}", coordinator_partition_str));
-    }
-
-    if (coordinator_partition < 0) {
-        throw ss::httpd::bad_param_exception(fmt::format(
-          "Invalid coordinator partition {}", coordinator_partition));
-    }
-
-    model::ntp tx_ntp(
-      model::tx_manager_nt.ns,
-      model::tx_manager_nt.tp,
-      model::partition_id(coordinator_partition));
-
-    if (need_redirect_to_leader(tx_ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, tx_ntp);
-    }
-
-    auto& tx_frontend = _partition_manager.local().get_tx_frontend();
-    if (!tx_frontend.local_is_initialized()) {
-        throw ss::httpd::bad_request_exception("Can not get tx_frontend");
-    }
-
-    auto res = co_await tx_frontend.local()
-                 .get_all_transactions_for_one_tx_partition(tx_ntp);
-    if (!res.has_value()) {
-        co_await throw_on_error(*req, res.error(), tx_ntp);
-    }
-
-    using tx_info = ss::httpd::transaction_json::transaction_summary;
-    std::vector<tx_info> ans;
-    ans.reserve(res.value().size());
-
-    for (auto& tx : res.value()) {
-        if (tx.status == cluster::tm_transaction::tx_status::tombstone) {
-            continue;
-        }
-
-        tx_info new_tx;
-
-        new_tx.transactional_id = tx.id;
-
-        ss::httpd::transaction_json::producer_identity pid;
-        pid.id = tx.pid.id;
-        pid.epoch = tx.pid.epoch;
-        new_tx.pid = pid;
-
-        new_tx.tx_seq = tx.tx_seq;
-        new_tx.etag = tx.etag;
-
-        // The motivation behind mapping killed to aborting is to make
-        // user not to think about the subtle differences between both
-        // statuses
-        if (tx.status == cluster::tm_transaction::tx_status::killed) {
-            tx.status = cluster::tm_transaction::tx_status::aborting;
-        }
-        new_tx.status = ss::sstring(tx.get_status());
-
-        new_tx.timeout_ms = tx.get_timeout().count();
-        new_tx.staleness_ms = tx.get_staleness().count();
-
-        for (auto& partition : tx.partitions) {
-            ss::httpd::transaction_json::partition partition_info;
-            partition_info.ns = partition.ntp.ns;
-            partition_info.topic = partition.ntp.tp.topic;
-            partition_info.partition_id = partition.ntp.tp.partition;
-            partition_info.etag = partition.etag;
-
-            new_tx.partitions.push(partition_info);
-        }
-
-        for (auto& group : tx.groups) {
-            ss::httpd::transaction_json::group group_info;
-            group_info.group_id = group.group_id;
-            group_info.etag = group.etag;
-
-            new_tx.groups.push(group_info);
-        }
-
-        ans.push_back(std::move(new_tx));
-    }
-
-    co_return ss::json::json_return_type(ans);
-}
-
-ss::future<ss::json::json_return_type>
-admin_server::find_tx_coordinator_handler(
-  std::unique_ptr<ss::http::request> req) {
-    auto transaction_id = req->param["transactional_id"];
-    kafka::transactional_id tid(transaction_id);
-    auto& tx_frontend = _partition_manager.local().get_tx_frontend();
-    auto r = co_await tx_frontend.local().find_coordinator(tid);
-
-    ss::httpd::transaction_json::find_coordinator_reply reply;
-    if (r.coordinator) {
-        reply.coordinator = r.coordinator.value()();
-    }
-    if (r.ntp) {
-        ss::httpd::transaction_json::ntp ntp;
-        ntp.ns = r.ntp->ns();
-        ntp.topic = r.ntp->tp.topic();
-        ntp.partition = r.ntp->tp.partition();
-        reply.ntp = ntp;
-    }
-    reply.ec = static_cast<int>(r.ec);
-
-    co_return ss::json::json_return_type(std::move(reply));
-}
-
-ss::future<ss::json::json_return_type>
-admin_server::delete_partition_handler(std::unique_ptr<ss::http::request> req) {
-    auto& tx_frontend = _partition_manager.local().get_tx_frontend();
-    if (!tx_frontend.local_is_initialized()) {
-        throw ss::httpd::bad_request_exception("Transaction are disabled");
-    }
-    auto transaction_id = req->param["transactional_id"];
-    kafka::transactional_id tid(transaction_id);
-
-    auto r = co_await tx_frontend.local().find_coordinator(tid);
-    if (!r.ntp) {
-        throw ss::httpd::bad_request_exception("Coordinator not available");
-    }
-    if (need_redirect_to_leader(*r.ntp, _metadata_cache)) {
-        throw co_await redirect_to_leader(*req, *r.ntp);
-    }
-
-    auto tx_ntp = tx_frontend.local().ntp_for_tx_id(tid);
-    if (!tx_ntp) {
-        throw ss::httpd::bad_request_exception("Coordinator not available");
-    }
-
-    auto ntp = parse_ntp_from_query_param(req);
-
-    auto etag_str = req->get_query_param("etag");
-    int64_t etag;
-    try {
-        etag = std::stoi(etag_str);
-    } catch (...) {
-        throw ss::httpd::bad_param_exception(
-          fmt::format("Etag must be an integer: {}", etag_str));
-    }
-
-    if (etag < 0) {
-        throw ss::httpd::bad_param_exception(
-          fmt::format("Invalid etag {}", etag));
-    }
-
-    cluster::tm_transaction::tx_partition partition_for_delete{
-      .ntp = ntp, .etag = model::term_id(etag)};
-
-    vlog(
-      adminlog.info,
-      "Delete partition(ntp: {}, etag: {}) from transaction({})",
-      ntp,
-      etag,
-      tid);
-
-    auto res = co_await tx_frontend.local().delete_partition_from_tx(
-      tid, partition_for_delete);
-    co_await throw_on_error(*req, res, ntp);
-    co_return ss::json::json_return_type(ss::json::json_void());
-}
-void admin_server::register_transaction_routes() {
-    register_route<user>(
-      ss::httpd::transaction_json::get_all_transactions,
-      [this](std::unique_ptr<ss::http::request> req) {
-          return get_all_transactions_handler(std::move(req));
-      });
-
-    register_route<user>(
-      ss::httpd::transaction_json::delete_partition,
-      [this](std::unique_ptr<ss::http::request> req) {
-          return delete_partition_handler(std::move(req));
-      });
-
-    register_route<user>(
-      ss::httpd::transaction_json::find_coordinator,
-      [this](std::unique_ptr<ss::http::request> req) {
-          return find_tx_coordinator_handler(std::move(req));
       });
 }
 

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -395,6 +395,9 @@ private:
     static bool need_redirect_to_leader(
       model::ntp ntp, ss::sharded<cluster::metadata_cache>& metadata_cache);
 
+    static model::ntp
+    parse_ntp_from_query_param(const std::unique_ptr<ss::http::request>& req);
+
     void log_request(
       const ss::http::request& req,
       const request_auth_result& auth_state) const;

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -208,6 +208,8 @@ private:
 
     static model::node_id parse_broker_id(const ss::http::request& req);
 
+    static bool str_to_bool(std::string_view s);
+
     /**
      * Helper for binding handlers to routes, which also adds in
      * authentication step and common request logging.  Expects

--- a/src/v/redpanda/admin/transaction.cc
+++ b/src/v/redpanda/admin/transaction.cc
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cluster/partition_manager.h"
+#include "cluster/tx_gateway_frontend.h"
+#include "redpanda/admin/api-doc/transaction.json.hh"
+#include "redpanda/admin/server.h"
+
+void admin_server::register_transaction_routes() {
+    register_route<user>(
+      ss::httpd::transaction_json::get_all_transactions,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return get_all_transactions_handler(std::move(req));
+      });
+
+    register_route<user>(
+      ss::httpd::transaction_json::delete_partition,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return delete_partition_handler(std::move(req));
+      });
+
+    register_route<user>(
+      ss::httpd::transaction_json::find_coordinator,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return find_tx_coordinator_handler(std::move(req));
+      });
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::get_all_transactions_handler(
+  std::unique_ptr<ss::http::request> req) {
+    if (!config::shard_local_cfg().enable_transactions) {
+        throw ss::httpd::bad_request_exception("Transaction are disabled");
+    }
+
+    auto coordinator_partition_str = req->get_query_param(
+      "coordinator_partition_id");
+    int64_t coordinator_partition;
+    try {
+        coordinator_partition = std::stoi(coordinator_partition_str);
+    } catch (...) {
+        throw ss::httpd::bad_param_exception(fmt::format(
+          "Partition must be an integer: {}", coordinator_partition_str));
+    }
+
+    if (coordinator_partition < 0) {
+        throw ss::httpd::bad_param_exception(fmt::format(
+          "Invalid coordinator partition {}", coordinator_partition));
+    }
+
+    model::ntp tx_ntp(
+      model::tx_manager_nt.ns,
+      model::tx_manager_nt.tp,
+      model::partition_id(coordinator_partition));
+
+    if (need_redirect_to_leader(tx_ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, tx_ntp);
+    }
+
+    auto& tx_frontend = _partition_manager.local().get_tx_frontend();
+    if (!tx_frontend.local_is_initialized()) {
+        throw ss::httpd::bad_request_exception("Can not get tx_frontend");
+    }
+
+    auto res = co_await tx_frontend.local()
+                 .get_all_transactions_for_one_tx_partition(tx_ntp);
+    if (!res.has_value()) {
+        co_await throw_on_error(*req, res.error(), tx_ntp);
+    }
+
+    using tx_info = ss::httpd::transaction_json::transaction_summary;
+    std::vector<tx_info> ans;
+    ans.reserve(res.value().size());
+
+    for (auto& tx : res.value()) {
+        if (tx.status == cluster::tm_transaction::tx_status::tombstone) {
+            continue;
+        }
+
+        tx_info new_tx;
+
+        new_tx.transactional_id = tx.id;
+
+        ss::httpd::transaction_json::producer_identity pid;
+        pid.id = tx.pid.id;
+        pid.epoch = tx.pid.epoch;
+        new_tx.pid = pid;
+
+        new_tx.tx_seq = tx.tx_seq;
+        new_tx.etag = tx.etag;
+
+        // The motivation behind mapping killed to aborting is to make
+        // user not to think about the subtle differences between both
+        // statuses
+        if (tx.status == cluster::tm_transaction::tx_status::killed) {
+            tx.status = cluster::tm_transaction::tx_status::aborting;
+        }
+        new_tx.status = ss::sstring(tx.get_status());
+
+        new_tx.timeout_ms = tx.get_timeout().count();
+        new_tx.staleness_ms = tx.get_staleness().count();
+
+        for (auto& partition : tx.partitions) {
+            ss::httpd::transaction_json::partition partition_info;
+            partition_info.ns = partition.ntp.ns;
+            partition_info.topic = partition.ntp.tp.topic;
+            partition_info.partition_id = partition.ntp.tp.partition;
+            partition_info.etag = partition.etag;
+
+            new_tx.partitions.push(partition_info);
+        }
+
+        for (auto& group : tx.groups) {
+            ss::httpd::transaction_json::group group_info;
+            group_info.group_id = group.group_id;
+            group_info.etag = group.etag;
+
+            new_tx.groups.push(group_info);
+        }
+
+        ans.push_back(std::move(new_tx));
+    }
+
+    co_return ss::json::json_return_type(ans);
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::find_tx_coordinator_handler(
+  std::unique_ptr<ss::http::request> req) {
+    auto transaction_id = req->param["transactional_id"];
+    kafka::transactional_id tid(transaction_id);
+    auto& tx_frontend = _partition_manager.local().get_tx_frontend();
+    auto r = co_await tx_frontend.local().find_coordinator(tid);
+
+    ss::httpd::transaction_json::find_coordinator_reply reply;
+    if (r.coordinator) {
+        reply.coordinator = r.coordinator.value()();
+    }
+    if (r.ntp) {
+        ss::httpd::transaction_json::ntp ntp;
+        ntp.ns = r.ntp->ns();
+        ntp.topic = r.ntp->tp.topic();
+        ntp.partition = r.ntp->tp.partition();
+        reply.ntp = ntp;
+    }
+    reply.ec = static_cast<int>(r.ec);
+
+    co_return ss::json::json_return_type(std::move(reply));
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::delete_partition_handler(std::unique_ptr<ss::http::request> req) {
+    auto& tx_frontend = _partition_manager.local().get_tx_frontend();
+    if (!tx_frontend.local_is_initialized()) {
+        throw ss::httpd::bad_request_exception("Transaction are disabled");
+    }
+    auto transaction_id = req->param["transactional_id"];
+    kafka::transactional_id tid(transaction_id);
+
+    auto r = co_await tx_frontend.local().find_coordinator(tid);
+    if (!r.ntp) {
+        throw ss::httpd::bad_request_exception("Coordinator not available");
+    }
+    if (need_redirect_to_leader(*r.ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, *r.ntp);
+    }
+
+    auto tx_ntp = tx_frontend.local().ntp_for_tx_id(tid);
+    if (!tx_ntp) {
+        throw ss::httpd::bad_request_exception("Coordinator not available");
+    }
+
+    auto ntp = parse_ntp_from_query_param(req);
+
+    auto etag_str = req->get_query_param("etag");
+    int64_t etag;
+    try {
+        etag = std::stoi(etag_str);
+    } catch (...) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("Etag must be an integer: {}", etag_str));
+    }
+
+    if (etag < 0) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("Invalid etag {}", etag));
+    }
+
+    cluster::tm_transaction::tx_partition partition_for_delete{
+      .ntp = ntp, .etag = model::term_id(etag)};
+
+    vlog(
+      adminlog.info,
+      "Delete partition(ntp: {}, etag: {}) from transaction({})",
+      ntp,
+      etag,
+      tid);
+
+    auto res = co_await tx_frontend.local().delete_partition_from_tx(
+      tid, partition_for_delete);
+    co_await throw_on_error(*req, res, ntp);
+    co_return ss::json::json_return_type(ss::json::json_void());
+}

--- a/src/v/redpanda/admin/usage.cc
+++ b/src/v/redpanda/admin/usage.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "kafka/server/usage_manager.h"
+#include "redpanda/admin/api-doc/usage.json.hh"
+#include "redpanda/admin/server.h"
+
+namespace {
+ss::json::json_return_type raw_data_to_usage_response(
+  const std::vector<kafka::usage_window>& total_usage, bool include_open) {
+    std::vector<ss::httpd::usage_json::usage_response> resp;
+    resp.reserve(total_usage.size());
+    for (size_t i = (include_open ? 0 : 1); i < total_usage.size(); ++i) {
+        resp.emplace_back();
+        const auto& e = total_usage[i];
+        resp.back().begin_timestamp = e.begin;
+        resp.back().end_timestamp = e.end;
+        resp.back().open = e.is_open();
+        resp.back().kafka_bytes_received_count = e.u.bytes_received;
+        resp.back().kafka_bytes_sent_count = e.u.bytes_sent;
+        if (e.u.bytes_cloud_storage) {
+            resp.back().cloud_storage_bytes_gauge = *e.u.bytes_cloud_storage;
+        } else {
+            resp.back().cloud_storage_bytes_gauge = -1;
+        }
+    }
+    if (include_open && !resp.empty()) {
+        /// Handle case where client does not want to observe
+        /// value of 0 for open buckets end timestamp
+        auto& e = resp.at(0);
+        vassert(e.open(), "Bucket not open when expecting to be");
+        e.end_timestamp = std::chrono::duration_cast<std::chrono::seconds>(
+                            ss::lowres_system_clock::now().time_since_epoch())
+                            .count();
+    }
+    return resp;
+}
+} // namespace
+
+void admin_server::register_usage_routes() {
+    register_route<user>(
+      ss::httpd::usage_json::get_usage,
+      [this](std::unique_ptr<ss::http::request> req) {
+          if (!config::shard_local_cfg().enable_usage()) {
+              throw ss::httpd::bad_request_exception(
+                "Usage tracking is not enabled");
+          }
+          bool include_open = false;
+          auto include_open_str = req->get_query_param("include_open_bucket");
+          vlog(
+            adminlog.info,
+            "Request to observe usage info, include_open_bucket={}",
+            include_open_str);
+          if (!include_open_str.empty()) {
+              include_open = str_to_bool(include_open_str);
+          }
+          return _usage_manager
+            .invoke_on(
+              kafka::usage_manager::usage_manager_main_shard,
+              [](kafka::usage_manager& um) { return um.get_usage_stats(); })
+            .then([include_open](auto total_usage) {
+                return raw_data_to_usage_response(total_usage, include_open);
+            });
+      });
+}


### PR DESCRIPTION
Splits out admin endpoints for:

* Usage
* Transactions

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
