### PR TITLE
rpk: add /proc/kallsyms to debug bundle and extend help texts

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -73,6 +73,7 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveK8SLogs(ctx, ps, bp.namespace, bp.logsSince, bp.logsLimitBytes, bp.labelSelector),
 		saveK8SResources(ctx, ps, bp.namespace, bp.labelSelector),
 		saveKafkaMetadata(ctx, ps, bp.cl),
+		saveKernelSymbols(ps),
 		saveMdstat(ps),
 		saveMountedFilesystems(ps),
 		saveNTPDrift(ps),

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -138,6 +138,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveIP(ctx, ps),
 		saveInterrupts(ps),
 		saveKafkaMetadata(ctx, ps, bp.cl),
+		saveKernelSymbols(ps),
 		saveLogs(ctx, ps, bp.logsSince, bp.logsUntil, bp.logsLimitBytes),
 		saveLspci(ctx, ps),
 		saveMdstat(ps),
@@ -581,6 +582,17 @@ func saveMdstat(ps *stepParams) step {
 			return err
 		}
 		return writeFileToZip(ps, "proc/mdstat", bs)
+	}
+}
+
+// Saves the contents of '/proc/kallsyms'.
+func saveKernelSymbols(ps *stepParams) step {
+	return func() error {
+		bs, err := afero.ReadFile(ps.fs, "/proc/kallsyms")
+		if err != nil {
+			return err
+		}
+		return writeFileToZip(ps, "proc/kallsyms", bs)
 	}
 }
 

--- a/src/go/rpk/pkg/cli/redpanda/mode.go
+++ b/src/go/rpk/pkg/cli/redpanda/mode.go
@@ -26,7 +26,7 @@ func NewModeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "mode [MODE]",
 		Short: "Enable a default configuration mode",
-		Long:  "",
+		Long:  modeHelpText,
 		Args:  cobra.ExactArgs(1),
 		ValidArgsFunction: func(_ *cobra.Command, _ []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 			// We complete "dev" and "prod", but if the user is typing
@@ -63,3 +63,27 @@ func executeMode(fs afero.Fs, p *config.Params, mode string) error {
 	}
 	return cfg.SetMode(fs, mode)
 }
+
+const modeHelpText = `Enable a default configuration mode
+
+This command allows you to set one of the following modes: Development,
+Production, or Recovery.
+
+PRODUCTION
+
+  - Enforces optimal runtime checks.
+  - Enables all rpk tuners, for you to run 'rpk redpanda tune'.
+
+DEVELOPMENT
+
+  - Disables optimal checks and bypasses fsync, which results in unrealistically
+    fast clusters and may result in data loss.
+  - Disables all rpk tuners. The tuners are intended to run only for production 
+    mode.
+
+RECOVERY
+
+Sets the broker configuration property 'redpanda.recovery_mode_enabled=true' in 
+your redpanda.yaml. This provides a stable environment for troubleshooting and 
+restoring a failed cluster. Restart required.
+`

--- a/src/go/rpk/pkg/cli/registry/compatibility_level.go
+++ b/src/go/rpk/pkg/cli/registry/compatibility_level.go
@@ -83,12 +83,7 @@ func compatSetCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "set [SUBJECT...]",
 		Short: "Set the global or per-subject compatibility levels",
-		Long: `Set the global or per-subject compatibility levels.
-
-Running this command with no subject returns the global level, alternatively
-you can use the --global flag to set the global level at the same time as
-per-subject levels.
-`,
+		Long:  compatHelpText,
 		Run: func(_ *cobra.Command, subjects []string) {
 			f := p.Formatter
 			if h, ok := f.Help([]compatibilityLevelResponse{}); ok {
@@ -113,7 +108,7 @@ per-subject levels.
 	}
 
 	cmd.Flags().BoolVar(&global, "global", false, "Set the global level in addition to subject levels")
-	cmd.Flags().StringVar(&level, "level", "", "Level to set, one of NONE, {BACKWARD,FORWARD,FULL}{,_TRANSITIVE}")
+	cmd.Flags().StringVar(&level, "level", "", "Level to set, see the 'help' text of this command for the full list")
 	cmd.MarkFlagRequired("level")
 	return cmd
 }
@@ -152,3 +147,35 @@ func printCompatibilityResult(results []sr.CompatibilityResult, f config.OutForm
 	}
 	return nil
 }
+
+const compatHelpText = `Set the global or per-subject compatibility levels.
+
+Running this command without a subject sets the global compatibility level. To
+set the global level at the same time as per-subject levels, use the --global
+flag.
+
+LEVELS:
+
+  - BACKWARD (default): Consumers using the new schema (for example, version 10)
+    can read data from producers using the previous schema (for example, version
+    9).
+
+  - BACKWARD_TRANSITIVE: Consumers using the new schema (for example, version
+    10) can read data from producers using all previous schemas (for example,
+    versions 1-9).
+
+  - FORWARD: Consumers using the previous schema (for example, version 9) can
+    read data from producers using the new schema (for example, version 10).
+
+  - FORWARD_TRANSITIVE: Consumers using any previous schema (for example,
+    versions 1-9) can read data from producers using the new schema (for example,
+    version 10).
+
+  - FULL: A new schema and the previous schema (for example, versions 10 and 9)
+    are both backward and forward compatible with each other.
+
+  - FULL_TRANSITIVE: Each schema is both backward and forward compatible with
+    all registered schemas.
+
+  - NONE: No schema compatibility checks are done.
+`

--- a/src/go/rpk/pkg/tuners/factory/factory.go
+++ b/src/go/rpk/pkg/tuners/factory/factory.go
@@ -14,6 +14,7 @@ package factory
 
 import (
 	"runtime"
+	"sort"
 	"time"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cloud/gcp"
@@ -120,6 +121,7 @@ func AvailableTuners() []string {
 	for key := range allTuners {
 		keys = append(keys, key)
 	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i] < keys[j] })
 	return keys
 }
 


### PR DESCRIPTION
 - 02482a82dc74f62e97f3c6d9e6bfcb705c04f764 Fixes #14357 
 - Added extended help text for `rpk redpanda mode` and `rpk registry compatibility-level`

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
### Improvements

* rpk debug bundle: now collects the output of /proc/kallsyms
