### PR TITLE
Revert "redpanda: Make `redpanda_cpu_busy_seconds_total` a counter"

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -634,7 +634,7 @@ void application::setup_public_metrics() {
       .invoke_on_all([](auto& public_metrics) {
           public_metrics.groups.add_group(
             "cpu",
-            {sm::make_counter(
+            {sm::make_gauge(
               "busy_seconds_total",
               [] {
                   return std::chrono::duration<double>(


### PR DESCRIPTION
Reverts redpanda-data/redpanda#14905

This breaks metrics integrations that don't support the types of metrics changing.

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is **already** backported
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none