### PR TITLE
compaction: do not adjacent compact non self compacted segements

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -395,7 +395,7 @@ kafka_stages partition::replicate_in_stages(
         }
     }
 
-    if (bid.has_idempotent()) {
+    if (bid.is_idempotent()) {
         if (!_is_idempotence_enabled) {
             vlog(
               clusterlog.error,

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -979,7 +979,7 @@ ss::future<result<kafka_result>> rm_stm::do_replicate(
         auto pid = bid.pid.get_id();
         auto tx_units = co_await get_tx_lock(pid)->get_units();
         co_return co_await transactional_replicate(bid, std::move(b));
-    } else if (bid.has_idempotent()) {
+    } else if (bid.is_idempotent()) {
         co_return co_await idempotent_replicate(
           bid, std::move(b), opts, enqueued);
     }
@@ -1910,7 +1910,7 @@ ss::future<> rm_stm::reduce_aborted_list() {
 
 void rm_stm::apply_data(
   model::batch_identity bid, const model::record_batch_header& header) {
-    if (bid.has_idempotent()) {
+    if (bid.is_idempotent()) {
         _highest_producer_id = std::max(_highest_producer_id, bid.pid.get_id());
         const auto last_offset = header.last_offset();
         const auto last_kafka_offset = from_log_offset(header.last_offset());

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -709,6 +709,14 @@ public:
     void set_term(model::term_id i) { _header.ctx.term = i; }
     // Size in bytes of the header plus records.
     int32_t size_bytes() const { return _header.size_bytes; }
+    bool contains_transactional_data() const {
+        // A transactional batch can be a
+        // 1. transactional data batch - transactional bit set
+        // 2. transactional control batch (fence, abort etc) - control batch
+        // and pid >= 0
+        return _header.attrs.is_transactional()
+               || (_header.attrs.is_control() && _header.producer_id >= 0);
+    }
 
     int32_t memory_usage() const {
         return sizeof(*this) + _records.size_bytes();

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -581,7 +581,7 @@ struct batch_identity {
     timestamp max_timestamp;
     bool is_transactional{false};
 
-    bool has_idempotent() { return pid.id >= 0; }
+    bool is_idempotent() const { return pid.id >= 0; }
 
     friend std::ostream& operator<<(std::ostream&, const batch_identity&);
 };

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -551,7 +551,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
           gclog.debug,
           "[{}] segment {} self compaction result: {}",
           config().ntp(),
-          seg->reader().filename(),
+          seg,
           result);
         has_self_compacted = true;
     }

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -811,9 +811,15 @@ disk_log_impl::find_compaction_range(const compaction_config& cfg) {
     // the chosen segments all need to be stable.
     // Each participating segment should individually pass the compactible
     // offset check for the compacted segment to be stable.
+    // Additionally each segment should have finished self compaction. This
+    // is needed by transactions because the compaction index of segments
+    // with transactional batches is only populated during self compaction.
+    // Not having this check would result in concatenating with an empty
+    // compaction index and a data loss.
     const auto unstable = std::any_of(
       range.first, range.second, [&cfg](ss::lw_shared_ptr<segment>& seg) {
-          return seg->has_appender() || !seg->has_compactible_offsets(cfg);
+          return !seg->finished_self_compaction() || seg->has_appender()
+                 || !seg->has_compactible_offsets(cfg);
       });
     if (unstable) {
         return std::nullopt;
@@ -837,6 +843,20 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
             all_window_compacted = false;
             break;
         }
+    }
+
+    auto all_segments_self_compacted = std::ranges::all_of(
+      segments, &segment::finished_self_compaction);
+
+    if (unlikely(!all_segments_self_compacted)) {
+        const auto total_size = std::accumulate(
+          segments.begin(),
+          segments.end(),
+          size_t(0),
+          [](size_t acc, ss::lw_shared_ptr<segment>& seg) {
+              return acc + seg->size_bytes();
+          });
+        co_return compaction_result{total_size};
     }
 
     if (gclog.is_enabled(ss::log_level::debug)) {

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -583,7 +583,7 @@ ss::future<append_result> segment::do_append(const model::record_batch& b) {
 }
 
 ss::future<append_result> segment::append(const model::record_batch& b) {
-    if (has_compaction_index() && b.header().attrs.is_transactional()) {
+    if (has_compaction_index() && b.contains_transactional_data()) {
         // With transactional batches, we do not know ahead of time whether the
         // batch will be committed or aborted. We may not have this information
         // during the lifetime of this segment as the batch may be aborted in


### PR DESCRIPTION
Adjacent compaction works by concatenating compaction indexes of
adjacent segments. When a segment has transactional batches, we
prematurely close the compaction index during segment append because
we do not know upfront whether a batch will be committed/aborted. We
recompute the index at the time of self compaction as it guarantees all
the batches are either committed/aborted.

Adjacent compacting a non self compacted index can result in incomplete
concatenated index, this fix avoids it.

This issue was exposed by running house keeping in a tight loop with low segment.ms but
has a very low probability of occurrence in practice.

Fixes: https://github.com/redpanda-data/redpanda/issues/15376


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Bug Fixes

* Fixes an issue where adjacent segment compaction concatenates with an empty index resulting in incorrect concatenated segment.


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
