### PR TITLE
tests: shutdown node after decommissioning

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -1104,11 +1104,12 @@ class NodeDecommissionSpaceManagementTest(RedpandaTest):
 
         totals = self._kafka_usage()
         self.logger.info(f"totals: {hmb(totals)}")
-
-        to_decommission_id = self.redpanda.node_id(self.redpanda.nodes[3])
+        to_decommission = self.redpanda.nodes[3]
+        to_decommission_id = self.redpanda.node_id(to_decommission)
         Admin(self.redpanda).decommission_broker(to_decommission_id)
         waiter = NodeDecommissionWaiter(self.redpanda,
                                         to_decommission_id,
                                         self.logger,
                                         progress_timeout=60)
         waiter.wait_for_removal()
+        self.redpanda.stop_node(to_decommission)


### PR DESCRIPTION
Shutdown node after it is decommissioned. This will prevent tiered storage scrubber from querying node which metadata may be stale

Fixes: #15038

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none