### PR TITLE
c/partition: do not try to translate log end offset if log is empty

### DIFF
--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -217,8 +217,14 @@ partition_cloud_storage_status partition::get_cloud_storage_status() const {
     const auto local_log_offsets = local_log->offsets();
     status.local_log_start_offset = wrap_model_offset(
       local_log_offsets.start_offset);
-    status.local_log_last_offset = wrap_model_offset(
-      local_log_offsets.committed_offset);
+    /**
+     * If committed offset is smaller than the log start offset it indicates
+     * that committed offset wasn't yet established (log is empty)
+     */
+    if (local_log_offsets.committed_offset >= local_log_offsets.start_offset) {
+        status.local_log_last_offset = wrap_model_offset(
+          local_log_offsets.committed_offset);
+    }
 
     if (status.mode != cloud_storage_mode::disabled && _archival_meta_stm) {
         const auto& manifest = _archival_meta_stm->manifest();


### PR DESCRIPTION
If local log is empty `committed_offset` is smaller than the start offset. In this case log end offset should not be translated to kafka offset domain as it is outside of the translation range and it is not valid.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none