### PR TITLE
cluster: ignore _last_replicate value in destructor

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -599,6 +599,15 @@ archival_metadata_stm::archival_metadata_stm(
   , _cloud_storage_api(remote)
   , _feature_table(ft) {}
 
+archival_metadata_stm::~archival_metadata_stm() {
+    // Last replicate future is an internal barrier for sync operations. Ignore
+    // its value if we're shutting down to prevent seastar logging warnings for
+    // unhandled exception.
+    if (_last_replicate.has_value()) {
+        _last_replicate->ignore_ready_future();
+    }
+}
+
 ss::future<std::error_code> archival_metadata_stm::truncate(
   model::offset start_rp_offset,
   ss::lowres_clock::time_point deadline,

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -111,6 +111,7 @@ public:
       features::feature_table&,
       ss::logger& logger,
       ss::shared_ptr<util::mem_tracker> partition_mem_tracker = nullptr);
+    ~archival_metadata_stm() override;
 
     /// Add segments to the raft log, replicate them and
     /// wait until it is applied to the STM.


### PR DESCRIPTION
Last replicate future is an internal barrier for sync operations. Ignore its value if we're shutting down to prevent seastar logging warnings for unhandled exception.

Couldn't come up with a CI test for this. Happened in ManyPartitionsTest with TS.

See https://github.com/redpanda-data/redpanda/pull/13896 if you are looking for context on what is `_last_replicate`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
