### PR TITLE
config: rename recovery bootstrap property to restore

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -796,7 +796,7 @@ ss::future<> controller::create_cluster(bootstrap_cluster_cmd_data cmd_data) {
         if (
           bucket_opt.has_value()
           && config::shard_local_cfg()
-               .cloud_storage_attempt_cluster_recovery_on_bootstrap.value()) {
+               .cloud_storage_attempt_cluster_restore_on_bootstrap.value()) {
             retry_chain_node retry_node(_as.local(), 300s, 5s);
             auto res
               = co_await cloud_metadata::download_highest_manifest_in_bucket(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1667,14 +1667,14 @@ configuration::configuration()
       "Number of attempts metadata operations may be retried.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       5)
-  , cloud_storage_attempt_cluster_recovery_on_bootstrap(
+  , cloud_storage_attempt_cluster_restore_on_bootstrap(
       *this,
-      "cloud_storage_attempt_cluster_recovery_on_bootstrap",
+      "cloud_storage_attempt_cluster_restore_on_bootstrap",
       "If set to `true`, when a cluster is started for the first time and "
       "there is cluster metadata in the configured cloud storage bucket, "
-      "Redpanda automatically starts a cluster recovery from that metadata. If "
+      "Redpanda automatically starts a cluster restore from that metadata. If "
       "using an automated method for deployment where it's not easy to "
-      "predictably determine that a recovery is needed, we recommend setting "
+      "predictably determine that a restore is needed, we recommend setting "
       "to `true`. Take care to ensure that in such deployments, a cluster "
       "bootstrap with a given bucket means that any previous cluster using "
       "that bucket is fully destroyed; otherwise tiered storage subsystems may "

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -324,7 +324,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       cloud_storage_cluster_metadata_upload_timeout_ms;
     property<int16_t> cloud_storage_cluster_metadata_retries;
-    property<bool> cloud_storage_attempt_cluster_recovery_on_bootstrap;
+    property<bool> cloud_storage_attempt_cluster_restore_on_bootstrap;
     property<double> cloud_storage_idle_threshold_rps;
     property<int32_t> cloud_storage_background_jobs_quota;
     property<bool> cloud_storage_enable_segment_merging;

--- a/tests/rptest/tests/cluster_recovery_test.py
+++ b/tests/rptest/tests/cluster_recovery_test.py
@@ -140,7 +140,7 @@ class ClusterRecoveryTest(RedpandaTest):
         """
         rpk = RpkTool(self.redpanda)
         rpk.cluster_config_set(
-            "cloud_storage_attempt_cluster_recovery_on_bootstrap", True)
+            "cloud_storage_attempt_cluster_restore_on_bootstrap", True)
         for t in self.topics:
             KgoVerifierProducer.oneshot(self.test_context,
                                         self.redpanda,
@@ -159,7 +159,7 @@ class ClusterRecoveryTest(RedpandaTest):
 
         # Restart the nodes, overriding the recovery bootstrap config.
         extra_rp_conf = dict(
-            cloud_storage_attempt_cluster_recovery_on_bootstrap=True)
+            cloud_storage_attempt_cluster_restore_on_bootstrap=True)
         self.redpanda.set_extra_rp_conf(extra_rp_conf)
         self.redpanda.write_bootstrap_cluster_config()
         self.redpanda.restart_nodes(self.redpanda.nodes,


### PR DESCRIPTION
To avoid confusion with the new "recovery mode", cluster recovery-related commands/configs are being renamed to "restore". This commit changes the `cloud_storage_attempt_cluster_recovery_on_bootstrap` property accordingly.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
