### PR TITLE
storage: further improvements to windowed compaction short circuit

### DIFF
--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -436,12 +436,18 @@ struct record_batch_header
     // -- below the CRC are checksummed by the kafka crc. see @crc field
 
     record_batch_attributes attrs;
+
+    // The difference in offset between the first and last offset in the batch.
     int32_t last_offset_delta{0};
     timestamp first_timestamp;
     timestamp max_timestamp;
     int64_t producer_id{0};
     int16_t producer_epoch{0};
     int32_t base_sequence{0};
+
+    // The number of records in the batch. Note, this may not necessarily be
+    // the same as last_offset_delta, which is preserved across compaction,
+    // unlike record_count.
     int32_t record_count{0};
 
     auto serde_fields() {

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -287,7 +287,8 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
     if (to_copy == std::nullopt) {
         co_return stop_t::no;
     }
-    if (_compacted_idx && is_compactible(to_copy.value())) {
+    bool compactible_batch = is_compactible(to_copy.value());
+    if (_compacted_idx && compactible_batch) {
         co_await model::for_each_record(
           to_copy.value(),
           [&batch = to_copy.value(), this](const model::record& r) {
@@ -316,7 +317,8 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
           batch.header().max_timestamp,
           std::nullopt,
           _internal_topic
-            || batch.header().type == model::record_batch_type::raft_data)) {
+            || batch.header().type == model::record_batch_type::raft_data,
+          compactible_batch)) {
         _acc = 0;
     }
     co_await _appender->append(batch);

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -280,7 +280,7 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
     co_return new_batch;
 }
 
-ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
+ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
   model::compression original, model::record_batch b) {
     using stop_t = ss::stop_iteration;
     auto to_copy = co_await filter(std::move(b));
@@ -301,7 +301,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
           });
     }
     auto batch = co_await compress_batch(original, std::move(to_copy.value()));
-    auto const start_offset = _appender->file_byte_offset();
+    auto const start_pos = _appender->file_byte_offset();
     auto const header_size = batch.header().size_bytes;
     _acc += header_size;
     // do not set broker_timestamp in this index, leave the operation to the
@@ -309,7 +309,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
     if (_idx.maybe_index(
           _acc,
           32_KiB,
-          start_offset,
+          start_pos,
           batch.base_offset(),
           batch.last_offset(),
           batch.header().first_timestamp,
@@ -321,10 +321,10 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::do_compaction(
     }
     co_await _appender->append(batch);
     vassert(
-      _appender->file_byte_offset() == start_offset + header_size,
+      _appender->file_byte_offset() == start_pos + header_size,
       "Size must be deterministic. Expected:{} == {}",
       _appender->file_byte_offset(),
-      start_offset + header_size);
+      start_pos + header_size);
 
     co_return stop_t::no;
 }
@@ -333,11 +333,11 @@ ss::future<ss::stop_iteration>
 copy_data_segment_reducer::operator()(model::record_batch b) {
     const auto comp = b.header().attrs.compression();
     if (!b.compressed()) {
-        co_return co_await do_compaction(comp, std::move(b));
+        co_return co_await filter_and_append(comp, std::move(b));
     }
     auto batch = co_await decompress_batch(std::move(b));
 
-    co_return co_await do_compaction(comp, std::move(batch));
+    co_return co_await filter_and_append(comp, std::move(batch));
 }
 
 ss::future<ss::stop_iteration>

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -138,7 +138,7 @@ public:
 
 private:
     ss::future<ss::stop_iteration>
-      do_compaction(model::compression, model::record_batch);
+      filter_and_append(model::compression, model::record_batch);
 
     ss::future<> maybe_keep_offset(
       const model::record_batch&, const model::record&, std::vector<int32_t>&);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -620,12 +620,14 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
               seg->filename());
             continue;
         }
-        if (auto first_data_offset = seg->index().first_data_offset();
-            !first_data_offset.is_disabled()) {
-            auto has_data_batches = first_data_offset.has_optional_value();
+        if (auto first_compactible_offset
+            = seg->index().first_compactible_offset();
+            !first_compactible_offset.is_disabled()) {
+            auto has_compactible_batches
+              = first_compactible_offset.has_optional_value();
             if (
-              !has_data_batches
-              || first_data_offset.get_optional()
+              !has_compactible_batches
+              || first_compactible_offset.get_optional()
                    == seg->index().max_offset()) {
                 // All data records are already compacted away. Skip to avoid a
                 // needless rewrite.

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -480,15 +480,26 @@ segment_set disk_log_impl::find_sliding_range(
     // Collect all segments that have stable data.
     segment_set::underlying_t buf;
     for (const auto& seg : _segs) {
+        if (seg->has_appender() || !seg->has_compactible_offsets(cfg)) {
+            // Stop once we get to an unstable segment.
+            break;
+        }
         if (
           new_start_offset
           && seg->offsets().base_offset < new_start_offset.value()) {
             // Skip over segments that are being truncated.
             continue;
         }
-        if (seg->has_appender() || !seg->has_compactible_offsets(cfg)) {
-            // Stop once we get to an unstable segment.
-            break;
+        if (buf.empty() && !seg->has_compactible_data_records()) {
+            // To find the start of the sliding range, skip over segments that
+            // have been effectively entirely compacted away, i.e. who no
+            // longer have data or have only their last batch remaining.
+            //
+            // NOTE: We don't do this past the beginning of the sliding range
+            // so that the rest of the segments are contiguous.
+            seg->mark_as_finished_self_compaction();
+            seg->mark_as_finished_windowed_compaction();
+            continue;
         }
         buf.emplace_back(seg);
     }
@@ -620,26 +631,17 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
               seg->filename());
             continue;
         }
-        if (auto first_compactible_offset
-            = seg->index().first_compactible_offset();
-            !first_compactible_offset.is_disabled()) {
-            auto has_compactible_batches
-              = first_compactible_offset.has_optional_value();
-            if (
-              !has_compactible_batches
-              || first_compactible_offset.get_optional()
-                   == seg->index().max_offset()) {
-                // All data records are already compacted away. Skip to avoid a
-                // needless rewrite.
-                seg->mark_as_finished_windowed_compaction();
-                vlog(
-                  gclog.trace,
-                  "[{}] treating segment as compacted, either all non-data "
-                  "records or the only record is a data record: {}",
-                  config().ntp(),
-                  seg->filename());
-                continue;
-            }
+        if (!seg->has_compactible_data_records()) {
+            // All data records are already compacted away. Skip to avoid a
+            // needless rewrite.
+            seg->mark_as_finished_windowed_compaction();
+            vlog(
+              gclog.trace,
+              "[{}] treating segment as compacted, either all non-data "
+              "records or the only record is a data record: {}",
+              config().ntp(),
+              seg->filename());
+            continue;
         }
         // TODO: implement a segment replacement strategy such that each term
         // tries to write only one segment (or more if the term had a large

--- a/src/v/storage/index_state.h
+++ b/src/v/storage/index_state.h
@@ -139,14 +139,14 @@ struct index_state
     // the index.
     std::optional<model::timestamp> broker_timestamp{std::nullopt};
 
-    // The offset of the first data record in the segment. This may not
+    // The offset of the first compactible record in the segment. This may not
     // necessarily correspond to one of the values in the indexing vectors.
     //
     // Special values:
-    // - nullopt: indicates no data batches are in the segment.
+    // - nullopt: indicates no compactible batches are in the segment.
     // - disabled: indicates this index was written in a version that didn't
     //             support this field, and we can't conclude anything.
-    tristate<model::offset> first_data_offset{std::nullopt};
+    tristate<model::offset> first_compactible_offset{std::nullopt};
 
     size_t size() const { return relative_offset_index.size(); }
 
@@ -215,7 +215,8 @@ struct index_state
       model::timestamp first_timestamp,
       model::timestamp last_timestamp,
       std::optional<model::timestamp> new_broker_timestamp,
-      bool user_data);
+      bool user_data,
+      bool compactible);
 
     void update_batch_timestamps_are_monotonic(bool pred) {
         batch_timestamps_are_monotonic = batch_timestamps_are_monotonic && pred;
@@ -242,7 +243,7 @@ private:
       , with_offset(o.with_offset)
       , non_data_timestamps(o.non_data_timestamps)
       , broker_timestamp(o.broker_timestamp)
-      , first_data_offset(o.first_data_offset) {}
+      , first_compactible_offset(o.first_compactible_offset) {}
 };
 
 } // namespace storage

--- a/src/v/storage/offset_to_filepos.h
+++ b/src/v/storage/offset_to_filepos.h
@@ -42,6 +42,8 @@ public:
 
     ss::future<ss::stop_iteration> operator()(::model::record_batch batch);
 
+    // Returns the offsets corresponding to the batch end offset strictly below
+    // the target offset.
     type end_of_stream();
 
 private:
@@ -49,8 +51,7 @@ private:
     model::offset _target_last_offset;
     model::offset _prev_batch_last_offset;
     model::timestamp _prev_batch_max_timestamp;
-    size_t _accumulator;
-    size_t _prev;
+    size_t _prev_end_pos;
 };
 
 } // namespace internal

--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -363,33 +363,33 @@ ss::future<> remove_compacted_index(const segment_full_path& reader_path) {
 }
 
 ss::future<> segment::truncate(
-  model::offset prev_last_offset,
+  model::offset new_max_offset,
   size_t physical,
   model::timestamp new_max_timestamp) {
     check_segment_not_closed("truncate()");
     return write_lock().then(
-      [this, prev_last_offset, physical, new_max_timestamp](
+      [this, new_max_offset, physical, new_max_timestamp](
         ss::rwlock::holder h) {
-          return do_truncate(prev_last_offset, physical, new_max_timestamp)
+          return do_truncate(new_max_offset, physical, new_max_timestamp)
             .finally([this, h = std::move(h)] { clear_cached_disk_usage(); });
       });
 }
 
 ss::future<> segment::do_truncate(
-  model::offset prev_last_offset,
+  model::offset new_max_offset,
   size_t physical,
   model::timestamp new_max_timestamp) {
-    _tracker.committed_offset = prev_last_offset;
-    _tracker.stable_offset = prev_last_offset;
-    _tracker.dirty_offset = prev_last_offset;
+    _tracker.committed_offset = new_max_offset;
+    _tracker.stable_offset = new_max_offset;
+    _tracker.dirty_offset = new_max_offset;
     _reader->set_file_size(physical);
     vlog(
       stlog.trace,
       "truncating segment {} at {}",
       _reader->filename(),
-      prev_last_offset);
+      new_max_offset);
     _generation_id++;
-    cache_truncate(prev_last_offset + model::offset(1));
+    cache_truncate(new_max_offset + model::offset(1));
     auto f = ss::now();
     if (is_compacted_segment()) {
         // if compaction index is opened close it
@@ -404,8 +404,8 @@ ss::future<> segment::do_truncate(
         f = f.then([this] { return remove_compacted_index(_reader->path()); });
     }
 
-    f = f.then([this, prev_last_offset, new_max_timestamp] {
-        return _idx.truncate(prev_last_offset, new_max_timestamp);
+    f = f.then([this, new_max_offset, new_max_timestamp] {
+        return _idx.truncate(new_max_offset, new_max_timestamp);
     });
 
     // physical file only needs *one* truncation call
@@ -626,17 +626,17 @@ segment::offset_data_stream(model::offset o, ss::io_priority_class iopc) {
     return _reader->data_stream(position, iopc);
 }
 
-void segment::advance_stable_offset(size_t offset) {
+void segment::advance_stable_offset(size_t filepos) {
     if (_inflight.empty()) {
         return;
     }
 
-    auto it = _inflight.upper_bound(offset);
+    auto it = _inflight.upper_bound(filepos);
     if (it != _inflight.begin()) {
         --it;
     }
 
-    if (it->first > offset) {
+    if (it->first > filepos) {
         return;
     }
 

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -54,11 +54,12 @@ public:
         /// `batch.base_offset()` which might be confusing at first,
         /// but allow us to keep track of the actual last logical offset
 
-        // Offset of last message fsync'd to disk
+        // Offset of last message fsynced to disk.
         model::offset committed_offset;
-        // Offset of last message written to this log
+        // Offset of last message written to this log, may not yet be stable.
         model::offset dirty_offset;
-        // Offset of last message written to disk
+        // Offset of last message written to disk, may not yet have been
+        // fsynced.
         model::offset stable_offset;
         friend std::ostream& operator<<(std::ostream&, const offset_tracker&);
     };

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -125,6 +125,13 @@ public:
     bool finished_windowed_compaction() const;
     /// \brief used for compaction, to reset the tracker from index
     void force_set_commit_offset_from_index();
+
+    /// \brief Returns whether the underlying segment has data records that
+    /// might be removed if compaction were to run. May return false positives,
+    /// e.g. if the underlying index was written in a version with insufficient
+    /// metadata.
+    bool has_compactible_data_records() const;
+
     // low level api's are discouraged and might be deprecated
     // please use higher level API's when possible
     segment_reader& reader();

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -134,7 +134,8 @@ void segment_index::maybe_track(
           hdr.max_timestamp,
           to_optional_model_timestamp(new_broker_ts),
           path().is_internal_topic()
-            || hdr.type == model::record_batch_type::raft_data)) {
+            || hdr.type == model::record_batch_type::raft_data,
+          internal::is_compactible(hdr))) {
         _acc = 0;
     }
     _needs_persistence = true;

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -196,6 +196,12 @@ ss::future<> segment_index::truncate(
       i,
       std::less<uint32_t>{});
 
+    if (
+      _state.first_compactible_offset.has_optional_value()
+      && _state.first_compactible_offset.value() > new_max_offset) {
+        _state.first_compactible_offset = tristate<model::offset>{std::nullopt};
+    }
+
     if (it != _state.relative_offset_index.end()) {
         _needs_persistence = true;
         int remove_back_elems = std::distance(

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -183,12 +183,12 @@ segment_index::find_nearest(model::offset o) {
     return std::nullopt;
 }
 
-ss::future<>
-segment_index::truncate(model::offset o, model::timestamp new_max_timestamp) {
-    if (o < _state.base_offset) {
+ss::future<> segment_index::truncate(
+  model::offset new_max_offset, model::timestamp new_max_timestamp) {
+    if (new_max_offset < _state.base_offset) {
         co_return;
     }
-    const uint32_t i = o() - _state.base_offset();
+    const uint32_t i = new_max_offset() - _state.base_offset();
     auto it = std::lower_bound(
       std::begin(_state.relative_offset_index),
       std::end(_state.relative_offset_index),
@@ -204,14 +204,14 @@ segment_index::truncate(model::offset o, model::timestamp new_max_timestamp) {
         }
     }
 
-    if (o < _state.max_offset) {
+    if (new_max_offset < _state.max_offset) {
         _needs_persistence = true;
         if (_state.empty()) {
             _state.max_timestamp = _state.base_timestamp;
             _state.max_offset = _state.base_offset;
         } else {
             _state.max_timestamp = new_max_timestamp;
-            _state.max_offset = o;
+            _state.max_offset = new_max_offset;
         }
     }
 

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -159,7 +159,9 @@ public:
     std::optional<model::timestamp>
       find_highest_timestamp_before(model::timestamp) const;
 
-    auto first_data_offset() const { return _state.first_data_offset; }
+    auto first_compactible_offset() const {
+        return _state.first_compactible_offset;
+    }
     model::offset base_offset() const { return _state.base_offset; }
     model::offset max_offset() const { return _state.max_offset; }
     model::timestamp max_timestamp() const { return _state.max_timestamp; }

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -211,11 +211,14 @@ struct clean_segment_value
     ss::sstring segment_name;
 };
 
-inline bool is_compactible(const model::record_batch& b) {
+inline bool is_compactible(const model::record_batch_header& h) {
     static const auto filtered_types = model::offset_translator_batch_types();
-    auto n = std::count(
-      filtered_types.begin(), filtered_types.end(), b.header().type);
+    auto n = std::count(filtered_types.begin(), filtered_types.end(), h.type);
     return n == 0;
+}
+
+inline bool is_compactible(const model::record_batch& b) {
+    return is_compactible(b.header());
 }
 
 offset_delta_time should_apply_delta_time_offset(

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -263,6 +263,7 @@ struct truncate_config {
     truncate_config(model::offset o, ss::io_priority_class p)
       : base_offset(o)
       , prio(p) {}
+    // Lowest offset to remove.
     model::offset base_offset;
     ss::io_priority_class prio;
     friend std::ostream& operator<<(std::ostream&, const truncate_config&);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds a few improvements to the recently added short-circuit in windowed compaction. Previously we would skip over compacting segments in the sliding range when we could tell that there was one or zero data batches. The tweaks here are:
- Tweaking the short-circuit condition to consider "compactible" records (those that are removed during compaction) rather than `raft_data` records only.
- Updating the start of the sliding range to be the first segment that has compactible records, so we don't needlessly iterate through such segments, add them to the key-offset map, etc.
- Resetting the "first compactible offset" field when it is suffix truncated.
- Various non-functional cleanup in adjacent code

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
