### PR TITLE
rpk/transform: Rust SDK support

### DIFF
--- a/src/go/rpk/pkg/cli/transform/project/project.go
+++ b/src/go/rpk/pkg/cli/transform/project/project.go
@@ -22,11 +22,13 @@ type WasmLang string
 const (
 	WasmLangTinygoWithGoroutines WasmLang = "tinygo-with-goroutines"
 	WasmLangTinygoNoGoroutines   WasmLang = "tinygo-no-goroutines"
+	WasmLangRust                 WasmLang = "rust"
 )
 
 var AllWasmLangs = []string{
 	string(WasmLangTinygoNoGoroutines),
 	string(WasmLangTinygoWithGoroutines),
+	string(WasmLangRust),
 }
 
 // AllWasmLangsWithDescriptions is AllWasmLangs but with extended descriptions.
@@ -35,6 +37,7 @@ var AllWasmLangs = []string{
 var AllWasmLangsWithDescriptions = []string{
 	"Tinygo (no goroutines) - higher throughput",
 	"Tinygo (with goroutines)",
+	"Rust",
 }
 
 func (l *WasmLang) Set(str string) error {

--- a/src/go/rpk/pkg/cli/transform/template/rust/README.md
+++ b/src/go/rpk/pkg/cli/transform/template/rust/README.md
@@ -1,0 +1,15 @@
+# Redpanda Rust WASM Transform
+
+To get started you first need to have at least stable rust 1.72 installed.
+
+You can get started by modifying the <code>src/bin.rs</code> file
+with your logic.
+
+Once you're ready to test out your transform live you need to:
+
+1. Make sure you have a container running via <code>rpk container start</code>
+1. Run <code>rpk transform build</code>
+1. Create your topics via <code>rpk topic create</code>
+1. Run <code>rpk transform deploy</code>
+1. Then use <code>rpk topic produce</code> and <code>rpk topic consume</code>
+   to see your transformation live!

--- a/src/go/rpk/pkg/cli/transform/template/rust/main.rustsrc
+++ b/src/go/rpk/pkg/cli/transform/template/rust/main.rustsrc
@@ -1,0 +1,23 @@
+use redpanda_transform_sdk::*;
+use std::fmt::Error;
+
+fn main() {
+    // Register your transform function.
+    // This is a good place to perform other setup too.
+    on_record_written(my_transform);
+}
+
+// my_transform is where you read the record that was written, and then you can
+// return new records that will be written to the output topic
+fn my_transform(event: WriteEvent) -> Result<Vec<Record>, Error> {
+    Ok(vec![Record::new_with_headers(
+        event.record.key().map(|b| b.to_owned()),
+        event.record.value().map(|b| b.to_owned()),
+        event
+            .record
+            .headers()
+            .iter()
+            .map(|h| h.to_owned())
+            .collect(),
+    )])
+}

--- a/src/go/rpk/pkg/cli/transform/template/rust_template.go
+++ b/src/go/rpk/pkg/cli/transform/template/rust_template.go
@@ -1,0 +1,42 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package template
+
+import (
+	_ "embed"
+	"fmt"
+)
+
+//go:embed rust/main.rustsrc
+var rustMainFile string
+
+func WasmRustMain() string {
+	return rustMainFile
+}
+
+const cargoTomlTemplate = `[package]
+name = "%s"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+redpanda-transform-sdk = "*"
+`
+
+func WasmRustCargoConfig(name string) string {
+	return fmt.Sprintf(cargoTomlTemplate, name)
+}
+
+//go:embed rust/README.md
+var wasmRustReadme string
+
+func WasmRustReadme() string {
+	return wasmRustReadme
+}


### PR DESCRIPTION
Now that we have a Rust SDK, add support for using it in rpk 🦀

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Features

* Support authoring WebAssembly Data Transforms in Rust
