### PR TITLE
tests: fix FollowerFetchingTest.test_with_leadership_transfers

### DIFF
--- a/tests/rptest/services/kafka_cli_consumer.py
+++ b/tests/rptest/services/kafka_cli_consumer.py
@@ -82,9 +82,12 @@ class KafkaCliConsumer(BackgroundThreadService):
 
             for l in node.account.ssh_capture(' '.join(cmd)):
                 self._redpanda.logger.debug(l)
-                with self._lock:
-                    self._message_cnt += 1
-                    self._last_consumed = time.time()
+                # last line does not correspond to a consumed message and looks like
+                # "Processed a total of N messages"
+                if not l.startswith("Processed a total of "):
+                    with self._lock:
+                        self._message_cnt += 1
+                        self._last_consumed = time.time()
         except:
             if self._stopping.is_set():
                 # Expect a non-zero exit code when killing during teardown


### PR DESCRIPTION
KgoVerifierProducer under-reports the number of produced messages after it stops (because it could have made some progress after the last status report got queried). Rely on the reported high watermark instead to get the number of produced messages.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none
