### PR TITLE
c/topic_table: do not log duplicated lifecycle marker command

### DIFF
--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -173,9 +173,8 @@ topic_table::apply(topic_lifecycle_transition soft_del, model::offset offset) {
             _lifecycle_markers.erase(soft_del.topic);
             return ss::make_ready_future<std::error_code>(errc::success);
         } else {
-            // This is harmless but should not happen and indicates a bug.
             vlog(
-              clusterlog.error,
+              clusterlog.info,
               "Unexpected record at offset {} to drop non-existent lifecycle "
               "marker {} {}",
               offset,


### PR DESCRIPTION
It is possible that the drop topic lifecycle marker replicate request would timeout. In this case requester has no other option than to retry dropping lifecycle marker. Logic in `cluster::topic_table` is idempotent and duplicate marker drop command does not harm to Redpanda. Changed log level of an entry notifying about duplicated drop command from an error to info level.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none