### PR TITLE
rpk: gather k8s bundle logs of redpanda container

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -414,6 +414,7 @@ func saveK8SLogs(ctx context.Context, ps *stepParams, namespace, since string, l
 		limitBytes := int64(logsLimitBytes)
 		logOpts := &k8score.PodLogOptions{
 			LimitBytes: &limitBytes,
+			Container:  "redpanda",
 		}
 
 		if len(since) > 0 {


### PR DESCRIPTION
This request was failing in pods that had more
than 1 container. Now we default to get the
logs from the 'redpanda' container.

Fixes Helm Chart test: https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

This feature is only in v23.2
## Release Notes

### Bug Fixes

* rpk: Redpanda log collection now is possible in pods where you have multiple containers, by default, rpk will gather logs from the 'redpanda' container. 
