### PR TITLE
c/partition_balancer: handle members_table update during planning

### DIFF
--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -38,12 +38,6 @@ namespace cluster {
 static constexpr std::chrono::seconds controller_stm_sync_timeout = 10s;
 static constexpr std::chrono::seconds add_move_cmd_timeout = 10s;
 
-class balancer_tick_aborted_exception final : public std::runtime_error {
-public:
-    explicit balancer_tick_aborted_exception(const std::string& msg)
-      : std::runtime_error(msg) {}
-};
-
 partition_balancer_backend::partition_balancer_backend(
   consensus_ptr raft0,
   ss::sharded<controller_stm>& controller_stm,

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -1716,7 +1716,10 @@ ss::future<> partition_balancer_planner::get_counts_rebalancing_actions(
     auto scaled_count =
       [&](model::node_id id, partition_allocation_domain domain) {
           auto it = ctx.allocation_nodes().find(id);
-          vassert(it != ctx.allocation_nodes().end(), "node {} not found", id);
+          if (it == ctx.allocation_nodes().end()) {
+              throw balancer_tick_aborted_exception{
+                fmt::format("node id: {} disappeared", id)};
+          }
           return double(it->second->domain_final_partitions(domain))
                  / it->second->max_capacity();
       };

--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -255,4 +255,10 @@ struct partition_balancer_overview_reply
     }
 };
 
+class balancer_tick_aborted_exception final : public std::runtime_error {
+public:
+    explicit balancer_tick_aborted_exception(const std::string& msg)
+      : std::runtime_error(msg) {}
+};
+
 } // namespace cluster


### PR DESCRIPTION
If a controller snapshot is installed in the middle of the planning session, nodes can suddenly disappear from the partition_allocator state. We handle this case by aborting the planning session.

Fixes https://github.com/redpanda-data/redpanda/issues/13698

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none