### PR TITLE
storage: fix compaction short circuit check, redux

### DIFF
--- a/src/v/kafka/server/tests/produce_consume_utils.h
+++ b/src/v/kafka/server/tests/produce_consume_utils.h
@@ -34,14 +34,18 @@ struct kv_t {
     static std::vector<kv_t> sequence(
       size_t start,
       size_t num_records,
-      std::optional<size_t> val_start = std::nullopt) {
+      std::optional<size_t> val_start = std::nullopt,
+      size_t key_cardinality = 0) {
         size_t vstart = val_start.value_or(start);
         std::vector<kv_t> records;
         records.reserve(num_records);
         for (size_t i = 0; i < num_records; i++) {
+            auto key = start + i;
+            if (key_cardinality > 0) {
+                key = key % key_cardinality;
+            }
             records.emplace_back(
-              ssx::sformat("key{}", start + i),
-              ssx::sformat("val{}", vstart + i));
+              ssx::sformat("key{}", key), ssx::sformat("val{}", vstart + i));
         }
         return records;
     }

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -318,7 +318,7 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
           std::nullopt,
           _internal_topic
             || batch.header().type == model::record_batch_type::raft_data,
-          compactible_batch)) {
+          compactible_batch ? batch.header().record_count : 0)) {
         _acc = 0;
     }
     co_await _appender->append(batch);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -558,7 +558,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
     // Remove any of the beginning segments that may only have one or no
     // compactible records. They would be no-ops to compact.
     while (!segs.empty()) {
-        if (segs.front()->has_compactible_data_records()) {
+        if (segs.front()->may_have_compactible_records()) {
             break;
         }
         // For all intents and purposes, these segments are already compacted.
@@ -637,7 +637,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
               seg->filename());
             continue;
         }
-        if (!seg->has_compactible_data_records()) {
+        if (!seg->may_have_compactible_records()) {
             // All data records are already compacted away. Skip to avoid a
             // needless rewrite.
             seg->mark_as_finished_windowed_compaction();

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -490,17 +490,6 @@ segment_set disk_log_impl::find_sliding_range(
             // Skip over segments that are being truncated.
             continue;
         }
-        if (buf.empty() && !seg->has_compactible_data_records()) {
-            // To find the start of the sliding range, skip over segments that
-            // have been effectively entirely compacted away, i.e. who no
-            // longer have data or have only their last batch remaining.
-            //
-            // NOTE: We don't do this past the beginning of the sliding range
-            // so that the rest of the segments are contiguous.
-            seg->mark_as_finished_self_compaction();
-            seg->mark_as_finished_windowed_compaction();
-            continue;
-        }
         buf.emplace_back(seg);
     }
     segment_set segs(std::move(buf));
@@ -541,13 +530,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
         vlog(gclog.debug, "[{}] no more segments to compact", config().ntp());
         co_return false;
     }
-    vlog(
-      gclog.debug,
-      "[{}] compacting {} segments in interval [{}, {}]",
-      config().ntp(),
-      segs.size(),
-      segs.front()->filename(),
-      segs.back()->filename());
+    bool has_self_compacted = false;
     for (auto& seg : segs) {
         if (cfg.asrc) {
             cfg.asrc->check();
@@ -570,7 +553,30 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
           config().ntp(),
           seg->reader().filename(),
           result);
+        has_self_compacted = true;
     }
+    // Remove any of the beginning segments that may only have one or no
+    // compactible records. They would be no-ops to compact.
+    while (!segs.empty()) {
+        if (segs.front()->has_compactible_data_records()) {
+            break;
+        }
+        // For all intents and purposes, these segments are already compacted.
+        auto seg = segs.front();
+        seg->mark_as_finished_windowed_compaction();
+        segs.pop_front();
+    }
+    if (segs.empty()) {
+        vlog(gclog.debug, "[{}] no more segments to compact", config().ntp());
+        co_return has_self_compacted;
+    }
+    vlog(
+      gclog.debug,
+      "[{}] window compacting {} segments in interval [{}, {}]",
+      config().ntp(),
+      segs.size(),
+      segs.front()->filename(),
+      segs.back()->filename());
 
     // TODO: add configuration to use simple_key_offset_map.
     std::unique_ptr<simple_key_offset_map> simple_map;

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -130,7 +130,7 @@ public:
     /// might be removed if compaction were to run. May return false positives,
     /// e.g. if the underlying index was written in a version with insufficient
     /// metadata.
-    bool has_compactible_data_records() const;
+    bool may_have_compactible_records() const;
 
     // low level api's are discouraged and might be deprecated
     // please use higher level API's when possible

--- a/src/v/storage/segment_index.cc
+++ b/src/v/storage/segment_index.cc
@@ -135,7 +135,7 @@ void segment_index::maybe_track(
           to_optional_model_timestamp(new_broker_ts),
           path().is_internal_topic()
             || hdr.type == model::record_batch_type::raft_data,
-          internal::is_compactible(hdr))) {
+          internal::is_compactible(hdr) ? hdr.record_count : 0)) {
         _acc = 0;
     }
     _needs_persistence = true;
@@ -195,12 +195,6 @@ ss::future<> segment_index::truncate(
       std::end(_state.relative_offset_index),
       i,
       std::less<uint32_t>{});
-
-    if (
-      _state.first_compactible_offset.has_optional_value()
-      && _state.first_compactible_offset.value() > new_max_offset) {
-        _state.first_compactible_offset = tristate<model::offset>{std::nullopt};
-    }
 
     if (it != _state.relative_offset_index.end()) {
         _needs_persistence = true;

--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -159,8 +159,8 @@ public:
     std::optional<model::timestamp>
       find_highest_timestamp_before(model::timestamp) const;
 
-    auto first_compactible_offset() const {
-        return _state.first_compactible_offset;
+    auto num_compactible_records_appended() const {
+        return _state.num_compactible_records_appended;
     }
     model::offset base_offset() const { return _state.base_offset; }
     model::offset max_offset() const { return _state.max_offset; }

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -113,7 +113,10 @@ public:
     }
 
     ss::future<> generate_data(
-      size_t num_segments, size_t cardinality, size_t records_per_segment) {
+      size_t num_segments,
+      size_t cardinality,
+      size_t batches_per_segment,
+      size_t records_per_batch = 1) {
         tests::kafka_produce_transport producer(co_await make_kafka_client());
         co_await producer.start();
 
@@ -121,15 +124,15 @@ public:
         size_t val_count = 0;
         absl::btree_map<ss::sstring, ss::sstring> latest_kv;
         for (size_t i = 0; i < num_segments; i++) {
-            for (int r = 0; r < records_per_segment; r++) {
+            for (int r = 0; r < batches_per_segment; r++) {
                 auto kvs = tests::kv_t::sequence(
-                  val_count % cardinality, 1, val_count);
+                  val_count, records_per_batch, val_count, cardinality);
                 for (const auto& [k, v] : kvs) {
                     latest_kv[k] = v;
                 }
                 co_await producer.produce_to_partition(
                   topic_name, model::partition_id(0), std::move(kvs));
-                val_count++;
+                val_count += records_per_batch;
             }
             co_await log->flush();
             co_await log->force_roll(ss::default_priority_class());

--- a/src/v/storage/tests/offset_index_utils_tests.cc
+++ b/src/v/storage/tests/offset_index_utils_tests.cc
@@ -140,18 +140,13 @@ FIXTURE_TEST(bucket_truncate, offset_index_utils_fixture) {
       modify_get(model::offset{948}, 1667),
       std::nullopt,
       727007); // not indexed
-    BOOST_REQUIRE_EQUAL(
-      _idx->first_compactible_offset().get_optional().value_or(
-        model::offset(0)),
-      model::offset(824));
+    BOOST_REQUIRE_EQUAL(_idx->num_compactible_records_appended(), 0);
 
     // test range truncation next
     _idx->truncate(model::offset(926), model::timestamp{100}).get();
     index_entry_expect(879, 323968);
     index_entry_expect(901, 458048);
-    BOOST_REQUIRE(_idx->first_compactible_offset().has_optional_value());
-    BOOST_REQUIRE_EQUAL(
-      _idx->first_compactible_offset().get_optional(), model::offset(824));
+    BOOST_REQUIRE_EQUAL(_idx->num_compactible_records_appended(), 0);
     {
         auto p = _idx->find_nearest(model::offset(926));
         BOOST_REQUIRE(bool(p));
@@ -168,18 +163,14 @@ FIXTURE_TEST(bucket_truncate, offset_index_utils_fixture) {
     BOOST_REQUIRE(_idx->max_timestamp() == model::timestamp{100});
 
     _idx->truncate(model::offset(824), model::timestamp{100}).get();
-    BOOST_REQUIRE(_idx->first_compactible_offset().has_optional_value());
-    BOOST_REQUIRE_EQUAL(
-      _idx->first_compactible_offset().get_optional().value_or(
-        model::offset(0)),
-      model::offset(824));
+    BOOST_REQUIRE_EQUAL(_idx->num_compactible_records_appended(), 0);
     {
         auto p = _idx->find_nearest(model::offset(824));
         BOOST_REQUIRE(bool(!p));
     }
 
     _idx->truncate(model::offset(823), model::timestamp{100}).get();
-    BOOST_REQUIRE(!_idx->first_compactible_offset().has_optional_value());
+    BOOST_REQUIRE_EQUAL(_idx->num_compactible_records_appended(), 0);
     {
         auto p = _idx->find_nearest(model::offset(824));
         BOOST_REQUIRE(bool(!p));

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -114,7 +114,9 @@ TEST(FindSlidingRangeTest, TestCollectExcludesPrevious) {
     ASSERT_EQ(segs.front()->offsets().base_offset(), 0);
 }
 
-TEST(FindSlidingRangeTest, TestCollectExcludesOneRecordSegments) {
+// Even though segments with one record would be skipped over during
+// compaction, that shouldn't be reflected by the sliding range.
+TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
     storage::disk_log_builder b;
     build_segments(
       b,
@@ -127,17 +129,16 @@ TEST(FindSlidingRangeTest, TestCollectExcludesOneRecordSegments) {
     compaction_config cfg(
       model::offset{30}, ss::default_priority_class(), never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
-    // All segments so far have only one record and shouldn't be eligible for
-    // compaction.
-    ASSERT_EQ(0, segs.size());
-    for (int i = 0; i < 5; i++) {
-        auto& seg = disk_log.segments()[i];
-        ASSERT_TRUE(seg->finished_self_compaction());
-        ASSERT_TRUE(seg->finished_windowed_compaction());
+    // Even though these segments don't have compactible records, they should
+    // be collected. E.g., they should still be self compacted to rebuild
+    // indexes if necessary, etc.
+    ASSERT_EQ(5, segs.size());
+    for (const auto& seg : segs) {
+        ASSERT_FALSE(seg->has_compactible_data_records());
     }
 
     // Add some segments with multiple records. They should be eligible for
-    // compaction and are included in the range.
+    // compaction and are also included in the range.
     add_segments(
       b,
       /*num_segs=*/3,
@@ -145,25 +146,12 @@ TEST(FindSlidingRangeTest, TestCollectExcludesOneRecordSegments) {
       /*start_offset=*/6,
       /*mark_compacted=*/false);
     segs = disk_log.find_sliding_range(cfg);
-    ASSERT_EQ(3, segs.size());
+    ASSERT_EQ(8, segs.size());
+    int i = 0;
     for (const auto& seg : segs) {
-        ASSERT_FALSE(seg->finished_self_compaction()) << seg;
-        ASSERT_FALSE(seg->finished_windowed_compaction()) << seg;
-    }
-
-    // Adding more segments with one record, the range should include them
-    // since they're not at the beginning of the log.
-    add_segments(
-      b,
-      /*num_segs=*/4,
-      /*records_per_seg=*/1,
-      /*start_offset=*/13,
-      /*mark_compacted=*/false);
-    segs = disk_log.find_sliding_range(cfg);
-    ASSERT_EQ(7, segs.size());
-    for (const auto& seg : segs) {
-        ASSERT_FALSE(seg->finished_self_compaction());
-        ASSERT_FALSE(seg->finished_windowed_compaction());
+        bool should_have_records = i >= 5;
+        ASSERT_EQ(should_have_records, seg->has_compactible_data_records());
+        i++;
     }
 }
 

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -134,7 +134,7 @@ TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
     // indexes if necessary, etc.
     ASSERT_EQ(5, segs.size());
     for (const auto& seg : segs) {
-        ASSERT_FALSE(seg->has_compactible_data_records());
+        ASSERT_FALSE(seg->may_have_compactible_records());
     }
 
     // Add some segments with multiple records. They should be eligible for
@@ -150,7 +150,7 @@ TEST(FindSlidingRangeTest, TestCollectOneRecordSegments) {
     int i = 0;
     for (const auto& seg : segs) {
         bool should_have_records = i >= 5;
-        ASSERT_EQ(should_have_records, seg->has_compactible_data_records());
+        ASSERT_EQ(should_have_records, seg->may_have_compactible_records());
         i++;
     }
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
The [previous short-circuit check](https://github.com/redpanda-data/redpanda/pull/15404) for compaction aimed to compare the
first compactible offset against the max offset, which would supposedly
tell us whether the only data record were the last record, indicating a
sole data record that wouldn't be compacted.

This check didn't take into account batches of size > 1, whose first
data batch base offset would never equal the max offset (a batch end
offset).

This commit fixes this by changing this field to count the number of
compactible records appended. This value is sometimes an overestimate,
e.g. in cases where the segment is truncated and we don't count the
number of compactible records removed to subtract. But, that should be
sufficient since our check for having compactible records is okay with
false positives.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
