### PR TITLE
storage: fix comparison against last record in segment

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -126,17 +126,6 @@ ss::future<> copy_data_segment_reducer::maybe_keep_offset(
         offset_deltas.push_back(r.offset_delta());
         co_return;
     }
-    // Keep the last record to ensure the bounds of the segment remain.
-    auto o = batch.base_offset() + model::offset_delta(r.offset_delta());
-    if (o == _segment_last_offset) {
-        vlog(
-          stlog.trace,
-          "retaining last record: {} of segment from batch: {}",
-          r,
-          batch.header());
-        offset_deltas.push_back(r.offset_delta());
-        co_return;
-    }
 }
 
 ss::future<std::optional<model::record_batch>>
@@ -181,8 +170,21 @@ copy_data_segment_reducer::filter(model::record_batch batch) {
     // 1. compute which records to keep
     std::vector<int32_t> offset_deltas;
     offset_deltas.reserve(batch.record_count());
+    int last_batch_records_seen = 0;
     co_await batch.for_each_record_async(
-      [this, &batch, &offset_deltas](const model::record& r) {
+      [this, &batch, &offset_deltas, &last_batch_records_seen](
+        const model::record& r) {
+          if (
+            batch.last_offset() == _segment_last_offset
+            && batch.record_count() == ++last_batch_records_seen) {
+              vlog(
+                stlog.trace,
+                "retaining last record: {} of segment from batch: {}",
+                r,
+                batch.header());
+              offset_deltas.push_back(r.offset_delta());
+              return ss::make_ready_future<>();
+          }
           return maybe_keep_offset(batch, r, offset_deltas);
       });
 

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -110,7 +110,8 @@ rp_test(
 )
 
 set (fixture_srcs
-  storage_e2e_fixture_test.cc)
+  storage_e2e_fixture_test.cc
+  compaction_e2e_multinode_test.cc)
 
 rp_test(
   FIXTURE_TEST

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -1,0 +1,137 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/members_frontend.h"
+#include "cluster/tests/cluster_test_fixture.h"
+#include "cluster/topics_frontend.h"
+#include "cluster/types.h"
+#include "kafka/server/tests/produce_consume_utils.h"
+#include "model/metadata.h"
+#include "model/timestamp.h"
+#include "storage/tests/manual_mixin.h"
+#include "test_utils/async.h"
+#include "test_utils/scoped_config.h"
+#include "vlog.h"
+
+#include <seastar/core/io_priority_class.hh>
+
+#include <absl/container/btree_map.h>
+
+using namespace tests;
+
+namespace {
+ss::logger testlog("cmp_multi_testlog");
+} // namespace
+
+class compaction_multinode_test
+  : public storage_manual_mixin
+  , public cluster_test_fixture {};
+
+FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
+    const model::topic topic{"mocha"};
+    model::node_id id{0};
+    auto* app = create_node_application(id);
+    auto* rp = instance(id);
+    wait_for_controller_leadership(id).get();
+
+    cluster::topic_properties props;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::compaction;
+    // Try to roll on every batch.
+    rp->add_topic({model::kafka_namespace, topic}, 1, props).get();
+    model::partition_id pid{0};
+    auto ntp = model::ntp(model::kafka_namespace, topic, pid);
+    RPTEST_REQUIRE_EVENTUALLY(5s, [&] {
+        auto [_, prt] = get_leader(ntp);
+        return prt != nullptr;
+    });
+
+    kafka_produce_transport producer(rp->make_kafka_client().get());
+    producer.start().get();
+
+    // []: batch
+    // {}: segment
+    // Rough keys, excluding config batches:
+    // {[0 1 2 3 4 5] [4 5] [4 5] [4 5] [4 5]}
+    producer.produce_to_partition(topic, pid, kv_t::sequence(0, 5)).get();
+    producer.produce_to_partition(topic, pid, kv_t::sequence(4, 2)).get();
+    producer.produce_to_partition(topic, pid, kv_t::sequence(4, 2)).get();
+    producer.produce_to_partition(topic, pid, kv_t::sequence(4, 2)).get();
+
+    // Compact. The resulting segments will look roughly like:
+    // {[0 1 2 3] [4 5]}
+    auto [_, first_partition] = get_leader(ntp);
+    auto first_log = first_partition->log();
+    first_log->flush().get();
+    first_log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(first_log->segment_count(), 2);
+    ss::abort_source as;
+    storage::housekeeping_config conf(
+      model::timestamp::min(),
+      std::nullopt,
+      first_log->stm_manager()->max_collectible_offset(),
+      ss::default_priority_class(),
+      as);
+    first_log->housekeeping(conf).get();
+
+    // Update the segment size to be tiny, forcing our new replica to have a
+    // different segment layout.
+    auto update = cluster::topic_properties_update{
+      {model::kafka_namespace, topic}};
+    update.properties.segment_size.op
+      = cluster::incremental_update_operation::set;
+    update.properties.segment_size.value = 5;
+    app->controller->get_topics_frontend()
+      .local()
+      .update_topic_properties({update}, model::timeout_clock().now() + 5s)
+      .get();
+
+    // Decommission the original node, forcing replication to a new replica.
+    auto* app2 = create_node_application(model::node_id(1));
+    wait_for_all_members(10s).get();
+    auto err = app->controller->get_members_frontend()
+                 .local()
+                 .decommission_node(model::node_id(0))
+                 .get();
+    BOOST_REQUIRE(!err);
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        auto partition = app->partition_manager.local().get(ntp);
+        return partition == nullptr;
+    });
+    auto [new_rp, new_partition] = get_leader(ntp);
+    BOOST_REQUIRE(new_rp);
+    BOOST_REQUIRE(app2 == &new_rp->app);
+
+    // With the lower segment size, our segments will each only have one batch.
+    // Write new records, to encourage removal of older batches.
+    // {[0 1 2 3]} {[4 5]} {[0 1 2 3 4 5]}
+    kafka_produce_transport new_producer(new_rp->make_kafka_client().get());
+    new_producer.start().get();
+    new_producer.produce_to_partition(topic, pid, kv_t::sequence(0, 5)).get();
+    auto new_log = new_partition->log();
+    new_log->flush().get();
+    new_log->force_roll(ss::default_priority_class()).get();
+
+    // The segments should maintain their last records.
+    // {[3]} {[5]} {[0 1 2 3 4 5]}
+    storage::housekeeping_config conf2(
+      model::timestamp::min(),
+      std::nullopt,
+      new_log->stm_manager()->max_collectible_offset(),
+      ss::default_priority_class(),
+      as);
+    new_log->housekeeping(conf2).get();
+
+    // Make sure our segments are contiguous.
+    model::offset prev_last{-1};
+    for (const auto& seg : new_log->segments()) {
+        BOOST_REQUIRE_EQUAL(
+          seg->offsets().base_offset, model::next_offset(prev_last));
+        prev_last = seg->offsets().committed_offset;
+    }
+}

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -10,6 +10,7 @@
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/namespace.h"
 #include "redpanda/tests/fixture.h"
+#include "storage/tests/manual_mixin.h"
 #include "test_utils/async.h"
 #include "test_utils/scoped_config.h"
 #include "test_utils/test.h"
@@ -23,18 +24,6 @@
 namespace {
 ss::logger cmp_testlog("cmp_testlog");
 } // anonymous namespace
-
-class storage_manual_mixin {
-public:
-    storage_manual_mixin() {
-        cfg.get("log_segment_size_min")
-          .set_value(std::make_optional<uint64_t>(1));
-        cfg.get("log_disable_housekeeping_for_tests").set_value(true);
-    }
-
-private:
-    scoped_config cfg;
-};
 
 struct work_dir_summary {
     explicit work_dir_summary(ss::sstring path)

--- a/src/v/storage/tests/manual_mixin.h
+++ b/src/v/storage/tests/manual_mixin.h
@@ -1,0 +1,22 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "test_utils/scoped_config.h"
+
+class storage_manual_mixin {
+public:
+    storage_manual_mixin() {
+        cfg.get("log_segment_size_min")
+          .set_value(std::make_optional<uint64_t>(1));
+        cfg.get("log_disable_housekeeping_for_tests").set_value(true);
+    }
+
+private:
+    scoped_config cfg;
+};


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
We were previously comparing a given offset with the segment's last
offset, which in theory is the last record's offset, but across
compactions across multiple nodes, may end up not corresponding to a
real record. Take for example the following sequence:

node 1:
- Appends in order, end up with a segment [1707, 2000]. This segment contains
  batch [1785, 1799] with 15 records.
- Compaction runs, batch [1785, 1799] maintains its batch boundaries,
  but now has 6 records, e.g. the last one being 1790.
- The batches are replicated to node 2.

node 2:
- We have a different segment layout, but the batch ends up in segment
  [1230, 1799], still with only 6 records, the last one being 1790.
- We compact, and try to keep offset 1799, since this supposed to be the
  last offset.
- The last offset in the pre-compacted segment is actually 1790, and we
  end up not keeping the last batch because of this faulty comparison.
- The last batch in the post-compacted segment is actually 1784, and
  that's what is used for the max offset of the new segment.
- There is now a gap between the new compacted segment ending at 1784
  and the next, starting at 1800.

So, rather than comparing each record's offset with the segment's last
offset, this commit updates the check to compare the number of records
processed if the batch is the last batch in the segment.

Fixes #15403

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
