### PR TITLE
cloud_storage: Fix stuck reader problem

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -174,7 +174,11 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
     auto iter = _segments.find(mit->base_offset);
     if (iter != _segments.end()) {
         if (
-          iter->second->segment->get_max_rp_offset() != mit->committed_offset) {
+          iter->second->segment->get_segment_path()
+          != manifest.generate_segment_path(*mit)) {
+            // The segment was replaced and doesn't match metadata anymore. We
+            // want to avoid picking it up because otherwise we won't be able to
+            // make any progress.
             offload_segment(iter->first);
             iter = _segments.end();
         }

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -233,6 +233,8 @@ const kafka::offset remote_segment::get_base_kafka_offset() const {
     return _base_rp_offset - _base_offset_delta;
 }
 
+size_t remote_segment::get_segment_size() const { return _size; }
+
 const model::term_id remote_segment::get_term() const { return _term; }
 
 ss::future<> remote_segment::stop() {

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -96,6 +96,9 @@ public:
     /// Get base offset of the segment (kafka offset)
     const kafka::offset get_base_kafka_offset() const;
 
+    /// Get segment size
+    size_t get_segment_size() const;
+
     ss::future<> stop();
 
     /// create an input stream _sharing_ the underlying file handle

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -55,20 +55,27 @@ public:
         bool slowdown = false;
     };
 
-    /// Set expectaitions on REST API calls that supposed to be made
+    /// Set expectations on REST API calls that supposed to be made
     /// Only the requests that described in this call will be possible
     /// to make. This method can only be called once per test run.
     ///
     /// \param expectations is a collection of access points that allow GET,
     /// PUT, and DELETE requests, each expectation has url and body. The body
     /// will be returned by GET call if it's set or trigger error if its null.
-    /// The expectations are statefull. If the body of the expectation was set
+    /// The expectations are stateful. If the body of the expectation was set
     /// to null but there was PUT call that sent some data, subsequent GET call
     /// will retrieve this data.
     void set_expectations_and_listen(
       const std::vector<expectation>& expectations,
       std::optional<absl::flat_hash_set<ss::sstring>> headers_to_store
       = std::nullopt);
+
+    /// Update expectations for the REST API.
+    void add_expectations(const std::vector<expectation>& expectations);
+    void remove_expectations(const std::vector<ss::sstring>& urls);
+
+    /// Get object from S3 or nullopt if it doesn't exist
+    std::optional<ss::sstring> get_object(const ss::sstring& url) const;
 
     /// Access all http requests ordered by time
     const std::vector<http_test_utils::request_info>& get_requests() const;
@@ -98,6 +105,9 @@ private:
     ss::socket_address _server_addr;
     ss::shared_ptr<ss::httpd::http_server_control> _server;
 
+    struct content_handler;
+    friend struct content_handler;
+    ss::shared_ptr<content_handler> _content_handler;
     std::unique_ptr<ss::httpd::handler_base> _handler;
     /// Contains saved requests
     std::vector<http_test_utils::request_info> _requests;

--- a/src/v/cloud_storage/tests/util.h
+++ b/src/v/cloud_storage/tests/util.h
@@ -187,4 +187,11 @@ void reupload_compacted_segments(
   const std::vector<in_memory_segment>& segments,
   bool truncate_segments = false);
 
+std::vector<in_memory_segment> replace_segments(
+  cloud_storage_fixture& fixture,
+  cloud_storage::partition_manifest& manifest,
+  model::offset base_offset,
+  model::offset_delta base_delta,
+  const std::vector<std::vector<batch_t>>& batches);
+
 } // namespace cloud_storage


### PR DESCRIPTION
The reader can get stuck while reading from tiered-storage if the segment is replaced concurrently.
The mechanism of the failure:
- the reader creates the `remote_segment` that refers to segment A in the cloud
- concurrently, the segment A gets replaced with segment B
- another reader is trying to read the offset range covered by both A and B and finds that A is already materialized
- the reader checks that the committed offset is the same and tries to reuse A which triggers failure

We had the protection from this in the `remote_partition` but the code assumed that reupload will always merge segments. This is not always the case because compaction can reupload segment without merging it with its neighbor. The PR fixes this by adding size check. The reupload may have the same offset range but not the same size.

Fixes #15422 #15312 #15042


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix stuck reader problem in tiered-storage