### PR TITLE
Manage STM creation outside of `cluster::partition` 

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -30,6 +30,7 @@
 #include "serde/envelope.h"
 #include "serde/serde.h"
 #include "ssx/future-util.h"
+#include "storage/ntp_config.h"
 #include "storage/record_batch_builder.h"
 #include "storage/segment_appender_utils.h"
 #include "utils/fragmented_vector.h"
@@ -39,6 +40,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/defer.hh>
 
@@ -1600,6 +1602,27 @@ archival_metadata_stm::state_dirty archival_metadata_stm::get_dirty(
                  ? state_dirty::clean
                  : state_dirty::dirty;
     }
+}
+
+archival_metadata_stm_factory::archival_metadata_stm_factory(
+  bool cloud_storage_enabled,
+  ss::sharded<cloud_storage::remote>& cloud_storage_api,
+  ss::sharded<features::feature_table>& feature_table)
+  : _cloud_storage_enabled(cloud_storage_enabled)
+  , _cloud_storage_api(cloud_storage_api)
+  , _feature_table(feature_table) {}
+
+bool archival_metadata_stm_factory::is_applicable_for(
+  const storage::ntp_config& ntp_cfg) const {
+    return _cloud_storage_enabled && _cloud_storage_api.local_is_initialized()
+           && ntp_cfg.ntp().ns == model::kafka_namespace;
+}
+
+void archival_metadata_stm_factory::create(
+  raft::state_machine_manager_builder& builder, raft::consensus* raft) {
+    auto stm = builder.create_stm<cluster::archival_metadata_stm>(
+      raft, _cloud_storage_api.local(), _feature_table.local(), clusterlog);
+    raft->log()->stm_manager()->add_stm(stm);
 }
 
 } // namespace cluster

--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -590,14 +590,12 @@ archival_metadata_stm::archival_metadata_stm(
   raft::consensus* raft,
   cloud_storage::remote& remote,
   features::feature_table& ft,
-  ss::logger& logger,
-  ss::shared_ptr<util::mem_tracker> partition_mem_tracker)
+  ss::logger& logger)
   : raft::persisted_stm<>(archival_stm_snapshot, logger, raft)
   , _logger(logger, ssx::sformat("ntp: {}", raft->ntp()))
+  , _mem_tracker(ss::make_shared<util::mem_tracker>(raft->ntp().path()))
   , _manifest(ss::make_shared<cloud_storage::partition_manifest>(
-      raft->ntp(),
-      raft->log_config().get_initial_revision(),
-      partition_mem_tracker))
+      raft->ntp(), raft->log_config().get_initial_revision(), _mem_tracker))
   , _cloud_storage_api(remote)
   , _feature_table(ft) {}
 

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -104,6 +104,7 @@ class archival_metadata_stm final : public raft::persisted_stm<> {
     friend class details::archival_metadata_stm_accessor;
 
 public:
+    static constexpr const char* name = "archival_metadata_stm";
     friend class command_batch_builder;
 
     explicit archival_metadata_stm(
@@ -247,7 +248,6 @@ public:
 
     model::offset max_collectible_offset() override;
 
-    std::string_view get_name() const final { return "archival_metadata_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 private:

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -111,8 +111,7 @@ public:
       raft::consensus*,
       cloud_storage::remote& remote,
       features::feature_table&,
-      ss::logger& logger,
-      ss::shared_ptr<util::mem_tracker> partition_mem_tracker = nullptr);
+      ss::logger& logger);
 
     /// Add segments to the raft log, replicate them and
     /// wait until it is applied to the STM.
@@ -322,6 +321,7 @@ private:
 
     mutex _lock;
 
+    ss::shared_ptr<util::mem_tracker> _mem_tracker;
     ss::shared_ptr<cloud_storage::partition_manifest> _manifest;
 
     // The offset of the last mark_clean_cmd applied: if the manifest is

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1798,7 +1798,6 @@ ss::future<std::error_code> controller_backend::do_create_partition(
                 initial_rev.value()),
               group_id,
               std::move(members),
-              *cfg,
               cfg->properties.remote_topic_properties,
               read_replica_bucket);
 

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -78,6 +78,7 @@ requires std::is_trivially_copyable_v<Key>
          && std::is_trivially_copyable_v<Value>
 class distributed_kv_stm final : public raft::persisted_stm<> {
 public:
+    static constexpr const char* name = "distributed_kv_stm";
     explicit distributed_kv_stm(
       size_t max_partitions, ss::logger& logger, raft::consensus* raft)
       : persisted_stm<>("distributed_kv_stm.snapshot", logger, raft)
@@ -156,7 +157,6 @@ public:
         co_return;
     }
 
-    std::string_view get_name() const final { return "distributed_kv_stm"; }
     // TODO: implement delete retention with incremental raft snapshots.
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -14,6 +14,7 @@
 #include "cluster/logger.h"
 #include "distributed_kv_stm_types.h"
 #include "raft/persisted_stm.h"
+#include "utils/fixed_string.h"
 
 #include <type_traits>
 
@@ -73,12 +74,13 @@ concept SerdeSerializable = requires(T t, iobuf buf, iobuf_parser parser) {
 template<
   SerdeSerializable Key,
   SerdeSerializable Value,
+  fixed_string Name = "distributed_kv_stm",
   size_t MaxMemoryUsage = 1_MiB>
 requires std::is_trivially_copyable_v<Key>
          && std::is_trivially_copyable_v<Value>
 class distributed_kv_stm final : public raft::persisted_stm<> {
 public:
-    static constexpr const char* name = "distributed_kv_stm";
+    static constexpr std::string_view name = Name;
     explicit distributed_kv_stm(
       size_t max_partitions, ss::logger& logger, raft::consensus* raft)
       : persisted_stm<>("distributed_kv_stm.snapshot", logger, raft)

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -71,6 +71,8 @@ class node_isolation_watcher;
 struct controller_snapshot;
 struct controller_join_snapshot;
 class tx_manager_migrator;
+struct state_machine_factory;
+class state_machine_registry;
 
 namespace node {
 class local_monitor;

--- a/src/v/cluster/id_allocator_stm.cc
+++ b/src/v/cluster/id_allocator_stm.cc
@@ -13,9 +13,11 @@
 #include "cluster/logger.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "model/namespace.h"
 #include "raft/consensus.h"
 #include "raft/errc.h"
 #include "raft/types.h"
+#include "storage/ntp_config.h"
 #include "storage/record_batch_builder.h"
 
 #include <seastar/core/coroutine.hh>
@@ -234,6 +236,16 @@ ss::future<> id_allocator_stm::apply_raft_snapshot(const iobuf&) {
     _next_snapshot = _raft->start_offset();
     _processed = 0;
     return ss::now();
+}
+
+bool id_allocator_stm_factory::is_applicable_for(
+  const storage::ntp_config& cfg) const {
+    return cfg.ntp() == model::id_allocator_ntp;
+}
+
+void id_allocator_stm_factory::create(
+  raft::state_machine_manager_builder& builder, raft::consensus* raft) {
+    builder.create_stm<id_allocator_stm>(clusterlog, raft);
 }
 
 } // namespace cluster

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -34,6 +34,8 @@ namespace cluster {
 
 class id_allocator_stm final : public raft::persisted_stm<> {
 public:
+    static constexpr const char* name = "id_allocator_stm";
+
     struct stm_allocation_result {
         int64_t id;
         raft::errc raft_status{raft::errc::success};
@@ -47,7 +49,6 @@ public:
     ss::future<stm_allocation_result>
     allocate_id(model::timeout_clock::duration timeout);
 
-    std::string_view get_name() const final { return "id_allocator_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
     ss::future<stm_allocation_result>

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/fwd.h"
+#include "cluster/state_machine_registry.h"
 #include "cluster/types.h"
 #include "model/fundamental.h"
 #include "model/record.h"
@@ -34,7 +35,7 @@ namespace cluster {
 
 class id_allocator_stm final : public raft::persisted_stm<> {
 public:
-    static constexpr const char* name = "id_allocator_stm";
+    static constexpr std::string_view name = "id_allocator_stm";
 
     struct stm_allocation_result {
         int64_t id;
@@ -142,6 +143,16 @@ private:
     int64_t _state{0};
 
     bool _is_writing_snapshot{false};
+};
+
+class id_allocator_stm_factory : public state_machine_factory {
+public:
+    id_allocator_stm_factory() = default;
+    bool is_applicable_for(const storage::ntp_config& cfg) const final;
+
+    void create(
+      raft::state_machine_manager_builder& builder,
+      raft::consensus* raft) final;
 };
 
 } // namespace cluster

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -46,6 +46,8 @@ class consensus;
 class log_eviction_stm
   : public raft::persisted_stm<raft::kvstore_backed_stm_snapshot> {
 public:
+    static constexpr const char* name = "log_eviction_stm";
+
     using offset_result = result<model::offset, std::error_code>;
     log_eviction_stm(raft::consensus*, ss::logger&, storage::kvstore&);
 
@@ -103,7 +105,6 @@ public:
         return model::next_offset(_delete_records_eviction_offset);
     }
 
-    std::string_view get_name() const final { return "log_eviction_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 protected:

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -380,9 +380,7 @@ kafka_stages partition::replicate_in_stages(
       std::move(res.request_enqueued), std::move(replicate_finished));
 }
 
-ss::future<> partition::start(
-  std::optional<topic_configuration> topic_cfg,
-  state_machine_registry& stm_registry) {
+ss::future<> partition::start(state_machine_registry& stm_registry) {
     const auto& ntp = _raft->ntp();
     raft::state_machine_manager_builder builder = stm_registry.make_builder_for(
       _raft.get());

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -433,9 +433,12 @@ kafka_stages partition::replicate_in_stages(
       std::move(res.request_enqueued), std::move(replicate_finished));
 }
 
-ss::future<> partition::start(std::optional<topic_configuration> topic_cfg) {
+ss::future<> partition::start(
+  std::optional<topic_configuration> topic_cfg,
+  state_machine_registry& stm_registry) {
     const auto& ntp = _raft->ntp();
-    raft::state_machine_manager_builder builder;
+    raft::state_machine_manager_builder builder = stm_registry.make_builder_for(
+      _raft.get());
     // special cases for id_allocator and transaction coordinator partitions
     if (is_id_allocator_topic(ntp)) {
         _id_allocator_stm = builder.create_stm<cluster::id_allocator_stm>(

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -445,6 +445,7 @@ ss::future<> partition::start(std::optional<topic_configuration> topic_cfg) {
 
     if (is_tx_manager_topic(_raft->ntp()) && _is_tx_enabled) {
         _tm_stm = builder.create_stm<cluster::tm_stm>(
+          ss::sstring(tm_stm_name),
           clusterlog,
           _raft.get(),
           _feature_table,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -435,13 +435,6 @@ ss::future<> partition::start(
     const auto& ntp = _raft->ntp();
     raft::state_machine_manager_builder builder = stm_registry.make_builder_for(
       _raft.get());
-    // special cases for id_allocator and transaction coordinator partitions
-    if (is_id_allocator_topic(ntp)) {
-        _id_allocator_stm = builder.create_stm<cluster::id_allocator_stm>(
-          clusterlog, _raft.get());
-        co_return co_await _raft->start(std::move(builder));
-    }
-
     if (is_transform_offsets_topic(_raft->ntp())) {
         vassert(
           topic_cfg.has_value(),

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -32,17 +32,6 @@
 
 #include <exception>
 
-namespace {
-bool is_id_allocator_topic(model::ntp ntp) {
-    return ntp.ns == model::kafka_internal_namespace
-           && ntp.tp.topic == model::id_allocator_topic;
-}
-
-bool is_transform_offsets_topic(const model::ntp& ntp) {
-    return ntp.ns == model::kafka_internal_namespace
-           && ntp.tp.topic == model::transform_offsets_topic;
-}
-}; // namespace
 namespace cluster {
 
 partition::partition(
@@ -435,14 +424,7 @@ ss::future<> partition::start(
     const auto& ntp = _raft->ntp();
     raft::state_machine_manager_builder builder = stm_registry.make_builder_for(
       _raft.get());
-    if (is_transform_offsets_topic(_raft->ntp())) {
-        vassert(
-          topic_cfg.has_value(),
-          "No topic configuration passed, stm requires configuration for "
-          "partition count.");
-        _transform_offsets_stm = builder.create_stm<transform_offsets_stm_t>(
-          topic_cfg->partition_count, clusterlog, _raft.get());
-    }
+
     /**
      * Data partitions
      */

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -506,6 +506,8 @@ ss::future<> partition::start(
     // store rm_stm pointer in partition as this is commonly used stm
     _rm_stm = _raft->stm_manager()->get<cluster::rm_stm>(
       rm_stm_factory::stm_name);
+    _raft->stm_manager()->get<cluster::log_eviction_stm>(
+      cluster::log_eviction_stm_factory::stm_name);
 }
 
 ss::future<> partition::stop() {

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -48,8 +48,6 @@ partition::partition(
   storage::kvstore& kvstore,
   std::optional<cloud_storage_clients::bucket_name> read_replica_bucket)
   : _raft(std::move(r))
-  , _partition_mem_tracker(
-      ss::make_shared<util::mem_tracker>(_raft->ntp().path()))
   , _probe(std::make_unique<replicated_partition_probe>(*this))
   , _tx_gateway_frontend(tx_gateway_frontend)
   , _feature_table(feature_table)
@@ -435,8 +433,7 @@ ss::future<> partition::start(
           _raft.get(),
           _cloud_storage_api.local(),
           _feature_table.local(),
-          clusterlog,
-          _partition_mem_tracker);
+          clusterlog);
         _raft->log()->stm_manager()->add_stm(_archival_meta_stm);
 
         if (_cloud_storage_cache.local_is_initialized()) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -282,11 +282,7 @@ public:
     }
 
     ss::shared_ptr<cluster::id_allocator_stm> id_allocator_stm() const {
-        return _id_allocator_stm;
-    }
-
-    ss::shared_ptr<transform_offsets_stm_t> transform_offsets_stm() const {
-        return _transform_offsets_stm;
+        return _raft->stm_manager()->get<cluster::id_allocator_stm>();
     }
 
     ss::lw_shared_ptr<const storage::offset_translator_state>
@@ -513,7 +509,6 @@ private:
     consensus_ptr _raft;
     ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
-    ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::shared_ptr<transform_offsets_stm_t> _transform_offsets_stm;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -310,7 +310,9 @@ public:
         return _raft->log()->config();
     }
 
-    ss::shared_ptr<cluster::tm_stm> tm_stm() { return _tm_stm; }
+    ss::shared_ptr<cluster::tm_stm> tm_stm() {
+        return _raft->stm_manager()->get<cluster::tm_stm>();
+    }
 
     ss::future<fragmented_vector<rm_stm::tx_range>>
     aborted_transactions(model::offset from, model::offset to) {
@@ -513,7 +515,6 @@ private:
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::id_allocator_stm> _id_allocator_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
-    ss::shared_ptr<cluster::tm_stm> _tm_stm;
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::shared_ptr<transform_offsets_stm_t> _transform_offsets_stm;
     ss::abort_source _as;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/fwd.h"
 #include "cluster/archival_metadata_stm.h"
 #include "cluster/distributed_kv_stm.h"
+#include "cluster/fwd.h"
 #include "cluster/id_allocator_stm.h"
 #include "cluster/log_eviction_stm.h"
 #include "cluster/partition_probe.h"
@@ -67,7 +68,8 @@ public:
     ~partition();
 
     raft::group_id group() const { return _raft->group(); }
-    ss::future<> start(std::optional<topic_configuration>);
+    ss::future<>
+    start(std::optional<topic_configuration>, state_machine_registry&);
     ss::future<> stop();
 
     bool should_construct_archiver();

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -502,7 +502,6 @@ private:
       local_timequery(storage::timequery_config);
 
     consensus_ptr _raft;
-    ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -48,15 +48,11 @@ class partition {
 public:
     partition(
       consensus_ptr r,
-      ss::sharded<cluster::tx_gateway_frontend>&,
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<cloud_storage::cache>&,
       ss::lw_shared_ptr<const archival::configuration>,
       ss::sharded<features::feature_table>&,
-      ss::sharded<cluster::tm_stm_cache_manager>&,
       ss::sharded<archival::upload_housekeeping_service>&,
-      ss::sharded<producer_state_manager>&,
-      storage::kvstore&,
       std::optional<cloud_storage_clients::bucket_name> read_replica_bucket
       = std::nullopt);
 
@@ -507,11 +503,7 @@ private:
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
     ss::abort_source _as;
     partition_probe _probe;
-    ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
     ss::sharded<features::feature_table>& _feature_table;
-    ss::sharded<cluster::tm_stm_cache_manager>& _tm_stm_cache_manager;
-    bool _is_tx_enabled{false};
-    bool _is_idempotence_enabled{false};
     ss::lw_shared_ptr<const archival::configuration> _archival_conf;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
@@ -533,9 +525,6 @@ private:
     std::unique_ptr<cluster::topic_configuration> _topic_cfg;
 
     ss::sharded<archival::upload_housekeeping_service>& _upload_housekeeping;
-
-    storage::kvstore& _kvstore;
-    ss::sharded<cluster::producer_state_manager>& _producer_state_manager;
 
     friend std::ostream& operator<<(std::ostream& o, const partition& x);
 };

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -45,11 +45,6 @@ class partition_manager;
 /// holds cluster logic that is not raft related
 /// all raft logic is proxied transparently
 class partition {
-private:
-    using transform_offsets_stm_t = cluster::distributed_kv_stm<
-      model::transform_offsets_key,
-      model::transform_offsets_value>;
-
 public:
     partition(
       consensus_ptr r,
@@ -511,7 +506,6 @@ private:
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;
     ss::shared_ptr<cluster::rm_stm> _rm_stm;
     ss::shared_ptr<archival_metadata_stm> _archival_meta_stm;
-    ss::shared_ptr<transform_offsets_stm_t> _transform_offsets_stm;
     ss::abort_source _as;
     partition_probe _probe;
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -59,8 +59,7 @@ public:
     ~partition();
 
     raft::group_id group() const { return _raft->group(); }
-    ss::future<>
-    start(std::optional<topic_configuration>, state_machine_registry&);
+    ss::future<> start(state_machine_registry&);
     ss::future<> stop();
 
     bool should_construct_archiver();

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -105,7 +105,6 @@ ss::future<consensus_ptr> partition_manager::manage(
   storage::ntp_config ntp_cfg,
   raft::group_id group,
   std::vector<model::broker> initial_nodes,
-  std::optional<topic_configuration> topic_cfg,
   std::optional<remote_topic_properties> rtp,
   std::optional<cloud_storage_clients::bucket_name> read_replica_bucket,
   raft::with_learner_recovery_throttle enable_learner_recovery_throttle,
@@ -248,7 +247,7 @@ ss::future<consensus_ptr> partition_manager::manage(
 
     _manage_watchers.notify(p->ntp(), p);
 
-    co_await p->start(std::move(topic_cfg), _stm_registry);
+    co_await p->start(_stm_registry);
 
     co_return c;
 }

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -258,7 +258,7 @@ ss::future<consensus_ptr> partition_manager::manage(
 
     _manage_watchers.notify(p->ntp(), p);
 
-    co_await p->start(std::move(topic_cfg));
+    co_await p->start(std::move(topic_cfg), _stm_registry);
 
     co_return c;
 }

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -87,7 +87,6 @@ public:
       storage::ntp_config,
       raft::group_id,
       std::vector<model::broker>,
-      std::optional<topic_configuration> topic_config = std::nullopt,
       std::optional<remote_topic_properties> = std::nullopt,
       std::optional<cloud_storage_clients::bucket_name> = std::nullopt,
       raft::with_learner_recovery_throttle

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -208,6 +208,11 @@ public:
     ss::future<cloud_storage::cache_usage_target>
     get_cloud_cache_disk_usage_target() const;
 
+    template<typename T, typename... Args>
+    void register_factory(Args&&... args) {
+        _stm_registry.register_factory<T>(std::forward<Args>(args)...);
+    }
+
 private:
     /// Download log if partition_recovery_manager is initialized.
     ///
@@ -252,6 +257,8 @@ private:
 
     // Our handle from registering for leadership notifications on group_manager
     std::optional<cluster::notification_id_type> _leader_notify_handle;
+
+    state_machine_registry _stm_registry;
 
     friend std::ostream& operator<<(std::ostream&, const partition_manager&);
 };

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -39,15 +39,12 @@ public:
     partition_manager(
       ss::sharded<storage::api>&,
       ss::sharded<raft::group_manager>&,
-      ss::sharded<cluster::tx_gateway_frontend>&,
       ss::sharded<cloud_storage::partition_recovery_manager>&,
       ss::sharded<cloud_storage::remote>&,
       ss::sharded<cloud_storage::cache>&,
       ss::lw_shared_ptr<const archival::configuration>,
       ss::sharded<features::feature_table>&,
-      ss::sharded<cluster::tm_stm_cache_manager>&,
-      ss::sharded<archival::upload_housekeeping_service>&,
-      ss::sharded<producer_state_manager>&);
+      ss::sharded<archival::upload_housekeeping_service>&);
 
     ~partition_manager();
 
@@ -166,10 +163,6 @@ public:
      */
     const ntp_table_container& partitions() const { return _ntp_table; }
 
-    ss::sharded<cluster::tx_gateway_frontend>& get_tx_frontend() {
-        return _tx_gateway_frontend;
-    }
-
     /*
      * Block/unblock current node from leadership for new and existing raft
      * groups.
@@ -235,14 +228,13 @@ private:
     ntp_table_container _ntp_table;
     absl::flat_hash_map<raft::group_id, ss::lw_shared_ptr<partition>>
       _raft_table;
-    ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
+
     ss::sharded<cloud_storage::partition_recovery_manager>&
       _partition_recovery_mgr;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     ss::sharded<cloud_storage::cache>& _cloud_storage_cache;
     ss::lw_shared_ptr<const archival::configuration> _archival_conf;
     ss::sharded<features::feature_table>& _feature_table;
-    ss::sharded<cluster::tm_stm_cache_manager>& _tm_stm_cache_manager;
     ss::sharded<archival::upload_housekeeping_service>& _upload_hks;
     ss::gate _gate;
 
@@ -252,8 +244,6 @@ private:
     ss::abort_source _as;
 
     bool _block_new_leadership{false};
-
-    ss::sharded<producer_state_manager>& _producer_state_manager;
 
     // Our handle from registering for leadership notifications on group_manager
     std::optional<cluster::notification_id_type> _leader_notify_handle;

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -37,7 +37,6 @@ static ss::future<consensus_ptr> create_raft0(
         std::move(initial_brokers),
         std::nullopt,
         std::nullopt,
-        std::nullopt,
         raft::with_learner_recovery_throttle::no,
         raft::keep_snapshotted_log::yes)
       .then([&st](consensus_ptr p) {

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -64,6 +64,7 @@ namespace cluster {
  */
 class rm_stm final : public raft::persisted_stm<> {
 public:
+    static constexpr const char* name = "rm_stm";
     using clock_type = ss::lowres_clock;
     using time_point_type = clock_type::time_point;
     using duration_type = clock_type::duration;
@@ -261,7 +262,6 @@ public:
 
     uint64_t get_local_snapshot_size() const override;
 
-    std::string_view get_name() const final { return "rm_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
     const producers_t& get_producers() const { return _producers; }

--- a/src/v/cluster/state_machine_registry.h
+++ b/src/v/cluster/state_machine_registry.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "raft/consensus.h"
+#include "raft/fwd.h"
+#include "storage/ntp_config.h"
+
+namespace cluster {
+
+/**
+ * State machine factory is a class used by registry to create stm instance if
+ * it is required for a given Raft group. The factory has two main
+ * responsibilities expressed by its interface method.
+ * Firstly it has to answer query if given stm is required for particular raft
+ * group. Secondly it must created an stm instance using a builder which is
+ * passed into `create` method. State machine factory must encapsulate all
+ * dependencies required to create state machine
+ */
+struct state_machine_factory {
+    /**
+     * Must return true if STM should be created for a partition underlaid by
+     * passed raft group
+     */
+    virtual bool is_applicable_for(const storage::ntp_config&) const = 0;
+
+    /**
+     * A method must call builder interface to create STM instance.
+     */
+    virtual void create(raft::state_machine_manager_builder&, raft::consensus*)
+      = 0;
+
+    virtual ~state_machine_factory() = default;
+};
+
+/**
+ * State machine registry is a class holding all registered state machines
+ * factories. Registry is used by partition_manger whenever a new partition
+ * instance is created. Registry builds all state machines that are required for
+ * a give partition instance.
+ */
+class state_machine_registry {
+public:
+    template<typename T, typename... Args>
+    void register_factory(Args&&... args) {
+        _stm_factories.push_back(
+          std::make_unique<T>(std::forward<Args>(args)...));
+    }
+
+    raft::state_machine_manager_builder
+    make_builder_for(raft::consensus* raft) {
+        raft::state_machine_manager_builder builder;
+        for (auto& factory : _stm_factories) {
+            if (factory->is_applicable_for(raft->log_config())) {
+                factory->create(builder, raft);
+            }
+        }
+        return builder;
+    }
+
+private:
+    std::vector<std::unique_ptr<state_machine_factory>> _stm_factories;
+};
+} // namespace cluster

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -115,6 +115,7 @@ public:
  */
 class tm_stm final : public raft::persisted_stm<> {
 public:
+    static constexpr const char* name = "tm_stm";
     using clock_type = ss::lowres_system_clock;
 
     enum op_status {
@@ -354,7 +355,6 @@ public:
     size_t tx_cache_size() const;
 
     std::optional<tm_transaction> oldest_tx() const;
-    std::string_view get_name() const final { return "tm_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 protected:

--- a/src/v/raft/fwd.h
+++ b/src/v/raft/fwd.h
@@ -17,5 +17,6 @@ class consensus;
 class group_manager;
 class recovery_throttle;
 class state_machine_manager;
+class state_machine_base;
 
 } // namespace raft

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -201,6 +201,14 @@ public:
         return raft::state_machine_base::last_applied_offset();
     }
 
+    size_t get_local_state_size() const final {
+        return get_local_snapshot_size();
+    }
+
+    ss::future<> remove_local_state() final {
+        return remove_persistent_state();
+    }
+
     ss::future<bool> wait_no_throw(
       model::offset offset,
       model::timeout_clock::time_point,

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -61,13 +61,6 @@ public:
     virtual ss::future<> apply_raft_snapshot(const iobuf&) = 0;
 
     /**
-     * Returns a unique identifier of this state machine. Each stm built on top
-     * of the same Raft group must have different id.
-     * Id is going to be used when logging and to mark parts of the snapshots.
-     */
-    virtual std::string_view get_name() const = 0;
-
-    /**
      * Returns a snapshot of an STM state with requested last included offset
      */
     virtual ss::future<iobuf>

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -73,6 +73,18 @@ public:
         return model::prev_offset(_next);
     }
 
+    /**
+     * Some of the state machines may persist additional local state, to account
+     * for it we provide a method that should return size of local state in
+     * bytes.
+     */
+    virtual size_t get_local_state_size() const = 0;
+    /**
+     * Some of the state machines may persist additional local state. This
+     * method is used by stm manager to clean the persistent state of the stm
+     */
+    virtual ss::future<> remove_local_state() = 0;
+
 protected:
     /**
      *  Lifecycle is managed by state_machine_manager

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -124,7 +124,7 @@ batch_applicator::apply_to_stm(
       _log.trace,
       "[{}][{}] applying batch with base {} and last {} offsets",
       _ctx,
-      state.stm_entry->stm->get_name(),
+      state.stm_entry->name,
       batch.header().base_offset,
       last_offset);
 
@@ -145,7 +145,7 @@ batch_applicator::apply_to_stm(
           _log.warn,
           "[{}][{}] error applying batch with base_offset: {} - {}",
           _ctx,
-          state.stm_entry->stm->get_name(),
+          state.stm_entry->name,
           batch.base_offset(),
           std::current_exception());
         state.error = true;
@@ -153,16 +153,20 @@ batch_applicator::apply_to_stm(
     }
 }
 
+state_machine_manager::named_stm::named_stm(ss::sstring name, stm_ptr stm)
+  : name(std::move(name))
+  , stm(std::move(stm)) {}
+
 state_machine_manager::state_machine_manager(
-  consensus* raft, std::vector<stm_ptr> stms, ss::scheduling_group apply_sg)
+  consensus* raft, std::vector<named_stm> stms, ss::scheduling_group apply_sg)
   : _raft(raft)
   , _log(ctx_log(_raft->group(), _raft->ntp()))
   , _apply_sg(apply_sg) {
-    for (auto& stm : stms) {
-        std::string_view name = stm->get_name();
+    for (auto& n_stm : stms) {
         _machines.try_emplace(
-          ss::sstring(name),
-          ss::make_lw_shared<state_machine_entry>(std::move(stm)));
+          n_stm.name,
+          ss::make_lw_shared<state_machine_entry>(
+            n_stm.name, std::move(n_stm.stm)));
     }
 }
 
@@ -377,7 +381,7 @@ void state_machine_manager::maybe_start_background_apply(
     vlog(
       _log.debug,
       "starting background apply fiber for '{}' state machine",
-      entry->stm->get_name());
+      entry->name);
 
     ssx::spawn_with_gate(_gate, [this, entry] {
         return entry->background_apply_mutex.get_units().then(
@@ -400,7 +404,7 @@ ss::future<> state_machine_manager::background_apply_fiber(entry_ptr entry) {
           "reading batches in range [{}, {}] for '{}' stm background apply",
           entry->stm->next(),
           _next,
-          entry->stm->get_name());
+          entry->name);
         bool error = false;
         try {
             model::record_batch_reader reader = co_await _raft->make_reader(
@@ -414,7 +418,7 @@ ss::future<> state_machine_manager::background_apply_fiber(entry_ptr entry) {
             vlog(
               _log.warn,
               "exception thrown from background apply fiber for {} - {}",
-              entry->stm->get_name(),
+              entry->name,
               std::current_exception());
         }
         if (error) {
@@ -424,7 +428,7 @@ ss::future<> state_machine_manager::background_apply_fiber(entry_ptr entry) {
     vlog(
       _log.debug,
       "finished background apply for '{}' state machine",
-      entry->stm->get_name());
+      entry->name);
 }
 
 ss::future<iobuf>

--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -487,4 +487,10 @@ state_machine_manager::acquire_background_apply_mutexes() {
     return ss::when_all_succeed(futures.begin(), futures.end());
 }
 
+ss::future<> state_machine_manager::remove_local_state() {
+    co_await ss::coroutine::parallel_for_each(_machines, [](auto entry_pair) {
+        return entry_pair.second->stm->remove_local_state();
+    });
+}
+
 } // namespace raft

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -82,6 +82,24 @@ public:
     ss::future<> stop();
 
     model::offset last_applied() const { return model::prev_offset(_next); }
+    /**
+     * Returns a pointer to specific type of state machine.
+     *
+     * This API provides basic runtime validation verifying if requested STM
+     * type matches the name passed. It returns a nullptr if state machine with
+     * requested name is not registered in manager.
+     */
+    template<ManagableStateMachine T>
+    ss::shared_ptr<T> get() {
+        auto it = _machines.find(T::name);
+        if (it == _machines.end()) {
+            return nullptr;
+        }
+        auto ptr = ss::dynamic_pointer_cast<T>(it->second->stm);
+        vassert(
+          ptr != nullptr, "Incorrect STM type requested for STM {}", T::name);
+        return ptr;
+    }
 
     template<StateMachineIterateFunc Func>
     void for_each_stm(Func&& func) const {

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -20,21 +20,27 @@
 #include "serde/envelope.h"
 #include "storage/snapshot.h"
 #include "storage/types.h"
+#include "utils/absl_sstring_hash.h"
 #include "utils/mutex.h"
 
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sstring.hh>
 
 #include <absl/container/flat_hash_map.h>
 
 #include <concepts>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 namespace raft {
 
 template<typename T>
-concept ManagableStateMachine = std::derived_from<T, state_machine_base>;
+concept ManagableStateMachine = requires(T stm) {
+    std::derived_from<T, state_machine_base>;
+    { T::name } -> std::convertible_to<std::string_view>;
+};
 template<typename Func>
 concept StateMachineIterateFunc = requires(
   Func f, const ss::sstring& name, const state_machine_base& stm) {
@@ -86,10 +92,15 @@ public:
 
 private:
     using stm_ptr = ss::shared_ptr<state_machine_base>;
+    struct named_stm {
+        named_stm(ss::sstring, stm_ptr);
+        ss::sstring name;
+        stm_ptr stm;
+    };
 
     state_machine_manager(
       consensus* raft,
-      std::vector<stm_ptr> stms_to_manage,
+      std::vector<named_stm> stms_to_manage,
       ss::scheduling_group apply_sg);
 
     friend class batch_applicator;
@@ -98,8 +109,10 @@ private:
     static constexpr const char* background_ctx = "background";
 
     struct state_machine_entry {
-        explicit state_machine_entry(ss::shared_ptr<state_machine_base> stm)
-          : stm(std::move(stm)) {}
+        explicit state_machine_entry(
+          ss::sstring name, ss::shared_ptr<state_machine_base> stm)
+          : name(std::move(name))
+          , stm(std::move(stm)) {}
         state_machine_entry(state_machine_entry&&) noexcept = default;
         state_machine_entry(const state_machine_entry&) noexcept = delete;
         state_machine_entry& operator=(state_machine_entry&&) noexcept = delete;
@@ -107,11 +120,13 @@ private:
           = delete;
         ~state_machine_entry() = default;
 
+        ss::sstring name;
         ss::shared_ptr<state_machine_base> stm;
         mutex background_apply_mutex;
     };
     using entry_ptr = ss::lw_shared_ptr<state_machine_entry>;
-    using state_machines_t = absl::flat_hash_map<ss::sstring, entry_ptr>;
+    using state_machines_t
+      = absl::flat_hash_map<ss::sstring, entry_ptr, sstring_hash, sstring_eq>;
 
     void maybe_start_background_apply(const entry_ptr&);
     ss::future<> background_apply_fiber(entry_ptr);
@@ -158,7 +173,7 @@ public:
     template<ManagableStateMachine T, typename... Args>
     ss::shared_ptr<T> create_stm(Args&&... args) {
         auto machine = ss::make_shared<T>(std::forward<Args>(args)...);
-        _stms.push_back(machine);
+        _stms.emplace_back(ss::sstring(T::name), machine);
 
         return machine;
     }
@@ -170,7 +185,7 @@ public:
     }
 
 private:
-    std::vector<state_machine_manager::stm_ptr> _stms;
+    std::vector<state_machine_manager::named_stm> _stms;
     ss::scheduling_group _sg = ss::default_scheduling_group();
 };
 

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -108,6 +108,8 @@ public:
         }
     }
 
+    ss::future<> remove_local_state();
+
 private:
     using stm_ptr = ss::shared_ptr<state_machine_base>;
     struct named_stm {

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -123,11 +123,10 @@ struct kv_state
 
 class persisted_kv : public persisted_stm<> {
 public:
+    static constexpr std::string_view name = "persited_kv_stm";
     explicit persisted_kv(raft_node_instance& rn)
       : persisted_stm<>("simple-kv", logger, rn.raft().get())
       , raft_node(rn) {}
-
-    std::string_view get_name() const final { return "persisted_kv"; };
 
     ss::future<> start() override { return persisted_stm<>::start(); }
     ss::future<> stop() override { return persisted_stm<>::stop(); }

--- a/src/v/raft/tests/stm_test_fixture.h
+++ b/src/v/raft/tests/stm_test_fixture.h
@@ -40,7 +40,6 @@
 
 using namespace raft;
 namespace {
-
 /**
  * We use value entry struct to make kv_store apply operations not
  * idempotent
@@ -70,6 +69,7 @@ struct value_entry
  */
 struct simple_kv : public raft::state_machine_base {
     using state_t = absl::flat_hash_map<ss::sstring, value_entry>;
+    static constexpr std::string_view name = "simple_kv";
     explicit simple_kv(raft_node_instance& rn)
       : raft_node(rn) {}
 
@@ -106,8 +106,6 @@ struct simple_kv : public raft::state_machine_base {
         state = serde::from_iobuf<state_t>(buffer.copy());
         co_return;
     };
-
-    std::string_view get_name() const override { return "simple_kv"; };
 
     ss::future<iobuf>
     take_snapshot(model::offset last_included_offset) override {

--- a/src/v/raft/tests/stm_test_fixture.h
+++ b/src/v/raft/tests/stm_test_fixture.h
@@ -107,6 +107,9 @@ struct simple_kv : public raft::state_machine_base {
         co_return;
     };
 
+    size_t get_local_state_size() const final { return 0; }
+    ss::future<> remove_local_state() final { co_return; }
+
     ss::future<iobuf>
     take_snapshot(model::offset last_included_offset) override {
         state_t inc_state;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -45,6 +45,7 @@
 #include "cluster/topic_recovery_status_frontend.h"
 #include "cluster/topic_recovery_status_rpc_handler.h"
 #include "cluster/topics_frontend.h"
+#include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
@@ -303,7 +304,8 @@ admin_server::admin_server(
   ss::sharded<transform::service>* transform_service,
   ss::sharded<security::audit::audit_log_manager>& audit_mgr,
   std::unique_ptr<cluster::tx_manager_migrator>& tx_manager_migrator,
-  ss::sharded<kafka::server>& kafka_server)
+  ss::sharded<kafka::server>& kafka_server,
+  ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend)
   : _log_level_timer([this] { log_level_timer_handler(); })
   , _server("admin")
   , _cfg(std::move(cfg))
@@ -333,6 +335,7 @@ admin_server::admin_server(
   , _audit_mgr(audit_mgr)
   , _tx_manager_migrator(tx_manager_migrator)
   , _kafka_server(kafka_server)
+  , _tx_gateway_frontend(tx_gateway_frontend)
   , _default_blocked_reactor_notify(
       ss::engine().get_blocked_reactor_notify_ms()) {
     _server.set_content_streaming(true);

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -13,6 +13,7 @@
 
 #include "cloud_storage/fwd.h"
 #include "cluster/fwd.h"
+#include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
 #include "config/endpoint_tls_config.h"
 #include "finjector/stress_fiber.h"
@@ -90,7 +91,8 @@ public:
       ss::sharded<transform::service>*,
       ss::sharded<security::audit::audit_log_manager>&,
       std::unique_ptr<cluster::tx_manager_migrator>&,
-      ss::sharded<kafka::server>&);
+      ss::sharded<kafka::server>&,
+      ss::sharded<cluster::tx_gateway_frontend>&);
 
     ss::future<> start();
     ss::future<> stop();
@@ -674,6 +676,7 @@ private:
     ss::sharded<security::audit::audit_log_manager>& _audit_mgr;
     std::unique_ptr<cluster::tx_manager_migrator>& _tx_manager_migrator;
     ss::sharded<kafka::server>& _kafka_server;
+    ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;
 
     // Value before the temporary override
     std::chrono::milliseconds _default_blocked_reactor_notify;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2469,6 +2469,8 @@ void application::start_runtime_services(
             tx_gateway_frontend,
             producer_manager,
             feature_table);
+          pm.register_factory<cluster::log_eviction_stm_factory>(
+            storage.local().kvs());
       })
       .get();
     partition_manager.invoke_on_all(&cluster::partition_manager::start).get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -52,6 +52,7 @@
 #include "cluster/partition_recovery_manager.h"
 #include "cluster/producer_state_manager.h"
 #include "cluster/rm_partition_frontend.h"
+#include "cluster/rm_stm.h"
 #include "cluster/security_frontend.h"
 #include "cluster/self_test_rpc_handler.h"
 #include "cluster/service.h"
@@ -2462,6 +2463,12 @@ void application::start_runtime_services(
           pm.register_factory<cluster::id_allocator_stm_factory>();
           pm.register_factory<transform::transform_offsets_stm_factory>(
             controller->get_topics_state());
+          pm.register_factory<cluster::rm_stm_factory>(
+            config::shard_local_cfg().enable_transactions.value(),
+            config::shard_local_cfg().enable_idempotence.value(),
+            tx_gateway_frontend,
+            producer_manager,
+            feature_table);
       })
       .get();
     partition_manager.invoke_on_all(&cluster::partition_manager::start).get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2471,6 +2471,10 @@ void application::start_runtime_services(
             feature_table);
           pm.register_factory<cluster::log_eviction_stm_factory>(
             storage.local().kvs());
+          pm.register_factory<cluster::archival_metadata_stm_factory>(
+            config::shard_local_cfg().cloud_storage_enabled(),
+            cloud_storage_api,
+            feature_table);
       })
       .get();
     partition_manager.invoke_on_all(&cluster::partition_manager::start).get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -110,6 +110,7 @@
 #include "transform/api.h"
 #include "transform/rpc/client.h"
 #include "transform/rpc/service.h"
+#include "transform/transform_offsets_stm.h"
 #include "utils/file_io.h"
 #include "utils/human.h"
 #include "utils/uuid.h"
@@ -2459,6 +2460,8 @@ void application::start_runtime_services(
           pm.register_factory<cluster::tm_stm_factory>(
             tm_stm_cache_manager, feature_table);
           pm.register_factory<cluster::id_allocator_stm_factory>();
+          pm.register_factory<transform::transform_offsets_stm_factory>(
+            controller->get_topics_state());
       })
       .get();
     partition_manager.invoke_on_all(&cluster::partition_manager::start).get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -37,6 +37,7 @@
 #include "cluster/fwd.h"
 #include "cluster/id_allocator.h"
 #include "cluster/id_allocator_frontend.h"
+#include "cluster/id_allocator_stm.h"
 #include "cluster/members_manager.h"
 #include "cluster/members_table.h"
 #include "cluster/metadata_dissemination_handler.h"
@@ -2457,6 +2458,7 @@ void application::start_runtime_services(
       .invoke_on_all([this](cluster::partition_manager& pm) {
           pm.register_factory<cluster::tm_stm_factory>(
             tm_stm_cache_manager, feature_table);
+          pm.register_factory<cluster::id_allocator_stm_factory>();
       })
       .get();
     partition_manager.invoke_on_all(&cluster::partition_manager::start).get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1015,7 +1015,8 @@ void application::configure_admin_server() {
       &_transform_service,
       std::ref(audit_mgr),
       std::ref(_tx_manager_migrator),
-      std::ref(_kafka_server))
+      std::ref(_kafka_server),
+      std::ref(tx_gateway_frontend))
       .get();
 }
 
@@ -1420,7 +1421,6 @@ void application::wire_up_redpanda_services(
       partition_manager,
       std::ref(storage),
       std::ref(raft_group_manager),
-      std::ref(tx_gateway_frontend),
       std::ref(partition_recovery_manager),
       std::ref(cloud_storage_api),
       std::ref(shadow_index_cache),
@@ -1437,9 +1437,7 @@ void application::wire_up_redpanda_services(
             }
         }),
       std::ref(feature_table),
-      std::ref(tm_stm_cache_manager),
-      std::ref(_archival_upload_housekeeping),
-      std::ref(producer_manager))
+      std::ref(_archival_upload_housekeeping))
       .get();
     vlog(_log.info, "Partition manager started");
     construct_service(

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -16,6 +16,7 @@ v_cc_library(
     transform_manager.cc
     commit_batcher.cc
     txn_reader.cc
+    transform_offsets_stm.cc
   DEPS
     v::wasm
     v::model

--- a/src/v/transform/rpc/deps.cc
+++ b/src/v/transform/rpc/deps.cc
@@ -25,6 +25,7 @@
 #include "model/namespace.h"
 #include "model/transform.h"
 #include "transform/rpc/logger.h"
+#include "transform/transform_offsets_stm.h"
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/future.hh>
@@ -146,7 +147,8 @@ private:
             }
             co_return response;
         }
-        auto stm = partition->transform_offsets_stm();
+        auto stm
+          = partition->raft()->stm_manager()->get<transform_offsets_stm_t>();
         if (partition->ntp().tp.partition != coordinator_partition) {
             for (const auto& key : request.keys) {
                 response.errors[key] = cluster::errc::not_leader;
@@ -176,7 +178,8 @@ private:
             response.errc = cluster::errc::not_leader;
             co_return response;
         }
-        auto stm = partition->transform_offsets_stm();
+        auto stm
+          = partition->raft()->stm_manager()->get<transform_offsets_stm_t>();
         response.errc = co_await stm->put(std::move(req.kvs));
         co_return response;
     }
@@ -191,7 +194,8 @@ private:
             }
             co_return response;
         }
-        auto stm = partition->transform_offsets_stm();
+        auto stm
+          = partition->raft()->stm_manager()->get<transform_offsets_stm_t>();
         for (const auto& key : request.keys) {
             auto result = co_await stm->get(key);
             if (result.has_error()) {

--- a/src/v/transform/transform_offsets_stm.cc
+++ b/src/v/transform/transform_offsets_stm.cc
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/transform_offsets_stm.h"
+
+#include "model/metadata.h"
+#include "transform/logger.h"
+
+namespace transform {
+
+transform_offsets_stm_factory::transform_offsets_stm_factory(
+  ss::sharded<cluster::topic_table>& topics)
+  : _topics(topics) {}
+
+bool transform_offsets_stm_factory::is_applicable_for(
+  const storage::ntp_config& cfg) const {
+    const auto& ntp = cfg.ntp();
+    return ntp.ns == model::kafka_internal_namespace
+           && ntp.tp.topic == model::transform_offsets_topic;
+}
+
+void transform_offsets_stm_factory::create(
+  raft::state_machine_manager_builder& builder, raft::consensus* raft) {
+    auto cfg = _topics.local().get_topic_cfg(
+      model::topic_namespace_view(raft->ntp().ns, raft->ntp().tp.topic));
+    vassert(
+      cfg.has_value(),
+      "When creating transform stm the topic configuration must exists");
+
+    builder.create_stm<transform_offsets_stm_t>(
+      cfg->partition_count, tlog, raft);
+}
+
+} // namespace transform

--- a/src/v/transform/transform_offsets_stm.h
+++ b/src/v/transform/transform_offsets_stm.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cluster/distributed_kv_stm.h"
+#include "cluster/state_machine_registry.h"
+#include "cluster/topic_table.h"
+
+namespace transform {
+
+using transform_offsets_stm_t = cluster::distributed_kv_stm<
+  model::transform_offsets_key,
+  model::transform_offsets_value,
+  "transform_offsets_stm">;
+
+class transform_offsets_stm_factory : public cluster::state_machine_factory {
+public:
+    explicit transform_offsets_stm_factory(ss::sharded<cluster::topic_table>&);
+    bool is_applicable_for(const storage::ntp_config& cfg) const final;
+
+    void create(
+      raft::state_machine_manager_builder& builder,
+      raft::consensus* raft) final;
+
+private:
+    ss::sharded<cluster::topic_table>& _topics;
+};
+} // namespace transform

--- a/src/v/utils/fixed_string.h
+++ b/src/v/utils/fixed_string.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <algorithm>
+#include <string_view>
+
+/**
+ * Compile time string owning string literal.
+ * Inspired by
+ * https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0259r0.pdf
+ */
+template<size_t N>
+struct fixed_string {
+    // NOLINTNEXTLINE(hicpp-explicit-conversions,hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays,cppcoreguidelines-pro-type-member-init,hicpp-member-init)
+    constexpr fixed_string(const char (&str)[N + 1]) noexcept {
+        std::copy_n(str, N, value);
+    }
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
+    constexpr operator const char*() const { return value; }
+    // NOLINTNEXTLINE(hicpp-explicit-conversions)
+    constexpr operator std::string_view() const {
+        return std::string_view(value, N);
+    }
+    // NOLINTNEXTLINE(hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+    char value[N];
+};
+
+/**
+ * Helper for deducing N (size of the string based on the size of reference to
+ * an array of chars)
+ * N - 1 is used to remove the terminating argument
+ */
+template<size_t N>
+// NOLINTNEXTLINE(hicpp-avoid-c-arrays,modernize-avoid-c-arrays,cppcoreguidelines-avoid-c-arrays)
+fixed_string(const char (&)[N]) -> fixed_string<N - 1>;


### PR DESCRIPTION
Changed the way how state machines are managed in Redpanda. Previously all the STMs were a part of `cluster::partition`. This was convenient as the partition STM lifecycle is in general bound with the partition lifecycle. There were two main problems with that approach: 
1) all the state machines had to be defined in cluster module or other modules that the cluster module dependent on
2) `cluster::partition` interface and behaviour was customised in runtime based solely on the partition name.

The new approach introduced with this PR makes it possible to create STMs outside of the cluster module as the STM interface is generalised at the `cluster` module level. Newly introduced `state_machine_registry` allows registering an STM factory. Factory decide whether the stm is required for given Raft group and if that is the case the STM is then created. 

With the new approach STM implementer can simply create an STM by implementing either a `raft::state_machine_base` interface or extending `raft::persisted_stm`. Implementer provides and register a factory in partition manager instance. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none