### PR TITLE
security/config_rcl: fmt::format for exception message

### DIFF
--- a/src/v/security/config_rcl.cc
+++ b/src/v/security/config_rcl.cc
@@ -89,9 +89,9 @@ parse_rules(const std::vector<ss::sstring>& unparsed_rules) {
               num_components_str.end(),
               num_components);
             if (conv_rc.ec != std::errc()) {
-                throw std::runtime_error(
-                  "Invalid rule - Invalid value for number of components: "
-                  + num_components_str.as_string());
+                throw std::runtime_error(fmt::format(
+                  "Invalid rule - Invalid value for number of components: {}",
+                  num_components_str));
             }
             gssapi_rule::case_change_operation case_change
               = gssapi_rule::case_change_operation::noop;


### PR DESCRIPTION
re2 >= 2023-06-01 changes the type of re2::StringPiece and removes as_string().

fmt::format works with both versions

fixes #15408
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* fixes a compatibility issue with re2 >= 2023-06-01