### PR TITLE
r/state_machine: ignore broken semaphore and condition var exceptions

### DIFF
--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -175,9 +175,13 @@ ss::future<> state_machine::apply() {
             "Timeout in state_machine::apply on ntp {}",
             _raft->ntp());
       })
-      .handle_exception_type([](const ss::abort_requested_exception&) {})
-      .handle_exception_type([](const ss::gate_closed_exception&) {})
       .handle_exception([this](const std::exception_ptr& e) {
+          // do not log shutdown exceptions not to pollute logs with irrelevant
+          // errors
+          if (ssx::is_shutdown_exception(e)) {
+              return;
+          }
+
           vlog(
             _log.error,
             "State machine for ntp={} caught exception {}",


### PR DESCRIPTION
Seastar `broken_semaphore` and `broken_condition_variable` exceptions are thrown from when Redpanda is shutting down. Those exceptions doesn't have to be logged with error severity.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none