### PR TITLE
c/archival_stm: do not reset _last_replicate on timeout

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -37,11 +37,13 @@
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/shared_future.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/util/bool_class.hh>
 #include <seastar/util/defer.hh>
 
 #include <algorithm>
+#include <optional>
 
 namespace cluster {
 
@@ -599,15 +601,6 @@ archival_metadata_stm::archival_metadata_stm(
   , _cloud_storage_api(remote)
   , _feature_table(ft) {}
 
-archival_metadata_stm::~archival_metadata_stm() {
-    // Last replicate future is an internal barrier for sync operations. Ignore
-    // its value if we're shutting down to prevent seastar logging warnings for
-    // unhandled exception.
-    if (_last_replicate.has_value()) {
-        _last_replicate->ignore_ready_future();
-    }
-}
-
 ss::future<std::error_code> archival_metadata_stm::truncate(
   model::offset start_rp_offset,
   ss::lowres_clock::time_point deadline,
@@ -696,9 +689,7 @@ archival_metadata_stm::sync(model::timeout_clock::duration timeout) {
     // below. If replication failed, exit unsuccessfully.
 
     if (_last_replicate) {
-        auto fut = std::exchange(_last_replicate, std::nullopt).value();
-
-        if (!fut.available()) {
+        if (!_last_replicate->result.available()) {
             vlog(
               _logger.debug, "Waiting for ongoing replication before syncing");
         }
@@ -706,8 +697,8 @@ archival_metadata_stm::sync(model::timeout_clock::duration timeout) {
         try {
             const auto before = model::timeout_clock::now();
 
-            const auto res = co_await ss::with_timeout(
-              before + timeout, std::move(fut));
+            const auto res = co_await _last_replicate->result.get_future(
+              before + timeout);
 
             const auto after = model::timeout_clock::now();
             // Update the timeout whille accounting for under/overflow.
@@ -721,11 +712,23 @@ archival_metadata_stm::sync(model::timeout_clock::duration timeout) {
 
             timeout -= duration;
 
+            // If we've got this far it means that the _last_replicate future
+            // was resolved. If it resolved successfully, then we can continue.
+            // If it failed for any reason, it is safe to "forget" about it in
+            // only if the term changed. Otherwise we can't make any assumptions
+            // about its state.
+            // Stepping down (liveness) is guaranteed by the logic in the
+            // `do_replicate_commands` method.
+            if (res || _last_replicate->term < _insync_term) {
+                _last_replicate = std::nullopt;
+            }
+
             if (!res) {
                 vlog(
                   _logger.warn,
                   "Replication failed for archival STM command: {}",
                   res.error());
+
                 co_return false;
             }
         } catch (const ss::timed_out_error&) {
@@ -806,8 +809,9 @@ ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
 
     const auto current_term = _insync_term;
 
-    ss::promise<result<raft::replicate_result>> replication_promise;
-    _last_replicate = replication_promise.get_future();
+    ss::shared_promise<result<raft::replicate_result>> replication_promise;
+    _last_replicate = last_replicate{
+      .term = current_term, .result = replication_promise.get_shared_future()};
 
     auto fut
       = _raft

--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -15,6 +15,7 @@
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
 #include "features/fwd.h"
+#include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
 #include "raft/persisted_stm.h"
@@ -111,7 +112,6 @@ public:
       features::feature_table&,
       ss::logger& logger,
       ss::shared_ptr<util::mem_tracker> partition_mem_tracker = nullptr);
-    ~archival_metadata_stm() override;
 
     /// Add segments to the raft log, replicate them and
     /// wait until it is applied to the STM.
@@ -332,7 +332,11 @@ private:
     model::offset _last_dirty_at;
 
     // The last replication future
-    std::optional<ss::future<result<raft::replicate_result>>> _last_replicate;
+    struct last_replicate {
+        model::term_id term;
+        ss::shared_future<result<raft::replicate_result>> result;
+    };
+    std::optional<last_replicate> _last_replicate;
 
     cloud_storage::remote& _cloud_storage_api;
     features::feature_table& _feature_table;


### PR DESCRIPTION
For same term syncing we store the replicate commands future so that it can be awaited in the next sync call. However, the `std::exchange(_last_replicate, std::nullopt)` before the wait is problematic as it "forgets" the last replicate. If sync times out and we retry it then it behaves as if the last replicate command succeeded. This is not necessarily true as the newly added test assertion shows.

Use a shared future for _last_replicate so that it can be awaited multiple times and reset it only after it is resolved. This guarantees that sync will only return after last replicate command actually resolved.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
