### PR TITLE
[v22.3.x] kafka/client: Stop the broker if `do_authenticate` failed

### DIFF
--- a/src/v/kafka/client/broker.cc
+++ b/src/v/kafka/client/broker.cc
@@ -54,9 +54,13 @@ ss::future<shared_broker_t> make_broker(
           return ss::make_exception_future<shared_broker_t>(ex);
       })
       .then([&config](shared_broker_t broker) {
-          return do_authenticate(broker, config).then([broker]() {
-              return broker;
-          });
+          return do_authenticate(broker, config)
+            .then([broker]() { return broker; })
+            .handle_exception([broker](std::exception_ptr ex) {
+                return broker->stop().then([ex]() {
+                    return ss::make_exception_future<shared_broker_t>(ex);
+                });
+            });
       });
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15414
Fixes: https://github.com/redpanda-data/redpanda/issues/15431,