### PR TITLE
Backport of #12716 avoid returning stale describeACL responses

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -247,6 +247,7 @@ controller::start(cluster_discovery& discovery, ss::abort_source& shard0_as) {
       .then([this] {
           return _security_frontend.start(
             _raft0->self().id(),
+            this,
             std::ref(_stm),
             std::ref(_connections),
             std::ref(_partition_leaders),

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -158,6 +158,10 @@ public:
         });
     }
 
+    ss::future<result<model::offset>> linearizable_barrier() {
+        return _raft0->linearizable_barrier();
+    }
+
     /// Helper for use during cluster join: a join RPC reply may
     /// tip us off about the last applied controller offset of some
     /// other node, and we may wait for that to ensure our controller

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -135,6 +135,11 @@
             "name": "get_partition_state",
             "input_type": "partition_state_request",
             "output_type": "partition_state_reply"
+        },
+        {
+            "name": "get_controller_committed_offset",
+            "input_type": "controller_committed_offset_request",
+            "output_type": "controller_committed_offset_reply"
         }
     ]
 }

--- a/src/v/cluster/security_frontend.h
+++ b/src/v/cluster/security_frontend.h
@@ -26,7 +26,8 @@ namespace cluster {
 class security_frontend final {
 public:
     security_frontend(
-      model::node_id,
+      model::node_id self,
+      controller* controller,
       ss::sharded<controller_stm>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_leaders_table>&,
@@ -64,7 +65,13 @@ public:
     static std::optional<user_and_credential>
     get_bootstrap_user_creds_from_env();
 
+    ss::future<std::error_code>
+      wait_until_caughtup_with_leader(model::timeout_clock::duration);
+
 private:
+    ss::future<result<model::offset>>
+      get_leader_committed(model::timeout_clock::duration);
+
     ss::future<std::vector<errc>> do_create_acls(
       std::vector<security::acl_binding>, model::timeout_clock::duration);
 
@@ -83,6 +90,7 @@ private:
       model::timeout_clock::duration);
 
     model::node_id _self;
+    controller* _controller;
     ss::sharded<controller_stm>& _stm;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<partition_leaders_table>& _leaders;

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -10,6 +10,7 @@
 #include "cluster/service.h"
 
 #include "cluster/config_frontend.h"
+#include "cluster/controller.h"
 #include "cluster/controller_api.h"
 #include "cluster/errc.h"
 #include "cluster/feature_manager.h"
@@ -38,6 +39,7 @@ namespace cluster {
 service::service(
   ss::scheduling_group sg,
   ss::smp_service_group ssg,
+  controller* controller,
   ss::sharded<topics_frontend>& tf,
   ss::sharded<members_manager>& mm,
   ss::sharded<metadata_cache>& cache,
@@ -52,6 +54,7 @@ service::service(
   ss::sharded<rpc::connection_cache>& conn_cache,
   ss::sharded<partition_manager>& partition_manager)
   : controller_service(sg, ssg)
+  , _controller(controller)
   , _topics_frontend(tf)
   , _members_manager(mm)
   , _md_cache(cache)
@@ -741,6 +744,26 @@ ss::future<partition_state_reply> service::get_partition_state(
   partition_state_request&& req, rpc::streaming_context&) {
     return ss::with_scheduling_group(get_scheduling_group(), [this, req]() {
         return do_get_partition_state(req);
+    });
+}
+
+ss::future<controller_committed_offset_reply>
+service::get_controller_committed_offset(
+  controller_committed_offset_request&&, rpc::streaming_context&) {
+    return ss::with_scheduling_group(get_scheduling_group(), [this]() {
+        return ss::smp::submit_to(controller_stm_shard, [this]() {
+            if (!_controller->is_raft0_leader()) {
+                return ss::make_ready_future<controller_committed_offset_reply>(
+                  controller_committed_offset_reply{
+                    .result = errc::not_leader_controller});
+            }
+            return _controller->linearizable_barrier().then([](auto r) {
+                const auto errc = r.has_error() ? errc::not_leader_controller
+                                                : errc::success;
+                return controller_committed_offset_reply{
+                  .last_committed = r.value(), .result = errc};
+            });
+        });
     });
 }
 

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -27,6 +27,7 @@ public:
     service(
       ss::scheduling_group,
       ss::smp_service_group,
+      controller* controller,
       ss::sharded<topics_frontend>&,
       ss::sharded<members_manager>&,
       ss::sharded<metadata_cache>&,
@@ -118,6 +119,10 @@ public:
     ss::future<partition_state_reply> get_partition_state(
       partition_state_request&&, rpc::streaming_context&) final;
 
+    ss::future<controller_committed_offset_reply>
+    get_controller_committed_offset(
+      controller_committed_offset_request&&, rpc::streaming_context&) final;
+
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
     std::
@@ -158,6 +163,7 @@ private:
     ss::future<partition_state_reply>
       do_get_partition_state(partition_state_request);
 
+    controller* _controller;
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<metadata_cache>& _md_cache;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3909,6 +3909,26 @@ struct metrics_reporter_cluster_info
     auto serde_fields() { return std::tie(uuid, creation_timestamp); }
 };
 
+struct controller_committed_offset_request
+  : serde::envelope<
+      controller_committed_offset_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+};
+
+struct controller_committed_offset_reply
+  : serde::envelope<
+      controller_committed_offset_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+    model::offset last_committed;
+    errc result;
+
+    auto serde_fields() { return std::tie(last_committed, result); }
+};
+
 template<typename V>
 std::ostream& operator<<(
   std::ostream& o, const configuration_with_assignment<V>& with_assignment) {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2228,6 +2228,7 @@ void application::start_runtime_services(
           runtime_services.push_back(std::make_unique<cluster::service>(
             sched_groups.cluster_sg(),
             smp_service_groups.cluster_smp_sg(),
+            controller.get(),
             std::ref(controller->get_topics_frontend()),
             std::ref(controller->get_members_manager()),
             std::ref(metadata_cache),

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1035,7 +1035,7 @@ class RpkTool:
             ]
         return flags
 
-    def acl_list(self):
+    def acl_list(self, request_timeout_overhead=None):
         """
         Run `rpk acl list` and return the results.
 
@@ -1051,6 +1051,13 @@ class RpkTool:
             "acl",
             "list",
         ] + self._kafka_conn_settings()
+
+        # How long rpk will wait for a response from the broker, default is 5s
+        if request_timeout_overhead is not None:
+            cmd += [
+                "-X", "globals.request_timeout_overhead=" +
+                f'{str(request_timeout_overhead)}s'
+            ]
 
         output = self._execute(cmd)
 

--- a/tests/rptest/tests/rpk_acl_test.py
+++ b/tests/rptest/tests/rpk_acl_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import time
+from rptest.services.failure_injector import make_failure_injector, FailureSpec
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool, RpkException
@@ -26,10 +26,12 @@ class RpkACLTest(RedpandaTest):
         security = SecurityConfig()
         security.enable_sasl = True
         security.endpoint_authn_method = 'sasl'
-        super(RpkACLTest, self).__init__(test_ctx,
-                                         security=security,
-                                         *args,
-                                         **kwargs)
+        super(RpkACLTest,
+              self).__init__(test_ctx,
+                             security=security,
+                             extra_rp_conf={'election_timeout_ms': 10000},
+                             *args,
+                             **kwargs)
         self._rpk = RpkTool(redpanda=self.redpanda,
                             username=self.username,
                             password=self.password,
@@ -41,6 +43,42 @@ class RpkACLTest(RedpandaTest):
                        username=self.superuser.username,
                        password=self.superuser.password,
                        sasl_mechanism=self.mechanism)
+
+    @cluster(num_nodes=3)
+    def test_modify_then_query_error(self):
+        """
+        This test ensures that even in cases where multiple nodes may
+        think they are the leader, the freshest data is returned
+        """
+        superclient = self._superclient()
+        superclient.acl_create_allow_cluster(self.superuser.username,
+                                             "describe")
+
+        # Modify an ACL
+        self._rpk.sasl_allow_principal(f'User:{self.username}', ['CREATE'],
+                                       'topic', 'foo', self.superuser.username,
+                                       self.superuser.password,
+                                       self.superuser.algorithm)
+        described = superclient.acl_list()
+        assert 'CREATE' in described, "Failed to modify ACL"
+        assert self.redpanda.search_log_any(
+            ".*Failed waiting on catchup with controller leader.*") is False
+
+        # Network partition the leader away from the rest of the cluster
+        with make_failure_injector(self.redpanda) as fi:
+            fi.inject_failure(
+                FailureSpec(FailureSpec.FAILURE_ISOLATE,
+                            self.redpanda.controller()))
+
+            # Timeout must be larger then hardcoded timeout of 5s within redpanda
+            _ = superclient.acl_list(request_timeout_overhead=30)
+
+            # Of the other remaining nodes, none can be declared a leader before
+            # the election timeout occurs; also the "current" leader is technically
+            # stale so it cannot be sure its returning the freshest data either. In
+            # all cases the log below should be observed on the node handling the req.
+            assert self.redpanda.search_log_any(
+                ".*Failed waiting on catchup with controller leader.*") is True
 
     @cluster(num_nodes=3)
     def test_modify_then_query(self):


### PR DESCRIPTION
Backport of #12716

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

- Modifications to avoid stale responses returned from DescribeACLs requests
