### PR TITLE
s/audit: Fix bug with incorrect calculation in audit probe buffer usage ratio

### DIFF
--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -754,8 +754,8 @@ ss::future<> audit_log_manager::start() {
     }
     _probe = std::make_unique<audit_probe>();
     _probe->setup_metrics([this] {
-        return static_cast<double>(pending_events())
-               / static_cast<double>(_max_queue_size_bytes);
+        return 1.0
+               - (static_cast<double>(_queue_bytes_sem.available_units()) / static_cast<double>(_max_queue_size_bytes));
     });
     if (ss::this_shard_id() != client_shard_id) {
         co_return;


### PR DESCRIPTION
Fix bug with incorrect calculation in audit probe buffer usage ratio. Bug was likely introduced when the PR to bound audit queue by size bytes instead of number of elements was introduced

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

