### PR TITLE
storage/disk_log_impl: defensive reverse iteration of _segs

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1545,8 +1545,11 @@ size_t disk_log_impl::max_segment_size() const {
 }
 
 uint64_t disk_log_impl::size_bytes_after_offset(model::offset o) const {
+    if (_segs.empty()) {
+        return 0;
+    }
     uint64_t size = 0;
-    for (size_t i = _segs.size() - 1; i-- > 0;) {
+    for (size_t i = _segs.size(); i-- > 0;) {
         auto& seg = _segs[i];
         if (seg->offsets().base_offset < o) {
             break;


### PR DESCRIPTION
if _segs is empty (not in the precondition) size() -1 would underflow and we would access garbage
if _segs has size 1, we would underflow afther the loop check (i-->0) and access garbage
if _segs is bigger than 1, we would exclude from the count the active segment

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes #15417 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
