### PR TITLE
archival: Disable cross term merging of adjacent segments

### DIFF
--- a/src/v/archival/adjacent_segment_merger.cc
+++ b/src/v/archival/adjacent_segment_merger.cc
@@ -108,7 +108,7 @@ std::optional<adjacent_segment_run> adjacent_segment_merger::scan_manifest(
             break;
         }
         if (run.maybe_add_segment(*it, max_segment_size)) {
-            // We have found a run whith the size close to max_segment_size
+            // We have found a run with the size close to max_segment_size
             // and can proceed early.
             break;
         }

--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -146,10 +146,14 @@ bool adjacent_segment_run::maybe_add_segment(
                 ntp, s));
         }
     } else {
-        if (meta.size_bytes + s.size_bytes <= max_size) {
+        if (
+          meta.segment_term == s.segment_term
+          && meta.size_bytes + s.size_bytes <= max_size) {
+            // Cross term merging is disallowed. Because of that we need to stop
+            // if the term doesn't match the previous term.
             if (model::next_offset(meta.committed_offset) != s.base_offset) {
-                // In case if we're dealing with one of the old manifests with
-                // inconsistencies (overlapping offsets, etc).
+                // In case if we're dealing with one of the old manifests
+                // with inconsistencies (overlapping offsets, etc).
                 num_segments = 0;
                 meta = {};
                 segments.clear();

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -193,7 +193,8 @@ struct adjacent_segment_run {
     /// of the run is below the threshold. The object keeps track
     /// of all segment names.
     ///
-    /// \return true if the segment is added, false otherwise
+    /// \return true if the run is assembled, false if more segments can be
+    ///         added to the run
     bool
     maybe_add_segment(const cloud_storage::segment_meta& s, size_t max_size);
 };


### PR DESCRIPTION
Avoid merging adjacent segments if they have different terms. 
Currently, the adjacent segment merger can pick up segments that have different term id and merge them into one. The term id of the first segment will be used for the resulting merged segment. Going forward, we need to disable this because it may cause some kafka clients to erroneously detect the data loss.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none