### PR TITLE
Replace deprecated re2::StringPiece::as_string method

### DIFF
--- a/src/v/security/config_rcl.cc
+++ b/src/v/security/config_rcl.cc
@@ -91,7 +91,7 @@ parse_rules(const std::vector<ss::sstring>& unparsed_rules) {
             if (conv_rc.ec != std::errc()) {
                 throw std::runtime_error(
                   "Invalid rule - Invalid value for number of components: "
-                  + num_components_str.as_string());
+                  + std::string(num_components_str));
             }
             gssapi_rule::case_change_operation case_change
               = gssapi_rule::case_change_operation::noop;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

`as_string` got removed in recent re2 versions, because StringPiece became an
alias for std::string_view.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
