### PR TITLE
wasm: enforce memory limits on number of deployed functions

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -78,6 +78,7 @@ enum class errc : int16_t {
     partition_disabled,
     invalid_partition_operation,
     concurrent_modification_error,
+    transform_count_limit_exceeded,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -217,7 +218,7 @@ struct errc_category final : public std::error_category {
         case errc::transform_invalid_environment:
             return "Invalid transform environment";
         case errc::trackable_keys_limit_exceeded:
-            return "Too many keys are currently tracked, no space for more.";
+            return "Too many keys are currently tracked, no space for more";
         case errc::topic_disabled:
             return "Topic disabled by user";
         case errc::partition_disabled:
@@ -226,6 +227,8 @@ struct errc_category final : public std::error_category {
             return "Invalid partition operation";
         case errc::concurrent_modification_error:
             return "Concurrent modification error";
+        case errc::transform_count_limit_exceeded:
+            return "Too many transforms deployed";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/plugin_frontend.cc
+++ b/src/v/cluster/plugin_frontend.cc
@@ -238,17 +238,23 @@ errc plugin_frontend::validate_mutation(const transform_cmd& cmd) {
     for (const auto& topic : noproduce) {
         no_sink_topics.emplace(topic);
     }
-    validator v(_topics, _table, std::move(no_sink_topics));
+    const size_t max_transforms
+      = config::shard_local_cfg().wasm_per_core_memory_reservation.value()
+        / config::shard_local_cfg().wasm_per_function_memory_limit.value();
+
+    validator v(_topics, _table, std::move(no_sink_topics), max_transforms);
     return v.validate_mutation(cmd);
 }
 
 plugin_frontend::validator::validator(
   topic_table* topic_table,
   plugin_table* plugin_table,
-  absl::flat_hash_set<model::topic> no_sink_topics)
+  absl::flat_hash_set<model::topic> no_sink_topics,
+  size_t max)
   : _topics(topic_table)
   , _table(plugin_table)
-  , _no_sink_topics(std::move(no_sink_topics)) {}
+  , _no_sink_topics(std::move(no_sink_topics))
+  , _max_transforms(max) {}
 
 errc plugin_frontend::validator::validate_mutation(const transform_cmd& cmd) {
     return ss::visit(
@@ -391,6 +397,13 @@ errc plugin_frontend::validator::validate_mutation(const transform_cmd& cmd) {
           }
 
           // create!
+
+          if (_table->all_transforms().size() >= _max_transforms) {
+              vlog(
+                clusterlog.info, "too many transforms, more memory required");
+              return errc::transform_count_limit_exceeded;
+          }
+
           if (cmd.value.name().empty()) {
               vlog(
                 clusterlog.info,

--- a/src/v/cluster/plugin_frontend.cc
+++ b/src/v/cluster/plugin_frontend.cc
@@ -239,8 +239,10 @@ errc plugin_frontend::validate_mutation(const transform_cmd& cmd) {
         no_sink_topics.emplace(topic);
     }
     const size_t max_transforms
-      = config::shard_local_cfg().wasm_per_core_memory_reservation.value()
-        / config::shard_local_cfg().wasm_per_function_memory_limit.value();
+      = config::shard_local_cfg()
+          .data_transforms_per_core_memory_reservation.value()
+        / config::shard_local_cfg()
+            .data_transforms_per_function_memory_limit.value();
 
     validator v(_topics, _table, std::move(no_sink_topics), max_transforms);
     return v.validate_mutation(cmd);

--- a/src/v/cluster/plugin_frontend.h
+++ b/src/v/cluster/plugin_frontend.h
@@ -129,7 +129,10 @@ public:
     class validator {
     public:
         validator(
-          topic_table*, plugin_table*, absl::flat_hash_set<model::topic>);
+          topic_table*,
+          plugin_table*,
+          absl::flat_hash_set<model::topic>,
+          size_t max_transforms);
 
         // Ensures that the mutation is valid.
         //
@@ -147,6 +150,7 @@ public:
         topic_table* _topics;
         plugin_table* _table;
         absl::flat_hash_set<model::topic> _no_sink_topics;
+        size_t _max_transforms;
     };
 
 private:

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -159,33 +159,35 @@ configuration::configuration()
       "The interval at which Data Transforms commits progress.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       3s)
-  , wasm_per_core_memory_reservation(
+  , data_transforms_per_core_memory_reservation(
       *this,
-      "wasm_per_core_memory_reservation",
-      "The amount of memory to reserve per core for all WebAssembly Virtual "
-      "Machines. Memory is reserved on boot. The maximum number of functions "
-      "that can be deployed to a cluster is equal to "
-      "wasm_per_core_memory_reservation / "
-      "wasm_per_function_memory_limit",
+      "data_transforms_per_core_memory_reservation",
+      "The amount of memory to reserve per core for Data Transform WebAssembly "
+      "Virtual Machines. Memory is reserved on boot. The maximum number of "
+      "functions that can be deployed to a cluster is equal to "
+      "data_transforms_per_core_memory_reservation / "
+      "data_transforms_per_function_memory_limit",
       {
         .needs_restart = needs_restart::yes,
         .example = std::to_string(25_MiB),
         .visibility = visibility::user,
+        .aliases = {"wasm_per_core_memory_reservation"},
       },
       20_MiB,
       {.min = 64_KiB, .max = 100_GiB})
-  , wasm_per_function_memory_limit(
+  , data_transforms_per_function_memory_limit(
       *this,
-      "wasm_per_function_memory_limit",
-      "The amount of memory to give an instance of a WebAssembly Virtual "
-      "Machine. The maximum number of functions "
+      "data_transforms_per_function_memory_limit",
+      "The amount of memory to give an instance of a Data Transform "
+      "WebAssembly Virtual Machine. The maximum number of functions "
       "that can be deployed to a cluster is equal to "
-      "wasm_per_core_memory_reservation / "
-      "wasm_per_function_memory_limit",
+      "data_transforms_per_core_memory_reservation / "
+      "data_transforms_per_function_memory_limit",
       {
         .needs_restart = needs_restart::yes,
         .example = std::to_string(5_MiB),
         .visibility = visibility::user,
+        .aliases = {"wasm_per_function_memory_limit"},
       },
       2_MiB,
       // WebAssembly uses 64KiB pages and has a 32bit address space

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -70,10 +70,8 @@ struct configuration final : public config_store {
     // Data Transforms
     property<bool> data_transforms_enabled;
     property<std::chrono::milliseconds> data_transforms_commit_interval_ms;
-
-    // Wasm
-    bounded_property<size_t> wasm_per_core_memory_reservation;
-    bounded_property<size_t> wasm_per_function_memory_limit;
+    bounded_property<size_t> data_transforms_per_core_memory_reservation;
+    bounded_property<size_t> data_transforms_per_function_memory_limit;
 
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -96,6 +96,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::trackable_keys_limit_exceeded:
     case cluster::errc::invalid_partition_operation:
     case cluster::errc::concurrent_modification_error:
+    case cluster::errc::transform_count_limit_exceeded:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1179,6 +1179,19 @@ ss::future<> admin_server::throw_on_error(
         case cluster::errc::invalid_partition_operation:
             throw ss::httpd::bad_request_exception(
               fmt::format("{}", ec.message()));
+        case cluster::errc::transform_count_limit_exceeded: {
+            const size_t max_transforms
+              = config::shard_local_cfg()
+                  .wasm_per_core_memory_reservation.value()
+                / config::shard_local_cfg()
+                    .wasm_per_function_memory_limit.value();
+            throw ss::httpd::bad_request_exception(ss::format(
+              "The limit of transforms has been reached ({}), more "
+              "memory must be configured via {}",
+              max_transforms,
+              config::shard_local_cfg()
+                .wasm_per_core_memory_reservation.name()));
+        }
         default:
             throw ss::httpd::server_error_exception(
               fmt::format("Unexpected cluster error: {}", ec.message()));

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1182,15 +1182,15 @@ ss::future<> admin_server::throw_on_error(
         case cluster::errc::transform_count_limit_exceeded: {
             const size_t max_transforms
               = config::shard_local_cfg()
-                  .wasm_per_core_memory_reservation.value()
+                  .data_transforms_per_core_memory_reservation.value()
                 / config::shard_local_cfg()
-                    .wasm_per_function_memory_limit.value();
+                    .data_transforms_per_function_memory_limit.value();
             throw ss::httpd::bad_request_exception(ss::format(
               "The limit of transforms has been reached ({}), more "
               "memory must be configured via {}",
               max_transforms,
               config::shard_local_cfg()
-                .wasm_per_core_memory_reservation.name()));
+                .data_transforms_per_core_memory_reservation.name()));
         }
         default:
             throw ss::httpd::server_error_exception(

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2395,8 +2395,8 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
         const auto& cluster = config::shard_local_cfg();
         wasm::runtime::config config = {
           .heap_memory = {
-            .per_core_pool_size_bytes = cluster.wasm_per_core_memory_reservation.value(),
-            .per_engine_memory_limit = cluster.wasm_per_function_memory_limit.value(),
+            .per_core_pool_size_bytes = cluster.data_transforms_per_core_memory_reservation.value(),
+            .per_engine_memory_limit = cluster.data_transforms_per_function_memory_limit.value(),
           },
           .stack_memory = {
             .debug_host_stack_usage = false,

--- a/src/v/resource_mgmt/memory_groups.cc
+++ b/src/v/resource_mgmt/memory_groups.cc
@@ -112,7 +112,7 @@ system_memory_groups& memory_groups() {
     const auto& cfg = config::shard_local_cfg();
     if (wasm) {
         size_t wasm_memory_reservation
-          = cfg.wasm_per_core_memory_reservation.value();
+          = cfg.data_transforms_per_core_memory_reservation.value();
         total -= wasm_memory_reservation;
     }
     compaction_memory_reservation compaction;


### PR DESCRIPTION
There is a cap on the number of functions that can be deployed due to memory resources, make that cap explicit with directions if a user hits the limit.

Additionally, we rename the memory config settings so they are consistent with other `data_transforms` settings (a product ask).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

### Improvements

* Produce a better error message when deploying the maximum number of data transforms configured.
