### PR TITLE
Fix `cluster partitions list` flags and help text

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/partitions/list.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/list.go
@@ -41,7 +41,7 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short:   "List partitions in the cluster",
 		Long: `List partitions in the cluster
 
-This command lists the cluster-level metadata of all partitions in the cluster.
+This command lists the cluster-level metadata of partitions in the cluster.
 It shows the current replica assignments on both brokers and CPU cores for given
 topics. By default, it assumes the "kafka" namespace, but you can specify an
 internal namespace using the "{namespace}/" prefix.
@@ -54,14 +54,9 @@ command against a cluster that does not support the underlying API.
 
 EXAMPLES
 
-List all partitions in the cluster.
-  rpk cluster partitions list --all
-
 List all partitions in the cluster, filtering for topic foo and bar.
   rpk cluster partitions list foo bar
 
-List only the disabled partitions.
-  rpk cluster partitions list -a --disabled-only
 `,
 		Run: func(cmd *cobra.Command, topics []string) {
 			if len(topics) == 0 && !all {
@@ -135,7 +130,9 @@ List only the disabled partitions.
 		},
 	}
 	cmd.Flags().BoolVarP(&all, "all", "a", false, "If true, list all partitions in the cluster")
+	cmd.Flags().MarkHidden("all")
 	cmd.Flags().BoolVar(&disabledOnly, "disabled-only", false, "If true, list disabled partitions only")
+	cmd.Flags().MarkHidden("disabled-only")
 	cmd.Flags().IntSliceVarP(&partitions, "partition", "p", nil, "List of comma-separated partitions IDs that you wish to filter the results with")
 
 	return cmd


### PR DESCRIPTION
Some of this functionality relies on the cluster being 23.3 or higher. This change keeps this functionality for utility, but updates the visible flags and help text to avoid confusion when running `rpk` that ships with 23.2

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.


### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
