### PR TITLE
Fix for CI Failure (TimeoutError) in AuditLogTestKafkaApi.test_management

### DIFF
--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -1130,7 +1130,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                             "resource_type": "topic",
                             "resource_name": "test",
                             "pattern_type": "literal",
-                            "acl_principal": "{type user name test}",
+                            "acl_principal": "type {user} name {test}",
                             "acl_host": "{{any_host}}",
                             "acl_operation": "all",
                             "acl_permission": "allow"
@@ -1149,7 +1149,7 @@ class AuditLogTestKafkaApi(AuditLogTestBase):
                         "data": {
                             "resource_type": "topic",
                             "resource_name": "test",
-                            "acl_principal": "{type user name test}",
+                            "acl_principal": "type {user} name {test}",
                             "acl_operation": "all",
                             "acl_permission": "allow"
                         }


### PR DESCRIPTION
Fixes: #15445

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
