### PR TITLE
tests: Fix broken OMB MPT

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -809,8 +809,8 @@ class ManyPartitionsTest(PreallocNodesTest):
         # causes OMB to start failing internally with 500s when it backs up,
         # or when it runs through, to fail because it didn't hit its latency
         # target.
-        if PARTITIONS_PER_SHARD > 1000:
-            producer_rate *= (1000.0 / PARTITIONS_PER_SHARD)
+        if scale.partition_limit > 1000:
+            producer_rate *= (1000.0 / scale.partition_limit)
 
         # on 12x i3en.3xlarge
         # it is stable driving 1159.661 MB/s
@@ -913,7 +913,11 @@ class ManyPartitionsTest(PreallocNodesTest):
 
     @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_omb(self):
-        scale = ScaleParameters(self.redpanda, replication_factor=3)
+        scale = ScaleParameters(
+            self.redpanda,
+            replication_factor=3,
+            mib_per_partition=DEFAULT_MIB_PER_PARTITION,
+            topic_partitions_per_shard=DEFAULT_PARTITIONS_PER_SHARD)
         self.redpanda.start()
 
         # We have other OMB benchmark tests, but this one runs at the


### PR DESCRIPTION
Was lacking two parameters in the ScalaParameters after adding
parameterization to the other MPT tests.

Fixes https://github.com/redpanda-data/redpanda/issues/15444

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes


* none

