### PR TITLE
[v23.2.x] r/state_machine: ignore broken semaphore and condition var exceptions

### DIFF
--- a/src/v/raft/state_machine.cc
+++ b/src/v/raft/state_machine.cc
@@ -175,9 +175,13 @@ ss::future<> state_machine::apply() {
             "Timeout in state_machine::apply on ntp {}",
             _raft->ntp());
       })
-      .handle_exception_type([](const ss::abort_requested_exception&) {})
-      .handle_exception_type([](const ss::gate_closed_exception&) {})
       .handle_exception([this](const std::exception_ptr& e) {
+          // do not log shutdown exceptions not to pollute logs with irrelevant
+          // errors
+          if (ssx::is_shutdown_exception(e)) {
+              return ss::now();
+          }
+
           vlog(
             _log.error,
             "State machine for ntp={} caught exception {}",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15426
