### PR TITLE
[v23.2.x] tests/e2e_shadow_indexing_test: wait until segments has one entry

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -939,7 +939,7 @@ class ShadowIndexingInfiniteRetentionTest(EndToEndShadowIndexingBase):
             s3_snapshot = BucketView(self.redpanda, topics=self.topics)
             manifest = s3_snapshot.manifest_for_ntp(self.infinite_topic_name,
                                                     0)
-            return "segments" in manifest
+            return len(manifest.get("segments", {})) > 0
 
         wait_until(manifest_has_segments, timeout_sec=10, backoff_sec=1)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15579
Fixes: https://github.com/redpanda-data/redpanda/issues/15598,