### PR TITLE
[v23.2.x] storage/disk_log_impl: defensive reverse iteration of _segs

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1198,8 +1198,11 @@ size_t disk_log_impl::max_segment_size() const {
 }
 
 uint64_t disk_log_impl::size_bytes_after_offset(model::offset o) const {
+    if (_segs.empty()) {
+        return 0;
+    }
     uint64_t size = 0;
-    for (size_t i = _segs.size() - 1; i-- > 0;) {
+    for (size_t i = _segs.size(); i-- > 0;) {
         auto& seg = _segs[i];
         if (seg->offsets().base_offset < o) {
             break;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15440
Fixes: https://github.com/redpanda-data/redpanda/issues/15601,