### PR TITLE
[v23.1.x] rptest: change detection of when to run with azurite

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -384,7 +384,8 @@ class SISettings:
             self.endpoint_url = None
             self.cloud_storage_disable_tls = False
             self.cloud_storage_api_endpoint_port = 443
-        if test_context.globals.get(self.GLOBAL_S3_SECRET_KEY, None):
+        if test_context.globals.get(self.GLOBAL_CLOUD_STORAGE_CRED_SOURCE_KEY,
+                                    None):
             test_context.ok_to_fail = True
 
             msg = (


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/devprod/issues/965

For specifically the `v23.1.x` branch, azurite should not be running when running CDT tests on EC2, so we should be marking those types of test as `OFAIL`. We cannot expect `globals.json` to have `s3_secret_key` set when run on EC2 because of a change in getting CDT tests to use IAM roles. Instead, can assume `cloud_store_cred_source` is set on EC2 runs of CDT.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
