### PR TITLE
Add at: in Top-N alloc site output

### DIFF
--- a/src/v/resource_mgmt/memory_sampling.cc
+++ b/src/v/resource_mgmt/memory_sampling.cc
@@ -36,6 +36,12 @@ constexpr std::string_view confluence_reference() {
            "https://vectorizedio.atlassian.net/l/cp/iuEMd2NN\n";
 }
 
+fmt::appender fmt::formatter<seastar::memory::allocation_site>::format(
+  const seastar::memory::allocation_site& site, fmt::format_context& ctx) {
+    return fmt::format_to(
+      ctx.out(), "{} {} {}", site.size, site.count, site.backtrace);
+}
+
 /// Put `top_n` allocation sites into the front of `allocation_sites`
 static void top_n_allocation_sites(
   std::vector<ss::memory::allocation_site>& allocation_sites, size_t top_n) {

--- a/src/v/resource_mgmt/memory_sampling.cc
+++ b/src/v/resource_mgmt/memory_sampling.cc
@@ -27,9 +27,7 @@
 #include <limits>
 #include <vector>
 
-constexpr std::string_view diagnostics_header() {
-    return "Top-N alloc sites - size count stack:";
-}
+constexpr std::string_view diagnostics_header() { return "Top-N alloc sites:"; }
 
 constexpr std::string_view confluence_reference() {
     return "If you work at Redpanda please refer to "
@@ -39,7 +37,11 @@ constexpr std::string_view confluence_reference() {
 fmt::appender fmt::formatter<seastar::memory::allocation_site>::format(
   const seastar::memory::allocation_site& site, fmt::format_context& ctx) {
     return fmt::format_to(
-      ctx.out(), "{} {} {}", site.size, site.count, site.backtrace);
+      ctx.out(),
+      "size: {} count: {} at: {}",
+      site.size,
+      site.count,
+      site.backtrace);
 }
 
 /// Put `top_n` allocation sites into the front of `allocation_sites`
@@ -66,6 +68,12 @@ memory_sampling::get_oom_diagnostics_callback() {
         const size_t top_n = std::min(size_t(10), num_sites);
         top_n_allocation_sites(allocation_sites, top_n);
 
+        writer("Alloc sites legend:\n"
+               "    size: the estimated total size of all allocations at this "
+               "stack (i.e., adjusted up from observed samples)\n"
+               "    count: the number of live samples at this "
+               "stack (i.e., NOT adjusted up from observed samples)\n"
+               "    at: the backtrace for this allocation site\n");
         writer(diagnostics_header());
         writer("\n");
 

--- a/src/v/resource_mgmt/memory_sampling.h
+++ b/src/v/resource_mgmt/memory_sampling.h
@@ -34,12 +34,8 @@
 template<>
 struct fmt::formatter<seastar::memory::allocation_site>
   : fmt::formatter<std::string_view> {
-    template<typename FormatContext>
-    auto
-    format(const seastar::memory::allocation_site& site, FormatContext& ctx) {
-        return fmt::format_to(
-          ctx.out(), "{} {} {}", site.size, site.count, site.backtrace);
-    }
+    fmt::appender
+    format(const seastar::memory::allocation_site&, fmt::format_context&);
 };
 
 /// Very simple service enabling memory profiling on all shards.


### PR DESCRIPTION
When we OOM we output the top-N alloc sites and a one-line backtrace.

However, sesatar-addr2line fails to recognize it because the one-line regex requires backtrace: or another suitable token in order to understand that it's a one-line backtrace.

So we add at:.

Fixes #15615.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none

