### PR TITLE
Legacy default upgrade test

### DIFF
--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -258,8 +258,8 @@ class RedpandaInstaller:
             cmd = None
             if self._head_backed_up:
                 cmd = f"mv /opt/redpanda {head_root_path}"
-            elif not node.account.exists(head_root_path):
-                cmd = f"ln -s {rp_install_path_root} {head_root_path}"
+            else:
+                cmd = f"ln -sf {rp_install_path_root} {head_root_path}"
             if cmd:
                 node.account.ssh_output(cmd)
 

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1890,7 +1890,10 @@ class ClusterConfigLegacyDefaultTest(RedpandaTest, ClusterConfigHelpersMixin):
         self._check_value_everywhere(self.key, self.legacy_default)
 
         self._upgrade(wipe_cache)
+        self._check_value_everywhere(self.key, self.legacy_default)
         expected = self.new_default + 1
         self.redpanda.set_cluster_config({self.key: expected})
 
+        self._check_value_everywhere(self.key, expected)
+        self.redpanda.restart_nodes(self.redpanda.nodes)
         self._check_value_everywhere(self.key, expected)


### PR DESCRIPTION
    test: check upgrade legacy default with restart

    After changing a legacy value upgrade upgrade, restart and make sure the
    change persists.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

