### PR TITLE
r/persisted_stm: do initial cleanup only for kvstore-backed snapshots

### DIFF
--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -68,6 +68,7 @@ class file_backed_stm_snapshot {
 public:
     file_backed_stm_snapshot(
       ss::sstring snapshot_name, prefix_logger& log, raft::consensus* c);
+    ss::future<> perform_initial_cleanup();
     ss::future<std::optional<stm_snapshot>> load_snapshot();
     ss::future<> persist_local_snapshot(stm_snapshot&&);
     const ss::sstring& name();
@@ -105,6 +106,7 @@ public:
       model::ntp ntp,
       storage::kvstore& kvstore);
 
+    ss::future<> perform_initial_cleanup();
     ss::future<std::optional<stm_snapshot>> load_snapshot();
     ss::future<> persist_local_snapshot(stm_snapshot&&);
     const ss::sstring& name();
@@ -130,6 +132,7 @@ ss::future<> move_persistent_stm_state(
 
 template<typename T>
 concept supported_stm_snapshot = requires(T s, stm_snapshot&& snapshot) {
+    { s.perform_initial_cleanup() } -> std::same_as<ss::future<>>;
     {
         s.load_snapshot()
     } -> std::same_as<ss::future<std::optional<stm_snapshot>>>;


### PR DESCRIPTION
As the log directory name contains the partition revision, any file-based snapshots that we'll find there for a newly created log are not coming from the previous incarnation of this ntp (and were likely put there deliberately). Therefore we skip initial cleanup phase for file-based snapshots.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none