### PR TITLE
rpk: deprecate topic-name-pattern in cluster restore

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_cloud_storage.go
+++ b/src/go/rpk/pkg/adminapi/api_cloud_storage.go
@@ -17,9 +17,8 @@ import (
 
 // RecoveryRequestParams represents the request body schema for the automated recovery API endpoint.
 type RecoveryRequestParams struct {
-	TopicNamesPattern string `json:"topic_names_pattern"`
-	RetentionBytes    *int   `json:"retention_bytes,omitempty"`
-	RetentionMs       *int   `json:"retention_ms,omitempty"`
+	RetentionBytes *int `json:"retention_bytes,omitempty"`
+	RetentionMs    *int `json:"retention_ms,omitempty"`
 }
 
 type RecoveryStartResponse struct {
@@ -80,10 +79,8 @@ type (
 )
 
 // StartAutomatedRecovery starts the automated recovery process by sending a request to the automated recovery API endpoint.
-func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context, topicNamesPattern string) (RecoveryStartResponse, error) {
-	requestParams := &RecoveryRequestParams{
-		TopicNamesPattern: topicNamesPattern,
-	}
+func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context) (RecoveryStartResponse, error) {
+	requestParams := &RecoveryRequestParams{}
 	var response RecoveryStartResponse
 
 	return response, a.sendAny(ctx, http.MethodPost, "/v1/cloud_storage/automated_recovery", requestParams, &response)

--- a/src/go/rpk/pkg/adminapi/api_cloud_storage_test.go
+++ b/src/go/rpk/pkg/adminapi/api_cloud_storage_test.go
@@ -38,7 +38,7 @@ func TestStartAutomatedRecovery(t *testing.T) {
 		client, err := NewAdminAPI([]string{server.URL}, new(NopAuth), nil)
 		assert.NoError(t, err)
 
-		response, err := client.StartAutomatedRecovery(context.Background(), ".*")
+		response, err := client.StartAutomatedRecovery(context.Background())
 
 		assert.NoError(t, err)
 		assert.Equal(t, test.exp, response)
@@ -97,9 +97,7 @@ func TestPollAutomatedRecoveryStatus(t *testing.T) {
 				FailedDownloads:     0,
 			},
 		},
-		RecoveryRequest: RecoveryRequestParams{
-			TopicNamesPattern: ".*",
-		},
+		RecoveryRequest: RecoveryRequestParams{},
 	}
 
 	runTest := func(t *testing.T, test testCase) {

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
@@ -23,9 +23,8 @@ import (
 
 func newStartCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var (
-		topicNamePattern string
-		wait             bool
-		pollingInterval  time.Duration
+		wait            bool
+		pollingInterval time.Duration
 	)
 
 	cmd := &cobra.Command{
@@ -46,7 +45,7 @@ recovery process until it's finished.`,
 
 			ctx := cmd.Context()
 
-			_, err = client.StartAutomatedRecovery(ctx, topicNamePattern)
+			_, err = client.StartAutomatedRecovery(ctx)
 			var he *adminapi.HTTPResponseError
 			if errors.As(err, &he) {
 				if he.Response.StatusCode == 404 {
@@ -109,7 +108,7 @@ recovery process until it's finished.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&topicNamePattern, "topic-name-pattern", ".*", "A regex pattern that restores any matching topics")
+	cmd.Flags().MarkDeprecated("topic-name-pattern", "Not supported")
 	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "Wait until auto-restore is complete")
 	cmd.Flags().DurationVar(&pollingInterval, "polling-interval", 5*time.Second, "The status check interval (e.g. '30s', '1.5m'); ignored if --wait is not used")
 


### PR DESCRIPTION
Whole cluster restore doesn't currently support filtering topics, and we don't have immediate plans to support it. This field was never formally documented, so to avoid confusion, this commit deprecates it.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
