### PR TITLE
tests: repro for zombie txs after compaction

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -155,13 +155,13 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
     auto* remote_p = app.partition_manager.local()
                        .get(model::ntp{remote_tp_ns.ns, remote_tp_ns.tp, 0})
                        .get();
-    cluster::random_tx_generator::spec spec{
+    cluster::tx_executor::spec spec{
       ._num_txes = num_txns,
       ._num_rolls = 3,
-      ._types = cluster::random_tx_generator::mixed,
+      ._types = cluster::tx_executor::mixed,
       ._interleave = true,
       ._compact = false};
-    cluster::random_tx_generator{}.run_workload(
+    cluster::tx_executor{}.run_random_workload(
       spec, remote_p->raft()->term(), remote_p->rm_stm(), remote_p->log());
 
     for (const auto& [ntp, p] : app.partition_manager.local().partitions()) {

--- a/src/v/cluster/cloud_metadata/tests/producer_id_recovery_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/producer_id_recovery_test.cc
@@ -39,13 +39,13 @@ public:
     }
 
     void generate_txn_data(int num_txns) {
-        cluster::random_tx_generator::spec spec{
+        cluster::tx_executor::spec spec{
           ._num_txes = num_txns,
           ._num_rolls = 3,
-          ._types = cluster::random_tx_generator::mixed,
+          ._types = cluster::tx_executor::mixed,
           ._interleave = true,
           ._compact = false};
-        cluster::random_tx_generator{}.run_workload(
+        cluster::tx_executor{}.run_random_workload(
           spec, partition->raft()->term(), partition->rm_stm(), log);
     }
 

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -10,7 +10,7 @@
 
 static ss::logger test_logger{"tx_compaction_tests"};
 
-using cluster::random_tx_generator;
+using cluster::tx_executor;
 
 #define STM_BOOTSTRAP()                                                        \
     storage::ntp_config::default_overrides o{                                  \
@@ -45,19 +45,19 @@ FIXTURE_TEST(test_tx_compaction_combinations, rm_stm_test_fixture) {
     for (auto num_tx : {10, 20, 30}) {
         for (auto num_rolls : {0, 1, 2, 3, 5}) {
             for (auto type :
-                 {random_tx_generator::tx_types::commit_only,
-                  random_tx_generator::tx_types::abort_only,
-                  random_tx_generator::mixed}) {
+                 {tx_executor::tx_types::commit_only,
+                  tx_executor::tx_types::abort_only,
+                  tx_executor::mixed}) {
                 for (auto interleave : {true, false}) {
                     {
-                        random_tx_generator::spec spec{
+                        tx_executor::spec spec{
                           ._num_txes = num_tx,
                           ._num_rolls = num_rolls,
                           ._types = type,
                           ._interleave = interleave};
                         STM_BOOTSTRAP();
                         vlog(test_logger.info, "Running spec: {}", spec);
-                        random_tx_generator{}.run_workload(
+                        tx_executor{}.run_random_workload(
                           spec, _raft->term(), stm, log);
                         vlog(test_logger.info, "Finished spec: {}", spec);
                     }

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -15,6 +15,9 @@
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/async.h"
 #include "test_utils/randoms.h"
+#include "test_utils/test_macros.h"
+
+#include <seastar/core/future.hh>
 
 namespace cluster {
 
@@ -25,6 +28,38 @@ public:
 
     // Types of tx ops to generate
     enum tx_types { commit_only, abort_only, mixed };
+
+    enum tx_op_type : int {
+        begin,
+        commit,
+        abort,
+        data,
+        roll,
+    };
+
+    struct tx_op_ctx {
+        ss::shared_ptr<linear_int_kv_batch_generator> _data_gen;
+        ss::shared_ptr<rm_stm> _stm;
+        ss::shared_ptr<storage::log> _log;
+        model::producer_identity _pid;
+        model::term_id _term;
+    };
+
+    struct tx_op {
+    public:
+        explicit tx_op(tx_op_ctx&& ctx, int weight)
+          : _ctx(std::move(ctx))
+          , _weight(weight) {}
+        virtual ~tx_op() noexcept = default;
+        virtual ss::future<> execute() = 0;
+        virtual ss::sstring debug() = 0;
+        virtual tx_op_type type() = 0;
+        int weight() const { return _weight; }
+
+    protected:
+        tx_op_ctx _ctx;
+        int _weight;
+    };
 
     struct spec {
         int _num_txes = 5;
@@ -48,6 +83,47 @@ public:
         }
     };
 
+    using tx_op_ptr = ss::shared_ptr<tx_op>;
+    struct tx_op_cmp {
+        bool operator()(tx_op_ptr l, tx_op_ptr r) {
+            return l->weight() > r->weight();
+        }
+    };
+    using sorted_tx_ops_t
+      = std::priority_queue<tx_op_ptr, std::vector<tx_op_ptr>, tx_op_cmp>;
+
+    ss::future<>
+    execute(sorted_tx_ops_t ops, ss::shared_ptr<storage::log> log = nullptr) {
+        auto dummy_as = ss::abort_source{};
+        constexpr auto ret_duration = 10s;
+        auto housekeeping = [&]() {
+            if (!log) {
+                return ss::make_ready_future<>();
+            }
+            return log->apply_segment_ms().then([&] {
+                return log
+                  ->housekeeping(storage::housekeeping_config{
+                    model::timestamp(
+                      model::timestamp::now().value() - ret_duration.count()),
+                    std::nullopt,
+                    log->stm_manager()->max_collectible_offset(),
+                    ss::default_priority_class(),
+                    dummy_as,
+                  })
+                  .handle_exception_type(
+                    [](const storage::segment_closed_exception&) {});
+            });
+        };
+        while (!ops.empty()) {
+            auto housekeeping_fut = housekeeping();
+            auto op = ops.top();
+            co_await op->execute();
+            vlog(clusterlog.info, "Executed op: {}", op->debug());
+            ops.pop();
+            co_await std::move(housekeeping_fut);
+        }
+    }
+
     void run_workload(
       spec s,
       model::term_id term,
@@ -57,7 +133,7 @@ public:
         // As we generate random txns, we populate them in a priority queue that
         // orders them by their associated weight, which controls the sequence
         // of transactions.
-        std::priority_queue<tx_op_ptr, std::vector<tx_op_ptr>, tx_op_cmp> ops;
+        sorted_tx_ops_t ops;
         int num_ops = 3 * s._num_txes + s._num_rolls;
         auto rand_weight = [num_ops](int prev) {
             return prev + random_generators::get_int(1, num_ops);
@@ -105,34 +181,8 @@ public:
               random_generators::get_int(1, num_ops)}));
         }
 
-        auto dummy_as = ss::abort_source{};
-        constexpr auto ret_duration = 10s;
-        auto housekeeping = [&]() {
-            return log->apply_segment_ms().then([&] {
-                return log
-                  ->housekeeping(storage::housekeeping_config{
-                    model::timestamp(
-                      model::timestamp::now().value() - ret_duration.count()),
-                    std::nullopt,
-                    log->stm_manager()->max_collectible_offset(),
-                    ss::default_priority_class(),
-                    dummy_as,
-                  })
-                  .handle_exception_type(
-                    [](const storage::segment_closed_exception&) {});
-            });
-        };
-
         //----- Step 2: Execute ops
-        while (!ops.empty()) {
-            auto housekeeping_fut = housekeeping();
-            ss::yield().get();
-            auto op = ops.top();
-            op->execute();
-            vlog(clusterlog.info, "Executed op: {}", op->debug());
-            ops.pop();
-            housekeeping_fut.get();
-        }
+        execute(std::move(ops), log).get();
 
         //---- Step 3: Force a roll and compact the log.
         log->flush().get0();
@@ -170,76 +220,33 @@ public:
         int fence_batch_count = 0;
         for (auto& batch : batches) {
             auto type = batch.header().type;
-            BOOST_REQUIRE_NE(type, model::record_batch_type::tx_prepare);
+            RPTEST_REQUIRE_NE(type, model::record_batch_type::tx_prepare);
             if (batch.header().attrs.is_transactional()) {
                 model::producer_identity pid{
                   batch.header().producer_id, batch.header().producer_epoch};
                 // no control (commit/abort) batches.
-                BOOST_REQUIRE(!batch.header().attrs.is_control());
-                BOOST_REQUIRE_EQUAL(type, model::record_batch_type::raft_data);
-                BOOST_REQUIRE(_committed_pids.contains(pid));
-                BOOST_REQUIRE(!_aborted_pids.contains(pid));
+                RPTEST_REQUIRE(!batch.header().attrs.is_control());
+                RPTEST_REQUIRE_EQ(type, model::record_batch_type::raft_data);
+                RPTEST_REQUIRE(_committed_pids.contains(pid));
+                RPTEST_REQUIRE(!_aborted_pids.contains(pid));
             }
             if (type == model::record_batch_type::tx_fence) {
                 fence_batch_count++;
             }
         }
-        BOOST_REQUIRE_EQUAL(fence_batch_count, s._num_txes);
+        RPTEST_REQUIRE_EQ(fence_batch_count, s._num_txes);
     }
 
-private:
-    enum tx_op_type : int {
-        begin,
-        commit,
-        abort,
-        data,
-        roll,
-    };
-
-    struct tx_op_ctx {
-        ss::shared_ptr<linear_int_kv_batch_generator> _data_gen;
-        ss::shared_ptr<rm_stm> _stm;
-        ss::shared_ptr<storage::log> _log;
-        model::producer_identity _pid;
-        model::term_id _term;
-    };
-
-    struct tx_op {
-    public:
-        explicit tx_op(tx_op_ctx&& ctx, int weight)
-          : _ctx(std::move(ctx))
-          , _weight(weight) {}
-        virtual ~tx_op() noexcept = default;
-        virtual void execute() = 0;
-        virtual ss::sstring debug() = 0;
-        virtual tx_op_type type() = 0;
-        int weight() const { return _weight; }
-
-    protected:
-        tx_op_ctx _ctx;
-        int _weight;
-    };
-
-    using tx_op_ptr = ss::shared_ptr<tx_op>;
-    struct tx_op_cmp {
-        bool operator()(tx_op_ptr l, tx_op_ptr r) {
-            return l->weight() > r->weight();
-        }
-    };
+    auto& data_gen() { return _data_gen; }
 
     struct begin_op final : tx_op {
     public:
         explicit begin_op(tx_op_ctx&& ctx, int weight)
           : tx_op(std::move(ctx), weight) {}
 
-        void execute() override {
-            BOOST_REQUIRE(_ctx._stm
-                            ->begin_tx(
-                              _ctx._pid,
-                              model::tx_seq{0},
-                              tx_timeout,
-                              model::partition_id(0))
-                            .get0());
+        ss::future<> execute() override {
+            RPTEST_REQUIRE_CORO(co_await _ctx._stm->begin_tx(
+              _ctx._pid, model::tx_seq{0}, tx_timeout, model::partition_id(0)));
         }
 
         tx_op_type type() override { return tx_op_type::begin; }
@@ -253,10 +260,10 @@ private:
         explicit commit_op(tx_op_ctx&& ctx, int weight)
           : tx_op(std::move(ctx), weight) {}
 
-        void execute() override {
-            BOOST_REQUIRE_EQUAL(
-              _ctx._stm->commit_tx(_ctx._pid, model::tx_seq{0}, tx_timeout)
-                .get0(),
+        ss::future<> execute() override {
+            RPTEST_REQUIRE_EQ_CORO(
+              co_await _ctx._stm->commit_tx(
+                _ctx._pid, model::tx_seq{0}, tx_timeout),
               cluster::tx_errc::none);
         }
         tx_op_type type() override { return tx_op_type::commit; }
@@ -269,10 +276,10 @@ private:
     public:
         explicit abort_op(tx_op_ctx&& ctx, int weight)
           : tx_op(std::move(ctx), weight) {}
-        void execute() override {
-            BOOST_REQUIRE_EQUAL(
-              _ctx._stm->abort_tx(_ctx._pid, model::tx_seq{0}, tx_timeout)
-                .get0(),
+        ss::future<> execute() override {
+            RPTEST_REQUIRE_EQ_CORO(
+              co_await _ctx._stm->abort_tx(
+                _ctx._pid, model::tx_seq{0}, tx_timeout),
               cluster::tx_errc::none);
         }
         tx_op_type type() override { return tx_op_type::abort; }
@@ -286,7 +293,7 @@ private:
         explicit data_op(tx_op_ctx&& ctx, int weight)
           : tx_op(std::move(ctx), weight) {}
 
-        void execute() override {
+        ss::future<> execute() override {
             model::test::record_batch_spec spec;
             spec.producer_id = _ctx._pid.id;
             spec.producer_epoch = _ctx._pid.epoch;
@@ -294,7 +301,7 @@ private:
             spec.count = 5;
             auto batches = _ctx._data_gen->operator()(spec, 1);
             _data_idx = _ctx._data_gen->_idx - 1;
-            BOOST_REQUIRE_EQUAL(batches.size(), 1);
+            RPTEST_REQUIRE_EQ_CORO(batches.size(), 1);
             model::batch_identity bid{
               .pid = _ctx._pid,
               .first_seq = 0,
@@ -303,17 +310,14 @@ private:
               .is_transactional = true};
             auto reader = model::make_memory_record_batch_reader(
               std::move(batches[0]));
-            auto result = _ctx._stm
-                            ->replicate(
-                              bid,
-                              std::move(reader),
-                              raft::replicate_options(
-                                raft::consistency_level::quorum_ack))
-                            .get0();
+            auto result = co_await _ctx._stm->replicate(
+              bid,
+              std::move(reader),
+              raft::replicate_options(raft::consistency_level::quorum_ack));
             if (!result.has_value()) {
                 vlog(clusterlog.error, "Error {}", result.error());
             }
-            BOOST_REQUIRE((bool)result);
+            RPTEST_REQUIRE_EQ_CORO((bool)result, true);
         }
 
         tx_op_type type() override { return tx_op_type::data; }
@@ -329,13 +333,14 @@ private:
     public:
         explicit roll_op(tx_op_ctx&& ctx, int weight)
           : tx_op(std::move(ctx), weight) {}
-        void execute() override {
-            _ctx._log->force_roll(ss::default_priority_class()).get0();
+        ss::future<> execute() override {
+            co_await _ctx._log->force_roll(ss::default_priority_class());
         }
         tx_op_type type() override { return tx_op_type::roll; }
         ss::sstring debug() override { return "roll log"; }
     };
 
+private:
     ss::future<ss::circular_buffer<model::record_batch>>
     copy_to_mem(model::record_batch_reader& reader) {
         using data_t = ss::circular_buffer<model::record_batch>;

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -21,7 +21,7 @@
 
 namespace cluster {
 
-class random_tx_generator {
+class tx_executor {
 public:
     constexpr static const auto tx_timeout = std::chrono::milliseconds(
       std::numeric_limits<int32_t>::max());
@@ -124,7 +124,7 @@ public:
         }
     }
 
-    void run_workload(
+    void run_random_workload(
       spec s,
       model::term_id term,
       ss::shared_ptr<cluster::rm_stm> stm,

--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -299,15 +299,16 @@ public:
 
     struct data_op final : tx_op {
     public:
-        explicit data_op(tx_op_ctx&& ctx, int weight)
-          : tx_op(std::move(ctx), weight) {}
+        explicit data_op(tx_op_ctx&& ctx, int weight, int records = 5)
+          : tx_op(std::move(ctx), weight)
+          , _num_records(records) {}
 
         ss::future<> execute() override {
             model::test::record_batch_spec spec;
             spec.producer_id = _ctx._pid.id;
             spec.producer_epoch = _ctx._pid.epoch;
             spec.is_transactional = true;
-            spec.count = 5;
+            spec.count = _num_records;
             auto batches = _ctx._data_gen->operator()(spec, 1);
             _data_idx = _ctx._data_gen->_idx - 1;
             RPTEST_REQUIRE_EQ_CORO(batches.size(), 1);
@@ -335,6 +336,7 @@ public:
         }
 
     private:
+        int _num_records;
         int _data_idx{};
     };
 

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -117,7 +117,7 @@ rp_test(
   FIXTURE_TEST
   BINARY_NAME storage_e2e
   SOURCES ${fixture_srcs}
-  LIBRARIES v::seastar_testing_main v::application v::raft v::config v::kafka_test_utils
+  LIBRARIES v::seastar_testing_main v::application v::raft v::config v::kafka_test_utils v::model_test_utils
   ARGS "-- -c 1"
   LABELS storage
 )

--- a/src/v/test_utils/test_macros.h
+++ b/src/v/test_utils/test_macros.h
@@ -16,9 +16,21 @@
 
 #define RPTEST_FAIL(m) BOOST_FAIL(m)
 #define RPTEST_FAIL_CORO(m) BOOST_FAIL(m)
+#define RPTEST_REQUIRE(m) BOOST_REQUIRE(m)
+#define RPTEST_REQUIRE_CORO(m) BOOST_REQUIRE(m)
+#define RPTEST_REQUIRE_EQ(m, n) BOOST_REQUIRE_EQUAL(m, n)
+#define RPTEST_REQUIRE_EQ_CORO(m, n) BOOST_REQUIRE_EQUAL(m, n)
+#define RPTEST_REQUIRE_NE(m, n) BOOST_REQUIRE_NE(m, n)
+#define RPTEST_REQUIRE_NE_CORO(m, n) BOOST_REQUIRE_NE(m, n)
 #else
 #include "test_utils/test.h"
 
 #define RPTEST_FAIL(m) FAIL() << (m)
 #define RPTEST_FAIL_CORO(m) ASSERT_TRUE_CORO(false) << (m)
+#define RPTEST_REQUIRE(m) ASSERT_TRUE(m)
+#define RPTEST_REQUIRE_CORO(m) ASSERT_TRUE_CORO(m)
+#define RPTEST_REQUIRE_EQ(m, n) ASSERT_EQ(m, n)
+#define RPTEST_REQUIRE_EQ_CORO(m, n) ASSERT_EQ_CORO(m, n)
+#define RPTEST_REQUIRE_NE(m, n) ASSERT_NE(m, n)
+#define RPTEST_REQUIRE_NE_CORO(m, n) ASSERT_NE_CORO(m, n)
 #endif


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

    This reproduces a bug fixed by e8e9ab7f27056d31b5287b2f6bc6cccae0e703fa
    wherein an aborted transaction was visible by a consumer after
    compaction and replication.

    The bug was caused by the fact that we would skip over segments of size
    1, rather than self compacting them.

    The sequence is roughly:

    node 1:
    - begin tx 1 (seg 1)
    - roll segment
    - data batch in tx 1 (seg 2)
    - roll segment
    - abort tx 1 (seg 3)
    - begin tx 2, data batch in tx 2, abort tx 2 (seg 3)
    - run compaction: skips first two segments from tx 1, removes abort
      marker tx 1 because it's deduplicated in favor of abort tx 2's abort
      marker (all aborts markers have the same key)
    - replicate to node 2

    node 2:
    - gets everything remaining in a single segment, now including just
      [begin tx 1, data tx 1, abort tx 2]
    - self compaction runs, but tx 1 is not an ongoing aborted transaction
    - data tx 1 is left in the segment as committed data
 
Along the way, I made a few changes to `tx_compaction_utils` to be reused in this test.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
