### PR TITLE
cluster: fix order of cluster recovery shutdown

### DIFF
--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -122,6 +122,8 @@ ss::future<> cluster_recovery_backend::stop_and_wait() {
         _term_as.value().get().request_abort();
     }
     _as.request_abort();
+    co_await _recovery_table.invoke_on_all(
+      &cluster_recovery_table::stop_waiters);
     vlog(clusterlog.info, "Closing cluster recovery backend gate...");
     co_await _gate.close();
 }

--- a/src/v/cluster/cluster_recovery_table.h
+++ b/src/v/cluster/cluster_recovery_table.h
@@ -78,9 +78,11 @@ may_require_offsets_recovery(std::optional<recovery_stage> cur_stage) {
 class cluster_recovery_table {
 public:
     ss::future<> stop() {
-        _has_active_recovery.broken();
+        stop_waiters();
         return ss::make_ready_future();
     }
+
+    void stop_waiters() { _has_active_recovery.broken(); }
 
     bool is_recovery_active() const {
         if (_states.empty()) {

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -718,14 +718,14 @@ ss::future<> controller::stop() {
               }
               return ss::make_ready_future();
           })
-          .then([this] { return _recovery_table.stop(); })
-          .then([this] { return _recovery_manager.stop(); })
           .then([this] {
               if (_recovery_backend) {
                   return _recovery_backend->stop_and_wait();
               }
               return ss::make_ready_future();
           })
+          .then([this] { return _recovery_manager.stop(); })
+          .then([this] { return _recovery_table.stop(); })
           .then([this] { return _partition_balancer.stop(); })
           .then([this] { return _metrics_reporter.stop(); })
           .then([this] { return _feature_manager.stop(); })


### PR DESCRIPTION
The recovery table would previously be destructed first, leaving the backend to potentially access destructed state.

Related https://github.com/redpanda-data/redpanda/issues/15402
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
