### PR TITLE
Add checkbox and placeholders for assessing whether docs changes are required

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.md
@@ -27,6 +27,8 @@ Describe benefit and urgency for the user and Redpanda
 
 ### Additional notes
 
+- [ ] Docs Update Required (add `doc-needed` label)
+
 <!--
 Relevant GH issues and pull requests
 Dependencies on other features or components

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,3 +53,7 @@ point of the change, e.g.
 * Short description of how this PR improves existing behavior.
 
 -->
+## Documentation Updates
+<!--
+If the changes in this PR affect the behaviour or configurability of Redpanda in a way that requires users to be aware, then we may need to update the documentation. Be sure to add the `doc-needed` label and enter in this section a few words to highlight to the docs team what may need to be documented
+-->


### PR DESCRIPTION
Updating Github settings to encourage people to use the `doc-needed` label on feature requests and on PRs.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes
* none

