### PR TITLE
c/topics_dispatcher: do not guesstimate leader ids

### DIFF
--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -221,25 +221,6 @@ void partition_leaders_table::update_partition_leader(
     }
 }
 
-ss::future<> partition_leaders_table::update_with_estimates() {
-    for (const auto& [ns_tp, topic] :
-         _topic_table.local().all_topics_metadata()) {
-        for (const auto& part : topic.metadata.get_assignments()) {
-            if (!_leaders.contains(leader_key_view{ns_tp, part.id})) {
-                model::ntp ntp{ns_tp.ns, ns_tp.tp, part.id};
-                vassert(
-                  !part.replicas.empty(),
-                  "set of replicas for ntp {} can't be empty",
-                  ntp);
-                update_partition_leader(
-                  ntp, model::term_id{1}, part.replicas.begin()->node_id);
-            }
-
-            co_await ss::coroutine::maybe_yield();
-        }
-    }
-}
-
 ss::future<model::node_id> partition_leaders_table::wait_for_leader(
   const model::ntp& ntp,
   ss::lowres_clock::time_point timeout,

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -88,12 +88,6 @@ public:
       model::term_id,
       std::optional<model::node_id>);
 
-    // Intended to be called when we apply the topic snapshot: add leader
-    // guesses for partitions that are present in the topic table but we have
-    // not leader information for (i.e. all as-yet unseen partitions).  Assumes
-    // that topic_table doesn't change during the call.
-    ss::future<> update_with_estimates();
-
     struct leader_info_t {
         model::topic_namespace tp_ns;
         model::partition_id pid;

--- a/src/v/cluster/topic_updates_dispatcher.h
+++ b/src/v/cluster/topic_updates_dispatcher.h
@@ -115,8 +115,6 @@ private:
 
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
-    ss::future<>
-    update_leaders_with_estimates(ss::chunked_fifo<ntp_leader> leaders);
     template<typename T>
     void
     add_allocations_for_new_partitions(const T&, partition_allocation_domain);

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -80,8 +80,14 @@ std::optional<cluster::leader_term> get_leader_term(
   const cluster::metadata_cache& md_cache,
   const std::vector<model::node_id>& replicas) {
     auto leader_term = md_cache.get_leader_term(tp_ns, p_id);
+    /**
+     * If current broker do not yet have any information about leadership we
+     * simply return random node to force the client metadata update.
+     */
     if (!leader_term) {
-        return std::nullopt;
+        auto idx = fast_prng_source() % replicas.size();
+        leader_term.emplace(replicas[idx], model::term_id(-1));
+        return leader_term;
     }
     if (!leader_term->leader.has_value()) {
         const auto previous = md_cache.get_previous_leader_id(tp_ns, p_id);

--- a/tests/rptest/tests/consumer_group_recovery_tool_test.py
+++ b/tests/rptest/tests/consumer_group_recovery_tool_test.py
@@ -38,7 +38,8 @@ class ConsumerOffsetsRecoveryToolTest(PreallocNodesTest):
                 # clear topics from the the kafka_nodelete_topics to allow for
                 # __consumer_offsets to be configured in this test.
                 "kafka_nodelete_topics": [],
-                "group_topic_partitions": self.initial_partition_count
+                "group_topic_partitions": self.initial_partition_count,
+                "enable_leader_balancer": False,
             },
             node_prealloc_count=1,
             **kwargs)

--- a/tests/rptest/tests/partition_force_reconfiguration_test.py
+++ b/tests/rptest/tests/partition_force_reconfiguration_test.py
@@ -21,6 +21,7 @@ from rptest.services.admin import Replica
 from rptest.clients.kcl import KCL
 from threading import Thread, Condition
 from rptest.services.redpanda import RedpandaService
+from rptest.util import wait_until_result
 
 
 class ControllerLeadershipTransferInjector():
@@ -140,17 +141,26 @@ class PartitionForceReconfigurationTest(EndToEndTest, PartitionMovementMixin):
     def _alive_nodes(self):
         return [n.account.hostname for n in self.redpanda.started_nodes()]
 
-    def _stop_majority_nodes(self, replication=5, conf=None):
+    def _stop_majority_nodes(self, replication=5):
         """
         Stops a random majority of nodes hosting partition 0 of test topic.
         """
         assert self.redpanda
-        if not conf:
-            conf = self.redpanda._admin._get_stable_configuration(
+
+        def _get_details():
+            d = self.redpanda._admin._get_stable_configuration(
                 hosts=self._alive_nodes(),
                 topic=self.topic,
                 replication=replication)
-        replicas = conf.replicas
+            if d is None:
+                return (False, None)
+            return (True, d)
+
+        partition_details = wait_until_result(_get_details,
+                                              timeout_sec=30,
+                                              backoff_sec=2)
+
+        replicas = partition_details.replicas
         shuffle(replicas)
         mid = len(replicas) // 2 + 1
         (killed, alive) = (replicas[0:mid], replicas[mid:])

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -226,6 +226,9 @@ class UpgradeBackToBackTest(PreallocNodesTest):
                 # First version, start up the workload
                 self._producer.start(clean=False)
                 self._producer.wait_for_offset_map()
+                self._producer.wait_for_acks(100,
+                                             timeout_sec=10,
+                                             backoff_sec=2)
                 wrote_at_least = self._producer.produce_status.acked
                 for consumer in self._consumers:
                     consumer.start(clean=False)


### PR DESCRIPTION
Updating leadership metadata before the topic is ready to serve traffic is not desired. It prevents waiting for leader to be reported by raft group when it is actually ready.

Fixes: #14673
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
