### PR TITLE
cloud_storage_clients: stricter but simpler invariants for the pool

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -442,7 +442,7 @@ void client_pool::populate_client_pool() {
     _cvar.signal();
 }
 
-client_pool::http_client_ptr client_pool::make_client() const {
+client_pool::http_client_ptr client_pool::make_client() const noexcept {
     return std::visit(
       [this](const auto& cfg) -> http_client_ptr {
           using cfg_type = std::decay_t<decltype(cfg)>;

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -18,6 +18,7 @@
 #include <seastar/core/smp.hh>
 
 #include <algorithm>
+#include <optional>
 #include <random>
 
 namespace {
@@ -240,7 +241,10 @@ std::tuple<unsigned int, unsigned int> pick_two_random_shards() {
 ss::future<client_pool::client_lease>
 client_pool::acquire(ss::abort_source& as) {
     auto guard = _gate.hold();
+
     std::optional<unsigned int> source_sid;
+    std::optional<http_client_ptr> client;
+
     try {
         // If credentials have not yet been acquired, wait for them. It is
         // possible that credentials are not initialized right after remote
@@ -253,9 +257,12 @@ client_pool::acquire(ss::abort_source& as) {
             u = co_await ss::get_units(_self_config_barrier, 1);
         }
 
-        while (unlikely(
-          _pool.empty() && !_gate.is_closed() && !_as.abort_requested())) {
-            if (
+        while (!client.has_value() && !_gate.is_closed()
+               && !_as.abort_requested()) {
+            if (likely(!_pool.empty())) {
+                client = _pool.back();
+                _pool.pop_back();
+            } else if (
               ss::smp::count == 1
               || _policy == client_pool_overdraft_policy::wait_if_empty
               || _leased.size() >= _capacity * 2) {
@@ -268,14 +275,14 @@ client_pool::acquire(ss::abort_source& as) {
                   "cvar triggered, pool size: {}",
                   _pool.size());
             } else {
+                // Try borrowing from peer shard.
                 auto clients_in_use = [](client_pool& other) {
                     return std::clamp(
                       other._capacity - other._pool.size(),
                       0UL,
                       other._capacity);
                 };
-                // Borrow from random shard. Use 2-random approach. Pick 2
-                // random shards
+                // Use 2-random approach. Pick 2 random shards
                 auto [sid1, sid2] = pick_two_random_shards();
                 auto cnt1 = co_await container().invoke_on(
                   sid1, clients_in_use);
@@ -301,12 +308,12 @@ client_pool::acquire(ss::abort_source& as) {
                 }
                 // Depending on the result either wait or create new connection
                 if (success) {
-                    vlog(pool_log.debug, "successfuly borrowed from {}", sid);
+                    vlog(pool_log.debug, "successfully borrowed from {}", sid);
                     if (_probe) {
                         _probe->register_borrow();
                     }
                     source_sid = sid;
-                    _pool.emplace_back(make_client());
+                    client = make_client();
                 } else {
                     vlog(pool_log.debug, "can't borrow connection, waiting");
                     co_await _cvar.wait();
@@ -322,9 +329,7 @@ client_pool::acquire(ss::abort_source& as) {
     if (_gate.is_closed() || _as.abort_requested()) {
         throw ss::gate_closed_exception();
     }
-    vassert(!_pool.empty(), "'acquire' invariant is broken");
-    auto client = _pool.back();
-    _pool.pop_back();
+    vassert(client.has_value(), "'acquire' invariant is broken");
 
     update_usage_stats();
     vlog(
@@ -339,19 +344,33 @@ client_pool::acquire(ss::abort_source& as) {
     }
 
     client_lease lease(
-      client,
+      client.value(),
       as,
       ss::make_deleter([pool = weak_from_this(),
-                        client,
+                        client = client.value(),
                         g = std::move(guard),
                         source_sid]() mutable {
           if (pool) {
               if (source_sid.has_value()) {
-                  vlog(
-                    pool_log.debug, "disposing the borrowed client connection");
-                  // Since the client was borrowed we can't just add it back to
-                  // the pool. This will lead to a situation when the connection
-                  // simultaneously exists on two different shards.
+                  // If all clients from the local pool are in-use we will
+                  // shutdown the borrowed one and return the "accounting unit"
+                  // to the source shard.
+                  // Otherwise, we replace the oldest client in the
+                  // pool to improve connection reuse.
+                  if (!pool->_pool.empty()) {
+                      vlog(
+                        pool_log.debug,
+                        "disposing the the oldest client connection and "
+                        "replacing it with the borrowed one");
+                      pool->_pool.push_back(std::move(client));
+                      client = std::move(pool->_pool.front());
+                      pool->_pool.pop_front();
+                  } else {
+                      vlog(
+                        pool_log.debug,
+                        "disposing the borrowed client connection");
+                  }
+
                   client->shutdown();
                   ssx::spawn_with_gate(pool->_bg_gate, [client] {
                       return client->stop().finally([client] {});
@@ -416,18 +435,17 @@ bool client_pool::borrow_one(unsigned other) {
 
 void client_pool::return_one(unsigned other) {
     vlog(pool_log.debug, "shard {} returns a client", other);
-    if (_pool.size() + _leased.size() < _capacity) {
-        // The _pool has fewer elements than it should have because it was
-        // borrowed from previously.
-        _pool.emplace_back(make_client());
-        update_usage_stats();
-        vlog(
-          pool_log.debug,
-          "creating new client, current usage is {}/{}",
-          normalized_num_clients_in_use(),
-          _capacity);
-        _cvar.signal();
-    }
+    vassert(
+      _pool.size() < _capacity,
+      "tried to return a borrowed client but the pool is full");
+    _pool.emplace_back(make_client());
+    update_usage_stats();
+    vlog(
+      pool_log.debug,
+      "creating new client, current usage is {}/{}",
+      normalized_num_clients_in_use(),
+      _capacity);
+    _cvar.signal();
 }
 
 size_t client_pool::size() const noexcept { return _pool.size(); }
@@ -435,6 +453,7 @@ size_t client_pool::size() const noexcept { return _pool.size(); }
 size_t client_pool::max_size() const noexcept { return _capacity; }
 
 void client_pool::populate_client_pool() {
+    _pool.reserve(_capacity);
     for (size_t i = 0; i < _capacity; i++) {
         _pool.emplace_back(make_client());
     }
@@ -463,9 +482,10 @@ void client_pool::release(http_client_ptr leased) {
       "releasing a client, pool size: {}, capacity: {}",
       _pool.size(),
       _capacity);
-    if (_pool.size() < _capacity) {
-        _pool.emplace_back(std::move(leased));
-    }
+    vassert(
+      _pool.size() < _capacity,
+      "tried to release a client but the pool is at capacity");
+    _pool.emplace_back(std::move(leased));
     _cvar.signal();
 }
 

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -21,6 +21,7 @@
 #include <algorithm>
 #include <optional>
 #include <random>
+#include <utility>
 
 namespace {
 constexpr auto self_configure_attempts = 3;
@@ -442,7 +443,8 @@ void client_pool::return_one(unsigned other) {
     vassert(
       _pool.size() < _capacity,
       "tried to return a borrowed client but the pool is full");
-    _pool.emplace_back(make_client());
+    // Cold clients are at the front. Hot clients are at the back.
+    _pool.emplace_front(make_client());
     update_usage_stats();
     vlog(
       pool_log.debug,

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -16,6 +16,7 @@
 #include "utils/intrusive_list_helpers.h"
 #include "utils/stop_signal.h"
 
+#include <seastar/core/circular_buffer.hh>
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -166,7 +167,7 @@ private:
     client_configuration _config;
     ss::shared_ptr<client_probe> _probe;
     client_pool_overdraft_policy _policy;
-    std::vector<http_client_ptr> _pool;
+    ss::circular_buffer<http_client_ptr> _pool;
     // List of all connections currently used by clients
     intrusive_list<client_lease, &client_lease::_hook> _leased;
     ss::condition_variable _cvar;

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -147,7 +147,7 @@ private:
       std::optional<client_self_configuration_output> result);
 
     void populate_client_pool();
-    http_client_ptr make_client() const;
+    http_client_ptr make_client() const noexcept;
     void release(http_client_ptr leased);
 
     /// Return number of clients which wasn't utilized

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -137,6 +137,8 @@ public:
         return _bg_gate.get_count() > 0;
     }
 
+    bool has_waiters() const noexcept { return _cvar.has_waiters(); }
+
 private:
     ss::future<>
     client_self_configure(std::optional<std::reference_wrapper<stop_signal>>

--- a/src/v/cloud_storage_clients/client_pool.h
+++ b/src/v/cloud_storage_clients/client_pool.h
@@ -132,6 +132,10 @@ public:
 
     size_t max_size() const noexcept;
 
+    bool has_background_operations() const noexcept {
+        return _bg_gate.get_count() > 0;
+    }
+
 private:
     ss::future<>
     client_self_configure(std::optional<std::reference_wrapper<stop_signal>>
@@ -168,6 +172,10 @@ private:
     ss::condition_variable _cvar;
     ss::abort_source _as;
     ss::gate _gate;
+    // A gate for background operations. Most useful in testing where we want
+    // to wait all async housekeeping to complete before asserting state
+    // invariants.
+    ss::gate _bg_gate;
 
     /// Holds and applies the credentials for requests to S3. Shared pointer to
     /// enable rotating credentials to all clients.

--- a/src/v/cloud_storage_clients/tests/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ rp_test(
   BINARY_NAME cloud_storage_clients_single_thread
   SOURCES
     backend_detection_test.cc
+    client_pool_test.cc
     s3_client_test.cc
     xml_sax_parser_test.cc
     exception_test.cc

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -10,27 +10,25 @@
 
 #include "cloud_storage_clients/client_pool.h"
 #include "cloud_storage_clients/s3_client.h"
-#include "net/dns.h"
 #include "seastarx.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/timed_out_error.hh>
 #include <seastar/core/with_timeout.hh>
-#include <seastar/http/function_handlers.hh>
-#include <seastar/http/handlers.hh>
-#include <seastar/http/httpd.hh>
-#include <seastar/http/routes.hh>
-#include <seastar/testing/test_case.hh>
 #include <seastar/testing/thread_test_case.hh>
 #include <seastar/util/defer.hh>
+#include <seastar/util/later.hh>
 
+#include <boost/range/irange.hpp>
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <chrono>
+#include <deque>
 #include <exception>
 
 using namespace std::chrono_literals;
@@ -194,6 +192,121 @@ SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_blocked_on_this_shard) {
     auto fut = pool.local().acquire(leases.local().as);
     try {
         ss::with_timeout(ss::lowres_clock::now() + 1s, std::move(fut)).get();
+    } catch (const ss::timed_out_error&) {
+        BOOST_FAIL("Timed out");
+    }
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_after_leasing_all) {
+    BOOST_REQUIRE(ss::smp::count == 2);
+    auto sconf = ss::sharded_parameter([] {
+        auto conf = transport_configuration();
+        return conf;
+    });
+    auto conf = transport_configuration();
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    size_t num_connections_per_shard = 4;
+    pool
+      .start(
+        num_connections_per_shard,
+        sconf,
+        cloud_storage_clients::client_pool_overdraft_policy::borrow_if_empty)
+      .get();
+
+    pool
+      .invoke_on_all([](cloud_storage_clients::client_pool& p) {
+          auto tcfg = transport_configuration();
+          auto cred = cloud_roles::aws_credentials{
+            tcfg.access_key.value(),
+            tcfg.secret_key.value(),
+            std::nullopt,
+            tcfg.region};
+          p.load_credentials(cred);
+      })
+      .get();
+    auto pool_stop = ss::defer([&pool] { pool.stop().get(); });
+    auto pool_no_bg_ops = [&pool] {
+        return pool.invoke_on_all([](cloud_storage_clients::client_pool& pool) {
+            while (pool.has_background_operations()) {
+                return ss::yield();
+            }
+            return ss::now();
+        });
+    };
+
+    ss::abort_source as;
+
+    struct shard_leases {
+        ss::abort_source as;
+        std::deque<cloud_storage_clients::client_pool::client_lease> leases;
+    };
+    ss::sharded<shard_leases> leases;
+    leases.start().get();
+    auto leases_stop = ss::defer([&leases] { leases.stop().get(); });
+
+    // Lease all connections from all the shards.
+    for (size_t i = 0; i < ss::smp::count * num_connections_per_shard; i++) {
+        leases.local().leases.push_back(
+          pool.local().acquire(leases.local().as).get());
+    }
+
+    vlog(test_log.debug, "connections depleted");
+
+    // Release clients from local shard. They are the first in the queue.
+    for (size_t i = 0; i < num_connections_per_shard; i++) {
+        leases.local().leases.pop_front();
+    }
+
+    vlog(test_log.debug, "done returning local leases");
+
+    // Lease local connections from the remote shard.
+    leases
+      .invoke_on(
+        1,
+        [&pool, num_connections_per_shard](shard_leases& sl) {
+            return ss::async([&sl, &pool, num_connections_per_shard] {
+                for (size_t i = 0; i < num_connections_per_shard; i++) {
+                    sl.leases.push_back(pool.local().acquire(sl.as).get());
+                }
+            });
+        })
+      .get();
+
+    vlog(test_log.debug, "done borrowing leases");
+
+    auto pending_acquire = pool.local().acquire(as);
+    ss::yield().get();
+
+    if (pending_acquire.available()) {
+        BOOST_FAIL("Expecting to get blocked on acquire");
+    }
+
+    // Return all connections from the remote shard.
+    leases
+      .invoke_on(
+        1,
+        [&pool_no_bg_ops, num_connections_per_shard](shard_leases& sl) {
+            return ss::async([&sl, &pool_no_bg_ops, num_connections_per_shard] {
+                for (size_t i = 0; i < num_connections_per_shard; i++) {
+                    sl.leases.pop_back();
+                    pool_no_bg_ops().get();
+                }
+            });
+        })
+      .get();
+
+    // Return connections from the local shard.
+    for (size_t i = 0; i < num_connections_per_shard; i++) {
+        leases.local().leases.pop_front();
+        pool_no_bg_ops().get();
+    }
+    vlog(test_log.debug, "done returning everything, will try to acquire now");
+
+    try {
+        ss::with_timeout(
+          ss::lowres_clock::now() + 1s, std::move(pending_acquire))
+          .get();
     } catch (const ss::timed_out_error&) {
         BOOST_FAIL("Timed out");
     }

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -37,7 +37,7 @@ ss::logger test_log("test-log");
 static const uint16_t httpd_port_number = 4434;
 static constexpr const char* httpd_host_name = "127.0.0.1";
 
-cloud_storage_clients::s3_configuration transport_configuration() {
+static cloud_storage_clients::s3_configuration transport_configuration() {
     net::unresolved_address server_addr(httpd_host_name, httpd_port_number);
     cloud_storage_clients::s3_configuration conf;
     conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_clients/client_pool.h"
+#include "seastarx.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+#include <seastar/util/later.hh>
+
+#include <boost/test/tools/interface.hpp>
+
+#include <chrono>
+#include <exception>
+
+using namespace std::chrono_literals;
+
+ss::logger test_log("test-log");
+static const uint16_t httpd_port_number = 4434;
+static constexpr const char* httpd_host_name = "127.0.0.1";
+
+static cloud_storage_clients::s3_configuration transport_configuration() {
+    net::unresolved_address server_addr(httpd_host_name, httpd_port_number);
+    cloud_storage_clients::s3_configuration conf;
+    conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);
+    conf.access_key = cloud_roles::public_key_str("acess-key");
+    conf.secret_key = cloud_roles::private_key_str("secret-key");
+    conf.region = cloud_roles::aws_region_name("us-east-1");
+    conf.server_addr = server_addr;
+    conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
+      net::metrics_disabled::yes,
+      net::public_metrics_disabled::yes,
+      cloud_roles::aws_region_name{"region"},
+      cloud_storage_clients::endpoint_url{"endpoint"});
+    return conf;
+}
+
+SEASTAR_THREAD_TEST_CASE(test_client_pool_acquire_abortable) {
+    auto sconf = ss::sharded_parameter([] {
+        auto conf = transport_configuration();
+        return conf;
+    });
+    auto conf = transport_configuration();
+
+    ss::sharded<cloud_storage_clients::client_pool> pool;
+    size_t num_connections_per_shard = 0;
+    pool
+      .start(
+        num_connections_per_shard,
+        sconf,
+        cloud_storage_clients::client_pool_overdraft_policy::borrow_if_empty)
+      .get();
+
+    pool
+      .invoke_on_all([&conf](cloud_storage_clients::client_pool& p) {
+          auto cred = cloud_roles::aws_credentials{
+            conf.access_key.value(),
+            conf.secret_key.value(),
+            std::nullopt,
+            conf.region};
+          p.load_credentials(cred);
+      })
+      .get();
+    auto pool_stop = ss::defer([&pool] { pool.stop().get(); });
+
+    ss::abort_source as;
+
+    auto f = pool.local().acquire(as);
+    while (!pool.local().has_waiters()) {
+        ss::yield().get();
+    }
+
+    BOOST_TEST_REQUIRE(
+      !f.available(), "acquire should be blocked as pool is empty");
+
+    as.request_abort();
+
+    BOOST_REQUIRE_THROW(f.get(), ss::abort_requested_exception);
+}

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -299,7 +299,7 @@ struct configured_test_pair {
     ss::shared_ptr<cloud_storage_clients::s3_client> client;
 };
 
-cloud_storage_clients::s3_configuration transport_configuration() {
+static cloud_storage_clients::s3_configuration transport_configuration() {
     net::unresolved_address server_addr(httpd_host_name, httpd_port_number);
     cloud_storage_clients::s3_configuration conf;
     conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes


### Bug Fixes

* Fix a rare bug where http client connections would vanish from the connection pool leading to various operations hanging while waiting for an http client.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
