### PR TITLE
Modify github template backport versions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,9 +21,9 @@ If this PR is a backport, link to the original with `Backport of PR`, e.g.
 - [ ] none - this is a backport
 - [ ] none - issue does not exist in previous branches
 - [ ] none - papercut/not impactful enough to backport
+- [ ] v23.3.x
 - [ ] v23.2.x
 - [ ] v23.1.x
-- [ ] v22.3.x
 
 ## Release Notes
 


### PR DESCRIPTION
- v22.3.x is no longer supported and v23.3.x becomes the newest supported version

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.2.x
- [ ] v23.1.x
- [ ] v22.3.x

## Release Notes

* none
