### PR TITLE
Fix behavior around feature table original/active version interaction with legacy defaults

### DIFF
--- a/tests/rptest/tests/cluster_features_test.py
+++ b/tests/rptest/tests/cluster_features_test.py
@@ -292,10 +292,6 @@ class FeaturesMultiNodeUpgradeTest(FeaturesTestBase):
 
         wait_until(complete, timeout_sec=5, backoff_sec=1)
 
-        # Check that initial version is properly remembered past restarts
-        self.redpanda.restart_nodes(self.redpanda.nodes)
-        assert complete()
-
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_rollback(self):
         """


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

PR improves behavior around updating `feature_table::_original_version`.

In particular, when we first start up after an upgrade, we apply a feature table snapshot from the pre-upgrade version. This is what we want, and we rightly set `feature_table::_original_version` to the correct logical version. Compatible properties take their legacy defaults, the cluster eventually agrees on the active logical version (of the new binary), which is written to the feature table, eventually snapshotted, and all is good.

Now we can apply additional configs to redpanda as desired. The problem is that, after a subsequent restart, `legacy_default`ed configs revert to their previous values. This occurs because feature table snapshot application entails multiple calls to `feature_table::set_original_version`, first with `feature_table_snapshot::version`, and then with `feature_table_snapshot::original_version`. I don't completely understand why we do this. Hopefully somebody else can comment. The problem then is that these back-to-back `set_original_version` calls are not aware of each other, which means that the second one effectively moves `original_version` back in time, forcing a re-application of the legacy defaults.

The fix then is to disallow this sequence of events outright, setting `feature_table::_original_version` iff the proposed version is `>=` the current one. I'm not 100% certain that these are the correct semantics, but it makes sense to me and does "fix" the bug.

Fixes #15674 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug Fixes

* Fix an issue where new configs would continually revert to legacy defaults after an upgrade.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
