### PR TITLE
hashing: use absl::crc32c implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,8 @@ if(Redpanda_ENABLE_SANITIZERS)
   add_compile_options(-fsanitize=address,leak,undefined)
 endif()
 
+add_compile_options(-msse4 -mpclmul)
+
 include(dependencies)
 include(v_library)
 include(testing)

--- a/src/v/hashing/tests/CMakeLists.txt
+++ b/src/v/hashing/tests/CMakeLists.txt
@@ -20,6 +20,6 @@ rp_test(
   BENCHMARK_TEST
   BINARY_NAME hashing_bench
   SOURCES hash_bench.cc
-  LIBRARIES Seastar::seastar_perf_testing v::rphashing v::rprandom absl::hash
+  LIBRARIES Seastar::seastar_perf_testing v::rphashing v::rprandom absl::hash absl::crc32c
   LABELS hashing
 )


### PR DESCRIPTION
* <1ns difference in benchmark.
* Can remove our crc32c dependency
* Need to check arm
* Make sure our -march stuff is setup correctly to detect sse4.2/pclmul

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
