### PR TITLE
rptest: add `test_add_and_decommission()`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1656,6 +1656,11 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
         """
         return self._kubectl._cmd(remote_cmd)
 
+    def scale_cluster(self, nodes_count):
+        """Scale out/in cluster to specified number of nodes.
+        """
+        return self._cloud_cluster.scale_cluster(nodes_count)
+
 
 class RedpandaService(RedpandaServiceBase):
     def __init__(self,

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -100,6 +100,7 @@ class CloudClusterConfig:
     oauth_client_secret: str = ""
     oauth_audience: str = ""
     api_url: str = ""
+    admin_api_url: str = ""
     teleport_auth_server: str = ""
     teleport_bot_token: str = ""
     id: str = ""  # empty string makes it easier to pass thru default value from duck.py
@@ -1369,3 +1370,16 @@ class CloudCluster():
                         product['advertisedMaxPartitionCount']))
 
         return None
+
+    def scale_cluster(self, nodes_count):
+        """Scale out/in cluster to specified number of nodes.
+
+        Uses cloud admin api.
+        """
+        payload = {
+            'cluster_id': self.cluster_id,
+            'nodes_count': str(nodes_count)
+        }
+        return self.cloudv2._http_post(base_url=self.config.admin_api_url,
+                                       endpoint='/ScaleCluster',
+                                       json=payload)


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/cloudv2/issues/10807

Blocked by PR: https://github.com/redpanda-data/vtools/pull/2407

Example command to run new test:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  --test-runner-timeout=3600000 \
  tests/rptest/redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_add_and_decommission
```

output from test run:
```
test_id:    rptest.redpanda_cloud_tests.high_throughput_test.HighThroughputTest.test_add_and_decommission
status:     PASS
run time:   11 minutes 35.892 seconds
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
============================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2023-12-21--006
run time:         11 minutes 35.913 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
==========================================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
