### PR TITLE
cluster/config_manager: use property's main name in store_delta

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -797,8 +797,29 @@ void config_manager::merge_apply_result(
  */
 ss::future<>
 config_manager::store_delta(cluster_config_delta_cmd_data const& data) {
+    auto& cfg = config::shard_local_cfg();
+
     for (const auto& u : data.upsert) {
-        _raw_values[u.key] = u.value;
+        if (!cfg.contains(u.key)) {
+            // passthrough unknown values
+            _raw_values[u.key] = u.value;
+            continue;
+        }
+
+        auto& prop = cfg.get(u.key);
+        if (prop.name() == u.key) {
+            // u key is already the main name of the property
+            _raw_values[u.key] = u.value;
+            continue;
+        }
+
+        // ensure only the main name is used
+        _raw_values[ss::sstring{prop.name()}] = u.value;
+        // cleanup any old alias lying around (it should be normally not
+        // necessary, and at most one loop)
+        for (auto const& alias : prop.aliases()) {
+            _raw_values.erase(ss::sstring{alias});
+        }
     }
     for (const auto& d : data.remove) {
         _raw_values.erase(d);


### PR DESCRIPTION
prevents a proprety set via alias and main name to appear twice in the _raw_values map.

also take care of cleaning up aliases in the map. this can happen when reusing a snapshot during an upgrade scenario, where an old property becomes an alias of a new property

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
