### PR TITLE
transform-sdk/rust: fix publishing

### DIFF
--- a/src/transform-sdk/rust/scripts/publish.py
+++ b/src/transform-sdk/rust/scripts/publish.py
@@ -27,6 +27,8 @@ def publish_package(pkg: str):
 
 
 def publish(version: str):
+    # Cargo does not like the `v` prefix we add to tags, so remove it.
+    version = version.removeprefix('v')
     # Set the version in the TOML file
     toml = CARGO_TOML_FILE.read_text()
     toml = re.sub(pattern='^version = "[^"]+"',


### PR DESCRIPTION
Rust doesn't like the `v` prefix we add to tags, so remove it.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
