### PR TITLE
rptest: fix an always true assertion

### DIFF
--- a/tests/rptest/tests/controller_availability_test.py
+++ b/tests/rptest/tests/controller_availability_test.py
@@ -73,9 +73,8 @@ class ControllerAvailabilityTest(Test):
         for m in sent_vote_metrics.samples:
             self.logger.debug("Vote requests metric sample: {m}")
             assert (
-                m.value <= 2 * cluster_size,
-                f"two rounds of leader election must be enough to elect a leader, current node vote request count: {m.value}"
-            )
+                m.value <= 2 * cluster_size
+            ), f"two rounds of leader election must be enough to elect a leader, current node vote request count: {m.value}"
 
     @cluster(num_nodes=5)
     @matrix(cluster_size=[3, 4, 5], stop=["single", "minority"])


### PR DESCRIPTION
/home/ubuntu/redpanda/tests/rptest/tests/controller_availability_test.py:75: SyntaxWarning: assertion is always true, perhaps remove parentheses?

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
