### PR TITLE
[v23.3.x] cluster/config_manager: use property's main name in store_delta

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -797,8 +797,29 @@ void config_manager::merge_apply_result(
  */
 ss::future<>
 config_manager::store_delta(cluster_config_delta_cmd_data const& data) {
+    auto& cfg = config::shard_local_cfg();
+
     for (const auto& u : data.upsert) {
-        _raw_values[u.key] = u.value;
+        if (!cfg.contains(u.key)) {
+            // passthrough unknown values
+            _raw_values[u.key] = u.value;
+            continue;
+        }
+
+        auto& prop = cfg.get(u.key);
+        if (prop.name() == u.key) {
+            // u key is already the main name of the property
+            _raw_values[u.key] = u.value;
+            continue;
+        }
+
+        // ensure only the main name is used
+        _raw_values[ss::sstring{prop.name()}] = u.value;
+        // cleanup any old alias lying around (it should be normally not
+        // necessary, and at most one loop)
+        for (auto const& alias : prop.aliases()) {
+            _raw_values.erase(ss::sstring{alias});
+        }
     }
     for (const auto& d : data.remove) {
         _raw_values.erase(d);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15725
Fixes: https://github.com/redpanda-data/redpanda/issues/15733,