### PR TITLE
Fix bad argument passed to kgo-repeater constructor

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -884,7 +884,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         with repeater_traffic(context=self._ctx,
                               redpanda=self.redpanda,
                               nodes=self.preallocated_nodes,
-                              topic=topic_names[0],
+                              topics=[topic_names[0]],
                               msg_size=repeater_msg_size,
                               rate_limit_bps=rate_limit_bps,
                               workers=self._repeater_worker_count(scale),


### PR DESCRIPTION
- 'topic' has been deprecated for 'topics' it is now also an array of strings

- Fixes: #15712
- Fixes: #15713

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
