### PR TITLE
c/members_member: don't ignore update_broker_client future

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1769,7 +1769,6 @@ ss::future<std::error_code> controller_backend::do_create_partition(
         co_return errc::success;
     }
 
-    auto f = ss::now();
     // handle partially created topic
     auto partition = _partition_manager.local().get(ntp);
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2099,7 +2099,6 @@ consensus::do_append_entries(append_entries_request&& r) {
              std::move(r).release_batches(), update_last_quorum_index::no)
       .then([this, m = request_metadata, target = reply.target_node_id](
               offsets_ret ofs) {
-          auto f = ss::make_ready_future<>();
           auto last_visible = std::min(ofs.last_offset, m.last_visible_index);
           maybe_update_last_visible_index(last_visible);
           _last_leader_visible_offset = std::max(


### PR DESCRIPTION
A new clang tidy check I'm developing caught that we're not awaiting for
the future `f` to finish. I've converted it into a coroutine and
co_awaited this future, which I assume is the intended semantics.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
