### PR TITLE
Increase audit buffer sizes for audit scale test

### DIFF
--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -135,7 +135,7 @@ class AuditLogTest(RedpandaTest):
             # at the kafka client size
             # default: 16MiB
             'audit_client_max_buffer_size':
-            16000000,
+            16000000 * 10,
 
             # This is the frequency at which queues are drained for data to be
             # buffered to the kafka client. Increase this value to buffer more
@@ -143,7 +143,7 @@ class AuditLogTest(RedpandaTest):
             # and reducing the total amount of data sent to the audit topic
             # default: 500ms
             'audit_queue_drain_interval_ms':
-            2000,
+            2000 * 2,
 
             # How large the per shard audit buffers are. The more unique events
             # and the more time the data spends residing in the buffer, the
@@ -152,7 +152,7 @@ class AuditLogTest(RedpandaTest):
             # enqueued
             # default: 1MiB
             'audit_queue_max_buffer_size_per_shard':
-            1000000,
+            1000000 * 10,
         }
 
         super().__init__(test_context=ctx,


### PR DESCRIPTION
10x-ing the buffer sizes ( defaults are 1 and 10Mib respectively) and doubling the audit log runloop interval to give time to catch duplicate records

Also changing the order of the runs, so the firstline run will be the run without auditing, to get a baseline of what the CDT system can do with the given number of topics/partitions, producers & consumers

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

