### PR TITLE
[v23.3.x] Fix bad argument passed to kgo-repeater constructor #15741

### DIFF
--- a/tests/rptest/scale_tests/many_partitions_test.py
+++ b/tests/rptest/scale_tests/many_partitions_test.py
@@ -884,7 +884,7 @@ class ManyPartitionsTest(PreallocNodesTest):
         with repeater_traffic(context=self._ctx,
                               redpanda=self.redpanda,
                               nodes=self.preallocated_nodes,
-                              topic=topic_names[0],
+                              topics=[topic_names[0]],
                               msg_size=repeater_msg_size,
                               rate_limit_bps=rate_limit_bps,
                               workers=self._repeater_worker_count(scale),


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/redpanda/issues/15741

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
