### PR TITLE
cloud_storage_clients: use appropriate beast error for end of stream

### DIFF
--- a/src/v/cloud_storage_clients/util.cc
+++ b/src/v/cloud_storage_clients/util.cc
@@ -77,7 +77,7 @@ error_outcome handle_client_transport_error(
         vlog(logger.warn, "Connection timeout {}", terr.what());
     } catch (const boost::system::system_error& err) {
         if (
-          err.code() != boost::beast::http::error::short_read
+          err.code() != boost::beast::http::error::end_of_stream
           && err.code() != boost::beast::http::error::partial_message) {
             vlog(logger.warn, "Connection failed {}", err.what());
             outcome = error_outcome::fail;

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -305,7 +305,7 @@ ss::future<iobuf> client::response_stream::recv_some() {
               if (!_parser.is_header_done()) {
                   // We can't put EOF before all header bytes are received
                   ec = boost::beast::http::make_error_code(
-                    boost::beast::http::error::short_read);
+                    boost::beast::http::error::end_of_stream);
               } else {
                   _parser.put_eof(ec);
               }

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -302,8 +302,8 @@ ss::future<iobuf> client::response_stream::recv_some() {
               // we'll have to manually check the headers and the last chunk
               // status.
               boost::beast::error_code ec;
-              if (!_parser.is_header_done()) {
-                  // We can't put EOF before all header bytes are received
+              if (!_parser.got_some()) {
+                  // We can't put EOF if no bytes were received yet.
                   ec = boost::beast::http::make_error_code(
                     boost::beast::http::error::end_of_stream);
               } else {


### PR DESCRIPTION
No functionality changes except the log messages. While testing Redpanda against real S3 endpoint I got concerned by log messages looking like this: `Server disconnected: 'unexpected eof in body [beast.http:26]', retrying HTTP request`.

As a result, spent 3 hours debugging why S3 would close connection mid-message. The problem was that we were using a bit of an inappropriate message to indicate cleanly closed connection. Use a more appropriate error code to avoid confusion in the future.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
