### PR TITLE
k/h/metadata: use fragmented vec for topic metadata

### DIFF
--- a/src/v/kafka/client/topic_cache.cc
+++ b/src/v/kafka/client/topic_cache.cc
@@ -14,13 +14,14 @@
 #include "kafka/client/partitioners.h"
 #include "kafka/protocol/metadata.h"
 #include "random/generators.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/future.hh>
 
 namespace kafka::client {
 
 ss::future<>
-topic_cache::apply(std::vector<metadata_response::topic>&& topics) {
+topic_cache::apply(small_fragment_vector<metadata_response::topic>&& topics) {
     topics_t cache;
     cache.reserve(topics.size());
     for (const auto& t : topics) {

--- a/src/v/kafka/client/topic_cache.h
+++ b/src/v/kafka/client/topic_cache.h
@@ -17,6 +17,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "seastarx.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/future.hh>
 
@@ -46,7 +47,8 @@ public:
     ~topic_cache() noexcept = default;
 
     /// \brief Apply the given metadata response.
-    ss::future<> apply(std::vector<metadata_response::topic>&& topics);
+    ss::future<>
+    apply(small_fragment_vector<metadata_response::topic>&& topics);
 
     /// \brief Obtain the leader for the given topic-partition
     ss::future<model::node_id> leader(model::topic_partition tp) const;

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -465,6 +465,7 @@ extra_headers = {
 # the container type from std::vector
 override_member_container = {
     'metadata_response_partition': 'large_fragment_vector',
+    'metadata_response_topic': 'small_fragment_vector',
     'fetchable_partition_response': 'small_fragment_vector'
 }
 

--- a/src/v/kafka/server/tests/delete_topics_test.cc
+++ b/src/v/kafka/server/tests/delete_topics_test.cc
@@ -108,8 +108,8 @@ public:
     void validate_topic_is_deleteted(const model::topic& tp) {
         kafka::metadata_response resp = get_topic_metadata(tp);
         auto it = std::find_if(
-          std::cbegin(resp.data.topics),
-          std::cend(resp.data.topics),
+          resp.data.topics.begin(),
+          resp.data.topics.end(),
           [tp](const kafka::metadata_response::topic& md_tp) {
               return md_tp.name == tp;
           });


### PR DESCRIPTION
For workloads with a large amount of topics, this topics vector can grow
to be an oversized allocation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Prevent metadata oversized allocations when requesting many topics.

