### PR TITLE
[v23.3.x] cluster_recovery: direct requests to controller leader

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_cloud_storage.go
+++ b/src/go/rpk/pkg/adminapi/api_cloud_storage.go
@@ -83,13 +83,13 @@ func (a *AdminAPI) StartAutomatedRecovery(ctx context.Context) (RecoveryStartRes
 	requestParams := &RecoveryRequestParams{}
 	var response RecoveryStartResponse
 
-	return response, a.sendAny(ctx, http.MethodPost, "/v1/cloud_storage/automated_recovery", requestParams, &response)
+	return response, a.sendToLeader(ctx, http.MethodPost, "/v1/cloud_storage/automated_recovery", requestParams, &response)
 }
 
 // PollAutomatedRecoveryStatus polls the automated recovery status API endpoint to retrieve the latest status of the recovery process.
 func (a *AdminAPI) PollAutomatedRecoveryStatus(ctx context.Context) (*TopicRecoveryStatus, error) {
 	var response TopicRecoveryStatus
-	return &response, a.sendAny(ctx, http.MethodGet, "/v1/cloud_storage/automated_recovery", http.NoBody, &response)
+	return &response, a.sendToLeader(ctx, http.MethodGet, "/v1/cloud_storage/automated_recovery", http.NoBody, &response)
 }
 
 func (a *AdminAPI) CloudStorageStatus(ctx context.Context, topic, partition string) (CloudStorageStatus, error) {

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3526,6 +3526,9 @@ admin_server::initialize_cluster_recovery(
 }
 ss::future<ss::json::json_return_type>
 admin_server::get_cluster_recovery(std::unique_ptr<ss::http::request> req) {
+    if (need_redirect_to_leader(model::controller_ntp, _metadata_cache)) {
+        throw co_await redirect_to_leader(*req, model::controller_ntp);
+    }
     ss::httpd::shadow_indexing_json::cluster_recovery_status ret;
     ret.state = "inactive";
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15740
