### PR TITLE
rptest: log error on failure to delete bucket

### DIFF
--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -145,7 +145,7 @@ class S3Client:
         try:
             self._cli.delete_bucket(Bucket=name)
         except Exception as e:
-            self.logger.warn(f"Error deleting bucket {name}: {e}")
+            self.logger.error(f"Error deleting bucket {name}: {e}")
             self.logger.warn(f"Contents of bucket {name}:")
             for o in self.list_objects(name):
                 self.logger.warn(f"  {o.key}")


### PR DESCRIPTION
In general this seems like an unexpected case. Perhaps it's sometimes an S3 issue, but it's certainly possible this is caused by a ducktape bug (see https://github.com/redpanda-data/redpanda/pull/15754).

In either case, it seems worthwhile to flag, if anything, to inform us when to expect artifacts to show up in our S3 account.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
