### PR TITLE
storage: account for windowed compaction in backlog computation

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -45,6 +45,7 @@
 #include <seastar/core/fair_queue.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/io_priority_class.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -476,7 +477,8 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
 }
 
 segment_set disk_log_impl::find_sliding_range(
-  const compaction_config& cfg, std::optional<model::offset> new_start_offset) {
+  const compaction_config& cfg,
+  std::optional<model::offset> new_start_offset) const {
     // Collect all segments that have stable data.
     segment_set::underlying_t buf;
     for (const auto& seg : _segs) {
@@ -2255,12 +2257,14 @@ int64_t compaction_backlog_term(
  * According to this assumption compaction backlog consist of two components
  *
  * 1) size of not yet self compacted segments
- * 2) size of all possible adjacent segments compactions
+ * 2) size of not yet window compacted segments (if applicable), scaled by the
+ *    expected compaction ratio
+ * 3) size of all possible adjacent segments compactions
  *
- * Component 1. of a compaction backlog is simply a sum of sizes of all not self
- * compacted segments.
+ * Component 1, 2. of a compaction backlog is simply a sum of sizes of all not
+ * self compacted and window compacted segments.
  *
- * Calculation of 2nd part of compaction backlog is based on the observation
+ * Calculation of 3rd part of compaction backlog is based on the observation
  * that adjacent segment compactions can be presented as a tree
  * (each leaf represents a log segment)
  *                              ┌────┐
@@ -2326,10 +2330,35 @@ int64_t disk_log_impl::compaction_backlog() const {
     // or enabling compaction on a previously non-compacted topic.
     static constexpr size_t limit_segments_this_term = 1024;
 
-    for (auto& s : _segs) {
-        if (!s->finished_self_compaction()) {
-            backlog += static_cast<int64_t>(s->size_bytes());
+    if (config::shard_local_cfg().log_compaction_use_sliding_window()) {
+        ss::abort_source never_abort;
+        // NOTE: the backlog estimate is just that -- an estimate. Don't bother
+        // passing in real offsets, priority classes, etc.
+        auto segs = find_sliding_range(compaction_config{
+          model::offset::max(), ss::default_priority_class(), never_abort});
+        for (auto& s : segs) {
+            if (!s->finished_self_compaction()) {
+                backlog += static_cast<int64_t>(s->size_bytes());
+            }
+            // TODO: using the average compaction ratio here is a crude
+            // approximation, since the ratio also includes the size reduction
+            // from windowed compaction itself.
+            if (!s->finished_windowed_compaction()) {
+                backlog += static_cast<int64_t>(s->size_bytes() * cf);
+            }
         }
+    } else {
+        for (auto& s : _segs) {
+            if (!s->finished_self_compaction()) {
+                backlog += static_cast<int64_t>(s->size_bytes());
+            }
+        }
+    }
+
+    // Compute the adjacent segment merge backlog. Note that we consider all
+    // segments rather than just those in the sliding window because all
+    // segments may be subject to merging.
+    for (auto& s : _segs) {
         // if has appender do not include into adjacent segments calculation
         if (s->has_appender()) {
             continue;

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -148,7 +148,7 @@ public:
     // window compaction.
     segment_set find_sliding_range(
       const compaction_config& cfg,
-      std::optional<model::offset> new_start_offset = std::nullopt);
+      std::optional<model::offset> new_start_offset = std::nullopt) const;
 
     void set_last_compaction_window_start_offset(model::offset o) {
         _last_compaction_window_start_offset = o;


### PR DESCRIPTION
The current backlog computation doesn't account for IO done by windowed compaction: in addition to reading all segments for self compaction, we read them again post-self compaction once they are window compacted.

This adjusts the calculation to account for this by determining the sliding range and scaling the to-be-window-compacted segments by the compaction ratio.

TODO: tests

Fixes #15756

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
