### PR TITLE
Overrides for space_management_enable and retention_local_strict

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2092,6 +2092,12 @@ configuration::configuration()
       true,
       property<bool>::noop_validator,
       legacy_default<bool>(false, legacy_version{9}))
+  , space_management_enable_override(
+      *this,
+      "space_management_enable_override",
+      "Enable automatic space management.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , disk_reservation_percent(
       *this,
       "disk_reservation_percent",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2030,6 +2030,15 @@ configuration::configuration()
       false,
       property<bool>::noop_validator,
       legacy_default<bool>(true, legacy_version{9}))
+  , retention_local_strict_override(
+      *this,
+      "retention_local_strict_override",
+      "Trim log data when a cloud topic reaches its local retention limit. "
+      "When this option is disabled Redpanda will allow partitions to grow "
+      "past the local retention limit, and will be trimmed automatically as "
+      "storage reaches the configured target size.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      true)
   , retention_local_target_capacity_bytes(
       *this,
       "retention_local_target_capacity_bytes",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -379,6 +379,7 @@ struct configuration final : public config_store {
     property<std::optional<size_t>> retention_local_target_bytes_default;
     property<std::chrono::milliseconds> retention_local_target_ms_default;
     property<bool> retention_local_strict;
+    property<bool> retention_local_strict_override;
     property<std::optional<uint64_t>> retention_local_target_capacity_bytes;
     bounded_property<std::optional<double>, numeric_bounds>
       retention_local_target_capacity_percent;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -386,6 +386,7 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> retention_local_trim_interval;
     property<double> retention_local_trim_overage_coeff;
     property<bool> space_management_enable;
+    property<bool> space_management_enable_override;
     bounded_property<double, numeric_bounds> disk_reservation_percent;
     bounded_property<uint16_t> space_management_max_log_concurrency;
     bounded_property<uint16_t> space_management_max_segment_concurrency;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1652,6 +1652,7 @@ void application::wire_up_redpanda_services(
     construct_single_service(
       space_manager,
       config::shard_local_cfg().space_management_enable.bind(),
+      config::shard_local_cfg().space_management_enable_override.bind(),
       config::shard_local_cfg().retention_local_target_capacity_bytes.bind(),
       config::shard_local_cfg().retention_local_target_capacity_percent.bind(),
       config::shard_local_cfg().disk_reservation_percent.bind(),

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -221,6 +221,7 @@ class disk_space_manager {
 public:
     disk_space_manager(
       config::binding<bool> enabled,
+      config::binding<bool> enabled_override,
       config::binding<std::optional<uint64_t>> retention_target_capacity_bytes,
       config::binding<std::optional<double>> retention_target_capacity_percent,
       config::binding<double> disk_reservation_percent,
@@ -236,11 +237,14 @@ public:
     disk_space_manager& operator=(const disk_space_manager&) = delete;
     ~disk_space_manager() = default;
 
+    bool enabled();
+
     ss::future<> start();
     ss::future<> stop();
 
 private:
     config::binding<bool> _enabled;
+    config::binding<bool> _enabled_override;
     ss::sharded<cluster::node::local_monitor>* _local_monitor;
     ss::sharded<storage::api>* _storage;
     ss::sharded<storage::node>* _storage_node;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1009,7 +1009,9 @@ gc_config disk_log_impl::maybe_override_retention_config(gc_config cfg) const {
      * don't override with local retention settings--let partition data expand
      * up to standard retention settings.
      */
-    if (!config::shard_local_cfg().retention_local_strict()) {
+    if (
+      !config::shard_local_cfg().retention_local_strict()
+      || !config::shard_local_cfg().retention_local_strict_override()) {
         vlog(
           gclog.trace,
           "[{}] Skipped retention override for topic with remote write "


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR works around an issue where certain configs could be impossible to move durably off their legacy defaults after an upgrade by providing override config properties without legacy defaults (and with default values _matching_ the legacy default value).

Fixes #15674 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug Fixes

* Fix an issue where new configs would continually revert to legacy defaults after an upgrade.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Fix an issue where new configs would continually revert to legacy defaults after an upgrade.
### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
