### PR TITLE
[v23.3.x] transform-sdk/rust: fix publishing

### DIFF
--- a/src/transform-sdk/rust/scripts/publish.py
+++ b/src/transform-sdk/rust/scripts/publish.py
@@ -27,6 +27,8 @@ def publish_package(pkg: str):
 
 
 def publish(version: str):
+    # Cargo does not like the `v` prefix we add to tags, so remove it.
+    version = version.removeprefix('v')
     # Set the version in the TOML file
     toml = CARGO_TOML_FILE.read_text()
     toml = re.sub(pattern='^version = "[^"]+"',


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15726
