### PR TITLE
net/probes: move produce_bad_create_time to server/public_metric

### DIFF
--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -110,11 +110,6 @@ void server_probe::setup_metrics(
           sm::description(ssx::sformat(
             "{}: Number of connections are blocked by connection rate",
             proto))),
-        sm::make_counter(
-          "produce_bad_create_time",
-          [this] { return _produce_bad_create_time; },
-          sm::description("number of produce requests with timestamps too far "
-                          "in the future or in the past")),
       },
       {},
       {sm::shard_label});
@@ -158,6 +153,13 @@ void server_probe::setup_public_metrics(
           [this] { return _out_bytes; },
           sm::description(
             ssx::sformat("{}: Number of bytes sent to clients", proto)),
+          {server_label(proto)})
+          .aggregate({sm::shard_label}),
+        sm::make_counter(
+          "produce_bad_create_time",
+          [this] { return _produce_bad_create_time; },
+          sm::description("number of produce requests with timestamps too far "
+                          "in the future or in the past"),
           {server_label(proto)})
           .aggregate({sm::shard_label}),
       });


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Backport of #15322 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* redpanda_kafka_rpc_produce_bad_create_time public_metric to count produce requests with timestamps skewed from brokers's timestamp 