### PR TITLE
Support for clamping replication factor

### DIFF
--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -58,7 +58,8 @@ public:
       ss::sharded<shard_table>&,
       plugin_table&,
       metadata_cache&,
-      config::binding<unsigned>);
+      config::binding<unsigned>,
+      config::binding<int16_t>);
 
     ss::future<std::vector<topic_result>> create_topics(
       std::vector<custom_assignable_topic_configuration>,
@@ -189,6 +190,10 @@ public:
     ss::future<result<std::vector<partition_state>>>
       get_partition_state(model::ntp);
 
+    /// Prints a warning log for every topic that has a replication factor
+    /// less than the minimum specified in minimum_topic_replication
+    void print_rf_warning_message();
+
 private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
@@ -274,6 +279,7 @@ private:
     ss::sharded<shard_table>& _shard_table;
 
     config::binding<unsigned> _hard_max_disk_usage_ratio;
+    config::binding<int16_t> _minimum_topic_replication;
 
     static constexpr std::chrono::seconds _get_health_report_timeout = 10s;
 };

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -753,6 +753,13 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       1,
       {.min = 1, .oddeven = odd_even_constraint::odd})
+  , minimum_topic_replication(
+      *this,
+      "minimum_topic_replications",
+      "Minimum permitted value of replication factor for new topics",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      1,
+      {.min = 1, .oddeven = odd_even_constraint::odd})
   , transaction_coordinator_replication(
       *this, "transaction_coordinator_replication")
   , id_allocator_replication(*this, "id_allocator_replication")

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -163,6 +163,7 @@ struct configuration final : public config_store {
     property<std::optional<size_t>> retention_bytes;
     property<int32_t> group_topic_partitions;
     bounded_property<int16_t> default_topic_replication;
+    bounded_property<int16_t> minimum_topic_replication;
     deprecated_property transaction_coordinator_replication;
     deprecated_property id_allocator_replication;
     property<int32_t> transaction_coordinator_partitions;

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -227,6 +227,7 @@ create_topic_properties_update(
             }
             if (cfg.name == topic_property_replication_factor) {
                 parse_and_set_topic_replication_factor(
+                  tp_ns,
                   update.custom_properties.replication_factor,
                   cfg.value,
                   kafka::config_resource_operation::set,

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -83,7 +83,8 @@ using validators = make_validator_types<
   cleanup_policy_validator,
   remote_read_and_write_are_not_supported_for_read_replica,
   batch_max_bytes_limits,
-  subject_name_strategy_validator>;
+  subject_name_strategy_validator,
+  replication_factor_must_be_greater_or_equal_to_minimum>;
 
 static std::vector<creatable_topic_configs>
 properties_to_result_configs(config_map_t config_map) {

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -233,6 +233,7 @@ create_topic_properties_update(
             }
             if (cfg.name == topic_property_replication_factor) {
                 parse_and_set_topic_replication_factor(
+                  tp_ns,
                   update.custom_properties.replication_factor,
                   cfg.value,
                   op,

--- a/src/v/kafka/server/tests/config_utils_test.cc
+++ b/src/v/kafka/server/tests/config_utils_test.cc
@@ -8,11 +8,15 @@
 // by the Apache License, Version 2.0
 
 #include "cluster/types.h"
+#include "config/configuration.h"
 #include "kafka/server/handlers/configs/config_utils.h"
 #include "kafka/types.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
 
 #include <boost/test/auto_unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <boost/test/tools/old/interface.hpp>
 
 BOOST_AUTO_TEST_CASE(parse_and_set_optional_bool_alpha_test_set) {
     using namespace kafka;
@@ -87,12 +91,16 @@ BOOST_AUTO_TEST_CASE(parse_and_set_topic_replication_factor_test) {
     cluster::property_update<std::optional<cluster::replication_factor>>
       property;
 
+    model::topic_namespace topic(model::kafka_namespace, model::topic{"test"});
+
     using rep_factor_validator = config_validator_list<
       cluster::replication_factor,
       replication_factor_must_be_positive,
-      replication_factor_must_be_odd>;
+      replication_factor_must_be_odd,
+      replication_factor_must_be_greater_or_equal_to_minimum>;
 
     parse_and_set_topic_replication_factor(
+      topic,
       property,
       "3",
       kafka::config_resource_operation::set,
@@ -108,6 +116,7 @@ BOOST_AUTO_TEST_CASE(parse_and_set_topic_replication_factor_test) {
 
     BOOST_CHECK_EXCEPTION(
       parse_and_set_topic_replication_factor(
+        topic,
         property,
         "0",
         kafka::config_resource_operation::set,
@@ -118,6 +127,7 @@ BOOST_AUTO_TEST_CASE(parse_and_set_topic_replication_factor_test) {
 
     BOOST_CHECK_EXCEPTION(
       parse_and_set_topic_replication_factor(
+        topic,
         property,
         "4",
         kafka::config_resource_operation::set,
@@ -125,4 +135,55 @@ BOOST_AUTO_TEST_CASE(parse_and_set_topic_replication_factor_test) {
       validation_error,
       is_odd_error);
     BOOST_REQUIRE_EQUAL(property.value.has_value(), false);
+}
+
+BOOST_AUTO_TEST_CASE(test_min_replication_factor) {
+    using namespace kafka;
+    cluster::property_update<std::optional<cluster::replication_factor>>
+      property;
+
+    model::topic_namespace topic(model::kafka_namespace, model::topic{"test"});
+    model::topic_namespace schemas_topic(
+      model::kafka_namespace, model::topic{"_schemas"});
+
+    config::shard_local_cfg().minimum_topic_replication.set_value(5);
+
+    using rep_factor_validator = config_validator_list<
+      cluster::replication_factor,
+      replication_factor_must_be_positive,
+      replication_factor_must_be_odd,
+      replication_factor_must_be_greater_or_equal_to_minimum>;
+
+    parse_and_set_topic_replication_factor(
+      topic,
+      property,
+      "5",
+      kafka::config_resource_operation::set,
+      rep_factor_validator{});
+
+    BOOST_REQUIRE_EQUAL(property.value, cluster::replication_factor{5});
+
+    auto is_too_small = [](const validation_error& ex) {
+        return ss::sstring(ex.what()).contains("must be greater or equal to");
+    };
+
+    BOOST_CHECK_EXCEPTION(
+      parse_and_set_topic_replication_factor(
+        topic,
+        property,
+        "3",
+        kafka::config_resource_operation::set,
+        rep_factor_validator{}),
+      validation_error,
+      is_too_small);
+    BOOST_REQUIRE(!property.value.has_value());
+
+    parse_and_set_topic_replication_factor(
+      schemas_topic,
+      property,
+      "3",
+      kafka::config_resource_operation::set,
+      rep_factor_validator{});
+
+    BOOST_REQUIRE_EQUAL(property.value, cluster::replication_factor{3});
 }

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -592,11 +592,18 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         # Don't modify oidc_principal mapping, the value is complex and tested elsewhere.
         exclude_settings.add('oidc_principal_mapping')
 
+        # List of settings that must be odd
+        odd_settings = [
+            'default_topic_replications', 'minimum_topic_replications'
+        ]
+
         initial_config = self.admin.get_cluster_config()
 
         for name, p in schema_properties.items():
             if name in exclude_settings:
                 continue
+
+            must_be_odd = name in odd_settings
 
             properties_require_restart |= p['needs_restart']
 
@@ -607,9 +614,15 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                     valid_value = yaml.full_load(valid_value)
             elif p['type'] == 'integer':
                 if initial_value:
-                    valid_value = initial_value * 2
+                    if must_be_odd:
+                        valid_value = initial_value * 3
+                    else:
+                        valid_value = initial_value * 2
                 else:
-                    valid_value = 100
+                    if must_be_odd:
+                        valid_value = 101
+                    else:
+                        valid_value = 100
             elif p['type'] == 'number':
                 if initial_value:
                     valid_value = float(initial_value * 2)

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -10,12 +10,16 @@
 import subprocess
 import time
 
+from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import SchemaRegistryConfig
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.kafka_cat import KafkaCat
+from rptest.tests.cluster_config_test import wait_for_version_sync
 from rptest.util import expect_exception
+from rptest.utils.schema_registry_utils import get_subjects
 
 from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
@@ -189,3 +193,67 @@ class InternalTopicProtectionTest(RedpandaTest):
         wait_until(lambda: test_topic not in client.list_topics(),
                    timeout_sec=90,
                    backoff_sec=3)
+
+
+class InternalTopicProtectionLargeClusterTest(RedpandaTest):
+    """
+    Verifies that constraints against minimum RF do not apply against
+    internally created topics
+    """
+    def __init__(self, *args, **kwargs):
+        kwargs['num_brokers'] = 5
+        kwargs['schema_registry_config'] = SchemaRegistryConfig()
+        super().__init__(*args, extra_rp_conf={}, **kwargs)
+
+        self.rpk = RpkTool(self.redpanda)
+        self.admin = Admin(self.redpanda)
+
+    def _modify_cluster_config(self, upsert):
+        patch_result = self.admin.patch_cluster_config(upsert=upsert)
+        wait_for_version_sync(self.admin, self.redpanda,
+                              patch_result['config_version'])
+
+    def setUp(self):
+        super().setUp()
+        # Set default RF to 5
+        # Set minimum Rf to 5
+        self._modify_cluster_config({'default_topic_replications': 5})
+        self._modify_cluster_config({'minimum_topic_replications': 5})
+
+    @cluster(num_nodes=5)
+    def test_schemas_topic(self):
+        # Now access the SR, which should result in an RF of 3
+        _ = get_subjects(self.redpanda.nodes, self.logger)
+
+        topics = self.rpk.list_topics()
+        assert "_schemas" in topics, f'_schemas not in topics {topics}'
+        config = list(self.rpk.describe_topic('_schemas'))[0]
+        assert len(
+            config.replicas
+        ) == 3, f'Expected RF of 3 for _schemas but got {len(config.replicas)}'
+
+        self.redpanda.restart_nodes(nodes=self.redpanda.nodes)
+
+        num_found = self.redpanda.count_log_node(
+            self.redpanda.nodes[0],
+            "Topic {kafka/_schemas} has a replication factor less than specified"
+        )
+        assert num_found == 0, f'Expected to find 0 messages about _schemas but found {num_found}'
+
+    @cluster(num_nodes=5)
+    def test_consumer_offset_topic(self):
+        self.rpk.create_topic("test")
+        self.rpk.produce("test", key="key1", msg="Hi there")
+        self.rpk.consume("test", group="TestGroup", n=1)
+        config = list(self.rpk.describe_topic('__consumer_offsets'))[0]
+        assert len(
+            config.replicas
+        ) == 3, f'Expected RF of 3 for __consumer_offsets but got {len(config.replicas)}'
+
+        self.redpanda.restart_nodes(nodes=self.redpanda.nodes)
+
+        num_found = self.redpanda.count_log_node(
+            self.redpanda.nodes[0],
+            "Topic {kafka/__consumer_offsets} has a replication factor less than specified"
+        )
+        assert num_found == 0, f'Expected to find 0 messages about _schemas but found {num_found}'

--- a/tests/rptest/tests/replication_factor_change_test.py
+++ b/tests/rptest/tests/replication_factor_change_test.py
@@ -97,3 +97,17 @@ class ReplicationFactorChangeTest(RedpandaTest):
                                          new_rf)
         assert len(self.admin.list_reconfigurations()) == 0
         self.check_rf(self.replication_factor)
+
+        self.redpanda.set_cluster_config(
+            {'default_topic_replications': str(3)})
+        self.redpanda.set_cluster_config(
+            {'minimum_topic_replications': str(3)})
+        new_rf = 1
+        with expect_exception(
+                RpkException, lambda e: "INVALID_REPLICATION_FACTOR" in e.msg
+                or "INVALID_CONFIG" in e.msg):
+            self._rpk.alter_topic_config(self.topic_name, self.rf_property,
+                                         new_rf)
+
+        assert len(self.admin.list_reconfigurations()) == 0
+        self.check_rf(self.replication_factor)

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -25,6 +25,7 @@ from rptest.services.rpk_producer import RpkProducer
 from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.util import wait_for_local_storage_truncate, expect_exception
 from rptest.clients.kcl import KCL
+from rptest.tests.cluster_config_test import wait_for_version_sync
 
 from ducktape.utils.util import wait_until
 from ducktape.mark import matrix, parametrize
@@ -292,6 +293,34 @@ class CreateTopicsTest(RedpandaTest):
             timeout_sec=30,
             backoff_sec=3,
             err_msg="Timed out waiting for single create_topic command")
+
+    @staticmethod
+    def _modify_cluster_config(admin, redpanda, upsert):
+        patch_result = admin.patch_cluster_config(upsert=upsert)
+        wait_for_version_sync(admin, redpanda, patch_result['config_version'])
+
+    @cluster(num_nodes=3)
+    def test_create_with_min_rf(self):
+        """
+        Validate behavior of topic creation when setting
+        minimum_topic_replications
+        """
+        admin = Admin(self.redpanda)
+        # Set default RF to 3
+        self._modify_cluster_config(admin, self.redpanda,
+                                    {'default_topic_replications': 3})
+        # Now can set minimum RF to 3
+        self._modify_cluster_config(admin, self.redpanda,
+                                    {'minimum_topic_replications': 3})
+        rpk = RpkTool(self.redpanda)
+        try:
+            rpk.create_topic("should-fail", replicas=1)
+            assert False, "Creation should have failed"
+        except RpkException as e:
+            assert "Replication factor must be greater than or equal to specified minimum value" in str(
+                e), f'Unexpected return message: "{str(e)}"'
+
+        rpk.create_topic("should-succeed", replicas=None)
 
 
 class CreateSITopicsTest(RedpandaTest):

--- a/tests/rptest/utils/schema_registry_utils.py
+++ b/tests/rptest/utils/schema_registry_utils.py
@@ -1,0 +1,120 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+import requests
+import time
+
+HTTP_GET_HEADERS = {"Accept": "application/vnd.schemaregistry.v1+json"}
+
+HTTP_POST_HEADERS = {
+    "Accept": "application/vnd.schemaregistry.v1+json",
+    "Content-Type": "application/vnd.schemaregistry.v1+json"
+}
+
+
+def _request(nodes, logger, verb, path, hostname=None, **kwargs):
+    if hostname is None:
+        nodes = [n for n in nodes]
+        random.shuffle(nodes)
+        node = nodes[0]
+        hostname = node.account.hostname
+
+    scheme = 'http'
+    uri = f'{scheme}://{hostname}:8081/{path}'
+
+    if 'timeout' not in kwargs:
+        kwargs['timeout'] = 60
+
+    # Error codes that may appear during normal API operation, do not
+    # indicate an issue with the service
+    acceptable_errors = {409, 422, 404}
+
+    def accept_response(resp):
+        return 200 <= resp.status_code < 300 or resp.status_code in acceptable_errors
+
+    logger.debug(f"{verb} hostname={hostname} {path} {kwargs}")
+
+    r = requests.request(verb, uri, **kwargs)
+    if not accept_response(r):
+        logger.info(
+            f"Retrying for error {r.status_code} on {verb} {path} ({r.text})")
+        time.sleep(10)
+        r = requests.request(verb, uri, **kwargs)
+        if accept_response(r):
+            logger.info(
+                f"OK after retry {r.status_code} on {verb} {path} ({r.text})")
+        else:
+            logger.info(
+                f"Error after retry {r.status_code} on {verb} {path} ({r.text})"
+            )
+
+    logger.info(f"{r.status_code} {verb} hostname={hostname} {path} {kwargs}")
+
+    return r
+
+
+def get_config(nodes, logger, headers=HTTP_GET_HEADERS, **kwargs):
+    """Returns the config of the schema registry
+    
+    Parameters
+    ----------
+    nodes : 
+        List of nodes to pick from
+    
+    logger :
+        Logger to use
+
+    headers : {str:str}, optional
+        Headers to use
+
+    **kwargs : optional
+        Additional parameters to request module
+
+    Returns
+    -------
+    The configuration of SR
+    """
+    return _request(nodes, logger, "GET", "config", headers=headers, **kwargs)
+
+
+def get_subjects(nodes,
+                 logger,
+                 deleted=False,
+                 headers=HTTP_GET_HEADERS,
+                 **kwargs):
+    """Returns a list of subjects held by the SR
+    
+    Parameters
+    ----------
+    nodes : 
+        List of nodes to pick from
+    
+    logger :
+        Logger to use
+
+    deleted : bool, default=False
+       If True, return deleted subjects as well
+
+    headers : {str:str}, optional
+        Headers to use
+
+    **kwargs : optional
+        Additional parameters to request module
+
+    Returns
+    -------
+    List of subjects
+    """
+    return _request(nodes,
+                    logger,
+                    "GET",
+                    f"subjects{'?deleted=true' if deleted else ''}",
+                    headers=headers,
+                    **kwargs)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds a new cluster configuration parameter `minimum_topic_replications` which permits a user to
force all newly created topics to have a replication factor of at least that value.  By default this cluster config
is set to 1.

Any existing topics that have RFs less than the specified value will continue to function as normal however a WARN level
log from the cluster logging facility will be generated indicating that the specified topic has an RF less than the specified
config.  This message will be generated at start up and whenever the cluster config option is changed.

The new configuration option _does not_ have any effect on internal topics (topics outside of the `kafka` namespace or on `__audit_log`, `__consumer_offsets`, or `_schemas`).

Fixes: https://github.com/redpanda-data/core-internal/issues/947

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Adds new cluster configuration parameter `minimum_topic_replications` that permits Redpanda administrators to set a minimum permitted replication factor for newly created topics.
