### PR TITLE
verbose_logging_timeout_max

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -180,6 +180,16 @@ node_config::node_config() noexcept
       "injection",
       {.visibility = visibility::tunable},
       std::nullopt)
+  , verbose_logging_timeout_sec_max(
+      *this,
+      "verbose_logging_timeout_sec_max",
+      "Maximum duration in seconds for verbose (i.e. TRACE or DEBUG) logging. "
+      "Values configured above this will be clamped. If null (the default) "
+      "there is no limit. Can be overridded in the Admin API on a per-request "
+      "basis.",
+      {.visibility = visibility::tunable},
+      std::nullopt,
+      {.min = 1s})
   , _advertised_rpc_api(
       *this,
       "advertised_rpc_api",

--- a/src/v/config/node_config.h
+++ b/src/v/config/node_config.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include "config/bounded_property.h"
 #include "config/broker_authn_endpoint.h"
 #include "config/broker_endpoint.h"
 #include "config/convert.h"
@@ -81,6 +82,10 @@ public:
     // Path to the configuration file for low level storage failure injection.
     property<std::optional<std::filesystem::path>>
       storage_failure_injection_config_path;
+
+    // Timeout upper-bound for setting verbose (>=DEBUG) logging.
+    bounded_property<std::optional<std::chrono::seconds>>
+      verbose_logging_timeout_sec_max;
 
     // build pidfile path: `<data_directory>/pid.lock`
     std::filesystem::path pidfile_path() const {

--- a/src/v/redpanda/admin/api-doc/config.def.json
+++ b/src/v/redpanda/admin/api-doc/config.def.json
@@ -1,0 +1,23 @@
+"set_log_level_response": {
+    "description": "Response to get loggers",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the logger that was changed"
+        },
+        "previous_level": {
+            "type": "string",
+            "description": "The previous logging level of the logger"
+        },
+        "new_level": {
+            "type": "string",
+            "description": "The new logging level of this logger"
+        },
+        "expiration": {
+            "type": "long",
+            "description": "How long this new logging level will be at, in seconds.  0 for indefinite"
+        }
+    },
+    "required": ["name", "previous_level", "new_level", "expiration"]
+}

--- a/src/v/redpanda/admin/api-doc/config.def.json
+++ b/src/v/redpanda/admin/api-doc/config.def.json
@@ -1,5 +1,24 @@
-"set_log_level_response": {
+"get_log_level_response": {
     "description": "Response to get loggers",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string",
+            "description": "Name of the logger"
+        },
+        "level": {
+            "type": "string",
+            "description": "Name of the logger"
+        },
+        "expiration": {
+            "type": "long",
+            "description": "How long until this level expires, 0 if default"
+        }
+    },
+    "required": ["name","level","expiration"]
+},
+"set_log_level_response": {
+    "description": "Response to set log level",
     "type": "object",
     "properties": {
         "name": {

--- a/src/v/redpanda/admin/api-doc/config.json
+++ b/src/v/redpanda/admin/api-doc/config.json
@@ -103,6 +103,13 @@
             "required": false,
             "allowMultiple": false,
             "type": "long"
+        },
+        {
+            "name": "force",
+            "in": "query",
+            "required": false,
+            "allowMultiple": false,
+            "type": "boolean"
         }
     ],
     "responses": {

--- a/src/v/redpanda/admin/api-doc/config.json
+++ b/src/v/redpanda/admin/api-doc/config.json
@@ -30,6 +30,15 @@
   "get": {
     "summary": "List all logger names",
     "operationId": "get_loggers",
+    "parameters": [
+      {
+        "name": "include-levels",
+        "in": "query",
+        "required": false,
+        "type": "boolean",
+        "allow_multiple": "false"
+      }
+    ],
     "produces": [
       "application/json"
     ],

--- a/src/v/redpanda/admin/api-doc/config.json
+++ b/src/v/redpanda/admin/api-doc/config.json
@@ -50,6 +50,29 @@
   }
 },
 "/v1/config/log_level/{name}": {
+  "get": {
+    "summary": "Get log level",
+    "operationId": "get_log_level",
+    "parameters": [
+      {
+        "name": "name",
+        "in": "path",
+        "required": true,
+        "type": "string"
+      }
+    ],
+    "responses": {
+      "200": {
+        "description": "Returned logger info",
+        "schema": {
+          "$ref": "#/definitions/get_log_level_response"
+        }
+      },
+      "400": {
+        "description": "error getting log level"
+      }
+    }
+  },
   "put": {
     "summary": "Set log level",
     "operationId": "set_log_level",

--- a/src/v/redpanda/admin/api-doc/config.json
+++ b/src/v/redpanda/admin/api-doc/config.json
@@ -84,7 +84,13 @@
     ],
     "responses": {
       "200": {
-        "description": "Log level"
+        "description": "Updated logging level",
+        "schema": {
+          "$ref": "#/definitions/set_log_level_response"
+        }
+      },
+      "400": {
+        "description": "Bad request"
       }
     }
   }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1342,15 +1342,25 @@ void admin_server::register_config_routes() {
 
     register_route_raw_sync<superuser>(
       ss::httpd::config_json::get_loggers,
-      [](ss::httpd::const_req, ss::http::reply& reply) {
+      [](ss::httpd::const_req req, ss::http::reply& reply) {
           json::StringBuffer buf;
           json::Writer<json::StringBuffer> writer(buf);
+          bool include_levels = false;
+          auto include_levels_str = req.get_query_param("include-levels");
+          if (!include_levels_str.empty()) {
+              include_levels = str_to_bool(include_levels_str);
+          }
           writer.StartArray();
           for (const auto& name :
                ss::global_logger_registry().get_all_logger_names()) {
               writer.StartObject();
               writer.Key("name");
               writer.String(name);
+              if (include_levels) {
+                  writer.Key("level");
+                  writer.String(fmt::to_string(
+                    ss::global_logger_registry().get_logger_level(name)));
+              }
               writer.EndObject();
           }
           writer.EndArray();

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -785,32 +785,28 @@ void admin_server::rearm_log_level_timer() {
     _log_level_timer.cancel();
 
     auto next = std::min_element(
-      _log_level_resets.begin(),
-      _log_level_resets.end(),
-      [](const auto& a, const auto& b) {
-          return a.second.expires < b.second.expires;
-      });
+      _log_level_resets.begin(), _log_level_resets.end());
 
-    if (next != _log_level_resets.end()) {
-        _log_level_timer.arm(next->second.expires);
+    if (next != _log_level_resets.end() && next->second.expires.has_value()) {
+        _log_level_timer.arm(next->second.expires.value());
     }
 }
 
 void admin_server::log_level_timer_handler() {
-    for (auto it = _log_level_resets.begin(); it != _log_level_resets.end();) {
-        if (it->second.expires <= ss::timer<>::clock::now()) {
+    absl::c_for_each(_log_level_resets, [](auto& pr) {
+        auto& [name, lr] = pr;
+        if (lr.expires.has_value() && lr.expires <= ss::timer<>::clock::now()) {
+            ss::global_logger_registry().set_logger_level(name, lr.level);
             vlog(
               adminlog.info,
               "Expiring log level for {{{}}} to {}",
-              it->first,
-              it->second.level);
-            ss::global_logger_registry().set_logger_level(
-              it->first, it->second.level);
-            _log_level_resets.erase(it++);
-        } else {
-            ++it;
+              name,
+              lr.level);
+            // we've reset this logger to its default level, which
+            // should never expire
+            lr.expires.reset();
         }
-    }
+    });
     rearm_log_level_timer();
 }
 
@@ -1391,10 +1387,12 @@ void admin_server::register_config_routes() {
           rsp.level = ss::to_sstring(cur_level);
 
           auto find_iter = _log_level_resets.find(name);
-          if (find_iter == _log_level_resets.end()) {
+          if (
+            find_iter == _log_level_resets.end()
+            || !find_iter->second.expires.has_value()) {
               rsp.expiration = 0;
           } else {
-              auto remaining_dur = find_iter->second.expires
+              auto remaining_dur = find_iter->second.expires.value()
                                    - ss::timer<>::clock::now();
               rsp.expiration = std::chrono::duration_cast<std::chrono::seconds>(
                                  remaining_dur)
@@ -1480,8 +1478,9 @@ void admin_server::register_config_routes() {
                   res.first->second.expires = when;
               }
           } else {
-              // perm change. no need to store prev level
-              _log_level_resets.erase(name);
+              // new log level never expires, but we still want an entry in the
+              // resets map as a record of the default
+              _log_level_resets.try_emplace(name, cur_level, std::nullopt);
           }
 
           rsp.expiration = expires->count();

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1369,6 +1369,42 @@ void admin_server::register_config_routes() {
       });
 
     register_route<superuser>(
+      ss::httpd::config_json::get_log_level,
+      [this](std::unique_ptr<ss::http::request> req) {
+          ss::httpd::config_json::get_log_level_response rsp{};
+          ss::sstring name;
+          if (!ss::http::internal::url_decode(req->param["name"], name)) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Invalid parameter 'name' got {{{}}}", req->param["name"]));
+          }
+          validate_no_control(name, string_conversion_exception{name});
+
+          ss::log_level cur_level;
+          try {
+              cur_level = ss::global_logger_registry().get_logger_level(name);
+          } catch (std::out_of_range&) {
+              throw ss::httpd::bad_param_exception(fmt::format(
+                "Cannot set log level: unknown logger {{{}}}", name));
+          }
+
+          rsp.name = name;
+          rsp.level = ss::to_sstring(cur_level);
+
+          auto find_iter = _log_level_resets.find(name);
+          if (find_iter == _log_level_resets.end()) {
+              rsp.expiration = 0;
+          } else {
+              auto remaining_dur = find_iter->second.expires
+                                   - ss::timer<>::clock::now();
+              rsp.expiration = std::chrono::duration_cast<std::chrono::seconds>(
+                                 remaining_dur)
+                                 .count();
+          }
+
+          return ss::make_ready_future<ss::json::json_return_type>(rsp);
+      });
+
+    register_route<superuser>(
       ss::httpd::config_json::set_log_level,
       [this](std::unique_ptr<ss::http::request> req) {
           ss::httpd::config_json::set_log_level_response rsp{};

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1405,6 +1405,7 @@ void admin_server::register_config_routes() {
     register_route<superuser>(
       ss::httpd::config_json::set_log_level,
       [this](std::unique_ptr<ss::http::request> req) {
+          using namespace std::chrono_literals;
           ss::httpd::config_json::set_log_level_response rsp{};
           ss::sstring name;
           if (!ss::http::internal::url_decode(req->param["name"], name)) {
@@ -1454,25 +1455,60 @@ void admin_server::register_config_routes() {
               }
           }
 
+          // Should we force the supplied expiration over the configured max?
+          auto force = false;
+          if (auto f = req->get_query_param("force"); !f.empty()) {
+              force = str_to_bool(f);
+          }
+
+          auto is_verbose = [](auto new_level) {
+              static std::unordered_set verbose_levels{
+                ss::log_level::debug, ss::log_level::trace};
+              return verbose_levels.contains(new_level);
+          };
+
+          auto clamp_expiry = [&is_verbose](
+                                auto& expires, auto level, auto force) {
+              // if no expiration was given, then use some reasonable
+              // default that will prevent the system from remaining in a
+              // non-optimal state (e.g. trace logging) indefinitely.
+              auto exp = expires.value_or(600s);
+
+              auto verbose = is_verbose(level);
+
+              // subject to a node-config'ed max value, overrideable by
+              // `force` query param
+              auto max_exp
+                = (!verbose || force)
+                    ? std::nullopt
+                    : config::node().verbose_logging_timeout_sec_max();
+
+              // don't allow indefinite trace logging if we have a max
+              // configured
+              if (max_exp.has_value() && exp / 1s == 0) {
+                  return max_exp.value();
+              }
+
+              return std::min(
+                exp, max_exp.value_or(std::chrono::seconds::max()));
+          };
+
+          // Maybe clamp expiration to node config
+          auto expires_v = clamp_expiry(expires, new_level, force);
+
           vlog(
             adminlog.info,
-            "Set log level for {{{}}}: {} -> {}",
+            "Set log level for {{{}}}: {} -> {} (expiring {})",
             name,
             cur_level,
-            new_level);
+            new_level,
+            expires_v / 1s > 0 ? ss::to_sstring(expires_v) : "NEVER");
 
           ss::global_logger_registry().set_logger_level(name, new_level);
 
-          if (!expires) {
-              // if no expiration was given, then use some reasonable default
-              // that will prevent the system from remaining in a non-optimal
-              // state (e.g. trace logging) indefinitely.
-              expires = std::chrono::minutes(10);
-          }
-
           // expires=0 is same as not specifying it at all
-          if (expires->count() > 0) {
-              auto when = ss::timer<>::clock::now() + expires.value();
+          if (expires_v / 1s > 0) {
+              auto when = ss::timer<>::clock::now() + expires_v;
               auto res = _log_level_resets.try_emplace(name, cur_level, when);
               if (!res.second) {
                   res.first->second.expires = when;
@@ -1483,7 +1519,7 @@ void admin_server::register_config_routes() {
               _log_level_resets.try_emplace(name, cur_level, std::nullopt);
           }
 
-          rsp.expiration = expires->count();
+          rsp.expiration = expires_v / 1s;
 
           rearm_log_level_timer();
 

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1371,6 +1371,7 @@ void admin_server::register_config_routes() {
     register_route<superuser>(
       ss::httpd::config_json::set_log_level,
       [this](std::unique_ptr<ss::http::request> req) {
+          ss::httpd::config_json::set_log_level_response rsp{};
           ss::sstring name;
           if (!ss::http::internal::url_decode(req->param["name"], name)) {
               throw ss::httpd::bad_param_exception(fmt::format(
@@ -1387,6 +1388,9 @@ void admin_server::register_config_routes() {
                 "Cannot set log level: unknown logger {{{}}}", name));
           }
 
+          rsp.name = name;
+          rsp.previous_level = ss::to_sstring(cur_level);
+
           // decode new level
           ss::log_level new_level;
           try {
@@ -1398,6 +1402,8 @@ void admin_server::register_config_routes() {
                 name,
                 req->get_query_param("level")));
           }
+
+          rsp.new_level = ss::to_sstring(new_level);
 
           // how long should the new log level be active
           std::optional<std::chrono::seconds> expires;
@@ -1442,10 +1448,11 @@ void admin_server::register_config_routes() {
               _log_level_resets.erase(name);
           }
 
+          rsp.expiration = expires->count();
+
           rearm_log_level_timer();
 
-          return ss::make_ready_future<ss::json::json_return_type>(
-            ss::json::json_void());
+          return ss::make_ready_future<ss::json::json_return_type>(rsp);
       });
 }
 

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -613,12 +613,22 @@ private:
     struct level_reset {
         using time_point = ss::timer<>::clock::time_point;
 
-        level_reset(ss::log_level level, time_point expires)
+        level_reset(ss::log_level level, std::optional<time_point> expires)
           : level(level)
           , expires(expires) {}
 
+        friend bool operator<(const level_reset& l, const level_reset& r) {
+            if (!l.expires.has_value()) {
+                return false;
+            } else if (!r.expires.has_value()) {
+                return true;
+            } else {
+                return l.expires.value() < r.expires.value();
+            }
+        }
+
         ss::log_level level;
-        time_point expires;
+        std::optional<time_point> expires;
     };
 
     ss::timer<> _log_level_timer;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -502,16 +502,31 @@ class Admin:
             for l in self._request("GET", "loggers", node=node).json()
         ]
 
-    def set_log_level(self, name, level, expires=None):
+    def get_log_level(self, name):
+        """
+        Get broker log level
+        """
+        responses = []
+        name = name.replace("/", "%2F")
+        for node in self.redpanda.nodes:
+            path = f"config/log_level/{name}"
+            responses.append(self._request('get', path, node=node).json())
+        return responses
+
+    def set_log_level(self, name, level, expires=None, force=False):
         """
         Set broker log level
         """
+        responses = []
         name = name.replace("/", "%2F")
         for node in self.redpanda.nodes:
             path = f"config/log_level/{name}?level={level}"
-            if expires:
+            if expires is not None:
                 path = f"{path}&expires={expires}"
-            self._request('put', path, node=node)
+            if force:
+                path = f"{path}&force=true"
+            responses.append(self._request('put', path, node=node).json())
+        return responses
 
     def get_brokers(self, node=None):
         """

--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -10,22 +10,29 @@
 import ducktape.errors
 import requests.exceptions
 import urllib.parse
+import json
 
 from ducktape.utils.util import wait_until
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
 from rptest.utils.utf8 import CONTROL_CHARS_MAP
+from rptest.util import expect_exception
 
 
 class LogLevelTest(RedpandaTest):
     initial_log_level = "trace"
+    MAX_LOG_EXPIRY_S = 5
+    extra_node_conf = {'verbose_logging_timeout_sec_max': MAX_LOG_EXPIRY_S}
 
     def __init__(self, *args, **kwargs):
         # Set an explicit log level rather than relying on the externally
         # configurable redpanda log level, so that the test knows where
         # it will start.
-        super().__init__(*args, log_level=self.initial_log_level, **kwargs)
+        super().__init__(*args,
+                         log_level=self.initial_log_level,
+                         extra_node_conf=self.extra_node_conf,
+                         **kwargs)
 
     @cluster(num_nodes=3)
     def test_get_loggers(self):
@@ -67,7 +74,7 @@ class LogLevelTest(RedpandaTest):
         # set to debug. log level at warn, so shouldn't see it
         try:
             with self.redpanda.monitor_log(node) as mon:
-                admin.set_log_level("admin_api_server", "debug")
+                admin.set_log_level("admin_api_server", "debug", force=True)
                 mon.wait_until(
                     "Set log level for {admin_api_server}: warn -> debug",
                     timeout_sec=10,
@@ -93,6 +100,106 @@ class LogLevelTest(RedpandaTest):
                 timeout_sec=10,
                 backoff_sec=1,
                 err_msg="Never saw message")
+
+    @cluster(num_nodes=3)
+    def test_max_expiry(self):
+        admin = Admin(self.redpanda)
+        node = self.redpanda.nodes[0]
+
+        def set_log_and_check(level,
+                              expiration,
+                              actual,
+                              force=False,
+                              orig=self.initial_log_level):
+            with self.redpanda.monitor_log(node) as mon:
+                # note that this sends the request to all nodes in the cluster, synchronously
+                rsps = admin.set_log_level("admin_api_server",
+                                           level,
+                                           expires=expiration,
+                                           force=force)
+                assert all(
+                    r['expiration'] == actual for r in rsps
+                ), f"Expected clamped expirations: {json.dumps([{'expiration': r['expiration']} for r in rsps])}"
+                # check the log line
+                mon.wait_until(
+                    f"Set log level for {{admin_api_server}}: {orig} -> {level} (expiring {actual}s)",
+                    timeout_sec=5,
+                    backoff_sec=1,
+                    err_msg="Never saw message")
+                # confirm that the admin API reflects the expected settings
+                rsps = admin.get_log_level("admin_api_server")
+                assert all(
+                    r['expiration'] <= actual and r['level'] == level
+                    for r in rsps
+                ), f"Expected {level} level expiring w/in {actual}s, got {json.dumps(rsps)}"
+
+                # wait for a single node to expire
+                mon.wait_until(
+                    f"Expiring log level for {{admin_api_server}} to {self.initial_log_level}",
+                    timeout_sec=actual + 1,
+                    backoff_sec=1,
+                    err_msg="Never saw message")
+
+                rsps = admin.get_log_level("admin_api_server")
+                # No guarantee that all servers have expired at this point
+                assert any(
+                    r['expiration'] == 0
+                    and r['level'] == self.initial_log_level for r in rsps
+                ), f"Expected expiration to {self.initial_log_level}, got {json.dumps(rsps)}"
+
+        # set verbose level with expiration that exceeds the configured limit
+        # and confirm that we clamp
+        for lvl in ['trace', 'debug']:
+            set_log_and_check(lvl,
+                              expiration=self.MAX_LOG_EXPIRY_S * 10,
+                              actual=self.MAX_LOG_EXPIRY_S)
+
+        # set non-verbose level with expiration that exceeds configured max
+        # and confirm that we DON'T clamp
+        for lvl in ['error', 'warn', 'info']:
+            set_log_and_check(lvl,
+                              expiration=self.MAX_LOG_EXPIRY_S * 2,
+                              actual=self.MAX_LOG_EXPIRY_S * 2)
+
+        # try forcing an expiry that is longer than the configured max
+        set_log_and_check('debug',
+                          expiration=self.MAX_LOG_EXPIRY_S * 3,
+                          actual=self.MAX_LOG_EXPIRY_S * 3,
+                          force=True)
+
+        # try non-expiring setting, confirm that it's clamped
+        set_log_and_check('debug', expiration=0, actual=self.MAX_LOG_EXPIRY_S)
+
+        # try forcing non-expiring level
+        with self.redpanda.monitor_log(node) as mon:
+            expiration = 0
+            actual = 0
+            lvl = 'debug'
+            force = True
+            with self.redpanda.monitor_log(node) as mon:
+                rsps = admin.set_log_level("admin_api_server",
+                                           lvl,
+                                           expires=expiration,
+                                           force=force)
+                assert all(
+                    r['expiration'] == actual for r in rsps
+                ), f"Expected clamped expirations: {json.dumps([{'expiration': r['expiration']} for r in rsps])}"
+                mon.wait_until(
+                    f"Set log level for {{admin_api_server}}: trace -> {lvl} (expiring NEVER)",
+                    timeout_sec=5,
+                    backoff_sec=1,
+                    err_msg="Never saw message")
+                with expect_exception(ducktape.errors.TimeoutError,
+                                      lambda _: True):
+                    mon.wait_until(
+                        f"Expiring log level for {{admin_api_server}} to {self.initial_log_level}",
+                        timeout_sec=self.MAX_LOG_EXPIRY_S + 1,
+                        backoff_sec=1,
+                        err_msg="Never saw message")
+
+        # finally, set with any expiration to confirm that we expire to the default
+        # and NOT some previously set "permanent" level (debug in this case)
+        set_log_and_check('info', expiration=2, actual=2, orig='debug')
 
     @cluster(num_nodes=3)
     def test_invalid_logger_name(self):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR introduces `verbose_logging_timeout_max`, which, if set, causes expiration times included in set_log_level requests to be clamped before timeouts are calculated.

Includes an assortment of minor improvements to the logic around setting log levels and managing timeouts around those settings.

Fixes https://github.com/redpanda-data/core-internal/issues/938
Fixes https://github.com/redpanda-data/core-internal/issues/931
Fixes https://github.com/redpanda-data/core-internal/issues/930

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes

### Improvements

* `verbose_logging_timeout_max` node config, to prevent setting TRACE and DEBUG log level indefinitely

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
