### PR TITLE
c/archival_stm: downgrade timeout log to warn

### DIFF
--- a/src/v/cluster/archival_metadata_stm.cc
+++ b/src/v/cluster/archival_metadata_stm.cc
@@ -732,7 +732,10 @@ archival_metadata_stm::sync(model::timeout_clock::duration timeout) {
                 co_return false;
             }
         } catch (const ss::timed_out_error&) {
-            vlog(_logger.error, "Replication wait for archival STM timed out");
+            vlog(
+              _logger.warn,
+              "Replication wait for archival STM timed out (timeout = {})",
+              timeout);
             co_return false;
         } catch (...) {
             vlog(


### PR DESCRIPTION
Some operations try to sync with relatively low timeouts. Under stress, they are expected to time out occasionally. This is a warning at most.

Downgrade the log level to avoid spooking users and ducktape tests.

---

This should have been part of #15677 but I forgot to push local changes...

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
