### PR TITLE
[v23.2.x] tests/scale: htt import missing ignore mark

### DIFF
--- a/tests/rptest/scale_tests/high_throughput_test.py
+++ b/tests/rptest/scale_tests/high_throughput_test.py
@@ -11,6 +11,7 @@ import math
 import time
 
 from ducktape.tests.test import TestContext
+from ducktape.mark import ignore
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
 from rptest.services.failure_injector import FailureInjector, FailureSpec


### PR DESCRIPTION
causing cdt to fail with the import error

ref redpanda-data/devprod#972

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
