### PR TITLE
rptest: update cloud test suite to subset

### DIFF
--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -10,7 +10,8 @@
 # Tests to run on a Redpanda Cloud cluster.
 cloud:
   included:
-    - redpanda_cloud_tests
-    - tests/rpk_topic_test.py::RpkToolTest.test_consume_from_partition
-    - tests/services_self_test.py::SimpleSelfTest
-    - tests/services_self_test.py::OpenBenchmarkSelfTest
+    - redpanda_cloud_tests/config_profile_verify_test.py
+    - redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_decommission_and_add
+    - redpanda_cloud_tests/observe_test.py
+    - redpanda_cloud_tests/omb_validation_test.py
+    - tests/services_self_test.py::SimpleSelfTest.test_cloud


### PR DESCRIPTION
Just enable a subset of tests that are currently OK'ed to run.

Related issue: https://github.com/redpanda-data/cloudv2/issues/11277

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
