### PR TITLE
archival: disable scrubber by default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1721,7 +1721,7 @@ configuration::configuration()
       "Enable scrubbing of cloud storage partitions. The scrubber validates "
       "the integrity of data and metadata uploaded to cloud storage",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      true)
+      false)
   , cloud_storage_partial_scrub_interval_ms(
       *this,
       "cloud_storage_partial_scrub_interval_ms",

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -634,6 +634,9 @@ class SISettings:
             conf[
                 'cloud_storage_max_throughput_per_shard'] = self.cloud_storage_max_throughput_per_shard
 
+        # Always run with scrubbing in testing.
+        conf['cloud_storage_enable_scrubbing'] = True
+
         return conf
 
     def set_expected_damage(self, damage_types: set[str]):
@@ -3190,6 +3193,11 @@ class RedpandaService(RedpandaServiceBase):
                     self._extra_rp_conf))
             conf.update(self._extra_rp_conf)
 
+        if cur_ver != RedpandaInstaller.HEAD and cur_ver < (23, 3, 1):
+            # this configuration property was introduced in 23.3, ensure
+            # it doesn't appear in older configurations
+            conf.pop('cloud_storage_enable_scrubbing', None)
+
         if cur_ver != RedpandaInstaller.HEAD and cur_ver < (23, 2, 1):
             # this configuration property was introduced in 23.2, ensure
             # it doesn't appear in older configurations
@@ -4016,6 +4024,8 @@ class RedpandaService(RedpandaServiceBase):
             return None
 
         self.set_cluster_config({
+            "cloud_storage_enable_scrubbing":
+            True,
             "cloud_storage_partial_scrub_interval_ms":
             100,
             "cloud_storage_full_scrub_interval_ms":


### PR DESCRIPTION
Keep it enabled for all the tests. Need some extra time to understand the cost implications for high usage clusters.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
