### PR TITLE
cluster/config_manager: ensure cleanup of old aliases

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -800,21 +800,22 @@ config_manager::store_delta(cluster_config_delta_cmd_data const& data) {
     auto& cfg = config::shard_local_cfg();
 
     for (const auto& u : data.upsert) {
+        /// skip section
         if (!cfg.contains(u.key)) {
             // passthrough unknown values
             _raw_values[u.key] = u.value;
             continue;
         }
 
+        /// conversion + cleanup section
         auto& prop = cfg.get(u.key);
         if (prop.name() == u.key) {
             // u key is already the main name of the property
             _raw_values[u.key] = u.value;
-            continue;
+        } else {
+            // ensure only the main name is used
+            _raw_values[ss::sstring{prop.name()}] = u.value;
         }
-
-        // ensure only the main name is used
-        _raw_values[ss::sstring{prop.name()}] = u.value;
         // cleanup any old alias lying around (it should be normally not
         // necessary, and at most one loop)
         for (auto const& alias : prop.aliases()) {

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1434,13 +1434,13 @@ class ClusterConfigAliasTest(RedpandaTest, ClusterConfigHelpersMixin):
         of setting a property to accept the old name (alias) as well as the new one.
         """
         # Aliases should work when used in bootstrap
-        # NOTE due to https://github.com/redpanda-data/redpanda/issues/13362 this is incomplete (see commented line)
         self.redpanda.set_extra_rp_conf({
             prop_set.aliased_name:
             prop_set.test_values[0],
         })
         self.redpanda.start()
-        # self._check_value_everywhere(prop_set.primary_name, prop_set.values[0])
+        self._check_value_everywhere(prop_set.primary_name,
+                                     prop_set.test_values[0])
 
         # The configuration schema should include aliases
         schema = self.admin.get_cluster_config_schema()['properties']


### PR DESCRIPTION
Config aliases:

Part of the fix for https://github.com/redpanda-data/redpanda/issues/15263 requires ensuring that a cluster property is saved only once in the config_manager::_raw_values map. 

When storing a property, the name is converted to the main property name and any aliases are removed from the map, in case the node inherits the snapshot from an old version.

the fix make sure that the cleanup part is always performed, before this it would be skipped the incoming key was already the main name

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none