### PR TITLE
[v23.3.x] cluster/config_manager: ensure cleanup of old aliases

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -800,21 +800,22 @@ config_manager::store_delta(cluster_config_delta_cmd_data const& data) {
     auto& cfg = config::shard_local_cfg();
 
     for (const auto& u : data.upsert) {
+        /// skip section
         if (!cfg.contains(u.key)) {
             // passthrough unknown values
             _raw_values[u.key] = u.value;
             continue;
         }
 
+        /// conversion + cleanup section
         auto& prop = cfg.get(u.key);
         if (prop.name() == u.key) {
             // u key is already the main name of the property
             _raw_values[u.key] = u.value;
-            continue;
+        } else {
+            // ensure only the main name is used
+            _raw_values[ss::sstring{prop.name()}] = u.value;
         }
-
-        // ensure only the main name is used
-        _raw_values[ss::sstring{prop.name()}] = u.value;
         // cleanup any old alias lying around (it should be normally not
         // necessary, and at most one loop)
         for (auto const& alias : prop.aliases()) {

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1434,13 +1434,13 @@ class ClusterConfigAliasTest(RedpandaTest, ClusterConfigHelpersMixin):
         of setting a property to accept the old name (alias) as well as the new one.
         """
         # Aliases should work when used in bootstrap
-        # NOTE due to https://github.com/redpanda-data/redpanda/issues/13362 this is incomplete (see commented line)
         self.redpanda.set_extra_rp_conf({
             prop_set.aliased_name:
             prop_set.test_values[0],
         })
         self.redpanda.start()
-        # self._check_value_everywhere(prop_set.primary_name, prop_set.values[0])
+        self._check_value_everywhere(prop_set.primary_name,
+                                     prop_set.test_values[0])
 
         # The configuration schema should include aliases
         schema = self.admin.get_cluster_config_schema()['properties']


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15815
