### PR TITLE
Skip assertion in audit log tests if results beat the baseline

### DIFF
--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -393,24 +393,26 @@ class AuditLogTest(RedpandaTest):
         self._enable_auditing()
         audit_enabled_results = self._run_repeater(topic_names, scale)
 
-        # Assert that there is no more then a x% difference in produce and consume throughput
+        # Assert that there is no more then a x% difference in observed results
         allowable_threshold = 10.0
 
-        def pct_difference(a, b):
-            return (abs(a - b) / abs((a + b) / 2)) * 100
+        def pct_chg(new, orig):
+            return ((orig - new) / abs(orig)) * 100
 
         self.redpanda.logger.info(
             f"audit_disabled_results: {audit_disabled_results}")
         self.redpanda.logger.info(
             f"audit_enabled_results: {audit_enabled_results}")
 
-        assert pct_difference(
-            audit_disabled_results.produce_mbps,
-            audit_enabled_results.produce_mbps) <= allowable_threshold
-        assert pct_difference(
-            audit_disabled_results.consume_mbps,
-            audit_enabled_results.consume_mbps) <= allowable_threshold
-        assert pct_difference(audit_disabled_results.p90,
-                              audit_enabled_results.p90) <= allowable_threshold
-        assert pct_difference(audit_disabled_results.p99,
-                              audit_enabled_results.p99) <= allowable_threshold
+        assert pct_chg(
+            audit_enabled_results.produce_mbps,
+            audit_disabled_results.produce_mbps) < allowable_threshold
+        assert pct_chg(
+            audit_enabled_results.consume_mbps,
+            audit_disabled_results.consume_mbps) < allowable_threshold
+        assert pct_chg(audit_enabled_results.p50,
+                       audit_disabled_results.p50) > (allowable_threshold * -1)
+        assert pct_chg(audit_enabled_results.p90,
+                       audit_disabled_results.p90) > (allowable_threshold * -1)
+        assert pct_chg(audit_enabled_results.p99,
+                       audit_disabled_results.p99) > (allowable_threshold * -1)

--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -9,7 +9,6 @@
 
 import time
 import threading
-from ducktape.mark import ok_to_fail
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
@@ -302,10 +301,6 @@ class AuditLogTest(RedpandaTest):
             # to me able to assert on other properties of the test run.
             return make_result_set(t1, repeater)
 
-    # Temporarily marking as ok_to_fail so we can observe in CI how full
-    # the audit queues are during the scale test so we can appropriately
-    # set the audit configuration parameters listed above
-    @ok_to_fail
     @cluster(num_nodes=5)
     def test_audit_log(self):
         """


### PR DESCRIPTION
From the most recent run of the audit log scale tests:

```
Traceback (most recent call last):
  File "/home/ubuntu/redpanda/tests/rptest/services/cluster.py", line 82, in wrapped
    r = f(self, *args, **kwargs)
  File "/home/ubuntu/redpanda/tests/rptest/scale_tests/audit_log_test.py", line 413, in test_audit_log
    assert pct_difference(audit_disabled_results.p90,
AssertionError
```

The test ended up failing because the results beat the baseline by greater then the hardcoded 10% threshold:

```
[INFO  - 2023-12-20 13:02:43,395 - audit_log_test - test_audit_log - lineno:402]: audit_disabled_results: {'time_elapsed': 163.91215109825134, 'total_produced': 837362, 'total_consumed': 837330, 'p50': 15477.83203125, 'p90': 134794.0625, 'p99': 839466.16796875}
[INFO  - 2023-12-20 13:02:43,395 - audit_log_test - test_audit_log - lineno:404]: audit_enabled_results: {'time_elapsed': 178.89132976531982, 'total_produced': 913621, 'total_consumed': 913596, 'p50': 16713.26171875, 'p90': 112903.02734375, 'p99': 730726.29296875}
```
The difference between p90 results is 17% however the enabled run was better ! 

This patch changes the logic to only perform the assertion in the case the run didn't beat the baseline run. Also removes the `ok_to_fail` tag 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
