### PR TITLE
Check that the data dir exists

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -525,6 +525,10 @@ void application::initialize(
     }).get0();
 
     if (config::shard_local_cfg().enable_pid_file()) {
+        // check that the data directory exists now, because we are about to
+        // create the pidfile
+        syschecks::directory_must_exist(
+          "data directory", config::node().data_directory().path);
         syschecks::pidfile_create(config::node().pidfile_path());
     }
     smp_groups::config smp_groups_cfg{

--- a/src/v/syschecks/syschecks.cc
+++ b/src/v/syschecks/syschecks.cc
@@ -102,4 +102,21 @@ ss::future<> systemd_raw_message(ss::sstring out) {
     co_return;
 }
 
+void directory_must_exist(
+  std::string_view name, const std::filesystem::path& dir) {
+    // check that the data directory exists
+    auto dir_str = dir.string();
+    std::optional<ss::directory_entry_type> data_dir_type
+      = ss::file_type(dir_str).get();
+    auto throw_bad_dir = [=](auto detail) {
+        throw std::invalid_argument(
+          fmt::format("Configured {} {}: {}", name, detail, dir_str));
+    };
+    if (!data_dir_type) {
+        throw_bad_dir("did not exist");
+    } else if (*data_dir_type != ss::directory_entry_type::directory) {
+        throw_bad_dir("is not a directory");
+    }
+}
+
 } // namespace syschecks

--- a/src/v/syschecks/syschecks.h
+++ b/src/v/syschecks/syschecks.h
@@ -64,6 +64,16 @@ ss::future<> systemd_message(fmt::format_string<Args...> fmt, Args&&... args) {
     return systemd_raw_message(std::move(s));
 }
 
+/**
+ * Ensure that the path specified by dir exists and is a directory.
+ *
+ * If it does not exist, throw an std::invalid_argument exception
+ * which embeds details of the failure, using name as a human-readable
+ * name in the error string.
+ */
+void directory_must_exist(
+  std::string_view name, const std::filesystem::path& dir);
+
 /*
  * write the pid lock file for this process at the given path. if the lock file
  * cannot be created or locked an exception is thrown.


### PR DESCRIPTION
If you start up Redpanda point to a data dir that doesn't exist, the error is fairly obscure: a std::system_error mentioning failed to open but no indication of _what_ we were trying to open.

This has tripped up several people, including externally (and yours truly) so let's just fix it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* A clearer error message when the data directory does not exist or is the wrong type


