### PR TITLE
node_config: Disallow empty rack

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -761,6 +761,20 @@ void application::hydrate_config(const po::variables_map& cfg) {
     if (node_config_errors.size() > 0) {
         throw std::invalid_argument("Validation errors in node config");
     }
+    /// Special case scenario with Rack ID being set to ''
+    /// Redpanda supplied ansible scripts are setting "rack: ''" which has
+    /// caused issues with some of our customers.  This hacky work around is an
+    /// alternative to using validation in node config to stop Redpanda from
+    /// starting if rack is supplied with an empty string.
+    auto& rack_id = config::node().rack.value();
+    if (rack_id.has_value() && *rack_id == model::rack_id{""}) {
+        vlog(
+          _log.warn,
+          "redpanda.rack specified as empty string.  Please remove "
+          "`redpanda.rack = ''` from your node config as in the future this "
+          "may result in Redpanda failing to start");
+        config::node().rack.set_value(std::nullopt);
+    }
 
     // This includes loading from local bootstrap file or legacy
     // config file on first-start or upgrade cases.


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Some customers have run into issues where they set `rack: ''` in their node config.  This change will convert an empty string for the rack node config to a `std::nullopt`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [X] v23.2.x
- [X] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Redpanda used to accept an empty string in `redpanda.rack` in node config.  This would cause issues in Kafka operations.  Redpanda will now error on startup if `redpanda.rack` is set to an empty string.