### PR TITLE
gha: remove invalid permission

### DIFF
--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -18,7 +18,6 @@ jobs:
     name: List Golang Transform SDK
     runs-on: ubuntu-latest
     permissions:
-      metadata: read
       contents: write
     steps:
       - name: Check out code


### PR DESCRIPTION
Remove invalid permission, this check should only need write access to the repo to push the tag.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
