### PR TITLE
cloud_storage: Add randomized cstore test

### DIFF
--- a/src/v/random/generators.h
+++ b/src/v/random/generators.h
@@ -71,6 +71,12 @@ T get_int(T min, T max) {
     return dist(internal::gen);
 }
 
+inline bool with_probability(float p) {
+    std::uniform_real_distribution<float> dist(0, 1.0);
+    float e = dist(internal::gen);
+    return e <= p;
+}
+
 template<typename T>
 T get_int(T max) {
     return get_int<T>(0, max);


### PR DESCRIPTION
Create new cstore test that
- adds random segments
- truncates the c-store
- introduces gaps between segments
- adds segments/truncations out of order

This is a result of my attempts to reproduce #15723 (which was fixed by another PR)
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none