### PR TITLE
kafka: Don't set rack ID if empty

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -814,7 +814,10 @@ class simple_fetch_planner final : public fetch_planner::impl {
               .strict_max_bytes = octx.response_size > 0,
               .skip_read = bytes_left_in_plan == 0 && max_bytes == 0,
               .read_from_follower = octx.request.has_rack_id(),
-              .consumer_rack_id = octx.request.data.rack_id,
+              .consumer_rack_id = octx.request.has_rack_id()
+                                    ? std::make_optional(
+                                      octx.request.data.rack_id)
+                                    : std::nullopt,
               .abort_source = octx.rctx.abort_source(),
               .client_address = model::client_address_t{client_address},
             };


### PR DESCRIPTION
Take into consideration that if the fetch request's rack ID is an empty string, act as if no rack ID was provided.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [X] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Redpanda will now correctly handle an empty rack ID provided in a fetch request