### PR TITLE
[v23.3.x] kafka: Don't set rack ID if empty

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -814,7 +814,10 @@ class simple_fetch_planner final : public fetch_planner::impl {
               .strict_max_bytes = octx.response_size > 0,
               .skip_read = bytes_left_in_plan == 0 && max_bytes == 0,
               .read_from_follower = octx.request.has_rack_id(),
-              .consumer_rack_id = octx.request.data.rack_id,
+              .consumer_rack_id = octx.request.has_rack_id()
+                                    ? std::make_optional(
+                                      octx.request.data.rack_id)
+                                    : std::nullopt,
               .abort_source = octx.rctx.abort_source(),
               .client_address = model::client_address_t{client_address},
             };


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15846
