### PR TITLE
c/s/leader_balancer: prevent oversized alloc

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer_constraints.h
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.h
@@ -131,7 +131,7 @@ class even_topic_distributon_constraint final
     using topic_id_t = model::revision_id::type;
 
     template<typename ValueType>
-    using topic_map = absl::flat_hash_map<topic_id_t, ValueType>;
+    using topic_map = absl::btree_map<topic_id_t, ValueType>;
 
 public:
     even_topic_distributon_constraint(


### PR DESCRIPTION
When there are many topics within in a system we can get oversized
allocations, so switch to a btree_map. In particular this is while
rebuilding the index for `_topic_replica_index`, but presumably all 
these data structures have a similar order of magnitude.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes

* none
