### PR TITLE
[v23.3.x] rptest: allow the new version of xfs/ext4 fs error msg

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -87,6 +87,8 @@ DEFAULT_LOG_ALLOW_LIST = [
     re.compile("not on XFS. This is a non-supported setup."),
     # >= 23.2 version of the message
     re.compile("not on XFS or ext4. This is a non-supported"),
+    # >= 23.2.22, 23.3 version of the message
+    re.compile("not XFS or ext4. This is a unsupported"),
 
     # This is expected when tests are intentionally run on low memory configurations
     re.compile(r"Memory: '\d+' below recommended"),


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15853
