### PR TITLE
[v23.3.x] t/kgo: upgrade kgo to do a full run after /last_pass

### DIFF
--- a/tests/docker/ducktape-deps/kgo-verifier
+++ b/tests/docker/ducktape-deps/kgo-verifier
@@ -2,6 +2,6 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/kgo-verifier.git
 cd /opt/kgo-verifier
-git reset --hard e3f1f87896194a607f468feb97dd3e66d720d771
+git reset --hard bb6953c81662237c9a8fb42ee90cc870df258907
 go mod tidy
 make


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15852
Fixes: https://github.com/redpanda-data/redpanda/issues/15875,