### PR TITLE
[v23.3.x] cluster/config_manager: protect cfg.get() behind cfg.contains()

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -345,8 +345,8 @@ static void preload_local(
   std::optional<std::reference_wrapper<config_manager::preload_result>>
     result) {
     auto& cfg = config::shard_local_cfg();
-    auto& property = cfg.get(key);
     if (cfg.contains(key)) {
+        auto& property = cfg.get(key);
         std::string raw_value;
         try {
             raw_value = value.as<std::string>();

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -379,15 +379,11 @@ class Admin:
         return self._request("GET", "cluster_config/schema", node=node).json()
 
     def patch_cluster_config(self,
-                             upsert=None,
-                             remove=None,
+                             upsert: dict[str, str] = {},
+                             remove: list[str] = [],
                              force=False,
                              dry_run=False,
                              node=None):
-        if upsert is None:
-            upsert = {}
-        if remove is None:
-            remove = []
 
         path = "cluster_config"
         params = {}
@@ -880,7 +876,7 @@ class Admin:
 
     def maintenance_start(self, node, dst_node=None):
         """
-        Start maintenanceing on 'node', sending the request to 'dst_node'.
+        Start maintenance on 'node', sending the request to 'dst_node'.
         """
         id = self.redpanda.node_id(node)
         url = f"brokers/{id}/maintenance"
@@ -890,7 +886,7 @@ class Admin:
 
     def maintenance_stop(self, node, dst_node=None):
         """
-        Stop maintenanceing on 'node', sending the request to 'dst_node'.
+        Stop maintenance on 'node', sending the request to 'dst_node'.
         """
         id = self.redpanda.node_id(node)
         url = f"brokers/{id}/maintenance"


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15840
Fixes: https://github.com/redpanda-data/redpanda/issues/15878,