### PR TITLE
gha: s/git.ref_name/github.ref_name

### DIFF
--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -35,7 +35,7 @@ jobs:
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/src/transform-sdk/go/transform/${{git.ref_name}}',
+              ref: 'refs/tags/src/transform-sdk/go/transform/${{github.ref_name}}',
               sha: context.sha
             })
 


### PR DESCRIPTION
I really wish there was a better way to test these GHA other than
needing to do an actual release 😢

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
