### PR TITLE
gha: improve backport reviewers

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -95,18 +95,11 @@ jobs:
           TARGET_MILESTONE: ${{ steps.create_milestone.outputs.milestone }}
           ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
           ORIG_LABELS: ${{ toJson(github.event.client_payload.github.payload.issue.labels) }}
-          ORIG_ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
+          ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
         id: create_issue
         run: $SCRIPT_DIR/create_issue.sh 
         shell: bash
           
-      - name: Get reviewers of PR
-        if: needs.backport-type.outputs.commented_on == 'pr'
-        env:
-          REVIEWERS: ${{ toJson(github.event.client_payload.pull_request.requested_reviewers) }}
-        id: reviewers
-        run: echo "reviewers=$(echo $REVIEWERS | jq -r '.[].login' | paste -s -d ',' -)" >> $GITHUB_OUTPUT
-
       - name: Get commits of PR
         if: needs.backport-type.outputs.commented_on == 'pr'
         env:
@@ -145,7 +138,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}
           TARGET_MILESTONE: ${{ steps.create_milestone.outputs.milestone }}
           ORIG_TITLE: ${{ github.event.client_payload.github.payload.issue.title }}
-          ORIG_REVIEWERS: ${{ steps.reviewers.outputs.reviewers }}
+          AUTHOR: ${{ github.event.client_payload.pull_request.user.login }}
           HEAD_BRANCH: ${{ steps.pr_details.outputs.head_branch }}
           FIXING_ISSUE_URLS: ${{ steps.pr_details.outputs.fixing_issue_urls }}
           ORIG_PR_NUMBER: ${{ github.event.client_payload.pull_request.number }}
@@ -189,7 +182,7 @@ jobs:
           ORIG_LABELS: ${{ toJson(github.event.client_payload.github.payload.issue.labels) }}
           ORIG_ASSIGNEES: ${{ steps.assignees.outputs.assignees }}
           CREATE_ISSUE_ON_ERROR: "true"
-          ORIG_REVIEWERS: ${{ steps.reviewers.outputs.reviewers }}
+          ASSIGNEES: ${{ github.event.client_payload.pull_request.user.login }}
           HEAD_BRANCH: ${{ steps.pr_details.outputs.head_branch }}
           GIT_USER: ${{ steps.user.outputs.username }}
           BACKPORT_COMMITS: ${{ steps.backport_commits.outputs.backport_commits }}

--- a/.github/workflows/scripts/backport-command/create_issue.sh
+++ b/.github/workflows/scripts/backport-command/create_issue.sh
@@ -15,8 +15,6 @@ if [[ -n $(echo "$ORIG_LABELS" | jq '.[] | select(.name == "kind/backport")') ]]
 fi
 
 additional_body=""
-orig_assignees=$ORIG_ASSIGNEES
-
 if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
   additional_body="Note that this issue was created as a placeholder, since the original PR's commit(s) could not be automatically cherry-picked."
 
@@ -38,11 +36,8 @@ if [[ -n $CREATE_ISSUE_ON_ERROR ]]; then
     --head \"$local_branch\" \\
     --draft \\
     --repo \"$TARGET_ORG/$TARGET_REPO\" \\
-    --reviewer \"$ORIG_REVIEWERS\" \\
     --milestone \"$TARGET_MILESTONE\" \\
     --body \"Backport of PR $ORIG_ISSUE_URL \""
-
-  orig_assignees=$(gh issue view $PR_NUMBER --json author --jq .author.login)
 fi
 
 backport_issue_url=$(gh_issue_url)
@@ -50,7 +45,7 @@ if [[ -z $backport_issue_url ]]; then
   gh issue create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
     --label "kind/backport" \
     --repo "$TARGET_ORG/$TARGET_REPO" \
-    --assignee "$orig_assignees" \
+    --assignee "$ASSIGNEES" \
     --milestone "$TARGET_MILESTONE" \
     --body "Backport $ORIG_ISSUE_URL to branch $BACKPORT_BRANCH. $additional_body"
 else

--- a/.github/workflows/scripts/backport-command/create_pr.sh
+++ b/.github/workflows/scripts/backport-command/create_pr.sh
@@ -56,7 +56,7 @@ gh pr create --title "[$BACKPORT_BRANCH] $ORIG_TITLE" \
   --head "$GIT_USER:$HEAD_BRANCH" \
   --draft \
   --repo "$TARGET_ORG/$TARGET_REPO" \
-  --reviewer "$ORIG_REVIEWERS" \
+  --reviewer "$AUTHOR" \
   --milestone "$TARGET_MILESTONE" \
   --body "Backport of PR $ORIG_ISSUE_URL
 $backport_issue_urls"


### PR DESCRIPTION
In the case of a clean backport, the original PR author is the reviewer,
otherwise when creating an issue, we don't list reviewers, as we assume
the reviewer will assign them appropriately.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
