### PR TITLE
kafka/protocol: use frag vec for offset fetch

### DIFF
--- a/src/v/kafka/protocol/offset_fetch.h
+++ b/src/v/kafka/protocol/offset_fetch.h
@@ -18,6 +18,7 @@
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "seastarx.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/future.hh>
 
@@ -62,7 +63,8 @@ struct offset_fetch_response final {
         data.error_code = error_code::none;
         if (topics) {
             for (auto& topic : *topics) {
-                std::vector<offset_fetch_response_partition> partitions;
+                small_fragment_vector<offset_fetch_response_partition>
+                  partitions;
                 for (auto id : topic.partition_indexes) {
                     offset_fetch_response_partition p = {
                       .partition_index = id,

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -466,7 +466,8 @@ extra_headers = {
 override_member_container = {
     'metadata_response_partition': 'large_fragment_vector',
     'metadata_response_topic': 'small_fragment_vector',
-    'fetchable_partition_response': 'small_fragment_vector'
+    'fetchable_partition_response': 'small_fragment_vector',
+    'offset_fetch_response_partition': 'small_fragment_vector',
 }
 
 

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -29,6 +29,7 @@
 #include "raft/errc.h"
 #include "ssx/future-util.h"
 #include "storage/record_batch_builder.h"
+#include "utils/fragmented_vector.h"
 #include "utils/to_string.h"
 #include "vassert.h"
 
@@ -2501,7 +2502,7 @@ group::handle_offset_fetch(offset_fetch_request&& r) {
     if (!r.data.topics) {
         absl::flat_hash_map<
           model::topic,
-          std::vector<offset_fetch_response_partition>>
+          small_fragment_vector<offset_fetch_response_partition>>
           tmp;
         for (const auto& e : _offsets) {
             offset_fetch_response_partition p = {

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1159,7 +1159,6 @@ offset_fetch_handler::handle(request_context ctx, ss::smp_service_group) {
     for (auto& req_topic : unauthorized) {
         auto& topic = resp.data.topics.emplace_back();
         topic.name = std::move(req_topic.name);
-        topic.partitions.reserve(req_topic.partition_indexes.size());
         for (auto partition_index : req_topic.partition_indexes) {
             auto& partition = topic.partitions.emplace_back();
             partition.partition_index = partition_index;


### PR DESCRIPTION
We've seen oversized allocs with this field when group fetches are used.
This switches to a frag vec for partitions.

Fixes: https://github.com/redpanda-data/redpanda/issues/15909

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes

### Bug Fixes

* Prevent oversized allocs when group fetching from many partitions.


