### PR TITLE
r/offset_translator: remove unsafe bootstrap code

### DIFF
--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -957,7 +957,7 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
       raft::group_id{0},
       manifest_ntp,
       b.storage());
-    tr.start(raft::offset_translator::must_reset::yes, {}).get();
+    tr.start(raft::offset_translator::must_reset::yes).get();
     const auto& tr_state = *tr.state();
 
     // first offset that is not yet uploaded

--- a/src/v/raft/offset_translator.h
+++ b/src/v/raft/offset_translator.h
@@ -59,15 +59,9 @@ public:
 
     using must_reset = ss::bool_class<struct must_reset_tag>;
 
-    struct bootstrap_state {
-        absl::btree_map<model::offset, int64_t> offset2delta;
-        model::offset highest_known_offset;
-    };
-
     /// Load persistent state from kvstore. If `reset` is true, resets to an
-    /// empty state and persists it. If persistent state is not found, uses
-    /// information from `bootstrap_state` and persists it.
-    ss::future<> start(must_reset reset, bootstrap_state&&);
+    /// empty state and persists it.
+    ss::future<> start(must_reset reset);
 
     /// Searches for non-data batches up to the tip of the log. After this
     /// method succeeds, offset translator is usable.

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -108,7 +108,7 @@ void validate_translation(
 struct offset_translator_fixture : base_fixture {
     offset_translator_fixture()
       : tr(make_offset_translator()) {
-        tr.start(raft::offset_translator::must_reset::yes, {}).get();
+        tr.start(raft::offset_translator::must_reset::yes).get();
     }
 
     void validate_offset_translation(
@@ -321,7 +321,7 @@ struct fuzz_checker {
 
     ss::future<> start() {
         _tr.emplace(_make_offset_translator());
-        co_await _tr->start(raft::offset_translator::must_reset::yes, {});
+        co_await _tr->start(raft::offset_translator::must_reset::yes);
         co_await _tr->sync_with_log(_log, std::nullopt);
     }
 
@@ -472,7 +472,7 @@ struct fuzz_checker {
             _tr.emplace(_make_offset_translator());
             _gate = ss::gate{};
 
-            co_await _tr->start(raft::offset_translator::must_reset::no, {});
+            co_await _tr->start(raft::offset_translator::must_reset::no);
             co_await _tr->prefix_truncate_reset(
               _snapshot_offset, _snapshot_delta);
             co_await _tr->sync_with_log(_log, std::nullopt);
@@ -613,11 +613,7 @@ FIXTURE_TEST(test_moving_persistent_state, base_fixture) {
       // data batch @ 9 -> kafka 3
     };
     auto local_ot = make_offset_translator();
-    local_ot
-      .start(
-        raft::offset_translator::must_reset::yes,
-        raft::offset_translator::bootstrap_state{})
-      .get();
+    local_ot.start(raft::offset_translator::must_reset::yes).get();
     for (auto o : batch_offsets) {
         local_ot.process(
           create_batch(model::record_batch_type::raft_configuration, o));
@@ -658,10 +654,7 @@ FIXTURE_TEST(test_moving_persistent_state, base_fixture) {
             ntp,
             api.local()};
           return ss::do_with(std::move(remote_ot), [](auto& remote_ot) {
-              return remote_ot
-                .start(
-                  raft::offset_translator::must_reset::no,
-                  raft::offset_translator::bootstrap_state{})
+              return remote_ot.start(raft::offset_translator::must_reset::no)
                 .then([&remote_ot] {
                     validate_translation(
                       remote_ot, model::offset(0), model::offset(0));


### PR DESCRIPTION
When the corresponding kvstore state is not found, we should recover offset_translator state from the log, not use configuration_manager state - the latter is incorrect because there are other batch types contributing to offset delta, not just configuration batches. This code is a vestige from the time when the separate offset_translator component was just introduced and its kvstore state needed to be bootstrapped from configuration_manager state.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes
* none