### PR TITLE
Use async compression in kafka client

### DIFF
--- a/src/v/kafka/client/produce_batcher.h
+++ b/src/v/kafka/client/produce_batcher.h
@@ -85,10 +85,11 @@ public:
         return _client_reqs.back().promise.get_future();
     }
 
-    model::record_batch consume() {
-        auto batch = std::exchange(_builder, make_builder()).build();
+    ss::future<model::record_batch> consume() {
+        auto batch
+          = co_await std::exchange(_builder, make_builder()).build_async();
         _broker_reqs.emplace_back(batch.record_count());
-        return batch;
+        co_return batch;
     }
 
     void handle_response(partition_response res) {

--- a/src/v/kafka/client/test/produce_batcher.cc
+++ b/src/v/kafka/client/test/produce_batcher.cc
@@ -44,12 +44,12 @@ struct produce_batcher_context {
         produce_futs.push_back(batcher.produce(std::move(batch)));
         client_req_offset += count;
     }
-    auto consume() {
-        auto batch = batcher.consume();
+    ss::future<int32_t> consume() {
+        model::record_batch batch = co_await batcher.consume();
         auto record_count = batch.record_count();
         broker_batches.emplace_back(broker_req_offset, std::move(batch));
         broker_req_offset += record_count;
-        return record_count;
+        co_return record_count;
     }
     auto handle_response(kafka::error_code error = kafka::error_code::none) {
         auto batch = kc::consume_front(broker_batches);
@@ -88,13 +88,13 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_single) {
     produce_batcher_context ctx;
 
     ctx.produce(2);
-    BOOST_REQUIRE(ctx.consume() == 2);
+    BOOST_REQUIRE(ctx.consume().get() == 2);
     BOOST_REQUIRE(ctx.handle_response() == 2);
 
     auto offsets = ctx.get_response_offsets().get0();
     BOOST_REQUIRE(offsets == ctx.expected_offsets);
 
-    BOOST_REQUIRE(ctx.consume() == 0);
+    BOOST_REQUIRE(ctx.consume().get() == 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_partition_producer_seq) {
@@ -102,18 +102,18 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_seq) {
 
     ctx.produce(2);
     ctx.produce(2);
-    BOOST_REQUIRE(ctx.consume() == 4);
+    BOOST_REQUIRE(ctx.consume().get() == 4);
     BOOST_REQUIRE(ctx.handle_response() == 4);
 
     ctx.produce(2);
     ctx.produce(2);
-    BOOST_REQUIRE(ctx.consume() == 4);
+    BOOST_REQUIRE(ctx.consume().get() == 4);
     BOOST_REQUIRE(ctx.handle_response() == 4);
 
     auto offsets = ctx.get_response_offsets().get0();
     BOOST_REQUIRE(offsets == ctx.expected_offsets);
 
-    BOOST_REQUIRE(ctx.consume() == 0);
+    BOOST_REQUIRE(ctx.consume().get() == 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_partition_producer_overlapped) {
@@ -121,11 +121,11 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_overlapped) {
 
     ctx.produce(2);
     ctx.produce(2);
-    BOOST_REQUIRE(ctx.consume() == 4);
+    BOOST_REQUIRE(ctx.consume().get() == 4);
 
     ctx.produce(2);
     ctx.produce(2);
-    BOOST_REQUIRE(ctx.consume() == 4);
+    BOOST_REQUIRE(ctx.consume().get() == 4);
 
     BOOST_REQUIRE(ctx.handle_response() == 4);
     BOOST_REQUIRE(ctx.handle_response() == 4);
@@ -133,7 +133,7 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_overlapped) {
     auto offsets = ctx.get_response_offsets().get0();
     BOOST_REQUIRE(offsets == ctx.expected_offsets);
 
-    BOOST_REQUIRE(ctx.consume() == 0);
+    BOOST_REQUIRE(ctx.consume().get() == 0);
 }
 
 SEASTAR_THREAD_TEST_CASE(test_partition_producer_error) {
@@ -141,11 +141,11 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_error) {
 
     ctx.produce(2);
     ctx.produce(2);
-    BOOST_REQUIRE(ctx.consume() == 4);
+    BOOST_REQUIRE(ctx.consume().get() == 4);
 
     ctx.produce(2);
     ctx.produce(2);
-    BOOST_REQUIRE(ctx.consume() == 4);
+    BOOST_REQUIRE(ctx.consume().get() == 4);
 
     BOOST_REQUIRE(ctx.handle_response() == 4);
     BOOST_REQUIRE(
@@ -166,5 +166,5 @@ SEASTAR_THREAD_TEST_CASE(test_partition_producer_error) {
     BOOST_REQUIRE(
       responses[3].error_code == kafka::error_code::not_leader_for_partition);
 
-    BOOST_REQUIRE(ctx.consume() == 0);
+    BOOST_REQUIRE(ctx.consume().get() == 0);
 }

--- a/src/v/kafka/client/test/produce_partition.cc
+++ b/src/v/kafka/client/test/produce_partition.cc
@@ -16,6 +16,7 @@
 #include "kafka/protocol/produce.h"
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "test_utils/async.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
@@ -42,6 +43,11 @@ SEASTAR_THREAD_TEST_CASE(test_produce_partition_record_count) {
 
     auto c_res0_fut = producer.produce(make_batch(model::offset(0), 2));
     auto c_res1_fut = producer.produce(make_batch(model::offset(2), 1));
+
+    tests::cooperative_spin_wait_with_timeout(5s, [&consumed_batches]() {
+        return consumed_batches.size() > 0;
+    }).get();
+
     producer.handle_response(kafka::produce_response::partition{
       .partition_index{model::partition_id{42}},
       .error_code = kafka::error_code::none,
@@ -55,6 +61,9 @@ SEASTAR_THREAD_TEST_CASE(test_produce_partition_record_count) {
     BOOST_REQUIRE_EQUAL(c_res1.base_offset, model::offset{2});
 
     auto c_res2_fut = producer.produce(make_batch(model::offset(3), 3));
+    tests::cooperative_spin_wait_with_timeout(5s, [&consumed_batches]() {
+        return consumed_batches.size() > 1;
+    }).get();
     producer.handle_response(kafka::produce_response::partition{
       .partition_index{model::partition_id{42}},
       .error_code = kafka::error_code::none,
@@ -64,4 +73,5 @@ SEASTAR_THREAD_TEST_CASE(test_produce_partition_record_count) {
     BOOST_REQUIRE_EQUAL(consumed_batches[1].record_count(), 3);
     auto c_res2 = c_res2_fut.get0();
     BOOST_REQUIRE_EQUAL(c_res2.base_offset, model::offset{3});
+    producer.stop().get();
 }

--- a/src/v/storage/record_batch_builder.h
+++ b/src/v/storage/record_batch_builder.h
@@ -30,7 +30,8 @@ public:
       std::optional<iobuf>&& key,
       std::optional<iobuf>&& value,
       std::vector<model::record_header> headers);
-    virtual model::record_batch build() &&;
+    model::record_batch build() &&;
+    ss::future<model::record_batch> build_async() &&;
     virtual ~record_batch_builder();
 
     void set_producer_identity(int64_t id, int16_t epoch) {
@@ -81,6 +82,7 @@ private:
         std::vector<model::record_header> headers;
     };
 
+    model::record_batch_header build_header() const;
     uint32_t record_size(int32_t offset_delta, const serialized_record& r);
 
     model::record_batch_type _batch_type;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes: #15900 

Utilize asynchronous compression in kafka client to reduce possibility of oversized allocation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [X] v23.2.x
- [X] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Internal kafka client now uses asynchronous compression (when possible) to reduce possibility of oversized allocations and reactor stalls
