### PR TITLE
[v23.2.x] goreleaser: disable homebrew uploads for go builds

### DIFF
--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -61,37 +61,5 @@ release:
     name: redpanda
   draft: true
   discussion_category_name: Releases
-brews:
-  - name: redpanda
-    homepage: "https://redpanda.com"
-    description: "Redpanda CLI & toolbox"
-    repository:
-      owner: redpanda-data
-      name: homebrew-tap
-    folder: Formula
-    skip_upload: auto
-    ids:
-      - rpk
-    caveats: |
-        Redpanda Keeper (rpk) is Redpanda's command line interface (CLI)
-        utility. The rpk commands let you configure, manage, and tune
-        Redpanda clusters. They also let you manage topics, groups,
-        and access control lists (ACLs).
-        Start a three-node docker cluster locally:
-
-            rpk container start -n 3
-
-        Interact with the cluster using commands like:
-
-            rpk topic list
-
-        When done, stop and delete the docker cluster:
-
-            rpk container purge
-
-        For more examples and guides, visit: https://docs.redpanda.com
-    commit_author:
-      name: vbotbuildovich
-      email: vbot@redpanda.com
 announce:
   skip: "true"


### PR DESCRIPTION
Only patch versions of latest stable release should be uploaded

fixes redpanda-data/vtools#2424

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
