### PR TITLE
transform-sdk/go: introduce RecordWriter

### DIFF
--- a/src/go/rpk/pkg/cli/transform/template/golang/transform.gosrc
+++ b/src/go/rpk/pkg/cli/transform/template/golang/transform.gosrc
@@ -11,7 +11,7 @@ func main() {
 }
 
 // doTransform is where you read the record that was written, and then you can
-// return new records that will be written to the output topic
-func doTransform(e transform.WriteEvent) ([]transform.Record, error) {
-	return []transform.Record{e.Record()}, nil
+// output new records that will be written to the destination topic
+func doTransform(e transform.WriteEvent, w transform.RecordWriter) error {
+	return w.Write(e.Record())
 }

--- a/src/transform-sdk/go/transform/example_mirror_test.go
+++ b/src/transform-sdk/go/transform/example_mirror_test.go
@@ -32,7 +32,7 @@ func Example_identityTransform() {
 
 // This will be called for each record in the source topic.
 //
-// The output records returned will be written to the destination topic.
-func mirrorTransform(e transform.WriteEvent) ([]transform.Record, error) {
-	return []transform.Record{e.Record()}, nil
+// The records written to w be output to the destination topic.
+func mirrorTransform(e transform.WriteEvent, w transform.RecordWriter) error {
+	return w.Write(e.Record())
 }

--- a/src/transform-sdk/go/transform/example_regexp_filter_test.go
+++ b/src/transform-sdk/go/transform/example_regexp_filter_test.go
@@ -42,7 +42,7 @@ func Example_regularExpressionFilter() {
 	transform.OnRecordWritten(doRegexFilter)
 }
 
-func doRegexFilter(e transform.WriteEvent) ([]transform.Record, error) {
+func doRegexFilter(e transform.WriteEvent, w transform.RecordWriter) error {
 	var b []byte
 	if checkValue {
 		b = e.Record().Value
@@ -50,12 +50,12 @@ func doRegexFilter(e transform.WriteEvent) ([]transform.Record, error) {
 		b = e.Record().Key
 	}
 	if b == nil {
-		return nil, nil
+		return nil
 	}
 	pass := re.Match(b)
 	if pass {
-		return []transform.Record{e.Record()}, nil
+		return w.Write(e.Record())
 	} else {
-		return nil, nil
+		return nil
 	}
 }

--- a/src/transform-sdk/go/transform/internal/testdata/identity/transform.go
+++ b/src/transform-sdk/go/transform/internal/testdata/identity/transform.go
@@ -22,6 +22,6 @@ func main() {
 	transform.OnRecordWritten(identityTransform)
 }
 
-func identityTransform(e transform.WriteEvent) ([]transform.Record, error) {
-	return []transform.Record{e.Record()}, nil
+func identityTransform(e transform.WriteEvent, w transform.RecordWriter) error {
+	return w.Write(e.Record())
 }

--- a/src/transform-sdk/go/transform/internal/testdata/transform-error/transform.go
+++ b/src/transform-sdk/go/transform/internal/testdata/transform-error/transform.go
@@ -24,6 +24,6 @@ func main() {
 	transform.OnRecordWritten(errTransform)
 }
 
-func errTransform(e transform.WriteEvent) ([]transform.Record, error) {
-	return nil, errors.New("oh noes!")
+func errTransform(e transform.WriteEvent, w transform.RecordWriter) error {
+	return errors.New("oh noes!")
 }

--- a/src/transform-sdk/go/transform/internal/testdata/transform-panic/transform.go
+++ b/src/transform-sdk/go/transform/internal/testdata/transform-panic/transform.go
@@ -22,6 +22,6 @@ func main() {
 	transform.OnRecordWritten(panicTransform)
 }
 
-func panicTransform(e transform.WriteEvent) ([]transform.Record, error) {
+func panicTransform(e transform.WriteEvent, w transform.RecordWriter) error {
 	panic("oh noes!")
 }

--- a/src/transform-sdk/go/transform/internal/testdata/wasi/transform.go
+++ b/src/transform-sdk/go/transform/internal/testdata/wasi/transform.go
@@ -34,16 +34,16 @@ type WasiInfo struct {
 	RandomNumber int
 }
 
-func wasiTransform(e transform.WriteEvent) ([]transform.Record, error) {
-	w := &WasiInfo{
+func wasiTransform(e transform.WriteEvent, w transform.RecordWriter) error {
+	i := &WasiInfo{
 		Args:         os.Args,
 		Env:          os.Environ(),
 		NowNanos:     time.Now().UnixNano(),
 		RandomNumber: rand.Int(),
 	}
-	b, err := json.Marshal(w)
+	b, err := json.Marshal(i)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return []transform.Record{{Value: b}}, nil
+	return w.Write(transform.Record{Value: b})
 }

--- a/src/transform-sdk/go/transform/sdk.go
+++ b/src/transform-sdk/go/transform/sdk.go
@@ -26,7 +26,7 @@ func OnRecordWritten(fn OnRecordWrittenCallback) {
 }
 
 // OnRecordWrittenCallback is a callback to transform records after a write event happens in the input topic.
-type OnRecordWrittenCallback func(e WriteEvent) ([]Record, error)
+type OnRecordWrittenCallback func(e WriteEvent, w RecordWriter) error
 
 // WriteEvent contains information about the write that took place,
 // namely it contains the record that was written.
@@ -35,14 +35,14 @@ type WriteEvent interface {
 	Record() Record
 }
 
-// Look at options/builder pattern for making TransformEvent, and make it a "private" interface
-
-type writeEvent struct {
-	record Record
-}
-
-func (e *writeEvent) Record() Record {
-	return e.record
+// RecordWriter is an interface for writing transformed records to the destination topic.
+type RecordWriter interface {
+	// Write writes a record to the output topic.
+	//
+	// When writing a record, only the key, value and headers are
+	// used other information like the timestamp will be overridden
+	// by the broker.
+	Write(Record) error
 }
 
 // Headers are optional key/value pairs that are passed along with


### PR DESCRIPTION
We've recieved good feedback that a more idiomatic interface for
transforms is using a pattern similar to http.HandlerFunc. This is much
cleaner IMO and allows for emitting records without buffering, as slices
are sometimes akward to work with.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Data Transforms written in Golang now use a non-buffered write mechanism. Transforms that used to be written as

  ```
  func myTransform(e transform.WriteEvent) ([]transform.Record, error) {
    return transform.Record[]{e.Record()}, nil
  }
  ```

  Can now be written as

  ```
  func myTransform(e transform.WriteEvent, w transform.RecordWriter) error {
    return w.Write(e.Record())
  }
  ```

