### PR TITLE
transform-sdk/rust: introduce RecordWriter

### DIFF
--- a/src/go/rpk/pkg/cli/transform/template/rust/main.rustsrc
+++ b/src/go/rpk/pkg/cli/transform/template/rust/main.rustsrc
@@ -9,8 +9,8 @@ fn main() {
 
 // my_transform is where you read the record that was written, and then you can
 // return new records that will be written to the output topic
-fn my_transform(event: WriteEvent) -> Result<Vec<Record>, Error> {
-    Ok(vec![Record::new_with_headers(
+fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<()> {
+    writer.write(Record::new_with_headers(
         event.record.key().map(|b| b.to_owned()),
         event.record.value().map(|b| b.to_owned()),
         event
@@ -19,5 +19,6 @@ fn my_transform(event: WriteEvent) -> Result<Vec<Record>, Error> {
             .iter()
             .map(|h| h.to_owned())
             .collect(),
-    )])
+    ))?;
+    Ok(())
 }

--- a/src/transform-sdk/rust/core-types/src/lib.rs
+++ b/src/transform-sdk/rust/core-types/src/lib.rs
@@ -30,6 +30,30 @@ pub struct WriteEvent<'a> {
     pub record: BorrowedRecord<'a>,
 }
 
+/// A writer trait for output transformed records to the destination topic.
+pub trait RecordWriter {
+    /// Write a record to the output topic returning any errors.
+    fn write(&mut self, r: Record) -> Result<(), WriteError>;
+}
+
+/// An error that can occur when writing records to the output topic.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum WriteError {
+    /// Unknown error from the broker with the corresponding error code.
+    Unknown(i32),
+}
+
+impl std::fmt::Display for WriteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            WriteError::Unknown(errno) => write!(f, "writing record failed with errno: {}", errno),
+        }
+    }
+}
+
+impl std::error::Error for WriteError {}
+
 /// A zero-copy [`BorrowedRecord`] header.
 #[derive(Debug)]
 pub struct BorrowedHeader<'a> {

--- a/src/transform-sdk/rust/examples/identity.rs
+++ b/src/transform-sdk/rust/examples/identity.rs
@@ -21,8 +21,8 @@ fn main() {
     on_record_written(my_transform);
 }
 
-fn my_transform(event: WriteEvent) -> Result<Vec<Record>> {
-    Ok(vec![Record::new_with_headers(
+fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<()> {
+    writer.write(Record::new_with_headers(
         event.record.key().map(|b| b.to_owned()),
         event.record.value().map(|b| b.to_owned()),
         event
@@ -31,5 +31,6 @@ fn my_transform(event: WriteEvent) -> Result<Vec<Record>> {
             .iter()
             .map(|h| h.to_owned())
             .collect(),
-    )])
+    ))?;
+    Ok(())
 }

--- a/src/transform-sdk/rust/src/lib.rs
+++ b/src/transform-sdk/rust/src/lib.rs
@@ -26,7 +26,7 @@
 //! This crate provides a framework for writing transforms.
 //!
 //! [`on_record_written`]: Transforms individual records after they have been written to an input topic.
-//! Resulting records are written to the output topic.
+//! Written records are output to the destination topic.
 
 use std::fmt::Debug;
 
@@ -53,19 +53,18 @@ pub use redpanda_transform_sdk_types::*;
 /// }
 ///
 /// // A transform that duplicates the record on the input topic to the output topic.
-/// fn my_transform(event: WriteEvent) -> Result<Vec<Record>> {
-///   Ok(vec![
-///     Record::new(
-///       event.record.key().map(|k| k.to_owned()),
-///       event.record.value().map(|v| v.to_owned()),
-///     )
-///   ])
+/// fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<()> {
+///   writer.write(Record::new(
+///     event.record.key().map(|k| k.to_owned()),
+///     event.record.value().map(|v| v.to_owned()),
+///   ))?;
+///   Ok(())
 /// }
 /// ```
 pub fn on_record_written<E, F>(cb: F) -> !
 where
     E: Debug,
-    F: Fn(WriteEvent) -> Result<Vec<Record>, E>,
+    F: Fn(WriteEvent, &mut dyn RecordWriter) -> Result<(), E>,
 {
     redpanda_transform_sdk_sys::process(cb)
 }


### PR DESCRIPTION
In a similar change to our Golang SDK (https://github.com/redpanda-data/redpanda/pull/15922), also have a non-buffering record writer to output transformed records to.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Data Transforms written in Rust now use a non-buffered write mechanism. Transforms that used to be written as

  ```
  fn my_transform(event: WriteEvent) -> Result<Vec<Record>> {
    Ok(vec![
      Record::new(
        event.record.key().map(|k| k.to_owned()),
        event.record.value().map(|v| v.to_owned()),
      )
    ])
  }
  ```

  Can now be written as

  ```
  fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<()> {
    writer.write(Record::new(
      event.record.key().map(|k| k.to_owned()),
      event.record.value().map(|v| v.to_owned()),
    ))?;
    Ok(())
  }
  ```


