### PR TITLE
rm_stm: remove dead code

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1539,9 +1539,6 @@ ss::future<> rm_stm::do_abort_old_txes() {
     for (auto& [k, _] : _mem_state.estimated) {
         pids.push_back(k);
     }
-    for (auto& [k, _] : _mem_state.tx_start) {
-        pids.push_back(k);
-    }
     for (auto& [k, _] : _log_state.ongoing_map) {
         pids.push_back(k);
     }
@@ -2421,11 +2418,9 @@ std::ostream& operator<<(std::ostream& o, const rm_stm::abort_snapshot& as) {
 std::ostream& operator<<(std::ostream& o, const rm_stm::mem_state& state) {
     fmt::print(
       o,
-      "{{ estimated: {}, tx_start: {}, tx_starts: {}, preparing: "
+      "{{ estimated: {}, preparing: "
       "{} }}",
       state.estimated.size(),
-      state.tx_start.size(),
-      state.tx_starts.size(),
       state.preparing.size());
     return o;
 }

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -514,10 +514,6 @@ private:
                      model::producer_identity,
                      model::offset>(_tracker))
           , tx_starts(mt::set<absl::btree_set, model::offset>(_tracker))
-          , expected(mt::map<
-                     absl::flat_hash_map,
-                     model::producer_identity,
-                     model::tx_seq>(_tracker))
           , preparing(mt::map<
                       absl::flat_hash_map,
                       model::producer_identity,
@@ -555,13 +551,7 @@ private:
           tx_start;
         // a heap of the first offsets of all ongoing transactions
         mt::set_t<absl::btree_set, model::offset> tx_starts;
-        // a set of ongoing sessions. we use it  to prevent some client protocol
-        // errors like the transactional writes outside of a transaction
-        mt::unordered_map_t<
-          absl::flat_hash_map,
-          model::producer_identity,
-          model::tx_seq>
-          expected;
+
         // `preparing` helps to identify failed prepare requests and use them to
         // filter out stale abort requests
         mt::unordered_map_t<
@@ -571,7 +561,6 @@ private:
           preparing;
 
         void forget(model::producer_identity pid) {
-            expected.erase(pid);
             estimated.erase(pid);
             preparing.erase(pid);
             auto tx_start_it = tx_start.find(pid);

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -507,11 +507,7 @@ private:
           , estimated(mt::map<
                       absl::flat_hash_map,
                       model::producer_identity,
-                      model::offset>(_tracker))
-          , preparing(mt::map<
-                      absl::flat_hash_map,
-                      model::producer_identity,
-                      prepare_marker>(_tracker)) {}
+                      model::offset>(_tracker)) {}
 
         ss::shared_ptr<util::mem_tracker> _tracker;
         // once raft's term has passed mem_state::term we wipe mem_state
@@ -535,19 +531,7 @@ private:
         // it with last_lso
         model::offset last_lso{-1};
 
-        // FIELDS TO GO AFTER GA
-        // `preparing` helps to identify failed prepare requests and use them to
-        // filter out stale abort requests
-        mt::unordered_map_t<
-          absl::flat_hash_map,
-          model::producer_identity,
-          prepare_marker>
-          preparing;
-
-        void forget(model::producer_identity pid) {
-            estimated.erase(pid);
-            preparing.erase(pid);
-        }
+        void forget(model::producer_identity pid) { estimated.erase(pid); }
     };
 
     ss::lw_shared_ptr<mutex> get_tx_lock(model::producer_id pid) {


### PR DESCRIPTION
mem_state::expected - This map is never written to, after commit
https://github.com/redpanda-data/redpanda/commit/d7fe6e796a732282a105959b7bbf59bb5f2673ae
mem_state::tx_start(s) - Unused after is_tx_ga=true 
mem_state::preparing - preparing phase is no longer used as a part of the protocol.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
