### PR TITLE
net: Cache value of local address

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -133,6 +133,7 @@ connection::connection(
   , _hook(hook)
   , _name(std::move(name))
   , _fd(std::move(f))
+  , _local_addr(_fd.local_address())
   , _in(_fd.input())
   , _out(_fd.output())
   , _probe(p)

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -54,12 +54,12 @@ public:
     ss::future<> write(ss::scattered_message<char> msg);
     ss::future<> shutdown();
     void shutdown_input();
-    ss::socket_address local_address() const noexcept {
-        return _fd.local_address();
+    const ss::socket_address& local_address() const noexcept {
+        return _local_addr;
     }
 
     // NOLINTNEXTLINE
-    const ss::socket_address addr;
+    const ss::socket_address addr; // remote addr
 
     /// Returns DN from client certificate
     ///
@@ -79,6 +79,7 @@ private:
     boost::intrusive::list<connection>& _hook;
     ss::sstring _name;
     ss::connected_socket _fd;
+    ss::socket_address _local_addr;
     ss::input_stream<char> _in;
     net::batched_output_stream _out;
     server_probe& _probe;


### PR DESCRIPTION
- Performance testing has shown excessive CPU time is spent when local_address() is called within a tight loop, this has been tracked down to the fact that ss::file_desc::local_address() invokes a system call, getsockname.

- To mitigate this issue, the connection class now caches the value of local address upon instantiation.

- Relates to: #15898

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Caches the connections local address preventing the need to make a system calls to grab this value when auditing events.
