### PR TITLE
rpk/transform/deploy: introduce --file flag

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1623,6 +1623,7 @@ class RpkTool:
             input_topic,
             "--output-topic",
             output_topic,
+            "--file",
             "/opt/transforms/tinygo/identity.wasm",
         ])
 


### PR DESCRIPTION
Instead of having the positional arg for a binary to deploy, use a flag,
so we can support other (mutually exclusive) binary sources.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* `rpk transform deploy` takes a `--file` flag to deploy a compiled WebAssembly binary.

