### PR TITLE
transform: prevent double processor starts

### DIFF
--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -112,6 +112,8 @@ TEST_F(ProcessorTestFixture, HandlesDoubleStops) {
     stop();
 }
 
+TEST_F(ProcessorTestFixture, HandlesDoubleStarts) { start(); }
+
 TEST_F(ProcessorTestFixture, ProcessOne) {
     auto batch = make_tiny_batch();
     push_batch(batch.share());

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -131,6 +131,11 @@ processor::processor(
 }
 
 ss::future<> processor::start() {
+    // Don't allow double starts of this module - we use the abort_requested
+    // flag to determine if the module is "running" or not.
+    if (!_as.abort_requested()) {
+        co_return;
+    }
     _as = {};
     co_await _source->start();
     co_await _offset_tracker->start();

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -269,6 +269,9 @@ void processor::report_lag(int64_t lag) {
 model::transform_id processor::id() const { return _id; }
 const model::ntp& processor::ntp() const { return _ntp; }
 const model::transform_metadata& processor::meta() const { return _meta; }
-bool processor::is_running() const { return !_task.available(); }
+bool processor::is_running() const {
+    // Only mark this as running if we've called start without calling stop.
+    return !_as.abort_requested();
+}
 int64_t processor::current_lag() const { return _last_reported_lag; }
 } // namespace transform


### PR DESCRIPTION
It's possible to get a double start of the processor if the wasm VM immediately stops, as we check to see if the task is running in the manager to decide if we start a processor or not. Fix that by correcting the predicate to be "have I called start without calling stop". Since the consequence of messing up reference counting is a crash, I've also added another cautionary check to start to prevent double starts.

I will followup with some ducktape tests around failing modules to hopefully check this kind of thing in the future.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug Fixes

* Prevent an assertion from being triggered when Wasm VMs fail immediately.
