### PR TITLE
rpk/transform/init: fix cargo.toml template

### DIFF
--- a/src/go/rpk/pkg/cli/transform/template/rust_template.go
+++ b/src/go/rpk/pkg/cli/transform/template/rust_template.go
@@ -27,7 +27,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-redpanda-transform-sdk = "*"
 `
 
 func WasmRustCargoConfig(name string) string {


### PR DESCRIPTION
We will manually add the package to get the latest version when using
`cargo add redpanda-transform-sdk`

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug Fixes

* Fix an issue with `Cargo.toml` when initializing a Rust Data Transform project via `rpk transform init`
