### PR TITLE
gha: create stale issue workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+# See all the configuration options here: https://github.com/actions/stale#all-options
+name: Mark stale issues
+
+on:
+  schedule:
+  - cron: '32 6 * * 1-5'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 90 # 3 months
+        days-before-close: 14 # 2 weeks
+        stale-issue-message: "This issue hasn't seen activity in 3 months. If you want to keep it open, post a comment or remove the `stale` label – otherwise this will be closed in two weeks."
+        close-issue-message: "This issue was closed due to lack of activity. Feel free to reopen if it's still relevant."
+        stale-issue-label: 'stale'
+        exempt-issue-labels: 'preserve'
+        any-of-labels: 'kind/bug'


### PR DESCRIPTION
A Github action to mark all bug reports that haven't had activity in 3 months as stale. Stale issues are closed after 2 weeks. This is setup using https://github.com/actions/stale

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
