### PR TITLE
ssx/work_queue: support recursive tasks

### DIFF
--- a/src/v/ssx/work_queue.h
+++ b/src/v/ssx/work_queue.h
@@ -15,6 +15,8 @@
 #include "ssx/future-util.h"
 
 #include <seastar/core/abort_source.hh>
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/condition-variable.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -43,8 +45,11 @@ public:
 private:
     void submit_after(ss::future<>, ss::noncopyable_function<ss::future<>()>);
 
+    ss::future<> process();
+
     error_reporter_fn _error_reporter;
-    ss::future<> _tail = ss::now();
+    ss::condition_variable _cond_var;
+    ss::chunked_fifo<ss::noncopyable_function<ss::future<>()>> _tasks;
     ss::abort_source _as;
     ss::gate _gate;
 };


### PR DESCRIPTION
There are situations where we need to support recursive tasks for the
transform subsystem, and in order to do that we can't keep a single
variable of the tail, as it's possible for recursive tasks to try to
tail off a single future. Fix this by tracking the pending work in an
explicit data structure.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug Fixes

* Fixes a crash if a WebAssembly function is deployed that immediately crashes.
