### PR TITLE
cloud_storage: Improve scrubber

### DIFF
--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -376,7 +376,7 @@ void scrub_segment_meta(
   segment_meta_anomalies& detected);
 
 struct anomalies
-  : serde::envelope<anomalies, serde::version<0>, serde::compat_version<0>> {
+  : serde::envelope<anomalies, serde::version<1>, serde::compat_version<0>> {
     // Missing partition manifests
     bool missing_partition_manifest{false};
     // Spillover manifests referenced by the manifest which were not
@@ -391,13 +391,21 @@ struct anomalies
     // the scrub of the full log completed.
     std::optional<model::timestamp> last_complete_scrub;
 
+    // Number of discarded anomalies
+    uint32_t num_discarded_missing_spillover_manifests{0};
+    uint32_t num_discarded_missing_segments{0};
+    uint32_t num_discarded_metadata_anomalies{0};
+
     auto serde_fields() {
         return std::tie(
           missing_partition_manifest,
           missing_spillover_manifests,
           missing_segments,
           segment_metadata_anomalies,
-          last_complete_scrub);
+          last_complete_scrub,
+          num_discarded_missing_spillover_manifests,
+          num_discarded_missing_segments,
+          num_discarded_metadata_anomalies);
     }
 
     bool has_value() const;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1741,7 +1741,7 @@ configuration::configuration()
       "cloud_storage_full_scrub_interval_ms",
       "Time interval between a final scrub and thte next scrub",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      1h)
+      12h)
   , cloud_storage_scrubbing_interval_jitter_ms(
       *this,
       "cloud_storage_scrubbing_interval_jitter_ms",

--- a/src/v/redpanda/admin/api-doc/shadow_indexing.json
+++ b/src/v/redpanda/admin/api-doc/shadow_indexing.json
@@ -203,8 +203,7 @@
           "summary": "Invoke trimming on the local cache of tiered storage objects",
           "operationId": "cloud_storage_cache_trim",
           "nickname": "post_cloud_storage_cache_trim",
-          "parameters": [
-          ]
+          "parameters": []
         }
       ]
     },
@@ -398,85 +397,84 @@
       "id": "partition_cloud_storage_status",
       "properties": {
         "cloud_storage_mode": {
-            "type": "string",
-            "description": "The partition's cloud storage mode (one of: disabled, write_only, read_only, full and read_replica)"
+          "type": "string",
+          "description": "The partition's cloud storage mode (one of: disabled, write_only, read_only, full and read_replica)"
         },
         "ms_since_last_manifest_upload": {
-            "type": "long",
-            "nullable": true,
-            "description": "Delta in milliseconds since the last upload of the partition's manifest"
+          "type": "long",
+          "nullable": true,
+          "description": "Delta in milliseconds since the last upload of the partition's manifest"
         },
         "ms_since_last_segment_upload": {
-            "type": "long",
-            "nullable": true,
-            "description": "Delta in milliseconds since the last segment upload for the partition"
+          "type": "long",
+          "nullable": true,
+          "description": "Delta in milliseconds since the last segment upload for the partition"
         },
         "ms_since_last_manifest_sync": {
-            "type": "long",
-            "nullable": true,
-            "description": "Delta in milliseconds since the last manifest sync (only present for read replicas)"
+          "type": "long",
+          "nullable": true,
+          "description": "Delta in milliseconds since the last manifest sync (only present for read replicas)"
         },
         "metadata_update_pending": {
           "type": "boolean",
           "description": "If true, the remote metadata may not yet include all segments that have been uploaded."
-
         },
         "total_log_size_bytes": {
-            "type": "long",
-            "description": "Total size of the log for the partition (overlap between local and cloud log is excluded)"
+          "type": "long",
+          "description": "Total size of the log for the partition (overlap between local and cloud log is excluded)"
         },
         "cloud_log_size_bytes": {
-            "type": "long",
-            "description": "Total size of the addressable cloud log for the partition"
+          "type": "long",
+          "description": "Total size of the addressable cloud log for the partition"
         },
         "stm_region_size_bytes": {
-            "type": "long",
-            "description": "Total size of the addressable segments in the STM region of the log"
+          "type": "long",
+          "description": "Total size of the addressable segments in the STM region of the log"
         },
         "archive_size_bytes": {
-            "type": "long",
-            "description": "Total size of the archive region of the log"
+          "type": "long",
+          "description": "Total size of the archive region of the log"
         },
         "local_log_size_bytes": {
-            "type": "long",
-            "description": "Total size of the addressable local log for the partition"
+          "type": "long",
+          "description": "Total size of the addressable local log for the partition"
         },
         "stm_region_segment_count": {
-            "type": "long",
-            "description": "Number of segments in the STM region of the cloud log"
+          "type": "long",
+          "description": "Number of segments in the STM region of the cloud log"
         },
         "cloud_log_segment_count": {
-            "type": "long",
-            "description": "Number of segments in the STM region of the cloud log"
+          "type": "long",
+          "description": "Number of segments in the STM region of the cloud log"
         },
         "local_log_segment_count": {
-            "type": "long",
-            "description": "Number of segments in the local log"
+          "type": "long",
+          "description": "Number of segments in the local log"
         },
         "cloud_log_start_offset": {
-            "type": "long",
-            "nullable": true,
-            "description": "The first Kafka offset accessible from the cloud (inclusive)"
+          "type": "long",
+          "nullable": true,
+          "description": "The first Kafka offset accessible from the cloud (inclusive)"
         },
         "stm_region_start_offset": {
-            "type": "long",
-            "nullable": true,
-            "description": "The first Kafka offset accessible from the cloud in the STM region (inclusive)"
+          "type": "long",
+          "nullable": true,
+          "description": "The first Kafka offset accessible from the cloud in the STM region (inclusive)"
         },
         "cloud_log_last_offset": {
-            "type": "long",
-            "nullable": true,
-            "description": "The last Kafka offset accessible from the cloud (inclusive)"
+          "type": "long",
+          "nullable": true,
+          "description": "The last Kafka offset accessible from the cloud (inclusive)"
         },
         "local_log_start_offset": {
-            "type": "long",
-            "nullable": true,
-            "description": "The first Kafka offset accessible locally (inclusive)"
+          "type": "long",
+          "nullable": true,
+          "description": "The first Kafka offset accessible locally (inclusive)"
         },
         "local_log_last_offset": {
-            "type": "long",
-            "nullable": true,
-            "description": "The last Kafka offset accessible locally (inclusive)"
+          "type": "long",
+          "nullable": true,
+          "description": "The last Kafka offset accessible locally (inclusive)"
         }
       }
     },
@@ -504,7 +502,9 @@
       "properties": {
         "markers": {
           "type": "array",
-          "items": {"type":  "lifecycle_marker"}
+          "items": {
+            "type": "lifecycle_marker"
+          }
         }
       }
     },
@@ -590,20 +590,38 @@
         },
         "missing_spillover_manifests": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "nullable": true
         },
         "missing_segments": {
           "type": "array",
-          "items": {"type": "string"},
+          "items": {
+            "type": "string"
+          },
           "nullable": true
         },
         "segment_metadata_anomalies": {
           "type": "array",
-          "items": {"type": "metadata_anomaly"},
+          "items": {
+            "type": "metadata_anomaly"
+          },
           "nullable": true
         },
         "last_complete_scrub_at": {
+          "type": "long",
+          "nullable": true
+        },
+        "num_discarded_missing_spillover_manifests": {
+          "type": "long",
+          "nullable": true
+        },
+        "num_discarded_missing_segments": {
+          "type": "long",
+          "nullable": true
+        },
+        "num_discarded_metadata_anomalies": {
           "type": "long",
           "nullable": true
         }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3868,6 +3868,21 @@ map_anomalies_to_json(
         json.last_complete_scrub_at = detected.last_complete_scrub->value();
     }
 
+    if (detected.num_discarded_missing_spillover_manifests) {
+        json.num_discarded_missing_spillover_manifests
+          = detected.num_discarded_missing_spillover_manifests;
+    }
+
+    if (detected.num_discarded_missing_segments) {
+        json.num_discarded_missing_segments
+          = detected.num_discarded_missing_segments;
+    }
+
+    if (detected.num_discarded_metadata_anomalies) {
+        json.num_discarded_metadata_anomalies
+          = detected.num_discarded_metadata_anomalies;
+    }
+
     if (detected.missing_partition_manifest) {
         json.missing_partition_manifest = true;
     }


### PR DESCRIPTION
Limit number of scrubber anomalies in memory to 100.
Limit full scrub interval to 10h.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


* none