### PR TITLE
tx_migration: avoid ping pong of requests between brokers

### DIFF
--- a/src/v/cluster/leader_router.h
+++ b/src/v/cluster/leader_router.h
@@ -182,8 +182,9 @@ ss::future<resp_t> leader_router<req_t, resp_t, handler_t>::process_or_dispatch(
         } else {
             vlog(
               clusterlog.trace,
-              "dispatching {} from {} to {} ",
+              "dispatching request {} for ntp {} from {} to {}",
               handler_t::process_name(),
+              ntp,
               _self,
               leader);
             r = co_await dispatch_to_leader(req, leader, timeout);
@@ -206,9 +207,13 @@ ss::future<resp_t> leader_router<req_t, resp_t, handler_t>::process_or_dispatch(
           fmt::runtime("{} failed with {}"), handler_t::process_name(), r.ec);
         vlog(
           clusterlog.trace,
-          "{} failed, retries left: {}",
+          "request {} for ntp {} failed, error: {} retries left: {}, delay ms: "
+          "{}",
           handler_t::process_name(),
-          retries);
+          ntp,
+          error,
+          retries,
+          delay_ms.count());
         co_await sleep_abortable(delay_ms, _as);
     }
     if (error) {

--- a/src/v/cluster/migrations/tx_manager_migrator_handler.h
+++ b/src/v/cluster/migrations/tx_manager_migrator_handler.h
@@ -42,14 +42,14 @@ public:
     ss::future<tx_manager_replicate_reply> tx_manager_replicate(
       tx_manager_replicate_request&& request, ::rpc::streaming_context&) final {
         auto ntp = request.ntp;
-        return _replicate_router.process_or_dispatch(
+        return _replicate_router.find_shard_and_process(
           std::move(request), ntp, tx_manager_migrator::default_timeout);
     }
 
     ss::future<tx_manager_read_reply> tx_manager_read(
       tx_manager_read_request&& request, ::rpc::streaming_context&) final {
         auto ntp = request.ntp;
-        return _read_router.process_or_dispatch(
+        return _read_router.find_shard_and_process(
           std::move(request), ntp, tx_manager_migrator::default_timeout);
     }
 


### PR DESCRIPTION
When leader table is stale (say at startup or during failures), the
current code can result in a ping pong of requests between two brokers
in a tight loop.

Example

- tx_migration_replicate dispatched from node 1 to node 2 (because node 1
thinks node 2 is the leader)
- node 2 dispatches the request back to node 1 because it thinks node 1
is the leader.

Until leadership stabilizes this results in a huge pile up of requests
which manifested as an oversized allocation.

Don't think a router is the right choice in the handler as the handler
is supposed to process the request locally. If it returns an error, it
is propagated to the source router which dispatches to the correct
leader. This also breaks the ping pong loop as the source router has
sleeps induced for retry backoff.

Fixes: https://github.com/redpanda-data/redpanda/issues/15901

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
