### PR TITLE
Add partition aggregation to some metrics

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -2498,7 +2498,7 @@ void rm_stm::setup_metrics() {
           labels),
       },
       {},
-      {sm::shard_label});
+      {sm::shard_label, partition_label});
 }
 
 ss::future<> rm_stm::maybe_log_tx_stats() {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -44,6 +44,7 @@
 #include <seastar/core/fstream.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/metrics.hh>
 #include <seastar/core/semaphore.hh>
 #include <seastar/util/defer.hh>
 
@@ -185,7 +186,7 @@ void consensus::setup_metrics() {
           labels),
       },
       {},
-      {sm::shard_label});
+      {sm::shard_label, sm::label("partition")});
 }
 
 void consensus::setup_public_metrics() {

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -159,6 +159,8 @@ void probe::setup_metrics(const model::ntp& ntp) {
     _metrics.add_group(
       group_name,
       {
+        // compaction_ratio cannot easily be aggregated since aggregation always
+        // sums values and sum is nonsensical for a compaction ratio
         sm::make_total_bytes(
           "compaction_ratio",
           [this] { return _compaction_ratio; },


### PR DESCRIPTION
This series adds partition label aggregation to some metrics that were missing it.

When metrics aggregation is turned on, we want to aggregate away the partition labels on most metrics: this wasn't occurring in some cases, perhaps due to oversight (this logic needs to be applied at each metrics registration site), or because it was believed that the metrics were not suitable for aggregation.

This change enable aggregation on the partition label for most metrics, leaving 3+1 unaggregated as detailed in this comment:

https://github.com/redpanda-data/core-internal/issues/677#issuecomment-1879103823

It affects only the internal `/metrics` endpoint.

Fixes #15811.
Fixes redpanda-data/core-internal#677.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug Fixes

* Several additional metrics will have their "partition" label aggregated away (i.e., into a single series per remaining label set with no partition label, whose value is the sum of all input series with the same label set and different partition labels). This is already the default behavior for most metrics, but this change extends it to almost all remaining metrics.