### PR TITLE
wasm: add runtime and max binary configs

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -193,6 +193,24 @@ configuration::configuration()
       2_MiB,
       // WebAssembly uses 64KiB pages and has a 32bit address space
       {.min = 64_KiB, .max = 4_GiB})
+  , data_transforms_runtime_limit_ms(
+      *this,
+      "data_transforms_runtime_limit_ms",
+      "The maximum amount of runtime for startup time of a data transform, and "
+      "the time it takes for a single record to be transformed.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      3s)
+  , data_transforms_binary_max_size(
+      *this,
+      "data_transforms_binary_max_size",
+      "The maximum size for a deployable WebAssembly binary that the broker "
+      "can store.",
+      {
+        .needs_restart = needs_restart::no,
+        .visibility = visibility::tunable,
+      },
+      10_MiB,
+      {.min = 1_MiB, .max = 128_MiB})
   , topic_memory_per_partition(
       *this,
       "topic_memory_per_partition",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -72,6 +72,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds> data_transforms_commit_interval_ms;
     bounded_property<size_t> data_transforms_per_core_memory_reservation;
     bounded_property<size_t> data_transforms_per_function_memory_limit;
+    property<std::chrono::milliseconds> data_transforms_runtime_limit_ms;
+    bounded_property<size_t> data_transforms_binary_max_size;
 
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2418,6 +2418,9 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
           .stack_memory = {
             .debug_host_stack_usage = false,
           },
+          .cpu = {
+            .per_invocation_timeout = cluster.data_transforms_runtime_limit_ms.value(),
+          },
         };
         _wasm_runtime->start(config).get();
         _transform_service.invoke_on_all(&transform::service::start).get();

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -138,6 +138,12 @@ public:
       int32_t partition_count,
       cluster::topic_properties)
       = 0;
+
+    /**
+     * Update a topic.
+     */
+    virtual ss::future<cluster::errc>
+      update_topic(cluster::topic_properties_update) = 0;
 };
 
 /**

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -17,6 +17,7 @@
 #include "seastarx.h"
 #include "wasm/fwd.h"
 
+#include <chrono>
 #include <memory>
 
 namespace wasm {
@@ -101,6 +102,16 @@ public:
             bool debug_host_stack_usage;
         };
         stack_memory stack_memory;
+        struct cpu {
+            // per transform timeout (CPU time) also is applied for startup
+            // timeout.
+            //
+            // NOTE: This is translated into fuel (instruction count limits) so
+            // it's an approximate limit in terms of actual timeout at the
+            // moment.
+            std::chrono::milliseconds per_invocation_timeout;
+        };
+        cpu cpu;
     };
 
     virtual ss::future<> start(config) = 0;

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -149,6 +149,9 @@ void WasmTestFixture::SetUp() {
           .debug_host_stack_usage = false,
 #endif
         },
+        .cpu = {
+          .per_invocation_timeout = 3s,
+        },
     };
     _runtime->start(wasm_runtime_config).get();
     _meta = {

--- a/src/v/wasm/tests/wasm_transform_bench.cc
+++ b/src/v/wasm/tests/wasm_transform_bench.cc
@@ -53,6 +53,9 @@ public:
                 .stack_memory = {
                   .debug_host_stack_usage = false,
                 },
+                .cpu = {
+                  .per_invocation_timeout = 30s,
+                },
             };
             co_await _runtime->start(wasm_runtime_config);
         }


### PR DESCRIPTION
Support 2 new cluster tunables:

- Max wasm binary size
- Wasm function max runtime

Before these were not tunables, but hardcoded. This allows overriding these if needed.

Note that the max wasm binary size isn't dynamic, and is harder to do that without passing a sharded config property. So as a stop gap, it's marked as needing a restart.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Support dynamically changing the limit for WebAssembly binary size
* Support changing the timeout for WebAssembly functions

