### PR TITLE
rpc: pass requests by value

### DIFF
--- a/src/v/cluster/bootstrap_service.cc
+++ b/src/v/cluster/bootstrap_service.cc
@@ -20,7 +20,7 @@ namespace cluster {
 
 ss::future<cluster_bootstrap_info_reply>
 bootstrap_service::cluster_bootstrap_info(
-  cluster_bootstrap_info_request&&, rpc::streaming_context&) {
+  cluster_bootstrap_info_request, rpc::streaming_context&) {
     cluster_bootstrap_info_reply r{};
     r.broker = make_self_broker(config::node());
     r.version = features::feature_table::get_latest_logical_version();

--- a/src/v/cluster/bootstrap_service.h
+++ b/src/v/cluster/bootstrap_service.h
@@ -28,7 +28,7 @@ public:
       , _storage(storage) {}
 
     ss::future<cluster_bootstrap_info_reply> cluster_bootstrap_info(
-      cluster_bootstrap_info_request&&, rpc::streaming_context&) override;
+      cluster_bootstrap_info_request, rpc::streaming_context&) override;
 
 private:
     ss::sharded<storage::api>& _storage;

--- a/src/v/cluster/cloud_metadata/offsets_recovery_service.h
+++ b/src/v/cluster/cloud_metadata/offsets_recovery_service.h
@@ -36,19 +36,19 @@ public:
             .cloud_storage_cluster_metadata_upload_timeout_ms.bind()) {}
 
     ss::future<offsets_lookup_reply> offsets_lookup(
-      offsets_lookup_request&& req, rpc::streaming_context&) override {
+      offsets_lookup_request req, rpc::streaming_context&) override {
         co_return co_await _offsets_lookup.local().lookup(std::move(req));
     }
 
     ss::future<offsets_upload_reply> offsets_upload(
-      offsets_upload_request&& req, rpc::streaming_context& ctx) override {
+      offsets_upload_request req, rpc::streaming_context& ctx) override {
         auto ntp = req.offsets_ntp;
         co_return co_await _offsets_upload_router.local().process_or_dispatch(
           std::move(req), std::move(ntp), _metadata_timeout_ms());
     }
 
     ss::future<offsets_recovery_reply> offsets_recovery(
-      offsets_recovery_request&& req, rpc::streaming_context& ctx) override {
+      offsets_recovery_request req, rpc::streaming_context& ctx) override {
         auto ntp = req.offsets_ntp;
         co_return co_await _offsets_recovery_router.local().process_or_dispatch(
           std::move(req), std::move(ntp), 30s);

--- a/src/v/cluster/ephemeral_credential_service.cc
+++ b/src/v/cluster/ephemeral_credential_service.cc
@@ -15,7 +15,7 @@ namespace cluster {
 
 ss::future<put_ephemeral_credential_reply>
 ephemeral_credential_service::put_ephemeral_credential(
-  put_ephemeral_credential_request&& r, rpc::streaming_context&) {
+  put_ephemeral_credential_request r, rpc::streaming_context&) {
     co_await _fe.local().put(r.principal, r.user, r.credential);
     co_return errc::success;
 }

--- a/src/v/cluster/ephemeral_credential_service.h
+++ b/src/v/cluster/ephemeral_credential_service.h
@@ -23,7 +23,7 @@ public:
       , _fe(fe) {}
 
     ss::future<put_ephemeral_credential_reply> put_ephemeral_credential(
-      put_ephemeral_credential_request&&, rpc::streaming_context&) override;
+      put_ephemeral_credential_request, rpc::streaming_context&) override;
 
 private:
     ss::sharded<ephemeral_credential_frontend>& _fe;

--- a/src/v/cluster/id_allocator.cc
+++ b/src/v/cluster/id_allocator.cc
@@ -27,7 +27,7 @@ id_allocator::id_allocator(
   , _id_allocator_frontend(id_allocator_frontend) {}
 
 ss::future<allocate_id_reply>
-id_allocator::allocate_id(allocate_id_request&& req, rpc::streaming_context&) {
+id_allocator::allocate_id(allocate_id_request req, rpc::streaming_context&) {
     auto timeout = req.timeout;
     return _id_allocator_frontend.local()
       .allocator_router()
@@ -36,7 +36,7 @@ id_allocator::allocate_id(allocate_id_request&& req, rpc::streaming_context&) {
 }
 
 ss::future<reset_id_allocator_reply> id_allocator::reset_id_allocator(
-  reset_id_allocator_request&& req, rpc::streaming_context&) {
+  reset_id_allocator_request req, rpc::streaming_context&) {
     auto timeout = req.timeout;
     return _id_allocator_frontend.local().id_reset_router().process_or_dispatch(
       std::move(req), model::id_allocator_ntp, timeout);

--- a/src/v/cluster/id_allocator.h
+++ b/src/v/cluster/id_allocator.h
@@ -25,10 +25,10 @@ public:
       ss::sharded<cluster::id_allocator_frontend>&);
 
     virtual ss::future<allocate_id_reply>
-    allocate_id(allocate_id_request&&, rpc::streaming_context&) final;
+    allocate_id(allocate_id_request, rpc::streaming_context&) final;
 
     virtual ss::future<reset_id_allocator_reply> reset_id_allocator(
-      reset_id_allocator_request&&, rpc::streaming_context&) final;
+      reset_id_allocator_request, rpc::streaming_context&) final;
 
 private:
     ss::sharded<cluster::id_allocator_frontend>& _id_allocator_frontend;

--- a/src/v/cluster/metadata_dissemination_handler.cc
+++ b/src/v/cluster/metadata_dissemination_handler.cc
@@ -38,7 +38,7 @@ metadata_dissemination_handler::metadata_dissemination_handler(
 
 ss::future<update_leadership_reply>
 metadata_dissemination_handler::update_leadership_v2(
-  update_leadership_request_v2&& req, rpc::streaming_context&) {
+  update_leadership_request_v2 req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req = std::move(req)]() mutable {
           return do_update_leadership(std::move(req.leaders));
@@ -88,7 +88,7 @@ make_get_leadership_reply(const partition_leaders_table& leaders) {
 }
 
 ss::future<get_leadership_reply> metadata_dissemination_handler::get_leadership(
-  get_leadership_request&&, rpc::streaming_context&) {
+  get_leadership_request, rpc::streaming_context&) {
     return ss::with_scheduling_group(get_scheduling_group(), [this]() mutable {
         return ss::make_ready_future<get_leadership_reply>(
           make_get_leadership_reply(_leaders.local()));

--- a/src/v/cluster/metadata_dissemination_handler.h
+++ b/src/v/cluster/metadata_dissemination_handler.h
@@ -40,10 +40,10 @@ public:
       ss::sharded<partition_leaders_table>&);
 
     ss::future<get_leadership_reply>
-    get_leadership(get_leadership_request&&, rpc::streaming_context&) final;
+    get_leadership(get_leadership_request, rpc::streaming_context&) final;
 
     ss::future<update_leadership_reply> update_leadership_v2(
-      update_leadership_request_v2&&, rpc::streaming_context&) final;
+      update_leadership_request_v2, rpc::streaming_context&) final;
 
 private:
     ss::future<update_leadership_reply>

--- a/src/v/cluster/migrations/tx_manager_migrator_handler.h
+++ b/src/v/cluster/migrations/tx_manager_migrator_handler.h
@@ -40,14 +40,14 @@ public:
           pm, st, metadata_cache, connection_cache, leaders, self) {}
 
     ss::future<tx_manager_replicate_reply> tx_manager_replicate(
-      tx_manager_replicate_request&& request, ::rpc::streaming_context&) final {
+      tx_manager_replicate_request request, ::rpc::streaming_context&) final {
         auto ntp = request.ntp;
         return _replicate_router.process_or_dispatch(
           std::move(request), ntp, tx_manager_migrator::default_timeout);
     }
 
     ss::future<tx_manager_read_reply> tx_manager_read(
-      tx_manager_read_request&& request, ::rpc::streaming_context&) final {
+      tx_manager_read_request request, ::rpc::streaming_context&) final {
         auto ntp = request.ntp;
         return _read_router.process_or_dispatch(
           std::move(request), ntp, tx_manager_migrator::default_timeout);

--- a/src/v/cluster/node_status_rpc_handler.cc
+++ b/src/v/cluster/node_status_rpc_handler.cc
@@ -10,7 +10,7 @@ node_status_rpc_handler::node_status_rpc_handler(
   , _node_status_backend(node_status_backend) {}
 
 ss::future<node_status_reply> node_status_rpc_handler::node_status(
-  node_status_request&& r, rpc::streaming_context&) {
+  node_status_request r, rpc::streaming_context&) {
     return _node_status_backend.invoke_on(
       node_status_backend::shard, [r = std::move(r)](auto& service) {
           return service.process_request(std::move(r));

--- a/src/v/cluster/node_status_rpc_handler.h
+++ b/src/v/cluster/node_status_rpc_handler.h
@@ -14,7 +14,7 @@ public:
       ss::sharded<node_status_backend>&);
 
     virtual ss::future<node_status_reply>
-    node_status(node_status_request&&, rpc::streaming_context&) override;
+    node_status(node_status_request, rpc::streaming_context&) override;
 
 private:
     ss::sharded<node_status_backend>& _node_status_backend;

--- a/src/v/cluster/partition_balancer_rpc_handler.cc
+++ b/src/v/cluster/partition_balancer_rpc_handler.cc
@@ -23,7 +23,7 @@ partition_balancer_rpc_handler::partition_balancer_rpc_handler(
 
 ss::future<partition_balancer_overview_reply>
 partition_balancer_rpc_handler::overview(
-  partition_balancer_overview_request&&, rpc::streaming_context&) {
+  partition_balancer_overview_request, rpc::streaming_context&) {
     auto overview = co_await _backend.invoke_on(
       partition_balancer_backend::shard,
       [](partition_balancer_backend& backend) { return backend.overview(); });

--- a/src/v/cluster/partition_balancer_rpc_handler.h
+++ b/src/v/cluster/partition_balancer_rpc_handler.h
@@ -27,7 +27,7 @@ public:
       ss::sharded<partition_balancer_backend>&);
 
     virtual ss::future<partition_balancer_overview_reply> overview(
-      partition_balancer_overview_request&&, rpc::streaming_context&) override;
+      partition_balancer_overview_request, rpc::streaming_context&) override;
 
 private:
     ss::sharded<partition_balancer_backend>& _backend;

--- a/src/v/cluster/self_test_rpc_handler.cc
+++ b/src/v/cluster/self_test_rpc_handler.cc
@@ -21,28 +21,28 @@ self_test_rpc_handler::self_test_rpc_handler(
   , _self_test_backend(backend) {}
 
 ss::future<get_status_response> self_test_rpc_handler::start_test(
-  start_test_request&& r, rpc::streaming_context&) {
+  start_test_request r, rpc::streaming_context&) {
     return _self_test_backend.invoke_on(
       self_test_backend::shard,
       [r](auto& service) { return service.start_test(r); });
 }
 
 ss::future<get_status_response>
-self_test_rpc_handler::stop_test(empty_request&&, rpc::streaming_context&) {
+self_test_rpc_handler::stop_test(empty_request, rpc::streaming_context&) {
     return _self_test_backend.invoke_on(
       self_test_backend::shard,
       [](auto& service) { return service.stop_test(); });
 }
 
 ss::future<get_status_response>
-self_test_rpc_handler::get_status(empty_request&&, rpc::streaming_context&) {
+self_test_rpc_handler::get_status(empty_request, rpc::streaming_context&) {
     return _self_test_backend.invoke_on(
       self_test_backend::shard,
       [](auto& service) { return service.get_status(); });
 }
 
 ss::future<netcheck_response>
-self_test_rpc_handler::netcheck(netcheck_request&& r, rpc::streaming_context&) {
+self_test_rpc_handler::netcheck(netcheck_request r, rpc::streaming_context&) {
     return _self_test_backend.invoke_on(
       self_test_backend::shard, [r = std::move(r)](auto& service) mutable {
           return service.netcheck(r.source, std::move(r.buf));

--- a/src/v/cluster/self_test_rpc_handler.h
+++ b/src/v/cluster/self_test_rpc_handler.h
@@ -25,16 +25,16 @@ public:
       ss::sharded<self_test_backend>&);
 
     ss::future<get_status_response>
-    start_test(start_test_request&&, rpc::streaming_context&) final;
+    start_test(start_test_request, rpc::streaming_context&) final;
 
     ss::future<get_status_response>
-    stop_test(empty_request&&, rpc::streaming_context&) final;
+    stop_test(empty_request, rpc::streaming_context&) final;
 
     ss::future<get_status_response>
-    get_status(empty_request&&, rpc::streaming_context&) final;
+    get_status(empty_request, rpc::streaming_context&) final;
 
     ss::future<netcheck_response>
-    netcheck(netcheck_request&&, rpc::streaming_context&) final;
+    netcheck(netcheck_request, rpc::streaming_context&) final;
 
 private:
     ss::sharded<self_test_backend>& _self_test_backend;

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -75,7 +75,7 @@ service::service(
   , _plugin_frontend(pf) {}
 
 ss::future<join_node_reply>
-service::join_node(join_node_request&& req, rpc::streaming_context&) {
+service::join_node(join_node_request req, rpc::streaming_context&) {
     cluster_version expect_version
       = _feature_table.local().get_active_version();
     if (expect_version == invalid_version) {
@@ -130,7 +130,7 @@ service::join_node(join_node_request&& req, rpc::streaming_context&) {
 }
 
 ss::future<create_topics_reply>
-service::create_topics(create_topics_request&& r, rpc::streaming_context&) {
+service::create_topics(create_topics_request r, rpc::streaming_context&) {
     return ss::with_scheduling_group(
              get_scheduling_group(),
              [this, r = std::move(r)]() mutable {
@@ -147,7 +147,7 @@ service::create_topics(create_topics_request&& r, rpc::streaming_context&) {
 }
 
 ss::future<purged_topic_reply>
-service::purged_topic(purged_topic_request&& r, rpc::streaming_context&) {
+service::purged_topic(purged_topic_request r, rpc::streaming_context&) {
     return ss::with_scheduling_group(
              get_scheduling_group(),
              [this, r = std::move(r)]() mutable {
@@ -177,7 +177,7 @@ service::fetch_metadata_and_cfg(const std::vector<topic_result>& res) {
 }
 
 ss::future<configuration_update_reply> service::update_node_configuration(
-  configuration_update_request&& req, rpc::streaming_context&) {
+  configuration_update_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req = std::move(req)]() mutable {
           return _members_manager
@@ -197,7 +197,7 @@ ss::future<configuration_update_reply> service::update_node_configuration(
 }
 
 ss::future<finish_partition_update_reply> service::finish_partition_update(
-  finish_partition_update_request&& req, rpc::streaming_context&) {
+  finish_partition_update_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req = std::move(req)]() mutable {
           return do_finish_partition_update(std::move(req));
@@ -205,7 +205,7 @@ ss::future<finish_partition_update_reply> service::finish_partition_update(
 }
 
 ss::future<finish_partition_update_reply>
-service::do_finish_partition_update(finish_partition_update_request&& req) {
+service::do_finish_partition_update(finish_partition_update_request req) {
     auto ec
       = co_await _topics_frontend.local().finish_moving_partition_replicas(
         req.ntp,
@@ -225,7 +225,7 @@ service::do_finish_partition_update(finish_partition_update_request&& req) {
 }
 
 ss::future<update_topic_properties_reply> service::update_topic_properties(
-  update_topic_properties_request&& req, rpc::streaming_context&) {
+  update_topic_properties_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req = std::move(req)]() mutable {
           return do_update_topic_properties(std::move(req));
@@ -233,7 +233,7 @@ ss::future<update_topic_properties_reply> service::update_topic_properties(
 }
 
 ss::future<update_topic_properties_reply>
-service::do_update_topic_properties(update_topic_properties_request&& req) {
+service::do_update_topic_properties(update_topic_properties_request req) {
     // local topic frontend instance will eventually dispatch request to _raft0
     // core
     auto res = co_await _topics_frontend.local().update_topic_properties(
@@ -245,7 +245,7 @@ service::do_update_topic_properties(update_topic_properties_request&& req) {
 }
 
 ss::future<create_acls_reply>
-service::create_acls(create_acls_request&& request, rpc::streaming_context&) {
+service::create_acls(create_acls_request request, rpc::streaming_context&) {
     return ss::with_scheduling_group(
              get_scheduling_group(),
              [this, r = std::move(request)]() mutable {
@@ -258,7 +258,7 @@ service::create_acls(create_acls_request&& request, rpc::streaming_context&) {
 }
 
 ss::future<delete_acls_reply>
-service::delete_acls(delete_acls_request&& request, rpc::streaming_context&) {
+service::delete_acls(delete_acls_request request, rpc::streaming_context&) {
     return ss::with_scheduling_group(
              get_scheduling_group(),
              [this, r = std::move(request)]() mutable {
@@ -271,7 +271,7 @@ service::delete_acls(delete_acls_request&& request, rpc::streaming_context&) {
 }
 
 ss::future<reconciliation_state_reply> service::get_reconciliation_state(
-  reconciliation_state_request&& req, rpc::streaming_context&) {
+  reconciliation_state_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req = std::move(req)]() mutable {
           return do_get_reconciliation_state(std::move(req));
@@ -286,7 +286,7 @@ service::do_get_reconciliation_state(reconciliation_state_request req) {
 }
 
 ss::future<decommission_node_reply> service::decommission_node(
-  decommission_node_request&& req, rpc::streaming_context&) {
+  decommission_node_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req]() mutable {
           return _members_frontend.local().decommission_node(req.id).then(
@@ -304,7 +304,7 @@ ss::future<decommission_node_reply> service::decommission_node(
 }
 
 ss::future<recommission_node_reply> service::recommission_node(
-  recommission_node_request&& req, rpc::streaming_context&) {
+  recommission_node_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req]() mutable {
           return _members_frontend.local().recommission_node(req.id).then(
@@ -322,7 +322,7 @@ ss::future<recommission_node_reply> service::recommission_node(
 }
 
 ss::future<finish_reallocation_reply> service::finish_reallocation(
-  finish_reallocation_request&& req, rpc::streaming_context&) {
+  finish_reallocation_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(),
       [this, req]() mutable { return do_finish_reallocation(req); });
@@ -330,14 +330,14 @@ ss::future<finish_reallocation_reply> service::finish_reallocation(
 
 ss::future<revert_cancel_partition_move_reply>
 service::revert_cancel_partition_move(
-  revert_cancel_partition_move_request&& req, rpc::streaming_context&) {
+  revert_cancel_partition_move_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(),
       [this, req]() mutable { return do_revert_cancel_partition_move(req); });
 }
 
 ss::future<set_maintenance_mode_reply> service::set_maintenance_mode(
-  set_maintenance_mode_request&& req, rpc::streaming_context&) {
+  set_maintenance_mode_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req]() mutable {
           return _members_frontend.local()
@@ -365,7 +365,7 @@ ss::future<set_maintenance_mode_reply> service::set_maintenance_mode(
  * start calling for votes which may cause disruption.
  */
 ss::future<hello_reply>
-service::hello(hello_request&& req, rpc::streaming_context&) {
+service::hello(hello_request req, rpc::streaming_context&) {
     vlog(
       clusterlog.debug,
       "Handling hello request from node {} with start time {}",
@@ -385,7 +385,7 @@ service::hello(hello_request&& req, rpc::streaming_context&) {
 }
 
 ss::future<config_status_reply>
-service::config_status(config_status_request&& req, rpc::streaming_context&) {
+service::config_status(config_status_request req, rpc::streaming_context&) {
     // Move to stack to avoid referring to reference argument after a
     // scheduling point
     auto status = std::move(req.status);
@@ -416,7 +416,7 @@ service::config_status(config_status_request&& req, rpc::streaming_context&) {
 }
 
 ss::future<config_update_reply>
-service::config_update(config_update_request&& req, rpc::streaming_context&) {
+service::config_update(config_update_request req, rpc::streaming_context&) {
     auto patch_result = co_await _config_frontend.invoke_on(
       config_frontend::version_shard,
       [req = std::move(req)](config_frontend& fe) mutable {
@@ -489,7 +489,7 @@ cluster::errc map_health_monitor_error_code(std::error_code e) {
 }
 
 ss::future<get_node_health_reply> service::collect_node_health_report(
-  get_node_health_request&& req, rpc::streaming_context&) {
+  get_node_health_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req = std::move(req)]() mutable {
           return do_collect_node_health_report(std::move(req));
@@ -497,7 +497,7 @@ ss::future<get_node_health_reply> service::collect_node_health_report(
 }
 
 ss::future<get_cluster_health_reply> service::get_cluster_health_report(
-  get_cluster_health_request&& req, rpc::streaming_context&) {
+  get_cluster_health_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(
       get_scheduling_group(), [this, req = std::move(req)]() mutable {
           return do_get_cluster_health_report(std::move(req));
@@ -581,7 +581,7 @@ service::do_get_cluster_health_report(get_cluster_health_request req) {
 }
 
 ss::future<feature_action_response>
-service::feature_action(feature_action_request&& req, rpc::streaming_context&) {
+service::feature_action(feature_action_request req, rpc::streaming_context&) {
     co_await _feature_manager.invoke_on(
       feature_manager::backend_shard,
       [req = std::move(req)](feature_manager& fm) {
@@ -593,8 +593,8 @@ service::feature_action(feature_action_request&& req, rpc::streaming_context&) {
     };
 }
 
-ss::future<feature_barrier_response> service::feature_barrier(
-  feature_barrier_request&& req, rpc::streaming_context&) {
+ss::future<feature_barrier_response>
+service::feature_barrier(feature_barrier_request req, rpc::streaming_context&) {
     auto result = co_await _feature_manager.invoke_on(
       feature_manager::backend_shard,
       [req = std::move(req)](feature_manager& fm) {
@@ -607,14 +607,14 @@ ss::future<feature_barrier_response> service::feature_barrier(
 
 ss::future<cancel_partition_movements_reply>
 service::cancel_all_partition_movements(
-  cancel_all_partition_movements_request&& req, rpc::streaming_context&) {
+  cancel_all_partition_movements_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(get_scheduling_group(), [this, req]() {
         return do_cancel_all_partition_movements(req);
     });
 }
 ss::future<cancel_partition_movements_reply>
 service::cancel_node_partition_movements(
-  cancel_node_partition_movements_request&& req, rpc::streaming_context&) {
+  cancel_node_partition_movements_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(get_scheduling_group(), [this, req]() {
         return do_cancel_node_partition_movements(req);
     });
@@ -655,7 +655,7 @@ service::do_cancel_node_partition_movements(
 }
 
 ss::future<transfer_leadership_reply> service::transfer_leadership(
-  transfer_leadership_request&& r, rpc::streaming_context&) {
+  transfer_leadership_request r, rpc::streaming_context&) {
     auto shard_id = _api.local().shard_for(r.group);
     if (!shard_id.has_value()) {
         co_return transfer_leadership_reply{
@@ -680,7 +680,7 @@ ss::future<transfer_leadership_reply> service::transfer_leadership(
 }
 
 ss::future<producer_id_lookup_reply> service::highest_producer_id(
-  producer_id_lookup_request&&, rpc::streaming_context&) {
+  producer_id_lookup_request, rpc::streaming_context&) {
     producer_id_lookup_reply reply;
     auto highest_pid = co_await _partition_manager.map_reduce0(
       [](const partition_manager& pm) {
@@ -701,7 +701,7 @@ ss::future<producer_id_lookup_reply> service::highest_producer_id(
 }
 
 ss::future<cloud_storage_usage_reply> service::cloud_storage_usage(
-  cloud_storage_usage_request&& req, rpc::streaming_context&) {
+  cloud_storage_usage_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(get_scheduling_group(), [this, req]() {
         return do_cloud_storage_usage(req);
     });
@@ -767,7 +767,7 @@ service::do_cloud_storage_usage(cloud_storage_usage_request req) {
 }
 
 ss::future<partition_state_reply> service::get_partition_state(
-  partition_state_request&& req, rpc::streaming_context&) {
+  partition_state_request req, rpc::streaming_context&) {
     return ss::with_scheduling_group(get_scheduling_group(), [this, req]() {
         return do_get_partition_state(req);
     });
@@ -775,7 +775,7 @@ ss::future<partition_state_reply> service::get_partition_state(
 
 ss::future<controller_committed_offset_reply>
 service::get_controller_committed_offset(
-  controller_committed_offset_request&&, rpc::streaming_context&) {
+  controller_committed_offset_request, rpc::streaming_context&) {
     return ss::with_scheduling_group(get_scheduling_group(), [this]() {
         return ss::smp::submit_to(controller_stm_shard, [this]() {
             if (!_controller->is_raft0_leader()) {
@@ -822,7 +822,7 @@ service::do_get_partition_state(partition_state_request req) {
 }
 
 ss::future<upsert_plugin_response>
-service::upsert_plugin(upsert_plugin_request&& req, rpc::streaming_context&) {
+service::upsert_plugin(upsert_plugin_request req, rpc::streaming_context&) {
     // Capture the request values in this coroutine
     auto transform = std::move(req.transform);
     auto deadline = model::timeout_clock::now() + req.timeout;
@@ -833,7 +833,7 @@ service::upsert_plugin(upsert_plugin_request&& req, rpc::streaming_context&) {
 }
 
 ss::future<remove_plugin_response>
-service::remove_plugin(remove_plugin_request&& req, rpc::streaming_context&) {
+service::remove_plugin(remove_plugin_request req, rpc::streaming_context&) {
     // Capture the request values in this coroutine
     auto name = std::move(req.name);
     auto deadline = model::timeout_clock::now() + req.timeout;
@@ -844,7 +844,7 @@ service::remove_plugin(remove_plugin_request&& req, rpc::streaming_context&) {
 }
 
 ss::future<delete_topics_reply>
-service::delete_topics(delete_topics_request&& req, rpc::streaming_context&) {
+service::delete_topics(delete_topics_request req, rpc::streaming_context&) {
     // Capture the request values in this coroutine
     auto topics = req.topics_to_delete;
     auto timeout = req.timeout;

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -44,97 +44,96 @@ public:
       ss::sharded<partition_manager>&);
 
     virtual ss::future<join_node_reply>
-    join_node(join_node_request&&, rpc::streaming_context&) override;
+    join_node(join_node_request, rpc::streaming_context&) override;
 
     virtual ss::future<create_topics_reply>
-    create_topics(create_topics_request&&, rpc::streaming_context&) override;
+    create_topics(create_topics_request, rpc::streaming_context&) override;
 
     virtual ss::future<purged_topic_reply>
-    purged_topic(purged_topic_request&&, rpc::streaming_context&) override;
+    purged_topic(purged_topic_request, rpc::streaming_context&) override;
 
     ss::future<configuration_update_reply> update_node_configuration(
-      configuration_update_request&&, rpc::streaming_context&) final;
+      configuration_update_request, rpc::streaming_context&) final;
 
     ss::future<finish_partition_update_reply> finish_partition_update(
-      finish_partition_update_request&&, rpc::streaming_context&) final;
+      finish_partition_update_request, rpc::streaming_context&) final;
 
     ss::future<revert_cancel_partition_move_reply> revert_cancel_partition_move(
-      revert_cancel_partition_move_request&&, rpc::streaming_context&) final;
+      revert_cancel_partition_move_request, rpc::streaming_context&) final;
 
     ss::future<update_topic_properties_reply> update_topic_properties(
-      update_topic_properties_request&&, rpc::streaming_context&) final;
+      update_topic_properties_request, rpc::streaming_context&) final;
     ss::future<reconciliation_state_reply> get_reconciliation_state(
-      reconciliation_state_request&&, rpc::streaming_context&) final;
+      reconciliation_state_request, rpc::streaming_context&) final;
 
     ss::future<create_acls_reply>
-    create_acls(create_acls_request&&, rpc::streaming_context&) final;
+    create_acls(create_acls_request, rpc::streaming_context&) final;
 
     ss::future<delete_acls_reply>
-    delete_acls(delete_acls_request&&, rpc::streaming_context&) final;
+    delete_acls(delete_acls_request, rpc::streaming_context&) final;
 
-    ss::future<decommission_node_reply> decommission_node(
-      decommission_node_request&&, rpc::streaming_context&) final;
+    ss::future<decommission_node_reply>
+    decommission_node(decommission_node_request, rpc::streaming_context&) final;
 
-    ss::future<recommission_node_reply> recommission_node(
-      recommission_node_request&&, rpc::streaming_context&) final;
+    ss::future<recommission_node_reply>
+    recommission_node(recommission_node_request, rpc::streaming_context&) final;
 
     ss::future<finish_reallocation_reply> finish_reallocation(
-      finish_reallocation_request&&, rpc::streaming_context&) final;
+      finish_reallocation_request, rpc::streaming_context&) final;
 
     ss::future<config_status_reply>
-    config_status(config_status_request&&, rpc::streaming_context&) final;
+    config_status(config_status_request, rpc::streaming_context&) final;
 
     ss::future<config_update_reply>
-    config_update(config_update_request&&, rpc::streaming_context&) final;
+    config_update(config_update_request, rpc::streaming_context&) final;
 
     ss::future<get_node_health_reply> collect_node_health_report(
-      get_node_health_request&&, rpc::streaming_context&) final;
+      get_node_health_request, rpc::streaming_context&) final;
 
     ss::future<get_cluster_health_reply> get_cluster_health_report(
-      get_cluster_health_request&&, rpc::streaming_context&) final;
+      get_cluster_health_request, rpc::streaming_context&) final;
 
     ss::future<feature_action_response>
-    feature_action(feature_action_request&& req, rpc::streaming_context&) final;
+    feature_action(feature_action_request req, rpc::streaming_context&) final;
 
     ss::future<feature_barrier_response>
-    feature_barrier(feature_barrier_request&&, rpc::streaming_context&) final;
+    feature_barrier(feature_barrier_request, rpc::streaming_context&) final;
 
     ss::future<set_maintenance_mode_reply> set_maintenance_mode(
-      set_maintenance_mode_request&&, rpc::streaming_context&) final;
+      set_maintenance_mode_request, rpc::streaming_context&) final;
 
-    ss::future<hello_reply>
-    hello(hello_request&&, rpc::streaming_context&) final;
+    ss::future<hello_reply> hello(hello_request, rpc::streaming_context&) final;
 
     ss::future<cancel_partition_movements_reply> cancel_all_partition_movements(
-      cancel_all_partition_movements_request&&, rpc::streaming_context&) final;
+      cancel_all_partition_movements_request, rpc::streaming_context&) final;
     ss::future<cancel_partition_movements_reply>
     cancel_node_partition_movements(
-      cancel_node_partition_movements_request&&, rpc::streaming_context&) final;
+      cancel_node_partition_movements_request, rpc::streaming_context&) final;
 
     ss::future<transfer_leadership_reply> transfer_leadership(
-      transfer_leadership_request&& r, rpc::streaming_context&) final;
+      transfer_leadership_request r, rpc::streaming_context&) final;
 
     ss::future<producer_id_lookup_reply> highest_producer_id(
-      producer_id_lookup_request&&, rpc::streaming_context&) final;
+      producer_id_lookup_request, rpc::streaming_context&) final;
 
     ss::future<cloud_storage_usage_reply> cloud_storage_usage(
-      cloud_storage_usage_request&& r, rpc::streaming_context&) final;
+      cloud_storage_usage_request r, rpc::streaming_context&) final;
 
-    ss::future<partition_state_reply> get_partition_state(
-      partition_state_request&&, rpc::streaming_context&) final;
+    ss::future<partition_state_reply>
+    get_partition_state(partition_state_request, rpc::streaming_context&) final;
 
     ss::future<controller_committed_offset_reply>
     get_controller_committed_offset(
-      controller_committed_offset_request&&, rpc::streaming_context&) final;
+      controller_committed_offset_request, rpc::streaming_context&) final;
 
     ss::future<upsert_plugin_response>
-    upsert_plugin(upsert_plugin_request&&, rpc::streaming_context&) final;
+    upsert_plugin(upsert_plugin_request, rpc::streaming_context&) final;
 
     ss::future<remove_plugin_response>
-    remove_plugin(remove_plugin_request&&, rpc::streaming_context&) final;
+    remove_plugin(remove_plugin_request, rpc::streaming_context&) final;
 
     ss::future<delete_topics_reply>
-    delete_topics(delete_topics_request&&, rpc::streaming_context&) final;
+    delete_topics(delete_topics_request, rpc::streaming_context&) final;
 
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
@@ -143,10 +142,10 @@ private:
       fetch_metadata_and_cfg(const std::vector<topic_result>&);
 
     ss::future<finish_partition_update_reply>
-    do_finish_partition_update(finish_partition_update_request&&);
+      do_finish_partition_update(finish_partition_update_request);
 
     ss::future<update_topic_properties_reply>
-    do_update_topic_properties(update_topic_properties_request&&);
+      do_update_topic_properties(update_topic_properties_request);
 
     ss::future<reconciliation_state_reply>
       do_get_reconciliation_state(reconciliation_state_request);

--- a/src/v/cluster/topic_recovery_status_rpc_handler.cc
+++ b/src/v/cluster/topic_recovery_status_rpc_handler.cc
@@ -49,7 +49,7 @@ status_response map_log_to_response(
 }
 
 ss::future<status_response> topic_recovery_status_rpc_handler::get_status(
-  status_request&&, rpc::streaming_context&) {
+  status_request, rpc::streaming_context&) {
     if (!_topic_recovery_service.local_is_initialized()) {
         co_return status_response{
           .status_log = {

--- a/src/v/cluster/topic_recovery_status_rpc_handler.h
+++ b/src/v/cluster/topic_recovery_status_rpc_handler.h
@@ -31,7 +31,7 @@ public:
       ss::sharded<cloud_storage::topic_recovery_service>& service);
 
     ss::future<status_response>
-    get_status(status_request&&, rpc::streaming_context&) final;
+    get_status(status_request, rpc::streaming_context&) final;
 
 private:
     ss::sharded<cloud_storage::topic_recovery_service>& _topic_recovery_service;

--- a/src/v/cluster/tx_gateway.cc
+++ b/src/v/cluster/tx_gateway.cc
@@ -34,18 +34,18 @@ tx_gateway::tx_gateway(
   , _rm_partition_frontend(rm_partition_frontend) {}
 
 ss::future<fetch_tx_reply>
-tx_gateway::fetch_tx(fetch_tx_request&& request, rpc::streaming_context&) {
+tx_gateway::fetch_tx(fetch_tx_request request, rpc::streaming_context&) {
     return _tx_gateway_frontend.local().fetch_tx_locally(
       request.tx_id, request.term, request.tm);
 }
 
 ss::future<try_abort_reply>
-tx_gateway::try_abort(try_abort_request&& request, rpc::streaming_context&) {
+tx_gateway::try_abort(try_abort_request request, rpc::streaming_context&) {
     return _tx_gateway_frontend.local().route_locally(std::move(request));
 }
 
 ss::future<init_tm_tx_reply>
-tx_gateway::init_tm_tx(init_tm_tx_request&& request, rpc::streaming_context&) {
+tx_gateway::init_tm_tx(init_tm_tx_request request, rpc::streaming_context&) {
     return _tx_gateway_frontend.local().init_tm_tx(
       request.tx_id,
       request.transaction_timeout_ms,
@@ -54,7 +54,7 @@ tx_gateway::init_tm_tx(init_tm_tx_request&& request, rpc::streaming_context&) {
 }
 
 ss::future<begin_tx_reply>
-tx_gateway::begin_tx(begin_tx_request&& request, rpc::streaming_context&) {
+tx_gateway::begin_tx(begin_tx_request request, rpc::streaming_context&) {
     return _rm_partition_frontend.local().begin_tx_locally(
       request.ntp,
       request.pid,
@@ -64,7 +64,7 @@ tx_gateway::begin_tx(begin_tx_request&& request, rpc::streaming_context&) {
 }
 
 ss::future<prepare_tx_reply>
-tx_gateway::prepare_tx(prepare_tx_request&&, rpc::streaming_context&) {
+tx_gateway::prepare_tx(prepare_tx_request, rpc::streaming_context&) {
     // prepare_tx is unsupported starting 23.3.x original transactions
     // design used a preparing/prepare phase as an intent to commit
     // transaction and it has been redesigned since then starting 22.3.0
@@ -76,24 +76,24 @@ tx_gateway::prepare_tx(prepare_tx_request&&, rpc::streaming_context&) {
 }
 
 ss::future<commit_tx_reply>
-tx_gateway::commit_tx(commit_tx_request&& request, rpc::streaming_context&) {
+tx_gateway::commit_tx(commit_tx_request request, rpc::streaming_context&) {
     return _rm_partition_frontend.local().commit_tx_locally(
       request.ntp, request.pid, request.tx_seq, request.timeout);
 }
 
 ss::future<abort_tx_reply>
-tx_gateway::abort_tx(abort_tx_request&& request, rpc::streaming_context&) {
+tx_gateway::abort_tx(abort_tx_request request, rpc::streaming_context&) {
     return _rm_partition_frontend.local().abort_tx_locally(
       request.ntp, request.pid, request.tx_seq, request.timeout);
 }
 
 ss::future<begin_group_tx_reply> tx_gateway::begin_group_tx(
-  begin_group_tx_request&& request, rpc::streaming_context&) {
+  begin_group_tx_request request, rpc::streaming_context&) {
     return _rm_group_proxy->begin_group_tx_locally(std::move(request));
 };
 
 ss::future<prepare_group_tx_reply> tx_gateway::prepare_group_tx(
-  prepare_group_tx_request&&, rpc::streaming_context&) {
+  prepare_group_tx_request, rpc::streaming_context&) {
     // group_prepare is no longer part of the transaction lifecycle after
     // 22.3.0 redesign. There are no callers for this.
     return ss::make_exception_future<cluster::prepare_group_tx_reply>(
@@ -104,17 +104,17 @@ ss::future<prepare_group_tx_reply> tx_gateway::prepare_group_tx(
 };
 
 ss::future<commit_group_tx_reply> tx_gateway::commit_group_tx(
-  commit_group_tx_request&& request, rpc::streaming_context&) {
+  commit_group_tx_request request, rpc::streaming_context&) {
     return _rm_group_proxy->commit_group_tx_locally(std::move(request));
 };
 
 ss::future<abort_group_tx_reply> tx_gateway::abort_group_tx(
-  abort_group_tx_request&& request, rpc::streaming_context&) {
+  abort_group_tx_request request, rpc::streaming_context&) {
     return _rm_group_proxy->abort_group_tx_locally(std::move(request));
 }
 
 ss::future<find_coordinator_reply> tx_gateway::find_coordinator(
-  find_coordinator_request&& r, rpc::streaming_context&) {
+  find_coordinator_request r, rpc::streaming_context&) {
     co_return co_await _tx_gateway_frontend.local().find_coordinator(r.tid);
 }
 

--- a/src/v/cluster/tx_gateway.h
+++ b/src/v/cluster/tx_gateway.h
@@ -37,40 +37,40 @@ public:
       ss::sharded<cluster::rm_partition_frontend>&);
 
     ss::future<init_tm_tx_reply>
-    init_tm_tx(init_tm_tx_request&&, rpc::streaming_context&) override;
+    init_tm_tx(init_tm_tx_request, rpc::streaming_context&) override;
 
     ss::future<fetch_tx_reply>
-    fetch_tx(fetch_tx_request&&, rpc::streaming_context&) override;
+    fetch_tx(fetch_tx_request, rpc::streaming_context&) override;
 
     ss::future<try_abort_reply>
-    try_abort(try_abort_request&&, rpc::streaming_context&) override;
+    try_abort(try_abort_request, rpc::streaming_context&) override;
 
     ss::future<begin_tx_reply>
-    begin_tx(begin_tx_request&&, rpc::streaming_context&) override;
+    begin_tx(begin_tx_request, rpc::streaming_context&) override;
 
     ss::future<prepare_tx_reply>
-    prepare_tx(prepare_tx_request&&, rpc::streaming_context&) override;
+    prepare_tx(prepare_tx_request, rpc::streaming_context&) override;
 
     ss::future<commit_tx_reply>
-    commit_tx(commit_tx_request&&, rpc::streaming_context&) override;
+    commit_tx(commit_tx_request, rpc::streaming_context&) override;
 
     ss::future<abort_tx_reply>
-    abort_tx(abort_tx_request&&, rpc::streaming_context&) override;
+    abort_tx(abort_tx_request, rpc::streaming_context&) override;
 
     ss::future<begin_group_tx_reply>
-    begin_group_tx(begin_group_tx_request&&, rpc::streaming_context&) override;
+    begin_group_tx(begin_group_tx_request, rpc::streaming_context&) override;
 
     ss::future<prepare_group_tx_reply> prepare_group_tx(
-      prepare_group_tx_request&&, rpc::streaming_context&) override;
+      prepare_group_tx_request, rpc::streaming_context&) override;
 
-    ss::future<commit_group_tx_reply> commit_group_tx(
-      commit_group_tx_request&&, rpc::streaming_context&) override;
+    ss::future<commit_group_tx_reply>
+    commit_group_tx(commit_group_tx_request, rpc::streaming_context&) override;
 
     ss::future<abort_group_tx_reply>
-    abort_group_tx(abort_group_tx_request&&, rpc::streaming_context&) override;
+    abort_group_tx(abort_group_tx_request, rpc::streaming_context&) override;
 
     ss::future<find_coordinator_reply> find_coordinator(
-      find_coordinator_request&&, rpc::streaming_context&) override;
+      find_coordinator_request, rpc::streaming_context&) override;
 
 private:
     ss::sharded<cluster::tx_gateway_frontend>& _tx_gateway_frontend;

--- a/src/v/raft/service.h
+++ b/src/v/raft/service.h
@@ -72,7 +72,7 @@ public:
     }
 
     [[gnu::always_inline]] ss::future<heartbeat_reply>
-    heartbeat(heartbeat_request&& r, rpc::streaming_context&) final {
+    heartbeat(heartbeat_request r, rpc::streaming_context&) final {
         using ret_t = std::vector<append_entries_reply>;
         auto const req_sz = r.heartbeats.size();
         auto grouped = group_hbeats_by_shard(std::move(r.heartbeats));
@@ -112,7 +112,7 @@ public:
     }
 
     ss::future<heartbeat_reply_v2>
-    heartbeat_v2(heartbeat_request_v2&& r, rpc::streaming_context&) final {
+    heartbeat_v2(heartbeat_request_v2 r, rpc::streaming_context&) final {
         const auto source = r.source();
         const auto target = r.target();
         auto grouped = group_hbeats_by_shard(std::move(r));
@@ -160,7 +160,7 @@ public:
     }
 
     [[gnu::always_inline]] ss::future<vote_reply>
-    vote(vote_request&& r, rpc::streaming_context&) final {
+    vote(vote_request r, rpc::streaming_context&) final {
         return _probe.vote().then([this, r = std::move(r)]() mutable {
             return dispatch_request(
               std::move(r),
@@ -172,7 +172,7 @@ public:
     }
 
     [[gnu::always_inline]] ss::future<append_entries_reply>
-    append_entries(append_entries_request&& r, rpc::streaming_context&) final {
+    append_entries(append_entries_request r, rpc::streaming_context&) final {
         return _probe.append_entries().then([this, r = std::move(r)]() mutable {
             auto gr = r.target_group();
             return dispatch_request(
@@ -185,7 +185,7 @@ public:
     }
     [[gnu::always_inline]] ss::future<append_entries_reply>
     append_entries_full_serde(
-      append_entries_request_serde_wrapper&& r, rpc::streaming_context&) final {
+      append_entries_request_serde_wrapper r, rpc::streaming_context&) final {
         return _probe.append_entries().then([this, r = std::move(r)]() mutable {
             auto request = std::move(r).release();
             const raft::group_id gr = request.target_group();
@@ -199,7 +199,7 @@ public:
     }
 
     [[gnu::always_inline]] ss::future<install_snapshot_reply> install_snapshot(
-      install_snapshot_request&& r, rpc::streaming_context&) final {
+      install_snapshot_request r, rpc::streaming_context&) final {
         return _probe.install_snapshot().then([this,
                                                r = std::move(r)]() mutable {
             return dispatch_request(
@@ -213,7 +213,7 @@ public:
     }
 
     [[gnu::always_inline]] ss::future<timeout_now_reply>
-    timeout_now(timeout_now_request&& r, rpc::streaming_context&) final {
+    timeout_now(timeout_now_request r, rpc::streaming_context&) final {
         return _probe.timeout_now().then([this, r = std::move(r)]() mutable {
             return dispatch_request(
               std::move(r),
@@ -226,7 +226,7 @@ public:
 
     [[gnu::always_inline]] ss::future<transfer_leadership_reply>
     transfer_leadership(
-      transfer_leadership_request&& r, rpc::streaming_context&) final {
+      transfer_leadership_request r, rpc::streaming_context&) final {
         return _probe.transfer_leadership().then(
           [this, r = std::move(r)]() mutable {
               return dispatch_request(

--- a/src/v/rpc/rpc_compiler.py
+++ b/src/v/rpc/rpc_compiler.py
@@ -125,12 +125,12 @@ public:
                               {{method.output_type}},
                               Codec>::exec(in, ctx, {{method.name}}_method,
       [this](
-          {{method.input_type}}&& t, ::rpc::streaming_context& ctx) -> ss::future<{{method.output_type}}> {
+          {{method.input_type}} t, ::rpc::streaming_context& ctx) -> ss::future<{{method.output_type}}> {
           return {{method.name}}(std::move(t), ctx);
       });
     }
     virtual ss::future<{{method.output_type}}>
-    {{method.name}}({{method.input_type}}&&, ::rpc::streaming_context&) {
+    {{method.name}}({{method.input_type}}, ::rpc::streaming_context&) {
        throw std::runtime_error("unimplemented method");
     }
     {%- endfor %}

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -46,12 +46,12 @@ struct movistar final : cycling::team_movistar_service_base<Codec> {
     movistar(ss::scheduling_group& sc, ss::smp_service_group& ssg)
       : cycling::team_movistar_service_base<Codec>(sc, ssg) {}
     ss::future<cycling::mount_tamalpais>
-    ibis_hakka(cycling::san_francisco&&, rpc::streaming_context&) final {
+    ibis_hakka(cycling::san_francisco, rpc::streaming_context&) final {
         return ss::make_ready_future<cycling::mount_tamalpais>(
           cycling::mount_tamalpais{66});
     }
     ss::future<cycling::nairo_quintana>
-    canyon(cycling::ultimate_cf_slx&&, rpc::streaming_context&) final {
+    canyon(cycling::ultimate_cf_slx, rpc::streaming_context&) final {
         return ss::make_ready_future<cycling::nairo_quintana>(
           cycling::nairo_quintana{32});
     }
@@ -62,31 +62,31 @@ struct echo_impl final : echo::echo_service_base<Codec> {
     echo_impl(ss::scheduling_group& sc, ss::smp_service_group& ssg)
       : echo::echo_service_base<Codec>(sc, ssg) {}
     ss::future<echo::echo_resp>
-    prefix_echo(echo::echo_req&& req, rpc::streaming_context&) final {
+    prefix_echo(echo::echo_req req, rpc::streaming_context&) final {
         return ss::make_ready_future<echo::echo_resp>(
           echo::echo_resp{.str = ssx::sformat("prefix_{}", req.str)});
     }
     ss::future<echo::echo_resp>
-    suffix_echo(echo::echo_req&& req, rpc::streaming_context&) final {
+    suffix_echo(echo::echo_req req, rpc::streaming_context&) final {
         return ss::make_ready_future<echo::echo_resp>(
           echo::echo_resp{.str = ssx::sformat("{}_suffix", req.str)});
     }
 
     ss::future<echo::sleep_resp>
-    sleep_for(echo::sleep_req&& req, rpc::streaming_context&) final {
+    sleep_for(echo::sleep_req req, rpc::streaming_context&) final {
         return ss::sleep(std::chrono::seconds(req.secs)).then([]() {
             return echo::sleep_resp{.str = "Zzz..."};
         });
     }
 
     ss::future<echo::cnt_resp>
-    counter(echo::cnt_req&& req, rpc::streaming_context&) final {
+    counter(echo::cnt_req req, rpc::streaming_context&) final {
         return ss::make_ready_future<echo::cnt_resp>(
           echo::cnt_resp{.expected = req.expected, .current = cnt++});
     }
 
     ss::future<echo::throw_resp>
-    throw_exception(echo::throw_req&& req, rpc::streaming_context&) final {
+    throw_exception(echo::throw_req req, rpc::streaming_context&) final {
         switch (req.type) {
         case echo::failure_type::exceptional_future:
             return ss::make_exception_future<echo::throw_resp>(
@@ -99,7 +99,7 @@ struct echo_impl final : echo::echo_service_base<Codec> {
     }
 
     ss::future<echo::echo_resp>
-    echo(echo::echo_req&& req, rpc::streaming_context&) final {
+    echo(echo::echo_req req, rpc::streaming_context&) final {
         return ss::make_ready_future<echo::echo_resp>(
           echo::echo_resp{.str = req.str});
     }
@@ -113,7 +113,7 @@ struct echo_v2_impl final : echo_v2::echo_service_base<Codec> {
       : echo_v2::echo_service_base<Codec>(sc, ssg) {}
 
     ss::future<echo_v2::echo_resp>
-    echo(echo_v2::echo_req&& req, rpc::streaming_context&) final {
+    echo(echo_v2::echo_req req, rpc::streaming_context&) final {
         return ss::make_ready_future<echo_v2::echo_resp>(
           echo_v2::echo_resp{.str = req.str, .str_two = req.str_two});
     }

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -335,21 +335,21 @@ local_service::offset_fetch(offset_fetch_request request) {
 }
 
 ss::future<produce_reply>
-network_service::produce(produce_request&& req, ::rpc::streaming_context&) {
+network_service::produce(produce_request req, ::rpc::streaming_context&) {
     auto results = co_await _service->local().produce(
       std::move(req.topic_data), req.timeout);
     co_return produce_reply(std::move(results));
 }
 
 ss::future<delete_wasm_binary_reply> network_service::delete_wasm_binary(
-  delete_wasm_binary_request&& req, ::rpc::streaming_context&) {
+  delete_wasm_binary_request req, ::rpc::streaming_context&) {
     auto results = co_await _service->local().delete_wasm_binary(
       req.key, req.timeout);
     co_return delete_wasm_binary_reply(results);
 }
 
 ss::future<load_wasm_binary_reply> network_service::load_wasm_binary(
-  load_wasm_binary_request&& req, ::rpc::streaming_context&) {
+  load_wasm_binary_request req, ::rpc::streaming_context&) {
     auto results = co_await _service->local().load_wasm_binary(
       req.offset, req.timeout);
     if (results.has_error()) {
@@ -360,7 +360,7 @@ ss::future<load_wasm_binary_reply> network_service::load_wasm_binary(
 }
 
 ss::future<store_wasm_binary_reply> network_service::store_wasm_binary(
-  store_wasm_binary_request&& req, ::rpc::streaming_context&) {
+  store_wasm_binary_request req, ::rpc::streaming_context&) {
     auto results = co_await _service->local().store_wasm_binary(
       std::move(req.data), req.timeout);
     if (results.has_error()) {
@@ -370,22 +370,22 @@ ss::future<store_wasm_binary_reply> network_service::store_wasm_binary(
 }
 
 ss::future<find_coordinator_response> network_service::find_coordinator(
-  find_coordinator_request&& req, ::rpc::streaming_context&) {
+  find_coordinator_request req, ::rpc::streaming_context&) {
     co_return co_await _service->local().find_coordinator(std::move(req));
 }
 
 ss::future<offset_fetch_response> network_service::offset_fetch(
-  offset_fetch_request&& req, ::rpc::streaming_context&) {
+  offset_fetch_request req, ::rpc::streaming_context&) {
     co_return co_await _service->local().offset_fetch(req);
 }
 
 ss::future<offset_commit_response> network_service::offset_commit(
-  offset_commit_request&& req, ::rpc::streaming_context&) {
+  offset_commit_request req, ::rpc::streaming_context&) {
     co_return co_await _service->local().offset_commit(req);
 }
 
 ss::future<generate_report_reply> network_service::generate_report(
-  generate_report_request&&, ::rpc::streaming_context&) {
+  generate_report_request, ::rpc::streaming_context&) {
     auto report = co_await _service->local().compute_node_local_report();
     co_return generate_report_reply(std::move(report));
 }

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -84,28 +84,28 @@ public:
       , _service(service) {}
 
     ss::future<produce_reply>
-    produce(produce_request&&, ::rpc::streaming_context&) override;
+    produce(produce_request, ::rpc::streaming_context&) override;
 
     ss::future<store_wasm_binary_reply> store_wasm_binary(
-      store_wasm_binary_request&&, ::rpc::streaming_context&) override;
+      store_wasm_binary_request, ::rpc::streaming_context&) override;
 
     ss::future<load_wasm_binary_reply> load_wasm_binary(
-      load_wasm_binary_request&&, ::rpc::streaming_context&) override;
+      load_wasm_binary_request, ::rpc::streaming_context&) override;
 
     ss::future<delete_wasm_binary_reply> delete_wasm_binary(
-      delete_wasm_binary_request&&, ::rpc::streaming_context&) override;
+      delete_wasm_binary_request, ::rpc::streaming_context&) override;
 
     ss::future<find_coordinator_response> find_coordinator(
-      find_coordinator_request&&, ::rpc::streaming_context&) override;
+      find_coordinator_request, ::rpc::streaming_context&) override;
 
     ss::future<offset_commit_response>
-    offset_commit(offset_commit_request&&, ::rpc::streaming_context&) override;
+    offset_commit(offset_commit_request, ::rpc::streaming_context&) override;
 
     ss::future<offset_fetch_response>
-    offset_fetch(offset_fetch_request&&, ::rpc::streaming_context&) override;
+    offset_fetch(offset_fetch_request, ::rpc::streaming_context&) override;
 
     ss::future<generate_report_reply> generate_report(
-      generate_report_request&&, ::rpc::streaming_context&) override;
+      generate_report_request, ::rpc::streaming_context&) override;
 
 private:
     ss::sharded<local_service>* _service;


### PR DESCRIPTION
Pass RPC requests by value, as we start to write some handlers using
coroutines, it can be a footgun to access have a suspension point, then
the request is destroyed. An example that motivated this:

```c++
ss::future<reply> service::handle(request&& r, rpc::streaming_context&) {
  co_await ss::coroutine::switch_to(get_scheduling_group());
  co_return co_await handle_request(std::move(r));
}
```

In this case `r` is destroyed because the coroutine does not own the
value, and handle request would have a stack-use-after-return issue.

Now that we pass by value, we don't have to remember to move the value
into the current method.

Fixes: https://github.com/redpanda-data/core-internal/issues/898

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
