### PR TITLE
Reject PP/SR HTTP requests if cross shard semaphore has been exhausted

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2829,6 +2829,14 @@ configuration::configuration()
       "Per-shard capacity of the cache for validating schema IDs.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       128)
+  , pp_sr_smp_max_non_local_requests(
+      *this,
+      "pp_sr_smp_max_non_local_requests",
+      "Maximum number of x-core requests pending in Panda Proxy and Schema "
+      "Registry seastar::smp group.  (for more details look at "
+      "`seastar::smp_service_group` documentation)",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      std::nullopt)
   , kafka_memory_share_for_fetch(
       *this,
       "kafka_memory_share_for_fetch",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2837,6 +2837,24 @@ configuration::configuration()
       "`seastar::smp_service_group` documentation)",
       {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
       std::nullopt)
+  , max_in_flight_schema_registry_requests_per_shard(
+      *this,
+      "max_in_flight_schema_registry_requests_per_shard",
+      "Maximum number of in flight HTTP requests permitted in schema registry "
+      "per shard.  Any additional requests above this limit will be rejected "
+      "with a 429 error",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      500,
+      {.min = 1})
+  , max_in_flight_pandaproxy_requests_per_shard(
+      *this,
+      "max_in_flight_pandaproxy_requests_per_shard",
+      "Maximum number of in flight HTTP requests permitted in pandaproxy per "
+      "shard.  Any additional requests above this limit will be rejected with "
+      "a 429 error",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      500,
+      {.min = 1})
   , kafka_memory_share_for_fetch(
       *this,
       "kafka_memory_share_for_fetch",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -530,6 +530,8 @@ struct configuration final : public config_store {
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
     property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
+    bounded_property<size_t> max_in_flight_schema_registry_requests_per_shard;
+    bounded_property<size_t> max_in_flight_pandaproxy_requests_per_shard;
 
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
     property<size_t> kafka_memory_batch_size_estimate_for_fetch;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -529,6 +529,8 @@ struct configuration final : public config_store {
       enable_schema_id_validation;
     config::property<size_t> kafka_schema_id_validation_cache_capacity;
 
+    property<std::optional<uint32_t>> pp_sr_smp_max_non_local_requests;
+
     bounded_property<double, numeric_bounds> kafka_memory_share_for_fetch;
     property<size_t> kafka_memory_batch_size_estimate_for_fetch;
     // debug controls

--- a/src/v/pandaproxy/reply.h
+++ b/src/v/pandaproxy/reply.h
@@ -60,6 +60,11 @@ inline ss::http::reply& set_reply_unavailable(ss::http::reply& rep) {
       .add_header("Retry-After", "0");
 }
 
+inline ss::http::reply& set_reply_too_many_requests(ss::http::reply& rep) {
+    return rep.set_status(ss::http::reply::status_type::too_many_requests)
+      .add_header("Retry-After", "0");
+}
+
 inline std::unique_ptr<ss::http::reply> reply_unavailable() {
     auto rep = std::make_unique<ss::http::reply>(ss::http::reply{});
     set_reply_unavailable(*rep);

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -116,7 +116,7 @@ proxy::proxy(
   , _inflight_config_binding(config::shard_local_cfg().max_in_flight_pandaproxy_requests_per_shard.bind())
   , _client(client)
   , _client_cache(client_cache)
-  , _ctx{{{{}, _mem_sem, {}, smp_sg}, *this},
+  , _ctx{{{{}, _mem_sem, _inflight_sem, {}, smp_sg}, *this},
         {config::always_true(), config::shard_local_cfg().superusers.bind(), controller},
         _config.pandaproxy_api.value()}
   , _server(

--- a/src/v/pandaproxy/rest/proxy.cc
+++ b/src/v/pandaproxy/rest/proxy.cc
@@ -12,6 +12,7 @@
 #include "cluster/controller.h"
 #include "cluster/ephemeral_credential_frontend.h"
 #include "cluster/members_table.h"
+#include "config/configuration.h"
 #include "kafka/client/config_utils.h"
 #include "net/unresolved_address.h"
 #include "pandaproxy/api/api-doc/rest.json.hh"
@@ -111,6 +112,8 @@ proxy::proxy(
   cluster::controller* controller)
   : _config(config)
   , _mem_sem(max_memory, "pproxy/mem")
+  , _inflight_sem(config::shard_local_cfg().max_in_flight_pandaproxy_requests_per_shard(), "pproxy/inflight")
+  , _inflight_config_binding(config::shard_local_cfg().max_in_flight_pandaproxy_requests_per_shard.bind())
   , _client(client)
   , _client_cache(client_cache)
   , _ctx{{{{}, _mem_sem, {}, smp_sg}, *this},
@@ -125,7 +128,10 @@ proxy::proxy(
       _ctx,
       json::serialization_format::application_json)
   , _ensure_started{[this]() { return do_start(); }}
-  , _controller(controller) {}
+  , _controller(controller) {
+    _inflight_config_binding.watch(
+      [this]() { _inflight_sem.set_capacity(_inflight_config_binding()); });
+}
 
 ss::future<> proxy::start() {
     _server.routes(get_proxy_routes(_gate, _ensure_started));

--- a/src/v/pandaproxy/rest/proxy.h
+++ b/src/v/pandaproxy/rest/proxy.h
@@ -18,6 +18,7 @@
 #include "pandaproxy/server.h"
 #include "pandaproxy/util.h"
 #include "security/request_auth.h"
+#include "utils/adjustable_semaphore.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
@@ -56,6 +57,8 @@ private:
 
     configuration _config;
     ssx::semaphore _mem_sem;
+    adjustable_semaphore _inflight_sem;
+    config::binding<size_t> _inflight_config_binding;
     ss::gate _gate;
     ss::sharded<kafka::client::client>& _client;
     ss::sharded<kafka_client_cache>& _client_cache;

--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -509,7 +509,7 @@ service::service(
       config::shard_local_cfg()
         .max_in_flight_schema_registry_requests_per_shard.bind())
   , _client(client)
-  , _ctx{{{}, _mem_sem, {}, smp_sg}, *this}
+  , _ctx{{{}, _mem_sem, _inflight_sem, {}, smp_sg}, *this}
   , _server(
       "schema_registry", // server_name
       "schema_registry", // public_metric_group_name

--- a/src/v/pandaproxy/schema_registry/service.h
+++ b/src/v/pandaproxy/schema_registry/service.h
@@ -20,6 +20,7 @@
 #include "pandaproxy/util.h"
 #include "security/fwd.h"
 #include "security/request_auth.h"
+#include "utils/adjustable_semaphore.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/sharded.hh>
@@ -70,6 +71,8 @@ private:
     ss::future<> fetch_internal_topic();
     configuration _config;
     ssx::semaphore _mem_sem;
+    adjustable_semaphore _inflight_sem;
+    config::binding<size_t> _inflight_config_binding;
     ss::gate _gate;
     ss::sharded<kafka::client::client>& _client;
     ctx_server<service>::context_t _ctx;

--- a/src/v/pandaproxy/server.h
+++ b/src/v/pandaproxy/server.h
@@ -21,6 +21,7 @@
 #include "pandaproxy/kafka_client_cache.h"
 #include "pandaproxy/types.h"
 #include "security/request_auth.h"
+#include "utils/adjustable_semaphore.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
@@ -70,6 +71,7 @@ public:
     struct context_t {
         std::vector<net::unresolved_address> advertised_listeners;
         ssx::semaphore& mem_sem;
+        adjustable_semaphore& inflight_sem;
         ss::abort_source as;
         ss::smp_service_group smp_sg;
     };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -535,7 +535,10 @@ void application::initialize(
       .raft_group_max_non_local_requests
       = config::shard_local_cfg().raft_smp_max_non_local_requests().value_or(
         smp_groups::default_raft_non_local_requests(
-          config::shard_local_cfg().topic_partitions_per_shard()))};
+          config::shard_local_cfg().topic_partitions_per_shard())),
+      .proxy_group_max_non_local_requests
+      = config::shard_local_cfg().pp_sr_smp_max_non_local_requests().value_or(
+        smp_groups::default_max_nonlocal_requests)};
 
     smp_service_groups.create_groups(smp_groups_cfg).get();
     _deferred.emplace_back(

--- a/src/v/utils/adjustable_semaphore.h
+++ b/src/v/utils/adjustable_semaphore.h
@@ -90,6 +90,14 @@ public:
         return ss::get_units(_sem, units, as);
     }
 
+    /**
+     * Attempts to immediately get units from the semaphore, returning
+     * std::nullopt if no units exist.
+     */
+    std::optional<ssx::semaphore_units> try_get_units(size_t units) {
+        return ss::try_get_units(_sem, units);
+    }
+
     size_t current() const noexcept { return _sem.current(); }
     ssize_t available_units() const noexcept { return _sem.available_units(); }
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes: #14116 

Cross shard calls in SR/PP utilize an SMP resource group to limit the number of cross shard calls that
are made.  However, if the semaphore has been fully consumed, the call simply hangs.  Customers have
experienced issues where, under heavy load, SR appears to hang and not response.  Now, instead, once the
semaphore has been completely exhausted, new HTTP requests that attempt cross shard calls will be
rejected with a 500 error.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* SR/PP will now reply with a 500 error if an internal service semaphore has been completely exhausted
