### PR TITLE
k/metadata: guesstimate leader when information is not yet present

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -82,11 +82,12 @@ std::optional<cluster::leader_term> get_leader_term(
     auto leader_term = md_cache.get_leader_term(tp_ns, p_id);
     /**
      * If current broker do not yet have any information about leadership we
-     * simply return random node to force the client metadata update.
+     * fallback to leader guesstimating. We return first replica from the
+     * replica set and term 0. (This is the same logic that has been a part of
+     * cluster::topic_dispatcher before)
      */
     if (!leader_term) {
-        auto idx = fast_prng_source() % replicas.size();
-        leader_term.emplace(replicas[idx], model::term_id(-1));
+        leader_term.emplace(replicas[0], model::term_id(0));
         return leader_term;
     }
     if (!leader_term->leader.has_value()) {


### PR DESCRIPTION
When partition is first created in Redpanda some of the cluster nodes which are not hosting partition replicas may not yet have leadership metadata. In this case Redpanda still has to return partition metadata. In order not to disturb the client (returning -1 as a leader id may cause some clients to stop) Redpanda has to return a leader id. If the information is not present we will always return the first node from replica set in leader epoch equal to 0. This way client will either communicate with the actual leader or issue a metadata request to other node that may contain up to date information.

Fixes: #15949
Fixes: #15972

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none