### PR TITLE
c/partition_balancer: use full partition move when disk is full

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -125,13 +125,15 @@ public:
     static reconfiguration_policy
     map_change_reason_to_policy(change_reason reason) {
         switch (reason) {
-        case change_reason::node_unavailable:
-        case change_reason::rack_constraint_repair:
-            return reconfiguration_policy::full_local_retention;
-        case change_reason::disk_full:
+        // fast movement
         case change_reason::node_decommissioning:
         case change_reason::partition_count_rebalancing:
             return reconfiguration_policy::target_initial_retention;
+        // full retention
+        case change_reason::node_unavailable:
+        case change_reason::rack_constraint_repair:
+        case change_reason::disk_full:
+            return reconfiguration_policy::full_local_retention;
         }
     }
 


### PR DESCRIPTION
In order to be consistent and more careful changed the policy of partition reconfiguration issued by partition balancer when moving partition as a result of disk space exhaustion.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none