### PR TITLE
utils: allow memory data source to take tmpbuf

### DIFF
--- a/src/v/utils/memory_data_source.h
+++ b/src/v/utils/memory_data_source.h
@@ -22,13 +22,17 @@ class memory_data_source final : public ss::data_source_impl {
 public:
     using value_type = ss::temporary_buffer<char>;
     using vector_type = std::vector<value_type>;
-    explicit memory_data_source(vector_type buffers)
-      : _capacity(std::accumulate(
-        buffers.begin(),
-        buffers.end(),
-        size_t(0),
-        [](size_t acc, auto& it) { return acc + it.size(); }))
-      , _buffers(std::move(buffers)) {}
+
+    explicit memory_data_source(value_type buffer) {
+        add_buffer(std::move(buffer));
+    }
+
+    explicit memory_data_source(vector_type buffers) {
+        _buffers.reserve(buffers.size());
+        for (auto& buffer : buffers) {
+            add_buffer(std::move(buffer));
+        }
+    }
 
     ss::future<value_type> skip(uint64_t n) final {
         _byte_offset = std::min(_byte_offset + n, _capacity);
@@ -53,7 +57,12 @@ public:
     }
 
 private:
-    const size_t _capacity;
+    void add_buffer(value_type buffer) {
+        _capacity += buffer.size();
+        _buffers.push_back(std::move(buffer));
+    }
+
+    size_t _capacity = 0;
     vector_type _buffers;
     size_t _byte_offset = 0;
 };


### PR DESCRIPTION
utils: allow memory data source to take tmpbuf

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

