### PR TITLE
securit/:OIDC: Enable licence check and telemetry

### DIFF
--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -23,6 +23,7 @@
 #include "cluster/topic_table.h"
 #include "cluster/types.h"
 #include "config/configuration.h"
+#include "config/validators.h"
 #include "hashing/secure.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
@@ -264,6 +265,9 @@ metrics_reporter::build_metrics_snapshot() {
     snapshot.has_kafka_gssapi = absl::c_any_of(
       config::shard_local_cfg().sasl_mechanisms(),
       [](auto const& mech) { return mech == "GSSAPI"; });
+
+    snapshot.has_oidc = config::oidc_is_enabled_kafka()
+                        || config::oidc_is_enabled_http();
 
     auto env_value = std::getenv("REDPANDA_ENVIRONMENT");
     if (env_value) {
@@ -525,6 +529,9 @@ void rjson_serialize(
     w.EndArray();
     w.Key("has_kafka_gssapi");
     w.Bool(snapshot.has_kafka_gssapi);
+
+    w.Key("has_oidc");
+    w.Bool(snapshot.has_oidc);
 
     w.Key("config");
     config::shard_local_cfg().to_json_for_metrics(w);

--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -75,6 +75,7 @@ public:
 
         std::vector<node_metrics> nodes;
         bool has_kafka_gssapi;
+        bool has_oidc;
 
         static constexpr int64_t max_size_for_rp_env = 80;
         ss::sstring redpanda_environment;

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -12,6 +12,7 @@
 #include "config/validators.h"
 
 #include "config/client_group_byte_rate_quota.h"
+#include "config/configuration.h"
 #include "model/namespace.h"
 #include "model/validation.h"
 #include "net/inet_address_wrapper.h"
@@ -139,6 +140,18 @@ validate_http_authn_mechanisms(const std::vector<ss::sstring>& mechanisms) {
         }
     }
     return std::nullopt;
+}
+
+bool oidc_is_enabled_http() {
+    return absl::c_any_of(
+      config::shard_local_cfg().http_authentication(),
+      [](const auto& m) { return m == "OIDC"; });
+}
+
+bool oidc_is_enabled_kafka() {
+    return absl::c_any_of(
+      config::shard_local_cfg().sasl_mechanisms(),
+      [](const auto& m) { return m == "OAUTHBEARER"; });
 }
 
 std::optional<ss::sstring> validate_0_to_1_ratio(const double d) {

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -36,6 +36,9 @@ validate_sasl_mechanisms(const std::vector<ss::sstring>& mechanisms);
 std::optional<ss::sstring>
 validate_http_authn_mechanisms(const std::vector<ss::sstring>& mechanisms);
 
+bool oidc_is_enabled_http();
+bool oidc_is_enabled_kafka();
+
 std::optional<ss::sstring> validate_0_to_1_ratio(const double d);
 
 std::optional<ss::sstring>

--- a/tests/rptest/tests/metrics_reporter_test.py
+++ b/tests/rptest/tests/metrics_reporter_test.py
@@ -101,6 +101,7 @@ class MetricsReporterTest(RedpandaTest):
         assert_fields_are_the_same(metadata, 'cluster_created_ts')
         # Configuration should be the same across requests
         assert_fields_are_the_same(metadata, 'has_kafka_gssapi')
+        assert_fields_are_the_same(metadata, 'has_oidc')
         # cluster config should be the same
         assert_fields_are_the_same(metadata, 'config')
         # get the last report
@@ -108,6 +109,7 @@ class MetricsReporterTest(RedpandaTest):
         assert last['topic_count'] == total_topics
         assert last['partition_count'] == total_partitions
         assert last['has_kafka_gssapi'] is False
+        assert last['has_oidc'] is False
         assert last['active_logical_version'] == features['cluster_version']
         assert last['original_logical_version'] == features[
             'original_cluster_version']


### PR DESCRIPTION
* Add oidc to the licence nag
* Add a new field to the report: `has_oidc`

E.g.:
```json
{
  "cluster_uuid": "3d53d84c-69d3-4c5e-9098-9c3e4af079e6",
  "cluster_created_ts": 1673994399728,
  "topic_count": 5,
  "partition_count": 24,
  "nodes": [
    {
      "node_id": 1,
      "cpu_count": 2,
      "version": "no_version - 000-dev",
      "uptime_ms": 10223,
      "is_alive": true,
      "disks": [
        {
          "free": 153149313024,
          "total": 930158792704
        }
      ]
    }
  ],
  "has_kafka_gssapi": true,
  "has_oidc": true
}
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
