### PR TITLE
rptest: reduce max num_nodes in `redpanda_cloud_tests` of tests to just 10

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -141,7 +141,7 @@ class OMBValidationTest(RedpandaTest):
     def _mb_to_mib(self, mb):
         return math.floor(0.9537 * mb)
 
-    @cluster(num_nodes=12)
+    @cluster(num_nodes=10)
     def test_max_connections(self):
         tier_limits = self.tier_limits
 
@@ -285,7 +285,7 @@ class OMBValidationTest(RedpandaTest):
         finally:
             self.rpk.delete_topic(swarm_topic_name)
 
-    @cluster(num_nodes=12)
+    @cluster(num_nodes=10)
     def test_max_partitions(self):
         tier_limits = self.tier_limits
 
@@ -327,7 +327,7 @@ class OMBValidationTest(RedpandaTest):
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
 
-    @cluster(num_nodes=12)
+    @cluster(num_nodes=10)
     def test_common_workload(self):
         tier_limits = self.tier_limits
 
@@ -380,7 +380,7 @@ class OMBValidationTest(RedpandaTest):
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
 
-    @cluster(num_nodes=12)
+    @cluster(num_nodes=10)
     def test_retention(self):
         tier_limits = self.tier_limits
 


### PR DESCRIPTION
per conversation in https://github.com/redpanda-data/vtools/pull/2438#issuecomment-1881150068

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
