### PR TITLE
storage: enable space management by default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2061,16 +2061,15 @@ configuration::configuration()
       "past the local retention limit, and will be trimmed automatically as "
       "storage reaches the configured target size.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      false,
-      property<bool>::noop_validator,
-      legacy_default<bool>(true, legacy_version{9}))
+      false)
   , retention_local_strict_override(
       *this,
       "retention_local_strict_override",
       "Trim log data when a cloud topic reaches its local retention limit. "
       "When this option is disabled Redpanda will allow partitions to grow "
       "past the local retention limit, and will be trimmed automatically as "
-      "storage reaches the configured target size.",
+      "storage reaches the configured target size. This option is ignored and "
+      "deprecated in versions >= v23.3.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
   , retention_local_target_capacity_bytes(
@@ -2123,13 +2122,12 @@ configuration::configuration()
       "space_management_enable",
       "Enable automatic space management.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      true,
-      property<bool>::noop_validator,
-      legacy_default<bool>(false, legacy_version{9}))
+      true)
   , space_management_enable_override(
       *this,
       "space_management_enable_override",
-      "Enable automatic space management.",
+      "Enable automatic space management. This option is ignored and "
+      "deprecated in versions >= v23.3.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
   , disk_reservation_percent(

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -56,19 +56,12 @@ disk_space_manager::disk_space_manager(
           this->enabled() ? "Enabling" : "Disabling");
         _control_sem.signal();
     });
-    _enabled_override.watch([this] {
-        vlog(
-          rlog.info,
-          "{} disk space manager control loop",
-          this->enabled() ? "Enabling" : "Disabling");
-        _control_sem.signal();
-    });
     _retention_target_capacity_bytes.watch([this] { update_target_size(); });
     _retention_target_capacity_percent.watch([this] { update_target_size(); });
     _disk_reservation_percent.watch([this] { update_target_size(); });
 }
 
-bool disk_space_manager::enabled() { return _enabled() || _enabled_override(); }
+bool disk_space_manager::enabled() { return _enabled(); }
 
 ss::future<> disk_space_manager::start() {
     vlog(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1009,9 +1009,7 @@ gc_config disk_log_impl::maybe_override_retention_config(gc_config cfg) const {
      * don't override with local retention settings--let partition data expand
      * up to standard retention settings.
      */
-    if (
-      !config::shard_local_cfg().retention_local_strict()
-      || !config::shard_local_cfg().retention_local_strict_override()) {
+    if (!config::shard_local_cfg().retention_local_strict()) {
         vlog(
           gclog.trace,
           "[{}] Skipped retention override for topic with remote write "


### PR DESCRIPTION
Make the following configuration options have these default values regardless of the upgrade history of the cluster

  space_management_enable=true
  retention_local_strict=false

Additionally these options used to work around an issue in v23.2 which prevented changes to the above options from being sticky in an upgraded cluster no longer have any affect.

  space_management_enable_override
  retention_local_strict_override

They'll be fully deprecated at a later time.

Fixes: https://github.com/redpanda-data/redpanda/issues/15995

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

* Short description of how this PR improves existing behavior.

-->

### Improvements

Space management is now enabled by default for upgraded clusters starting in v23.3, unless the feature has been explicitly disabled.