### PR TITLE
rptest: clean cloudv2 cluster topics in `tearDown()`

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -347,6 +347,7 @@ class HighThroughputTest(PreallocNodesTest):
         for item in self.resources:
             if item['type'] == 'topic':
                 self.rpk.delete_topic(item['spec'].name)
+        self.redpanda.clean_cluster()
 
     @cluster(num_nodes=0)
     def test_cluster_cleanup(self):

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -359,6 +359,10 @@ class HighThroughputTest(PreallocNodesTest):
         # and/or config.use_same_cluster and current.tests_finished set to True
         self.redpanda._cloud_cluster.current.tests_finished = True
 
+    def setup(self):
+        super().setup()
+        self.redpanda.clean_cluster()
+
     def tearDown(self):
         # These tests may run on cloud ec2 instances where between each test
         # the same cluster is used. Therefore state between runs will still exist,

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -109,6 +109,10 @@ class OMBValidationTest(RedpandaTest):
             config_profile['machine_type'])
         self.rpk = RpkTool(self.redpanda)
 
+    def tearDown(self):
+        super().tearDown()
+        self.redpanda.clean_cluster()
+
     @staticmethod
     def base_validator(multiplier: float = 1):
         """Return a default validator object with reasonable latency targets for

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -109,6 +109,10 @@ class OMBValidationTest(RedpandaTest):
             config_profile['machine_type'])
         self.rpk = RpkTool(self.redpanda)
 
+    def setup(self):
+        super().setup()
+        self.redpanda.clean_cluster()
+
     def tearDown(self):
         super().tearDown()
         self.redpanda.clean_cluster()


### PR DESCRIPTION
related issue: https://github.com/redpanda-data/cloudv2/issues/11563

Have `OMBValidationTest` and `HighThroughputTest` clean cluster in `tearDown()` and `startup()` by deleting topics that may have been leftover from a test case. The `clean_cluster()` method can be added to later to clean more things we want to ensure is gone before the next test case runs.

Since `clean_cluster()` simply deletes all topics, it should only be called if there are no other tests running at the same time expecting topics to be there.

example run:
```console
ducktape \ 
 --debug \ 
 --globals=/home/ubuntu/redpanda/tests/globals.json \ 
 --cluster=ducktape.cluster.json.JsonCluster \ 
 --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \  
 --test-runner-timeout=3600000 \
 tests/rptest/redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_common_workload
```
output:
```
[DEBUG - 2024-01-19 02:19:16,802 - redpanda - clean_cluster - lineno:1681]: found topics to delete (2): ['test-topic-to-delete1', 'test-topic-to-delete2']
...
[DEBUG - 2024-01-19 02:30:28,011 - redpanda - clean_cluster - lineno:1681]: found topics to delete (1): ['test-topic-co1Cozg-0000']
...
test_id:    rptest.redpanda_cloud_tests.omb_validation_test.OMBValidationTest.test_common_workload
status:     PASS
run time:   11 minutes 41.601 seconds
-----------------------------------------------------------------------
======================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2024-01-19--012
run time:         11 minutes 41.621 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
=====================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
