### PR TITLE
Controller backend: reconcile each ntp in individual fibers

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -407,6 +407,10 @@ ss::future<> controller::start(
             std::ref(_feature_table),
             ss::sharded_parameter([] {
                 return config::shard_local_cfg()
+                  .controller_backend_housekeeping_interval_ms.bind();
+            }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
                   .initial_retention_local_target_bytes_default.bind();
             }),
             ss::sharded_parameter([] {

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -262,6 +262,8 @@ private:
     ss::future<result<ss::stop_iteration>>
     reconcile_ntp_step(const model::ntp&, ntp_reconciliation_state&);
 
+    ss::future<> stuck_ntp_watchdog_fiber();
+
     /**
      * Given the original and new replica set for a force configuration, splits
      * the new replica set into voters and learners and returns the equivalent

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -203,6 +203,7 @@ public:
       ss::sharded<topics_frontend>&,
       ss::sharded<storage::api>&,
       ss::sharded<features::feature_table>&,
+      config::binding<std::chrono::milliseconds> housekeeping_interval,
       config::binding<std::optional<size_t>>
         initial_retention_local_target_bytes,
       config::binding<std::optional<std::chrono::milliseconds>>
@@ -371,7 +372,7 @@ private:
     ss::sharded<features::feature_table>& _features;
     model::node_id _self;
     ss::sstring _data_directory;
-    std::chrono::milliseconds _housekeeping_timer_interval;
+    config::binding<std::chrono::milliseconds> _housekeeping_interval;
     config::binding<std::optional<size_t>>
       _initial_retention_local_target_bytes;
     config::binding<std::optional<std::chrono::milliseconds>>

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -373,6 +373,7 @@ private:
     model::node_id _self;
     ss::sstring _data_directory;
     config::binding<std::chrono::milliseconds> _housekeeping_interval;
+    simple_time_jitter<ss::lowres_clock> _housekeeping_jitter;
     config::binding<std::optional<size_t>>
       _initial_retention_local_target_bytes;
     config::binding<std::optional<std::chrono::milliseconds>>

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1237,7 +1237,7 @@ configuration::configuration()
       *this,
       "controller_backend_housekeeping_interval_ms",
       "Interval between iterations of controller backend housekeeping loop",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1s)
   , node_management_operation_timeout_ms(
       *this,

--- a/src/v/ssx/event.h
+++ b/src/v/ssx/event.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+#include "base/seastarx.h"
+#include "ssx/semaphore.h"
+
+namespace ssx {
+
+/*
+ * A simple notification mechanism. One fiber can set() the event and another
+ * can wait() for it. If there are no waiters the event is not lost. If there
+ * are several waiters they are all woken up. Successful wait resets the event.
+ *
+ * wait() methods
+ *
+ * This is pretty similar to ss::condition_variable, but is simpler and
+ * requires less exception handling.
+ */
+template<typename Clock>
+class basic_event {
+public:
+    using duration = typename Clock::duration;
+    using time_point = typename Clock::time_point;
+
+    explicit basic_event(ss::sstring name)
+      : _sem(0, std::move(name)) {}
+
+    bool is_set() const noexcept {
+        return _sem.waiters() == 0 && _sem.available_units() > 0;
+    }
+
+    void set() noexcept {
+        if (is_set()) {
+            return;
+        } else {
+            size_t waiters = _sem.waiters();
+            if (waiters > 0) {
+                _sem.signal(waiters);
+            } else {
+                _sem.signal(1);
+            }
+        }
+    }
+
+    /// Can throw ss::broken_semaphore exception.
+    ss::future<> wait() { return _sem.wait(1); }
+
+    /// Returns true if the wait was successful. Can throw ss::broken_semaphore
+    /// exception.
+    ss::future<bool> wait(time_point deadline) {
+        return _sem.wait(deadline)
+          .then([] { return true; })
+          .handle_exception_type(
+            [](const ss::semaphore_timed_out&) { return false; });
+    }
+
+    /// Returns true if the wait was successful. Can throw ss::broken_semaphore
+    /// exception.
+    ss::future<bool> wait(duration d) { return wait(Clock::now() + d); }
+
+    void broken() noexcept { _sem.broken(); }
+
+    size_t waiters() const noexcept { return _sem.waiters(); }
+
+private:
+    ssx::named_semaphore<Clock> _sem;
+};
+
+using event = basic_event<ssx::semaphore::clock>;
+
+} // namespace ssx

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ rp_test(
   BINARY_NAME ssx_gunit
   SOURCES
     work_queue_test.cc
+    event_test.cc
   LIBRARIES v::gtest_main v::ssx
   LABELS ssx
 )

--- a/src/v/ssx/tests/event_test.cc
+++ b/src/v/ssx/tests/event_test.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "ssx/event.h"
+
+#include <seastar/core/manual_clock.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace ssx {
+
+using namespace std::chrono_literals;
+
+TEST(Event, SimpleUsage) {
+    event ev{"test-event"};
+    EXPECT_FALSE(ev.is_set());
+    ev.set();
+    EXPECT_TRUE(ev.is_set());
+    ev.set();
+    EXPECT_TRUE(ev.is_set());
+    ev.wait().get();
+    EXPECT_FALSE(ev.is_set());
+}
+
+TEST(Event, SeveralWaiters) {
+    event ev{"test-event"};
+    auto f1 = ev.wait();
+    auto f2 = ev.wait();
+    EXPECT_FALSE(f1.available());
+    EXPECT_FALSE(f2.available());
+    ev.set();
+    f1.get();
+    f2.get();
+    EXPECT_FALSE(ev.is_set());
+}
+
+TEST(Event, Timeouts) {
+    basic_event<ss::manual_clock> ev{"test-event"};
+    auto f1 = ev.wait(3s);
+    auto f2 = ev.wait(1s);
+    EXPECT_FALSE(f1.available());
+    EXPECT_FALSE(f2.available());
+    ss::manual_clock::advance(2s);
+    ev.set();
+    EXPECT_TRUE(f1.get());
+    EXPECT_FALSE(f2.get());
+    EXPECT_FALSE(ev.is_set());
+}
+
+TEST(Event, Broken) {
+    event ev{"test-event"};
+    auto f1 = ev.wait();
+    auto f2 = ev.wait(1s);
+    EXPECT_FALSE(f1.available());
+    EXPECT_FALSE(f2.available());
+    ev.broken();
+    EXPECT_THROW(f1.get(), ss::broken_semaphore);
+    EXPECT_THROW(f2.get(), ss::broken_semaphore);
+}
+
+} // namespace ssx


### PR DESCRIPTION
In the future, when partitions will be assigned to shards by a node-level component (as opposed to topic table), controller backend will have to accept notifications from several sources. To support this it is more convenient to have per-ntp fibers doing reconciliation, as opposed to a single housekeeping fiber that periodically launches reconciliation for all pending ntps and waits for all reconciliation attempts to finish.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
* none