### PR TITLE
r/group_manager: protect against race with set_ready()

### DIFF
--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -135,6 +135,13 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
     return _groups_mutex.with([this, raft = std::move(raft)] {
         return ss::with_gate(_gate, [this, raft] {
             return _heartbeats.register_group(raft).then([this, raft] {
+                if (_is_ready) {
+                    // Check _is_ready flag again to guard against the case when
+                    // set_ready() was called after we created this consensus
+                    // instance but before we insert it into the _groups
+                    // collection.
+                    raft->reset_node_priority();
+                }
                 _groups.push_back(raft);
                 return raft;
             });


### PR DESCRIPTION
set_ready() may race with group creation if it is called after a consensus instance is created, but before it is added to the _groups collection.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes
### Bug Fixes
* Protect against a very rare scenario where after node restart, some of the partition replicas hosted on that node could not take part in leader elections.

