### PR TITLE
storage: don't enable non-strict retention by default

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2061,15 +2061,16 @@ configuration::configuration()
       "past the local retention limit, and will be trimmed automatically as "
       "storage reaches the configured target size.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      false)
+      false,
+      property<bool>::noop_validator,
+      legacy_default<bool>(true, legacy_version{9}))
   , retention_local_strict_override(
       *this,
       "retention_local_strict_override",
       "Trim log data when a cloud topic reaches its local retention limit. "
       "When this option is disabled Redpanda will allow partitions to grow "
       "past the local retention limit, and will be trimmed automatically as "
-      "storage reaches the configured target size. This option is ignored and "
-      "deprecated in versions >= v23.3.",
+      "storage reaches the configured target size.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       true)
   , retention_local_target_capacity_bytes(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1009,7 +1009,9 @@ gc_config disk_log_impl::maybe_override_retention_config(gc_config cfg) const {
      * don't override with local retention settings--let partition data expand
      * up to standard retention settings.
      */
-    if (!config::shard_local_cfg().retention_local_strict()) {
+    if (
+      !config::shard_local_cfg().retention_local_strict()
+      || !config::shard_local_cfg().retention_local_strict_override()) {
         vlog(
           gclog.trace,
           "[{}] Skipped retention override for topic with remote write "

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1941,24 +1941,20 @@ class ClusterConfigLegacyDefaultTest(RedpandaTest, ClusterConfigHelpersMixin):
         # upgraded clusters.
         self._upgrade(wipe_cache, self.intermediate_version)
         self._check_value_everywhere("space_management_enable", False)
-        self._check_value_everywhere("retention_local_strict", True)
 
-        # in >=23.3 (using upstream build) space management should be enabled by
-        # default provided that it wasn't explicitly disabled in 23.2. in this
-        # case no configs were changed so it should be enabled now.
+        # in >=23.3 space management should be enabled by default provided that
+        # it wasn't explicitly disabled in 23.2.
         self._upgrade(wipe_cache)
         self._check_value_everywhere("space_management_enable", True)
-        self._check_value_everywhere("retention_local_strict", False)
 
         # survives a restart
         self.redpanda.restart_nodes(self.redpanda.nodes)
         self._check_value_everywhere("space_management_enable", True)
-        self._check_value_everywhere("retention_local_strict", False)
 
     @cluster(num_nodes=3)
     @parametrize(wipe_cache=True)
     @parametrize(wipe_cache=False)
-    def test_removal_of_legacy_default_disabled(self, wipe_cache: bool):
+    def test_removal_of_legacy_default_overriden(self, wipe_cache: bool):
         # in 23.1 space management feature does not exist
         old_version, _ = self.installer.latest_for_line(self.legacy_version)
         self.installer.install(self.redpanda.nodes, old_version)
@@ -1968,26 +1964,21 @@ class ClusterConfigLegacyDefaultTest(RedpandaTest, ClusterConfigHelpersMixin):
         # upgraded clusters.
         self._upgrade(wipe_cache, self.intermediate_version)
         self._check_value_everywhere("space_management_enable", False)
-        self._check_value_everywhere("retention_local_strict", True)
 
-        # the interface seems to ignore setting a value to its current value. so
-        # we enable then disable to make sure it gets through.
+        # we need to toggle it to get it to stick since the api seems to not
+        # change the underlying value explicitly if its default is that value.
+        # the legacy default bits here are to blame for the weirdness i presume
         self.redpanda.set_cluster_config({"space_management_enable": True})
         self.redpanda.set_cluster_config({"space_management_enable": False})
-        self.redpanda.set_cluster_config({"retention_local_strict": False})
-        self.redpanda.set_cluster_config({"retention_local_strict": True})
 
-        # in >=23.3 (using upstream build) space management should be enabled by
-        # default provided that it wasn't explicitly disabled in 23.2. in this
-        # case we disabled it in 23.2 state so it should still be disabled here.
+        # in >=23.3 space management should be enabled by default provided that
+        # it wasn't explicitly disabled in 23.2.
         self._upgrade(wipe_cache)
         self._check_value_everywhere("space_management_enable", False)
-        self._check_value_everywhere("retention_local_strict", True)
 
         # survives a restart
         self.redpanda.restart_nodes(self.redpanda.nodes)
         self._check_value_everywhere("space_management_enable", False)
-        self._check_value_everywhere("retention_local_strict", True)
 
 
 class ClusterConfigUnknownTest(RedpandaTest):


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda/pull/15996 a change was made that enabled space management and non-strict retention mode when upgrading (unlike v23.1 -> v23.2 upgrade in which the features were disabled by default). It also maintained the behavior that new clusters would have the features enabled (the same behavior as a new v23.2 cluster). Only part of this behavior is desired, so this PR reverts the behavior for strict retention setting.

A new 23.3 cluster will have the same behavior as a new 23.2 cluster
* sm=true
* strict_retention=false

An upgrade sequence 23.1, 23.2, 23.2 will have
* sm=true
* strict_retention=true

**NOTE:** this requires the same workaround that we deployed for v23.2 to make upgrade options sticky. That is, `.retention_local_strict_override` needs to be set in upgraded clusters for the option to be sticky.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

* Short description of how this PR improves existing behavior.

-->

### Improvements
* This PR partially reverts the change such that strict retention remains enabled after upgrade unless it had been explicitly disabled before the upgrade.
