### PR TITLE
Fix for CI Failure (Failed to make list_offsets request, unknown broker) in DeleteRecordsTest.test_delete_records_segment_deletion

### DIFF
--- a/tests/rptest/tests/delete_records_test.py
+++ b/tests/rptest/tests/delete_records_test.py
@@ -166,18 +166,22 @@ class DeleteRecordsTest(RedpandaTest, PartitionMovementMixin):
 
     def retry_list_offset_request(self, fn, value_on_read):
         def check_bound():
+            self.redpanda.logger.debug("Inside of check_bound() method")
+            r = not value_on_read
             try:
                 if fn():
-                    return value_on_read
+                    r = value_on_read
             except Exception as e:
                 # Transient failure, desired to retry
                 if 'unknown broker' in str(e):
+                    self.redpanda.logger.warn("check_bound() retrying")
                     raise e
-            return not value_on_read
+            self.redpanda.logger.debug(f"check_bound() returning: {r}")
+            return r
 
         return wait_until_result(
             check_bound,
-            timeout_sec=10,
+            timeout_sec=60,
             backoff_sec=1,
             err_msg="Failed to make list_offsets request, unknown broker",
             retry_on_exc=True)


### PR DESCRIPTION
- The rpk consume single record test to verifiy a given offset has the exact same timeout as the retry logic that surrounds it.
- This commit bumps the timeout so that the retry logic may actually be implemented.
- Adding additional logs for debugging visibility

Link to underlying issue: https://github.com/redpanda-data/redpanda/issues/14641

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

