### PR TITLE
tests: Make the OMB validator use result.json

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -317,7 +317,18 @@ class OpenMessagingBenchmark(Service):
             self.raise_on_bad_log_lines(node)
         # Generate charts from the result
         self.logger.info(f"Generating charts with command {self.chart_cmd}")
-        metrics = json.loads(self.node.account.ssh_output(self.chart_cmd))
+        self.node.account.ssh_output(self.chart_cmd)
+        metrics = json.loads(
+            self.node.account.ssh_output(
+                f'cat {OpenMessagingBenchmark.RESULT_FILE}'))
+
+        # Previously we were using generate_charts.py to get the metrics which
+        # calculated this additional metric. Hence we do it here for backwards
+        # compatibility.
+        metrics['throughputMBps'] = (
+            sum(metrics['publishRate']) / len(metrics['publishRate']) *
+            metrics['messageSize']) / (1024.0 * 1024.0)
+
         if validate_metrics:
             OMBSampleConfigurations.validate_metrics(metrics, self.validator)
 

--- a/tests/rptest/services/openmessaging_benchmark_configs.py
+++ b/tests/rptest/services/openmessaging_benchmark_configs.py
@@ -91,20 +91,19 @@ class OMBSampleConfigurations:
 
     def validate_metrics(metrics, validator):
         """ Validates some predefined metrics rules against the metrics data and throws if any of the rules fail."""
-        assert len(metrics) == 1, "Unexpected metrics output {metrics}}"
-        metrics = next(iter(metrics.values()))
+        assert len(validator) > 0, "At least one metric should be validated"
+
         results = []
         kv_str = lambda k, v: f"Metric {k}, value {v}, "
-        count = 0
-        for key in metrics.keys():
-            if key not in validator:
-                continue
+
+        for key in validator.keys():
+            assert key in metrics, f"Missing requested validator key {key} in metrics"
+
             val = metrics[key]
-            count = count + 1
             for rule in validator[key]:
                 if not rule[0](val):
                     results.append(kv_str(key, val) + rule[1])
-        assert count > 0, f"At least one metric should be validated {metrics}"
+
         assert len(results) == 0, str(results)
 
     # ------ Driver configurations --------


### PR DESCRIPTION
The OMB validator was not validating p999 even though it was specified
in the validator requirements.

There was two reasons for that:
 - We were using the data from the output of the `generate_charts`
   command which is incomplete and doesn't return p999 e2e latency
 - This wasn't fatal because the validator logic silently failed to
   validate requested validation metrics if they were not in the metrics
   output

This patch fixes both by switching to actually using the `result.json`
file and further invert the validation loop such that it errors out if a
requested validation metric does not exist.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
