### PR TITLE
Removed deprecated Raft interfaces using `model::broker`

### DIFF
--- a/src/v/cluster/archival/tests/service_fixture.cc
+++ b/src/v/cluster/archival/tests/service_fixture.cc
@@ -21,6 +21,7 @@
 #include "cluster/archival/types.h"
 #include "cluster/members_table.h"
 #include "config/configuration.h"
+#include "model/metadata.h"
 #include "model/tests/random_batch.h"
 #include "random/generators.h"
 #include "storage/directories.h"
@@ -298,8 +299,6 @@ void archiver_fixture::initialize_shard(
         all_ntp[d.ntp] += 1;
     }
     wait_for_controller_leadership().get();
-    auto nm = app.controller->get_members_table().local().get_node_metadata(
-      model::node_id(1));
     for (const auto& ntp : all_ntp) {
         vlog(
           fixt_log.trace,
@@ -320,7 +319,7 @@ void archiver_fixture::initialize_shard(
             storage::ntp_config(
               ntp.first, data_dir.string(), std::move(defaults)),
             raft::group_id(1),
-            {nm->broker},
+            {raft::vnode(model::node_id(1), model::revision_id{0})},
             raft::with_learner_recovery_throttle::yes,
             raft::keep_snapshotted_log::no,
             std::nullopt)

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -458,7 +458,6 @@ ss::future<> controller::start(
       std::ref(_shard_placement),
       std::ref(_shard_table),
       std::ref(_partition_manager),
-      std::ref(_members_table),
       std::ref(_partition_leaders),
       std::ref(_tp_frontend),
       std::ref(_storage),

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -264,7 +264,6 @@ controller_backend::controller_backend(
   ss::sharded<shard_placement_table>& shard_placement,
   ss::sharded<shard_table>& st,
   ss::sharded<partition_manager>& pm,
-  ss::sharded<members_table>& members,
   ss::sharded<partition_leaders_table>& leaders,
   ss::sharded<topics_frontend>& frontend,
   ss::sharded<storage::api>& storage,
@@ -281,7 +280,6 @@ controller_backend::controller_backend(
   , _shard_placement(shard_placement.local())
   , _shard_table(st)
   , _partition_manager(pm)
-  , _members_table(members)
   , _partition_leaders_table(leaders)
   , _topics_frontend(frontend)
   , _storage(storage)

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -373,8 +373,6 @@ private:
 
     void setup_metrics();
 
-    bool command_based_membership_active() const;
-
     bool should_skip(const model::ntp&) const;
 
     std::optional<model::offset> calculate_learner_initial_offset(

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -201,7 +201,6 @@ public:
       ss::sharded<shard_placement_table>&,
       ss::sharded<shard_table>&,
       ss::sharded<partition_manager>&,
-      ss::sharded<members_table>&,
       ss::sharded<cluster::partition_leaders_table>&,
       ss::sharded<topics_frontend>&,
       ss::sharded<storage::api>&,
@@ -383,7 +382,6 @@ private:
     shard_placement_table& _shard_placement;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;
-    ss::sharded<members_table>& _members_table;
     ss::sharded<partition_leaders_table>& _partition_leaders_table;
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<storage::api>& _storage;

--- a/src/v/cluster/members_backend.cc
+++ b/src/v/cluster/members_backend.cc
@@ -443,10 +443,6 @@ ss::future<> members_backend::maybe_finish_decommissioning(update_meta& meta) {
 }
 
 ss::future<std::error_code> members_backend::do_remove_node(model::node_id id) {
-    if (!_features.local().is_active(
-          features::feature::membership_change_controller_cmds)) {
-        return _raft0->remove_member(id, model::revision_id{0});
-    }
     return _members_frontend.local().remove_node(id);
 }
 

--- a/src/v/cluster/members_manager.h
+++ b/src/v/cluster/members_manager.h
@@ -224,8 +224,6 @@ private:
     // Raft 0 config updates
     ss::future<>
       handle_raft0_cfg_update(raft::group_configuration, model::offset);
-    changed_nodes
-    calculate_changed_nodes(const raft::group_configuration&) const;
 
     ss::future<> maybe_update_current_node_configuration();
     ss::future<> dispatch_configuration_update(model::broker);
@@ -249,11 +247,6 @@ private:
     ss::future<std::error_code> update_node(model::broker);
 
     ss::future<join_node_reply> make_join_node_success_reply(model::node_id id);
-
-    bool command_based_membership_active() const {
-        return _feature_table.local().is_active(
-          features::feature::membership_change_controller_cmds);
-    }
 
     struct members_snapshot
       : serde::envelope<

--- a/src/v/cluster/members_table.cc
+++ b/src/v/cluster/members_table.cc
@@ -94,7 +94,7 @@ std::error_code members_table::apply(model::offset o, add_node_cmd cmd) {
 }
 
 void members_table::set_initial_brokers(std::vector<model::broker> brokers) {
-    vassert(!_nodes.empty(), "can not initialize not empty members table");
+    vassert(_nodes.empty(), "can not initialize not empty members table");
     vlog(clusterlog.info, "setting initial nodes {}", brokers);
     for (auto& b : brokers) {
         const auto id = b.id();

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1502,12 +1502,6 @@ ss::future<result<model::offset>> partition::linearizable_barrier() {
 }
 
 ss::future<std::error_code> partition::update_replica_set(
-  std::vector<raft::broker_revision> brokers,
-  model::revision_id new_revision_id) {
-    return _raft->replace_configuration(std::move(brokers), new_revision_id);
-}
-
-ss::future<std::error_code> partition::update_replica_set(
   std::vector<raft::vnode> nodes,
   model::revision_id new_revision_id,
   std::optional<model::offset> learner_start_offset) {

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -167,10 +167,6 @@ public:
       transfer_leadership(raft::transfer_leadership_request);
 
     ss::future<std::error_code> update_replica_set(
-      std::vector<raft::broker_revision> brokers,
-      model::revision_id new_revision_id);
-
-    ss::future<std::error_code> update_replica_set(
       std::vector<raft::vnode> nodes,
       model::revision_id new_revision_id,
       std::optional<model::offset> learner_start_offset);

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -115,7 +115,7 @@ ss::future<> partition_manager::start() {
 ss::future<consensus_ptr> partition_manager::manage(
   storage::ntp_config ntp_cfg,
   raft::group_id group,
-  std::vector<model::broker> initial_nodes,
+  std::vector<raft::vnode> initial_nodes,
   raft::with_learner_recovery_throttle enable_learner_recovery_throttle,
   raft::keep_snapshotted_log keep_snapshotted_log,
   std::optional<xshard_transfer_state> xst_state,

--- a/src/v/cluster/partition_manager.h
+++ b/src/v/cluster/partition_manager.h
@@ -25,6 +25,7 @@
 #include "model/fundamental.h"
 #include "model/ktp.h"
 #include "model/metadata.h"
+#include "raft/group_configuration.h"
 #include "raft/group_manager.h"
 #include "storage/api.h"
 
@@ -90,7 +91,7 @@ public:
     ss::future<consensus_ptr> manage(
       storage::ntp_config,
       raft::group_id,
-      std::vector<model::broker>,
+      std::vector<raft::vnode>,
       raft::with_learner_recovery_throttle,
       raft::keep_snapshotted_log,
       std::optional<xshard_transfer_state>,

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -25,8 +25,8 @@ static ss::future<consensus_ptr> create_raft0(
   ss::sharded<partition_manager>& pm,
   ss::sharded<shard_table>& st,
   const ss::sstring& data_directory,
-  std::vector<model::broker> initial_brokers) {
-    if (!initial_brokers.empty()) {
+  std::vector<raft::vnode> initial_nodes) {
+    if (!initial_nodes.empty()) {
         vlog(clusterlog.info, "Current node is a cluster founder");
     }
 
@@ -34,7 +34,7 @@ static ss::future<consensus_ptr> create_raft0(
       .manage(
         storage::ntp_config(model::controller_ntp, data_directory),
         raft::group_id(0),
-        std::move(initial_brokers),
+        std::move(initial_nodes),
         raft::with_learner_recovery_throttle::no,
         raft::keep_snapshotted_log::no,
         std::nullopt)

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -130,20 +130,6 @@ public:
 
     ss::future<timeout_now_reply> timeout_now(timeout_now_request&& r);
 
-    /// This method adds member to a group
-    ss::future<std::error_code>
-      add_group_member(model::broker, model::revision_id);
-    /// Updates given member configuration
-    ss::future<std::error_code> update_group_member(model::broker);
-    // Removes member from group
-    ss::future<std::error_code>
-      remove_member(model::node_id, model::revision_id);
-    /**
-     * Replace configuration, uses revision provided with brokers
-     */
-    ss::future<std::error_code>
-      replace_configuration(std::vector<broker_revision>, model::revision_id);
-
     /**
      * New simplified configuration change API, accepting only vnode instead of
      * full broker object

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -377,7 +377,7 @@ ss::future<> create_raft_state_for_pre_existing_partition(
   model::offset min_rp_offset,
   model::offset max_rp_offset,
   model::term_id last_included_term,
-  std::vector<model::broker> initial_nodes) {
+  std::vector<raft::vnode> initial_nodes) {
     // Prepare Raft state in kvstore
     vlog(
       raftlog.debug,
@@ -445,7 +445,7 @@ ss::future<> bootstrap_pre_existing_partition(
   model::offset min_rp_offset,
   model::offset max_rp_offset,
   model::term_id last_included_term,
-  std::vector<model::broker> initial_nodes,
+  std::vector<raft::vnode> initial_nodes,
   ss::lw_shared_ptr<storage::offset_translator_state> ot_state) {
     co_await create_offset_translator_state_for_pre_existing_partition(
       api, ntp_cfg, group, min_rp_offset, max_rp_offset, ot_state);

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -14,6 +14,7 @@
 #include "base/likely.h"
 #include "model/record.h"
 #include "raft/configuration_bootstrap_state.h"
+#include "raft/group_configuration.h"
 #include "raft/types.h"
 #include "storage/log.h"
 #include "storage/snapshot.h"
@@ -211,6 +212,6 @@ ss::future<> bootstrap_pre_existing_partition(
   model::offset min_rp_offset,
   model::offset max_rp_offset,
   model::term_id last_included_term,
-  std::vector<model::broker> initial_nodes,
+  std::vector<raft::vnode> initial_nodes,
   ss::lw_shared_ptr<storage::offset_translator_state> ot_state);
 } // namespace raft::details

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -13,6 +13,7 @@
 #include "config/property.h"
 #include "metrics/metrics.h"
 #include "model/metadata.h"
+#include "raft/consensus_client_protocol.h"
 #include "raft/heartbeat_manager.h"
 #include "raft/notification.h"
 #include "raft/recovery_memory_quota.h"
@@ -26,6 +27,8 @@
 #include <seastar/core/scheduling.hh>
 
 #include <absl/container/flat_hash_map.h>
+
+#include <tuple>
 
 namespace raft {
 
@@ -68,7 +71,7 @@ public:
 
     ss::future<ss::lw_shared_ptr<raft::consensus>> create_group(
       raft::group_id id,
-      std::vector<model::broker> nodes,
+      std::vector<raft::vnode> nodes,
       ss::shared_ptr<storage::log> log,
       with_learner_recovery_throttle enable_learner_recovery_throttle,
       keep_snapshotted_log = keep_snapshotted_log::no);
@@ -106,7 +109,8 @@ private:
     do_shutdown(ss::lw_shared_ptr<consensus>, bool remove_persistent_state);
 
     raft::group_configuration create_initial_configuration(
-      std::vector<model::broker>, model::revision_id) const;
+      std::vector<raft::vnode>, model::revision_id) const;
+    mutex _groups_mutex{"group_manager"};
     model::node_id _self;
     ss::scheduling_group _raft_sg;
     raft::consensus_client_protocol _client;

--- a/src/v/raft/tests/simple_raft_fixture.h
+++ b/src/v/raft/tests/simple_raft_fixture.h
@@ -14,6 +14,7 @@
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "raft/consensus.h"
+#include "raft/group_configuration.h"
 #include "raft/group_manager.h"
 #include "raft/types.h"
 #include "random/generators.h"
@@ -117,7 +118,7 @@ struct simple_raft_fixture {
                       auto group = raft::group_id(0);
                       return _group_mgr.local().create_group(
                         group,
-                        {self_broker()},
+                        {self_node()},
                         log,
                         raft::with_learner_recovery_throttle::yes);
                   })
@@ -161,14 +162,7 @@ struct simple_raft_fixture {
           storage::make_sanitized_file_config());
     }
 
-    model::broker self_broker() {
-        return model::broker(
-          _self,
-          net::unresolved_address("localhost", 9092),
-          net::unresolved_address("localhost", 35543),
-          std::nullopt,
-          model::broker_properties{});
-    }
+    raft::vnode self_node() { return {_self, model::revision_id{0}}; }
 
     void wait_for_becoming_leader() {
         using namespace std::chrono_literals;

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -191,7 +191,9 @@ class ClusterConfigHelpersMixin:
             return f"Not all the nodes are at the same config_version: {config_versions}"
 
         # wait for config_version to be the same on all the nodes
-        wait_until(_check_version, timeout_sec=5, err_msg=_assert_version_msg)
+        wait_until(_check_version,
+                   timeout_sec=5,
+                   err_msg=_assert_version_msg())
 
         # we expect that key is at expect_value by now
         values = {


### PR DESCRIPTION
Now as we progressed with Redpanda version and only support upgrades from the previous version it is perfectly possible to remove the broker based Raft reconfiguration API.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none