### PR TITLE
transform-sdk: decouple releases from broker

### DIFF
--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -11,7 +11,7 @@ name: transform-sdk-release
 on:
   push:
     tags:
-      - 'v*'
+      - 'transform-sdk/*'
 
 jobs:
   list-golang:
@@ -29,20 +29,25 @@ jobs:
           go-version: 1.20.6
 
       - name: Create golang specific tag
+        id: gotag
         uses: actions/github-script@v7
         with:
           script: |
+            const version = '${{github.ref_name}}'.slice('transform-sdk/'.length);
             github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: 'refs/tags/src/transform-sdk/go/transform/${{github.ref_name}}',
+              ref: 'refs/tags/src/transform-sdk/go/transform/' + version,
               sha: context.sha
-            })
-
+            });
+            // Return the result so we can use it to publish via `go list` below.
+            return version;
+          result-encoding: string
       - name: List module
         working-directory: src/transform-sdk/go
         # https://go.dev/doc/modules/publishing
-        run: go list -m github.com/redpanda-data/redpanda/src/transform-sdk/go/transform@${{github.ref_name}}
+        run: 
+          go list -m github.com/redpanda-data/redpanda/src/transform-sdk/go/transform@${{steps.gotag.outputs.result}}
 
   publish-rust:
     name: Publish Rust Transform SDK

--- a/src/transform-sdk/rust/scripts/publish.py
+++ b/src/transform-sdk/rust/scripts/publish.py
@@ -27,8 +27,8 @@ def publish_package(pkg: str):
 
 
 def publish(version: str):
-    # Cargo does not like the `v` prefix we add to tags, so remove it.
-    version = version.removeprefix('v')
+    # Cargo does not like the prefix we add to tags, so remove it.
+    version = version.removeprefix('transform-sdk/v')
     # Set the version in the TOML file
     toml = CARGO_TOML_FILE.read_text()
     toml = re.sub(pattern='^version = "[^"]+"',


### PR DESCRIPTION
Decouple the broker releases. Transform SDK releases will be in the
format of `transform-sdk/v0.0.0`. We can release these at any time
and all SDKs are released together.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
