### PR TITLE
Fix/inconsistent flushed offset

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -1542,6 +1542,8 @@ ss::future<> disk_log_impl::flush() {
     if (_segs.empty()) {
         return ss::make_ready_future<>();
     }
+    vlog(
+      stlog.trace, "flush on segment with offsets {}", _segs.back()->offsets());
     return _segs.back()->flush();
 }
 
@@ -2040,6 +2042,7 @@ ss::future<> disk_log_impl::do_truncate(
 
     auto stats = offsets();
 
+    vlog(stlog.trace, "do_truncate at {}, log {}", cfg.base_offset, stats);
     if (cfg.base_offset > stats.dirty_offset || _segs.empty()) {
         co_return;
     }
@@ -2084,6 +2087,12 @@ ss::future<> disk_log_impl::do_truncate(
     }
 
     auto initial_generation_id = last->get_generation_id();
+    vlog(
+      stlog.trace,
+      "do_truncate at {}, start {}, initial_size {}",
+      cfg.base_offset,
+      start,
+      initial_size);
 
     // an unchecked reader is created which does not enforce the logical
     // starting offset. this is needed because we really do want to read
@@ -2127,6 +2136,12 @@ ss::future<> disk_log_impl::do_truncate(
           *this));
     }
     auto [new_max_offset, file_position, new_max_timestamp] = phs.value();
+    vlog(
+      stlog.trace,
+      "do_truncate at {}, new_max_offset {}, file_position {}",
+      cfg.base_offset,
+      new_max_offset,
+      file_position);
 
     if (file_position == 0) {
         _segs.pop_back();

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -261,6 +261,8 @@ private:
     ss::future<std::optional<size_t>>
       disk_usage_target_time_retention(gc_config);
 
+    size_t get_log_truncation_counter() const noexcept override;
+
 private:
     size_t max_segment_size() const;
     // Computes the segment size based on the latest max_segment_size
@@ -312,6 +314,9 @@ private:
     // not, in order to ensure that writers wait for a background roll to
     // complete if one is ongoing.
     mutex _segments_rolling_lock;
+    // This counter is incremented when the log is truncated. It doesn't
+    // count logical truncations and can be incremented multiple times.
+    size_t _suffix_truncation_indicator{0};
 
     std::optional<model::offset> _cloud_gc_offset;
     std::optional<model::offset> _last_compaction_window_start_offset;

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -100,6 +100,8 @@ public:
 
     virtual size_t segment_count() const = 0;
     virtual storage::offset_stats offsets() const = 0;
+    // Returns counter which is incremented after every log suffix truncation
+    virtual size_t get_log_truncation_counter() const noexcept = 0;
     // Base offset of the first batch in the most recent term stored in log
     virtual model::offset find_last_term_start_offset() const = 0;
     virtual model::timestamp start_timestamp() const = 0;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2533,13 +2533,16 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
               auto offset = log->offsets();
               info("truncate offsets: {}", offset);
               auto start = ss::steady_clock_type::now();
+              auto orig_cnt = log->get_log_truncation_counter();
               return log
                 ->truncate(storage::truncate_config(
                   offset.dirty_offset, ss::default_priority_class()))
-                .finally([start] {
+                .finally([start, orig_cnt, log] {
                     // assert that truncation took less than 5 seconds
                     BOOST_REQUIRE_LT(
                       (ss::steady_clock_type::now() - start) / 1ms, 5000);
+                    auto new_cnt = log->get_log_truncation_counter();
+                    BOOST_REQUIRE_GT(new_cnt, orig_cnt);
                     info("truncate_done");
                 });
           });

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2634,16 +2634,23 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
                     offset,
                     truncate_at);
 
+                  auto orig_cnt = log->get_log_truncation_counter();
                   return log
                     ->truncate(storage::truncate_config(
                       truncate_at, ss::default_priority_class()))
-                    .then_wrapped([log, o = truncate_at](ss::future<> f) {
+                    .then_wrapped([log, o = truncate_at, orig_cnt](
+                                    ss::future<> f) {
                         vassert(
                           !f.failed(),
                           "truncation failed with {}",
                           f.get_exception());
                         BOOST_REQUIRE_LE(
                           log->offsets().dirty_offset, model::prev_offset(o));
+                        if (
+                          log->offsets().dirty_offset < model::prev_offset(o)) {
+                            auto new_cnt = log->get_log_truncation_counter();
+                            BOOST_REQUIRE_GT(new_cnt, orig_cnt);
+                        }
                     });
               });
           })


### PR DESCRIPTION
Fixes #15201

This PR improves logging to provide more information. It also fixes the problem in the `consensus::flush_log` method. The method is trying to detect the situation when the truncation happens concurrently. But the existing check fails in situation when there is not just concurrent truncation but truncation + log append.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix assertion triggered by interleaving of log flush and log truncation followed by append