### PR TITLE
rpk: improve --exit-when-healthy in cluster health

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/health.go
+++ b/src/go/rpk/pkg/cli/cluster/health.go
@@ -46,6 +46,9 @@ following conditions are met:
 			cl, err := adminapi.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize admin client: %v", err)
 
+			// --exit-when-healthy only makes sense with --watch, so we enable
+			// watch if --exit-when-healthy is provided.
+			watch = exit || watch
 			var lastOverview adminapi.ClusterHealthOverview
 			for {
 				ret, err := cl.GetHealthOverview(cmd.Context())
@@ -65,7 +68,7 @@ following conditions are met:
 	p.InstallSASLFlags(cmd)
 
 	cmd.Flags().BoolVarP(&watch, "watch", "w", false, "Blocks and writes out all cluster health changes")
-	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "When used with watch, exits after cluster is back in healthy state")
+	cmd.Flags().BoolVarP(&exit, "exit-when-healthy", "e", false, "Exits after cluster is back in healthy state")
 	return cmd
 }
 


### PR DESCRIPTION
--exit-when-healthy flag only makes sense with the --watch flag, so we enable now --watch if --exit-when-healthy is set.

Fixes #15818

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* rpk cluster health: now `--exit-when-healthy` enables `--watch` when provided.
