### PR TITLE
Rename max_client_count to max_connection_count

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -283,7 +283,7 @@ class HighThroughputTest(PreallocNodesTest):
         self._partitions_min = tier_product.max_partition_count // 50
         self._advertised_max_ingress = tier_product.max_ingress
         self._advertised_max_egress = tier_product.max_egress
-        self._advertised_max_client_count = tier_product.max_client_count
+        self._advertised_max_client_count = tier_product.max_connection_count
 
         if self.config_profile_name == CloudTierName.DOCKER:
             si_settings = SISettings(

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -212,8 +212,8 @@ class OMBValidationTest(RedpandaTest):
             producer_kwargs['max_record_size'] -
             producer_kwargs['min_record_size']) // 2
 
-        conn_limit = tier_limits.max_client_count - 3 * (total_producers +
-                                                         total_consumers)
+        conn_limit = tier_limits.max_connection_count - 3 * (total_producers +
+                                                             total_consumers)
         _target_per_node = conn_limit // SWARM_WORKERS
         _conn_per_node = int(_target_per_node * 0.7)
 

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -166,7 +166,7 @@ class LiveClusterParams:
 class ProductInfo:
     max_ingress: int
     max_egress: int
-    max_client_count: int
+    max_connection_count: int
     max_partition_count: int
 
 
@@ -1365,7 +1365,11 @@ class CloudCluster():
                 return ProductInfo(
                     max_ingress=int(product['advertisedMaxIngress']),
                     max_egress=int(product['advertisedMaxEgress']),
-                    max_client_count=int(product['advertisedMaxClientCount']),
+                    # note that despite the name advertisedMaxClientCount is actually
+                    # the advertised connection count, which is a much different value
+                    # (clients may make many connections to a single cluster)
+                    max_connection_count=int(
+                        product['advertisedMaxClientCount']),
                     max_partition_count=int(
                         product['advertisedMaxPartitionCount']))
 


### PR DESCRIPTION
The product field is wrongly named, it is actually max connection count. Rename it in the test code to avoid confusion.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

