### PR TITLE
transform: create smp and scheduling groups

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2635,7 +2635,7 @@ void application::start_runtime_services(
           if (wasm_data_transforms_enabled()) {
               runtime_services.push_back(
                 std::make_unique<transform::rpc::network_service>(
-                  sched_groups.cluster_sg(),
+                  sched_groups.transforms_sg(),
                   smp_service_groups.cluster_smp_sg(),
                   &_transform_rpc_service));
           }

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -100,6 +100,7 @@
 #include "resource_mgmt/io_priority.h"
 #include "resource_mgmt/memory_groups.h"
 #include "resource_mgmt/memory_sampling.h"
+#include "resource_mgmt/smp_groups.h"
 #include "rpc/rpc_utils.h"
 #include "security/audit/audit_log_manager.h"
 #include "ssx/abort_source.h"
@@ -1204,7 +1205,9 @@ void application::wire_up_runtime_services(
           }),
           ss::sharded_parameter([this] {
               return transform::rpc::partition_manager::make_default(
-                &shard_table, &partition_manager);
+                &shard_table,
+                &partition_manager,
+                smp_service_groups.transform_smp_sg());
           }),
           ss::sharded_parameter([this] {
               return transform::service::create_reporter(&_transform_service);
@@ -2636,7 +2639,7 @@ void application::start_runtime_services(
               runtime_services.push_back(
                 std::make_unique<transform::rpc::network_service>(
                   sched_groups.transforms_sg(),
-                  smp_service_groups.cluster_smp_sg(),
+                  smp_service_groups.transform_smp_sg(),
                   &_transform_rpc_service));
           }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1246,7 +1246,8 @@ void application::wire_up_runtime_services(
           &raft_group_manager,
           &controller->get_topics_state(),
           &partition_manager,
-          &_transform_rpc_client)
+          &_transform_rpc_client,
+          sched_groups.transforms_sg())
           .get();
     }
 

--- a/src/v/resource_mgmt/CMakeLists.txt
+++ b/src/v/resource_mgmt/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     memory_sampling.cc
     cpu_profiler.cc
     logger.cc
+    smp_groups.cc
   DEPS
     Seastar::seastar
     v::ssx

--- a/src/v/resource_mgmt/cpu_scheduling.h
+++ b/src/v/resource_mgmt/cpu_scheduling.h
@@ -38,6 +38,7 @@ public:
         _node_status = co_await ss::create_scheduling_group("node_status", 50);
         _self_test = co_await ss::create_scheduling_group("self_test", 100);
         _fetch = co_await ss::create_scheduling_group("fetch", 1000);
+        _transforms = co_await ss::create_scheduling_group("transforms", 100);
     }
 
     ss::future<> destroy_groups() {
@@ -52,7 +53,7 @@ public:
         co_await destroy_scheduling_group(_node_status);
         co_await destroy_scheduling_group(_self_test);
         co_await destroy_scheduling_group(_fetch);
-        co_return;
+        co_await destroy_scheduling_group(_transforms);
     }
 
     ss::scheduling_group admin_sg() { return _admin; }
@@ -70,6 +71,7 @@ public:
     ss::scheduling_group archival_upload() { return _archival_upload; }
     ss::scheduling_group node_status() { return _node_status; }
     ss::scheduling_group self_test_sg() { return _self_test; }
+    ss::scheduling_group transforms_sg() { return _transforms; }
     /**
      * @brief Scheduling group for fetch requests.
      *
@@ -95,7 +97,8 @@ public:
           std::cref(_archival_upload),
           std::cref(_node_status),
           std::cref(_self_test),
-          std::cref(_fetch)};
+          std::cref(_fetch),
+          std::cref(_transforms)};
     }
 
 private:
@@ -112,4 +115,5 @@ private:
     ss::scheduling_group _node_status;
     ss::scheduling_group _self_test;
     ss::scheduling_group _fetch;
+    ss::scheduling_group _transforms;
 };

--- a/src/v/resource_mgmt/smp_groups.cc
+++ b/src/v/resource_mgmt/smp_groups.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "resource_mgmt/smp_groups.h"
+
+#include <seastar/core/coroutine.hh>
+
+ss::future<> smp_groups::create_groups(config cfg) {
+    _raft = co_await create_service_group(
+      cfg.raft_group_max_non_local_requests);
+    _kafka = co_await create_service_group(
+      cfg.kafka_group_max_non_local_requests);
+    _cluster = co_await create_service_group(
+      cfg.cluster_group_max_non_local_requests);
+    _proxy = co_await create_service_group(
+      cfg.proxy_group_max_non_local_requests);
+    _transform = co_await create_service_group(
+      cfg.transform_group_max_non_local_requests);
+}
+
+ss::future<> smp_groups::destroy_groups() {
+    co_await destroy_smp_service_group(*_kafka);
+    co_await destroy_smp_service_group(*_raft);
+    co_await destroy_smp_service_group(*_cluster);
+    co_await destroy_smp_service_group(*_proxy);
+    co_await destroy_smp_service_group(*_transform);
+}
+
+uint32_t
+smp_groups::default_raft_non_local_requests(uint32_t max_partitions_per_core) {
+    /**
+     * raft max non local requests
+     * - up to 7000 groups per core
+     * - up to 256 concurrent append entries per group
+     * - additional requests like (vote, snapshot, timeout now)
+     *
+     * All the values have to be multiplied by core count minus one since
+     * part of the requests will be core local
+     *
+     * 7000*256 * (number of cores-1) + 10 * 7000 * (number of cores-1)
+     *         ^                                 ^
+     * append entries requests          additional requests
+     */
+
+    static constexpr uint32_t max_append_requests_per_follower = 256;
+    static constexpr uint32_t additional_requests_per_follower = 10;
+
+    return max_partitions_per_core
+           * (max_append_requests_per_follower + additional_requests_per_follower)
+           * (ss::smp::count - 1);
+}
+
+ss::future<std::unique_ptr<ss::smp_service_group>>
+smp_groups::create_service_group(unsigned max_non_local_requests) {
+    ss::smp_service_group_config smp_sg_config{
+      .max_nonlocal_requests = max_non_local_requests};
+    auto sg = co_await create_smp_service_group(smp_sg_config);
+    co_return std::make_unique<ss::smp_service_group>(sg);
+}

--- a/src/v/resource_mgmt/smp_groups.h
+++ b/src/v/resource_mgmt/smp_groups.h
@@ -30,8 +30,9 @@ public:
           = default_max_nonlocal_requests;
         uint32_t cluster_group_max_non_local_requests
           = default_max_nonlocal_requests;
-
         uint32_t proxy_group_max_non_local_requests
+          = default_max_nonlocal_requests;
+        uint32_t transform_group_max_non_local_requests
           = default_max_nonlocal_requests;
     };
 
@@ -45,18 +46,22 @@ public:
           cfg.cluster_group_max_non_local_requests);
         _proxy = co_await create_service_group(
           cfg.proxy_group_max_non_local_requests);
+        _transform = co_await create_service_group(
+          cfg.transform_group_max_non_local_requests);
     }
 
     ss::smp_service_group raft_smp_sg() { return *_raft; }
     ss::smp_service_group kafka_smp_sg() { return *_kafka; }
     ss::smp_service_group cluster_smp_sg() { return *_cluster; }
     ss::smp_service_group proxy_smp_sg() { return *_proxy; }
+    ss::smp_service_group transform_smp_sg() { return *_transform; }
 
     ss::future<> destroy_groups() {
-        return destroy_smp_service_group(*_kafka)
-          .then([this] { return destroy_smp_service_group(*_raft); })
-          .then([this] { return destroy_smp_service_group(*_cluster); })
-          .then([this] { return destroy_smp_service_group(*_proxy); });
+        co_await destroy_smp_service_group(*_kafka);
+        co_await destroy_smp_service_group(*_raft);
+        co_await destroy_smp_service_group(*_cluster);
+        co_await destroy_smp_service_group(*_proxy);
+        co_await destroy_smp_service_group(*_transform);
     }
 
     static uint32_t
@@ -97,4 +102,5 @@ private:
     std::unique_ptr<ss::smp_service_group> _kafka;
     std::unique_ptr<ss::smp_service_group> _cluster;
     std::unique_ptr<ss::smp_service_group> _proxy;
+    std::unique_ptr<ss::smp_service_group> _transform;
 };

--- a/src/v/resource_mgmt/smp_groups.h
+++ b/src/v/resource_mgmt/smp_groups.h
@@ -13,8 +13,7 @@
 
 #include "base/seastarx.h"
 
-#include <seastar/core/coroutine.hh>
-#include <seastar/core/reactor.hh>
+#include <seastar/core/smp.hh>
 
 // manage SMP scheduling groups. These scheduling groups are global, so one
 // instance of this class can be created at the top level and passed down into
@@ -37,18 +36,7 @@ public:
     };
 
     smp_groups() = default;
-    ss::future<> create_groups(config cfg) {
-        _raft = co_await create_service_group(
-          cfg.raft_group_max_non_local_requests);
-        _kafka = co_await create_service_group(
-          cfg.kafka_group_max_non_local_requests);
-        _cluster = co_await create_service_group(
-          cfg.cluster_group_max_non_local_requests);
-        _proxy = co_await create_service_group(
-          cfg.proxy_group_max_non_local_requests);
-        _transform = co_await create_service_group(
-          cfg.transform_group_max_non_local_requests);
-    }
+    ss::future<> create_groups(config cfg);
 
     ss::smp_service_group raft_smp_sg() { return *_raft; }
     ss::smp_service_group kafka_smp_sg() { return *_kafka; }
@@ -56,47 +44,14 @@ public:
     ss::smp_service_group proxy_smp_sg() { return *_proxy; }
     ss::smp_service_group transform_smp_sg() { return *_transform; }
 
-    ss::future<> destroy_groups() {
-        co_await destroy_smp_service_group(*_kafka);
-        co_await destroy_smp_service_group(*_raft);
-        co_await destroy_smp_service_group(*_cluster);
-        co_await destroy_smp_service_group(*_proxy);
-        co_await destroy_smp_service_group(*_transform);
-    }
+    ss::future<> destroy_groups();
 
     static uint32_t
-    default_raft_non_local_requests(uint32_t max_partitions_per_core) {
-        /**
-         * raft max non local requests
-         * - up to 7000 groups per core
-         * - up to 256 concurrent append entries per group
-         * - additional requests like (vote, snapshot, timeout now)
-         *
-         * All the values have to be multiplied by core count minus one since
-         * part of the requests will be core local
-         *
-         * 7000*256 * (number of cores-1) + 10 * 7000 * (number of cores-1)
-         *         ^                                 ^
-         * append entries requests          additional requests
-         */
-
-        static constexpr uint32_t max_append_requests_per_follower = 256;
-        static constexpr uint32_t additional_requests_per_follower = 10;
-
-        return max_partitions_per_core
-               * (max_append_requests_per_follower + additional_requests_per_follower)
-               * (ss::smp::count - 1);
-    }
+    default_raft_non_local_requests(uint32_t max_partitions_per_core);
 
 private:
     ss::future<std::unique_ptr<ss::smp_service_group>>
-    create_service_group(unsigned max_non_local_requests) {
-        ss::smp_service_group_config smp_sg_config{
-          .max_nonlocal_requests = max_non_local_requests};
-        auto sg = co_await create_smp_service_group(smp_sg_config);
-
-        co_return std::make_unique<ss::smp_service_group>(sg);
-    }
+    create_service_group(unsigned max_non_local_requests);
 
     std::unique_ptr<ss::smp_service_group> _raft;
     std::unique_ptr<ss::smp_service_group> _kafka;

--- a/src/v/ssx/work_queue.h
+++ b/src/v/ssx/work_queue.h
@@ -20,6 +20,7 @@
 #include <seastar/core/future-util.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 namespace ssx {
@@ -33,6 +34,7 @@ public:
       = ss::noncopyable_function<void(const std::exception_ptr&)>;
 
     explicit work_queue(error_reporter_fn);
+    work_queue(ss::scheduling_group, error_reporter_fn);
     // Add a task to the queue to be processed.
     void submit(ss::noncopyable_function<ss::future<>()>);
     // Add a task to the queue to be processed after some timeout.

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -21,6 +21,7 @@
 #include "wasm/fwd.h"
 
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/util/defer.hh>
 #include <seastar/util/noncopyable_function.hh>
@@ -44,7 +45,8 @@ public:
       ss::sharded<raft::group_manager>* group_manager,
       ss::sharded<cluster::topic_table>* topic_table,
       ss::sharded<cluster::partition_manager>* partition_manager,
-      ss::sharded<rpc::client>* rpc_client);
+      ss::sharded<rpc::client>* rpc_client,
+      ss::scheduling_group sg);
     service(const service&) = delete;
     service(service&&) = delete;
     service& operator=(const service&) = delete;
@@ -107,6 +109,7 @@ private:
     std::unique_ptr<commit_batcher<ss::lowres_clock>> _batcher;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>
       _notification_cleanups;
+    ss::scheduling_group _sg;
 };
 
 } // namespace transform

--- a/src/v/transform/rpc/deps.cc
+++ b/src/v/transform/rpc/deps.cc
@@ -30,6 +30,7 @@
 #include <seastar/core/do_with.hh>
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/smp.hh>
 
 #include <memory>
 #include <type_traits>
@@ -74,9 +75,11 @@ class partition_manager_impl final : public partition_manager {
 public:
     partition_manager_impl(
       ss::sharded<cluster::shard_table>* table,
-      ss::sharded<cluster::partition_manager>* manager)
+      ss::sharded<cluster::partition_manager>* manager,
+      ss::smp_service_group smp_group)
       : _table(table)
-      , _manager(manager) {}
+      , _manager(manager)
+      , _smp_group(smp_group) {}
 
     std::optional<ss::shard_id> shard_owner(const model::ktp& ntp) final {
         return _table->local().shard_for(ntp);
@@ -211,19 +214,12 @@ private:
         co_return response;
     }
 
-    template<class Func>
-    requires requires(Func f, cluster::partition_manager& mgr) { f(mgr); }
-    std::invoke_result_t<Func, cluster::partition_manager&>
-    invoke_func_on_shard_impl(ss::shard_id shard, Func&& func) {
-        return _manager->invoke_on(shard, std::forward<Func>(func));
-    }
-
     ss::future<cluster::errc> invoke_on_shard_impl(
       ss::shard_id shard,
       const model::any_ntp auto& ntp,
       ss::noncopyable_function<
         ss::future<cluster::errc>(kafka::partition_proxy*)> fn) {
-        return _manager->invoke_on(
+        return invoke_func_on_shard_impl(
           shard,
           [ntp, fn = std::move(fn)](cluster::partition_manager& mgr) mutable {
               auto pp = kafka::make_partition_proxy(ntp, mgr);
@@ -239,8 +235,17 @@ private:
           });
     }
 
+    template<class Func>
+    requires requires(Func f, cluster::partition_manager& mgr) { f(mgr); }
+    std::invoke_result_t<Func, cluster::partition_manager&>
+    invoke_func_on_shard_impl(ss::shard_id shard, Func&& func) {
+        return _manager->invoke_on(
+          shard, {_smp_group}, std::forward<Func>(func));
+    }
+
     ss::sharded<cluster::shard_table>* _table;
     ss::sharded<cluster::partition_manager>* _manager;
+    ss::smp_service_group _smp_group;
 };
 
 class topic_creator_impl : public topic_creator {
@@ -331,8 +336,9 @@ transform::rpc::topic_metadata_cache::make_default(
 std::unique_ptr<partition_manager>
 transform::rpc::partition_manager::make_default(
   ss::sharded<cluster::shard_table>* table,
-  ss::sharded<cluster::partition_manager>* manager) {
-    return std::make_unique<partition_manager_impl>(table, manager);
+  ss::sharded<cluster::partition_manager>* manager,
+  ss::smp_service_group smp_group) {
+    return std::make_unique<partition_manager_impl>(table, manager, smp_group);
 }
 
 std::optional<ss::shard_id>

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -160,7 +160,8 @@ public:
 
     static std::unique_ptr<partition_manager> make_default(
       ss::sharded<cluster::shard_table>*,
-      ss::sharded<cluster::partition_manager>*);
+      ss::sharded<cluster::partition_manager>*,
+      ss::smp_service_group smp_group);
 
     /**
      * Lookup which shard owns a particular ntp.

--- a/src/v/transform/rpc/service.cc
+++ b/src/v/transform/rpc/service.cc
@@ -35,6 +35,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/semaphore.hh>
+#include <seastar/coroutine/switch_to.hh>
 
 #include <algorithm>
 #include <iterator>
@@ -336,6 +337,7 @@ local_service::offset_fetch(offset_fetch_request request) {
 
 ss::future<produce_reply>
 network_service::produce(produce_request req, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
     auto results = co_await _service->local().produce(
       std::move(req.topic_data), req.timeout);
     co_return produce_reply(std::move(results));
@@ -343,6 +345,7 @@ network_service::produce(produce_request req, ::rpc::streaming_context&) {
 
 ss::future<delete_wasm_binary_reply> network_service::delete_wasm_binary(
   delete_wasm_binary_request req, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
     auto results = co_await _service->local().delete_wasm_binary(
       req.key, req.timeout);
     co_return delete_wasm_binary_reply(results);
@@ -350,6 +353,7 @@ ss::future<delete_wasm_binary_reply> network_service::delete_wasm_binary(
 
 ss::future<load_wasm_binary_reply> network_service::load_wasm_binary(
   load_wasm_binary_request req, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
     auto results = co_await _service->local().load_wasm_binary(
       req.offset, req.timeout);
     if (results.has_error()) {
@@ -361,6 +365,7 @@ ss::future<load_wasm_binary_reply> network_service::load_wasm_binary(
 
 ss::future<store_wasm_binary_reply> network_service::store_wasm_binary(
   store_wasm_binary_request req, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
     auto results = co_await _service->local().store_wasm_binary(
       std::move(req.data), req.timeout);
     if (results.has_error()) {
@@ -371,21 +376,25 @@ ss::future<store_wasm_binary_reply> network_service::store_wasm_binary(
 
 ss::future<find_coordinator_response> network_service::find_coordinator(
   find_coordinator_request req, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
     co_return co_await _service->local().find_coordinator(std::move(req));
 }
 
 ss::future<offset_fetch_response> network_service::offset_fetch(
   offset_fetch_request req, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
     co_return co_await _service->local().offset_fetch(req);
 }
 
 ss::future<offset_commit_response> network_service::offset_commit(
   offset_commit_request req, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
     co_return co_await _service->local().offset_commit(req);
 }
 
 ss::future<generate_report_reply> network_service::generate_report(
   generate_report_request, ::rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
     auto report = co_await _service->local().compute_node_local_report();
     co_return generate_report_reply(std::move(report));
 }

--- a/src/v/transform/tests/transform_manager_test.cc
+++ b/src/v/transform/tests/transform_manager_test.cc
@@ -14,6 +14,7 @@
 #include <seastar/core/manual_clock.hh>
 #include <seastar/core/print.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/util/later.hh>
 #include <seastar/util/noncopyable_function.hh>
 
@@ -290,7 +291,10 @@ public:
         auto t = std::make_unique<processor_tracker>();
         _tracker = t.get();
         _manager = std::make_unique<manager<ss::manual_clock>>(
-          /*self=*/model::node_id(0), std::move(r), std::move(t));
+          /*self=*/model::node_id(0),
+          std::move(r),
+          std::move(t),
+          ss::current_scheduling_group());
         _manager->start().get();
     }
     void TearDown() override {

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -25,6 +25,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/when_all.hh>
@@ -253,11 +254,14 @@ template<typename ClockType>
 manager<ClockType>::manager(
   model::node_id self,
   std::unique_ptr<registry> r,
-  std::unique_ptr<processor_factory> f)
+  std::unique_ptr<processor_factory> f,
+  ss::scheduling_group sg)
   : _self(self)
-  , _queue([](const std::exception_ptr& ex) {
-      vlog(tlog.error, "unexpected transform manager error: {}", ex);
-  })
+  , _queue(
+      sg,
+      [](const std::exception_ptr& ex) {
+          vlog(tlog.error, "unexpected transform manager error: {}", ex);
+      })
   , _registry(std::move(r))
   , _processors(std::make_unique<processor_table<ClockType>>())
   , _processor_factory(std::move(f)) {}

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -23,6 +23,7 @@
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/manual_clock.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/bool_class.hh>
 
@@ -107,7 +108,8 @@ public:
     manager(
       model::node_id self,
       std::unique_ptr<registry>,
-      std::unique_ptr<processor_factory>);
+      std::unique_ptr<processor_factory>,
+      ss::scheduling_group);
     manager(const manager&) = delete;
     manager& operator=(const manager&) = delete;
     manager(manager&&) = delete;


### PR DESCRIPTION
Introduce SMP and CPU scheduling groups for transforms.

The main motivation for this is to allow for internal metrics on CPU usage for the transform subsystem. While doing this change, I also see that we generally also have smp groups too, so I created one for the internal data path, where there are a few cross shard calls to produce.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Add a dedicated CPU scheduling policy for Data Transforms

