### PR TITLE
rptest/scale_test: Remove p50 check in audit test

### DIFF
--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -405,8 +405,6 @@ class AuditLogTest(RedpandaTest):
         assert pct_chg(
             audit_enabled_results.consume_mbps,
             audit_disabled_results.consume_mbps) < allowable_threshold
-        assert pct_chg(audit_enabled_results.p50,
-                       audit_disabled_results.p50) > (allowable_threshold * -1)
         assert pct_chg(audit_enabled_results.p90,
                        audit_disabled_results.p90) > (allowable_threshold * -1)
         assert pct_chg(audit_enabled_results.p99,


### PR DESCRIPTION
- Removing the p50 assertion as this represents the average latency time which has a large variance.

- Fixes: #16009

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
