### PR TITLE
rptest: Wait for the group to be in a stable state before starting tests

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -91,7 +91,7 @@ class ConsumerGroupTest(RedpandaTest):
 
         def group_is_ready():
             gr = rpk.group_describe(group=group, summary=True)
-            return gr.members == consumer_count
+            return gr.members == consumer_count and gr.state == "Stable"
 
         wait_until(group_is_ready, 60, 1)
         return consumers


### PR DESCRIPTION
- Its been observed many times in the ConsumerGroupTests that an unbalanced consumer consumes all messages and and some type of assertion that expects at least all members to consume some records fails by way of timing out.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
