### PR TITLE
[v23.3.x] rptest/scale_test: Remove p50 check in audit test

### DIFF
--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -405,8 +405,6 @@ class AuditLogTest(RedpandaTest):
         assert pct_chg(
             audit_enabled_results.consume_mbps,
             audit_disabled_results.consume_mbps) < allowable_threshold
-        assert pct_chg(audit_enabled_results.p50,
-                       audit_disabled_results.p50) > (allowable_threshold * -1)
         assert pct_chg(audit_enabled_results.p90,
                        audit_disabled_results.p90) > (allowable_threshold * -1)
         assert pct_chg(audit_enabled_results.p99,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16125
Fixes: https://github.com/redpanda-data/redpanda/issues/16130,