### PR TITLE
rptest: bad field use in test_consume_miss_cache

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -1500,10 +1500,10 @@ class HighThroughputTest(PreallocNodesTest):
                        backoff_sec=30)
         except Exception as e:
             _percent = (producer.produce_status.sent * 100) / expected_sent
-            self.log.warning("# Timeout waiting for all messages: "
-                             f"expected {expected_sent}, "
-                             f"current {producer.produce_status.sent} "
-                             f"({_percent}%)\n{e}")
+            self.logger.warning("# Timeout waiting for all messages: "
+                                f"expected {expected_sent}, "
+                                f"current {producer.produce_status.sent} "
+                                f"({_percent}%)\n{e}")
 
         post_prod_offsets = [(p.id, p.high_watermark)
                              for p in self.rpk.describe_topic(self.topic)


### PR DESCRIPTION
We used the log field which doesn't exist, should be logger.

This was presumably mostly working because it is on an error type.

This bug was found through typing.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

