### PR TITLE
rptest: invalid comparison in test_max_connections

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -604,7 +604,7 @@ class HighThroughputTest(PreallocNodesTest):
             if (len(swarm) - calc_alive_swarm_nodes(swarm)) > 1:
                 break
             elif _elapsed > FINISH_TIMEOUT_SEC and \
-                _connections < (self._advertised_max_client_count * 0.01):
+                _total < (self._advertised_max_client_count * 0.01):
                 # Number of connections after timeout is less than 1%
                 break
             # sleep before next measurement


### PR DESCRIPTION
We comared a list to a float, which will fail at runtime. Presumably we don't hit this case when the test passes but we can hit it for some failures.

This bug was found through typing.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
