### PR TITLE
rptest: more typing 2

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -450,7 +450,7 @@ class RpkTool:
         ]
         return self._run(cmd)
 
-    def delete_topic(self, topic):
+    def delete_topic(self, topic: str):
         cmd = ["delete", topic]
         output = self._run_topic(cmd)
         table = parse_rpk_table(output)

--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -7,12 +7,14 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from __future__ import annotations
+
 import os
 import time
 import signal
 import threading
 import requests
-from typing import Optional
+from typing import Any, Optional
 
 from ducktape.services.service import Service
 from ducktape.utils.util import wait_until
@@ -445,8 +447,8 @@ class ValidatorStatus:
     internally to kgo-verifier.  Other parts of consumer status are allowed to
     differ per-worker, although at time of writing they don't.
     """
-    def __init__(self, name, valid_reads, invalid_reads,
-                 out_of_scope_invalid_reads, max_offsets_consumed):
+    def __init__(self, name: str, valid_reads: int, invalid_reads: int,
+                 out_of_scope_invalid_reads: int, max_offsets_consumed: int):
         # Validator name is just a unique name per worker thread in kgo-verifier: useful in logging
         # but we mostly don't care
         self.name = name
@@ -462,7 +464,7 @@ class ValidatorStatus:
         # terminates as soon as it sees an invalid read
         return self.valid_reads + self.out_of_scope_invalid_reads
 
-    def merge(self, rhs):
+    def merge(self, rhs: ValidatorStatus):
         # Clear name if we are merging multiple statuses together, to avoid confusion.
         self.name = ""
 
@@ -475,7 +477,11 @@ class ValidatorStatus:
 
 
 class ConsumerStatus:
-    def __init__(self, topic=None, validator=None, errors=0, active=True):
+    def __init__(self,
+                 topic: str = None,
+                 validator: dict[str, Any] | None = None,
+                 errors: int = 0,
+                 active: bool = True):
         """
         `active` defaults to True, because we use it for deciding when to drop out in `wait()` -- the initial
         state of a worker should be presumed that it is busy, and we must wait to see it go `active=False`
@@ -494,7 +500,7 @@ class ConsumerStatus:
         self.errors = errors
         self.active = active
 
-    def merge(self, rhs):
+    def merge(self, rhs: ConsumerStatus):
         self.active = self.active or rhs.active
         self.errors += rhs.errors
         self.validator.merge(rhs.validator)

--- a/tests/rptest/tests/prealloc_nodes.py
+++ b/tests/rptest/tests/prealloc_nodes.py
@@ -7,8 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+from typing import Any
 from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.cluster.cluster_spec import ClusterSpec
+from ducktape.cluster.cluster import ClusterNode
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
@@ -23,8 +25,11 @@ class PreallocNodesTest(RedpandaTest):
     run services that need to be on the same host (e.g. the KgoVerifier
     producer/consumers that coordinate via a local file)
     """
+
+    _preallocated_nodes: list[ClusterNode]
+
     def __init__(self, test_context: TestContext, node_prealloc_count: int,
-                 *args, **kwargs):
+                 *args: Any, **kwargs: Any):
         super(PreallocNodesTest, self).__init__(test_context, *args, **kwargs)
         self.node_prealloc_count = node_prealloc_count
 

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -33,7 +33,7 @@ class RedpandaTest(Test):
     def __init__(self,
                  test_context: TestContext,
                  num_brokers: int | None = None,
-                 cloud_tier: CloudTierName | None = None,
+                 cloud_tier: str | None = None,
                  apply_cloud_tier_to_noncloud: bool = False,
                  extra_rp_conf: dict[str, Any] | None = None,
                  si_settings: SISettings | None = None,


### PR DESCRIPTION
Type more parts of rptest, concentrating on getting high_throughput_test to type fully at pyright "basic" setting.

After this change it types fully with some additional ducktape stubbing (not part of this change).

This change is largely pure typing (which can't affect runtime) though there are a handful of small runtime changes to assist in the typing, e.g., asserts that properties are not None immediately prior to using them which would otherwise be a typing failure. This only changes a crash at use to a crash immediately before at the assert.


## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

