### PR TITLE
ci: Fix flink install on ARM64

### DIFF
--- a/tests/docker/ducktape-deps/flink
+++ b/tests/docker/ducktape-deps/flink
@@ -19,6 +19,14 @@ wget https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-k
 /opt/flink/bin/flink --version
 
 # Prepare python venv archive
+
+# At this point, for ARM64 there is no JAVA_HOME, but java is installed
+# So get the folder from java itself
+if [[ -z $JAVA_HOME ]]; then
+  export JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | cut -d'=' -f2 | xargs);
+fi
+echo "Using Java home folder at $JAVA_HOME"
+
 cd /opt/flink/
 pip install virtualenv
 virtualenv flink_venv


### PR DESCRIPTION
For ARM64 architecture JAVA_HOME env var is empty for some reason.
Flink installation expects it. Safety wise, no checking of arch, and extracting JAVA_HOME from java app itself if target var is empty

Fixes: redpanda-data/devprod#1015

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none