### PR TITLE
OMBSampleConfigurations predicates are static

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark_configs.py
+++ b/tests/rptest/services/openmessaging_benchmark_configs.py
@@ -34,14 +34,17 @@ class OMBSampleConfigurations:
     E2E_LATENCY_MAX = "aggregatedEndToEndLatencyMax"
     AVG_THROUGHPUT_MBPS = "throughputMBps"
 
+    @staticmethod
     def range(min_val, max_val):
         return (lambda x: x >= min_val and x <= max_val,
                 f"Expected in range [{min_val}, {max_val}], check failed.")
 
+    @staticmethod
     def lte(max_val):
         return (lambda x: x <= max_val,
                 f"Expected to be <= {max_val}, check failed.")
 
+    @staticmethod
     def gte(min_val):
         return (lambda x: x >= min_val,
                 f"Expected to be >= {min_val}, check failed.")


### PR DESCRIPTION
The predicates in OMBSampleConfigurations are static methods but are not marked as such.

This bug was detected by typing.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

