### PR TITLE
gha: run build-redpanda workflow once per day

### DIFF
--- a/.github/workflows/build-redpanda.yml
+++ b/.github/workflows/build-redpanda.yml
@@ -9,22 +9,8 @@
 
 name: build-redpanda
 on:
-  push:
-    branches:
-      - dev
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - ready_for_review
-    paths:
-      - 'src/v/**'
-      - 'cmake/**'
-      - 'CMakeLists.txt'
-      - 'CMakePresets.json'
-      - 'install-dependencies.sh'
-      - '.github/workflows/build-redpanda.yml'
+  schedule:
+    - cron: '0 0 * * 1-5'
 
 jobs:
   build:


### PR DESCRIPTION
Run mon-fri at 00:00 hrs for now; it'll be moved to BK shortly

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none