### PR TITLE
rptest: Transaction workload with scaling in mind

### DIFF
--- a/tests/rptest/e2e_tests/flink_scale_test.py
+++ b/tests/rptest/e2e_tests/flink_scale_test.py
@@ -1,0 +1,135 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from rptest.clients.types import TopicSpec
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.e2e_tests.workload_manager import WorkloadManager
+from rptest.services.cluster import cluster
+from rptest.services.flink import FlinkService
+from rptest.tests.redpanda_test import RedpandaTest
+
+
+class FlinkScaleTests(RedpandaTest):
+    def __init__(self, test_context, *args, **kwargs):
+        # Init parent
+        super(FlinkScaleTests, self).__init__(test_context, log_level="trace")
+
+        self.flink = FlinkService(test_context)
+        # Prepare client
+        config = self.redpanda.security_config()
+        user = config.get("sasl_plain_username")
+        passwd = config.get("sasl_plain_password")
+        protocol = config.get("security_protocol", "SASL_PLAINTEXT")
+        self.kafkacli = KafkaCliTools(self.redpanda,
+                                      user=user,
+                                      passwd=passwd,
+                                      protocol=protocol)
+        # Prepare Workloads
+        self.workload_manager = WorkloadManager(self.logger)
+
+        return
+
+    def tearDown(self):
+        # Clean all up
+        for spec in self.topic_specs:
+            self.kafkacli.delete_topic(spec.name)
+        return super().tearDown()
+
+    def _run_workloads(self, workloads, config):
+        """
+            Run workloads from the list with supplied config
+
+            Return: list of failed jobs
+        """
+        # Run produce job
+        for workload in workloads:
+            # Add script as a job
+            self.logger.info(f"Adding {workload['name']} to flink")
+            ids = self.flink.run_flink_job(workload['path'], config)
+            if ids is None:
+                raise RuntimeError("Failed to run job on flink for "
+                                   f"workload: {workload['name']}")
+
+            self.logger.debug(f"Workload '{workload['name']}' "
+                              f"generated {len(ids)} "
+                              f"jobs: {', '.join(ids)}")
+
+        return ids
+
+    @cluster(num_nodes=4)
+    def test_transactions_scale(self):
+        """
+            Test uses same workload with different modes to produce
+            and consume/process given number of transactions
+        """
+        def assert_failed_jobs(job_list):
+            # Collect failed jobs
+            failed = []
+            for id in job_list:
+                job = self.flink.get_job_by_id(id)
+                if job['state'] == self.flink.STATE_FAILED:
+                    self.logger.warning(f"Job '{id}' has failed")
+                    failed.append(job)
+
+            desc = [f"{j['name']} ({j['jid']}): {j['state']}" for j in failed]
+            desc = "\n".join(desc)
+            assert len(failed) == 0, \
+                "Flink reports fails for " \
+                f"transaction workload:\n{desc}"
+
+        # TODO: Validate/Gather info on
+        # - Transactions can be generated per one flink job
+        # - Transactions per node
+        # - Transactions total >500K
+
+        # Prepare topics
+        self.topic_name = "flink_scale_1"
+        self.topic_specs = [TopicSpec(name=self.topic_name, partition_count=8)]
+        for spec in self.topic_specs:
+            self.kafkacli.create_topic(spec)
+
+        # Start Flink
+        self.flink.start()
+
+        # Load python workload to target node
+        # TODO: Add workload config management
+        _workload_config = {
+            "log_level": "DEBUG",
+            "brokers": self.redpanda.brokers(),
+            "producer_group": "flink_group",
+            "consumer_group": "flink_group",
+            "topic_name": self.topic_name,
+            "mode": "produce",
+            "count": 65535 * 32
+        }
+
+        # Get workload
+        workloads = self.workload_manager.get_workloads(
+            ['flink', 'transactions', 'scale'])
+        # Run produce part
+        all = self._run_workloads(workloads, _workload_config)
+        # Assert failed jobs
+        assert_failed_jobs(all)
+        # Wait to finish
+        self.flink.wait(timeout_sec=1800)
+
+        # Run consume part
+        _workload_config['mode'] = "consume"
+        all = self._run_workloads(workloads, _workload_config)
+        # Assert failed jobs
+        assert_failed_jobs(all)
+
+        # Wait to finish
+        self.flink.wait(timeout_sec=1800)
+
+        # TODO: Validate according to metrics
+        # vectorized_internal_rpc_latency_sum{method="commit_tx",service="tx_gateway",shard="1"} 20029
+        # vectorized_internal_rpc_latency_sum{method="commit_tx",service="tx_gateway",shard="2"} 11483
+        # vectorized_internal_rpc_latency_sum{method="commit_tx",service="tx_gateway",shard="3"} 21542
+
+        return

--- a/tests/rptest/e2e_tests/flink_scale_test.py
+++ b/tests/rptest/e2e_tests/flink_scale_test.py
@@ -6,11 +6,15 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+import json
+
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
 from rptest.e2e_tests.workload_manager import WorkloadManager
 from rptest.services.cluster import cluster
 from rptest.services.flink import FlinkService
+from rptest.services.redpanda import MetricsEndpoint, MetricSamples
 from rptest.tests.redpanda_test import RedpandaTest
 
 
@@ -29,6 +33,7 @@ class FlinkScaleTests(RedpandaTest):
                                       user=user,
                                       passwd=passwd,
                                       protocol=protocol)
+        self.rpk = RpkTool(self.redpanda)
         # Prepare Workloads
         self.workload_manager = WorkloadManager(self.logger)
 
@@ -47,6 +52,7 @@ class FlinkScaleTests(RedpandaTest):
             Return: list of failed jobs
         """
         # Run produce job
+        ids = []
         for workload in workloads:
             # Add script as a job
             self.logger.info(f"Adding {workload['name']} to flink")
@@ -62,7 +68,7 @@ class FlinkScaleTests(RedpandaTest):
         return ids
 
     @cluster(num_nodes=4)
-    def test_transactions_scale(self):
+    def test_transactions_scale_single_node(self):
         """
             Test uses same workload with different modes to produce
             and consume/process given number of transactions
@@ -82,54 +88,140 @@ class FlinkScaleTests(RedpandaTest):
                 "Flink reports fails for " \
                 f"transaction workload:\n{desc}"
 
-        # TODO: Validate/Gather info on
-        # - Transactions can be generated per one flink job
-        # - Transactions per node
-        # - Transactions total >500K
+        def get_hwm_for_topic(topic):
+            _hwm = 0
+            for partition in self.rpk.describe_topic(topic):
+                # Add currect high watermark for topic
+                _hwm += partition.high_watermark
+            return _hwm
+
+        # Validate test according to
+        # - How many transactions can be generated per one job
+        # - How mane transactions for the node
 
         # Prepare topics
-        self.topic_name = "flink_scale_1"
-        self.topic_specs = [TopicSpec(name=self.topic_name, partition_count=8)]
-        for spec in self.topic_specs:
+        topics_per_node = 4
+        # 4 mil events total
+        total_events = 4 * 1024 * 1024
+
+        self.topic_specs = []
+        for idx in range(topics_per_node):
+            topic_name = f"flink_scale_{idx}"
+            spec = TopicSpec(name=topic_name, partition_count=8)
             self.kafkacli.create_topic(spec)
+            self.topic_specs.append(spec)
 
         # Start Flink
         self.flink.start()
 
         # Load python workload to target node
+        # Hardcoded file
         # TODO: Add workload config management
+        # Currently, each INSERT operator will generate 1 subjob
+        # So this config will generate 256 / 64 jobs
         _workload_config = {
             "log_level": "DEBUG",
             "brokers": self.redpanda.brokers(),
             "producer_group": "flink_group",
             "consumer_group": "flink_group",
-            "topic_name": self.topic_name,
+            "topic_name": "flink_scale_topic_placeholder",
             "mode": "produce",
-            "count": 65535 * 32
+            "count": total_events // topics_per_node
         }
 
         # Get workload
         workloads = self.workload_manager.get_workloads(
             ['flink', 'transactions', 'scale'])
         # Run produce part
-        all = self._run_workloads(workloads, _workload_config)
+        all_jobs = []
+        for spec in self.topic_specs:
+            _workload_config['topic_name'] = spec.name
+            self.logger.debug("Submitting job with config: \n"
+                              f"{json.dumps(_workload_config, indent=2)}")
+            all_jobs += self._run_workloads(workloads, _workload_config)
+
         # Assert failed jobs
-        assert_failed_jobs(all)
+        assert_failed_jobs(all_jobs)
+
         # Wait to finish
         self.flink.wait(timeout_sec=1800)
 
-        # Run consume part
-        _workload_config['mode'] = "consume"
-        all = self._run_workloads(workloads, _workload_config)
-        # Assert failed jobs
-        assert_failed_jobs(all)
+        topic_watermarks = []
+        for spec in self.topic_specs:
+            hwm = get_hwm_for_topic(spec.name)
+            topic_watermarks.append(hwm)
 
-        # Wait to finish
-        self.flink.wait(timeout_sec=1800)
+        # Print out in one place:
+        for idx in range(len(topic_watermarks)):
+            self.logger.info(f"Topic: {self.topic_specs[idx].name}, "
+                             f"watermark: {topic_watermarks[idx]}")
+        self.logger.info(
+            f"Total messages/High watermark sum: {sum(topic_watermarks)}")
 
-        # TODO: Validate according to metrics
-        # vectorized_internal_rpc_latency_sum{method="commit_tx",service="tx_gateway",shard="1"} 20029
-        # vectorized_internal_rpc_latency_sum{method="commit_tx",service="tx_gateway",shard="2"} 11483
-        # vectorized_internal_rpc_latency_sum{method="commit_tx",service="tx_gateway",shard="3"} 21542
+        # Simple validation according to RP topic watermarks
+        sum_hwm = sum(topic_watermarks)
+        assert sum_hwm >= total_events, \
+            "High watermark is less than targer total events: " \
+            f"{sum_hwm} hwm, {total_events} target total"
+
+        # Calculate per-node vectorized_internal_rpc_latency_sum/commit_tx
+        def current_rpc_latency_sum(method, nodes) -> list[MetricSamples]:
+            # Get metrics from redpanda nodes
+            metrics = self.redpanda.metrics_sample(  # type: ignore
+                "vectorized_internal_rpc_latency_sum",
+                nodes=nodes,
+                metrics_endpoint=MetricsEndpoint.METRICS)
+
+            # Check if metrics received
+            if not isinstance(metrics, MetricSamples):
+                raise RuntimeError("Failed to get metrics")
+
+            # Filter whole series with supplied method
+            samples = []
+            for s in metrics.samples:
+                if s[4]['method'] == method:
+                    samples.append(s)
+            return samples
+
+        # Get metric for commit_tx method
+        rpc_latency_sum = current_rpc_latency_sum(
+            "commit_tx", self.redpanda.started_nodes())
+
+        # Rearrange as dict
+        # {
+        #   <node_hostname>: {
+        #     shard_num: value
+        #     total: sum(shards)
+        #   }
+        # }
+        metric_per_node = {}
+        rpc_latency_sum_total = 0
+        for node in self.redpanda.started_nodes():
+            h = node.account.hostname
+            for metric in rpc_latency_sum:
+                if node == metric.node:  # type: ignore
+                    if h not in metric_per_node:
+                        metric_per_node[h] = {}
+                    metric_per_node[h].update(
+                        {metric.labels["shard"]: metric.value})  # type: ignore
+            metric_per_node[h]['total'] = sum(metric_per_node[h].values())
+            rpc_latency_sum_total += metric_per_node[h]['total']
+
+        # Collected metric is a count of commit_tx RPCs on the shard.
+        # Since there is a commit_tx for each transaction, i.e. checkpoint
+        # happens each 1 ms (see workload code). It is set in line:
+        #       env.get_checkpoint_config().set_min_pause_between_checkpoints(1)
+
+        # So, this is a number of transactions happened
+        self.logger.info("Per-node metrics for latency is:\n"
+                         f"{json.dumps(metric_per_node, indent=2)}")
+        self.logger.info(f"Total: {rpc_latency_sum_total}")
+
+        # Number of total transactions should be not less than
+        # transaction_count / total_events. I.e. >0.1 in this case.
+        # I.e. flink should be able to send at least 1 transaction per 1 ms
+        assert 0.1 < rpc_latency_sum_total / total_events, \
+            "Flink failed to generate at least 1 transaction " \
+            "per checkpoint each 1 ms"
 
         return

--- a/tests/rptest/e2e_tests/workloads/flink_transactions_scale.py
+++ b/tests/rptest/e2e_tests/workloads/flink_transactions_scale.py
@@ -38,6 +38,7 @@ class WorkloadConfig:
     producer_group: str = "flink_group"
     consumer_group: str = "flink_group"
     topic_name: str = "flink_transactions_topic"
+    transaction_id_prefix: str = "flink_transaction_prefix"
     # options are produce/consume
     mode: str = MODE_PRODUCE
     # How many events generate
@@ -155,7 +156,7 @@ class FlinkWorkloadProduce:
             .set_bootstrap_servers(self.config.brokers) \
             .set_record_serializer(record_serializer) \
             .set_delivery_guarantee(DeliveryGuarantee.EXACTLY_ONCE) \
-            .set_transactional_id_prefix(self.config.topic_name) \
+            .set_transactional_id_prefix(self.config.transaction_id_prefix) \
             .build()
 
     def produce_sequence(self):

--- a/tests/rptest/e2e_tests/workloads/flink_transactions_scale.py
+++ b/tests/rptest/e2e_tests/workloads/flink_transactions_scale.py
@@ -1,0 +1,258 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import json
+import logging
+import os
+import sys
+
+from dataclasses import dataclass
+
+from pyflink.common import WatermarkStrategy, Types, SimpleStringSchema
+from pyflink.datastream.checkpointing_mode import CheckpointingMode
+from pyflink.datastream.checkpoint_config import ExternalizedCheckpointCleanup
+
+from pyflink.common import Configuration
+from pyflink.datastream import StreamExecutionEnvironment, RuntimeExecutionMode
+from pyflink.datastream.connectors.kafka import KafkaSink, DeliveryGuarantee, \
+    KafkaRecordSerializationSchema, KafkaSource, KafkaOffsetsInitializer
+from pyflink.datastream.connectors import NumberSequenceSource
+
+MODE_PRODUCE = 'produce'
+MODE_CONSUME = 'consume'
+
+
+@dataclass(kw_only=True)
+class WorkloadConfig:
+    # Default values are set for CDT run inside EC2 instance
+    connector_path: str = "File:///opt/flink/connectors/flink-sql-connector-kafka-3.0.1-1.18.jar"
+    python_lib_path: str = "File:///opt/flink/opt/flink-python-1.18.0.jar"
+    python_archive: str = "/opt/flink/flink_venv.tgz"
+    logger_path: str = "/workloads"
+    log_level: str = "DEBUG"
+    producer_group: str = "flink_group"
+    consumer_group: str = "flink_group"
+    topic_name: str = "flink_transactions_topic"
+    # options are produce/consume
+    mode: str = MODE_PRODUCE
+    # How many events generate
+    count: int = 512
+    # This should be updated to value from self.redpanda.brokers()
+    brokers: str = "localhost:9092"
+
+
+def setup_logger(logfilepath, level):
+    # Simple file logger
+    handler = logging.FileHandler(logfilepath)
+    handler.setFormatter(
+        logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    level = logging.getLevelName(level.upper())
+    handler.setLevel(level)
+    logger = logging.getLogger(__name__)
+    logger.addHandler(handler)
+
+    return logger
+
+
+class FlinkWorkloadProduce:
+    def __init__(self, config_override):
+        # Serialize config
+        self.config = WorkloadConfig(**config_override)
+        # Create logger
+        filename = f"{os.path.basename(__file__).split('.')[0]}.log"
+        logfile = os.path.join(self.config.logger_path, filename)
+        self.logger = setup_logger(logfile, self.config.log_level)
+
+    def setup(self):
+        self.logger.info("Initializing Produce workload")
+        # Initialize
+        config = Configuration()
+        # This is required for ducktape EC2 run
+        config.set_string("python.client.executable", "python3")
+        config.set_string("python.executable", "python3")
+        config.set_string("pipeline.jars", self.config.connector_path)
+        # This is needed for Scalar functions work
+        # See https://nightlies.apache.org/flink/flink-docs-master/docs/dev/python/dependency_management/
+        config.set_string("pipeline.classpaths", self.config.python_lib_path)
+
+        # Create flink env
+        # Streaming env is user in order to add kafka connector
+        env = StreamExecutionEnvironment.get_execution_environment()
+        env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
+
+        # Configure jars, alternatively
+        env.add_jars(self.config.connector_path)
+        # Add python venv archive to table_api
+        env.add_python_archive(self.config.python_archive, "venv")
+        env.set_python_executable("venv/bin/python")
+
+        # Checkpoints settings
+        # See: https://nightlies.apache.org/flink/flink-docs-master/api/python/reference/pyflink.datastream/checkpoint.html
+        # and: https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/fault-tolerance/checkpointing/
+
+        # start a checkpoint every 1000 ms
+        env.enable_checkpointing(1000)
+        # advanced options:
+        # set mode to exactly-once (this is the default)
+        env.get_checkpoint_config().set_checkpointing_mode(
+            CheckpointingMode.EXACTLY_ONCE)
+        # make sure 1 ms of progress happen between checkpoints
+        env.get_checkpoint_config().set_min_pause_between_checkpoints(1)
+        # checkpoints have to complete within one minute, or are discarded
+        env.get_checkpoint_config().set_checkpoint_timeout(30000)
+        # only two consecutive checkpoint failures are tolerated
+        env.get_checkpoint_config().set_tolerable_checkpoint_failure_number(2)
+        # allow only one checkpoint to be in progress at the same time
+        env.get_checkpoint_config().set_max_concurrent_checkpoints(1)
+        # enable externalized checkpoints which are retained
+        # after job cancellation
+        env.get_checkpoint_config().enable_externalized_checkpoints(
+            ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
+        # enables the unaligned checkpoints
+        env.get_checkpoint_config().enable_unaligned_checkpoints()
+
+        # Save env
+        self.stream_env = env
+
+    def prepare_produce_mode(self):
+        """
+            Initialized produce mode
+
+            Steps:
+            - Use simple number Sequence as a source
+            - Transform it to str
+            - Send to brokers
+        """
+
+        # NumberSequence produces Types.LONG
+        # Cast it to str
+        def transform(value):
+            yield str(value)
+
+        # Prepare data source
+        source = NumberSequenceSource(0, self.config.count)
+        # Create DataStream
+        ds = self.stream_env.from_source(
+            source=source,
+            watermark_strategy=WatermarkStrategy.no_watermarks(),
+            source_name="number_sequence")
+        # Assign transformation
+        self.datasource = ds.flat_map(transform, output_type=Types.STRING())
+        # Create simple serializer with String schema
+        record_serializer = KafkaRecordSerializationSchema.builder() \
+            .set_topic(self.config.topic_name) \
+            .set_key_serialization_schema(SimpleStringSchema()) \
+            .set_value_serialization_schema(SimpleStringSchema()) \
+            .build()
+        # Build KafkaSource class
+        self.sink = KafkaSink.builder() \
+            .set_bootstrap_servers(self.config.brokers) \
+            .set_record_serializer(record_serializer) \
+            .set_delivery_guarantee(DeliveryGuarantee.EXACTLY_ONCE) \
+            .set_transactional_id_prefix(self.config.topic_name) \
+            .build()
+
+    def produce_sequence(self):
+        # Add previously created KafkaSink class as a sink to DataStream
+        self.datasource.sink_to(self.sink)
+        # Do the sending
+        self.stream_env.execute()
+
+        return
+
+    def prepare_consume_mode(self):
+        """
+            Initialize consume mode
+
+            Steps:
+            - Use KafkaSource
+            - Just dump sequence to stdout
+        """
+        self.logger.info("Creating consumer with target topic of "
+                         f"'{self.config.topic_name}'")
+        # Create consumer from KafkaSource class
+        source = KafkaSource \
+            .builder() \
+            .set_bootstrap_servers(self.config.brokers) \
+            .set_group_id(self.config.consumer_group) \
+            .set_topics(self.config.topic_name) \
+            .set_value_only_deserializer(SimpleStringSchema()) \
+            .set_starting_offsets(KafkaOffsetsInitializer.earliest()) \
+            .set_bounded(KafkaOffsetsInitializer.latest()) \
+            .build()
+
+        ds = self.stream_env.from_source(source,
+                                         WatermarkStrategy.no_watermarks(),
+                                         "Kafka Source")
+        # Just print received message
+        ds.print()
+        self.datasource = ds
+
+    def consume_sequence(self):
+        """
+            Example of a consume task usign Table API
+        """
+        # Run
+        self.logger.info("Runnig consumer")
+        self.stream_env.execute()
+        self.logger.info("Done")
+
+        return
+
+    def run(self):
+        # Run selected mode
+        if self.config.mode == MODE_PRODUCE:
+            self.prepare_produce_mode()
+            self.produce_sequence()
+        elif self.config.mode == MODE_CONSUME:
+            self.prepare_consume_mode()
+            self.consume_sequence()
+        else:
+            self.logger.info(f"Mode '{self.config.mode}' not supported")
+
+        return
+
+    def cleanup(self):
+        """
+            Cleanup placeholder
+        """
+        pass
+
+
+if __name__ == '__main__':
+    # Load config if specified
+    if len(sys.argv) > 1:
+        # Validate arguments in a quick and dirty way.
+        # This will assign one argument to filename and generate exception if
+        # there is more than one argument
+        try:
+            [filename] = sys.argv[1:]
+        except Exception as e:
+            raise RuntimeError("Wrong number of arguments."
+                               "Should be one with path to "
+                               "flink_workload_conf.json") from e
+    else:
+        # No config path provided, just use defaults
+        filename = "/workloads/flink_workload_config.json"
+
+    # Load configuration
+    with open(filename, 'r+t') as f:
+        input_config = json.load(f)
+
+    # All messages past this point is intercepted by task manager
+    # and will be seen in its log
+    workload = FlinkWorkloadProduce(input_config)
+    try:
+        workload.setup()
+        workload.run()
+    except Exception as e:
+        # Do not re-throw not to cause a commoution
+        raise RuntimeError("Workload run failed") from e
+    finally:
+        workload.cleanup()

--- a/tests/rptest/services/flink.py
+++ b/tests/rptest/services/flink.py
@@ -490,13 +490,14 @@ class FlinkService(Service):
         # return True if >0
         return len(active_jobs) > 0
 
-    def wait_node(self, node, timeout_sec=300):
+    def wait_node(self, node, timeout_sec=300, detect_idle_jobs=True):
         """
             Wait for all jobs to finish, default timeout is half an hour
         """
         # Flush internal metrics
         self._metric = {}
-        wait_until(lambda: not self._has_active_jobs(node),
+        wait_until(lambda: not self._has_active_jobs(
+            node, detect_idle_jobs=detect_idle_jobs),
                    timeout_sec=timeout_sec,
                    backoff_sec=5)
 

--- a/tests/rptest/services/flink.py
+++ b/tests/rptest/services/flink.py
@@ -181,12 +181,12 @@ class FlinkService(Service):
     STATE_FINISHED = 'FINISHED'
     STATE_CANCELED = 'CANCELED'
 
-    def __init__(self, context, redpanda, topic, *args, **kwargs):
+    def __init__(self, context, *args, **kwargs):
         # No custom node support at this time
-        nodes_for_allocate = 1
+        nodes_to_allocate = 1
         # Init service
         super(FlinkService, self).__init__(context,
-                                           num_nodes=nodes_for_allocate,
+                                           num_nodes=nodes_to_allocate,
                                            *args,
                                            **kwargs)
 

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -31,7 +31,7 @@ class FlinkBasicTests(RedpandaTest):
         # Prepare FlinkService
         self.topic_name = "flink_workload_topic"
         self.topics = [TopicSpec(name=self.topic_name)]
-        self.flink = FlinkService(test_context, self.redpanda, self.topic)
+        self.flink = FlinkService(test_context)
         # Prepare client
         config = self.redpanda.security_config()
         user = config.get("sasl_plain_username")

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -283,9 +283,13 @@ class FlinkBasicTests(RedpandaTest):
                    err_msg="Flink transaction workload produced "
                    "no data files after 5 min")
 
-        # make sure that there is no active jobs
-        # 10 min for safety
-        self.flink.wait(timeout_sec=600)
+        # make sure that there is no active jobs with 20 min timeout.
+        # This big value is for safety due to overloads on docker env at
+        # CDT run. Under the hood, 'flink.wait_node' which is used
+        # by 'service.wait' has 'detect_idle_jobs' bool var that will check if
+        # job has been completely idle for 30 sec and skip it if so.
+        # To access that var, use 'wait_node' directly instead
+        self.flink.wait(timeout_sec=1200)
 
         # Since there is a possibility that after job is finished
         # data is still be written from buffers, make sure that


### PR DESCRIPTION
Implementation of test and workload that can be scaled to any number of tasks and jobs inside flink with no job overhead while running it, comparing to Table API.

Java version of similar workload is [here](https://github.com/redpanda-data/flink-repro/blob/main/src/main/java/com/redpanda/flink/Job.java).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none