### PR TITLE
scheduling_groups: report cpu usage for all cores

### DIFF
--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -100,6 +100,7 @@
 #include "resource_mgmt/io_priority.h"
 #include "resource_mgmt/memory_groups.h"
 #include "resource_mgmt/memory_sampling.h"
+#include "resource_mgmt/scheduling_groups_probe.h"
 #include "resource_mgmt/smp_groups.h"
 #include "rpc/rpc_utils.h"
 #include "security/audit/audit_log_manager.h"
@@ -555,11 +556,13 @@ void application::initialize(
     }
 
     sched_groups.create_groups().get();
-    _scheduling_groups_probe.wire_up(sched_groups);
-    _deferred.emplace_back([this] {
-        _scheduling_groups_probe.clear();
-        sched_groups.destroy_groups().get();
-    });
+    _deferred.emplace_back([this] { sched_groups.destroy_groups().get(); });
+
+    construct_service(_scheduling_groups_probe).get();
+    _scheduling_groups_probe
+      .invoke_on_all(
+        [this](scheduling_groups_probe& s) { return s.start(sched_groups); })
+      .get();
 
     if (proxy_cfg) {
         _proxy_config.emplace(*proxy_cfg);

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -284,7 +284,7 @@ private:
       _schema_reg_config;
     std::optional<kafka::client::configuration> _schema_reg_client_config;
     std::optional<kafka::client::configuration> _audit_log_client_config;
-    scheduling_groups_probe _scheduling_groups_probe;
+    ss::sharded<scheduling_groups_probe> _scheduling_groups_probe;
     ss::logger _log;
 
     std::optional<config::binding<bool>> _abort_on_oom;

--- a/src/v/resource_mgmt/scheduling_groups_probe.h
+++ b/src/v/resource_mgmt/scheduling_groups_probe.h
@@ -11,17 +11,14 @@
 
 #pragma once
 
-#include "cluster/partition_leaders_table.h"
 #include "config/configuration.h"
 #include "metrics/metrics.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "resource_mgmt/cpu_scheduling.h"
 
-#include <seastar/core/metrics.hh>
-
 class scheduling_groups_probe {
 public:
-    void wire_up(const scheduling_groups& scheduling_groups) {
+    void start(const scheduling_groups& scheduling_groups) {
         if (config::shard_local_cfg().disable_public_metrics()) {
             return;
         }
@@ -45,7 +42,10 @@ public:
         }
     }
 
-    void clear() { _public_metrics.clear(); }
+    ss::future<> stop() {
+        _public_metrics.clear();
+        return ss::now();
+    }
 
 private:
     metrics::public_metric_groups _public_metrics;


### PR DESCRIPTION
Currently we only report the breakdown by scheduling group for core 0, it's probably useful for all cores.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes

### Bug Fixes

* Report runtime public metrics by task queue for all cores, not just core 0
