### PR TITLE
config: Transform logging configs

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -211,6 +211,37 @@ configuration::configuration()
       },
       10_MiB,
       {.min = 1_MiB, .max = 128_MiB})
+  , data_transforms_logging_enabled(
+      *this,
+      "data_transforms_logging_enabled",
+      "Whether data transforms' stderr/stdout output will be produced to the "
+      "transform_logs topic. When disabled, transform logs are streamed into "
+      "broker logs.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      true)
+  , data_transforms_logging_buffer_capacity_bytes(
+      *this,
+      "data_transforms_logging_buffer_capacity_bytes",
+      "Buffer capacity for transofm logs, per shard. Buffer occupancy is "
+      "calculated as the total size of buffered (i.e. emitted but not yet "
+      "produced) log messages.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      1000_KiB,
+      {.min = 1000_KiB, .max = 2_MiB})
+  , data_transforms_logging_flush_interval_ms(
+      *this,
+      "data_transforms_logging_flush_interval_ms",
+      "Flush interval for transform logs. When a timer expires, pending logs "
+      "are collected and published to the transform_logs topic.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1s)
+  , data_transforms_logging_event_max_data_bytes(
+      *this,
+      "data_transforms_logging_event_truncate_bytes",
+      "Transform log lines will be truncate to this length. Truncation occurs "
+      "after any character escaping.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      1_KiB)
   , topic_memory_per_partition(
       *this,
       "topic_memory_per_partition",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -74,6 +74,14 @@ struct configuration final : public config_store {
     bounded_property<size_t> data_transforms_per_function_memory_limit;
     property<std::chrono::milliseconds> data_transforms_runtime_limit_ms;
     bounded_property<size_t> data_transforms_binary_max_size;
+    // Logging
+    property<bool> data_transforms_logging_enabled;
+    // TODO(oren): needs sensible limits and default
+    bounded_property<size_t> data_transforms_logging_buffer_capacity_bytes;
+    // TODO(oren): bounded?
+    property<std::chrono::milliseconds>
+      data_transforms_logging_flush_interval_ms;
+    property<size_t> data_transforms_logging_event_max_data_bytes;
 
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;


### PR DESCRIPTION
- data_transforms_logging_enabled : bool (default True)
- data_transforms_logging_buffer_capacity_bytes : integer (default 1000_KiB)
- data_transforms_logging_flush_interval_ms : integer (default 1000)
- data_transforms_logging_event_max_data_bytes : integer (default 1_KiB)

Closes https://github.com/redpanda-data/core-internal/issues/998

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
