### PR TITLE
rpc: fix correlation_id overflow

### DIFF
--- a/src/v/rpc/netbuf.cc
+++ b/src/v/rpc/netbuf.cc
@@ -32,11 +32,6 @@ ss::future<ss::scattered_message<char>> netbuf::as_scattered() && {
     iobuf out_buf = std::move(_out);
     auto hdr = _hdr;
 
-    if (hdr.correlation_id == 0 || hdr.meta == 0) {
-        throw std::runtime_error(
-          "cannot compose scattered view with incomplete header. missing "
-          "correlation_id or remote method id");
-    }
     if (
       out_buf.size_bytes() >= _min_compression_bytes
       && rpc::compression_type::zstd == hdr.compression) {

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -264,7 +264,8 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
               })
             .handle_exception([this, seq, corr](std::exception_ptr eptr) {
                 // This is unlikely but may potentially mean dispatch_send()
-                // is not called, stalling the sequence number.
+                // is not called, stalling the sequence number. Shut it down
+                // because in this case it is not usable anymore.
                 vlog(
                   rpclog.error,
                   "Exception {} dispatching rpc with sequence: {}, "
@@ -273,6 +274,8 @@ transport::do_send(sequence_t seq, netbuf b, rpc::client_opts opts) {
                   seq,
                   corr,
                   _last_seq);
+                _probe->request_error();
+                fail_outstanding_futures();
                 return ss::make_exception_future<ret_t>(eptr);
             });
       });


### PR DESCRIPTION
It is possible that in an active RPC client connection, `correlation_id` (which is uint32_t) will overflow  - at, say, 5k req/s (high, but not unreasonable value) overflow happens after 10 days. This isn't particularly bad, because it will just wrap around to 0, but we treat `correlation_id=0` as an invalid value and throw an exception. Because this exception gets thrown from an unexpected place, the connection send loop stalls and the connection becomes unusable afterwards.

Remove this check as it doesn't add much value, and also ensure that connections get shut down after these unexpected exceptions.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes
### Bug Fixes
* Fix internal RPC client connection stall after more than 2^32 requests are sent.