### PR TITLE
rptest: reduce HighThroughputTests.msg_size

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -207,7 +207,7 @@ def omb_runner(context, redpanda, driver, workload, omb_config):
 
 
 class HighThroughputTest(PreallocNodesTest):
-    msg_size = 256 * KiB
+    msg_size = 4 * KiB
     # Min segment size across all tiers
     min_segment_size = 16 * MiB
     unavailable_timeout = 60


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/core-internal/issues/986

Reduce to a range between 1K to 16K which is what we usually want to test within.

example test run:
```console
ducktape \ 
 --debug \ 
 --globals=/home/ubuntu/redpanda/tests/globals.json \ 
 --cluster=ducktape.cluster.json.JsonCluster \ 
 --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \  
 --test-runner-timeout=3600000 \
 tests/rptest/redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_throughput_simple
```
output:
```
test_id:    rptest.redpanda_cloud_tests.high_throughput_test.HighThroughputTest.test_throughput_simple
status:     PASS
run time:   1 minute 5.736 seconds
-----------------------------------------------------------------------
=====================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2024-01-19--016
run time:         1 minute 5.756 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
=====================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none