### PR TITLE
Change metrics to match generate_charts.py

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -328,6 +328,8 @@ class OpenMessagingBenchmark(Service):
         metrics['throughputMBps'] = (
             sum(metrics['publishRate']) / len(metrics['publishRate']) *
             metrics['messageSize']) / (1024.0 * 1024.0)
+        metrics['publishLatencyMin'] = min(metrics['publishLatencyMin'])
+        metrics['endToEndLatencyMin'] = min(metrics['endToEndLatencyMin'])
 
         if validate_metrics:
             OMBSampleConfigurations.validate_metrics(metrics, self.validator)


### PR DESCRIPTION
generate_charts.py takes the min of the `publishLatencyMin` and `endToEndLatencyMin` metrics in `result.json`. See https://github.com/redpanda-data/openmessaging-benchmark/blob/main/bin/generate_charts.py#L300 . Our validators for OMB results expect a single value for these metrics as well and not the list of values present in `result.json`. This PR changes our metrics validator to match this behavior and makes `publishLatencyMin` and `endToEndLatencyMin`  a single value that is the min of their lists in `result.json`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
