### PR TITLE
[v23.2.x] archival: Delete replaced segments during spillover GC

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2049,6 +2049,7 @@ ss::future<> ntp_archiver::housekeeping() {
             } else {
                 co_await apply_archive_retention();
                 co_await garbage_collect_archive();
+                co_await garbage_collect();
             }
             co_await apply_spillover();
         }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16163
