### PR TITLE
config/configuration: set cloud_storage_spillover_manifest_size

### DIFF
--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -34,6 +34,7 @@
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/archival.h"
 #include "test_utils/fixture.h"
+#include "test_utils/scoped_config.h"
 #include "utils/retry_chain_node.h"
 
 #include <seastar/core/future-util.hh>
@@ -523,9 +524,11 @@ FIXTURE_TEST(test_archive_retention, archiver_fixture) {
      * of the entire spillover manifest.
      */
 
-    config::shard_local_cfg()
-      .cloud_storage_spillover_manifest_max_segments.set_value(
-        std::optional<size_t>{2});
+    auto cfg = scoped_config{};
+    cfg.get("cloud_storage_spillover_manifest_max_segments")
+      .set_value(std::optional<size_t>{2});
+    cfg.get("cloud_storage_spillover_manifest_size")
+      .set_value(std::optional<size_t>{std::nullopt});
 
     // Write segments to local log
     auto old_stamp = model::timestamp{

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1907,7 +1907,7 @@ configuration::configuration()
       "split the manifest into two parts and one of them will be uploaded to "
       "S3.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      std::nullopt,
+      64_KiB,
       {.min = 4_KiB, .max = 4_MiB})
   , cloud_storage_spillover_manifest_max_segments(
       *this,

--- a/tests/rptest/perf/ts_read_openmessaging_test.py
+++ b/tests/rptest/perf/ts_read_openmessaging_test.py
@@ -20,7 +20,8 @@ class TSReadOpenmessagingTest(RedpandaTest):
 
     def __init__(self, ctx):
         extra_rp_conf = {
-            "retention_local_target_bytes_default": 16 * 1_000_000  # 16 MB
+            "retention_local_target_bytes_default": 16 * 1_000_000,  # 16 MB
+            "cloud_storage_spillover_manifest_size": None,
         }
         si_settings = SISettings(
             test_context=ctx,

--- a/tests/rptest/perf/ts_write_openmessaging_test.py
+++ b/tests/rptest/perf/ts_write_openmessaging_test.py
@@ -18,6 +18,9 @@ class TSWriteOpenmessagingTest(RedpandaTest):
     BENCHMARK_WAIT_TIME_MIN = 10
 
     def __init__(self, ctx):
+        extra_rp_conf = {
+            "cloud_storage_spillover_manifest_size": None,
+        }
         si_settings = SISettings(
             test_context=ctx,
             log_segment_size=16 * 1_000_000,  # 16 MB
@@ -25,9 +28,11 @@ class TSWriteOpenmessagingTest(RedpandaTest):
             cloud_storage_spillover_manifest_max_segments=10,
         )
         self._ctx = ctx
-        super(TSWriteOpenmessagingTest, self).__init__(test_context=ctx,
-                                                       num_brokers=3,
-                                                       si_settings=si_settings)
+        super(TSWriteOpenmessagingTest,
+              self).__init__(test_context=ctx,
+                             num_brokers=3,
+                             si_settings=si_settings,
+                             extra_rp_conf=extra_rp_conf)
 
     @cluster(num_nodes=6)
     @parametrize(driver_idx="ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT",

--- a/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
@@ -45,7 +45,9 @@ class TieredStorageSinglePartitionTest(RedpandaTest):
             'cloud_storage_manifest_max_upload_interval_sec':
             self.manifest_upload_interval,
             # Ensure spillover can happen promptly during test
-            'cloud_storage_housekeeping_interval_ms': 5000
+            'cloud_storage_housekeeping_interval_ms': 5000,
+            # But allow the test runtime to configure it.
+            'cloud_storage_spillover_manifest_size': None,
         }
         super().__init__(test_context, *args, **kwargs)
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3239,6 +3239,14 @@ class RedpandaService(RedpandaServiceBase):
             conf.update(
                 dict(http_authentication=self._security.http_authentication))
 
+        # in redpanda, cloud_storage_spillover_manifest_size takes preference over cloud_storage_spillover_manifest_max_segments.
+        # disable the former to use the latter
+        assert conf.get('cloud_storage_spillover_manifest_size', None) is None or \
+            conf.get('cloud_storage_spillover_manifest_max_segments', None) is None, \
+                  "cannot set cloud_storage_spillover_manifest_max_segments if cloud_storage_spillover_manifest_size is already set, it will not be used by redpanda"
+        if 'cloud_storage_spillover_manifest_max_segments' in conf:
+            conf['cloud_storage_spillover_manifest_size'] = None
+
         conf_yaml = yaml.dump(conf)
         for node in self.nodes:
             self.logger.info(

--- a/tests/rptest/tests/archive_retention_test.py
+++ b/tests/rptest/tests/archive_retention_test.py
@@ -32,6 +32,7 @@ class CloudArchiveRetentionTest(RedpandaTest):
         self.extra_rp_conf = dict(
             log_compaction_interval_ms=1000,
             cloud_storage_spillover_manifest_max_segments=5,
+            cloud_storage_spillover_manifest_size=None,
             cloud_storage_enable_segment_merging=False)
 
         self.next_base_timestamp = 1664453149000  # arbitrary value

--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -79,6 +79,7 @@ class CloudRetentionTest(PreallocNodesTest):
                              default_retention_segments * segment_size,
                              log_segment_size_jitter_percent=5,
                              group_initial_rebalance_delay=300,
+                             cloud_storage_spillover_manifest_size=None,
                              cloud_storage_segment_max_upload_interval_sec=60,
                              cloud_storage_housekeeping_interval_ms=10_000)
         self.redpanda.add_extra_rp_conf(extra_rp_conf)

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -211,7 +211,8 @@ class CloudStorageScrubberTest(RedpandaTest):
                 "cloud_storage_background_jobs_quota": 30,
                 # Disable segment merging since it can reupload
                 # the deleted segment and remove the gap
-                "cloud_storage_enable_segment_merging": False
+                "cloud_storage_enable_segment_merging": False,
+                "cloud_storage_spillover_manifest_size": None,
             },
             si_settings=self.si_settings)
 

--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -262,7 +262,8 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             cloud_storage_segment_size_min=2 * self.log_segment_size,
             retention_local_target_bytes_default=2 * self.log_segment_size,
             cloud_storage_enable_segment_merging=True,
-            cloud_storage_cache_chunk_size=self.chunk_size)
+            cloud_storage_cache_chunk_size=self.chunk_size,
+            cloud_storage_spillover_manifest_size=None)
 
         super(CloudStorageTimingStressTest,
               self).__init__(test_context=test_context,

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -66,9 +66,12 @@ class EndToEndShadowIndexingBase(EndToEndTest):
         self.test_context = test_context
         self.topic = self.s3_topic_name
 
-        conf = dict(enable_cluster_metadata_upload_loop=True,
-                    cloud_storage_cluster_metadata_upload_interval_ms=1000,
-                    controller_snapshot_max_age_sec=1)
+        conf = dict(
+            enable_cluster_metadata_upload_loop=True,
+            cloud_storage_cluster_metadata_upload_interval_ms=1000,
+            # Tests may configure spillover manually.
+            cloud_storage_spillover_manifest_size=None,
+            controller_snapshot_max_age_sec=1)
         if extra_rp_conf:
             for k, v in conf.items():
                 extra_rp_conf[k] = v
@@ -258,8 +261,6 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
             10000,
             "cloud_storage_spillover_manifest_max_segments":
             10,
-            "cloud_storage_spillover_manifest_size":
-            None,
         })
         msg_per_segment = self.segment_size // msg_size
         msg_count_before_reset = 50 * msg_per_segment
@@ -1209,6 +1210,7 @@ class EndToEndSpilloverTest(RedpandaTest):
                         cleanup_policy=TopicSpec.CLEANUP_DELETE), )
 
     def __init__(self, test_context):
+        extra_rp_conf = dict(cloud_storage_spillover_manifest_size=None)
         self.si_settings = SISettings(
             test_context,
             log_segment_size=1024,
@@ -1217,7 +1219,8 @@ class EndToEndSpilloverTest(RedpandaTest):
             cloud_storage_spillover_manifest_max_segments=10)
         super(EndToEndSpilloverTest,
               self).__init__(test_context=test_context,
-                             si_settings=self.si_settings)
+                             si_settings=self.si_settings,
+                             extra_rp_conf=extra_rp_conf)
 
         self.msg_size = 1024 * 256
         self.msg_count = 3000

--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -257,7 +257,9 @@ class EndToEndShadowIndexingTest(EndToEndShadowIndexingBase):
             "cloud_storage_housekeeping_interval_ms":
             10000,
             "cloud_storage_spillover_manifest_max_segments":
-            10
+            10,
+            "cloud_storage_spillover_manifest_size":
+            None,
         })
         msg_per_segment = self.segment_size // msg_size
         msg_count_before_reset = 50 * msg_per_segment

--- a/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_archival_test.py
@@ -40,7 +40,8 @@ class OffsetForLeaderEpochArchivalTest(RedpandaTest):
     def __init__(self, test_context):
         self.extra_rp_conf = {
             'enable_leader_balancer': False,
-            "log_compaction_interval_ms": 1000
+            "log_compaction_interval_ms": 1000,
+            "cloud_storage_spillover_manifest_size": None,
         }
         self.si_settings = SISettings(
             test_context,

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -128,6 +128,7 @@ class TestReadReplicaService(EndToEndTest):
     topic_name = "panda-topic"
 
     def __init__(self, test_context: TestContext):
+        extra_rp_conf = dict(cloud_storage_spillover_manifest_size=None)
         super(TestReadReplicaService, self).__init__(
             test_context=test_context,
             si_settings=SISettings(
@@ -140,7 +141,8 @@ class TestReadReplicaService(EndToEndTest):
                 cloud_storage_spillover_manifest_max_segments=4,
                 # Ensure metadata spilling happens promptly
                 cloud_storage_housekeeping_interval_ms=100,
-                fast_uploads=True))
+                fast_uploads=True),
+            extra_rp_conf=extra_rp_conf)
 
         # Read reaplica shouldn't have it's own bucket.
         # We're adding 'none' as a bucket name without creating

--- a/tests/rptest/tests/tiered_storage_model.py
+++ b/tests/rptest/tests/tiered_storage_model.py
@@ -1008,7 +1008,8 @@ class EnableSpillover(Expression):
         return [
             ClusterConfigInput(
                 "EnableSpillover",
-                dict(cloud_storage_spillover_manifest_max_segments=
+                dict(cloud_storage_spillover_manifest_size=None,
+                     cloud_storage_spillover_manifest_max_segments=
                      SPILLOVER_MANIFEST_SIZE))
         ]
 

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -57,6 +57,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         self.extra_rp_conf['cloud_storage_enable_segment_merging'] = False
         self.extra_rp_conf['compaction_ctrl_min_shares'] = 300
         self.extra_rp_conf['cloud_storage_disable_chunk_reads'] = True
+        self.extra_rp_conf['cloud_storage_spillover_manifest_size'] = None
 
         self.si_settings = SISettings(
             test_context,

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -310,7 +310,11 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
             'log_segment_size_min':
             32 * 1024,
             'cloud_storage_cache_chunk_size':
-            self.chunk_size
+            self.chunk_size,
+
+            # Avoid confiugring spillover so tests can do it themselves.
+            'cloud_storage_spillover_manifest_size':
+            None,
         })
 
         if cloud_storage:

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -387,7 +387,9 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
                 'cloud_storage_idle_timeout_ms': 3000,
                 'cloud_storage_housekeeping_interval_ms':
                 self.housekeeping_interval_ms,
-                "cloud_storage_topic_purge_grace_period_ms": 5000
+                "cloud_storage_topic_purge_grace_period_ms": 5000,
+                # This test will manually set spillover.
+                "cloud_storage_spillover_manifest_size": None,
             },
             si_settings=self.si_settings)
 
@@ -399,8 +401,6 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         self.redpanda.set_cluster_config({
             "cloud_storage_housekeeping_interval_ms":
             1000,
-            "cloud_storage_spillover_manifest_size":
-            None,
             "cloud_storage_spillover_manifest_max_segments":
             10
         })

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -399,6 +399,8 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         self.redpanda.set_cluster_config({
             "cloud_storage_housekeeping_interval_ms":
             1000,
+            "cloud_storage_spillover_manifest_size":
+            None,
             "cloud_storage_spillover_manifest_max_segments":
             10
         })


### PR DESCRIPTION
this enable splitting the partition_manifest into spillovers once it reaches 2*cloud_storage_spillover_manifest_size

Fixes https://github.com/redpanda-data/core-internal/issues/1012
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* spillover manifests are enabled by default for clusters that did not explicit set a value or null 