### PR TITLE
[v23.3.x] c/log_eviction_stm: do not request snapshot if already progressed

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -183,12 +183,34 @@ log_eviction_stm::do_write_raft_snapshot(model::offset truncation_point) {
           max_collectible_offset,
           truncation_point);
     }
+    if (truncation_point <= _raft->last_snapshot_index()) {
+        vlog(
+          _log.trace,
+          "Skipping writing snapshot as Raft already progressed with the new "
+          "snapshot. Current raft snapshot index: {}, requested truncation "
+          "point: {}",
+          _raft->last_snapshot_index(),
+          truncation_point);
+        co_return;
+    }
     vlog(
       _log.debug,
       "Requesting raft snapshot with final offset: {}",
       truncation_point);
     auto snapshot_data = co_await _raft->stm_manager()->take_snapshot(
       truncation_point);
+    // we need to check snapshot index again as it may already progressed after
+    // snapshot is taken by stm_manager
+    if (truncation_point <= _raft->last_snapshot_index()) {
+        vlog(
+          _log.trace,
+          "Skipping writing snapshot as Raft already progressed with the new "
+          "snapshot. Current raft snapshot index: {}, requested truncation "
+          "point: {}",
+          _raft->last_snapshot_index(),
+          truncation_point);
+        co_return;
+    }
     co_await _raft->write_snapshot(
       raft::write_snapshot_cfg(truncation_point, std::move(snapshot_data)));
 }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15945

Fixes: #15985