### PR TITLE
rpk/transform/init: fix rust template

### DIFF
--- a/src/go/rpk/pkg/cli/transform/template/rust/main.rustsrc
+++ b/src/go/rpk/pkg/cli/transform/template/rust/main.rustsrc
@@ -1,5 +1,5 @@
 use redpanda_transform_sdk::*;
-use std::fmt::Error;
+use std::error::Error;
 
 fn main() {
     // Register your transform function.
@@ -9,7 +9,7 @@ fn main() {
 
 // my_transform is where you read the record that was written, and then you can
 // return new records that will be written to the output topic
-fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<()> {
+fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<(), Box<dyn Error>> {
     writer.write(Record::new_with_headers(
         event.record.key().map(|b| b.to_owned()),
         event.record.value().map(|b| b.to_owned()),


### PR DESCRIPTION
The wrong Error import was used, and we need to specify the error type
as we don't import anyhow for users.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes


### Bug Fixes

* Fix the starter code for Rust projects in `rpk transform init`
