### PR TITLE
admin/server: fix get_cluster_id response formatting

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3389,7 +3389,7 @@ void admin_server::register_cluster_routes() {
             = _controller->get_storage().local().get_cluster_uuid();
           if (cluster_uuid) {
               ss::httpd::cluster_json::uuid ret;
-              ret.cluster_uuid = ssx::sformat("{}", cluster_uuid);
+              ret.cluster_uuid = ssx::sformat("{}", cluster_uuid.value());
               return ss::json::json_return_type(std::move(ret));
           }
           return ss::json::json_return_type(ss::json::json_void());

--- a/tests/rptest/tests/cluster_metadata_upload_test.py
+++ b/tests/rptest/tests/cluster_metadata_upload_test.py
@@ -161,7 +161,7 @@ class ClusterMetadataUploadTest(RedpandaTest):
         s3_snapshot = BucketView(self.redpanda, topics=self.topics)
         orig_cluster_uuid, orig_highest_manifest_id = \
             check_cluster_metadata_is_consistent(s3_snapshot)
-        assert orig_cluster_uuid in orig_cluster_uuid_resp, \
+        assert orig_cluster_uuid == orig_cluster_uuid_resp, \
             f"{orig_cluster_uuid_resp} vs {orig_cluster_uuid}"
         for n in self.redpanda.nodes:
             self.redpanda.remove_local_data(n)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Unwrap the cluster_uuid_t type when formatting the response  

Fixes #16162

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* get_cluster_uuid returns a correctly formatted string