### PR TITLE
transform: list committed offsets

### DIFF
--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -118,6 +118,15 @@ struct transform_offsets_value
 using transform_offsets_map
   = absl::btree_map<transform_offsets_key, transform_offsets_value>;
 
+/**
+ * A flattened entry of transorm_offsets_map to return to the admin API.
+ */
+struct transform_committed_offset {
+    transform_name name;
+    partition_id partition;
+    kafka::offset offset;
+};
+
 inline const model::topic transform_offsets_topic("transform_offsets");
 inline const model::topic_namespace transform_offsets_nt(
   model::kafka_internal_namespace, transform_offsets_topic);

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -115,6 +115,9 @@ struct transform_offsets_value
     auto serde_fields() { return std::tie(offset); }
 };
 
+using transform_offsets_map
+  = absl::btree_map<transform_offsets_key, transform_offsets_value>;
+
 inline const model::topic transform_offsets_topic("transform_offsets");
 inline const model::topic_namespace transform_offsets_nt(
   model::kafka_internal_namespace, transform_offsets_topic);

--- a/src/v/redpanda/admin/api-doc/transform.json
+++ b/src/v/redpanda/admin/api-doc/transform.json
@@ -61,6 +61,23 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/v1/transform/debug/committed_offsets",
+      "operations": [
+        {
+          "method": "GET",
+          "type": "array",
+          "items": {
+            "type": "committed_offset"
+          },
+          "summary": "List all the committed offsets for transforms.",
+          "nickname": "list_committed_offsets",
+          "produces": [
+            "application/json"
+          ]
+        }
+      ]
     }
   ],
   "models": {
@@ -155,6 +172,24 @@
         },
         "value": {
           "type": "string"
+        }
+      }
+    },
+    "committed_offset": {
+      "id": "committed_offset",
+      "description": "A committed offset for a single partition and transform",
+      "properties": {
+        "transform_name": {
+          "type": "string",
+          "description": "name of the transform"
+        },
+        "partition": {
+          "type": "int",
+          "description": "partition in the input topic"
+        },
+        "offset": {
+          "type": "int",
+          "description": "The offset within the input topic that has been committed"
         }
       }
     }

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -162,6 +162,7 @@
 using namespace std::chrono_literals;
 
 using admin::apply_validator;
+using admin::get_boolean_query_param;
 using admin::lw_shared_container;
 
 ss::logger adminlog{"admin_api_server"};
@@ -445,22 +446,6 @@ admin_server::parse_json_body(ss::http::request* req) {
 }
 
 namespace {
-
-/**
- * Helper for requests with boolean URL query parameters that should
- * be treated as false if absent, or true if "true" (case insensitive) or "1"
- */
-bool get_boolean_query_param(
-  const ss::http::request& req, std::string_view name) {
-    auto key = ss::sstring(name);
-    if (!req.query_parameters.contains(key)) {
-        return false;
-    }
-
-    const ss::sstring& str_param = req.query_parameters.at(key);
-    return ss::internal::case_insensitive_cmp()(str_param, "true")
-           || str_param == "1";
-}
 
 /**
  * Helper for requests with decimal_integer URL query parameters.

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -608,6 +608,8 @@ private:
       list_transforms(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       delete_transform(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      list_committed_offsets(std::unique_ptr<ss::http::request>);
 
     ss::future<> throw_on_error(
       ss::http::request& req,

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -86,11 +86,8 @@ admin_server::list_transforms(std::unique_ptr<ss::http::request>) {
     }
     auto report = co_await _transform_service->local().list_transforms();
 
-    ss::json::json_list<ss::httpd::transform_json::transform_metadata>
-      list_result;
-
-    co_return ss::json::json_return_type(
-      ss::json::stream_range_as_array(report.transforms, [](const auto& entry) {
+    co_return ss::json::json_return_type(ss::json::stream_range_as_array(
+      std::move(report.transforms), [](const auto& entry) {
           const model::transform_report& t = entry.second;
           ss::httpd::transform_json::transform_metadata meta;
           meta.name = t.metadata.name();

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -9,12 +9,15 @@
  * by the Apache License, Version 2.0
  */
 
+#include "model/transform.h"
+
 #include "bytes/streambuf.h"
 #include "json/document.h"
 #include "json/istreamwrapper.h"
 #include "json/validator.h"
 #include "redpanda/admin/api-doc/transform.json.hh"
 #include "redpanda/admin/server.h"
+#include "redpanda/admin/util.h"
 #include "transform/api.h"
 
 namespace {
@@ -36,6 +39,9 @@ void admin_server::register_wasm_transform_routes() {
     register_route<superuser>(
       ss::httpd::transform_json::delete_transform,
       [this](auto req) { return delete_transform(std::move(req)); });
+    register_route<superuser>(
+      ss::httpd::transform_json::list_committed_offsets,
+      [this](auto req) { return list_committed_offsets(std::move(req)); });
 }
 
 ss::future<ss::json::json_return_type>
@@ -79,6 +85,7 @@ admin_server::list_transforms(std::unique_ptr<ss::http::request>) {
         throw transforms_not_enabled();
     }
     auto report = co_await _transform_service->local().list_transforms();
+
     ss::json::json_list<ss::httpd::transform_json::transform_metadata>
       list_result;
 
@@ -215,4 +222,26 @@ admin_server::deploy_transform(std::unique_ptr<ss::http::request> req) {
 
     co_await throw_on_error(*req, ec, model::controller_ntp);
     co_return ss::json::json_void();
+}
+
+ss::future<ss::json::json_return_type>
+admin_server::list_committed_offsets(std::unique_ptr<ss::http::request> req) {
+    if (!_transform_service->local_is_initialized()) {
+        throw transforms_not_enabled();
+    }
+    auto result = co_await _transform_service->local().list_committed_offsets();
+    if (result.has_error()) {
+        co_await throw_on_error(*req, result.error(), model::controller_ntp);
+        co_return ss::json::json_void();
+    }
+
+    co_return ss::json::json_return_type(ss::json::stream_range_as_array(
+      admin::lw_shared_container(std::move(result).value()),
+      [](const model::transform_committed_offset& committed) {
+          ss::httpd::transform_json::committed_offset response;
+          response.transform_name = committed.name();
+          response.offset = committed.offset();
+          response.partition = committed.partition();
+          return response;
+      }));
 }

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -229,7 +229,8 @@ admin_server::list_committed_offsets(std::unique_ptr<ss::http::request> req) {
     if (!_transform_service->local_is_initialized()) {
         throw transforms_not_enabled();
     }
-    auto result = co_await _transform_service->local().list_committed_offsets();
+    auto result = co_await _transform_service->local().list_committed_offsets(
+      {.show_unknown = admin::get_boolean_query_param(*req, "show_unknown")});
     if (result.has_error()) {
         co_await throw_on_error(*req, result.error(), model::controller_ntp);
         co_return ss::json::json_void();

--- a/src/v/redpanda/admin/util.cc
+++ b/src/v/redpanda/admin/util.cc
@@ -23,4 +23,17 @@ void apply_validator(
           "JSON request body does not conform to schema: {}", err.what()));
     }
 }
+
+bool get_boolean_query_param(
+  const ss::http::request& req, std::string_view name) {
+    auto key = ss::sstring(name);
+    if (!req.query_parameters.contains(key)) {
+        return false;
+    }
+
+    const ss::sstring& str_param = req.query_parameters.at(key);
+    return ss::internal::case_insensitive_cmp()(str_param, "true")
+           || str_param == "1";
+}
+
 } // namespace admin

--- a/src/v/redpanda/admin/util.h
+++ b/src/v/redpanda/admin/util.h
@@ -11,6 +11,8 @@
 
 #include "json/validator.h"
 
+#include <seastar/http/request.hh>
+
 #pragma once
 
 namespace admin {
@@ -38,5 +40,12 @@ private:
  */
 void apply_validator(
   json::validator& validator, const json::Document::ValueType& doc);
+
+/**
+ * Helper for requests with boolean URL query parameters that should
+ * be treated as false if absent, or true if "true" (case insensitive) or "1"
+ */
+bool get_boolean_query_param(
+  const ss::http::request& req, std::string_view name);
 
 } // namespace admin

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -46,6 +46,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/optimized_optional.hh>
 
 namespace transform {
@@ -710,6 +711,31 @@ model::cluster_transform_report service::compute_default_report() {
 std::unique_ptr<rpc::reporter>
 service::create_reporter(ss::sharded<service>* s) {
     return std::make_unique<wrapped_service_reporter>(s);
+}
+
+ss::future<
+  result<ss::chunked_fifo<model::transform_committed_offset>, cluster::errc>>
+service::list_committed_offsets() {
+    if (!_feature_table->local().is_active(
+          features::feature::wasm_transforms)) {
+        co_return cluster::errc::feature_disabled;
+    }
+    auto _ = _gate.hold();
+    auto result = co_await _rpc_client->local().list_committed_offsets();
+    if (result.has_error()) {
+        co_return result.error();
+    }
+    auto all_transforms = _plugin_frontend->local().all_transforms();
+    ss::chunked_fifo<model::transform_committed_offset> commits;
+    for (const auto& [k, v] : result.value()) {
+        auto it = all_transforms.find(k.id);
+        if (it == all_transforms.end()) {
+            continue;
+        }
+        commits.emplace_back(it->second.name, k.partition, v.offset);
+        co_await ss::coroutine::maybe_yield();
+    }
+    co_return commits;
 }
 
 } // namespace transform

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -29,6 +29,10 @@
 
 namespace transform {
 
+struct list_committed_offsets_options {
+    bool show_unknown = false;
+};
+
 /**
  * The transform service is responsible for intersecting the current state of
  * plugins and topic partitions and ensures that the corresponding wasm
@@ -79,7 +83,7 @@ public:
     ss::future<result<
       ss::chunked_fifo<model::transform_committed_offset>,
       cluster::errc>>
-    list_committed_offsets();
+      list_committed_offsets(list_committed_offsets_options);
 
     /**
      * Create a reporter of the transform subsystem.

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "base/outcome.h"
 #include "base/seastarx.h"
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
@@ -71,6 +72,14 @@ public:
      * List all transforms from the entire cluster.
      */
     ss::future<model::cluster_transform_report> list_transforms();
+
+    /**
+     * List the committed offsets for each transform/partition.
+     */
+    ss::future<result<
+      ss::chunked_fifo<model::transform_committed_offset>,
+      cluster::errc>>
+    list_committed_offsets();
 
     /**
      * Create a reporter of the transform subsystem.

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -84,6 +84,12 @@ public:
 
     ss::future<model::cluster_transform_report> generate_report();
 
+    /**
+     * List all the tracked offsets for all transforms within the cluster.
+     */
+    ss::future<result<model::transform_offsets_map, cluster::errc>>
+    list_committed_offsets();
+
     ss::future<> start();
     ss::future<> stop();
 
@@ -148,6 +154,18 @@ private:
       do_remote_offset_commit(model::node_id, offset_commit_request);
     ss::future<offset_fetch_response>
       do_remote_offset_fetch(model::node_id, offset_fetch_request);
+
+    ss::future<result<model::transform_offsets_map, cluster::errc>>
+      do_list_committed_offsets(model::partition_id);
+    ss::future<result<model::transform_offsets_map, cluster::errc>>
+      do_list_committed_offsets_once(model::partition_id);
+    ss::future<result<model::transform_offsets_map, cluster::errc>>
+      do_local_list_committed_offsets(model::partition_id);
+    ss::future<result<model::transform_offsets_map, cluster::errc>>
+    do_remote_list_committed_offsets(
+      model::node_id,
+      model::partition_id,
+      model::timeout_clock::duration timeout);
 
     template<typename Func>
     std::invoke_result_t<Func> retry(Func&&);

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -197,6 +197,9 @@ public:
 
     virtual ss::future<offset_fetch_response>
     invoke_on_shard(ss::shard_id, const model::ntp&, offset_fetch_request) = 0;
+
+    virtual ss::future<result<model::transform_offsets_map, cluster::errc>>
+    list_committed_offsets_on_shard(ss::shard_id, const model::ntp&) = 0;
 };
 
 }; // namespace transform::rpc

--- a/src/v/transform/rpc/rpc.json
+++ b/src/v/transform/rpc/rpc.json
@@ -44,6 +44,11 @@
             "name": "offset_fetch",
             "input_type": "offset_fetch_request",
             "output_type": "offset_fetch_response"
+        },
+        {
+            "name": "list_committed_offsets",
+            "input_type": "list_commits_request",
+            "output_type": "list_commits_reply"
         }
     ]
 }

--- a/src/v/transform/rpc/serde.cc
+++ b/src/v/transform/rpc/serde.cc
@@ -1,5 +1,4 @@
-/*
- * Copyright 2023 Redpanda Data, Inc.
+/* Copyright 2023 Redpanda Data, Inc.
  *
  * Use of this software is governed by the Business Source License
  * included in the file licenses/BSL.md
@@ -174,6 +173,16 @@ operator<<(std::ostream& os, const transformed_topic_data_result& result) {
 std::ostream& operator<<(std::ostream& os, const transformed_topic_data& data) {
     fmt::print(
       os, "{{ tp: {}, batches_size: {} }}", data.tp, data.batches.size());
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const list_commits_request& req) {
+    fmt::print(os, "{{ partition: {} }}", req.partition);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const list_commits_reply& reply) {
+    fmt::print(os, "{{ ec: {}, map_size: {} }}", reply.errc, reply.map.size());
     return os;
 }
 

--- a/src/v/transform/rpc/serde.h
+++ b/src/v/transform/rpc/serde.h
@@ -417,4 +417,43 @@ struct generate_report_reply
 
     model::cluster_transform_report report;
 };
+
+struct list_commits_request
+  : serde::envelope<
+      list_commits_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    list_commits_request() = default;
+    explicit list_commits_request(model::partition_id partition)
+      : partition(partition) {}
+
+    auto serde_fields() { return std::tie(partition); }
+
+    friend std::ostream& operator<<(std::ostream&, const list_commits_request&);
+
+    model::partition_id partition;
+};
+
+struct list_commits_reply
+  : serde::envelope<
+      list_commits_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    list_commits_reply() = default;
+    explicit list_commits_reply(
+      cluster::errc ec, model::transform_offsets_map m)
+      : errc(ec)
+      , map(std::move(m)) {}
+
+    auto serde_fields() { return std::tie(errc, map); }
+
+    friend std::ostream& operator<<(std::ostream&, const list_commits_reply&);
+
+    cluster::errc errc{cluster::errc::success};
+    model::transform_offsets_map map;
+};
 } // namespace transform::rpc

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -12,6 +12,7 @@
 #include "cluster/fwd.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
+#include "model/transform.h"
 #include "transform/rpc/deps.h"
 #include "transform/rpc/rpc_service.h"
 #include "transform/rpc/serde.h"
@@ -53,6 +54,9 @@ public:
     ss::future<offset_fetch_response> offset_fetch(offset_fetch_request);
 
     ss::future<model::cluster_transform_report> compute_node_local_report();
+
+    ss::future<result<model::transform_offsets_map, cluster::errc>>
+      list_committed_offsets(list_commits_request);
 
 private:
     ss::future<transformed_topic_data_result>
@@ -103,6 +107,9 @@ public:
 
     ss::future<offset_fetch_response>
     offset_fetch(offset_fetch_request, ::rpc::streaming_context&) override;
+
+    ss::future<list_commits_reply> list_committed_offsets(
+      list_commits_request, ::rpc::streaming_context&) override;
 
     ss::future<generate_report_reply> generate_report(
       generate_report_request, ::rpc::streaming_context&) override;

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -316,12 +316,11 @@ public:
         _offsets.insert_or_assign(key, val);
     }
 
+    model::transform_offsets_map list() { return _offsets; }
+
 private:
     int _num_partitions = 3;
-    absl::flat_hash_map<
-      model::transform_offsets_key,
-      model::transform_offsets_value>
-      _offsets;
+    model::transform_offsets_map _offsets;
 };
 
 class fake_partition_manager : public partition_manager {
@@ -456,6 +455,20 @@ public:
             }
         }
         co_return resp;
+    }
+
+    ss::future<result<model::transform_offsets_map, cluster::errc>>
+    list_committed_offsets_on_shard(
+      ss::shard_id shard_id, const model::ntp& ntp) override {
+        auto owner = shard_owner(ntp);
+        if (!owner || shard_id != *owner) {
+            co_return cluster::errc::not_leader;
+        }
+        if (_errors_to_inject > 0) {
+            --_errors_to_inject;
+            co_return cluster::errc::timeout;
+        }
+        co_return _offset_tracker->list();
     }
 
 private:

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -967,6 +967,18 @@ TEST_P(TransformRpcTest, TestTransformOffsetRPCs) {
             ASSERT_EQ(read_result.value()->offset, request_val.offset);
         }
     }
+    auto offsets = client()->list_committed_offsets().get().value();
+    EXPECT_EQ(offsets.size(), num_transforms * num_src_partitions);
+    for (int i = 0; i < num_transforms; ++i) {
+        for (int32_t j = 0; j < num_src_partitions; ++j) {
+            model::transform_offsets_key key;
+            key.id = model::transform_id(i);
+            key.partition = model::partition_id(j);
+            auto it = offsets.find(key);
+            ASSERT_FALSE(it == offsets.end());
+            EXPECT_EQ(it->second.offset, kafka::offset(j));
+        }
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -84,6 +84,12 @@ class RedpandaNode(NamedTuple):
     id: int
 
 
+class CommittedWasmOffset(NamedTuple):
+    name: str
+    partition: int
+    offset: int
+
+
 class Admin:
     """
     Wrapper for Redpanda admin REST API.
@@ -1235,3 +1241,16 @@ class Admin:
     def get_tx_manager_recovery_status(self,
                                        node: Optional[ClusterNode] = None):
         return self._request("GET", "recovery/migrate_tx_manager", node=node)
+
+    def transforms_list_committed_offsets(
+            self,
+            show_unknown: bool = False,
+            node: Optional[ClusterNode] = None) -> list[CommittedWasmOffset]:
+        path = "transform/debug/committed_offsets"
+        if show_unknown:
+            path += "?show_unknown=true"
+        raw = self._request("GET", path, node=node).json()
+        return [
+            CommittedWasmOffset(c["transform_name"], c["partition"],
+                                c["offset"]) for c in raw
+        ]


### PR DESCRIPTION
We need to cleanup committed offsets when transforms are deleted. At the moment we do not do that. In an effort to do that and ensure we have tests for this, I've broken up that change into two parts, this one, which exposes the ability to view committed offsets, and another to do the cleanup. We'll use the infrastructure from this PR to enable the tests for ensuring that the offsets are cleaned up.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Features

* Add an internal debugging endpoint to see the committed progress of data transforms.
