### PR TITLE
Transform logging data model

### DIFF
--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -42,6 +42,9 @@ using transform_id = named_type<int64_t, struct transform_id_tag>;
  */
 using transform_name = named_type<ss::sstring, struct transform_name_tag>;
 
+using transform_name_view
+  = named_type<std::string_view, struct transform_name_view_tag>;
+
 /**
  * Metadata for a WebAssembly powered data transforms.
  */

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -25,3 +25,4 @@ v_cc_library(
 
 add_subdirectory(tests)
 add_subdirectory(rpc)
+add_subdirectory(logging)

--- a/src/v/transform/logging/CMakeLists.txt
+++ b/src/v/transform/logging/CMakeLists.txt
@@ -1,0 +1,11 @@
+v_cc_library(
+  NAME transform_logging
+  HDRS
+    event.h
+  SRCS
+    event.cc
+  DEPS
+    v::model
+)
+
+add_subdirectory(tests)

--- a/src/v/transform/logging/event.cc
+++ b/src/v/transform/logging/event.cc
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/logging/event.h"
+
+#include "bytes/streambuf.h"
+#include "json/json.h"
+#include "json/ostreamwrapper.h"
+
+#include <type_traits>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+using otel_xform_name_attr
+  = named_type<model::transform_name_view, struct otel_xform_name_attr_tag>;
+
+using otel_node_id_attr
+  = named_type<model::node_id, struct otel_node_id_attr_tag>;
+
+struct otel_log_event {
+    otel_log_event() = delete;
+    explicit otel_log_event(
+      model::transform_name_view name, const transform::logging::event& ev)
+      : name(name)
+      , source_id(ev.source_id)
+      , ts(ev.ts.time_since_epoch() / 1ns)
+      , level(ev.level)
+      , message(ev.message) {}
+    otel_xform_name_attr name;
+    otel_node_id_attr source_id;
+    uint64_t ts;
+    ss::log_level level;
+    std::string_view message;
+};
+
+} // namespace
+
+namespace json {
+
+inline void rjson_serialize(
+  Writer<OStreamWrapper>& w, const model::transform_name_view& name) {
+    w.String(name().data(), name().size());
+}
+
+inline void
+rjson_serialize(Writer<OStreamWrapper>& w, const ::otel_xform_name_attr& name) {
+    w.StartObject();
+    w.Key("key");
+    w.String("transform_name");
+    w.Key("value");
+    w.StartObject();
+    w.Key("stringValue");
+    rjson_serialize(w, name());
+    w.EndObject();
+    w.EndObject();
+}
+
+inline void
+rjson_serialize(Writer<OStreamWrapper>& w, const ::otel_node_id_attr& nid) {
+    w.StartObject();
+    w.Key("key");
+    w.String("node");
+    w.Key("value");
+    w.StartObject();
+    w.Key("intValue");
+    w.Int(static_cast<int>(nid()));
+    w.EndObject();
+    w.EndObject();
+}
+
+inline void
+rjson_serialize(Writer<OStreamWrapper>& w, const ::otel_log_event& ev) {
+    w.StartObject();
+    w.Key("body");
+    w.String(ev.message.data(), ev.message.size());
+    w.Key("timeUnixNano");
+    w.Uint64(ev.ts);
+    w.Key("severityNumber");
+    w.Uint(transform::logging::log_level_to_severity(ev.level));
+    w.Key("attributes");
+    w.StartArray();
+    rjson_serialize(w, ev.name);
+    rjson_serialize(w, ev.source_id);
+    w.EndArray();
+    w.EndObject();
+}
+
+} // namespace json
+
+namespace transform::logging {
+
+uint32_t log_level_to_severity(ss::log_level lvl) {
+    static const std::unordered_map<ss::log_level, int> severity{
+      {ss::log_level::trace, 1},
+      {ss::log_level::debug, 5},
+      {ss::log_level::info, 9},
+      {ss::log_level::warn, 13},
+      {ss::log_level::error, 17},
+    };
+    return severity.at(lvl);
+}
+
+event::event(
+  model::node_id source,
+  clock_type::time_point ts,
+  ss::log_level level,
+  ss::sstring message)
+  : source_id(source)
+  , ts(ts)
+  , level(level)
+  , message(std::move(message)) {}
+
+void event::to_json(model::transform_name_view name, iobuf& b) const {
+    iobuf_ostreambuf obuf{b};
+    std::ostream os{&obuf};
+    ::json::OStreamWrapper wrapper{os};
+    ::json::Writer<::json::OStreamWrapper> writer{wrapper};
+
+    using ::json::rjson_serialize;
+
+    rjson_serialize(writer, ::otel_log_event{name, *this});
+}
+
+} // namespace transform::logging

--- a/src/v/transform/logging/event.h
+++ b/src/v/transform/logging/event.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/seastarx.h"
+#include "model/transform.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sstring.hh>
+
+#pragma once
+
+namespace transform::logging {
+
+/**
+ * Map a seastar log level to a SeverityNumber as specified in
+ * https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+ */
+uint32_t log_level_to_severity(ss::log_level lvl);
+
+/**
+ * A singe log message emitted by some WASM data transform.
+ *
+ * Transforms emit log messages by writing to stdout/stderr, which
+ * is intercepted at the WASI layer and forwarded to the transform
+ * logging subsystem.
+ *
+ * That message is then packaged into an `event`, along with the source
+ * node ID, a timestamp, and a log_level, the latter of which is determined
+ * by whether the transform wrote to stdout (ss::log_level::info) or
+ * stderr (ss::log_level::warn).
+ *
+ */
+struct event {
+    using clock_type = std::chrono::system_clock;
+    event() = delete;
+    explicit event(
+      model::node_id source,
+      clock_type::time_point ts,
+      ss::log_level level,
+      ss::sstring message);
+
+    model::node_id source_id;
+    clock_type::time_point ts;
+    ss::log_level level;
+    ss::sstring message;
+
+    friend bool operator==(const event&, const event&) = default;
+
+    /**
+     * Serialize this event to JSON, with the result mapping directly to:
+     * https://github.com/open-telemetry/opentelemetry-proto/blob/34d29fe5ad4689b5db0259d3750de2bfa195bc85/opentelemetry/proto/logs/v1/logs.proto#L134
+     *
+     * NOTE: We include a `name` for the attributes here, but the transform
+     * name is omitted from the event itself to avoid duplicating it across
+     * every log entry.
+     */
+    void to_json(model::transform_name_view name, iobuf&) const;
+};
+} // namespace transform::logging

--- a/src/v/transform/logging/tests/CMakeLists.txt
+++ b/src/v/transform/logging/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+v_cc_library(
+  NAME transform_logging_test_utils
+  HDRS
+    utils.h
+  SRCS
+    utils.cc
+  DEPS
+    v::utils
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME transform_logging
+  SOURCES
+    model_test.cc
+  LIBRARIES
+    v::transform_logging
+    v::transform_logging_test_utils
+    v::gtest_main
+)

--- a/src/v/transform/logging/tests/model_test.cc
+++ b/src/v/transform/logging/tests/model_test.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "json/document.h"
+#include "transform/logging/event.h"
+#include "transform/logging/tests/utils.h"
+
+#include <gtest/gtest.h>
+
+namespace transform::logging {
+
+TEST(TransformLogEventTest, ValidateLogEventJson) {
+    using namespace std::chrono_literals;
+
+    ss::sstring message = "Hello";
+    auto now = transform::logging::event::clock_type::now();
+    model::node_id node_id{0};
+    ss::log_level level{ss::log_level::info};
+    model::transform_name name{"dummy"};
+
+    transform::logging::event ev{node_id, now, level, message};
+    iobuf b;
+    ev.to_json(model::transform_name_view{name()}, b);
+
+    auto doc = testing::parse_json(std::move(b));
+
+    EXPECT_TRUE(doc.IsObject());
+
+    EXPECT_TRUE(
+      doc.HasMember("body") && doc["body"].IsString()
+      && doc["body"].GetString() == message);
+
+    EXPECT_TRUE(
+      doc.HasMember("timeUnixNano") && doc["timeUnixNano"].IsUint64()
+      && doc["timeUnixNano"].GetUint64() == now.time_since_epoch() / 1ns);
+
+    EXPECT_TRUE(
+      doc.HasMember("severityNumber") && doc["severityNumber"].IsUint()
+      && doc["severityNumber"].GetUint()
+           == transform::logging::log_level_to_severity(level));
+
+    EXPECT_TRUE(
+      doc.HasMember("attributes") && doc["attributes"].IsArray()
+      && doc["attributes"].GetArray().Size() == 2);
+
+    const auto& attrs = doc["attributes"].GetArray();
+
+    for (const auto& attr : attrs) {
+        EXPECT_TRUE(
+          attr.IsObject() && attr.HasMember("key") && attr["key"].IsString()
+          && attr.HasMember("value") && attr["value"].IsObject());
+    }
+
+    EXPECT_TRUE(
+      attrs[0]["key"].GetString() == ss::sstring("transform_name")
+      && attrs[0]["value"]["stringValue"].IsString()
+      && attrs[0]["value"]["stringValue"].GetString() == name);
+
+    EXPECT_TRUE(
+      attrs[1]["key"].GetString() == ss::sstring("node")
+      && attrs[1]["value"]["intValue"].IsInt()
+      && attrs[1]["value"]["intValue"].GetInt() == node_id);
+}
+
+TEST(TransformLogEventTest, LogLevelToSeverity) {
+    for (auto lvl :
+         {ss::log_level::trace,
+          ss::log_level::debug,
+          ss::log_level::info,
+          ss::log_level::warn,
+          ss::log_level::error}) {
+        transform::logging::event ev{
+          model::node_id{0},
+          transform::logging::event::clock_type::now(),
+          lvl,
+          "bar"};
+        iobuf b;
+        ev.to_json(model::transform_name_view{"foo"}, b);
+        auto doc = testing::parse_json(std::move(b));
+        EXPECT_TRUE(
+          doc.HasMember("severityNumber") && doc["severityNumber"].IsUint()
+          && doc["severityNumber"].GetUint()
+               == transform::logging::log_level_to_severity(ev.level));
+    }
+}
+} // namespace transform::logging

--- a/src/v/transform/logging/tests/utils.cc
+++ b/src/v/transform/logging/tests/utils.cc
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/logging/tests/utils.h"
+
+#include "bytes/streambuf.h"
+#include "json/istreamwrapper.h"
+
+#include <istream>
+
+namespace transform::logging::testing {
+
+json::Document parse_json(iobuf resp) {
+    iobuf_istreambuf ibuf{resp};
+    std::istream stream{&ibuf};
+    json::Document doc;
+    json::IStreamWrapper wrapper(stream);
+    doc.ParseStream(wrapper);
+    return doc;
+}
+
+} // namespace transform::logging::testing

--- a/src/v/transform/logging/tests/utils.h
+++ b/src/v/transform/logging/tests/utils.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "json/document.h"
+
+namespace transform::logging::testing {
+
+json::Document parse_json(iobuf resp);
+
+} // namespace transform::logging::testing


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR introduces `transform_log_event` for in-memory storage of transform logs.

Also Includes RapidJSON serialization for a mapping of the OpenTelemetry
[logging format](https://opentelemetry.io/docs/specs/otel/logs/data-model/) and some internal helper types to that end.

Example JSON:

```json5
    {
      "body": {
        "stringValue": "my message goes here...",
      },
      "timeUnixNano": 1705462202516000000,
      "severityNumber": 9, // 9 for stdout, 13 for stderr
      "attributes": [
        {"key": "node", "value": {"intValue": 1}},
        {"key": "transform_name", "value": {"stringValue": "<xform name>"}}
      ]
    }
```
This will be the structure of log event records, as stored on the `transform_logs` redpanda topic.

Closes https://github.com/redpanda-data/core-internal/issues/999

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
