### PR TITLE
transform-sdk/rust: borrow output record

### DIFF
--- a/src/go/rpk/pkg/cli/transform/template/rust/main.rustsrc
+++ b/src/go/rpk/pkg/cli/transform/template/rust/main.rustsrc
@@ -9,16 +9,7 @@ fn main() {
 
 // my_transform is where you read the record that was written, and then you can
 // return new records that will be written to the output topic
-fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<(), Box<dyn Error>> {
-    writer.write(Record::new_with_headers(
-        event.record.key().map(|b| b.to_owned()),
-        event.record.value().map(|b| b.to_owned()),
-        event
-            .record
-            .headers()
-            .iter()
-            .map(|h| h.to_owned())
-            .collect(),
-    ))?;
+fn my_transform(event: WriteEvent, writer: &mut RecordWriter) -> Result<(), Box<dyn Error>> {
+    writer.write(event.record)?;
     Ok(())
 }

--- a/src/transform-sdk/rust/Cargo.lock
+++ b/src/transform-sdk/rust/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -38,9 +38,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "apache-avro"
@@ -73,9 +73,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.5"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bincode"
@@ -139,6 +139,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "dary_heap"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,9 +167,9 @@ checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "deranged"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb30d70a07a3b04884d2677f06bec33509dc67ca60d92949e5535352d3191dc"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
@@ -168,12 +189,6 @@ name = "dyn-clone"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
-
-[[package]]
-name = "either"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "env_logger"
@@ -203,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
+checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -254,19 +269,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jaq"
@@ -283,14 +289,13 @@ dependencies = [
 
 [[package]]
 name = "jaq-core"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb3a8be28328bc6c6dbb432487c854bcf48259be2cbea2f56c94d6fd3ef0b9"
+checksum = "03d6a5713b8f33675abfac79d1db0022a3f28764b2a6b96a185c199ad8dab86d"
 dependencies = [
  "aho-corasick",
  "base64",
  "hifijson",
- "itertools",
  "jaq-interpret",
  "libm",
  "log",
@@ -301,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-interpret"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfd5bfd4c44079c5b6666be9a855c382680136697792ba8c2e160fce4dd7b2b5"
+checksum = "f569e38e5fc677db8dfda89ee0b4c25b3f53e811b16434fd14bdc5b43fc362ac"
 dependencies = [
  "ahash",
  "dyn-clone",
@@ -316,9 +321,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-parse"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5b529357bc0b413959823a3c8f3f4e477819963cf44559d0c6b26b98c361c3"
+checksum = "ef6f8beb9f9922546419e774e24199e8a968f54c63a5a2323c8f3ef3321ace14"
 dependencies = [
  "chumsky",
  "jaq-syn",
@@ -326,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "jaq-std"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be4695fd0e804020e3a82b7e926dc5fee968e3311e9cd5b315fe026477dde8d"
+checksum = "5d7871c59297cbfdd18f6f1bbbafaad24e97fd555ee1e2a1be7a40a5a20f551a"
 dependencies = [
  "bincode",
  "jaq-parse",
@@ -362,9 +367,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libflate"
@@ -404,9 +409,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.6.4"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "num-bigint"
@@ -440,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "powerfmt"
@@ -458,9 +463,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
@@ -484,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -526,10 +531,13 @@ name = "redpanda-transform-sdk"
 version = "0.0.0-dev"
 dependencies = [
  "anyhow",
+ "csv",
  "quickcheck",
  "rand",
  "redpanda-transform-sdk-sys",
  "redpanda-transform-sdk-types",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -548,9 +556,9 @@ version = "0.0.0-dev"
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -560,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -595,24 +603,24 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "serde"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -621,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.108"
+version = "1.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
+checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
 dependencies = [
  "itoa",
  "ryu",
@@ -651,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -662,18 +670,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -682,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
 dependencies = [
  "deranged",
  "itoa",
@@ -702,9 +710,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
 dependencies = [
  "time-core",
 ]
@@ -749,9 +757,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "serde",
 ]
@@ -770,18 +778,18 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "zerocopy"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.26"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/transform-sdk/rust/Cargo.toml
+++ b/src/transform-sdk/rust/Cargo.toml
@@ -18,6 +18,9 @@ redpanda-transform-sdk-sys = { path = "./core-sys", version = "=0.0.0-dev" }
 quickcheck = { workspace = true }
 rand = { workspace = true }
 anyhow = { workspace = true }
+csv = "1.3.0"
+serde_json = "1.0.111"
+serde = { version = "1.0.195", features = ["derive"] }
 
 [workspace]
 resolver = "2"

--- a/src/transform-sdk/rust/core-types/src/lib.rs
+++ b/src/transform-sdk/rust/core-types/src/lib.rs
@@ -27,13 +27,116 @@ use std::time::SystemTime;
 #[derive(Debug)]
 pub struct WriteEvent<'a> {
     /// The record for which the event was generated for.
-    pub record: BorrowedRecord<'a>,
+    pub record: WrittenRecord<'a>,
+}
+
+/// A written [`Record`] within Redpanda.
+///
+/// A [`WrittenRecord`] is handed to `on_record_written` event handlers as the record that Redpanda
+/// wrote. The record contains a key value pair with some headers, along with the record's
+/// timestamp.
+#[derive(Debug)]
+pub struct WrittenRecord<'a> {
+    record: BorrowedRecord<'a>,
+    timestamp: SystemTime,
+}
+
+impl<'a> WrittenRecord<'a> {
+    /// Create a new record without any copies.
+    ///
+    /// NOTE: This method is useful for tests to mock out custom events to your transform function.
+    pub fn from_record(record: impl Into<BorrowedRecord<'a>>, timestamp: SystemTime) -> Self {
+        let record = record.into();
+        Self { record, timestamp }
+    }
+
+    /// Create a new record without any copies.
+    ///
+    /// NOTE: This method is useful for tests to mock out custom events to your transform function.
+    pub fn new(key: Option<&'a [u8]>, value: Option<&'a [u8]>, timestamp: SystemTime) -> Self {
+        Self {
+            record: BorrowedRecord::new(key, value),
+            timestamp,
+        }
+    }
+
+    /// Create a new record without any copies.
+    ///
+    /// NOTE: This method is useful for tests to mock out custom events to your transform function.
+    pub fn new_with_headers(
+        key: Option<&'a [u8]>,
+        value: Option<&'a [u8]>,
+        timestamp: SystemTime,
+        headers: Vec<BorrowedHeader<'a>>,
+    ) -> Self {
+        Self {
+            record: BorrowedRecord::new_with_headers(key, value, headers),
+            timestamp,
+        }
+    }
+
+    /// Returns the record's key or `None` if there is no key.
+    pub fn key(&self) -> Option<&'a [u8]> {
+        self.record.key()
+    }
+
+    /// Returns the record's value or `None` if there is no value.
+    pub fn value(&self) -> Option<&'a [u8]> {
+        self.record.value()
+    }
+
+    /// Returns the record's timestamp.
+    ///
+    /// NOTE: Record timestamps in Redpanda have millisecond resolution.
+    pub fn timestamp(&self) -> SystemTime {
+        self.timestamp
+    }
+
+    /// Return the headers for this record.
+    pub fn headers(&self) -> &[BorrowedHeader<'a>] {
+        self.record.headers()
+    }
+}
+
+impl<'a> AsRef<BorrowedRecord<'a>> for WrittenRecord<'a> {
+    fn as_ref(&self) -> &BorrowedRecord<'a> {
+        &self.record
+    }
+}
+
+impl<'a> From<WrittenRecord<'a>> for BorrowedRecord<'a> {
+    fn from(r: WrittenRecord<'a>) -> Self {
+        r.record
+    }
+}
+
+impl<'a> From<&'a WrittenRecord<'a>> for BorrowedRecord<'a> {
+    fn from(r: &'a WrittenRecord) -> Self {
+        r.record.clone()
+    }
+}
+
+/// A trait that can receive a stream of records and output them a destination topic.
+pub trait RecordSink {
+    /// Write a record to the output topic returning any errors.
+    fn write(&mut self, r: BorrowedRecord<'_>) -> Result<(), WriteError>;
 }
 
 /// A writer trait for output transformed records to the destination topic.
-pub trait RecordWriter {
+pub struct RecordWriter<'a> {
+    sink: &'a mut dyn RecordSink,
+}
+
+impl<'a> RecordWriter<'a> {
+    // Creates a new [`RecordWriter`] using the specified `sink`.
+    pub fn new(sink: &'a mut dyn RecordSink) -> Self {
+        Self { sink }
+    }
+
     /// Write a record to the output topic returning any errors.
-    fn write(&mut self, r: Record) -> Result<(), WriteError>;
+    pub fn write<'b>(&mut self, r: impl Into<BorrowedRecord<'b>>) -> Result<(), WriteError> {
+        self.sink.write(r.into())
+    }
 }
 
 /// An error that can occur when writing records to the output topic.
@@ -55,7 +158,7 @@ impl std::fmt::Display for WriteError {
 impl std::error::Error for WriteError {}
 
 /// A zero-copy [`BorrowedRecord`] header.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BorrowedHeader<'a> {
     key: &'a [u8],
     value: Option<&'a [u8]>,
@@ -83,44 +186,39 @@ impl<'a> BorrowedHeader<'a> {
     }
 }
 
+impl<'a> From<&'a BorrowedHeader<'a>> for BorrowedHeader<'a> {
+    fn from(r: &'a BorrowedHeader) -> Self {
+        r.clone()
+    }
+}
+
 /// A zero-copy representation of a [`Record`] within Redpanda.
-///
-/// A [`BorrowedRecord`] is handed to `on_record_written` event handlers as the record that Redpanda
-/// wrote.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BorrowedRecord<'a> {
     key: Option<&'a [u8]>,
     value: Option<&'a [u8]>,
-    timestamp: SystemTime,
     headers: Vec<BorrowedHeader<'a>>,
 }
 
 impl<'a> BorrowedRecord<'a> {
     /// Create a new record without any copies.
-    ///
-    /// NOTE: This method is useful for tests to mock out custom events to your transform function.
-    pub fn new(key: Option<&'a [u8]>, value: Option<&'a [u8]>, timestamp: SystemTime) -> Self {
+    pub fn new(key: Option<&'a [u8]>, value: Option<&'a [u8]>) -> Self {
         Self {
             key,
             value,
-            timestamp,
             headers: Vec::new(),
         }
     }
 
     /// Create a new record without any copies.
-    ///
-    /// NOTE: This method is useful for tests to mock out custom events to your transform function.
     pub fn new_with_headers(
         key: Option<&'a [u8]>,
         value: Option<&'a [u8]>,
-        timestamp: SystemTime,
         headers: Vec<BorrowedHeader<'a>>,
     ) -> Self {
         Self {
             key,
             value,
-            timestamp,
             headers,
         }
     }
@@ -135,16 +233,15 @@ impl<'a> BorrowedRecord<'a> {
         self.value
     }
 
-    /// Returns the record's timestamp.
-    ///
-    /// NOTE: Record timestamps in Redpanda have millisecond resolution.
-    pub fn timestamp(&self) -> SystemTime {
-        self.timestamp
-    }
-
     /// Return the headers for this record.
     pub fn headers(&self) -> &[BorrowedHeader<'a>] {
         &self.headers
+    }
+}
+
+impl<'a> From<&'a BorrowedRecord<'a>> for BorrowedRecord<'a> {
+    fn from(r: &'a BorrowedRecord) -> Self {
+        r.clone()
     }
 }
 
@@ -182,6 +279,12 @@ impl RecordHeader {
     /// Sets the value for this header.
     pub fn set_value(&mut self, v: Vec<u8>) {
         self.value = Some(v);
+    }
+}
+
+impl<'a> From<&'a RecordHeader> for BorrowedHeader<'a> {
+    fn from(header: &'a RecordHeader) -> Self {
+        Self::new(header.key(), header.value())
     }
 }
 
@@ -255,7 +358,13 @@ impl Record {
     }
 
     /// Returns a collection of headers for this record.
-    pub fn headers(&self) -> &[RecordHeader] {
-        &self.headers[..]
+    pub fn headers(&self) -> impl ExactSizeIterator<Item = BorrowedHeader> {
+        self.headers.iter().map(|h| h.into())
+    }
+}
+
+impl<'a> From<&'a Record> for BorrowedRecord<'a> {
+    fn from(record: &'a Record) -> Self {
+        Self::new_with_headers(record.key(), record.value(), record.headers().collect())
     }
 }

--- a/src/transform-sdk/rust/examples/identity.rs
+++ b/src/transform-sdk/rust/examples/identity.rs
@@ -12,25 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate redpanda_transform_sdk as redpanda;
-
 use anyhow::Result;
-use redpanda::*;
+use redpanda_transform_sdk::*;
 
 fn main() {
     on_record_written(my_transform);
 }
 
-fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<()> {
-    writer.write(Record::new_with_headers(
-        event.record.key().map(|b| b.to_owned()),
-        event.record.value().map(|b| b.to_owned()),
-        event
-            .record
-            .headers()
-            .iter()
-            .map(|h| h.to_owned())
-            .collect(),
-    ))?;
+fn my_transform(event: WriteEvent, writer: &mut RecordWriter) -> Result<()> {
+    writer.write(event.record)?;
     Ok(())
 }

--- a/src/transform-sdk/rust/examples/json2avro/src/main.rs
+++ b/src/transform-sdk/rust/examples/json2avro/src/main.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-extern crate redpanda_transform_sdk as redpanda;
-
 use anyhow::Result;
-use redpanda::*;
+use redpanda_transform_sdk::*;
 
 fn main() -> Result<()> {
     let schema = apache_avro::Schema::parse_str(

--- a/src/transform-sdk/rust/examples/json2avro/src/main.rs
+++ b/src/transform-sdk/rust/examples/json2avro/src/main.rs
@@ -46,22 +46,17 @@ fn main() -> Result<()> {
 fn my_transform(
     schema: &apache_avro::Schema,
     event: WriteEvent,
-    writer: &mut dyn RecordWriter,
+    writer: &mut RecordWriter,
 ) -> Result<()> {
     let transformed_value = match event.record.value() {
         Some(bytes) => Some(json_to_avro(schema, bytes)?),
         None => None,
     };
 
-    writer.write(Record::new_with_headers(
-        event.record.key().map(|b| b.to_owned()),
-        transformed_value,
-        event
-            .record
-            .headers()
-            .iter()
-            .map(|h| h.to_owned())
-            .collect(),
+    writer.write(BorrowedRecord::new_with_headers(
+        event.record.key(),
+        transformed_value.as_ref().map(|v| &v[..]),
+        event.record.headers().to_owned(),
     ))?;
     Ok(())
 }

--- a/src/transform-sdk/rust/examples/transcoder.rs
+++ b/src/transform-sdk/rust/examples/transcoder.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Redpanda Data, Inc.
+// Copyright 2024 Redpanda Data, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,19 +14,29 @@
 
 use anyhow::Result;
 use redpanda_transform_sdk::*;
+use serde::{Deserialize, Serialize};
 
-// This example shows the basic usage of the crate:
-// This transform does nothing but copy the same data from an
-// input topic to an output topic.
+// This example shows a transform that converts CSV inputs into JSON outputs.
 fn main() {
-    // Make sure to register your callback and perform other setup in main
     on_record_written(my_transform);
 }
 
-// This will be called for each record in the source topic.
-//
-// The output records returned will be written to the destination topic.
+#[derive(Serialize, Deserialize)]
+struct Foo {
+    a: String,
+    b: i32,
+}
+
 fn my_transform(event: WriteEvent, writer: &mut RecordWriter) -> Result<()> {
-    writer.write(event.record)?;
+    // The input data is a CSV (without a header row) that is defined as our Foo structure.
+    let mut reader = csv::Reader::from_reader(event.record.value().unwrap_or_default());
+    // For each record in our CSV
+    for result in reader.deserialize() {
+        let foo: Foo = result?;
+        // Convert it to JSON
+        let value = serde_json::to_vec(&foo)?;
+        // Then output it with the same key.
+        writer.write(BorrowedRecord::new(event.record.key(), Some(&value)))?;
+    }
     Ok(())
 }

--- a/src/transform-sdk/rust/src/lib.rs
+++ b/src/transform-sdk/rust/src/lib.rs
@@ -53,8 +53,8 @@ pub use redpanda_transform_sdk_types::*;
 /// }
 ///
 /// // A transform that duplicates the record on the input topic to the output topic.
-/// fn my_transform(event: WriteEvent, writer: &mut dyn RecordWriter) -> Result<()> {
-///   writer.write(Record::new(
+/// fn my_transform(event: WriteEvent, writer: &mut RecordWriter) -> Result<()> {
+///   writer.write(&Record::new(
 ///     event.record.key().map(|k| k.to_owned()),
 ///     event.record.value().map(|v| v.to_owned()),
 ///   ))?;
@@ -64,7 +64,7 @@ pub use redpanda_transform_sdk_types::*;
 pub fn on_record_written<E, F>(cb: F) -> !
 where
     E: Debug,
-    F: Fn(WriteEvent, &mut dyn RecordWriter) -> Result<(), E>,
+    F: Fn(WriteEvent, &mut RecordWriter) -> Result<(), E>,
 {
     redpanda_transform_sdk_sys::process(cb)
 }


### PR DESCRIPTION
We only need to borrow the output record. To do that we make the writer
take `Into<BorrowedRecord<'_>>`, so that it can take any type of record
for transforms (we can now do no copy transforms!).

Since `Into<_>` is a trait, we can't have a monomorphic trait take a
monomorphic trait as a function argument (see
https://doc.rust-lang.org/reference/items/traits.html#object-safety). So
we wrap our current trait in a struct that handles resolving the trait
argument to the concrete type our write function will take.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
