### PR TITLE
io: add fault injection helpers to persistence layer

### DIFF
--- a/src/v/io/page_set.h
+++ b/src/v/io/page_set.h
@@ -23,7 +23,7 @@ namespace experimental::io {
  * A container holding non-overlapping pages.
  */
 class page_set {
-    using map_type = io::interval_map<uint64_t, seastar::lw_shared_ptr<page>>;
+    using map_type = interval_map<uint64_t, seastar::lw_shared_ptr<page>>;
 
 public:
     /**

--- a/src/v/io/persistence.cc
+++ b/src/v/io/persistence.cc
@@ -67,21 +67,82 @@ std::optional<seastar::future<size_t>> check_alignment(
 
 namespace experimental::io {
 
+void persistence::file::fail_next_read(std::exception_ptr eptr) {
+    read_ex_ = std::move(eptr);
+}
+
+void persistence::file::fail_next_write(std::exception_ptr eptr) {
+    write_ex_ = std::move(eptr);
+}
+
+void persistence::file::fail_next_close(std::exception_ptr eptr) {
+    close_ex_ = std::move(eptr);
+}
+
+seastar::future<> persistence::file::maybe_fail_read() {
+    if (read_ex_) [[unlikely]] {
+        return seastar::make_exception_future(std::exchange(read_ex_, {}));
+    }
+    return seastar::make_ready_future<>();
+}
+
+seastar::future<> persistence::file::maybe_fail_write() {
+    if (write_ex_) [[unlikely]] {
+        return seastar::make_exception_future(std::exchange(write_ex_, {}));
+    }
+    return seastar::make_ready_future<>();
+}
+
+seastar::future<> persistence::file::maybe_fail_close() {
+    if (close_ex_) [[unlikely]] {
+        return seastar::make_exception_future(std::exchange(close_ex_, {}));
+    }
+    return seastar::make_ready_future<>();
+}
+
+void persistence::fail_next_create(std::exception_ptr eptr) {
+    create_ex_ = std::move(eptr);
+}
+
+void persistence::fail_next_open(std::exception_ptr eptr) {
+    open_ex_ = std::move(eptr);
+}
+
+seastar::future<> persistence::maybe_fail_create() {
+    if (create_ex_) [[unlikely]] {
+        return seastar::make_exception_future(std::exchange(create_ex_, {}));
+    }
+    return seastar::make_ready_future<>();
+}
+
+seastar::future<> persistence::maybe_fail_open() {
+    if (open_ex_) [[unlikely]] {
+        return seastar::make_exception_future(std::exchange(open_ex_, {}));
+    }
+    return seastar::make_ready_future<>();
+}
+
 disk_persistence::disk_file::disk_file(seastar::file file)
   : file_(std::move(file)) {}
 
 seastar::future<size_t> disk_persistence::disk_file::dma_read(
   uint64_t pos, char* buf, size_t len) noexcept {
+    return maybe_fail_read().then([this, pos, buf, len] {
     return file_.dma_read(pos, buf, len);
+    });
 }
 
 seastar::future<size_t> disk_persistence::disk_file::dma_write(
   uint64_t pos, const char* buf, size_t len) noexcept {
+    return maybe_fail_write().then([this, pos, buf, len] {
     return file_.dma_write(pos, buf, len);
+    });
 }
 
 seastar::future<> disk_persistence::disk_file::close() noexcept {
+    return maybe_fail_close().then([this] {
     return file_.close();
+    });
 }
 
 uint64_t disk_persistence::disk_file::disk_read_dma_alignment() const noexcept {
@@ -104,17 +165,23 @@ disk_persistence::allocate(uint64_t alignment, size_t size) noexcept {
 
 seastar::future<seastar::shared_ptr<persistence::file>>
 disk_persistence::create(std::filesystem::path path) noexcept {
+    return maybe_fail_create().then([path = std::move(path)] {
     using of = seastar::open_flags;
     const auto flags = of::create | of::exclusive | of::rw;
-    auto file = co_await seastar::open_file_dma(path.string(), flags);
-    co_return seastar::make_shared<disk_file>(std::move(file));
+    return seastar::open_file_dma(path.string(), flags).then([](auto file) {
+    return seastar::make_ready_future<seastar::shared_ptr<persistence::file>>(seastar::make_shared<disk_file>(std::move(file)));
+    });
+    });
 }
 
 seastar::future<seastar::shared_ptr<persistence::file>>
 disk_persistence::open(std::filesystem::path path) noexcept {
+    return maybe_fail_open().then([path = std::move(path)] {
     const auto flags = seastar::open_flags::rw;
-    auto file = co_await seastar::open_file_dma(path.string(), flags);
-    co_return seastar::make_shared<disk_file>(std::move(file));
+    return seastar::open_file_dma(path.string(), flags).then([](auto file) {
+    return seastar::make_ready_future<seastar::shared_ptr<persistence::file>>(seastar::make_shared<disk_file>(std::move(file)));
+    });
+    });
 }
 
 memory_persistence::memory_persistence()
@@ -150,6 +217,7 @@ memory_persistence::allocate(uint64_t alignment, size_t size) noexcept {
 
 seastar::future<seastar::shared_ptr<persistence::file>>
 memory_persistence::create(std::filesystem::path path) noexcept {
+    return maybe_fail_create().then([this, path = std::move(path)] {
     auto ret = files_.try_emplace(
       path, seastar::make_shared<memory_file>(this));
     if (!ret.second) {
@@ -162,10 +230,12 @@ memory_persistence::create(std::filesystem::path path) noexcept {
     }
     return seastar::make_ready_future<seastar::shared_ptr<persistence::file>>(
       ret.first->second);
+    });
 }
 
 seastar::future<seastar::shared_ptr<persistence::file>>
 memory_persistence::open(std::filesystem::path path) noexcept {
+    return maybe_fail_open().then([this, path = std::move(path)] {
     auto it = files_.find(path);
     if (it == files_.end()) {
         return seastar::make_exception_future<
@@ -177,6 +247,7 @@ memory_persistence::open(std::filesystem::path path) noexcept {
     }
     return seastar::make_ready_future<seastar::shared_ptr<persistence::file>>(
       it->second);
+    });
 }
 
 memory_persistence::memory_file::memory_file(memory_persistence* persistence)
@@ -184,6 +255,7 @@ memory_persistence::memory_file::memory_file(memory_persistence* persistence)
 
 seastar::future<size_t> memory_persistence::memory_file::dma_read(
   uint64_t pos, char* buf, size_t len) noexcept {
+    return maybe_fail_read().then([this, pos, buf, len] {
     if (auto err = check_alignment(
           "dma_read",
           pos,
@@ -194,10 +266,12 @@ seastar::future<size_t> memory_persistence::memory_file::dma_read(
         return std::move(err.value());
     }
     return read(pos, buf, len);
+    });
 }
 
 seastar::future<size_t> memory_persistence::memory_file::dma_write(
   uint64_t pos, const char* buf, size_t len) noexcept {
+    return maybe_fail_write().then([this, pos, buf, len] {
     if (auto err = check_alignment(
           "dma_write",
           pos,
@@ -211,10 +285,11 @@ seastar::future<size_t> memory_persistence::memory_file::dma_write(
         size_ = std::max(size_, pos + written);
         return written;
     });
+    });
 }
 
 seastar::future<> memory_persistence::memory_file::close() noexcept {
-    co_return;
+    return maybe_fail_close();
 }
 
 uint64_t

--- a/src/v/io/persistence.cc
+++ b/src/v/io/persistence.cc
@@ -67,15 +67,15 @@ std::optional<seastar::future<size_t>> check_alignment(
 
 namespace experimental::io {
 
-void persistence::file::fail_next_read(std::exception_ptr eptr) {
+void persistence::file::fail_next_read(std::exception_ptr eptr) noexcept {
     read_ex_ = std::move(eptr);
 }
 
-void persistence::file::fail_next_write(std::exception_ptr eptr) {
+void persistence::file::fail_next_write(std::exception_ptr eptr) noexcept {
     write_ex_ = std::move(eptr);
 }
 
-void persistence::file::fail_next_close(std::exception_ptr eptr) {
+void persistence::file::fail_next_close(std::exception_ptr eptr) noexcept {
     close_ex_ = std::move(eptr);
 }
 
@@ -100,11 +100,11 @@ seastar::future<> persistence::file::maybe_fail_close() {
     return seastar::make_ready_future<>();
 }
 
-void persistence::fail_next_create(std::exception_ptr eptr) {
+void persistence::fail_next_create(std::exception_ptr eptr) noexcept {
     create_ex_ = std::move(eptr);
 }
 
-void persistence::fail_next_open(std::exception_ptr eptr) {
+void persistence::fail_next_open(std::exception_ptr eptr) noexcept {
     open_ex_ = std::move(eptr);
 }
 

--- a/src/v/io/persistence.h
+++ b/src/v/io/persistence.h
@@ -88,6 +88,34 @@ public:
          */
         [[nodiscard]] virtual uint64_t memory_dma_alignment() const noexcept
           = 0;
+
+        /**
+         * Arrange for the next invocation of \ref read to return an exceptional
+         * future containing \p eptr.
+         */
+        void fail_next_read(std::exception_ptr);
+
+        /**
+         * Arrange for the next invocation of \ref write to return an
+         * exceptional future containing \p eptr.
+         */
+        void fail_next_write(std::exception_ptr);
+
+        /**
+         * Arrange for the next invocation of \ref close to return an
+         * exceptional future containing \p eptr.
+         */
+        void fail_next_close(std::exception_ptr);
+
+    protected:
+        seastar::future<> maybe_fail_read();
+        seastar::future<> maybe_fail_write();
+        seastar::future<> maybe_fail_close();
+
+    private:
+        std::exception_ptr read_ex_;
+        std::exception_ptr write_ex_;
+        std::exception_ptr close_ex_;
     };
 
     /**
@@ -107,6 +135,26 @@ public:
      */
     virtual seastar::future<seastar::shared_ptr<file>>
       open(std::filesystem::path) noexcept = 0;
+
+    /**
+     * Arrange for the next invocation of \ref create to return an exceptional
+     * future containing \p eptr.
+     */
+    void fail_next_create(std::exception_ptr eptr);
+
+    /**
+     * Arrange for the next invocation of \ref open to return an exceptional
+     * future containing \p eptr.
+     */
+    void fail_next_open(std::exception_ptr eptr);
+
+protected:
+    seastar::future<> maybe_fail_create();
+    seastar::future<> maybe_fail_open();
+
+private:
+    std::exception_ptr create_ex_;
+    std::exception_ptr open_ex_;
 };
 
 /**

--- a/src/v/io/persistence.h
+++ b/src/v/io/persistence.h
@@ -93,19 +93,48 @@ public:
          * Arrange for the next invocation of \ref read to return an exceptional
          * future containing \p eptr.
          */
-        void fail_next_read(std::exception_ptr);
+        void fail_next_read(std::exception_ptr eptr) noexcept;
+
+        /**
+         * Arrange for the next invocation of \ref read to return an exceptional
+         * future containing \p exception.
+         */
+        template<typename T>
+        void fail_next_read(T&& exception) noexcept {
+            fail_next_read(std::make_exception_ptr(std::forward<T>(exception)));
+        }
 
         /**
          * Arrange for the next invocation of \ref write to return an
          * exceptional future containing \p eptr.
          */
-        void fail_next_write(std::exception_ptr);
+        void fail_next_write(std::exception_ptr eptr) noexcept;
+
+        /**
+         * Arrange for the next invocation of \ref write to return an
+         * exceptional future containing \p exception.
+         */
+        template<typename T>
+        void fail_next_write(T&& exception) noexcept {
+            fail_next_write(
+              std::make_exception_ptr(std::forward<T>(exception)));
+        }
 
         /**
          * Arrange for the next invocation of \ref close to return an
          * exceptional future containing \p eptr.
          */
-        void fail_next_close(std::exception_ptr);
+        void fail_next_close(std::exception_ptr eptr) noexcept;
+
+        /**
+         * Arrange for the next invocation of \ref close to return an
+         * exceptional future containing \p exception.
+         */
+        template<typename T>
+        void fail_next_close(T&& exception) noexcept {
+            fail_next_close(
+              std::make_exception_ptr(std::forward<T>(exception)));
+        }
 
     protected:
         seastar::future<> maybe_fail_read();
@@ -140,13 +169,31 @@ public:
      * Arrange for the next invocation of \ref create to return an exceptional
      * future containing \p eptr.
      */
-    void fail_next_create(std::exception_ptr eptr);
+    void fail_next_create(std::exception_ptr eptr) noexcept;
+
+    /**
+     * Arrange for the next invocation of \ref create to return an exceptional
+     * future containing \p exception.
+     */
+    template<typename T>
+    void fail_next_create(T&& exception) noexcept {
+        fail_next_create(std::make_exception_ptr(std::forward<T>(exception)));
+    }
 
     /**
      * Arrange for the next invocation of \ref open to return an exceptional
      * future containing \p eptr.
      */
-    void fail_next_open(std::exception_ptr eptr);
+    void fail_next_open(std::exception_ptr eptr) noexcept;
+
+    /**
+     * Arrange for the next invocation of \ref open to return an exceptional
+     * future containing \p exception.
+     */
+    template<typename T>
+    void fail_next_open(T&& exception) noexcept {
+        fail_next_open(std::make_exception_ptr(std::forward<T>(exception)));
+    }
 
 protected:
     seastar::future<> maybe_fail_create();

--- a/src/v/io/tests/persistence_test.cc
+++ b/src/v/io/tests/persistence_test.cc
@@ -275,17 +275,27 @@ TYPED_TEST(PersistenceTest, ReadWrite) {
 }
 
 class fault_injection : std::exception {};
+class fault_injection2 : std::exception {};
 
 TYPED_TEST(PersistenceTest, ThrowCreate) {
     this->fs.fail_next_create(std::make_exception_ptr(fault_injection()));
     EXPECT_THROW(this->create(this->path), fault_injection);
+
+    this->fs.fail_next_create(fault_injection2());
+    EXPECT_THROW(this->create(this->path), fault_injection2);
+
     EXPECT_NO_THROW(this->create(this->path));
 }
 
 TYPED_TEST(PersistenceTest, ThrowOpen) {
     this->create(this->path);
+
     this->fs.fail_next_open(std::make_exception_ptr(fault_injection()));
     EXPECT_THROW(this->open(this->path), fault_injection);
+
+    this->fs.fail_next_open(fault_injection2());
+    EXPECT_THROW(this->open(this->path), fault_injection2);
+
     EXPECT_NO_THROW(this->open(this->path));
 }
 
@@ -293,9 +303,15 @@ TYPED_TEST(PersistenceTest, ThrowRead) {
     auto f = this->create(this->path);
     auto tmp = this->fs.allocate(
       f->memory_dma_alignment(), f->disk_read_dma_alignment());
+
     f->fail_next_read(std::make_exception_ptr(fault_injection()));
     EXPECT_THROW(
       f->dma_read(0, tmp.get_write(), tmp.size()).get(), fault_injection);
+
+    f->fail_next_read(fault_injection2());
+    EXPECT_THROW(
+      f->dma_read(0, tmp.get_write(), tmp.size()).get(), fault_injection2);
+
     EXPECT_NO_THROW(f->dma_read(0, tmp.get_write(), tmp.size()).get());
 }
 
@@ -303,15 +319,26 @@ TYPED_TEST(PersistenceTest, ThrowWrite) {
     auto f = this->create(this->path);
     auto tmp = this->fs.allocate(
       f->memory_dma_alignment(), f->disk_write_dma_alignment());
+
     f->fail_next_write(std::make_exception_ptr(fault_injection()));
     EXPECT_THROW(f->dma_write(0, tmp.get(), tmp.size()).get(), fault_injection);
+
+    f->fail_next_write(fault_injection2());
+    EXPECT_THROW(
+      f->dma_write(0, tmp.get(), tmp.size()).get(), fault_injection2);
+
     EXPECT_NO_THROW(f->dma_write(0, tmp.get(), tmp.size()).get());
 }
 
 TYPED_TEST(PersistenceTest, ThrowClose) {
     auto f = this->fs.create(this->path).get();
+
     f->fail_next_close(std::make_exception_ptr(fault_injection()));
     EXPECT_THROW(f->close().get(), fault_injection);
+
+    f->fail_next_close(fault_injection2());
+    EXPECT_THROW(f->close().get(), fault_injection2);
+
     EXPECT_NO_THROW(f->close().get());
 }
 

--- a/src/v/io/tests/persistence_test.cc
+++ b/src/v/io/tests/persistence_test.cc
@@ -274,6 +274,47 @@ TYPED_TEST(PersistenceTest, ReadWrite) {
     }
 }
 
+class fault_injection : std::exception {};
+
+TYPED_TEST(PersistenceTest, ThrowCreate) {
+    this->fs.fail_next_create(std::make_exception_ptr(fault_injection()));
+    EXPECT_THROW(this->create(this->path), fault_injection);
+    EXPECT_NO_THROW(this->create(this->path));
+}
+
+TYPED_TEST(PersistenceTest, ThrowOpen) {
+    this->create(this->path);
+    this->fs.fail_next_open(std::make_exception_ptr(fault_injection()));
+    EXPECT_THROW(this->open(this->path), fault_injection);
+    EXPECT_NO_THROW(this->open(this->path));
+}
+
+TYPED_TEST(PersistenceTest, ThrowRead) {
+    auto f = this->create(this->path);
+    auto tmp = this->fs.allocate(
+      f->memory_dma_alignment(), f->disk_read_dma_alignment());
+    f->fail_next_read(std::make_exception_ptr(fault_injection()));
+    EXPECT_THROW(
+      f->dma_read(0, tmp.get_write(), tmp.size()).get(), fault_injection);
+    EXPECT_NO_THROW(f->dma_read(0, tmp.get_write(), tmp.size()).get());
+}
+
+TYPED_TEST(PersistenceTest, ThrowWrite) {
+    auto f = this->create(this->path);
+    auto tmp = this->fs.allocate(
+      f->memory_dma_alignment(), f->disk_write_dma_alignment());
+    f->fail_next_write(std::make_exception_ptr(fault_injection()));
+    EXPECT_THROW(f->dma_write(0, tmp.get(), tmp.size()).get(), fault_injection);
+    EXPECT_NO_THROW(f->dma_write(0, tmp.get(), tmp.size()).get());
+}
+
+TYPED_TEST(PersistenceTest, ThrowClose) {
+    auto f = this->fs.create(this->path).get();
+    f->fail_next_close(std::make_exception_ptr(fault_injection()));
+    EXPECT_THROW(f->close().get(), fault_injection);
+    EXPECT_NO_THROW(f->close().get());
+}
+
 TEST(MemoryPersistenceTest, CustomAlignment) {
     std::vector<seastar::shared_ptr<io::persistence::file>> open_files;
     auto cleanup = seastar::defer([&open_files] {


### PR DESCRIPTION
io: add fault injection helpers to persistence layer

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

