### PR TITLE
all: Prefer ss::coroutine::maybe_yield

### DIFF
--- a/src/v/cloud_storage/access_time_tracker.cc
+++ b/src/v/cloud_storage/access_time_tracker.cc
@@ -16,6 +16,7 @@
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/smp.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include <absl/container/btree_map.h>
 #include <absl/container/btree_set.h>
@@ -221,7 +222,7 @@ access_time_tracker::trim(const fragmented_vector<file_list_item>& existent) {
         if (existent_hashes.contains(it.first)) {
             tmp.insert(it);
         }
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
     }
     if (_table.size() != tmp.size()) {
         // We dropped one or more entries, therefore mutated the table.

--- a/src/v/cluster/cloud_metadata/offsets_lookup.cc
+++ b/src/v/cluster/cloud_metadata/offsets_lookup.cc
@@ -19,7 +19,7 @@
 #include "kafka/server/partition_proxy.h"
 #include "model/ktp.h"
 
-#include <seastar/util/later.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace cluster::cloud_metadata {
 
@@ -109,7 +109,7 @@ offsets_lookup::lookup(offsets_lookup_request req) {
         }
         // NOTE: the scheduling point is safe since the state being operated on
         // is local to this frame.
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
     }
     co_return reply;
 }

--- a/src/v/cluster/cloud_metadata/offsets_recoverer.cc
+++ b/src/v/cluster/cloud_metadata/offsets_recoverer.cc
@@ -24,6 +24,7 @@
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/timed_out_error.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 namespace cluster::cloud_metadata {
 
@@ -217,7 +218,7 @@ ss::future<offsets_recovery_reply> offsets_recoverer::recover(
                 }
                 batched_groups = {};
             }
-            co_await ss::maybe_yield();
+            co_await ss::coroutine::maybe_yield();
         }
         // We've processed all groups in the snapshot. Send out any remaining
         // batches of offset commits.

--- a/src/v/cluster/cloud_metadata/tests/offsets_recovery_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/offsets_recovery_test.cc
@@ -45,7 +45,7 @@
 #include "test_utils/async.h"
 
 #include <seastar/core/io_priority_class.hh>
-#include <seastar/util/later.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 #include <absl/container/flat_hash_map.h>
 #include <boost/test/tools/old/interface.hpp>
@@ -232,9 +232,9 @@ public:
                 } else {
                     BOOST_REQUIRE(allowed_errors.contains(res.error()));
                 }
-                co_await ss::maybe_yield();
+                co_await ss::coroutine::maybe_yield();
             }
-            co_await ss::maybe_yield();
+            co_await ss::coroutine::maybe_yield();
         }
     }
 

--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -383,7 +383,7 @@ controller_api::get_partitions_reconfiguration_state(
                         .node = node_report.id, .bytes = p.size_bytes});
                 }
 
-                co_await ss::maybe_yield();
+                co_await ss::coroutine::maybe_yield();
             }
         }
     }

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -42,7 +42,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/sharded.hh>
 #include <seastar/core/smp.hh>
-#include <seastar/util/later.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/variant_utils.hh>
 
 #include <absl/container/flat_hash_map.h>
@@ -718,7 +718,7 @@ ss::future<> controller_backend::fetch_deltas() {
 
 ss::future<> controller_backend::bootstrap_partition_claims() {
     for (const auto& [ntp, rs] : _states) {
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
 
         if (rs->removed) {
             continue;

--- a/src/v/finjector/stress_fiber.cc
+++ b/src/v/finjector/stress_fiber.cc
@@ -17,11 +17,15 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/scheduling.hh>
 #include <seastar/core/timer.hh>
+#include <seastar/core/with_scheduling_group.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 
 class stress_payload {
 public:
-    // Starts the stress payload with the given configuration.
+    // Starts the stress payload with the given configuration in the given
+    // seastar scheduling group.
     static std::unique_ptr<stress_payload> start(stress_config cfg) {
         return std::unique_ptr<stress_payload>(new stress_payload(cfg));
     }
@@ -47,9 +51,11 @@ stress_payload::stress_payload(stress_config cfg) {
       && cfg.min_spins_per_scheduling_point.has_value()) {
         for (size_t i = 0; i < cfg.num_fibers; i++) {
             ssx::spawn_with_gate(_gate, [cfg, this] {
-                return run_count_fiber(
-                  *cfg.min_spins_per_scheduling_point,
-                  *cfg.max_spins_per_scheduling_point);
+                return ss::with_scheduling_group(cfg.sg, [cfg, this]() {
+                    return run_count_fiber(
+                      *cfg.min_spins_per_scheduling_point,
+                      *cfg.max_spins_per_scheduling_point);
+                });
             });
         }
     }
@@ -58,9 +64,11 @@ stress_payload::stress_payload(stress_config cfg) {
       && cfg.min_ms_per_scheduling_point.has_value()) {
         for (size_t i = 0; i < cfg.num_fibers; i++) {
             ssx::spawn_with_gate(_gate, [cfg, this] {
-                return run_delay_fiber(
-                  *cfg.min_ms_per_scheduling_point,
-                  *cfg.max_ms_per_scheduling_point);
+                return ss::with_scheduling_group(cfg.sg, [this, cfg]() {
+                    return run_delay_fiber(
+                      *cfg.min_ms_per_scheduling_point,
+                      *cfg.max_ms_per_scheduling_point);
+                });
             });
         }
     }

--- a/src/v/finjector/stress_fiber.cc
+++ b/src/v/finjector/stress_fiber.cc
@@ -80,7 +80,7 @@ ss::future<> stress_payload::run_count_fiber(int min_count, int max_count) {
                                            ? min_count
                                            : random_generators::get_int(
                                              min_count, max_count);
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
         volatile int spins = 0;
         while (true) {
             if (spins == spins_per_scheduling_point) {
@@ -97,7 +97,7 @@ ss::future<> stress_payload::run_delay_fiber(int min_ms, int max_ms) {
                                         ? min_ms
                                         : random_generators::get_int(
                                           min_ms, max_ms);
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
         const auto stop_time = ss::steady_clock_type::now()
                                + std::chrono::milliseconds(
                                  ms_per_scheduling_point);

--- a/src/v/finjector/stress_fiber.h
+++ b/src/v/finjector/stress_fiber.h
@@ -13,6 +13,7 @@
 #include "base/seastarx.h"
 
 #include <seastar/core/future.hh>
+#include <seastar/core/scheduling.hh>
 
 #include <memory>
 
@@ -27,7 +28,11 @@ struct stress_config {
     std::optional<int> min_ms_per_scheduling_point;
     std::optional<int> max_ms_per_scheduling_point;
 
+    // the number of stress fibers to run per shard
     size_t num_fibers;
+
+    // the seastar scheduling group to run the stress fibers in
+    ss::scheduling_group sg;
 };
 
 class stress_payload;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -38,8 +38,8 @@
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/loop.hh>
+#include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/defer.hh>
-#include <seastar/util/later.hh>
 
 #include <system_error>
 
@@ -684,7 +684,7 @@ ss::future<group_offsets_snapshot_result> group_manager::snapshot_groups(
             cur_snap->offsets_topic_pid = ntp.tp.partition;
         }
         cur_snap->groups.emplace_back(std::move(go));
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
     }
     co_return snapshots;
 }
@@ -753,7 +753,7 @@ group_manager::recover_offsets(group_offsets_snapshot snap) {
                 kafka_t.partitions.emplace_back(std::move(kafka_p));
             }
             kafka_topics.emplace_back(std::move(kafka_t));
-            co_await ss::maybe_yield();
+            co_await ss::coroutine::maybe_yield();
         }
         vlog(
           klog.info,

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -179,6 +179,7 @@ void admin_server::register_debug_routes() {
                     "Invalid parameter 'num_fibers' value {{{}}}", e));
               }
           }
+          cfg.sg = ss::default_scheduling_group();
           return _stress_fiber_manager
             .invoke_on_all([cfg](auto& stress_mgr) {
                 auto ran = stress_mgr.start(cfg);

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -134,7 +134,6 @@
 #include <seastar/json/json_elements.hh>
 #include <seastar/net/socket_defs.hh>
 #include <seastar/net/tls.hh>
-#include <seastar/util/later.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/short_streams.hh>
 #include <seastar/util/variant_utils.hh>
@@ -862,7 +861,7 @@ map_partition_results(std::vector<cluster::move_cancellation_result> results) {
         result.partition = r.ntp.tp.partition;
         result.result = cluster::make_error_code(r.result).message();
         ret.push_back(std::move(result));
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
     }
     co_return ret;
 }

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -856,7 +856,7 @@ ss::future<> audit_log_manager::drain() {
         b.append(as_json.c_str(), as_json.size());
         essences.push_back(
           kafka::client::record_essence{.value = std::move(b)});
-        co_await ss::maybe_yield();
+        co_await ss::coroutine::maybe_yield();
     }
 
     /// This call may block if the audit_clients semaphore is exhausted,


### PR DESCRIPTION
When used in a coroutine context `ss::coroutine::maybe_yield` saves a
couple hundred instructions over `ss::maybe_yield` as the whole `future`
machinery isn't getting involved.

Can be seen in the following godbolt: https://godbolt.org/z/Wdb441PYE

X-Coauthored-By: Travis Downs <travis.downs@redpanda.com>

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none


