### PR TITLE
transform-sdk: experimental C++ support

### DIFF
--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -120,7 +120,6 @@ jobs:
       - name: Run clippy
         working-directory: src/transform-sdk/rust
         run: cargo clippy --all
-      
 
   integration-test-rust:
     name: Integration Test Rust Transform SDK
@@ -145,6 +144,57 @@ jobs:
         working-directory: src/transform-sdk/rust
         env:
           IDENTITY: target/wasm32-wasi/release/examples/identity.wasm
+        run: |
+          chmod +x wasm-integration-test
+          ./wasm-integration-test -test.v
+
+  test-cpp:
+    name: Test C++ Transform SDK
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:40
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Clang
+        run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake
+
+      - name: Run tests
+        working-directory: src/transform-sdk/cpp
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          cmake -B build
+          cmake --build build
+          ctest --output-on-failure --test-dir build
+
+      - name: Run clang-tidy
+        working-directory: src/transform-sdk/cpp
+        run: clang-tidy --quiet -p build/compile_commands.json src/transform_sdk.cc
+
+  integration-test-cpp:
+    name: Integration Test C++ Transform SDK
+    needs: [test-cpp, build-integration-tests]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-21
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build integration tests
+        working-directory: src/transform-sdk/cpp/examples
+        run: cmake -B build && cmake --build build
+      - name: Download integration test suite
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-integration-test
+          path: src/transform-sdk/cpp/examples
+      - name: Run integration tests
+        working-directory: src/transform-sdk/cpp/examples
+        env:
+          IDENTITY: build/identity_transform
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v

--- a/src/transform-sdk/cpp/.clang-tidy
+++ b/src/transform-sdk/cpp/.clang-tidy
@@ -1,0 +1,13 @@
+# altera-*, fuschia-*, llvmlibc-*: project specific checks
+# llvm-header-guard: in redpanda we normally to use `#pragma once`
+# modernize-use-trailing-return-type: arbitrary style choice
+# misc-include-cleaner: is tripped up on <expected> header
+---
+Checks: '*,-altera-*,-fuchsia-*,-llvmlibc-*,-llvm-header-guard,-modernize-use-trailing-return-type,-misc-include-cleaner'
+WarningsAsErrors: '*'
+ExtraArgs:
+  - -DREDPANDA_TRANSFORM_SDK_ENABLE_TESTING
+CheckOptions:
+  - key:             readability-identifier-length.IgnoredVariableNames
+    value:           ^it$
+...

--- a/src/transform-sdk/cpp/.gitignore
+++ b/src/transform-sdk/cpp/.gitignore
@@ -1,0 +1,3 @@
+a.out
+.vim
+build

--- a/src/transform-sdk/cpp/CMakeLists.txt
+++ b/src/transform-sdk/cpp/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(
+    redpanda-transform-sdk
+    VERSION 0.0.0
+    DESCRIPTION "Redpanda Data Transforms SDK for C++"
+    HOMEPAGE_URL "https://redpanda.com/"
+    LANGUAGES CXX
+)
+
+if(PROJECT_IS_TOP_LEVEL)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+  set(CMAKE_CXX_STANDARD 23)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+  add_compile_options(-Wall)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fno-exceptions")
+  add_link_options(-fsanitize=address,leak,undefined)
+  add_compile_options(-fsanitize=address,leak,undefined)
+  add_executable(test_binary "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_sdk.cc")
+  set_target_properties(test_binary PROPERTIES COMPILE_FLAGS "-DREDPANDA_TRANSFORM_SDK_ENABLE_TESTING" )
+  target_include_directories(test_binary PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+  enable_testing()
+  add_test(NAME sdk_test COMMAND test_binary)
+endif()
+
+set_source_files_properties(
+  "${CMAKE_CURRENT_SOURCE_DIR}/include/redpanda/transform_sdk.h"
+  PROPERTIES LANGUAGE CXX
+)
+
+add_library(
+  redpanda_transform_sdk
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_sdk.cc"
+)
+target_include_directories(
+  redpanda_transform_sdk 
+  PUBLIC 
+  "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+add_library(Redpanda::transform_sdk ALIAS redpanda_transform_sdk)

--- a/src/transform-sdk/cpp/README.md
+++ b/src/transform-sdk/cpp/README.md
@@ -1,0 +1,95 @@
+# Experimental Redpanda Data Transforms C++ SDK
+
+This directory contains an experimental C++ SDK for Redpanda Data Transforms.
+C++23 is required for both language features and standard library support.
+
+When writing C++ in WebAssembly, note that certain language features are not supported.
+Noteably C++ exceptions, `setjmp`/`longjmp`, threads and networking is not supported, WebAssembly and WASI are quickly evolving, so some of these features may be supported in the future.
+
+## Usage 
+
+A specialized clang toolchain is needed for WebAssembly + WASI compilation. The easiest way to
+do this is using [zig cc][zig] or [WASI SDK][wasi-sdk] via docker.
+
+First create the identity transform that mirrors records to the output topic from the input topic.
+
+Create your `transform.cc` file that does this:
+
+```cpp
+#include <redpanda/transform_sdk.h>
+
+int main() {
+    redpanda::on_record_written([](redpanda::write_event event, redpanda::record_writer* writer) {
+      return writer->write(event.record);
+    });
+}
+```
+
+### CMake
+
+Using CMake create a `CMakeLists.txt` with the initial project boilerplate, which pulls down our C++ SDK and builds the transform.
+
+```cmake
+cmake_minimum_required(VERSION 3.22)
+
+project(
+  MyTransform
+  VERSION 0.1
+  LANGUAGES CXX)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_compile_options(-Wall)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+
+include(FetchContent)
+set(FETCHCONTENT_QUIET FALSE)
+
+FetchContent_Declare(
+  redpanda-transform-sdk
+  URL                    https://github.com/redpanda-data/redpanda/archive/refs/heads/dev.tar.gz
+  SOURCE_SUBDIR          src/transform-sdk/cpp
+)
+
+FetchContent_MakeAvailable(redpanda-transform-sdk)
+
+add_executable(
+  my_transform
+  transform.cc
+)
+target_link_libraries(
+  my_transform
+  Redpanda::transform_sdk
+)
+```
+
+Once this file is created generate the build and build the `my_transform` Wasm binary via:
+
+```shell
+docker run -v `pwd`:/src -w /src ghcr.io/webassembly/wasi-sdk /bin/bash -c 'cmake -Bbuild && cmake --build build'
+```
+
+### Standalone
+
+It can be compiled to WebAssembly using `zig`, the result will be a WebAssembly binary named `a.out` in the current directory.
+
+```shell
+zig c++ --target=wasm32-wasi -std=c++23 -fno-exceptions -flto -O3 -Iinclude transform.cc src/transform_sdk.cc
+```
+
+Alternatively using docker and WASI SDK, the same program can be compiled using the following:
+
+```shell
+docker run -v `pwd`:/src -w /src ghcr.io/webassembly/wasi-sdk /bin/bash -c '$CXX $CXX_FLAGS -std=c++23 -fno-exceptions -O3 -flto -Iinclude transform.cc src/transform_sdk.cc'
+```
+
+## Development
+
+CMake can be used for local development. There is a small test suite embeded that can be compiled via `-DREDPANDA_TRANSFORM_SDK_ENABLE_TESTING`. We keep the code to a single header and source file so it is easy to drop into other build systems.
+
+[zig]: https://andrewkelley.me/post/zig-cc-powerful-drop-in-replacement-gcc-clang.html
+[wasi-sdk]: https://github.com/WebAssembly/wasi-sdk

--- a/src/transform-sdk/cpp/examples/CMakeLists.txt
+++ b/src/transform-sdk/cpp/examples/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.22)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+project(
+  RedpandaDataTransformExamples
+  VERSION 0.1
+  LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_compile_options(-Wall)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+
+include(FetchContent)
+set(FETCHCONTENT_QUIET FALSE)
+
+FetchContent_Declare(
+  redpanda-transform-sdk
+  SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/.."
+)
+
+FetchContent_MakeAvailable(redpanda-transform-sdk)
+
+add_executable(
+  identity_transform
+  identity.cc
+)
+target_link_libraries(
+  identity_transform
+  Redpanda::transform_sdk
+)
+

--- a/src/transform-sdk/cpp/examples/identity.cc
+++ b/src/transform-sdk/cpp/examples/identity.cc
@@ -1,0 +1,23 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <redpanda/transform_sdk.h>
+
+int main() {
+    // This is an example of copying records from one location to another.
+    redpanda::on_record_written(
+      [](redpanda::write_event event, redpanda::record_writer* writer) {
+          return writer->write(event.record);
+      });
+}

--- a/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
+++ b/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
@@ -1,0 +1,208 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <ranges>
+#include <span>
+#include <string>
+#include <system_error>
+#include <vector>
+
+namespace redpanda {
+
+/**
+ * Owned variable sized byte array.
+ */
+using bytes = std::vector<uint8_t>;
+
+/**
+ * Unowned variable sized byte array.
+ *
+ * This is not `std::span` because `std::span` does not provide
+ * an equality operator, and it's a mutable view, where we want an immutable
+ * one.
+ */
+class bytes_view : public std::ranges::view_interface<bytes_view> {
+public:
+    /** A default empty view of bytes. */
+    bytes_view() = default;
+    /** A view over `size` bytes starting at `start`. */
+    bytes_view(bytes::const_pointer start, size_t size);
+    /** A view over `size` bytes starting at `start`. */
+    bytes_view(bytes::const_iterator start, size_t size);
+    /** A view from `start` to `end`. */
+    bytes_view(bytes::const_iterator start, bytes::const_iterator end);
+    /** A view from `start` to `end`. */
+    bytes_view(bytes::const_pointer start, bytes::const_pointer end);
+    /** A view over an entire bytes range. */
+    // NOLINTNEXTLINE(*-explicit-*)
+    bytes_view(const bytes&);
+
+    /** The start of this range. */
+    [[nodiscard]] bytes::const_pointer begin() const;
+    /** The end of this range. */
+    [[nodiscard]] bytes::const_pointer end() const;
+    /**
+     * Create a subview of this view. Similar to `std::span::subspan` or
+     * `std::string_view::substr`.
+     */
+    [[nodiscard]] bytes_view
+    subview(size_t offset, size_t count = std::dynamic_extent) const;
+
+    /** Access the nth element of the view. */
+    bytes::value_type operator[](size_t n) const;
+
+    /** Returns true if the views have the same contents. */
+    bool operator==(const bytes_view& other) const;
+
+private:
+    bytes::const_pointer _start{}, _end{};
+};
+
+/**
+ * A zero-copy `header`.
+ */
+struct header_view {
+    std::string_view key;
+    std::optional<bytes_view> value;
+
+    bool operator==(const header_view&) const = default;
+};
+
+/**
+ * A zero-copy representation of a record within Redpanda.
+ *
+ * `review_view` are handed to [`on_record_written`] event handlers as the
+ * record that Redpanda wrote.
+ */
+struct record_view {
+    std::optional<bytes_view> key;
+    std::optional<bytes_view> value;
+    std::vector<header_view> headers;
+
+    bool operator==(const record_view&) const = default;
+};
+
+/**
+ * Records may have a collection of headers attached to them.
+ *
+ * Headers are opaque to the broker and are purely a mechanism for the producer
+ * and consumers to pass information.
+ */
+struct header {
+    std::string key;
+    std::optional<bytes> value;
+
+    // NOLINTNEXTLINE(*-explicit-*)
+    operator header_view() const;
+    bool operator==(const header&) const = default;
+};
+
+/**
+ * A record in Redpanda.
+ *
+ * Records are generated as the result of any transforms that act upon a
+ * `record_view`.
+ */
+struct record {
+    std::optional<bytes> key;
+    std::optional<bytes> value;
+    std::vector<header> headers;
+
+    // NOLINTNEXTLINE(*-explicit-*)
+    operator record_view() const;
+    bool operator==(const record&) const = default;
+};
+
+/**
+ * A persisted record written to a topic within Redpanda.
+ *
+ * It is similar to a `record_view` except that it also carries a timestamp of
+ * when it was produced.
+ */
+struct written_record {
+    std::optional<bytes_view> key;
+    std::optional<bytes_view> value;
+    std::vector<header_view> headers;
+    std::chrono::system_clock::time_point timestamp;
+
+    // NOLINTNEXTLINE(*-explicit-*)
+    operator record_view() const;
+    bool operator==(const written_record&) const = default;
+};
+
+/**
+ * An event generated after a write event within the broker.
+ */
+struct write_event {
+    /** The record that was written as part of this event. */
+    written_record record;
+};
+
+/**
+ * A writer for transformed records that are output to the destination topic.
+ */
+class record_writer {
+public:
+    record_writer() = default;
+    record_writer(const record_writer&) = delete;
+    record_writer(record_writer&&) = delete;
+    record_writer& operator=(const record_writer&) = delete;
+    record_writer& operator=(record_writer&&) = delete;
+    virtual ~record_writer() = default;
+
+    /**
+     * Write a record to the output topic, returning any errors.
+     */
+    virtual std::error_code write(record_view) = 0;
+};
+
+/**
+ * A callback to process write events and respond with a number of records to
+ * write back to the output topic.
+ */
+using on_record_written_callback
+  = std::function<std::error_code(write_event, record_writer*)>;
+
+/**
+ * Register a callback to be fired when a record is written to the input topic.
+ *
+ * This callback is triggered after the record has been written and fsynced to
+ * disk and the producer has been acknowledged.
+ *
+ * This method blocks and runs forever, it should be called from `main` and any
+ * setup that is needed can be done before calling this method.
+ *
+ * # Example
+ *
+ * The following example copies every record on the input topic indentically to
+ * the output topic.
+ *
+ * ```cpp
+ * int main() {
+ *   redpanda::on_record_written(
+ *       [](redpanda::write_event event, redpanda::record_writer* writer) {
+ *          return writer->write(event.record);
+ *       });
+ * }
+ * ```
+ */
+[[noreturn]] void on_record_written(const on_record_written_callback& callback);
+
+} // namespace redpanda

--- a/src/transform-sdk/cpp/src/transform_sdk.cc
+++ b/src/transform-sdk/cpp/src/transform_sdk.cc
@@ -1,0 +1,632 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <redpanda/transform_sdk.h>
+
+#include <algorithm>
+#include <chrono>
+#include <climits>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <expected>
+#include <system_error>
+#include <utility>
+
+namespace redpanda {
+namespace {
+
+// NOLINTBEGIN(*-macro-usage,*-macro-parentheses)
+
+#define RP_CONCAT(x, y) RP_CONCAT_IMPL(x, y)
+#define RP_CONCAT_IMPL(x, y) x##y
+
+#define ASSIGN_OR_RETURN(lhs, rexpr)                                           \
+    RP_ASSIGN_OR_RETURN_IMPL(RP_CONCAT(expected_tmp_, __LINE__), lhs, rexpr);
+
+#define RP_ASSIGN_OR_RETURN_IMPL(uniq_var_name, lhs, rexpr)                    \
+    auto uniq_var_name = (rexpr);                                              \
+    if (!uniq_var_name.has_value()) [[unlikely]] {                             \
+        return std::unexpected(uniq_var_name.error());                         \
+    }                                                                          \
+    lhs = std::move(*uniq_var_name)
+
+// NOLINTEND(*-macro-usage,*-macro-parentheses)
+
+/**
+ * A simple println that writes to stderr. We don't use std::println because it
+ * doubles the compiled size of our SDK for no good reason.
+ */
+void println(std::string_view str) {
+    std::string msg;
+    msg.reserve(str.size() + 1);
+    msg.append(str);
+    msg.append("\n");
+    // We don't use C++23 format/print due to it including <iostreams> which
+    // blows up the size of the binary
+    // NOLINTNEXTLINE
+    std::fwrite(msg.c_str(), sizeof(char), msg.size(), stderr);
+    // NOLINTNEXTLINE
+    std::fflush(stderr);
+    std::abort();
+}
+
+/**
+ * A simple abort function that prints then aborts
+ */
+[[noreturn]] void abort(std::string_view str) {
+    println(str);
+    std::abort();
+}
+
+namespace abi {
+#ifdef __wasi__
+
+extern "C" {
+#define WASM_IMPORT(mod, name)                                                 \
+    __attribute__((import_module(#mod), import_name(#name)))
+
+WASM_IMPORT(redpanda_transform, check_abi_version_1)
+void redpanda_transform_check();
+constexpr auto check = redpanda_transform_check;
+
+WASM_IMPORT(redpanda_transform, read_batch_header)
+int32_t redpanda_transform_read_batch_header(
+  int64_t* base_offset,
+  int32_t* record_count,
+  int32_t* partition_leader_epoch,
+  int16_t* attributes,
+  int32_t* last_offset_delta,
+  int64_t* base_timestamp,
+  int64_t* max_timestamp,
+  int64_t* producer_id,
+  int16_t* producer_epoch,
+  int32_t* base_sequence);
+constexpr auto read_batch_header = redpanda_transform_read_batch_header;
+
+WASM_IMPORT(redpanda_transform, read_next_record)
+int32_t redpanda_transform_read_next_record(
+  uint8_t* attributes,
+  int64_t* timestamp,
+  int64_t* offset,
+  uint8_t* buf,
+  uint32_t len);
+constexpr auto read_next_record = redpanda_transform_read_next_record;
+
+WASM_IMPORT(redpanda_transform, write_record)
+int32_t redpanda_transform_write_record(uint8_t* buf, uint32_t len);
+constexpr auto write_record = redpanda_transform_write_record;
+
+#undef WASM_IMPORT
+}
+
+#else
+
+void check() { abort("check_abi - stub"); }
+
+int32_t read_batch_header(
+  int64_t* /*unused*/,
+  int32_t* /*unused*/,
+  int32_t* /*unused*/,
+  int16_t* /*unused*/,
+  int32_t* /*unused*/,
+  int64_t* /*unused*/,
+  int64_t* /*unused*/,
+  int64_t* /*unused*/,
+  int16_t* /*unused*/,
+  int32_t* /*unused*/) {
+    abort("read_batch_header - stub");
+}
+
+int32_t read_next_record(
+  uint8_t* /*unused*/,
+  int64_t* /*unused*/,
+  int64_t* /*unused*/,
+  uint8_t* /*unused*/,
+  uint32_t /*unused*/) {
+    abort("read_next_record - stub");
+}
+
+int32_t write_record(const uint8_t* /*unused*/, uint32_t /*unused*/) {
+    abort("write_record - stub");
+}
+
+#endif
+} // namespace abi
+
+namespace varint {
+
+constexpr size_t MAX_LENGTH = 10;
+
+template<typename T>
+struct decoded {
+    T value;
+    size_t read;
+};
+
+uint64_t zigzag_encode(int64_t num) {
+    constexpr unsigned int signbit_shift = (sizeof(int64_t) * CHAR_BIT) - 1;
+    // NOLINTNEXTLINE
+    return (static_cast<uint64_t>(num) << 1) ^ (num >> signbit_shift);
+}
+
+int64_t zigzag_decode(uint64_t num) {
+    // NOLINTNEXTLINE
+    return static_cast<int64_t>(num >> 1) ^ -static_cast<int64_t>(num & 1);
+}
+
+std::expected<decoded<uint64_t>, std::error_code>
+read_unsigned(bytes_view payload) {
+    uint64_t value = 0;
+    unsigned int shift = 0;
+    for (size_t i = 0; i < payload.size(); ++i) {
+        const uint8_t byte = payload[i];
+        if (i >= MAX_LENGTH) {
+            return std::unexpected(
+              std::make_error_code(std::errc::value_too_large));
+        }
+        constexpr unsigned int unsigned_bits = 0x7F;
+        value |= static_cast<uint64_t>(byte & unsigned_bits) << shift;
+        constexpr unsigned int sign_bit = 0x80;
+        if ((byte & sign_bit) == 0) {
+            return {{
+              .value = value,
+              .read = i + 1,
+            }};
+        }
+        shift += CHAR_BIT - 1;
+    }
+    return std::unexpected(
+      std::make_error_code(std::errc::illegal_byte_sequence));
+}
+
+std::expected<decoded<int64_t>, std::error_code> read(bytes_view payload) {
+    ASSIGN_OR_RETURN(const decoded<uint64_t> dec, read_unsigned(payload));
+    return {{
+      .value = zigzag_decode(dec.value),
+      .read = dec.read,
+    }};
+}
+
+std::expected<decoded<std::optional<bytes_view>>, std::error_code>
+read_sized_buffer(bytes_view payload) {
+    ASSIGN_OR_RETURN(const decoded<int64_t> result, read(payload));
+    if (result.value < 0) {
+        return {{.value = std::nullopt, .read = result.read}};
+    }
+    payload = payload.subview(result.read);
+    auto buf_size = static_cast<size_t>(result.value);
+    if (buf_size > payload.size()) [[unlikely]] {
+        return std::unexpected(
+          std::make_error_code(std::errc::illegal_byte_sequence));
+    }
+    return {{
+      .value = payload.subview(0, buf_size),
+      .read = result.read + buf_size,
+    }};
+}
+
+void write_unsigned(bytes* payload, uint64_t val) {
+    constexpr unsigned int msb = 0x80;
+    while (val >= msb) {
+        auto byte = static_cast<uint8_t>(val) | msb;
+        val >>= CHAR_BIT - 1;
+        payload->push_back(static_cast<char>(byte));
+    }
+    constexpr unsigned int byte_mask = 0xFF;
+    payload->push_back(static_cast<char>(val & byte_mask));
+}
+
+void write(bytes* payload, int64_t val) {
+    write_unsigned(payload, zigzag_encode(val));
+}
+
+template<typename B>
+void write_sized_buffer(bytes* payload, const std::optional<B>& buf) {
+    if (!buf.has_value()) {
+        write(payload, -1);
+        return;
+    }
+    write(payload, static_cast<int64_t>(buf->size()));
+    payload->append_range(buf.value());
+}
+
+} // namespace varint
+
+namespace decode {
+
+using kv_pair = std::pair<std::optional<bytes_view>, std::optional<bytes_view>>;
+
+std::expected<varint::decoded<kv_pair>, std::error_code>
+read_kv(bytes_view payload) {
+    ASSIGN_OR_RETURN(auto key, varint::read_sized_buffer(payload));
+    payload = payload.subview(key.read);
+    ASSIGN_OR_RETURN(auto value, varint::read_sized_buffer(payload));
+    return {{
+      .value = std::make_pair(key.value, value.value),
+      .read = key.read + value.read,
+    }};
+}
+
+std::expected<record_view, std::error_code>
+read_record_view(bytes_view payload) {
+    ASSIGN_OR_RETURN(auto kv_result, read_kv(payload));
+    payload = payload.subview(kv_result.read);
+    ASSIGN_OR_RETURN(auto header_count_result, varint::read(payload));
+    payload = payload.subview(header_count_result.read);
+    std::vector<header_view> headers;
+    headers.reserve(header_count_result.value);
+    for (int64_t i = 0; i < header_count_result.value; ++i) {
+        ASSIGN_OR_RETURN(auto kv_result, read_kv(payload));
+        payload = payload.subview(kv_result.read);
+        auto [key_opt, value] = kv_result.value;
+        const std::string_view key
+          = key_opt
+              .transform([](bytes_view buf) {
+                  return std::string_view{
+                    // NOLINTNEXTLINE(*reinterpret-cast)
+                    reinterpret_cast<const char*>(buf.data()),
+                    buf.size()};
+              })
+              .value_or(std::string_view{});
+        headers.emplace_back(key, value);
+    }
+    auto [key, value] = kv_result.value;
+    return {{
+      .key = key,
+      .value = value,
+      .headers = std::move(headers),
+    }};
+}
+
+void write_record(bytes* payload, const redpanda::record_view& rec) {
+    varint::write_sized_buffer(payload, rec.key);
+    varint::write_sized_buffer(payload, rec.value);
+    varint::write(payload, static_cast<int64_t>(rec.headers.size()));
+    for (const auto& header : rec.headers) {
+        varint::write_sized_buffer(payload, std::make_optional(header.key));
+        varint::write_sized_buffer(payload, header.value);
+    }
+}
+
+struct batch_header {
+    int64_t base_offset;
+    int32_t record_count;
+    int32_t partition_leader_epoch;
+    int16_t attributes;
+    int32_t last_offset_delta;
+    int64_t base_timestamp;
+    int64_t max_timestamp;
+    int64_t producer_id;
+    int16_t producer_epoch;
+    int32_t base_sequence;
+};
+
+} // namespace decode
+
+class abi_record_writer : public record_writer {
+public:
+    std::error_code write(record_view record) final {
+        _output_buffer.clear();
+        decode::write_record(&_output_buffer, record);
+        const int32_t errno_or_amt = abi::write_record(
+          _output_buffer.data(), _output_buffer.size());
+        if (errno_or_amt != _output_buffer.size()) [[unlikely]] {
+            return std::make_error_code(std::errc::io_error);
+        }
+        return {};
+    }
+
+private:
+    bytes _output_buffer;
+};
+
+void process_batch(const on_record_written_callback& callback) {
+    decode::batch_header header{};
+    const int32_t errno_or_buf_size = abi::read_batch_header(
+      &header.base_offset,
+      &header.record_count,
+      &header.partition_leader_epoch,
+      &header.attributes,
+      &header.last_offset_delta,
+      &header.base_timestamp,
+      &header.max_timestamp,
+      &header.producer_id,
+      &header.producer_epoch,
+      &header.base_sequence);
+    if (errno_or_buf_size < 0) [[unlikely]] {
+        abort(
+          "failed to read batch header (errno: "
+          + std::to_string(errno_or_buf_size) + ")");
+    }
+    const size_t buf_size = errno_or_buf_size;
+
+    bytes input_buffer;
+    input_buffer.resize(buf_size, 0);
+    abi_record_writer writer;
+    for (int32_t i = 0; i < header.record_count; ++i) {
+        uint8_t raw_attr = 0;
+        int64_t raw_timestamp = 0;
+        int64_t raw_offset = 0;
+        const int32_t errno_or_amt = abi::read_next_record(
+          &raw_attr,
+          &raw_timestamp,
+          &raw_offset,
+          input_buffer.data(),
+          input_buffer.size());
+        if (errno_or_amt < 0) [[unlikely]] {
+            abort(
+              "reading record failed (errno: " + std::to_string(errno_or_amt)
+              + ", buffer_size: " + std::to_string(buf_size) + ")");
+        }
+        const size_t amt = errno_or_amt;
+        const std::chrono::system_clock::time_point timestamp{
+          std::chrono::milliseconds{raw_timestamp}};
+        auto record = decode::read_record_view({input_buffer.begin(), amt});
+        if (!record.has_value()) [[unlikely]] {
+            abort("deserializing record failed: " + record.error().message());
+        }
+        written_record written = {
+          .key = record.value().key,
+          .value = record.value().value,
+          .headers = std::move(record.value().headers),
+          .timestamp = timestamp};
+        const std::error_code err = callback(
+          write_event{.record = std::move(written)}, &writer);
+        if (err) [[unlikely]] {
+            abort("transforming record failed: " + err.message());
+        }
+    }
+}
+
+} // namespace
+
+bytes_view::bytes_view(const bytes& buf)
+  : bytes_view(buf.begin(), buf.end()) {}
+
+bytes_view::bytes_view(bytes::const_pointer start, size_t size)
+  : bytes_view(start, start + static_cast<std::ptrdiff_t>(size)) {}
+
+bytes_view::bytes_view(bytes::const_iterator start, size_t size)
+  : bytes_view(start, start + static_cast<std::ptrdiff_t>(size)) {}
+
+bytes_view::bytes_view(bytes::const_iterator start, bytes::const_iterator end)
+  : bytes_view(std::to_address(start), std::to_address(end)) {}
+
+bytes_view::bytes_view(bytes::const_pointer start, bytes::const_pointer end)
+  : _start(start)
+  , _end(end) {}
+
+bytes::const_pointer bytes_view::begin() const { return _start; }
+
+bytes::const_pointer bytes_view::end() const { return _end; }
+
+bytes_view bytes_view::subview(size_t offset, size_t count) const {
+    if (count == std::dynamic_extent) {
+        return {_start + offset, _end};
+    }
+    return {_start + offset, _start + offset + count};
+}
+
+bytes::value_type bytes_view::operator[](size_t n) const { return _start[n]; }
+
+bool bytes_view::operator==(const bytes_view& other) const {
+    return std::ranges::equal(*this, other);
+}
+
+header::operator header_view() const {
+    return header_view{.key = key, .value = value};
+}
+
+record::operator record_view() const {
+    std::vector<header_view> view_headers;
+    view_headers.reserve(headers.size());
+    for (const header& header : headers) {
+        view_headers.push_back(header);
+    }
+    return record_view{
+      .key = key,
+      .value = value,
+      .headers = std::move(view_headers),
+    };
+}
+
+written_record::operator record_view() const {
+    return record_view{
+      .key = key,
+      .value = value,
+      .headers = headers,
+    };
+}
+
+[[noreturn]] void
+on_record_written(const on_record_written_callback& callback) {
+    abi::check();
+    while (true) {
+        process_batch(callback);
+    }
+}
+
+} // namespace redpanda
+
+#ifdef REDPANDA_TRANSFORM_SDK_ENABLE_TESTING
+
+#include <algorithm>
+#include <format>
+#include <print>
+#include <random>
+
+using random_bytes_engine
+  = std::independent_bits_engine<std::default_random_engine, CHAR_BIT, uint8_t>;
+
+namespace redpanda {
+
+bytes make_bytes(random_bytes_engine* rng, size_t length) {
+    bytes dat(length, '\0');
+    std::generate(dat.begin(), dat.end(), *rng);
+    return dat;
+}
+
+std::string make_string(random_bytes_engine* rng, size_t length) {
+    std::string dat(length, '\0');
+    std::generate(dat.begin(), dat.end(), *rng);
+    return dat;
+}
+
+template<class... Args>
+void assert(bool cond, std::format_string<Args...> fmt, Args&&... args) {
+    if (!cond) {
+        abort(std::format(fmt, std::forward<Args...>(args)...));
+    }
+}
+
+void test_zigzag_roundtrip() {
+    constexpr auto testcases = std::to_array<int64_t>(
+      {0,
+       1,
+       -1,
+       42,
+       -42,
+       -std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::min(),
+       std::numeric_limits<int64_t>::max()});
+    for (int64_t val : testcases) {
+        auto encoded = varint::zigzag_encode(val);
+        auto decoded = varint::zigzag_decode(encoded);
+        assert(decoded == val, "zigzag roundtrip failed: {}", val);
+    }
+}
+
+void test_varint_roundtrip() {
+    constexpr auto testcases = std::to_array<int64_t>(
+      {0,
+       1,
+       -1,
+       42,
+       -42,
+       -std::numeric_limits<int64_t>::max(),
+       std::numeric_limits<int64_t>::min(),
+       std::numeric_limits<int64_t>::max()});
+    for (const int64_t val : testcases) {
+        bytes encoded;
+        varint::write(&encoded, val);
+        auto decoded = varint::read(encoded);
+        assert(decoded.has_value(), "varint read failed");
+        assert(
+          decoded.value().read == encoded.size(),
+          "varint roundtrip failed: {}",
+          val);
+        assert(
+          decoded.value().value == val, "varint roundtrip failed: {}", val);
+    }
+}
+
+void test_null_buffer_roundtrip() {
+    bytes encoded;
+    varint::write_sized_buffer<bytes>(&encoded, std::nullopt);
+    auto decoded = varint::read_sized_buffer(encoded);
+    assert(decoded.has_value(), "varint read failed");
+    assert(decoded.value().read == encoded.size(), "nullbuf roundtrip failed");
+    assert(!decoded.value().value, "nullbuf roundtrip failed");
+}
+
+void test_sized_buffer_roundtrip(random_bytes_engine* rng) {
+    for (const size_t length : {0, 1, 9, 42, 64, 1024}) {
+        bytes original = make_bytes(rng, length);
+        bytes encoded;
+        varint::write_sized_buffer<bytes>(&encoded, original);
+        auto decoded = varint::read_sized_buffer(encoded);
+        assert(decoded.has_value(), "varint read failed");
+        assert(
+          decoded.value().read == encoded.size(),
+          "varbuf roundtrip failed: {}",
+          original.size());
+        assert(
+          decoded.value().value.has_value(),
+          "varbuf roundtrip failed: {}",
+          original.size());
+        assert(
+          std::ranges::equal(decoded.value().value.value(), original),
+          "varbuf roundtrip failed: {}",
+          original.size());
+    }
+}
+
+void test_record_roundtrip(random_bytes_engine* rng) {
+    constexpr size_t small = 42;
+    constexpr size_t big = 256;
+    const record empty{
+      .key = std::nullopt,
+      .value = std::nullopt,
+      .headers = {},
+    };
+    const record key_only{
+      .key = make_bytes(rng, small),
+      .value = std::nullopt,
+      .headers = {},
+    };
+    const record value_only{
+      .key = std::nullopt,
+      .value = make_bytes(rng, small),
+      .headers = {},
+    };
+    const record headers_only{
+      .key = std::nullopt,
+      .value = std::nullopt,
+      .headers = {
+        {.key = make_string(rng, small), .value = make_bytes(rng, small)},
+        {.key = make_string(rng, small), .value = make_bytes(rng, big)},
+        {.key = make_string(rng, small), .value = std::nullopt}}};
+    const record keyval{
+      .key = make_bytes(rng, small),
+      .value = make_bytes(rng, big),
+      .headers = {},
+    };
+    const record full{
+      .key = make_bytes(rng, small),
+      .value = make_bytes(rng, big),
+      .headers = {
+        {.key = make_string(rng, small), .value = make_bytes(rng, small)},
+        {.key = make_string(rng, small), .value = make_bytes(rng, big)},
+        {.key = make_string(rng, small), .value = std::nullopt}}};
+    for (const record& rec :
+         {empty, key_only, value_only, headers_only, keyval, full}) {
+        bytes encoded;
+        decode::write_record(&encoded, rec);
+        auto result = decode::read_record_view(encoded);
+        assert(result.has_value(), "expected value");
+        assert(result.value() == rec, "record mismatch");
+    }
+}
+
+void run_test_suite() {
+    unsigned seed = std::random_device()();
+    std::println("using seed: {}", seed);
+    random_bytes_engine rng(seed);
+    test_zigzag_roundtrip();
+    test_varint_roundtrip();
+    test_null_buffer_roundtrip();
+    test_sized_buffer_roundtrip(&rng);
+    test_record_roundtrip(&rng);
+    std::println("tests successful");
+}
+
+} // namespace redpanda
+
+int main() {
+    redpanda::run_test_suite();
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
Add experimental C++ SDK. It's currently not going to be more formally supported in docs or RPK at the moment.

Most of the implementation here falls out from mirroring similar patterns from the Rust SDK.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
