### PR TITLE
Change cloud test hierarchy, introduce cloud test base

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/observe_test.py
+++ b/tests/rptest/redpanda_cloud_tests/observe_test.py
@@ -5,18 +5,16 @@ from types import SimpleNamespace
 from io import BytesIO
 
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import make_redpanda_service
-from rptest.tests.rpk_cloud_test import get_ci_env_var
+from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
 
 
-class HTObserveTest(Test):
+class HTObserveTest(RedpandaCloudTest):
     """
     Cloudv2 only - ensure no firing alarms for cloud cluster - should be ran after all other tests
     this is acomplished by setting @cluster(num_nodes=0) which is good enough
     """
     def __init__(self, test_context):
         super(HTObserveTest, self).__init__(test_context=test_context)
-        self.redpanda = make_redpanda_service(test_context, 3)
         self._ctx = test_context
         self._token = self.redpanda._cloud_cluster.config.grafana_token
         self._endpoint = self.redpanda._cloud_cluster.config.grafana_alerts_url

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -32,6 +32,14 @@ GB = 10**9
 minutes = 60
 hours = 60 * minutes
 
+T = TypeVar('T')
+
+
+def not_none(value: T | None) -> T:
+    if value is None:
+        raise ValueError(f'value was unexpectedly None')
+    return value
+
 
 class OMBValidationTest(RedpandaTest):
 
@@ -111,7 +119,7 @@ class OMBValidationTest(RedpandaTest):
             self.s3_port = si_settings.cloud_storage_api_endpoint_port
 
         self.num_brokers = config_profile['nodes_count']
-        self.tier_limits: ProductInfo = self.redpanda.get_product()
+        self.tier_limits: ProductInfo = not_none(self.redpanda.get_product())
         self.tier_machine_info = get_machine_info(
             config_profile['machine_type'])
         self.rpk = RpkTool(self.redpanda)

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -9,9 +9,10 @@
 
 import math
 from time import sleep
-from typing import Any
+from typing import Any, TypeVar
 
 from rptest.services.cluster import cluster
+from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
 from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.tests.test import TestContext
 from rptest.services.producer_swarm import ProducerSwarm
@@ -41,7 +42,7 @@ def not_none(value: T | None) -> T:
     return value
 
 
-class OMBValidationTest(RedpandaTest):
+class OMBValidationTest(RedpandaCloudTest):
 
     # The numbers of nodes we expect to run with - this value (10) is the default
     # for duck.py so these tests should just work with that default, but not necessarily
@@ -67,30 +68,8 @@ class OMBValidationTest(RedpandaTest):
 
     def __init__(self, test_ctx: TestContext, *args, **kwargs):
         self._ctx = test_ctx
-        # Get tier name
-        self.config_profile_name = get_config_profile_name(
-            RedpandaServiceCloud.get_cloud_globals(self._ctx.globals))
-        extra_rp_conf = None
-        num_brokers = None
 
-        if self.config_profile_name == CloudTierName.DOCKER:
-            # TODO: Bake the docker config into a higher layer that will
-            # automatically load these settings upon call to make_rp_service
-            num_brokers = 3
-            extra_rp_conf = {
-                'log_segment_size': 128 * MiB,
-                'cloud_storage_cache_size': 20 * GiB,
-                'kafka_connections_max': 100,
-            }
-
-        super(OMBValidationTest,
-              self).__init__(test_ctx,
-                             *args,
-                             num_brokers=num_brokers,
-                             extra_rp_conf=extra_rp_conf,
-                             cloud_tier=self.config_profile_name,
-                             disable_cloud_storage_diagnostics=True,
-                             **kwargs)
+        super().__init__(test_ctx, *args, **kwargs)
 
         # Load install pack and check profile
         install_pack = self.redpanda.get_install_pack()
@@ -106,17 +85,6 @@ class OMBValidationTest(RedpandaTest):
             )
         config_profile = install_pack['config_profiles'][
             self.config_profile_name]
-        cluster_config = config_profile['cluster_config']
-
-        if self.config_profile_name == CloudTierName.DOCKER:
-            si_settings = SISettings(
-                test_ctx,
-                log_segment_size=self.min_segment_size,
-                cloud_storage_cache_size=cluster_config[
-                    'cloud_storage_cache_size'],
-            )
-            self.redpanda.set_si_settings(si_settings)
-            self.s3_port = si_settings.cloud_storage_api_endpoint_port
 
         self.num_brokers = config_profile['nodes_count']
         self.tier_limits: ProductInfo = not_none(self.redpanda.get_product())

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0
 
 import functools
+from itertools import chain
 import time
 from typing import Protocol
 import psutil
@@ -21,6 +22,7 @@ from ducktape.tests.test import TestContext
 def cluster(log_allow_list=None,
             check_allowed_error_logs=True,
             check_for_storage_usage_inconsistencies=True,
+            is_cloud_cluster=False,
             **kwargs):
     """
     Drop-in replacement for Ducktape `cluster` that imposes additional
@@ -37,10 +39,14 @@ def cluster(log_allow_list=None,
 
         We find all replicas by traversing ducktape's internal service registry.
         """
-        yield test.redpanda
+        rp = test.redpanda
+        assert isinstance(rp, RedpandaServiceBase) or isinstance(
+            rp, RedpandaServiceCloud)
+        yield rp
 
         for svc in test.test_context.services:
-            if isinstance(svc, RedpandaService) and svc is not test.redpanda:
+            if isinstance(svc, RedpandaServiceBase) or isinstance(
+                    svc, RedpandaServiceCloud) and svc is not test.redpanda:
                 yield svc
 
     def log_local_load(test_name, logger, t_initial, initial_disk_stats):
@@ -83,12 +89,16 @@ def cluster(log_allow_list=None,
             # such as RedpandaTest subclasses
             assert hasattr(self, 'redpanda')
 
+            # some checks only make sense on "vanilla" Redpanda nodes, i.e., those created on
+            # VMs or docker containers inside a ducktape node, where we have ssh access, for
+            # other environemnts we will skip those checks
+
             t_initial = time.time()
             disk_stats_initial = psutil.disk_io_counters()
             try:
                 r = f(self, *args, **kwargs)
             except:
-                if not hasattr(self, 'redpanda') or self.redpanda is None:
+                if self.redpanda is None:
                     # We failed so early there isn't even a RedpandaService instantiated
                     raise
 
@@ -105,15 +115,16 @@ def cluster(log_allow_list=None,
                     # (https://github.com/redpanda-data/redpanda/issues/5004)
                     # self.redpanda.decode_backtraces()
 
-                    redpanda.cloud_storage_diagnostics()
-
-                    redpanda.raise_on_crash(log_allow_list=log_allow_list)
+                    if isinstance(redpanda, RedpandaServiceBase):
+                        redpanda.cloud_storage_diagnostics()
+                        redpanda.raise_on_crash(log_allow_list=log_allow_list)
 
                 raise
             else:
-                if not hasattr(self, 'redpanda') or self.redpanda is None:
-                    # We passed without instantiating a RedpandaService, for example
-                    # in a skipped test
+                if not isinstance(self.redpanda, RedpandaServiceBase):
+                    # If None we passed without instantiating a RedpandaService, for example
+                    # in a skipped test.
+                    # Also skip if we are running against the cloud
                     return r
 
                 log_local_load(self.test_context.test_name,
@@ -124,7 +135,7 @@ def cluster(log_allow_list=None,
                 # load on the system and destabilize other tests.  Detect this with a
                 # post-test check for total bytes written.
                 debug_mode_data_limit = 64 * 1024 * 1024
-                if hasattr(self, 'debug_mode') and self.debug_mode is True:
+                if getattr(self, 'debug_mode', False) is True:
                     bytes_written = self.redpanda.estimate_bytes_written()
                     if bytes_written is not None:
                         self.redpanda.logger.info(
@@ -138,6 +149,14 @@ def cluster(log_allow_list=None,
                     redpanda.logger.info(
                         f"Test passed, doing log checks on {redpanda.who_am_i()}..."
                     )
+
+                    # the following checks don't work on cloud instances but we don't expect
+                    # any of those as we already early-outed above when Redpanda is not
+                    # RSB (technically, it might be that self.redpanda is RSB but some
+                    # additional redpanda in the registry is, but that situation never arises
+                    # in practice in our current tests)
+                    assert isinstance(redpanda, RedpandaServiceBase)
+
                     if check_allowed_error_logs:
                         # Only do log inspections on tests that are otherwise
                         # successful.  This executes *before* the end-of-test

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -6,8 +6,11 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
+from abc import ABC, abstractmethod
 import concurrent.futures
 import copy
+from functools import cached_property
+from logging import Logger
 
 import time
 import os
@@ -26,7 +29,7 @@ import zipfile
 import pathlib
 import shlex
 from enum import Enum, IntEnum
-from typing import Callable, Mapping, Optional, Protocol, Tuple, Any
+from typing import Callable, Mapping, Optional, Protocol, Tuple, Any, Type, cast
 
 import yaml
 from ducktape.services.service import Service
@@ -275,6 +278,17 @@ def get_cloud_storage_type(applies_only_on: list[CloudStorageType]
         cloud_storage_type = list(
             set(applies_only_on).intersection(cloud_storage_type))
     return cloud_storage_type
+
+
+def is_redpanda_cloud(context: TestContext):
+    """
+    Returns True if we are running againt a Redpanda Cloud cluster,
+    False otherwise."""
+
+    # we use the presence of a non-empty cloud_cluster key in the config as our
+    # global signal that it's a cloud run
+    return bool(
+        context.globals.get(RedpandaServiceCloud.GLOBAL_CLOUD_CLUSTER_CONFIG))
 
 
 class ResourceSettings:
@@ -833,7 +847,72 @@ class AuditLogConfig(TlsConfig):
         self.listener_authn_method = listener_authn_method
 
 
-class RedpandaServiceBase(Service):
+class RedpandaServiceABC(ABC):
+    """A base class for all Redpanda services. This lowest-common denominator
+    class has both implementation and abstract methods, only for methods which
+    can be implemented by all services. Any methods which the service should
+    implement should be @abstractmethod in order to ensure they are implemented
+    by base classes.
+
+    If a method can be implemented by more than one service implementation, but
+    not all of them, it does NOT belong here.
+    """
+
+    context: TestContext
+    logger: Logger
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Now ensure that this base is part of the right type of object.
+        # For these checks to work, this __init__ method should appear in
+        # the MRO after all the __init__ methods that would set these properties
+        self._check_attr('context', TestContext)
+        self._check_attr('logger', Logger)
+
+    def healthy(self) -> bool:
+        raise NotImplementedError(
+            f'{self.healthy.__name__} is not implemented yet')
+
+    @abstractmethod
+    def all_up(self):
+        pass
+
+    def wait_until(self, fn, timeout_sec, backoff_sec, err_msg: str = None):
+        """
+        Cluster-aware variant of wait_until, which will fail out
+        early if a node dies.
+
+        This is useful for long waits, which would otherwise not notice
+        a test failure until the end of the timeout, even if redpanda
+        already crashed.
+        """
+
+        t_initial = time.time()
+        # How long to delay doing redpanda liveness checks, to make short waits more efficient
+        grace_period = 15
+
+        def wrapped():
+            r = fn()
+            if not r and time.time() > t_initial + grace_period:
+                # Check the cluster is up before waiting + retrying
+                assert self.all_up() or getattr(self, '_tolerate_crashes',
+                                                False)
+            return r
+
+        wait_until(wrapped,
+                   timeout_sec=timeout_sec,
+                   backoff_sec=backoff_sec,
+                   err_msg=err_msg)
+
+    def _check_attr(self, name: str, t: Type):
+        v = getattr(self, name, None)
+        mro = self.__class__.__mro__
+        assert v is not None, f'RedpandaServiceABC was missing attribute {name} after __init__: {mro}\n'
+        assert isinstance(
+            v, t), f'{name} had wrong type, expected {t} but was {type(v)}'
+
+
+class RedpandaServiceBase(RedpandaServiceABC, Service):
     PERSISTENT_ROOT = "/var/lib/redpanda"
     TRIM_LOGS_KEY = "trim_logs"
     DATA_DIR = os.path.join(PERSISTENT_ROOT, "data")
@@ -1221,32 +1300,6 @@ class RedpandaServiceBase(Service):
     def security_config(self):
         return self._security_config
 
-    def wait_until(self, fn, timeout_sec, backoff_sec, err_msg=None):
-        """
-        Cluster-aware variant of wait_until, which will fail out
-        early if a node dies.
-
-        This is useful for long waits, which would otherwise not notice
-        a test failure until the end of the timeout, even if redpanda
-        already crashed.
-        """
-
-        t_initial = time.time()
-        # How long to delay doing redpanda liveness checks, to make short waits more efficient
-        grace_period = 15
-
-        def wrapped():
-            r = fn()
-            if not r and time.time() > t_initial + grace_period:
-                # Check the cluster is up before waiting + retrying
-                assert self.all_up() or self._tolerate_crashes
-            return r
-
-        wait_until(wrapped,
-                   timeout_sec=timeout_sec,
-                   backoff_sec=backoff_sec,
-                   err_msg=err_msg)
-
     def set_skip_if_no_redpanda_log(self, v: bool):
         self._skip_if_no_redpanda_log = v
 
@@ -1386,7 +1439,7 @@ class RedpandaServiceK8s(RedpandaServiceBase):
                              skip_if_no_redpanda_log=skip_if_no_redpanda_log)
         self._trim_logs = False
         self._helm = None
-        self._kubectl = None
+        self.__kubectl = None
 
     def start_node(self, node, **kwargs):
         pass
@@ -1412,26 +1465,6 @@ class RedpandaServiceK8s(RedpandaServiceBase):
 
     def clean_node(self, node, **kwargs):
         self._helm.uninstall()
-
-    def get_node_memory_mb(self):
-        line = self._kubectl.exec("cat /proc/meminfo | grep MemTotal")
-        memory_kb = int(line.strip().split()[1])
-        return memory_kb / 1024
-
-    def get_node_cpu_count(self):
-        core_count_str = self._kubectl.exec(
-            "cat /proc/cpuinfo | grep ^processor | wc -l")
-        return int(core_count_str.strip())
-
-    def get_node_disk_free(self):
-        if self._kubectl.exists(self.PERSISTENT_ROOT):
-            df_path = self.PERSISTENT_ROOT
-        else:
-            # If dir doesn't exist yet, use the parent.
-            df_path = os.path.dirname(self.PERSISTENT_ROOT)
-        df_out = self._kubectl.exec(f"df --output=avail {df_path}")
-        avail_kb = int(df_out.strip().split(b"\n")[1].strip())
-        return avail_kb * 1024
 
     def lsof_node(self, node: ClusterNode, filter: Optional[str] = None):
         """
@@ -1468,7 +1501,32 @@ class RedpandaServiceK8s(RedpandaServiceBase):
         self._helm.upgrade_config_cluster(values)
 
 
-class RedpandaServiceCloud(RedpandaServiceK8s):
+class KubeServiceMixin:
+
+    kubectl: KubectlTool
+
+    def get_node_memory_mb(self):
+        line = self.kubectl.exec("cat /proc/meminfo | grep MemTotal")
+        memory_kb = int(line.strip().split()[1])
+        return memory_kb / 1024
+
+    def get_node_cpu_count(self):
+        core_count_str = self.kubectl.exec(
+            "cat /proc/cpuinfo | grep ^processor | wc -l")
+        return int(core_count_str.strip())
+
+    def get_node_disk_free(self):
+        if self.kubectl.exists(RedpandaServiceBase.PERSISTENT_ROOT):
+            df_path = RedpandaServiceBase.PERSISTENT_ROOT
+        else:
+            # If dir doesn't exist yet, use the parent.
+            df_path = os.path.dirname(RedpandaServiceBase.PERSISTENT_ROOT)
+        df_out = self.kubectl.exec(f"df --output=avail {df_path}")
+        avail_kb = int(df_out.strip().split(b"\n")[1].strip())
+        return avail_kb * 1024
+
+
+class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
     """
     Service class for running tests against Redpanda Cloud.
 
@@ -1481,11 +1539,11 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
     def __init__(self,
                  context: TestContext,
-                 num_brokers,
                  *,
+                 config_profile_name: str,
                  superuser: Optional[SaslCredentials] = None,
                  skip_if_no_redpanda_log: Optional[bool] = False,
-                 tier_name: Optional[str] = None,
+                 min_brokers: int = 3,
                  **kwargs):
         """Initialize a RedpandaServiceCloud object.
 
@@ -1493,24 +1551,28 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
         :param num_brokers: ignored because Redpanda Cloud will launch the number of brokers necessary to satisfy the product needs
         :param superuser:  if None, then create SUPERUSER_CREDENTIALS with full acls
         :param tier_name:  the redpanda cloud tier name to create
+        :param min_brokers: the minimum number of brokers the consumer of the cluster (a test, typically) requires
+                            if the cloud cluster does not have this many brokers an exception is thrown
         """
 
-        super(RedpandaServiceCloud,
-              self).__init__(context,
-                             None,
-                             cluster_spec=ClusterSpec.empty(),
-                             superuser=superuser,
-                             skip_if_no_redpanda_log=skip_if_no_redpanda_log)
-        if num_brokers is not None:
-            self.logger.info(
-                f'num_brokers is {num_brokers}, but setting to None for cloud')
+        # we save the test context under both names since RedpandaService and Service
+        # save them under these two names, respetively
+        self.context = self._context = context
+        self.logger = context.logger
+
+        super().__init__()
+
+        self.config_profile_name = config_profile_name
+        self._min_brokers = min_brokers
+        self._superuser = superuser or RedpandaServiceBase.SUPERUSER_CREDENTIALS
+        self._skip_create_superuser = bool(superuser)
 
         self._trim_logs = False
 
         # Prepare values from globals.json to serialize
         # later to dataclass
-        self._cc_config = context.globals.get(self.GLOBAL_CLOUD_CLUSTER_CONFIG,
-                                              None)
+        self._cc_config = context.globals[self.GLOBAL_CLOUD_CLUSTER_CONFIG]
+
         self._provider_config = {
             "access_key":
             context.globals.get(SISettings.GLOBAL_S3_ACCESS_KEY, None),
@@ -1529,7 +1591,7 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
             self._cc_config,
             provider_config=self._provider_config)
         # Prepare kubectl
-        self._kubectl = None
+        self.__kubectl = None
 
         # Backward compatibility with RedpandaService
         # Fake out sasl_enabled callable
@@ -1542,11 +1604,14 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
     @property
     def kubectl(self):
-        assert self._kubectl, 'kubectl accessed before cluster was started?'
-        return self._kubectl
+        assert self.__kubectl, 'kubectl accessed before cluster was started?'
+        return self.__kubectl
 
-    def start_node(self, node, **kwargs):
-        pass
+    def who_am_i(self):
+        return self._cloud_cluster.cluster_id
+
+    def security_config(self):
+        return self._security_config
 
     def start(self, **kwargs):
         superuser = None
@@ -1562,7 +1627,7 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
         cluster_id = self._cloud_cluster.create(superuser=superuser)
         remote_uri = f'redpanda@{cluster_id}-agent'
-        self._kubectl = KubectlTool(
+        self.__kubectl = KubectlTool(
             self,
             remote_uri=remote_uri,
             cluster_id=self._cloud_cluster.cluster_id,
@@ -1573,15 +1638,18 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
         # Get pods and form node list
         self.pods = []
-        _r = self._kubectl.cmd('get pods -n redpanda -o json')
+        _r = self.kubectl.cmd('get pods -n redpanda -o json')
         _pods = json.loads(_r.decode())
         for p in _pods['items']:
             if not p['metadata']['name'].startswith(
                     f"rp-{self._cloud_cluster.config.id}"):
                 continue
             else:
-                _node = CloudBroker(p, self._kubectl, self.logger)
+                _node = CloudBroker(p, self.kubectl, self.logger)
                 self.pods.append(_node)
+
+        node_count = self.config_profile['nodes_count']
+        assert self._min_brokers <= node_count, f'Not enough brokers: test needs {self._min_brokers} but cluster has {node_count}'
 
     def get_node_by_id(self, id):
         for p in self.pods:
@@ -1589,8 +1657,10 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
                 return p
         return None
 
-    def stop_node(self, node, **kwargs):
-        pass
+    @cached_property
+    def config_profile(self) -> dict[str, Any]:
+        return self.get_install_pack()['config_profiles'][
+            self.config_profile_name]
 
     def stop(self, **kwargs):
         if self._cloud_cluster.config.delete_cluster:
@@ -1599,20 +1669,11 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
             self.logger.info(
                 f'skipping delete of cluster {self._cloud_cluster.cluster_id}')
 
-    def clean_node(self, node, **kwargs):
-        pass
-
-    def node_id(self, node, force_refresh=False, timeout_sec=30):
-        pass
-
-    def brokers(self, limit=None, listener: str = "dnslistener") -> str:
+    def brokers(self) -> str:
         return self._cloud_cluster.get_broker_address()
 
-    def get_version(self, node):
+    def install_pack_version(self) -> str:
         return self._cloud_cluster.get_install_pack_version()
-
-    def set_cluster_config(self, values: dict, timeout: int = 300):
-        pass
 
     def sockets_clear(self, node: RemoteClusterNode):
         return True
@@ -1682,7 +1743,7 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
 
         :param remote_cmd: The command to run on the agent node.
         """
-        return self._kubectl._cmd(remote_cmd)
+        return self.kubectl._cmd(remote_cmd)
 
     def scale_cluster(self, nodes_count):
         """Scale out/in cluster to specified number of nodes.
@@ -2944,7 +3005,7 @@ class RedpandaService(RedpandaServiceBase):
 
     def get_version(self, node):
         """
-        Returns the version as a string.
+        Returns the redpanda binary version as a string.
         """
         version_cmd = f"{self.find_binary('redpanda')} --version"
         VERSION_LINE_RE = re.compile(".*(v\\d+\\.\\d+\\.\\d+).*")
@@ -3290,14 +3351,6 @@ class RedpandaService(RedpandaServiceBase):
             )
             conf.update(
                 dict(http_authentication=self._security.http_authentication))
-
-        # in redpanda, cloud_storage_spillover_manifest_size takes preference over cloud_storage_spillover_manifest_max_segments.
-        # disable the former to use the latter
-        assert conf.get('cloud_storage_spillover_manifest_size', None) is None or \
-            conf.get('cloud_storage_spillover_manifest_max_segments', None) is None, \
-                  "cannot set cloud_storage_spillover_manifest_max_segments if cloud_storage_spillover_manifest_size is already set, it will not be used by redpanda"
-        if 'cloud_storage_spillover_manifest_max_segments' in conf:
-            conf['cloud_storage_spillover_manifest_size'] = None
 
         conf_yaml = yaml.dump(conf)
         for node in self.nodes:
@@ -4301,10 +4354,13 @@ def make_redpanda_service(context: TestContext,
                           num_brokers: Optional[int],
                           *,
                           cloud_tier: str | None = None,
-                          apply_cloud_tier_to_noncloud: bool = False,
                           extra_rp_conf=None,
-                          **kwargs) -> RedpandaServiceCloud | RedpandaService:
+                          **kwargs) -> RedpandaService:
     """Factory function for instatiating the appropriate RedpandaServiceBase subclass."""
+
+    # https://github.com/redpanda-data/core-internal/issues/1002
+    assert RedpandaServiceCloud.GLOBAL_CLOUD_CLUSTER_CONFIG not in context.globals, \
+        'make_redpanda_service should not be called in a cloud test context'
 
     if RedpandaServiceCloud.GLOBAL_CLOUD_CLUSTER_CONFIG in context.globals:
         if cloud_tier is None:
@@ -4314,16 +4370,13 @@ def make_redpanda_service(context: TestContext,
             context.logger.info(
                 f"extra_rp_conf is ignored with RedpandaServiceCloud")
 
+        assert num_brokers is None, f'num_broker specified but cloud tests cannot vary broker count'
+
         service = RedpandaServiceCloud(context,
-                                       num_brokers,
-                                       tier_name=cloud_tier,
+                                       config_profile_name=cloud_tier,
                                        **kwargs)
 
     else:
-        if apply_cloud_tier_to_noncloud:
-            raise RuntimeError(
-                'applying cloud tier to noncloud not implemented yet')
-
         if num_brokers is None:
             assert cloud_tier is not None
             num_brokers = 3
@@ -4333,4 +4386,56 @@ def make_redpanda_service(context: TestContext,
                                   extra_rp_conf=extra_rp_conf,
                                   **kwargs)
 
-    return service
+    # currently we just pretend we always return a RedpandaService, pending the
+    # deletion of the paths above that return a cloud service
+    return cast(RedpandaService, service)
+
+
+def make_redpanda_cloud_service(context: TestContext,
+                                *,
+                                min_brokers: int = 3) -> RedpandaServiceCloud:
+    """Create a RedpandaServiceCloud service. This can only be used in a test
+    running against Redpanda Cloud or else it will throw."""
+
+    cloud_config = context.globals.get(
+        RedpandaServiceCloud.GLOBAL_CLOUD_CLUSTER_CONFIG)
+
+    assert cloud_config, "Trying to create a cloud test, but no cloud_cluster section found in config"
+
+    config_profile_name = get_config_profile_name(cloud_config)
+
+    if config_profile_name == CloudTierName.DOCKER:
+        # TODO: Bake the docker config into a higher layer that will
+        # automatically load these settings upon call to make_rp_service
+
+        # this whole local hack is likely no longer working, but for now pretend by casting
+        return cast(
+            RedpandaServiceCloud,
+            RedpandaService(context,
+                            num_brokers=3,
+                            extra_rp_conf={
+                                'log_segment_size': 128 * 2**20,
+                                'cloud_storage_cache_size': 20 * 2**30,
+                                'kafka_connections_max': 100,
+                            }))
+
+    return RedpandaServiceCloud(context,
+                                config_profile_name=config_profile_name,
+                                min_brokers=min_brokers)
+
+
+def make_redpanda_service_mixed(context: TestContext, *, min_brokers: int = 3):
+    """Creates either a RedpandaService or RedpandaServiceCloud depending on which
+    environemnt we are running in. This allows you to write a so-called 'mixed' test
+    which can run against services of different types.
+
+    :param min_brokers: Create or expose a cluster with at least this many brokers."""
+
+    # For cloud tests, we can't affect the number of brokers (or any other cluster
+    # parameters, really), so we just check (eventually) that the number of brokers
+    # is at least the specified minimum (by passing as min_brokers). For vanilla tests,
+    # we create a cluster with exactly the requested number of brokers.
+    if is_redpanda_cloud(context):
+        return make_redpanda_cloud_service(context, min_brokers=min_brokers)
+    else:
+        return make_redpanda_service(context, num_brokers=min_brokers)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -26,7 +26,7 @@ import zipfile
 import pathlib
 import shlex
 from enum import Enum, IntEnum
-from typing import Mapping, Optional, Protocol, Tuple, Any
+from typing import Callable, Mapping, Optional, Protocol, Tuple, Any
 
 import yaml
 from ducktape.services.service import Service
@@ -45,7 +45,6 @@ from prometheus_client.parser import text_string_to_metric_families
 from ducktape.errors import TimeoutError
 from ducktape.tests.test import TestContext
 
-from rptest.archival.abs_client import build_connection_string
 from rptest.clients.helm import HelmTool
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kubectl import KubectlTool
@@ -957,7 +956,7 @@ class RedpandaServiceBase(Service):
         self._trim_logs = self._context.globals.get(self.TRIM_LOGS_KEY, True)
 
         self._node_id_by_idx = {}
-        self._security_config: dict[str, str] = {}
+        self._security_config: dict[str, str | int] = {}
 
         self._skip_if_no_redpanda_log = skip_if_no_redpanda_log
 
@@ -1153,7 +1152,7 @@ class RedpandaServiceBase(Service):
     def si_settings(self):
         return self._si_settings
 
-    def for_nodes(self, nodes, cb: callable) -> list:
+    def for_nodes(self, nodes, cb: Callable) -> list:
         n_workers = len(nodes)
         if n_workers > 0:
             with concurrent.futures.ThreadPoolExecutor(
@@ -1481,7 +1480,7 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
     GLOBAL_CLOUD_CLUSTER_CONFIG = 'cloud_cluster'
 
     def __init__(self,
-                 context,
+                 context: TestContext,
                  num_brokers,
                  *,
                  superuser: Optional[SaslCredentials] = None,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -869,10 +869,6 @@ class RedpandaServiceABC(ABC):
         self._check_attr('context', TestContext)
         self._check_attr('logger', Logger)
 
-    def healthy(self) -> bool:
-        raise NotImplementedError(
-            f'{self.healthy.__name__} is not implemented yet')
-
     @abstractmethod
     def all_up(self):
         pass

--- a/tests/rptest/tests/redpanda_cloud_test.py
+++ b/tests/rptest/tests/redpanda_cloud_test.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import os
+from typing import Sequence
+
+from ducktape.tests.test import Test, TestContext
+from rptest.services.redpanda import CloudTierName, SISettings, make_redpanda_cloud_service, make_redpanda_service, CloudStorageType
+from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.default import DefaultClient
+from rptest.tests.redpanda_test import RedpandaTestBase
+from rptest.util import Scale
+from rptest.utils import mode_checks
+from rptest.clients.types import TopicSpec
+from rptest.services.redpanda_installer import RedpandaInstaller, RedpandaVersion, RedpandaVersionLine, RedpandaVersionTriple
+from rptest.clients.rpk import RpkTool
+
+
+class RedpandaCloudTest(RedpandaTestBase):
+    """
+    Base class for tests which run against the Redpanda Cloud.
+    """
+    def __init__(self, test_context: TestContext):
+
+        super().__init__(test_context=test_context)
+
+        self.redpanda = make_redpanda_cloud_service(test_context)
+        self._client = DefaultClient(self.redpanda)
+
+        # for easy access but we should fix callers and remove this
+        self.config_profile_name = self.redpanda.config_profile_name
+
+    def client(self):
+        return self._client

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -19,7 +19,7 @@ from rptest.services.failure_injector import FailureSpec, make_failure_injector
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.kgo_repeater_service import repeater_traffic
 from rptest.services.kgo_verifier_services import KgoVerifierRandomConsumer, KgoVerifierSeqConsumer, KgoVerifierConsumerGroupConsumer, KgoVerifierProducer
-from rptest.services.redpanda import RedpandaServiceCloud, SISettings, CloudStorageType, get_cloud_storage_type, make_redpanda_service
+from rptest.services.redpanda import RedpandaServiceCloud, SISettings, CloudStorageType, get_cloud_storage_type, make_redpanda_service, make_redpanda_service_mixed
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.utils.si_utils import BucketView
 from rptest.util import expect_exception
@@ -257,7 +257,8 @@ class SimpleSelfTest(Test):
     """
     def __init__(self, test_context):
         super(SimpleSelfTest, self).__init__(test_context)
-        self.redpanda = make_redpanda_service(test_context, 3)
+        self.redpanda = make_redpanda_service_mixed(test_context,
+                                                    min_brokers=3)
 
     def setUp(self):
         self.redpanda.start()
@@ -292,7 +293,7 @@ class KubectlSelfTest(Test):
     """
     def __init__(self, test_context):
         super().__init__(test_context)
-        self.redpanda = make_redpanda_service(test_context, 3)
+        self.redpanda = make_redpanda_service_mixed(test_context)
 
     def setUp(self):
         self.redpanda.start()

--- a/tests/rptest/utils/test_mixins.py
+++ b/tests/rptest/utils/test_mixins.py
@@ -1,0 +1,78 @@
+from logging import Logger
+from typing import Any, Callable, cast
+from ducktape.cluster.cluster import ClusterNode
+from ducktape.cluster.cluster_spec import ClusterSpec
+from ducktape.tests.test import TestContext, Test
+from ducktape.utils.util import wait_until
+
+from rptest.services.redpanda import RedpandaService, RedpandaServiceCloud
+
+
+class PreallocNodesMixin:
+    """
+    A test mixin to preallocate some nodes.
+
+    Having some explicitly allocated nodes is useful for
+    re-using those nodes to run multiple services at once, or to
+    run services that need to be on the same host (e.g. the KgoVerifier
+    producer/consumers that coordinate via a local file)
+    """
+
+    _preallocated_nodes: list[ClusterNode]
+
+    # these must be provided by the mixin's environment (i.e., other
+    # parts of the class hierarchy)
+    test_context: TestContext
+    logger: Logger
+
+    def __init__(self, node_prealloc_count: int, **kwargs: Any):
+        super().__init__(**kwargs)
+        self.node_prealloc_count = node_prealloc_count
+
+        # Nodes are allocated later on first access
+        self._preallocated_nodes = []
+
+    @property
+    def preallocated_nodes(self):
+        if not self._preallocated_nodes:
+            self._preallocated_nodes = self.test_context.cluster.alloc(
+                ClusterSpec.simple_linux(self.node_prealloc_count))
+
+            for node in self._preallocated_nodes:
+                self.logger.debug(f'Allocated node {node.name}')
+
+        return self._preallocated_nodes
+
+    def free_nodes(self):
+        # Free the normally allocated nodes (e.g. RedpandaService)
+        cast(Test, super()).free_nodes()
+
+        self.free_preallocated_nodes()
+
+    def free_preallocated_nodes(self):
+        """
+        If `preallocated_nodes` has been accessed, free the nodes that
+        were allocated there.  If `preallocated_nodes` is used again after
+        calling this, then some fresh nodes will be allocated: it is safe
+        to do this repeatedly.
+        """
+        if self._preallocated_nodes:
+            assert len(self.preallocated_nodes) == self.node_prealloc_count
+
+            # Some tests may open huge numbers of connections, which can interfere
+            # with subsequent tests' use of the node. Clear them down first.
+            # For example, those tests that use KgoVerifierProducer.
+            for node in self.preallocated_nodes:
+                wait_until(lambda: self.__redpanda.sockets_clear(node),
+                           timeout_sec=120,
+                           backoff_sec=10)
+
+                # Free the hand-allocated nodes
+                self.logger.debug(f"Freeing node {node.name}")
+                self.test_context.cluster.free_single(node)
+
+            self._preallocated_nodes = []
+
+    @property
+    def __redpanda(self) -> RedpandaService | RedpandaServiceCloud:
+        return getattr(self, 'redpanda')


### PR DESCRIPTION
This change changes a bit the inheritance structure of the
RedpandaService tree, and introduces the RedpandaCloudTest.

On the service side, we split RedpandaServiceCloud out so that it is
not a subclass of Service (as it does not use Service nodes nor have
a typical Service lifecycle). It shares some common interface with
RedpandaService but this is currently much smaller than the existing
RedpandaServiceBase.

RedpandaCloudTest is the base class for tests which run in the cloud,
analagous to RedpandaTest for tests which run in vanilla environments.
It automatically creates a RedpandaServiceCloud as the .redpanda
property, giving you type safe access to only the methods which make
sense in the cloud.

Issue https://github.com/redpanda-data/core-internal/issues/1002.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

