### PR TITLE
tests: updated flink to 1.18.1

### DIFF
--- a/tests/docker/ducktape-deps/flink
+++ b/tests/docker/ducktape-deps/flink
@@ -3,9 +3,9 @@ set -e
 mkdir /opt/flink
 
 # Download
-FLINK_FILE=flink-1.18.0-bin-scala_2.12.tgz
+FLINK_FILE=flink-1.18.1-bin-scala_2.12.tgz
 KAFKA_CONNECTOR=flink-sql-connector-kafka-3.0.1-1.18.jar
-wget https://dlcdn.apache.org/flink/flink-1.18.0/${FLINK_FILE}
+wget https://dlcdn.apache.org/flink/flink-1.18.1/${FLINK_FILE}
 
 # Extract
 tar -xvf ${FLINK_FILE} -C /opt/flink --strip-components 1


### PR DESCRIPTION
Since the old version is not longer available on Apache servers we must upgrade to v1.18.1.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
