### PR TITLE
[v23.3.x] tests/rptest/tests/tiered_storage_model_test: ignore

### DIFF
--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, Future
 from threading import Condition
 from collections import defaultdict
 
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ignore
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
@@ -547,6 +547,7 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         self.stop_flag = True
         self.thread_pool.shutdown()
 
+    @ignore  #see https://github.com/redpanda-data/redpanda/issues/16208
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=get_cloud_storage_type(),
             test_case=get_tiered_storage_test_cases(fast_run=True))


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16226

Fixes #16245