### PR TITLE
Changed the `partition_status` `chunked_fifo` chunk size to `8`

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -735,8 +735,8 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
     return reports;
 }
 
-using reports_acc_t = absl::
-  node_hash_map<model::topic_namespace, ss::chunked_fifo<partition_status>>;
+using reports_acc_t
+  = absl::node_hash_map<model::topic_namespace, partition_statuses_t>;
 
 reports_acc_t reduce_reports_map(
   reports_acc_t acc, ss::chunked_fifo<ntp_report> current_reports) {

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -14,6 +14,7 @@
 #include "cluster/errc.h"
 #include "cluster/node/types.h"
 #include "features/feature_table.h"
+#include "health_monitor_types.h"
 #include "model/adl_serde.h"
 #include "model/metadata.h"
 #include "utils/to_string.h"
@@ -156,7 +157,7 @@ topic_status& topic_status::operator=(const topic_status& rhs) {
         return *this;
     }
 
-    ss::chunked_fifo<partition_status> p;
+    partition_statuses_t p;
     p.reserve(rhs.partitions.size());
     std::copy(
       rhs.partitions.begin(), rhs.partitions.end(), std::back_inserter(p));
@@ -167,7 +168,7 @@ topic_status& topic_status::operator=(const topic_status& rhs) {
 }
 
 topic_status::topic_status(
-  model::topic_namespace tp_ns, ss::chunked_fifo<partition_status> partitions)
+  model::topic_namespace tp_ns, partition_statuses_t partitions)
   : tp_ns(std::move(tp_ns))
   , partitions(std::move(partitions)) {}
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -97,13 +97,18 @@ struct partition_status
     friend bool operator==(const partition_status&, const partition_status&)
       = default;
 };
+/**
+ * We keep the chunk size in partition status small to make sure that we do not
+ * waste to much of memory for topics with small number of partitions.
+ */
+using partition_statuses_t = ss::chunked_fifo<partition_status, 8>;
 
 struct topic_status
   : serde::envelope<topic_status, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
 
     topic_status() = default;
-    topic_status(model::topic_namespace, ss::chunked_fifo<partition_status>);
+    topic_status(model::topic_namespace, partition_statuses_t);
     topic_status& operator=(const topic_status&);
     topic_status(const topic_status&);
     topic_status& operator=(topic_status&&) = default;
@@ -111,7 +116,7 @@ struct topic_status
     ~topic_status() = default;
 
     model::topic_namespace tp_ns;
-    ss::chunked_fifo<partition_status> partitions;
+    partition_statuses_t partitions;
     friend std::ostream& operator<<(std::ostream&, const topic_status&);
     friend bool operator==(const topic_status&, const topic_status&);
 

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -378,7 +378,7 @@ enum part_status { HEALTHY, LEADERLESS, URP };
 
 topic_status
 make_ts(ss::sstring name, const std::vector<part_status>& status_list) {
-    ss::chunked_fifo<cluster::partition_status> statuses;
+    cluster::partition_statuses_t statuses;
 
     partition_id pid{0};
     for (auto status : status_list) {

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -610,7 +610,7 @@ private:
 
             absl::flat_hash_map<
               model::topic_namespace,
-              ss::chunked_fifo<cluster::partition_status>>
+              cluster::partition_statuses_t>
               topic2partitions;
             for (const auto& [ntp, repl] : replicas) {
                 topic2partitions[model::topic_namespace(ntp.ns, ntp.tp.topic)]

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -18,6 +18,8 @@
 #include "storage/tests/randoms.h"
 #include "test_utils/randoms.h"
 
+#include <iterator>
+
 namespace cluster::node {
 
 inline local_state random_local_state() {
@@ -60,9 +62,10 @@ inline partition_status random_partition_status() {
 }
 
 inline topic_status random_topic_status() {
-    return topic_status(
-      model::random_topic_namespace(),
-      tests::random_chunked_fifo(random_partition_status));
+    auto d = tests::random_vector(random_partition_status);
+    cluster::partition_statuses_t partitions;
+    std::move(d.begin(), d.end(), std::back_inserter(partitions));
+    return {model::random_topic_namespace(), std::move(partitions)};
 }
 
 inline drain_manager::drain_status random_drain_status() {

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -681,7 +681,7 @@ cluster::drain_manager::drain_status random_drain_status() {
 }
 
 cluster::topic_status random_topic_status() {
-    ss::chunked_fifo<cluster::partition_status> partitions;
+    cluster::partition_statuses_t partitions;
     for (int i = 0, mi = random_generators::get_int(10); i < mi; i++) {
         partitions.push_back(cluster::partition_status{
           .id = tests::random_named_int<model::partition_id>(),

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -398,7 +398,7 @@ inline void read_value(json::Value const& rd, cluster::partition_status& obj) {
 
 inline void read_value(json::Value const& rd, cluster::topic_status& obj) {
     model::topic_namespace tp_ns;
-    ss::chunked_fifo<cluster::partition_status> partitions;
+    cluster::partition_statuses_t partitions;
 
     read_member(rd, "tp_ns", tp_ns);
     read_member(rd, "partitions", partitions);

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -109,8 +109,8 @@ void read_value(json::Value const& v, std::vector<T>& target) {
     }
 }
 
-template<typename T>
-void read_value(json::Value const& v, ss::chunked_fifo<T>& target) {
+template<typename T, size_t chunk_size = 128>
+void read_value(json::Value const& v, ss::chunked_fifo<T, chunk_size>& target) {
     for (auto const& e : v.GetArray()) {
         auto t = T{};
         read_value(e, t);

--- a/src/v/json/json.h
+++ b/src/v/json/json.h
@@ -106,9 +106,10 @@ void rjson_serialize(
     w.EndArray();
 }
 
-template<typename T>
+template<typename T, size_t chunk_size = 128>
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w, const ss::chunked_fifo<T>& v) {
+  json::Writer<json::StringBuffer>& w,
+  const ss::chunked_fifo<T, chunk_size>& v) {
     w.StartArray();
     for (const auto& e : v) {
         rjson_serialize(w, e);

--- a/src/v/utils/to_string.h
+++ b/src/v/utils/to_string.h
@@ -52,9 +52,9 @@ operator<<(std::ostream& o, const ss::lowres_clock::duration& d) {
 
 } // namespace std
 
-template<typename T>
-struct fmt::formatter<ss::chunked_fifo<T>> {
-    using type = ss::chunked_fifo<T>;
+template<typename T, size_t chunk_size>
+struct fmt::formatter<ss::chunked_fifo<T, chunk_size>> {
+    using type = ss::chunked_fifo<T, chunk_size>;
 
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 


### PR DESCRIPTION
With large number of topics that contain a small amount of partitions we
may end up wasting a lot of memory using the default `ss::chunked_fifo`
chunk size of 128.
Change the chunk size of `partition_status` `chunked_fifo` collection to
8 to minimize a waste with large number of small topics.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- smaller memory footprint when using with large number of topics with small partition count