### PR TITLE
"enable by default spillover manifest" testing followups

### DIFF
--- a/tests/rptest/infinite_retention/infinite_retention_test.py
+++ b/tests/rptest/infinite_retention/infinite_retention_test.py
@@ -197,8 +197,7 @@ class InfiniteRetentionTest(PreallocNodesTest):
             'cloud_storage_manifest_max_upload_interval_sec':
             self.params.manifest_upload_interval,
             # Default retention is infinite
-            'delete_retention_ms':
-            self.params.retention_ms,
+            'delete_retention_ms': self.params.retention_ms,
             # enable merging to generate more re-uploads
             'cloud_storage_enable_segment_merging':
             self.params.cloud_storage_enable_segment_merging,
@@ -224,6 +223,9 @@ class InfiniteRetentionTest(PreallocNodesTest):
             # evict it frequently
             'cloud_storage_materialized_manifest_ttl_ms':
             self.params.cloud_storage_materialized_manifest_ttl_ms,
+
+            # disable spillover: it will be explicitly set in the tests when needed
+            'cloud_storage_spillover_manifest_size': None,
         }
         super().__init__(test_context, node_prealloc_count=1, *args, **kwargs)
 

--- a/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
+++ b/tests/rptest/scale_tests/tiered_storage_single_partition_test.py
@@ -92,6 +92,8 @@ class TieredStorageSinglePartitionTest(RedpandaTest):
             f"Configuring to spill metadata after {spillover_segments} segments"
         )
         self.redpanda.set_cluster_config({
+            'cloud_storage_spillover_manifest_size':
+            None,
             'cloud_storage_spillover_manifest_max_segments':
             spillover_segments
         })

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -407,7 +407,7 @@ class Admin:
         return self._request("GET", "cluster_config/schema", node=node).json()
 
     def patch_cluster_config(self,
-                             upsert: dict[str, str | None] = {},
+                             upsert: dict[str, str | int | None] = {},
                              remove: list[str] = [],
                              force: bool = False,
                              dry_run: bool = False,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2597,12 +2597,8 @@ class RedpandaService(RedpandaServiceBase):
         if admin_client is None:
             admin_client = self._admin
 
-        patch_result = admin_client.patch_cluster_config(
-            upsert={
-                k: v
-                for k, v in values.items() if v is not None
-            },
-            remove=[k for k, v in values.items() if v is None])
+        patch_result = admin_client.patch_cluster_config(upsert=values,
+                                                         remove=[])
         new_version = patch_result['config_version']
 
         self._wait_for_config_version(new_version,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2590,7 +2590,7 @@ class RedpandaService(RedpandaServiceBase):
         Update cluster configuration and wait for all nodes to report that they
         have seen the new config.
 
-        :param values: dict of property name to value. if value is None, key will be removed from cluster config
+        :param values: dict of property name to value.
         :param expect_restart: set to true if you wish to permit a node restart for needs_restart=yes properties.
                                If you set such a property without this flag, an assertion error will be raised.
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3322,14 +3322,6 @@ class RedpandaService(RedpandaServiceBase):
             conf.update(
                 dict(http_authentication=self._security.http_authentication))
 
-        # in redpanda, cloud_storage_spillover_manifest_size takes preference over cloud_storage_spillover_manifest_max_segments.
-        # disable the former to use the latter
-        assert conf.get('cloud_storage_spillover_manifest_size', None) is None or \
-            conf.get('cloud_storage_spillover_manifest_max_segments', None) is None, \
-                  "cannot set cloud_storage_spillover_manifest_max_segments if cloud_storage_spillover_manifest_size is already set, it will not be used by redpanda"
-        if 'cloud_storage_spillover_manifest_max_segments' in conf:
-            conf['cloud_storage_spillover_manifest_size'] = None
-
         conf_yaml = yaml.dump(conf)
         for node in self.nodes:
             self.logger.info(

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor, Future
 from threading import Condition
 from collections import defaultdict
 
-from ducktape.mark import matrix, ignore
+from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
@@ -547,7 +547,6 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         self.stop_flag = True
         self.thread_pool.shutdown()
 
-    @ignore  #see https://github.com/redpanda-data/redpanda/issues/16208
     @cluster(num_nodes=4)
     @matrix(cloud_storage_type=get_cloud_storage_type(),
             test_case=get_tiered_storage_test_cases(fast_run=True))

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -312,7 +312,7 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
             'cloud_storage_cache_chunk_size':
             self.chunk_size,
 
-            # Avoid confiugring spillover so tests can do it themselves.
+            # Avoid configuring spillover so tests can do it themselves.
             'cloud_storage_spillover_manifest_size':
             None,
         })

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -506,7 +506,9 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
                 'cloud_storage_manifest_max_upload_interval_sec':
                 1,
                 'cloud_storage_spillover_manifest_max_segments':
-                2
+                2,
+                'cloud_storage_spillover_manifest_size':
+                None,
             },
                                        node=new_version_node)
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

adds `cloud_storage_spillover_manifest_size`: None when a test sets `cloud_storage_spillover_manifest_max_segments`.

`cloud_storage_spillover_manifest_size` takes precedence over the `cloud_storage_spillover_manifest_max_segments` variant https://github.com/redpanda-data/redpanda/blob/cc6bae525e5acdc24397f266876e2d5511a9fe3a/src/v/archival/ntp_archiver_service.cc#L2471-L2483
Now that the *size variant has a default value, the tests were failing because they were expecting a fast spillover while Redpanda behaves in a more "production mode" manner.

additionally, revert an old change in `RedpandaService.set_cluster_config()`: {prop_name: None} values were interpreted as properties to remove from the cluster config, but that reverts the value to the default value. the correct way to set an optional property is to pass it as "prop_name: null" in the upsert field.

Fixes #16193 
Fixes  #16220
Fixes #16208

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
