### PR TITLE
ci: Mark test ok_to_fail untill fix released

### DIFF
--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -10,6 +10,7 @@ import os
 import csv
 
 from ducktape.cluster.remoteaccount import RemoteCommandError
+from ducktape.mark import matrix, ok_to_fail
 from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
@@ -167,6 +168,7 @@ class FlinkBasicTests(RedpandaTest):
 
         return
 
+    @ok_to_fail
     @cluster(num_nodes=4)
     def test_transaction_workload(self):
         """


### PR DESCRIPTION
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
