### PR TITLE
rptest: Refactor consumer validation and tune table idle settings

### DIFF
--- a/tests/rptest/e2e_tests/workloads/flink_table_transactions_basic.py
+++ b/tests/rptest/e2e_tests/workloads/flink_table_transactions_basic.py
@@ -128,6 +128,12 @@ class FlinkWorkloadProduce:
         table_env = StreamTableEnvironment.create(
             stream_execution_environment=env, environment_settings=settings)
 
+        # Tune table idle state handling
+        # Clear the state if it has not changed
+        table_env.get_config().set("table.exec.state.ttl", "60 s")
+        # If a source does not received anything after 5 sec mark it as idle
+        table_env.get_config().set("table.exec.source.idle-timeout", "5000 ms")
+
         # Alternative way to add connector, just for illustrative purposes
         table_env.get_config().set("pipeline.jars", self.config.connector_path)
         # This is needed for Scalar functions work

--- a/tests/rptest/services/flink.py
+++ b/tests/rptest/services/flink.py
@@ -354,7 +354,11 @@ class FlinkService(Service):
 
         # Save node data for future log handling
         self.node = node
-        self.hostname = node.account.hostname
+        # Docker compatibility
+        # While in EC2 hostname and actual hostname is the same,
+        # in docker hostname is the container hash.
+        self.hostname = self.nodes[0].account.ssh_output(
+            "hostname").decode().strip()
         return
 
     def stop_node(self, node):

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -15,6 +15,7 @@ from ducktape.utils.util import wait_until
 
 from rptest.clients.types import TopicSpec
 from rptest.clients.kafka_cli_tools import KafkaCliTools
+from rptest.clients.rpk import RpkTool
 from rptest.e2e_tests.workload_manager import WorkloadManager
 from rptest.services.cluster import cluster
 from rptest.services.flink import FlinkService
@@ -39,6 +40,7 @@ class FlinkBasicTests(RedpandaTest):
                                       user=user,
                                       passwd=passwd,
                                       protocol=protocol)
+        self.rpk = RpkTool(self.redpanda)
         # Prepare Workloads
         self.workload_manager = WorkloadManager(self.logger)
 
@@ -175,6 +177,57 @@ class FlinkBasicTests(RedpandaTest):
             Test uses same workload with different modes to produce
             and consume/process given number of transactions
         """
+        def get_max_data_index(data_path, node):
+            # Max index and target column
+            index_column = 1
+            max_index = 0
+            for f in list_files(data_path, node):
+                # Copy file locally
+                tmpfile = os.path.join("/tmp", "tmpcsvdata")
+                filepath = os.path.join(data_path, f)
+                node.account.copy_from(filepath, tmpfile)
+
+                # processing file with csvreader will give most efficient memory
+                # usage. Only one row will present in memory at all times
+                # newline='' is critical, refer to: https://docs.python.org/3/library/csv.html
+                with open(tmpfile, newline='') as csvfile:
+                    c_reader = csv.reader(csvfile, delimiter=',')
+                    for row in c_reader:
+                        # Second parameter is the quick and dirty value type map
+                        values = self._serialize_csv_row(
+                            row, [int, int, int, str, int, str])
+                        if max_index < values[index_column]:
+                            max_index = values[index_column]
+                # Cleanup
+                os.remove(tmpfile)
+            return max_index
+
+        # Load data output. There should be 1 partition file
+        # with offset at the env equals to _workload_config['count']
+        # Example filename:
+        #     /workloads/data/part-cfbe2720-7117-40fd-8c28-fca31a459ff8-0-0
+        # Data sample:
+        # ...
+        # 542,415,31,"2024-01-09 22:22:43.647",17,TiJJtOuzOkiOsGmws
+        # ...
+        def list_files(data_path, node):
+            files = []
+            try:
+                # Note that there is no need to check file name as tmp file will
+                # have filename started with '.part' and it will not be listed by
+                # bare 'ls -1' command
+                files = node.account.ssh_output(f"ls -1 {data_path}")
+                files = files.decode().splitlines()
+            except RemoteCommandError:
+                # Ignore ssh_output command errors
+                # as folder will not be existent just yet
+                pass
+            return files
+
+        # Tunables
+        random_words_dict_size = 64
+        batch_size = 64
+        total_events = 256
 
         # Start Flink
         self.flink.start()
@@ -182,20 +235,20 @@ class FlinkBasicTests(RedpandaTest):
         # Load python workload to target node
         # Hardcoded file
         # TODO: Add workload config management
-        _data_path = "/workloads/data"
+        data_path = "/workloads/data"
         # Currently, each INSERT operator will generate 1 subjob
         # So this config will generate 256 / 64 jobs
         _workload_config = {
             "log_level": "DEBUG",
             "brokers": self.redpanda.brokers(),
-            "data_path": "file://" + _data_path,
+            "data_path": "file://" + data_path,
             "producer_group": "flink_group",
             "consumer_group": "flink_group",
             "topic_name": self.topic_name,
             "mode": "produce",
-            "word_size": 64,
-            "batch_size": 32,
-            "count": 512
+            "word_size": random_words_dict_size,
+            "batch_size": batch_size,
+            "count": total_events
         }
 
         # Get workload
@@ -223,71 +276,32 @@ class FlinkBasicTests(RedpandaTest):
         assert len(_failed) == 0, \
             f"Flink reports failed consume job for transaction workload {_failed}"
 
-        # Load data output. There should be 1 partition file
-        # with offset at the env equals to _workload_config['count']
-        # Example filename:
-        #     /workloads/data/part-cfbe2720-7117-40fd-8c28-fca31a459ff8-0-0
-        # Data sample:
-        # ...
-        # 542,415,31,"2024-01-09 22:22:43.647",17,TiJJtOuzOkiOsGmws
-        # ...
-        def list_files(path):
-            files = []
-            try:
-                # Note that there is no need to check file name as tmp file will
-                # have filename started with '.part' and it will not be listed by
-                # bare 'ls -1' command
-                files = self.flink.node.account.ssh_output(
-                    f"ls -1 {_data_path}")
-                files = files.decode().splitlines()
-            except RemoteCommandError:
-                # Ignore ssh_output command errors
-                # as folder will not be existent just yet
-                pass
-            return files
-
-        # Wait for file, timeout 5 min (10 sec * 30 iterations)
-        self.logger.info("Waiting for consume workload data file")
-        wait_until(lambda: len(list_files(_data_path)) > 0,
-                   timeout_sec=300,
+        # Wait for file, timeout 10 min (20 sec * 30 iterations)
+        # This will make sure that consumer started working
+        self.logger.info("Waiting for consumer to start writing data")
+        wait_until(lambda: len(list_files(data_path, self.flink.node)) > 0,
+                   timeout_sec=600,
                    backoff_sec=10,
-                   err_msg="Flink transaction workload produced"
+                   err_msg="Flink transaction workload produced "
                    "no data files after 5 min")
 
-        # Load data file and parse it
-        # For most efficient way of processing data it would be more
-        # convenient to copy script to target node and run it there
-        # But this is basic test, and copying file locally is a more
-        # simple approach in this case.
+        # Wait for index in data files to reach total_events
+        # 'count - 1' coz index starts with '0'
+        target_index = total_events - 1
+        self.logger.info("Waiting for consumer to emit message "
+                         f"with index {target_index}")
+        wait_until(lambda: get_max_data_index(data_path, self.flink.node) ==
+                   target_index,
+                   timeout_sec=300,
+                   backoff_sec=60,
+                   err_msg="Flink transaction workload failed to consume "
+                   f"{total_events} messages after 5 min")
 
-        # Max index and target column
-        index_column = 1
-        max_index = 0
-        for f in list_files(_data_path):
-            # Copy file locally
-            tmpfile = os.path.join("/tmp", "tmpcsvdata")
-            filepath = os.path.join(_data_path, f)
-            self.flink.node.account.copy_from(filepath, tmpfile)
-
-            # processing file with csvreader will give most efficient memory
-            # usage. Only one row will present in memory at all times
-            # newline='' is critical, refer to: https://docs.python.org/3/library/csv.html
-            with open(tmpfile, newline='') as csvfile:
-                c_reader = csv.reader(csvfile, delimiter=',')
-                for row in c_reader:
-                    # Second parameter is the quick and dirty value type map
-                    values = self._serialize_csv_row(
-                        row, [int, int, int, str, int, str])
-                    if max_index < values[index_column]:
-                        max_index = values[index_column]
-            # Cleanup
-            os.remove(tmpfile)
-
+        max_index = get_max_data_index(data_path, self.flink.node)
         # Stop flink
         self.flink.stop()
 
-        # 'count - 1' coz index starts with '0'
-        target_index = _workload_config['count'] - 1
+        # Assert the fail
         assert max_index == target_index, \
             f"Flink workload consume max offset is incorrect: {max_index} " \
             f"(should be: {target_index})"

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -170,7 +170,6 @@ class FlinkBasicTests(RedpandaTest):
 
         return
 
-    @ok_to_fail
     @cluster(num_nodes=4)
     def test_transaction_workload(self):
         """
@@ -301,7 +300,9 @@ class FlinkBasicTests(RedpandaTest):
         # Stop flink
         self.flink.stop()
 
-        # Assert the fail
+        # Assert the fail, this is for illustrative purposes and
+        # probably will always pass since wait_until will fail
+        # if max_index would be wrong
         assert max_index == target_index, \
             f"Flink workload consume max offset is incorrect: {max_index} " \
             f"(should be: {target_index})"

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -284,8 +284,14 @@ class FlinkBasicTests(RedpandaTest):
                    err_msg="Flink transaction workload produced "
                    "no data files after 5 min")
 
-        # Wait for index in data files to reach total_events
-        # 'count - 1' coz index starts with '0'
+        # make sure that there is no active jobs
+        # 10 min for safety
+        self.flink.wait(timeout_sec=600)
+
+        # Since there is a possibility that after job is finished
+        # data is still be written from buffers, make sure that
+        # desired index is reached. I.e. index in data files
+        # has to reach target_index
         target_index = total_events - 1
         self.logger.info("Waiting for consumer to emit message "
                          f"with index {target_index}")


### PR DESCRIPTION
Since Table API consumer waits for the index indefinitely, update validation to
- first wait for data file to be created
- then wait for data files to have proper index value

This PR also fixes logs copy for docker envs by properly getting hostname

Fixes: redpanda-data/devprod#1031

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none