### PR TITLE
wasm: transform callback

### DIFF
--- a/src/v/container/include/container/zip.h
+++ b/src/v/container/include/container/zip.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <boost/iterator/zip_iterator.hpp>
+
+#include <tuple>
+
+namespace container {
+namespace detail {
+template<typename IteratorTuple>
+class zipper {
+public:
+    zipper(
+      boost::zip_iterator<IteratorTuple> begin,
+      boost::zip_iterator<IteratorTuple> end)
+      : _begin(begin)
+      , _end(end) {}
+
+    auto begin() const { return _begin; }
+    auto end() const { return _end; }
+
+private:
+    boost::zip_iterator<IteratorTuple> _begin;
+    boost::zip_iterator<IteratorTuple> _end;
+};
+} // namespace detail
+
+/**
+ * A method to zip and iterate over two containers at the same time (at least
+ * until std::views::zip exists).
+ *
+ * NOTE: Containers passed into this method **must** have the same length.
+ *
+ * Example usage:
+ *
+ * ```
+ * std::vector<int> a = ...;
+ * std::vector<std::string> b = ...;
+ * for (const auto& [a_elem, b_elem] : zip(a, b)) {
+ *   // do something fun!
+ * }
+ * ```
+ */
+template<typename... Args>
+auto zip(Args&&... args) {
+    auto begin = boost::make_zip_iterator(boost::make_tuple((args.begin())...));
+    auto end = boost::make_zip_iterator(boost::make_tuple((args.end())...));
+    return detail::zipper(std::move(begin), std::move(end));
+}
+} // namespace container

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -82,7 +82,7 @@ public:
       , _val_size(v_len)
       , _value(std::move(v)) {}
 
-    int32_t memory_usage() const {
+    size_t memory_usage() const {
         return sizeof(*this) + _key.size_bytes() + _value.size_bytes();
     }
     record_header share() {
@@ -167,13 +167,13 @@ public:
 
     // Used for acquiring units from semaphores limiting
     // memory resources.
-    int32_t memory_usage() const {
+    size_t memory_usage() const {
         return sizeof(*this) + _key.size_bytes() + _value.size_bytes()
                + std::accumulate(
                  _headers.begin(),
                  _headers.end(),
-                 int32_t(0),
-                 [](int32_t acc, const record_header& h) {
+                 size_t(0),
+                 [](size_t acc, const record_header& h) {
                      return acc + h.memory_usage();
                  });
     }
@@ -718,7 +718,7 @@ public:
                || (_header.attrs.is_control() && _header.producer_id >= 0);
     }
 
-    int32_t memory_usage() const {
+    size_t memory_usage() const {
         return sizeof(*this) + _records.size_bytes();
     }
 

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -229,10 +229,15 @@ public:
     static std::optional<transformed_data> create_validated(iobuf);
 
     /**
+     * Create a transformed record from a record, generally used in testing.
+     */
+    static transformed_data from_record(record);
+
+    /**
      * Create a batch from transformed_data.
      */
-    static model::record_batch
-      make_batch(model::timestamp, ss::chunked_fifo<transformed_data>);
+    static record_batch
+      make_batch(timestamp, ss::chunked_fifo<transformed_data>);
 
     /**
      * Generate a serialized record from the following metadata.

--- a/src/v/transform/tests/CMakeLists.txt
+++ b/src/v/transform/tests/CMakeLists.txt
@@ -68,3 +68,18 @@ rp_test(
   ARGS "-- -c 1"
   LABELS transform
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME
+    transfer_queue_test
+  SOURCES
+    transfer_queue_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::model_test_utils
+    v::transform
+  ARGS "-- -c 1"
+  LABELS transform
+)

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -44,8 +44,10 @@ public:
         filter,
     };
 
-    ss::future<model::record_batch>
-    transform(model::record_batch batch, wasm::transform_probe*) override;
+    ss::future<> transform(
+      model::record_batch batch,
+      wasm::transform_probe*,
+      wasm::transform_callback) override;
 
     void set_mode(mode m);
 

--- a/src/v/transform/tests/transfer_queue_test.cc
+++ b/src/v/transform/tests/transfer_queue_test.cc
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/units.h"
+#include "test_utils/async.h"
+#include "transform/transfer_queue.h"
+
+#include <seastar/core/abort_source.hh>
+
+#include <gtest/gtest.h>
+
+#include <optional>
+
+namespace transform {
+namespace {
+
+struct entry {
+    size_t mem;
+
+    explicit entry(size_t mem)
+      : mem(mem) {}
+    entry(const entry&) = delete;
+    entry& operator=(const entry&) = delete;
+    entry(entry&&) = default;
+    entry& operator=(entry&&) = default;
+
+    size_t memory_usage() const { return mem; }
+};
+
+TEST(TransferQueue, IsFifo) {
+    ss::abort_source as;
+    transfer_queue<entry> q(32_KiB);
+    for (int i = 1; i <= 3; ++i) {
+        q.push(entry{i * 1_KiB}, &as).get();
+    }
+    for (int i = 1; i <= 3; ++i) {
+        auto entry = q.pop_one(&as).get();
+        ASSERT_NE(entry, std::nullopt);
+        EXPECT_EQ(entry->mem, i * 1_KiB);
+    }
+    auto fut = q.pop_one(&as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    as.request_abort();
+    EXPECT_EQ(fut.get(), std::nullopt);
+}
+
+TEST(TransferQueue, IsBatchFifo) {
+    ss::abort_source as;
+    transfer_queue<entry> q(32_KiB);
+    for (int i = 1; i <= 3; ++i) {
+        q.push(entry{i * 1_KiB}, &as).get();
+    }
+    auto entries = q.pop_all(&as).get();
+    ASSERT_EQ(entries.size(), 3);
+    for (int i = 1; i <= 3; ++i) {
+        EXPECT_EQ(entries.front().mem, i * 1_KiB);
+        entries.pop_front();
+    }
+}
+
+TEST(TransferQueue, PopCanBeAborted) {
+    ss::abort_source as;
+    transfer_queue<entry> q(2_KiB);
+    auto fut = q.pop_all(&as);
+    EXPECT_FALSE(fut.available());
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    as.request_abort();
+    tests::drain_task_queue().get();
+    EXPECT_TRUE(fut.available());
+}
+
+TEST(TransferQueue, LimitsMemoryUsage) {
+    ss::abort_source as;
+    transfer_queue<entry> q(8);
+    q.push(entry{4}, &as).get();
+    q.push(entry{2}, &as).get();
+    q.push(entry{1}, &as).get();
+    q.push(entry{1}, &as).get();
+    auto fut = q.push(entry{2}, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    q.pop_all(&as).get();
+    fut.get();
+    q.push(entry{6}, &as).get();
+    fut = q.push(entry{1}, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    EXPECT_NE(q.pop_one(&as).get(), std::nullopt);
+    fut.get();
+}
+
+TEST(TransferQueue, CanAlwaysPushAtLeastOneEntry) {
+    ss::abort_source as;
+    transfer_queue<entry> q(1);
+    q.push(entry{10}, &as).get();
+    auto fut = q.push(entry{20}, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    q.pop_one(&as).get();
+    fut.get();
+}
+
+TEST(TransferQueue, PushCanBeAborted) {
+    ss::abort_source as;
+    transfer_queue<entry> q(1);
+    q.push(entry{10}, &as).get();
+    auto fut = q.push(entry{20}, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    as.request_abort();
+    fut.get();
+}
+
+} // namespace
+} // namespace transform

--- a/src/v/transform/transfer_queue.h
+++ b/src/v/transform/transfer_queue.h
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/seastarx.h"
+#include "ssx/semaphore.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/semaphore.hh>
+
+#include <algorithm>
+#include <optional>
+
+namespace transform {
+
+template<typename T>
+concept MemoryMeasurable = requires(const T v) {
+    { v.memory_usage() } -> std::convertible_to<size_t>;
+};
+
+constexpr size_t default_items_per_chunk = 128;
+
+/**
+ * A queue for transfering variable sized entries between fibers.
+ *
+ * If needing a fixed number of elements (or have entries with fixed memory
+ * requirements) ss::queue is a better option. This queue limits based on the
+ * presence of a `memory_usage()` method. Note that this limit is a soft limit
+ * and we prefer making progress over keeping the limit. Concretely that means
+ * that if this queue is empty, `push` will always succeed.
+ *
+ * All public methods in the queue can be aborted using an existing
+ * `ss::abort_source`.
+ *
+ */
+template<MemoryMeasurable T, size_t items_per_chunk = default_items_per_chunk>
+class transfer_queue {
+public:
+    /**
+     * Construct a transfer queue with `max_memory_usage` being the soft limit
+     * at which to limit in the queue.
+     */
+    explicit transfer_queue(size_t max_memory_usage)
+      : _max_memory(max_memory_usage)
+      , _memory_sem(max_memory_usage, "transform::transfer_queue") {}
+
+    /**
+     * Push an entry into the queue, waiting for there to be available memory.
+     *
+     * NOTE: in the case of an empty queue, this operation always succeeds as
+     * the memory limit is soft and we prioritize making progress.
+     *
+     * If the abort source fires, we will noop the push and drop the entry on
+     * the floor.
+     */
+    ss::future<> push(T entry, ss::abort_source* as) {
+        // We want to be able to always insert at least one item, so cap memory
+        // usage by _max_memory so we don't overload our semaphore and so we
+        // can't get stuck.
+        size_t mem = std::min(entry.memory_usage(), _max_memory);
+        try {
+            co_await _memory_sem.wait(*as, mem);
+        } catch (const ss::semaphore_aborted&) {
+            co_return;
+        }
+        _entries.push_back(std::move(entry));
+        _cond_var.signal();
+    }
+
+    /**
+     * Take a single element out of the queue waiting until there is one.
+     *
+     * If the provided about_source is aborted, then this method will return
+     * `std::nullopt`.
+     */
+    ss::future<std::optional<T>> pop_one(ss::abort_source* as) {
+        co_await wait_for_non_empty(as);
+        if (as->abort_requested() || _entries.empty()) {
+            co_return std::nullopt;
+        }
+        T entry = std::move(_entries.front());
+        _entries.pop_front();
+        _memory_sem.signal(std::min(entry.memory_usage(), _max_memory));
+        co_return entry;
+    }
+
+    /**
+     * Extract all entries from this queue as soon as it is non-empty.
+     *
+     * If the abort_source is aborted, then this method will return an empty
+     * container.
+     */
+    ss::future<ss::chunked_fifo<T, items_per_chunk>>
+    pop_all(ss::abort_source* as) {
+        co_await wait_for_non_empty(as);
+        if (as->abort_requested()) {
+            co_return ss::chunked_fifo<T, items_per_chunk>{};
+        }
+        _memory_sem.signal(current_memory_usage());
+        co_return std::exchange(_entries, {});
+    }
+
+    /**
+     * Remove all entries from this queue.
+     */
+    void clear() {
+        _entries.clear();
+        _memory_sem.signal(current_memory_usage());
+    }
+
+private:
+    size_t current_memory_usage() const {
+        return _max_memory - _memory_sem.available_units();
+    }
+
+    ss::future<> wait_for_non_empty(ss::abort_source* as) {
+        auto sub = as->subscribe([this]() noexcept { _cond_var.signal(); });
+        if (sub) {
+            co_await _cond_var.wait([this, as] {
+                return as->abort_requested() || !_entries.empty();
+            });
+        }
+    }
+
+    ss::chunked_fifo<T, items_per_chunk> _entries;
+    ss::condition_variable _cond_var;
+    size_t _max_memory;
+    ssx::semaphore _memory_sem;
+};
+
+} // namespace transform

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -22,10 +22,13 @@
 #include "transform/logger.h"
 #include "wasm/api.h"
 
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/chunked_fifo.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/queue.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/util/variant_utils.hh>
 
 #include <optional>
 
@@ -34,9 +37,15 @@ namespace transform {
 namespace {
 
 class queue_output_consumer {
+    static constexpr size_t buffer_chunk_size = 8;
+
 public:
-    queue_output_consumer(ss::queue<model::record_batch>* output, probe* probe)
+    queue_output_consumer(
+      transfer_queue<model::record_batch, buffer_chunk_size>* output,
+      ss::abort_source* as,
+      probe* probe)
       : _output(output)
+      , _as(as)
       , _probe(probe) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch b) {
@@ -45,14 +54,15 @@ public:
         // model::record_batch.
         _last_offset = model::offset_cast(b.last_offset());
         _probe->increment_read_bytes(b.size_bytes());
-        co_await _output->push_eventually(std::move(b));
+        co_await _output->push(std::move(b), _as);
         co_return ss::stop_iteration::no;
     }
     std::optional<kafka::offset> end_of_stream() const { return _last_offset; }
 
 private:
     std::optional<kafka::offset> _last_offset;
-    ss::queue<model::record_batch>* _output;
+    transfer_queue<model::record_batch, buffer_chunk_size>* _output;
+    ss::abort_source* _as;
     probe* _probe;
 };
 
@@ -60,32 +70,6 @@ struct drain_result {
     ss::chunked_fifo<model::record_batch> batches;
     kafka::offset latest_offset;
 };
-
-ss::future<drain_result>
-drain_queue(ss::queue<transformed_batch>* queue, probe* p) {
-    static constexpr size_t max_batches_bytes = 1_MiB;
-    if (queue->empty()) {
-        co_await queue->not_empty();
-    }
-    drain_result result;
-    size_t batches_size = 0;
-    while (!queue->empty()) {
-        auto batch_size = queue->front().batch.size_bytes();
-        batches_size += queue->front().batch.size_bytes();
-        // ensure if there is a large batch we make some progress
-        // otherwise cap how much data we send to the sink at once.
-        if (!result.batches.empty() && batches_size > max_batches_bytes) {
-            break;
-        }
-        p->increment_write_bytes(batch_size);
-        auto transformed = queue->pop();
-        result.latest_offset = transformed.input_offset;
-        if (transformed.batch.record_count() > 0) {
-            result.batches.push_back(std::move(transformed.batch));
-        }
-    }
-    co_return result;
-}
 
 /**
  * A specific exception to throw on processor::stop so that we're not accidently
@@ -96,6 +80,10 @@ class processor_shutdown_exception : public std::exception {
         return "processor shutting down";
     }
 };
+
+// TODO(rockwood): This is an arbitrary value, we should instead be
+// limiting the size based on the amount of memory in the transform subsystem.
+constexpr size_t max_buffer_size = 64_KiB;
 
 } // namespace
 
@@ -118,8 +106,8 @@ processor::processor(
   , _offset_tracker(std::move(offset_tracker))
   , _state_callback(std::move(cb))
   , _probe(p)
-  , _consumer_transform_pipe(1)
-  , _transform_producer_pipe(1)
+  , _consumer_transform_pipe(max_buffer_size)
+  , _transform_producer_pipe(max_buffer_size)
   , _task(ss::now())
   , _logger(tlog, ss::format("{}/{}", _meta.name(), _ntp.tp.partition())) {
     vassert(
@@ -141,8 +129,6 @@ ss::future<> processor::start() {
     _as = {};
     co_await _source->start();
     co_await _offset_tracker->start();
-    _consumer_transform_pipe = ss::queue<model::record_batch>(1);
-    _transform_producer_pipe = ss::queue<transformed_batch>(1);
     _task = handle_processor_task(_engine->start().then([this] {
         return load_start_offset().then([this](kafka::offset start_offset) {
             // Mark that we're running now that the start offset is loaded.
@@ -163,9 +149,9 @@ ss::future<> processor::stop() {
     }
     auto ex = std::make_exception_ptr(processor_shutdown_exception());
     _as.request_abort_ex(ex);
-    _consumer_transform_pipe.abort(ex);
-    _transform_producer_pipe.abort(ex);
     co_await std::exchange(_task, ss::now());
+    _consumer_transform_pipe.clear();
+    _transform_producer_pipe.clear();
     co_await _source->stop();
     co_await _offset_tracker->stop();
     co_await _engine->stop();
@@ -216,7 +202,7 @@ ss::future<> processor::run_consumer_loop(kafka::offset offset) {
     while (!_as.abort_requested()) {
         auto reader = co_await _source->read_batch(offset, &_as);
         auto last_offset = co_await std::move(reader).consume(
-          queue_output_consumer(&_consumer_transform_pipe, _probe),
+          queue_output_consumer(&_consumer_transform_pipe, &_as, _probe),
           model::no_timeout);
         if (!last_offset) {
             vlog(
@@ -233,28 +219,48 @@ ss::future<> processor::run_consumer_loop(kafka::offset offset) {
 
 ss::future<> processor::run_transform_loop() {
     while (!_as.abort_requested()) {
-        auto batch = co_await _consumer_transform_pipe.pop_eventually();
-        auto offset = model::offset_cast(batch.last_offset());
+        auto batch = co_await _consumer_transform_pipe.pop_one(&_as);
+        if (!batch) {
+            continue;
+        }
+        auto offset = model::offset_cast(batch->last_offset());
         ss::chunked_fifo<model::transformed_data> transformed;
         co_await _engine->transform(
-          std::move(batch),
+          std::move(*batch),
           _probe,
           [&transformed](model::transformed_data data) {
               transformed.push_back(std::move(data));
           });
-        batch = model::transformed_data::make_batch(
-          model::timestamp::now(), std::move(transformed));
-        co_await _transform_producer_pipe.push_eventually(
-          {.batch = std::move(batch), .input_offset = offset});
+        if (!transformed.empty()) {
+            auto b = model::transformed_data::make_batch(
+              model::timestamp::now(), std::move(transformed));
+            co_await _transform_producer_pipe.push({std::move(b)}, &_as);
+        }
+        co_await _transform_producer_pipe.push({offset}, &_as);
     }
 }
 
 ss::future<> processor::run_producer_loop() {
     while (!_as.abort_requested()) {
-        auto drained = co_await drain_queue(&_transform_producer_pipe, _probe);
-        co_await _sinks[0]->write(std::move(drained.batches));
-        co_await _offset_tracker->commit_offset(drained.latest_offset);
-        report_lag(_source->latest_offset() - drained.latest_offset);
+        auto popped = co_await _transform_producer_pipe.pop_all(&_as);
+        if (popped.empty()) {
+            continue;
+        }
+        kafka::offset latest_offset;
+        ss::chunked_fifo<model::record_batch> batches;
+        for (auto& entry : popped) {
+            ss::visit(
+              entry.data,
+              [&batches](model::record_batch& b) {
+                  batches.push_back(std::move(b));
+              },
+              [&latest_offset](kafka::offset o) { latest_offset = o; });
+        }
+        co_await _sinks[0]->write(std::move(batches));
+        if (latest_offset != kafka::offset()) {
+            co_await _offset_tracker->commit_offset(latest_offset);
+            report_lag(_source->latest_offset() - latest_offset);
+        }
     }
 }
 
@@ -289,4 +295,18 @@ bool processor::is_running() const {
     return !_as.abort_requested();
 }
 int64_t processor::current_lag() const { return _last_reported_lag; }
+
+size_t transformed_output::memory_usage() const {
+    return sizeof(transformed_output)
+           + ss::visit(
+             data,
+             [](const model::record_batch& b) {
+                 // Account for the size of this struct, but don't double count
+                 // sizeof(model::record_batch), which b.memory_usage() accounts
+                 // for.
+                 return b.memory_usage() - sizeof(model::record_batch);
+             },
+             [](kafka::offset) { return size_t(0); });
+}
+
 } // namespace transform

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -17,10 +17,18 @@
 #include "pandaproxy/schema_registry/fwd.h"
 #include "wasm/fwd.h"
 
+#include <seastar/util/noncopyable_function.hh>
+
 #include <chrono>
 #include <memory>
 
 namespace wasm {
+
+/**
+ * The callback for when data emitted from the transform.
+ */
+using transform_callback
+  = ss::noncopyable_function<void(model::transformed_data)>;
 
 /**
  * A wasm engine is a running VM loaded with a user module and capable of
@@ -30,8 +38,8 @@ namespace wasm {
  */
 class engine {
 public:
-    virtual ss::future<model::record_batch>
-    transform(model::record_batch batch, transform_probe* probe) = 0;
+    virtual ss::future<>
+    transform(model::record_batch, transform_probe*, transform_callback) = 0;
 
     virtual ss::future<> start() = 0;
     virtual ss::future<> stop() = 0;

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -74,13 +74,15 @@ public:
       : _underlying(std::move(underlying))
       , _factory(std::move(f)) {}
 
-    ss::future<model::record_batch>
-    transform(model::record_batch batch, transform_probe* probe) override {
+    ss::future<> transform(
+      model::record_batch batch,
+      transform_probe* probe,
+      transform_callback cb) override {
         auto u = co_await _mu.get_units();
-        auto fut = co_await ss::coroutine::as_future<model::record_batch>(
-          _underlying->transform(std::move(batch), probe));
+        auto fut = co_await ss::coroutine::as_future(
+          _underlying->transform(std::move(batch), probe, std::move(cb)));
         if (!fut.failed()) {
-            co_return fut.get();
+            co_return;
         }
         // Restart the engine
         try {


### PR DESCRIPTION
Instead of buffering in the wasm layer we will have a callback for when data is emitted from the VM.

This will allow us to account for memory easier and will allow us to recieved additional data in the callback like which topic it should be output to.

Additional benefits/bug fixes:
* Fixes timing of execution for a single transform.
* Will allow us to batch independant of the transform, which will be important in the future as we need to handle output batches being over the size limit.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
