### PR TITLE
sh/linter: fix linting issues on flink deps script

### DIFF
--- a/tests/docker/ducktape-deps/flink
+++ b/tests/docker/ducktape-deps/flink
@@ -23,7 +23,7 @@ wget https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-k
 # At this point, for ARM64 there is no JAVA_HOME, but java is installed
 # So get the folder from java itself
 if [[ -z $JAVA_HOME ]]; then
-  export JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | cut -d'=' -f2 | xargs);
+  export JAVA_HOME=$(java -XshowSettings:properties -version 2>&1> /dev/null | grep 'java.home' | cut -d'=' -f2 | xargs)
 fi
 echo "Using Java home folder at $JAVA_HOME"
 
@@ -37,4 +37,4 @@ pip uninstall -y virtualenv
 cd flink_venv
 tar -zcvf ../flink_venv.tgz ./*
 cd ..
-rm -rf flink_venv   
+rm -rf flink_venv


### PR DESCRIPTION
Shell linter is failing due to this

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
