### PR TITLE
[v23.2.x] metrics: fix kafka_max_offset on read replicas

### DIFF
--- a/src/v/cluster/partition_probe.cc
+++ b/src/v/cluster/partition_probe.cc
@@ -212,6 +212,14 @@ void replicated_partition_probe::setup_public_metrics(const model::ntp& ntp) {
         sm::make_gauge(
           "max_offset",
           [this] {
+              // TODO: merge code with replicated_partition.h?
+              if (_partition.is_read_replica_mode_enabled()) {
+                  if (_partition.cloud_data_available()) {
+                      return _partition.next_cloud_offset();
+                  }
+                  // This is a read replica and there's no data in the cloud.
+                  return model::offset(0);
+              }
               auto log_offset = _partition.high_watermark();
               auto translator = _partition.get_offset_translator_state();
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -954,10 +954,25 @@ class RedpandaServiceBase(Service):
                 for sample in family.samples:
                     if sample.name != metric_name:
                         continue
-                    if ns and sample.labels["namespace"] != ns:
-                        continue
-                    if topic and sample.labels["topic"] != topic:
-                        continue
+                    labels = sample.labels
+                    if ns:
+                        if "redpanda_namespace" in labels:
+                            if labels["redpanda_namespace"] != ns:
+                                continue
+                        elif "namespace" in labels:
+                            if labels["namespace"] != ns:
+                                continue
+                        else:
+                            assert False, f"Missing namespace label: {sample}"
+                    if topic:
+                        if "redpanda_topic" in labels:
+                            if labels["redpanda_topic"] != topic:
+                                continue
+                        elif "topic" in labels:
+                            if labels["topic"] != topic:
+                                continue
+                        else:
+                            assert False, f"Missing topic label: {sample}"
                     count += int(sample.value)
         return count
 

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -19,7 +19,7 @@ from rptest.util import expect_exception
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 
-from rptest.services.redpanda import CloudStorageType, RedpandaService, get_cloud_storage_type, make_redpanda_service
+from rptest.services.redpanda import CloudStorageType, MetricsEndpoint, RedpandaService, get_cloud_storage_type, make_redpanda_service
 from rptest.services.redpanda_installer import InstallOptions, RedpandaInstaller
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.utils.expect_rate import ExpectRate, RateTarget
@@ -238,6 +238,13 @@ class TestReadReplicaService(EndToEndTest):
             backoff_sec=5,
             err_msg="Could not create read replica topic. Most likely " +
             "because topic manifest is not in S3.")
+        if num_messages > 0:
+            wait_until(lambda: self.second_cluster.metric_sum(
+                "redpanda_kafka_max_offset",
+                topic=self.topic_name,
+                metrics_endpoint=MetricsEndpoint.PUBLIC_METRICS) > 0,
+                       timeout_sec=10,
+                       backoff_sec=1)
 
     def _bucket_usage(self) -> BucketUsage:
         assert self.redpanda and self.redpanda.cloud_storage_client


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/16263

CONFLICT:
- removed the ducktape changes required for the cloud service since that infra isn't in v23.2.x

Fixes https://github.com/redpanda-data/redpanda/issues/16274
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
### Bug Fixes

* Fixes a bug that would previously cause read replicas to report the wrong value for the `redpand_kafka_max_offset` metric.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
