### PR TITLE
rptest: simplify metric_sum filtering

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1068,23 +1068,15 @@ class RedpandaServiceBase(Service):
                         continue
                     labels = sample.labels
                     if ns:
-                        if "redpanda_namespace" in labels:
-                            if labels["redpanda_namespace"] != ns:
-                                continue
-                        elif "namespace" in labels:
-                            if labels["namespace"] != ns:
-                                continue
-                        else:
-                            assert False, f"Missing namespace label: {sample}"
+                        assert "redpanda_namespace" in labels or "namespace" in labels, f"Missing namespace label: {sample}"
+                        if labels.get("redpanda_namespace",
+                                      labels.get("namespace")) != ns:
+                            continue
                     if topic:
-                        if "redpanda_topic" in labels:
-                            if labels["redpanda_topic"] != topic:
-                                continue
-                        elif "topic" in labels:
-                            if labels["topic"] != topic:
-                                continue
-                        else:
-                            assert False, f"Missing topic label: {sample}"
+                        assert "redpanda_topic" in labels or "topic" in labels, f"Missing topic label: {sample}"
+                        if labels.get("redpanda_topic",
+                                      labels.get("topic")) != topic:
+                            continue
                     count += int(sample.value)
         return count
 
@@ -1660,23 +1652,15 @@ class RedpandaServiceCloud(RedpandaServiceK8s):
             for sample in family.samples:
                 labels = sample.labels
                 if ns:
-                    if "redpanda_namespace" in labels:
-                        if labels["redpanda_namespace"] != ns:
-                            continue
-                    elif "namespace" in labels:
-                        if labels["namespace"] != ns:
-                            continue
-                    else:
-                        assert False, f"Missing namespace label: {sample}"
+                    assert "redpanda_namespace" in labels or "namespace" in labels, f"Missing namespace label: {sample}"
+                    if labels.get("redpanda_namespace",
+                                  labels.get("namespace")) != ns:
+                        continue
                 if topic:
-                    if "redpanda_topic" in labels:
-                        if labels["redpanda_topic"] != topic:
-                            continue
-                    elif "topic" in labels:
-                        if labels["topic"] != topic:
-                            continue
-                    else:
-                        assert False, f"Missing topic label: {sample}"
+                    assert "redpanda_topic" in labels or "topic" in labels, f"Missing topic label: {sample}"
+                    if labels.get("redpanda_topic",
+                                  labels.get("topic")) != topic:
+                        continue
                 if sample.name == metric_name:
                     count += int(sample.value)
         return count


### PR DESCRIPTION
Follow-up to e567d63 (#16263) to simplify the metrics_sum filtering.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
