### PR TITLE
[v23.3.x] rptest: Wait for the group to be in a stable state before starting tests

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -91,7 +91,7 @@ class ConsumerGroupTest(RedpandaTest):
 
         def group_is_ready():
             gr = rpk.group_describe(group=group, summary=True)
-            return gr.members == consumer_count
+            return gr.members == consumer_count and gr.state == "Stable"
 
         wait_until(group_is_ready, 60, 1)
         return consumers


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16127
