### PR TITLE
[v23.2.x] cloud_storage: hold gate in hydration

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -976,12 +976,16 @@ ss::future<> remote_segment::hydrate(storage::opt_abort_source_t as) {
 
     // A no-op abort source is created on heap so that `do_hydrate` can call
     // `with_timeout_abortable` if we do not have an input abort source.
-    return ss::do_with(ss::abort_source{}, [this, as](ss::abort_source& noop) {
-        return do_hydrate(
-          as.value_or(noop),
-          ss::lowres_clock::now()
-            + config::shard_local_cfg().cloud_storage_hydration_timeout_ms());
-    });
+    return ss::do_with(
+             ss::abort_source{},
+             [this, as](ss::abort_source& noop) {
+                 return do_hydrate(
+                   as.value_or(noop),
+                   ss::lowres_clock::now()
+                     + config::shard_local_cfg()
+                         .cloud_storage_hydration_timeout_ms());
+             })
+      .finally([holder = std::move(g)] {});
 }
 
 ss::future<> remote_segment::hydrate_chunk(segment_chunk_range range) {
@@ -1038,6 +1042,7 @@ remote_segment::materialize_chunk(chunk_start_offset_t chunk_start) {
 
 ss::future<std::vector<model::tx_range>>
 remote_segment::aborted_transactions(model::offset from, model::offset to) {
+    auto g = _gate.hold();
     co_await hydrate();
     std::vector<model::tx_range> result;
     if (!_tx_range) {


### PR DESCRIPTION
Most places were already holding the gate external to calls of hydrate() with the exception of aborted_transactions(). This commit fixes this by:
- holding the gate during aborted_transactions()
- making hydrate() hold the gate for the duration of its future

(cherry picked from commit 0aefe35edc2d4a693ed23135bc957d01ff1d6319)

Fixes https://github.com/redpanda-data/redpanda/issues/15708
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

* none
<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none