### PR TITLE
cloud_storage_compaction_test: a couple test fixes

### DIFF
--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -166,6 +166,14 @@ class CloudStorageCompactionTest(EndToEndTest):
     def _setup_read_replica(self):
         self._init_redpanda_read_replica()
         self.rr_cluster.start(start_si=False)
+
+        # Explicitly create the consumer offsets topic to avoid it uploading.
+        rpk_rr_cluster = RpkTool(self.rr_cluster)
+        conf = {
+            'redpanda.remote.write': "false",
+        }
+        rpk_rr_cluster.create_topic("__consumer_offsets", config=conf)
+
         wait_until(self._create_read_repica_topic_success,
                    timeout_sec=30,
                    backoff_sec=5)

--- a/tests/rptest/scale_tests/cloud_storage_compaction_test.py
+++ b/tests/rptest/scale_tests/cloud_storage_compaction_test.py
@@ -211,12 +211,12 @@ class CloudStorageCompactionTest(EndToEndTest):
 
         # read replica success and failures
         rr_upload_successes = sum([
-            sample.value for sample in self.redpanda.metrics_sample(
+            sample.value for sample in self.rr_cluster.metrics_sample(
                 "cloud_storage_successful_uploads",
                 metrics_endpoint=MetricsEndpoint.METRICS).samples
         ])
         rr_upload_failures = sum([
-            sample.value for sample in self.redpanda.metrics_sample(
+            sample.value for sample in self.rr_cluster.metrics_sample(
                 "cloud_storage_failed_uploads",
                 metrics_endpoint=MetricsEndpoint.METRICS).samples
         ])


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

There were a couple issues with this test:
- we were previously using the wrong cluster's metrics to determine whether the read replica cluster was uploading anything
- the read replica cluster _was_ uploading (or trying to) since the consumer offsets topic was created with the default tiered storage configuration for that cluster

Fixes #16008

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
