### PR TITLE
rm_stm: remove mem_state::last_end_tx

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -525,7 +525,6 @@ private:
           model::producer_identity,
           model::offset>
           estimated;
-        model::offset last_end_tx{-1};
 
         // depending on the inflight state we may use last_applied or
         // committed_index as LSO; the alternation between them may


### PR DESCRIPTION
It looks like last_end_tx was added to fix a violation when the code had lazy catchup on an abort transaction.

This field was added in commit [1] when the abort code looked like this [2]

```
    if (_mem_state.last_end_tx < r.value().last_offset) {
        _mem_state.last_end_tx = r.value().last_offset;
    }

    // don't need to wait for apply because tx is already aborted on the
    // coordinator level - nothing can go wrong
    co_return tx_errc::none;
}
```

This sort of seemed like an optimization where we could skip the wait and defer it to next command if needed.

However the code changed later in this commit [3] where an explicit wait after abort added thus obviating the need for this field.

Just looking at the code, anywhere this field is updated, we immediately have a wait for state machine to catchup until that offset which means any subsequent wait for it will anyway be a no-op, hence removing it.

This is a part of clean up before moving fields to producer_state.

[1] https://github.com/redpanda-data/redpanda/commit/51f42c1ff6574a664f13f477be489387180c7c57
[2] https://github.com/rystsov/redpanda/blob/51f42c1ff6574a664f13f477be489387180c7c57/src/v/cluster/rm_stm.cc#L656
[3] https://github.com/redpanda-data/redpanda/commit/d8c52549e4c9870cd65e09a9f40e7779db95d924

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
