### PR TITLE
Fixed large allocation in `kafka::wait_for_leaders`

### DIFF
--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -178,7 +178,7 @@ void generate_not_controller_errors(Iter begin, Iter end, ErrIter out_it) {
 }
 
 // Wait for leaders of all topic partitons for given set of results
-ss::future<std::vector<model::node_id>> wait_for_leaders(
+ss::future<> wait_for_leaders(
   cluster::metadata_cache&,
   std::vector<cluster::topic_result>,
   model::timeout_clock::time_point);

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -94,6 +94,9 @@ class TopicRecreateTest(RedpandaTest):
         rpk = RpkTool(self.redpanda)
 
         def topic_is_healthy():
+            if not swarm.is_alive(swarm.nodes[0]):
+                swarm.stop()
+                swarm.start()
             partitions = rpk.describe_topic(spec.name)
             hw_offsets = [p.high_watermark for p in partitions]
             offsets_present = [hw > 0 for hw in hw_offsets]
@@ -106,7 +109,10 @@ class TopicRecreateTest(RedpandaTest):
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
-            wait_until(topic_is_healthy, 30, 2)
+            wait_until(topic_is_healthy,
+                       30,
+                       2,
+                       err_msg=f"Topic {spec.name} health")
             sleep(5)
 
         swarm.stop()


### PR DESCRIPTION
Previously we used a simple `std::vector` of futures to make
waiting for partition leaders concurrent. Using a vector has a drawback
when dealing with large number of topics and partitions since it may be
required to allocate large contiguous chunk of memory for a future
vector. In this particular case we may not use a fragmented vector or
chunked fifo as the `when_all` uses a plain vector internally.

To make sure no large chunk of memory is allocated to wait for the
partition leaders changed the logic to use
`seastar::max_concurrent_for_each`.

Fixes: #15908, #16270
Fixes: #16036
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none