### PR TITLE
transform: validate wasm binaries at deploy time

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -104,6 +104,7 @@ fetch_dep(hdrhistogram
 list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --no-default-features)
 list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=async)
 list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=addr2line)
+list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=wat)
 
 # We need submodules for wasmtime to compile
 FetchContent_Declare(

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -110,7 +110,7 @@ list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=wat)
 FetchContent_Declare(
   wasmtime
   GIT_REPOSITORY https://github.com/bytecodealliance/wasmtime
-  GIT_TAG v15.0.0
+  GIT_TAG v16.0.0
   GIT_PROGRESS TRUE
   USES_TERMINAL_DOWNLOAD TRUE
   OVERRIDE_FIND_PACKAGE

--- a/licenses/third_party.md
+++ b/licenses/third_party.md
@@ -49,11 +49,11 @@ please keep this up to date with every new library use.
 These are dependencies of wasmtime and can be generated via a script like:
 
 ```bash
-# Make sure you run this in the vtools directory with the patched wasmtime to remove the features we don't need.
+# Make sure you run this in a checked out wasmtime repo with the same version that we use.
 rm -f /tmp/license.md
 for target in x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu
 do
-    cargo license --avoid-build-deps --avoid-dev-deps --filter-platform=$target --json \
+    cargo license --no-default-features --features=async --features=wat --avoid-build-deps --avoid-dev-deps --filter-platform=$target --json \
       | jq 'map({name, license})' | jq -r '(.[0] | keys_unsorted) as $keys | map([.[ $keys[] ]])[] | @text "| \(.[0]) | \(.[1]) |"' \
       >> /tmp/license.md
 done
@@ -65,7 +65,6 @@ cat /tmp/license.md | sort | uniq
 | :---------- | :------------ |
 | addr2line | Apache-2.0 OR MIT |
 | ahash | Apache-2.0 OR MIT |
-| aho-corasick | MIT OR Unlicense |
 | anyhow | Apache-2.0 OR MIT |
 | arbitrary | Apache-2.0 OR MIT |
 | async-trait | Apache-2.0 OR MIT |
@@ -89,7 +88,6 @@ cat /tmp/license.md | sort | uniq
 | cranelift-native | Apache-2.0 WITH LLVM-exception |
 | cranelift-wasm | Apache-2.0 WITH LLVM-exception |
 | crc32fast | Apache-2.0 OR MIT |
-| crossbeam-channel | Apache-2.0 OR MIT |
 | crossbeam-deque | Apache-2.0 OR MIT |
 | crossbeam-epoch | Apache-2.0 OR MIT |
 | crossbeam-utils | Apache-2.0 OR MIT |
@@ -101,10 +99,9 @@ cat /tmp/license.md | sort | uniq
 | dirs-sys-next | Apache-2.0 OR MIT |
 | either | Apache-2.0 OR MIT |
 | encoding_rs | (Apache-2.0 OR MIT) AND BSD-3-Clause |
-| env_logger | Apache-2.0 OR MIT |
 | equivalent | Apache-2.0 OR MIT |
+| errno | Apache-2.0 OR MIT |
 | fallible-iterator | Apache-2.0 OR MIT |
-| form_urlencoded | Apache-2.0 OR MIT |
 | futures | Apache-2.0 OR MIT |
 | futures-channel | Apache-2.0 OR MIT |
 | futures-core | Apache-2.0 OR MIT |
@@ -119,12 +116,8 @@ cat /tmp/license.md | sort | uniq
 | gimli | Apache-2.0 OR MIT |
 | hashbrown | Apache-2.0 OR MIT |
 | heck | Apache-2.0 OR MIT |
-| humantime | Apache-2.0 OR MIT |
 | id-arena | Apache-2.0 OR MIT |
-| idna | Apache-2.0 OR MIT |
 | indexmap | Apache-2.0 OR MIT |
-| io-lifetimes | Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT |
-| is-terminal | MIT |
 | itertools | Apache-2.0 OR MIT |
 | itoa | Apache-2.0 OR MIT |
 | ittapi | BSD-3-Clause OR GPL-2.0-only |
@@ -136,26 +129,16 @@ cat /tmp/license.md | sort | uniq
 | memchr | MIT OR Unlicense |
 | memfd | Apache-2.0 OR MIT |
 | memoffset | MIT |
-| num_cpus | Apache-2.0 OR MIT |
 | object | Apache-2.0 OR MIT |
 | once_cell | Apache-2.0 OR MIT |
 | paste | Apache-2.0 OR MIT |
-| percent-encoding | Apache-2.0 OR MIT |
 | pin-project-lite | Apache-2.0 OR MIT |
 | pin-utils | Apache-2.0 OR MIT |
-| ppv-lite86 | Apache-2.0 OR MIT |
 | proc-macro2 | Apache-2.0 OR MIT |
-| pulldown-cmark | MIT |
 | quote | Apache-2.0 OR MIT |
-| rand | Apache-2.0 OR MIT |
-| rand_chacha | Apache-2.0 OR MIT |
-| rand_core | Apache-2.0 OR MIT |
 | rayon | Apache-2.0 OR MIT |
 | rayon-core | Apache-2.0 OR MIT |
 | regalloc2 | Apache-2.0 WITH LLVM-exception |
-| regex | Apache-2.0 OR MIT |
-| regex-automata | Apache-2.0 OR MIT |
-| regex-syntax | Apache-2.0 OR MIT |
 | rustc-demangle | Apache-2.0 OR MIT |
 | rustc-hash | Apache-2.0 OR MIT |
 | rustix | Apache-2.0 OR Apache-2.0 WITH LLVM-exception OR MIT |
@@ -168,26 +151,21 @@ cat /tmp/license.md | sort | uniq
 | sha2 | Apache-2.0 OR MIT |
 | slice-group-by | MIT |
 | smallvec | Apache-2.0 OR MIT |
-| souper-ir | Apache-2.0 OR MIT |
 | sptr | Apache-2.0 OR MIT |
 | stable_deref_trait | Apache-2.0 OR MIT |
 | syn | Apache-2.0 OR MIT |
 | target-lexicon | Apache-2.0 WITH LLVM-exception |
-| termcolor | MIT OR Unlicense |
 | thiserror | Apache-2.0 OR MIT |
 | thiserror-impl | Apache-2.0 OR MIT |
-| tinyvec | Apache-2.0 OR MIT OR Zlib |
-| tinyvec_macros | Apache-2.0 OR MIT OR Zlib |
 | toml | Apache-2.0 OR MIT |
+| tracing-attributes | MIT |
+| tracing-core | MIT |
+| tracing | MIT |
 | typenum | Apache-2.0 OR MIT |
-| unicase | Apache-2.0 OR MIT |
-| unicode-bidi | Apache-2.0 OR MIT |
 | unicode-ident | (MIT OR Apache-2.0) AND Unicode-DFS-2016 |
-| unicode-normalization | Apache-2.0 OR MIT |
 | unicode-segmentation | Apache-2.0 OR MIT |
 | unicode-width | Apache-2.0 OR MIT |
 | unicode-xid | Apache-2.0 OR MIT |
-| url | Apache-2.0 OR MIT |
 | uuid | Apache-2.0 OR MIT |
 | wasm-encoder | Apache-2.0 WITH LLVM-exception |
 | wasmparser | Apache-2.0 WITH LLVM-exception |
@@ -195,7 +173,7 @@ cat /tmp/license.md | sort | uniq
 | wasmtime | Apache-2.0 WITH LLVM-exception |
 | wasmtime-asm-macros | Apache-2.0 WITH LLVM-exception |
 | wasmtime-cache | Apache-2.0 WITH LLVM-exception |
-| wasmtime-c-api | Apache-2.0 WITH LLVM-exception |
+| wasmtime-c-api-impl | Apache-2.0 WITH LLVM-exception |
 | wasmtime-c-api-macros | Apache-2.0 WITH LLVM-exception |
 | wasmtime-component-macro | Apache-2.0 WITH LLVM-exception |
 | wasmtime-component-util | Apache-2.0 WITH LLVM-exception |

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1162,6 +1162,14 @@ ss::future<> admin_server::throw_on_error(
         }
     } else if (ec.category() == wasm::error_category()) {
         switch (wasm::errc(ec.value())) {
+        case wasm::errc::invalid_module_missing_abi:
+            throw ss::httpd::bad_request_exception(
+              "Invalid WebAssembly - the binary is missing required transform "
+              "functions. Does the broker support this version of the Data "
+              "Transforms SDK?");
+        case wasm::errc::invalid_module_missing_wasi:
+            throw ss::httpd::bad_request_exception(
+              "invalid WebAssembly - missing required WASI functions");
         case wasm::errc::invalid_module:
             throw ss::httpd::bad_request_exception(
               "invalid WebAssembly module");

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -109,6 +109,7 @@
 #include "strings/string_switch.h"
 #include "strings/utf8.h"
 #include "transform/api.h"
+#include "wasm/errc.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/loop.hh>
@@ -1156,6 +1157,15 @@ ss::future<> admin_server::throw_on_error(
         case rpc::errc::method_not_found:
         case rpc::errc::version_not_supported:
         case rpc::errc::unknown:
+            throw ss::httpd::server_error_exception(
+              fmt::format("Unexpected error: {}", ec.message()));
+        }
+    } else if (ec.category() == wasm::error_category()) {
+        switch (wasm::errc(ec.value())) {
+        case wasm::errc::invalid_module:
+            throw ss::httpd::bad_request_exception(
+              "invalid WebAssembly module");
+        default:
             throw ss::httpd::server_error_exception(
               fmt::format("Unexpected error: {}", ec.message()));
         }

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -20,6 +20,8 @@
 #include "redpanda/admin/util.h"
 #include "transform/api.h"
 
+#include <system_error>
+
 namespace {
 
 ss::httpd::bad_request_exception transforms_not_enabled() {
@@ -210,7 +212,7 @@ admin_server::deploy_transform(std::unique_ptr<ss::http::request> req) {
     }
 
     // Now do the deploy!
-    cluster::errc ec = co_await _transform_service->local().deploy_transform(
+    std::error_code ec = co_await _transform_service->local().deploy_transform(
       {.name = name,
        .input_topic = input_nt,
        .output_topics = output_topics,

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -52,7 +52,7 @@ admin_server::delete_transform(std::unique_ptr<ss::http::request> req) {
         throw transforms_not_enabled();
     }
     auto name = model::transform_name(req->param["name"]);
-    auto ec = co_await _transform_service->local().delete_transform(
+    std::error_code ec = co_await _transform_service->local().delete_transform(
       std::move(name));
     co_await throw_on_error(*req, ec, model::controller_ntp);
     co_return ss::json::json_void();

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -38,6 +38,7 @@
 #include "transform/txn_reader.h"
 #include "wasm/api.h"
 #include "wasm/cache.h"
+#include "wasm/errc.h"
 
 #include <seastar/core/circular_buffer.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -48,6 +49,8 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/optimized_optional.hh>
+
+#include <system_error>
 
 namespace transform {
 
@@ -549,14 +552,23 @@ service::delete_transform(model::transform_name name) {
     co_return cluster::errc::success;
 }
 
-ss::future<cluster::errc>
+ss::future<std::error_code>
 service::deploy_transform(model::transform_metadata meta, iobuf binary) {
     if (!_feature_table->local().is_active(
           features::feature::wasm_transforms)) {
-        co_return cluster::errc::feature_disabled;
+        co_return cluster::make_error_code(cluster::errc::feature_disabled);
     }
     auto _ = _gate.hold();
-
+    try {
+        co_await _runtime->validate(binary.share(0, binary.size_bytes()));
+    } catch (const wasm::wasm_exception& ex) {
+        vlog(
+          tlog.warn,
+          "invalid wasm binary {} when deploying transform {}",
+          ex,
+          meta.name);
+        co_return wasm::make_error_code(ex.error_code());
+    }
     vlog(
       tlog.info,
       "deploying wasm binary (size={}) for transform {}",
@@ -568,7 +580,7 @@ service::deploy_transform(model::transform_metadata meta, iobuf binary) {
     if (result.has_error()) {
         vlog(
           tlog.warn, "storing wasm binary for transform {} failed", meta.name);
-        co_return result.error();
+        co_return cluster::make_error_code(result.error());
     }
     auto [key, offset] = result.value();
     meta.uuid = key;
@@ -588,7 +600,7 @@ service::deploy_transform(model::transform_metadata meta, iobuf binary) {
     if (ec != cluster::errc::success) {
         co_await cleanup_wasm_binary(key);
     }
-    co_return ec;
+    co_return cluster::make_error_code(ec);
 }
 
 ss::future<model::cluster_transform_report> service::list_transforms() {

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -27,6 +27,8 @@
 #include <seastar/util/defer.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+#include <system_error>
+
 namespace transform {
 
 struct list_committed_offsets_options {
@@ -70,7 +72,7 @@ public:
     /**
      * Delete a transform from the cluster.
      */
-    ss::future<cluster::errc> delete_transform(model::transform_name);
+    ss::future<std::error_code> delete_transform(model::transform_name);
 
     /**
      * List all transforms from the entire cluster.
@@ -82,7 +84,7 @@ public:
      */
     ss::future<result<
       ss::chunked_fifo<model::transform_committed_offset>,
-      cluster::errc>>
+      std::error_code>>
       list_committed_offsets(list_committed_offsets_options);
 
     /**

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -64,7 +64,7 @@ public:
     /**
      * Deploy a transform to the cluster.
      */
-    ss::future<cluster::errc>
+    ss::future<std::error_code>
       deploy_transform(model::transform_metadata, iobuf);
 
     /**

--- a/src/v/wasm/CMakeLists.txt
+++ b/src/v/wasm/CMakeLists.txt
@@ -19,6 +19,7 @@ v_cc_library(
     engine_probe.cc
   DEPS
     wasmtime
+    v::wasm_parser
     v::storage
     v::model
     v::pandaproxy_schema_registry

--- a/src/v/wasm/CMakeLists.txt
+++ b/src/v/wasm/CMakeLists.txt
@@ -26,3 +26,4 @@ v_cc_library(
 )
 
 add_subdirectory(tests)
+add_subdirectory(parser)

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -126,6 +126,15 @@ public:
      */
     virtual ss::future<ss::shared_ptr<factory>>
       make_factory(model::transform_metadata, iobuf) = 0;
+
+    /**
+     * Verify a WebAssembly module is valid and loosely adheres to our ABI
+     * format.
+     *
+     * Throws an exception when validation fails.
+     */
+    virtual ss::future<> validate(iobuf) = 0;
+
     virtual ~runtime() = default;
 };
 

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -357,4 +357,9 @@ ss::future<int64_t> caching_runtime::gc_engines() {
     return _engine_caches.map_reduce0(
       &engine_cache::gc, int64_t(0), std::plus<>());
 }
+
+ss::future<> caching_runtime::validate(iobuf buf) {
+    return _underlying->validate(std::move(buf));
+}
+
 } // namespace wasm

--- a/src/v/wasm/cache.h
+++ b/src/v/wasm/cache.h
@@ -65,6 +65,8 @@ public:
     ss::optimized_optional<ss::shared_ptr<factory>>
     get_cached_factory(const model::transform_metadata&);
 
+    ss::future<> validate(iobuf) override;
+
 private:
     friend class WasmCacheTest;
 

--- a/src/v/wasm/errc.h
+++ b/src/v/wasm/errc.h
@@ -26,6 +26,8 @@ enum class errc {
     engine_not_running,
     // Engine wasm shutdown
     engine_shutdown,
+    // invalid module
+    invalid_module
 };
 
 struct errc_category final : public std::error_category {
@@ -34,26 +36,30 @@ struct errc_category final : public std::error_category {
     std::string message(int c) const final {
         switch (static_cast<errc>(c)) {
         case errc::success:
-            return "wasm::errc::success";
+            return "Success";
         case errc::load_failure:
-            return "wasm::errc::load_failure";
+            return "WebAssembly load failure";
         case errc::engine_creation_failure:
-            return "wasm::errc::engine_creation_failure";
+            return "WebAssembly engine creation failure";
         case errc::user_code_failure:
-            return "wasm::errc::user_code_failure";
+            return "WebAssembly user code failure";
         case errc::engine_not_running:
-            return "wasm::errc::engine_not_running";
+            return "WebAssembly not running";
         case errc::engine_shutdown:
-            return "wasm::errc::engine_shutdown";
+            return "WebAssembly engine shutdown";
+        case errc::invalid_module:
+            return "invalid WebAssembly module";
         default:
             return "wasm::errc::unknown(" + std::to_string(c) + ")";
         }
     }
 };
+
 inline const std::error_category& error_category() noexcept {
     static errc_category e;
     return e;
 }
+
 inline std::error_code make_error_code(errc e) noexcept {
     return {static_cast<int>(e), error_category()};
 }

--- a/src/v/wasm/errc.h
+++ b/src/v/wasm/errc.h
@@ -26,8 +26,12 @@ enum class errc {
     engine_not_running,
     // Engine wasm shutdown
     engine_shutdown,
-    // invalid module
-    invalid_module
+    // invalid module without wasi _start
+    invalid_module_missing_wasi,
+    // invalid module without abi marker
+    invalid_module_missing_abi,
+    // invalid module otherwise
+    invalid_module,
 };
 
 struct errc_category final : public std::error_category {
@@ -47,8 +51,12 @@ struct errc_category final : public std::error_category {
             return "WebAssembly not running";
         case errc::engine_shutdown:
             return "WebAssembly engine shutdown";
+        case errc::invalid_module_missing_wasi:
+            return "invalid WebAssembly - not compiled for wasi/wasm32";
+        case errc::invalid_module_missing_abi:
+            return "invalid WebAssembly - invalid SDK";
         case errc::invalid_module:
-            return "invalid WebAssembly module";
+            return "invalid WebAssembly";
         default:
             return "wasm::errc::unknown(" + std::to_string(c) + ")";
         }

--- a/src/v/wasm/parser/CMakeLists.txt
+++ b/src/v/wasm/parser/CMakeLists.txt
@@ -1,0 +1,9 @@
+v_cc_library(
+  NAME wasm_parser
+  SRCS
+  DEPS
+    v::bytes
+    Seastar::seastar
+)
+
+add_subdirectory(tests)

--- a/src/v/wasm/parser/CMakeLists.txt
+++ b/src/v/wasm/parser/CMakeLists.txt
@@ -1,8 +1,10 @@
 v_cc_library(
   NAME wasm_parser
   SRCS
+    parser.cc
   DEPS
     v::bytes
+    v::strings
     Seastar::seastar
 )
 

--- a/src/v/wasm/parser/README.md
+++ b/src/v/wasm/parser/README.md
@@ -1,0 +1,13 @@
+# WebAssembly Parser Library
+
+The Wasm parser library contains routines to parse WebAssembly in the binary format. This can be used to do static analysis of WebAssembly modules as they are deployed.
+We only support what is defined in the WebAssembly v2 Core Spec. We do not support any proposals that have not been merged into the spec. We may choose to add some
+support for extra functionality as we make use of it in the Wasm subsystem. Lastly, this is not a full parser, but only parses the "API" so to speak of a module. Specifically
+that is imports and exports of the defined types and excludes parsing instructions (function bodies).
+
+If you're looking to develop this library or make changes the following links maybe helpful to understand WebAssembly's binary format:
+
+* [Offical WebAssembly Core Specification](https://webassembly.github.io/spec/core/)
+* [Offical WebAssembly Testsuite](https://github.com/WebAssembly/testsuite)
+* [WebAssembly Proposals](https://github.com/WebAssembly/proposals)
+* [Understanding Every Byte in a WASM Module](https://danielmangum.com/posts/every-byte-wasm-module/)

--- a/src/v/wasm/parser/include/wasm/parser/parser.h
+++ b/src/v/wasm/parser/include/wasm/parser/parser.h
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/seastarx.h"
+#include "bytes/iobuf.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <cstdint>
+#include <limits>
+#include <variant>
+#include <vector>
+
+namespace wasm {
+/**
+ * Fundamental types that exist in the WebAssembly core v2 specification.
+ */
+enum class val_type : uint8_t {
+    i32 = 0x7f,
+    i64 = 0x7e,
+    f32 = 0x7d,
+    f64 = 0x7c,
+    v128 = 0x7b,
+    funcref = 0x70,
+    externref = 0x6f,
+};
+
+/**
+ * A signature of a function within WebAssembly (yes they support multiple
+ * return types).
+ */
+struct function_signature {
+    std::vector<val_type> parameters;
+    std::vector<val_type> results;
+
+    bool operator==(const function_signature&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const function_signature&);
+};
+} // namespace wasm
+
+namespace wasm::parser {
+
+namespace declaration {
+
+/**
+ * Bounds on a component (table/memory) during runtime.
+ */
+struct limits {
+    uint32_t min = 0;
+    uint32_t max = std::numeric_limits<uint32_t>::max();
+
+    bool operator==(const limits&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const limits&);
+};
+
+/**
+ * A declaration of a function, with a signature.
+ */
+struct function {
+    function_signature signature;
+
+    bool operator==(const function&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const function&);
+};
+
+/**
+ * A declaration of a table it's types and bounds for it during runtime.
+ */
+struct table {
+    val_type reftype; // only ever funcref or externref
+    limits limits;
+
+    bool operator==(const table&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const table&);
+};
+
+/**
+ * A declaration of linear memory and bounds for it during runtime.
+ */
+struct memory {
+    limits limits;
+
+    bool operator==(const memory&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const memory&);
+};
+
+/**
+ * A declaration of a global variable and if it is mutable or not.
+ */
+struct global {
+    val_type valtype;
+    bool is_mutable;
+
+    bool operator==(const global&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const global&);
+};
+
+} // namespace declaration
+
+/**
+ * The type of import: functions/tables/memories/globals.
+ */
+using import_description = std::variant<
+  declaration::function,
+  declaration::table,
+  declaration::memory,
+  declaration::global>;
+
+/**
+ * An import in the WebAssembly v2 specification, which is namespaced by import
+ * module and the name of the item to import.
+ */
+struct module_import {
+    ss::sstring module_name;
+    ss::sstring item_name;
+    import_description description;
+
+    bool operator==(const module_import&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const module_import&);
+};
+
+/**
+ * The type of export: functions/tables/memories/globals.
+ */
+using export_description = std::variant<
+  declaration::function,
+  declaration::table,
+  declaration::memory,
+  declaration::global>;
+
+/**
+ * An export in the WebAssembly v2 specification, which is a name and the item
+ * being exported.
+ */
+struct module_export {
+    ss::sstring item_name;
+    export_description description;
+
+    bool operator==(const module_export&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const module_export&);
+};
+
+/**
+ * The declarations of a WebAssembly module.
+ */
+struct module_declarations {
+    std::vector<module_export> exports;
+    std::vector<module_import> imports;
+
+    bool operator==(const module_declarations&) const = default;
+    friend std::ostream& operator<<(std::ostream&, const module_declarations&);
+};
+
+/**
+ * An exception thrown for an invalid wasm module.
+ */
+class parse_exception : public std::exception {
+public:
+    explicit parse_exception(std::string msg)
+      : _msg(std::move(msg)) {}
+
+    const char* what() const noexcept final { return _msg.c_str(); }
+
+private:
+    std::string _msg;
+};
+
+/**
+ * An exception thrown when one of our parsing limits would be exceeded.
+ */
+class module_too_large_exception : public parse_exception {
+public:
+    explicit module_too_large_exception(std::string msg)
+      : parse_exception(std::move(msg)) {}
+};
+
+/**
+ * Given a WebAssembly module in binary form, extract the imports and exports
+ * the module declares.
+ *
+ * NOTE: We don't need a full blown wasm parser because we only validate that a
+ * module that is being deployed supports our ABI.
+ */
+ss::future<module_declarations> extract_declarations(iobuf binary_module);
+
+} // namespace wasm::parser

--- a/src/v/wasm/parser/leb128.h
+++ b/src/v/wasm/parser/leb128.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/bytes.h"
+#include "bytes/iobuf_parser.h"
+
+#include <climits>
+#include <cstdint>
+
+namespace wasm::parser::leb128 {
+
+template<typename int_type>
+bytes encode(int_type value) {
+    bytes output;
+
+    static_assert(
+      sizeof(int_type) == sizeof(uint32_t)
+        || sizeof(int_type) == sizeof(uint64_t),
+      "Only 32bit and 64bit integers are supported");
+    constexpr unsigned lower_seven_bits_mask = 0x7FU;
+    constexpr unsigned leading_bit_mask = 0x80U;
+    constexpr unsigned sign_bit_mask = 0x40U;
+    if constexpr (std::is_signed_v<int_type>) {
+        bool more = true;
+        while (more) {
+            uint8_t byte = value & lower_seven_bits_mask;
+            value >>= CHAR_BIT - 1;
+            if (
+              ((value == 0) && !(byte & sign_bit_mask))
+              || ((value == -1) && (byte & sign_bit_mask))) {
+                more = false;
+            } else {
+                byte |= leading_bit_mask;
+            }
+            output.append(&byte, 1);
+        }
+    } else {
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-do-while)
+        do {
+            uint8_t byte = value & lower_seven_bits_mask;
+            value >>= CHAR_BIT - 1;
+            if (value != 0) {
+                byte |= leading_bit_mask;
+            }
+            output.append(&byte, 1);
+        } while (value != 0);
+    }
+
+    return output;
+}
+
+class decode_exception : std::exception {};
+
+template<typename int_type>
+int_type decode(iobuf_parser_base* stream) {
+    constexpr unsigned lower_seven_bits_mask = 0x7FU;
+    constexpr unsigned continuation_bit_mask = 0x80U;
+    static_assert(
+      sizeof(int_type) == sizeof(uint32_t)
+        || sizeof(int_type) == sizeof(uint64_t),
+      "Only 32bit and 64bit integers are supported");
+    constexpr unsigned size = sizeof(int_type) * CHAR_BIT;
+    int_type result = 0;
+    unsigned shift = 0;
+    uint8_t byte = continuation_bit_mask;
+    while ((shift < size) && (byte & continuation_bit_mask)) {
+        byte = stream->consume_type<uint8_t>();
+        result |= int_type(byte & lower_seven_bits_mask) << shift;
+        shift += CHAR_BIT - 1;
+    }
+
+    if (byte & continuation_bit_mask) [[unlikely]] {
+        // Overflow!
+        throw decode_exception();
+    }
+
+    if constexpr (std::is_signed_v<int_type>) {
+        constexpr unsigned size = sizeof(int_type) * CHAR_BIT;
+        constexpr unsigned sign_bit_mask = 0x40U;
+        if ((shift < size) && (byte & sign_bit_mask)) {
+            // sign extend
+            result |= ~int_type(0) << shift;
+        }
+    }
+
+    return result;
+}
+
+} // namespace wasm::parser::leb128

--- a/src/v/wasm/parser/parser.cc
+++ b/src/v/wasm/parser/parser.cc
@@ -1,0 +1,567 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "wasm/parser/parser.h"
+
+#include "base/units.h"
+#include "bytes/iobuf_parser.h"
+#include "strings/utf8.h"
+#include "wasm/parser/leb128.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+#include <seastar/util/variant_utils.hh>
+
+#include <absl/algorithm/container.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+#include <sys/types.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <iterator>
+#include <ranges>
+#include <stdexcept>
+#include <variant>
+
+namespace wasm {
+
+namespace {
+std::string_view to_string(const wasm::val_type& vt) {
+    switch (vt) {
+    case wasm::val_type::i32:
+        return "i32";
+    case wasm::val_type::i64:
+        return "i64";
+    case wasm::val_type::f32:
+        return "f32";
+    case wasm::val_type::f64:
+        return "f64";
+    case wasm::val_type::v128:
+        return "v128";
+    case wasm::val_type::funcref:
+        return "funcref";
+    case wasm::val_type::externref:
+        return "externref";
+    }
+    return "unknown";
+}
+} // namespace
+
+std::ostream& operator<<(std::ostream& os, const function_signature& sig) {
+    fmt::print(
+      os,
+      "{{params:[{}],results:[{}]}}",
+      fmt::join(sig.parameters | std::views::transform(to_string), ","),
+      fmt::join(sig.results | std::views::transform(to_string), ","));
+    return os;
+}
+
+} // namespace wasm
+
+namespace wasm::parser {
+
+namespace declaration {
+std::ostream& operator<<(std::ostream& os, const limits& l) {
+    fmt::print(os, "{{min:{},max:{}}}", l.min, l.max);
+    return os;
+}
+std::ostream& operator<<(std::ostream& os, const function& f) {
+    fmt::print(os, "{{signature:{}}}", f.signature);
+    return os;
+}
+std::ostream& operator<<(std::ostream& os, const table& t) {
+    fmt::print(os, "{{reftype:{},limits:{}}}", to_string(t.reftype), t.limits);
+    return os;
+}
+std::ostream& operator<<(std::ostream& os, const memory& m) {
+    fmt::print(os, "{{limits:{}}}", m.limits);
+    return os;
+}
+std::ostream& operator<<(std::ostream& os, const global& m) {
+    fmt::print(os, "{{valtype:{},mut:{}}}", to_string(m.valtype), m.is_mutable);
+    return os;
+}
+
+} // namespace declaration
+
+std::ostream& operator<<(std::ostream& os, const module_import& m_import) {
+    std::visit(
+      [&](auto desc) {
+          fmt::print(
+            os,
+            "{{name:{}/{},desc:{}}}",
+            m_import.module_name,
+            m_import.item_name,
+            desc);
+      },
+      m_import.description);
+    return os;
+}
+std::ostream& operator<<(std::ostream& os, const module_export& m_export) {
+    std::visit(
+      [&](auto desc) {
+          fmt::print(os, "{{name:{},desc:{}}}", m_export.item_name, desc);
+      },
+      m_export.description);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const module_declarations& m_decls) {
+    fmt::print(
+      os, "{{imports:{},exports:{}}}", m_decls.imports, m_decls.exports);
+    return os;
+}
+
+namespace {
+constexpr size_t max_vector_bytes = 128_KiB;
+constexpr size_t max_functions
+  = max_vector_bytes
+    / std::max(sizeof(function_signature), sizeof(declaration::function));
+constexpr size_t max_items = max_vector_bytes
+                             / std::max({
+                               sizeof(declaration::memory),
+                               sizeof(declaration::table),
+                               sizeof(declaration::global),
+                             });
+constexpr size_t max_function_params = 128;
+constexpr size_t max_function_results = 64;
+constexpr size_t max_imports = max_vector_bytes / sizeof(module_import);
+constexpr size_t max_exports = max_vector_bytes / sizeof(module_export);
+constexpr size_t max_name_length = 512;
+
+template<typename Vector>
+void validate_in_range(std::string_view msg, size_t idx, const Vector& v) {
+    if (idx >= v.size()) {
+        throw parse_exception(
+          fmt::format("{} out of range - {} ∉ [0, {})", msg, idx, v.size()));
+    }
+}
+
+val_type parse_val_type(iobuf_parser_base* parser) {
+    auto type_id = parser->consume_type<uint8_t>();
+    switch (type_id) {
+    case uint8_t(val_type::i32):
+    case uint8_t(val_type::i64):
+    case uint8_t(val_type::f32):
+    case uint8_t(val_type::f64):
+    case uint8_t(val_type::funcref):
+    case uint8_t(val_type::externref):
+        return val_type(type_id);
+    default:
+        throw parse_exception(fmt::format("unknown valtype: {}", type_id));
+    }
+}
+
+ss::sstring parse_name(iobuf_parser_base* parser) {
+    auto str_len = leb128::decode<uint32_t>(parser);
+    if (str_len > max_name_length) {
+        throw parse_exception(fmt::format("name too long: {}", str_len));
+    }
+    auto b = parser->read_string(str_len);
+    if (!is_valid_utf8(b)) {
+        throw parse_exception("name invalid utf8");
+    }
+    return {b.begin(), b.end()};
+}
+
+std::vector<val_type>
+parse_signature_types(iobuf_parser_base* parser, size_t max) {
+    auto vector_size = leb128::decode<uint32_t>(parser);
+    if (vector_size > max) {
+        throw module_too_large_exception(
+          fmt::format("too many types to function: {}", vector_size));
+    }
+    std::vector<val_type> result_type;
+    result_type.reserve(vector_size);
+    for (uint32_t i = 0; i < vector_size; ++i) {
+        result_type.push_back(parse_val_type(parser));
+    }
+    return result_type;
+}
+
+function_signature parse_signature(iobuf_parser_base* parser) {
+    auto magic = parser->consume_type<uint8_t>();
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    if (magic != 0x60) {
+        throw parse_exception(
+          fmt::format("function type magic mismatch: {}", magic));
+    }
+    auto parameter_types = parse_signature_types(parser, max_function_params);
+    auto result_types = parse_signature_types(parser, max_function_results);
+    return {
+      .parameters = std::move(parameter_types),
+      .results = std::move(result_types)};
+}
+
+declaration::limits parse_limits(iobuf_parser_base* parser) {
+    if (parser->read_bool()) {
+        auto min = leb128::decode<uint32_t>(parser);
+        auto max = leb128::decode<uint32_t>(parser);
+        return {.min = min, .max = max};
+    } else {
+        auto min = leb128::decode<uint32_t>(parser);
+        return {.min = min, .max = std::numeric_limits<uint32_t>::max()};
+    }
+}
+
+declaration::table parse_table_type(iobuf_parser_base* parser) {
+    auto reftype = parse_val_type(parser);
+    if (reftype != val_type::externref && reftype != val_type::funcref) {
+        throw parse_exception(
+          fmt::format("invalid tabletype type: {}", uint8_t(reftype)));
+    }
+    auto limits = parse_limits(parser);
+    return {.reftype = reftype, .limits = limits};
+}
+
+declaration::memory parse_memory_type(iobuf_parser_base* parser) {
+    return {.limits = parse_limits(parser)};
+}
+
+declaration::global parse_global_type(iobuf_parser_base* parser) {
+    auto valtype = parse_val_type(parser);
+    auto mut = parser->read_bool();
+    return {.valtype = valtype, .is_mutable = bool(mut)};
+}
+
+class module_extractor {
+public:
+    explicit module_extractor(iobuf_parser_base* parser)
+      : _parser(parser) {}
+
+    // Parse a WebAssembly binary module.
+    //
+    // This specific function mostly checks the magic bytes and version, then
+    // parses each section of the module.
+    ss::future<module_declarations> parse() {
+        bytes magic = _parser->read_bytes(4);
+        const bytes magic_bytes = bytes({0x00, 0x61, 0x73, 0x6D});
+        if (magic != magic_bytes) {
+            throw parse_exception(
+              fmt::format("magic bytes incorrect: {}", magic));
+        }
+        auto version = _parser->consume_type<int32_t>();
+        if (version != 1) {
+            throw parse_exception("unsupported wasm version");
+        }
+        while (_parser->bytes_left() > 0) {
+            parse_one_section();
+            co_await ss::coroutine::maybe_yield();
+        }
+        co_return module_declarations{
+          .exports = std::move(_exports),
+          .imports = std::move(_imports),
+        };
+    }
+
+private:
+    // The main loop of parsing functions.
+    //
+    // At a high level from the spec. The sections are as follows and parsed in
+    // order:
+    // - type signatures
+    // - imports
+    // - function forward declarations
+    // - tables
+    // - memories
+    // - globals
+    // - exports
+    // - start function
+    // - elements (initializer code for tables)
+    // - data counts
+    // - code (the bodies of functions that were forward declared)
+    // - data (initializer code for memories)
+    //
+    // Around any of these sections can be a custom section.
+    //
+    // We currently ignore any of the sections we don't care about.
+    void parse_one_section() {
+        auto id = _parser->consume_type<uint8_t>();
+        if (id != 0) {
+            auto it = absl::c_find(_sections_left, id);
+            if (it == _sections_left.end()) {
+                throw parse_exception(
+                  fmt::format("invalid section with id {}", id));
+            }
+            _sections_left = _sections_left.last(
+              std::distance(it++, _sections_left.end()));
+        }
+        // The size of this section
+        auto size = leb128::decode<uint32_t>(_parser);
+        // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+        switch (id) {
+        case 0x00: // Custom section
+            // Skip over custom sections
+            _parser->skip(size);
+            break;
+        case 0x01: // type section
+            parse_signature_section();
+            break;
+        case 0x02: // import section
+            parse_import_section();
+            break;
+        case 0x03: // function section
+            parse_function_decl_section();
+            break;
+        case 0x04: // table section
+            parse_table_section();
+            break;
+        case 0x05: // memory section
+            parse_memories_section();
+            break;
+        case 0x06: // global section
+            parse_globals_section();
+            break;
+        case 0x07: // export section
+            parse_export_section();
+            break;
+        case 0x08: // start section
+        case 0x09: // element section
+        case 0x0C: // data count section
+        case 0x0A: // code section
+        case 0x0B: // data section
+            // Since we don't need the information from these sections at the
+            // moment, we can skip them.
+            _parser->skip(size);
+            break;
+        default:
+            throw parse_exception(fmt::format("unknown section id: {}", id));
+        }
+        // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+    }
+
+    void parse_signature_section() {
+        auto vector_size = leb128::decode<uint32_t>(_parser);
+        if (vector_size > max_functions) {
+            throw module_too_large_exception(fmt::format(
+              "too large of type section: {}, max: {}",
+              vector_size,
+              max_functions));
+        }
+        _func_signatures.reserve(vector_size);
+        for (uint32_t i = 0; i < vector_size; ++i) {
+            _func_signatures.push_back(parse_signature(_parser));
+        }
+    }
+
+    void parse_import_section() {
+        auto vector_size = leb128::decode<uint32_t>(_parser);
+        if (vector_size > max_imports) {
+            throw module_too_large_exception(fmt::format(
+              "too many imports: {}, max: {}", vector_size, max_imports));
+        }
+
+        _imports.reserve(vector_size);
+        for (uint32_t i = 0; i < vector_size; ++i) {
+            _imports.push_back(parse_one_import());
+        }
+    }
+
+    module_import parse_one_import() {
+        auto module_name = parse_name(_parser);
+        auto name = parse_name(_parser);
+        auto type = _parser->consume_type<uint8_t>();
+        std::optional<import_description> desc;
+        switch (type) {
+        case 0x00: { // func
+            auto funcidx = leb128::decode<uint32_t>(_parser);
+            validate_in_range(
+              "unknown import function signature", funcidx, _func_signatures);
+            auto func = declaration::function{_func_signatures[funcidx]};
+            _functions.push_back(func);
+            desc = std::move(func);
+            break;
+        }
+        case 0x01: { // table
+            auto table = parse_table_type(_parser);
+            _tables.push_back(table);
+            desc = table;
+            break;
+        }
+        case 0x02: { // memory
+            auto mem = parse_memory_type(_parser);
+            _memories.push_back(mem);
+            desc = mem;
+            break;
+        }
+        case 0x03: { // global
+            auto global = parse_global_type(_parser);
+            _globals.push_back(global);
+            desc = global;
+            break;
+        }
+        default:
+            throw parse_exception(fmt::format("unknown import type: {}", type));
+        }
+        return {
+          .module_name = std::move(module_name),
+          .item_name = std::move(name),
+          .description = desc.value()};
+    }
+
+    void parse_function_decl_section() {
+        auto vector_size = leb128::decode<uint32_t>(_parser);
+        if (vector_size > max_functions) {
+            throw module_too_large_exception(fmt::format(
+              "too many functions: {}, max: {}", vector_size, max_functions));
+        }
+        _tables.reserve(max_functions);
+        for (uint32_t i = 0; i < vector_size; ++i) {
+            auto funcidx = leb128::decode<uint32_t>(_parser);
+            validate_in_range(
+              "unknown function signature", funcidx, _func_signatures);
+            _functions.emplace_back(_func_signatures[funcidx]);
+        }
+    }
+
+    void parse_table_section() {
+        auto vector_size = leb128::decode<uint32_t>(_parser);
+        if (vector_size > max_items) {
+            throw module_too_large_exception(fmt::format(
+              "too many tables: {}, max: {}", vector_size, max_items));
+        }
+        _tables.reserve(vector_size);
+        for (uint32_t i = 0; i < vector_size; ++i) {
+            _tables.push_back(parse_table_type(_parser));
+        }
+    }
+
+    void parse_memories_section() {
+        auto vector_size = leb128::decode<uint32_t>(_parser);
+        if (vector_size > max_items) {
+            throw module_too_large_exception(fmt::format(
+              "too many memories: {}, max: {}", vector_size, max_items));
+        }
+        _memories.reserve(vector_size);
+        for (uint32_t i = 0; i < vector_size; ++i) {
+            _memories.push_back(parse_memory_type(_parser));
+        }
+    }
+
+    void parse_globals_section() {
+        auto vector_size = leb128::decode<uint32_t>(_parser);
+        if (vector_size > max_items) {
+            throw module_too_large_exception(fmt::format(
+              "too many globals: {}, max: {}", vector_size, max_items));
+        }
+        _globals.reserve(vector_size);
+        for (uint32_t i = 0; i < vector_size; ++i) {
+            _globals.push_back(parse_global_type(_parser));
+            // We currently don't care about the global constexpr, so just skip
+            // it (the end is delimited by 0x0B)
+            skip_global_constexpr();
+        }
+    }
+
+    void skip_global_constexpr() {
+        constexpr int max_constexpr_bytes = 64;
+        for (int i = 0; i < max_constexpr_bytes; ++i) {
+            // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+            if (_parser->consume_type<uint8_t>() == 0x0b) {
+                return;
+            }
+        }
+        throw parse_exception("unexpectedly large global constexpr");
+    }
+
+    void parse_export_section() {
+        auto vector_size = leb128::decode<uint32_t>(_parser);
+        if (vector_size > max_exports) {
+            throw module_too_large_exception(fmt::format(
+              "too many exports: {}, max: {}", vector_size, max_exports));
+        }
+        _exports.reserve(vector_size);
+        for (uint32_t i = 0; i < vector_size; ++i) {
+            _exports.push_back(parse_one_export());
+        }
+    }
+
+    module_export parse_one_export() {
+        auto name = parse_name(_parser);
+        auto type = _parser->consume_type<uint8_t>();
+        std::optional<export_description> desc;
+        switch (type) {
+        case 0x00: { // func
+            auto idx = leb128::decode<uint32_t>(_parser);
+            validate_in_range("unknown function export", idx, _functions);
+            desc = _functions[idx];
+            break;
+        }
+        case 0x01: { // table
+            auto idx = leb128::decode<uint32_t>(_parser);
+            validate_in_range("unknown function export", idx, _tables);
+            desc = _tables[idx];
+            break;
+        }
+        case 0x02: { // memory
+            auto idx = leb128::decode<uint32_t>(_parser);
+            validate_in_range("unknown memory export", idx, _memories);
+            desc = _memories[idx];
+            break;
+        }
+        case 0x03: { // global
+            auto idx = leb128::decode<uint32_t>(_parser);
+            validate_in_range("unknown global export", idx, _globals);
+            desc = _globals[idx];
+            break;
+        }
+        default:
+            throw parse_exception(fmt::format("unknown export type: {}", type));
+        }
+        return {.item_name = std::move(name), .description = desc.value()};
+    }
+
+    // In order to properly be able to stream parsing of modules, we need to
+    // ensure everything is created in the correct order. The spec enforces
+    // that modules are in order to achieve this usecase.
+    //
+    // NOTE: Custom sections are allowed to be anywhere.
+    static constexpr std::array section_order = std::to_array<uint8_t>(
+      {1, 2, 3, 4, 5, 6, 7, 8, 9, 12, 10, 11});
+    // The ordered list of sections left to encounter.
+    //
+    // This will become prefix truncated as we visit sections
+    std::span<const uint8_t> _sections_left = section_order;
+
+    // The currently parsed data.
+    // NOTE these vectors are all explicitly bounded as to prevent large
+    // allocations.
+
+    std::vector<function_signature> _func_signatures;
+    std::vector<module_import> _imports;
+    std::vector<declaration::function> _functions;
+    std::vector<declaration::table> _tables;
+    std::vector<declaration::memory> _memories;
+    std::vector<declaration::global> _globals;
+    std::vector<module_export> _exports;
+
+    iobuf_parser_base* _parser;
+};
+
+} // namespace
+
+ss::future<module_declarations> extract_declarations(iobuf binary_module) {
+    iobuf_parser parser(std::move(binary_module));
+    module_extractor extractor(&parser);
+    try {
+        co_return co_await extractor.parse();
+    } catch (const std::out_of_range& ex) {
+        // Catch a short read in the parser and translate to a parse_exception
+        throw parse_exception(ex.what());
+    } catch (const leb128::decode_exception& ex) {
+        // Catch invalid leb128 and translate to a parse_exception
+        throw parse_exception("invalid leb128");
+    }
+}
+
+} // namespace wasm::parser

--- a/src/v/wasm/parser/tests/CMakeLists.txt
+++ b/src/v/wasm/parser/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME leb128
+  SOURCES
+    leb128_test.cc
+  LIBRARIES 
+    v::gtest_main
+    v::wasm_parser
+  ARGS "-- -c 1"
+  LABELS wasm_parser wasm
+)

--- a/src/v/wasm/parser/tests/CMakeLists.txt
+++ b/src/v/wasm/parser/tests/CMakeLists.txt
@@ -10,3 +10,17 @@ rp_test(
   ARGS "-- -c 1"
   LABELS wasm_parser wasm
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME wasm_parser
+  SOURCES
+    parser_test.cc
+  LIBRARIES 
+    wasmtime
+    v::gtest_main
+    v::wasm_parser
+  ARGS "-- -c 1"
+  LABELS wasm_parser wasm
+)

--- a/src/v/wasm/parser/tests/leb128_test.cc
+++ b/src/v/wasm/parser/tests/leb128_test.cc
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/bytes.h"
+#include "bytes/iobuf_parser.h"
+#include "gtest/gtest.h"
+#include "wasm/parser/leb128.h"
+
+#include <gtest/gtest.h>
+
+namespace wasm::parser::leb128 {
+
+template<typename T>
+struct test_data {
+    T decoded;
+    bytes encoded;
+};
+
+template<typename T>
+testing::AssertionResult run_test(const test_data<T>& testcase) {
+    if (encode<T>(testcase.decoded) != testcase.encoded) {
+        return testing::AssertionFailure() << "encoding: " << testcase.decoded;
+    }
+
+    auto p = iobuf_parser(bytes_to_iobuf(testcase.encoded));
+    if (decode<T>(&p) != testcase.decoded) {
+        return testing::AssertionFailure() << "decoding: " << testcase.decoded;
+    }
+    return testing::AssertionSuccess();
+}
+
+template<typename T>
+class RoundTripTest : public testing::TestWithParam<test_data<T>> {};
+
+class SignedInt32RoundTripTest : public RoundTripTest<int32_t> {};
+class UnsignedInt32RoundTripTest : public RoundTripTest<uint32_t> {};
+class SignedInt64RoundTripTest : public RoundTripTest<int64_t> {};
+class UnsignedInt64RoundTripTest : public RoundTripTest<uint64_t> {};
+
+TEST_P(SignedInt32RoundTripTest, RoundTrip) {
+    EXPECT_TRUE(run_test(GetParam()));
+}
+TEST_P(UnsignedInt32RoundTripTest, RoundTrip) {
+    EXPECT_TRUE(run_test(GetParam()));
+}
+TEST_P(SignedInt64RoundTripTest, RoundTrip) {
+    EXPECT_TRUE(run_test(GetParam()));
+}
+TEST_P(UnsignedInt64RoundTripTest, RoundTrip) {
+    EXPECT_TRUE(run_test(GetParam()));
+}
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+INSTANTIATE_TEST_SUITE_P(
+  InterestingSignedIntegers,
+  SignedInt32RoundTripTest,
+  testing::ValuesIn<std::vector<test_data<int32_t>>>(
+    {{.decoded = std::numeric_limits<int32_t>::min(),
+      .encoded = {0x80, 0x80, 0x80, 0x80, 0x78}},
+     {.decoded = -165675008, .encoded = {0x80, 0x80, 0x80, 0xb1, 0x7f}},
+     {.decoded = -624485, .encoded = {0x9b, 0xf1, 0x59}},
+     {.decoded = -16256, .encoded = {0x80, 0x81, 0x7f}},
+     {.decoded = -4, .encoded = {0x7c}},
+     {.decoded = -1, .encoded = {0x7f}},
+     {.decoded = 0, .encoded = {0x00}},
+     {.decoded = 1, .encoded = {0x01}},
+     {.decoded = 4, .encoded = {0x04}},
+     {.decoded = 16256, .encoded = {0x80, 0xff, 0x0}},
+     {.decoded = 624485, .encoded = {0xe5, 0x8e, 0x26}},
+     {.decoded = 165675008, .encoded = {0x80, 0x80, 0x80, 0xcf, 0x0}},
+     {.decoded = std::numeric_limits<int32_t>::max(),
+      .encoded = {0xff, 0xff, 0xff, 0xff, 0x7}}}));
+
+INSTANTIATE_TEST_SUITE_P(
+  InterestingUnsignedIntegers,
+  UnsignedInt32RoundTripTest,
+  testing::ValuesIn<std::vector<test_data<uint32_t>>>(
+    {{.decoded = 0, .encoded = {0x00}},
+     {.decoded = 1, .encoded = {0x01}},
+     {.decoded = 4, .encoded = {0x04}},
+     {.decoded = 16256, .encoded = {0x80, 0x7f}},
+     {.decoded = 624485, .encoded = {0xe5, 0x8e, 0x26}},
+     {.decoded = 165675008, .encoded = {0x80, 0x80, 0x80, 0x4f}},
+     {.decoded = std::numeric_limits<uint32_t>::max(),
+      .encoded = {0xff, 0xff, 0xff, 0xff, 0xf}}}));
+
+INSTANTIATE_TEST_SUITE_P(
+  InterestingUnsignedLongs,
+  UnsignedInt64RoundTripTest,
+  testing::ValuesIn<std::vector<test_data<uint64_t>>>(
+    {{.decoded = 0, .encoded = {0x00}},
+     {.decoded = 1, .encoded = {0x01}},
+     {.decoded = 4, .encoded = {0x04}},
+     {.decoded = 16256, .encoded = {0x80, 0x7f}},
+     {.decoded = 624485, .encoded = {0xe5, 0x8e, 0x26}},
+     {.decoded = 165675008, .encoded = {0x80, 0x80, 0x80, 0x4f}},
+     {.decoded = std::numeric_limits<uint32_t>::max(),
+      .encoded = {0xff, 0xff, 0xff, 0xff, 0xf}},
+     {.decoded = std::numeric_limits<uint64_t>::max(),
+      .encoded = {
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x1}}}));
+
+INSTANTIATE_TEST_SUITE_P(
+  InterestingSignedLongs,
+  SignedInt64RoundTripTest,
+  testing::ValuesIn<std::vector<test_data<int64_t>>>({
+    {.decoded = -std::numeric_limits<int32_t>::max(),
+     .encoded = {0x81, 0x80, 0x80, 0x80, 0x78}},
+    {.decoded = -165675008, .encoded = {0x80, 0x80, 0x80, 0xb1, 0x7f}},
+    {.decoded = -624485, .encoded = {0x9b, 0xf1, 0x59}},
+    {.decoded = -16256, .encoded = {0x80, 0x81, 0x7f}},
+    {.decoded = -4, .encoded = {0x7c}},
+    {.decoded = -1, .encoded = {0x7f}},
+    {.decoded = 0, .encoded = {0x00}},
+    {.decoded = 1, .encoded = {0x01}},
+    {.decoded = 4, .encoded = {0x04}},
+    {.decoded = 16256, .encoded = {0x80, 0xff, 0x0}},
+    {.decoded = 624485, .encoded = {0xe5, 0x8e, 0x26}},
+    {.decoded = 165675008, .encoded = {0x80, 0x80, 0x80, 0xcf, 0x0}},
+    {.decoded = std::numeric_limits<int32_t>::max(),
+     .encoded = {0xff, 0xff, 0xff, 0xff, 0x7}},
+    {.decoded = std::numeric_limits<int64_t>::max(),
+     .encoded = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0}},
+  }));
+
+TEST(Overflow, Long) {
+    bytes encoded(size_t(11), 0xff);
+    auto p = iobuf_parser(bytes_to_iobuf(encoded));
+    EXPECT_THROW(decode<int64_t>(&p), decode_exception);
+    p = iobuf_parser(bytes_to_iobuf(encoded));
+    EXPECT_THROW(decode<uint64_t>(&p), decode_exception);
+}
+TEST(Overflow, Int) {
+    bytes encoded = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+    auto p = iobuf_parser(bytes_to_iobuf(encoded));
+    EXPECT_THROW(decode<int32_t>(&p), decode_exception);
+    p = iobuf_parser(bytes_to_iobuf(encoded));
+    EXPECT_THROW(decode<uint32_t>(&p), decode_exception);
+}
+// NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+} // namespace wasm::parser::leb128

--- a/src/v/wasm/parser/tests/parser_test.cc
+++ b/src/v/wasm/parser/tests/parser_test.cc
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/bytes.h"
+#include "bytes/iobuf_parser.h"
+#include "gtest/gtest.h"
+#include "wasm/parser/parser.h"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <stdexcept>
+#include <utility>
+#include <wasm.h>
+#include <wasmtime.h>
+
+namespace wasm::parser {
+
+namespace {
+bytes wat2wasm(std::string_view wat) {
+    wasm_byte_vec_t wasm_bytes;
+    wasm_byte_vec_new_empty(&wasm_bytes);
+    wasmtime_error_t* error = wasmtime_wat2wasm(
+      wat.data(), wat.size(), &wasm_bytes);
+    bytes b;
+    // NOLINTNEXTLINE(*-reinterpret-cast)
+    b.append(reinterpret_cast<uint8_t*>(wasm_bytes.data), wasm_bytes.size);
+    wasm_byte_vec_delete(&wasm_bytes);
+    if (error != nullptr) {
+        throw std::runtime_error("invalid wat");
+        wasmtime_error_delete(error);
+    }
+    return b;
+}
+
+struct test_data {
+    std::string wat;
+    module_declarations expected;
+};
+
+void PrintTo(const test_data& d, std::ostream* os) { *os << d.wat; }
+
+class ParserTest : public testing::TestWithParam<test_data> {};
+
+TEST_P(ParserTest, ExtractDeclarations) {
+    const auto& testcase = GetParam();
+    bytes wasm = wat2wasm(testcase.wat);
+    auto decls = extract_declarations(bytes_to_iobuf(wasm)).get();
+    EXPECT_EQ(decls, testcase.expected);
+}
+
+module_export func(
+  ss::sstring name,
+  std::vector<val_type> params,
+  std::vector<val_type> results) {
+    return {
+      .item_name = std::move(name),
+      .description = declaration::function{{params, results}},
+    };
+}
+
+module_import func(
+  ss::sstring mod,
+  ss::sstring name,
+  std::vector<val_type> params,
+  std::vector<val_type> results) {
+    return {
+      .module_name = std::move(mod),
+      .item_name = std::move(name),
+      .description = declaration::function{{params, results}},
+    };
+}
+
+module_export global(ss::sstring name, val_type ty) {
+    return {
+      .item_name = std::move(name),
+      .description = declaration::global{ty, false},
+    };
+}
+
+module_import global(ss::sstring mod, ss::sstring name, val_type ty) {
+    return {
+      .module_name = std::move(mod),
+      .item_name = std::move(name),
+      .description = declaration::global{ty, false},
+    };
+}
+
+module_export table(ss::sstring name, val_type ty, declaration::limits limits) {
+    return {
+      .item_name = std::move(name),
+      .description = declaration::table{ty, limits},
+    };
+}
+
+module_import table(
+  ss::sstring mod, ss::sstring name, val_type ty, declaration::limits limits) {
+    return {
+      .module_name = std::move(mod),
+      .item_name = std::move(name),
+      .description = declaration::table{ty, limits},
+    };
+}
+
+module_export memory(ss::sstring name, declaration::limits limits) {
+    return {
+      .item_name = std::move(name),
+      .description = declaration::memory{limits},
+    };
+}
+
+module_import
+memory(ss::sstring mod, ss::sstring name, declaration::limits limits) {
+    return {
+      .module_name = std::move(mod),
+      .item_name = std::move(name),
+      .description = declaration::memory{limits},
+    };
+}
+
+// Many of these tests are from the offical Wasm test suite.
+INSTANTIATE_TEST_SUITE_P(
+  WatTests,
+  ParserTest,
+  testing::ValuesIn<std::vector<test_data>>(
+    {
+      {
+        .wat = R"WAT((module))WAT",
+        .expected = {
+          .exports = {},
+          .imports = {},
+        }
+      },
+      {
+        .wat = R"WAT(
+(module
+  (import "console" "log" (func $log (param i32)))
+  (global $from_js (import "env" "from_js") i32)
+  (global $from_wasm i32 (i32.const 10))
+  (func $main
+    global.get $from_js
+    global.get $from_wasm
+    i32.add
+    call $log
+  )
+  (export "_start" (func $main))
+)
+)WAT",
+        .expected = {
+          .exports = {
+            func("_start", {}, {})
+          },
+          .imports = {
+            func("console", "log", {val_type::i32}, {}),
+            global("env", "from_js", val_type::i32),
+          },
+        }
+      },
+      {
+        .wat = R"WAT(
+(module
+  (import "spectest" "global_i32" (global i32))
+  (global (import "spectest" "global_i32") i32)
+
+  (import "spectest" "global_i32" (global $x i32))
+  (global $y (import "spectest" "global_i32") i32)
+
+  (import "spectest" "global_i64" (global i64))
+  (import "spectest" "global_f32" (global f32))
+  (import "spectest" "global_f64" (global f64))
+
+  (func (export "get-0") (result i32) (global.get 0))
+  (func (export "get-1") (result i32) (global.get 1))
+  (func (export "get-x") (result i32) (global.get $x))
+  (func (export "get-y") (result i32) (global.get $y))
+  (func (export "get-4") (result i64) (global.get 4))
+  (func (export "get-5") (result f32) (global.get 5))
+  (func (export "get-6") (result f64) (global.get 6))
+)
+)WAT",
+        .expected = {
+          .exports = {
+            func("get-0", {}, {val_type::i32}),
+            func("get-1", {}, {val_type::i32}),
+            func("get-x", {}, {val_type::i32}),
+            func("get-y", {}, {val_type::i32}),
+            func("get-4", {}, {val_type::i64}),
+            func("get-5", {}, {val_type::f32}),
+            func("get-6", {}, {val_type::f64}),
+          },
+          .imports = {
+            global("spectest", "global_i32", val_type::i32),
+            global("spectest", "global_i32", val_type::i32),
+            global("spectest", "global_i32", val_type::i32),
+            global("spectest", "global_i32", val_type::i32),
+            global("spectest", "global_i64", val_type::i64),
+            global("spectest", "global_f32", val_type::f32),
+            global("spectest", "global_f64", val_type::f64),
+          },
+        }
+      },
+      {
+        .wat = R"WAT(
+(module
+  (type (func (result i32)))
+  (import "spectest" "table" (table $tab 10 20 funcref))
+  (elem (table $tab) (i32.const 1) func $f $g)
+
+  (func (export "call") (param i32) (result i32)
+    (call_indirect $tab (type 0) (local.get 0))
+  )
+  (func $f (result i32) (i32.const 11))
+  (func $g (result i32) (i32.const 22))
+)
+)WAT",
+        .expected = {
+          .exports = {func("call", {val_type::i32}, {val_type::i32})},
+          .imports = {table("spectest", "table", val_type::funcref, {.min = 10, .max = 20})},
+        }
+      },
+      {
+        .wat = R"WAT(
+(module
+  (import "spectest" "memory" (memory 1 2))
+  (data (memory 0) (i32.const 10) "\10")
+
+  (func (export "load") (param i32) (result i32) (i32.load (local.get 0)))
+)
+)WAT",
+        .expected = {
+          .exports = {func("load", {val_type::i32}, {val_type::i32})},
+          .imports = {memory("spectest", "memory", {.min = 1, .max = 2})},
+        }
+      },
+      {
+        .wat = R"WAT(
+(module (memory (export "a") 0))
+)WAT",
+        .expected = {
+          .exports = {memory("a", {})},
+          .imports = {},
+        }
+      },
+      {
+        .wat = R"WAT(
+(module (table 0 funcref) (export "a" (table 0)))
+)WAT",
+        .expected = {
+          .exports = {table("a", val_type::funcref, {})},
+          .imports = {},
+        }
+      },
+      {
+        .wat = R"WAT(
+(module (global i32 (i32.const 0)) (export "a" (global 0)))
+)WAT",
+        .expected = {
+          .exports = {global("a", val_type::i32)},
+          .imports = {},
+        }
+      },
+      {
+        .wat = R"WAT(
+(module (func) (export "a" (func 0)))
+)WAT",
+        .expected = {
+          .exports = {func("a", {}, {})},
+          .imports = {},
+        }
+      },
+      {
+        .wat = R"WAT(
+(module
+  (type $func_i32 (func (param i32)))
+  (type $func_i64 (func (param i64)))
+  (type $func_f32 (func (param f32)))
+  (type $func_f64 (func (param f64)))
+
+  (import "spectest" "print_i32" (func (param i32)))
+  (func (import "spectest" "print_i64") (param i64))
+  (import "spectest" "print_i32" (func $print_i32 (param i32)))
+  (import "spectest" "print_i64" (func $print_i64 (param i64)))
+  (import "spectest" "print_f32" (func $print_f32 (param f32)))
+  (import "spectest" "print_f64" (func $print_f64 (param f64)))
+  (import "spectest" "print_i32_f32" (func $print_i32_f32 (param i32 f32)))
+  (import "spectest" "print_f64_f64" (func $print_f64_f64 (param f64 f64)))
+  (func $print_i32-2 (import "spectest" "print_i32") (param i32))
+  (func $print_f64-2 (import "spectest" "print_f64") (param f64))
+  (import "test" "func-i64->i64" (func $i64->i64 (param i64) (result i64)))
+
+  (func (export "p1") (import "spectest" "print_i32") (param i32))
+  (func $p (export "p2") (import "spectest" "print_i32") (param i32))
+  (func (export "p3") (export "p4") (import "spectest" "print_i32") (param i32))
+  (func (export "p5") (import "spectest" "print_i32") (type 0))
+  (func (export "p6") (import "spectest" "print_i32") (type 0) (param i32) (result))
+
+  (import "spectest" "print_i32" (func (type $forward)))
+  (func (import "spectest" "print_i32") (type $forward))
+  (type $forward (func (param i32)))
+
+  (table funcref (elem $print_i32 $print_f64))
+
+  (func (export "print32") (param $i i32)
+    (local $x f32)
+    (local.set $x (f32.convert_i32_s (local.get $i)))
+    (call 0 (local.get $i))
+    (call $print_i32_f32
+      (i32.add (local.get $i) (i32.const 1))
+      (f32.const 42)
+    )
+    (call $print_i32 (local.get $i))
+    (call $print_i32-2 (local.get $i))
+    (call $print_f32 (local.get $x))
+    (call_indirect (type $func_i32) (local.get $i) (i32.const 0))
+  )
+
+  (func (export "print64") (param $i i64)
+    (local $x f64)
+    (local.set $x (f64.convert_i64_s (call $i64->i64 (local.get $i))))
+    (call 1 (local.get $i))
+    (call $print_f64_f64
+      (f64.add (local.get $x) (f64.const 1))
+      (f64.const 53)
+    )
+    (call $print_i64 (local.get $i))
+    (call $print_f64 (local.get $x))
+    (call $print_f64-2 (local.get $x))
+    (call_indirect (type $func_f64) (local.get $x) (i32.const 1))
+  )
+)
+)WAT",
+        .expected = {
+          .exports = {
+            func("p1", {val_type::i32}, {}),
+            func("p2", {val_type::i32}, {}),
+            func("p3", {val_type::i32}, {}),
+            func("p4", {val_type::i32}, {}),
+            func("p5", {val_type::i32}, {}),
+            func("p6", {val_type::i32}, {}),
+            func("print32", {val_type::i32}, {}),
+            func("print64", {val_type::i64}, {}),
+          },
+          .imports = {
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_i64", {val_type::i64}, {}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_i64", {val_type::i64}, {}),
+            func("spectest", "print_f32", {val_type::f32}, {}),
+            func("spectest", "print_f64", {val_type::f64}, {}),
+            func("spectest", "print_i32_f32", {val_type::i32, val_type::f32}, {}),
+            func("spectest", "print_f64_f64", {val_type::f64, val_type::f64}, {}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_f64", {val_type::f64}, {}),
+            func("test", "func-i64->i64", {val_type::i64}, {val_type::i64}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+            func("spectest", "print_i32", {val_type::i32}, {}),
+          },
+        }
+      },
+      {
+        .wat = R"WAT(
+(module
+  (memory 1)
+  (data (i32.const 0) "a")
+)
+)WAT",
+        .expected = {
+          .exports = {},
+          .imports = {},
+        }
+      },
+}));
+
+} // namespace
+
+} // namespace wasm::parser

--- a/src/v/wasm/tests/wasm_cache_test.cc
+++ b/src/v/wasm/tests/wasm_cache_test.cc
@@ -125,6 +125,8 @@ public:
 
     state* get_state() { return &_state; }
 
+    ss::future<> validate(iobuf) override { co_return; }
+
 private:
     state _state;
 };

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -181,6 +181,7 @@ void WasmTestFixture::load_wasm(const std::string& path) {
     for (auto& chunk : wasm_file) {
         buf.append(std::move(chunk));
     }
+    _runtime->validate(buf.share(0, buf.size_bytes())).get();
     _factory = _runtime->make_factory(_meta, std::move(buf)).get();
     if (_engine) {
         _engine->stop().get();

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -1599,12 +1599,14 @@ ss::future<> wasmtime_runtime::validate(iobuf buf) {
     if (!has_wasi_main) {
         vlog(wasm_log.warn, "invalid module: missing _start function");
         throw wasm_exception(
-          "invalid module: missing _start function", errc::user_code_failure);
+          "invalid module: missing _start function",
+          errc::invalid_module_missing_wasi);
     }
     if (!has_exported_memory) {
         vlog(wasm_log.warn, "invalid module: missing memory export");
         throw wasm_exception(
-          "invalid module: missing memory export", errc::user_code_failure);
+          "invalid module: missing memory export",
+          errc::invalid_module_missing_wasi);
     }
     bool has_abi_check_fn = false;
     for (const auto& module_import : decls.imports) {
@@ -1618,7 +1620,7 @@ ss::future<> wasmtime_runtime::validate(iobuf buf) {
         vlog(wasm_log.warn, "invalid module: missing abi function");
         throw wasm_exception(
           "invalid module: missing transform sdk ABI check function",
-          errc::user_code_failure);
+          errc::invalid_module_missing_abi);
     }
 }
 

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -26,6 +26,7 @@
 #include "wasm/errc.h"
 #include "wasm/ffi.h"
 #include "wasm/logger.h"
+#include "wasm/parser/parser.h"
 #include "wasm/schema_registry_module.h"
 #include "wasm/transform_module.h"
 #include "wasm/transform_probe.h"
@@ -44,6 +45,7 @@
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/optimized_optional.hh>
 
+#include <absl/algorithm/container.h>
 #include <absl/strings/escaping.h>
 
 #include <alloca.h>
@@ -56,6 +58,7 @@
 #include <span>
 #include <unistd.h>
 #include <utility>
+#include <variant>
 #include <wasm.h>
 #include <wasmtime.h>
 
@@ -110,6 +113,8 @@ public:
 
     ss::future<ss::shared_ptr<factory>>
     make_factory(model::transform_metadata meta, iobuf buf) override;
+
+    ss::future<> validate(iobuf buf) override;
 
     wasm_engine_t* engine() const;
 
@@ -1538,6 +1543,83 @@ wasmtime_error_t* wasmtime_runtime::allocate_heap_memory(
         return wasmtime_error_new(msg.c_str());
     };
     return nullptr;
+}
+
+bool is_wasi_main(const parser::module_export& mod_export) {
+    // Expect a function called _start with no parameters or results.
+    return mod_export
+           == parser::module_export{
+             .item_name = "_start",
+             .description = parser::declaration::function{}};
+}
+
+bool is_exported_memory(const parser::module_export& mod_export) {
+    return mod_export.item_name == "memory"
+           && std::holds_alternative<parser::declaration::memory>(
+             mod_export.description);
+}
+
+bool is_transform_abi_check_fn(const parser::module_import& mod_import) {
+    return mod_import
+           == parser::module_import{
+             .module_name = ss::sstring(transform_module::name),
+             .item_name = "check_abi_version_1",
+             .description = parser::declaration::function{}};
+}
+
+ss::future<> wasmtime_runtime::validate(iobuf buf) {
+    parser::module_declarations decls;
+    try {
+        decls = co_await parser::extract_declarations(std::move(buf));
+    } catch (const parser::module_too_large_exception& ex) {
+        vlog(wasm_log.warn, "invalid module (too large): {}", ex);
+        throw wasm_exception(ex.what(), errc::invalid_module);
+    } catch (const parser::parse_exception& ex) {
+        vlog(wasm_log.warn, "invalid module (unable to parse): {}", ex);
+        throw wasm_exception(ex.what(), errc::invalid_module);
+    }
+    bool has_wasi_main = false;
+
+    bool has_exported_memory = false;
+
+    for (const auto& module_export : decls.exports) {
+        if (is_wasi_main(module_export)) {
+            has_wasi_main = true;
+            if (has_exported_memory) {
+                break;
+            }
+        } else if (is_exported_memory(module_export)) {
+            has_exported_memory = true;
+            if (has_wasi_main) {
+                break;
+            }
+        }
+        co_await ss::coroutine::maybe_yield();
+    }
+    if (!has_wasi_main) {
+        vlog(wasm_log.warn, "invalid module: missing _start function");
+        throw wasm_exception(
+          "invalid module: missing _start function", errc::user_code_failure);
+    }
+    if (!has_exported_memory) {
+        vlog(wasm_log.warn, "invalid module: missing memory export");
+        throw wasm_exception(
+          "invalid module: missing memory export", errc::user_code_failure);
+    }
+    bool has_abi_check_fn = false;
+    for (const auto& module_import : decls.imports) {
+        if (is_transform_abi_check_fn(module_import)) {
+            has_abi_check_fn = true;
+            break;
+        }
+        co_await ss::coroutine::maybe_yield();
+    }
+    if (!has_abi_check_fn) {
+        vlog(wasm_log.warn, "invalid module: missing abi function");
+        throw wasm_exception(
+          "invalid module: missing transform sdk ABI check function",
+          errc::user_code_failure);
+    }
 }
 
 } // namespace

--- a/tests/docker/ducktape-deps/tinygo-wasi-transforms
+++ b/tests/docker/ducktape-deps/tinygo-wasi-transforms
@@ -9,3 +9,29 @@ cd /transform-sdk/go/transform/internal/testdata
 tinygo build -target wasi -opt=z \
   -panic print -scheduler none \
   -o "/opt/transforms/tinygo/identity.wasm" ./identity
+
+# The following are some invalid wasm binarys for Redpanda, they either are invalid
+# as they are invalid bytes, or don't adhere to our ABI contract somehow
+#
+# Decode these at https://webassembly.github.io/wabt/demo/wasm2wat/
+mkdir -p /opt/transforms/validation/
+
+# Random bytes sourced from /dev/urandom with valid wasm prefix:
+echo "AGFzbQEAAAABBwFgAn9/63noHo07OzANmns7oZTsdHHpORQ=" |
+  base64 --decode >/opt/transforms/validation/garbage.wasm
+
+# WebAssembly Text Format of this module:
+# (module
+#  (func (export "addTwo") (param i32 i32) (result i32)
+#    local.get 0
+#    local.get 1
+#    i32.add))
+echo "AGFzbQEAAAABBwFgAn9/AX8DAgEABwoBBmFkZFR3bwAACgkBBwAgACABagsACgRuYW1lAgMBAAA=" |
+  base64 --decode >/opt/transforms/validation/add_two.wasm
+
+# WebAssembly Text Format of this module:
+# (module
+#  (memory (export "memory") 1)
+#  (func (export "_start")))
+echo "AGFzbQEAAAABBAFgAAADAgEABQMBAAEHEwIGbWVtb3J5AgAGX3N0YXJ0AAAKBAECAAsACgRuYW1lAgMBAAA=" |
+  base64 --decode >/opt/transforms/validation/wasi.wasm

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1614,7 +1614,11 @@ class RpkTool:
         cmd += rest
         return self._execute(cmd)
 
-    def deploy_wasm(self, name, input_topic, output_topic):
+    def deploy_wasm(self,
+                    name,
+                    input_topic,
+                    output_topic,
+                    file="tinygo/identity.wasm"):
         self._run_wasm([
             "deploy",
             "--name",
@@ -1624,7 +1628,7 @@ class RpkTool:
             "--output-topic",
             output_topic,
             "--file",
-            "/opt/transforms/tinygo/identity.wasm",
+            f"/opt/transforms/{file}",
         ])
 
     def delete_wasm(self, name):


### PR DESCRIPTION
As part of the multiple output topics project, we will be supporting multiple ABI versions.
To help reduce user confusion when the case of when the SDK is newer than Redpanda, we will
validate the versions we support at deploy time. As we currently will provide backwards compatibility,
but not forwards compatibility.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Validate transform code at deploy time to ensure the correct SDK is used.

