### PR TITLE
labeler: apply wasm label for Redpanda subsystems

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,3 +19,5 @@ area/redpanda:
 
 area/wasm:
 - src/transform-sdk/**/*
+- src/v/transform/**/*
+- src/v/wasm/**/*


### PR DESCRIPTION
When working on transform or wasm subsystems, I would like to see those
on my GitHub project, which auto adding this label allow me to automate
that process.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
