### PR TITLE
tx/compaction: don't deduplicate control batches

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -97,6 +97,8 @@ std::string_view to_string_view(feature f) {
         return "cloud_metadata_cluster_recovery";
     case feature::audit_logging:
         return "audit_logging";
+    case feature::compaction_placeholder_batch:
+        return "compaction_placeholder_batch";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -73,6 +73,7 @@ enum class feature : std::uint64_t {
     disabling_partitions = 1ULL << 39U,
     cloud_metadata_cluster_recovery = 1ULL << 40U,
     audit_logging = 1ULL << 41U,
+    compaction_placeholder_batch = 1ULL << 42U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -362,6 +363,12 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{11},
     "audit_logging",
     feature::audit_logging,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{12},
+    "compaction_placeholder_batch",
+    feature::compaction_placeholder_batch,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always}};
 

--- a/src/v/kafka/protocol/batch_consumer.h
+++ b/src/v/kafka/protocol/batch_consumer.h
@@ -37,6 +37,11 @@ public:
         // transactions spanning compacted and non-compacted segments.
         // For more details, check the details in the commit that added
         // this.
+        // Note: This offset tracking is not needed after
+        // https://github.com/redpanda-data/redpanda/pull/16295
+        // but only retained for old data segments where abort markers
+        // were compacted away. Perhaps multiple major releases later
+        // this code can be removed.
         std::optional<model::offset> first_tx_batch_offset;
     };
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -365,6 +365,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::tx_registry";
     case record_batch_type::cluster_recovery_cmd:
         return o << "batch_type::cluster_recovery_cmd";
+    case record_batch_type::compaction_placeholder:
+        return o << "batch_type::compaction_placeholder";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -346,8 +346,6 @@ public:
 
     void set_transactional_type() { _attributes |= transactional_mask; }
 
-    void unset_transactional_type() { _attributes &= ~transactional_mask; }
-
     bool operator==(const record_batch_attributes& other) const {
         return _attributes == other._attributes;
     }

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -46,7 +46,9 @@ enum class record_batch_type : int8_t {
     plugin_update = 26,              // Wasm plugin update
     tx_registry = 27,                // tx_registry_batch_type
     cluster_recovery_cmd = 28,       // cluster recovery command
-    MAX = cluster_recovery_cmd
+    compaction_placeholder
+    = 29, // place holder for last batch in a segment that was aborted
+    MAX = compaction_placeholder,
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -459,19 +459,6 @@ ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {
         if (is_control) {
             // tx_commit / tx_abort / unknown
 
-            // Control batches are not discarded but are compacted in the same
-            // manner as other data batches. This approach prevents the
-            // elimination of the last batch within a segment when it happens to
-            // be a control batch. If the final batch in a segment is discarded,
-            // and there are no subsequent data batches, it could lead to
-            // clients being unable to advance their consumable offset until the
-            // Last Stable Offset (LSO) is reached, creating the perception of a
-            // stuck consumer unable to make progress.
-
-            // However, this situation is not problematic when the last batch is
-            // an aborted data batch. This is because we can guarantee the
-            // presence of user consumable batches following it, specifically
-            // the abort control batch, ensuring continuous consumer progress.
             handle_tx_control_batch(b);
         } else if (is_data) {
             // User produced data batches in tx scope..

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -118,13 +118,13 @@ private:
 class copy_data_segment_reducer : public compaction_reducer {
 public:
     using filter_t = ss::noncopyable_function<ss::future<bool>(
-      const model::record_batch&, const model::record&)>;
+      const model::record_batch&, const model::record&, bool)>;
     copy_data_segment_reducer(
       filter_t f,
       segment_appender* a,
       bool internal_topic,
       offset_delta_time apply_offset,
-      model::offset segment_last_offset = model::offset{},
+      model::offset segment_last_offset,
       compacted_index_writer* cidx = nullptr)
       : _should_keep_fn(std::move(f))
       , _segment_last_offset(segment_last_offset)
@@ -141,7 +141,10 @@ private:
       filter_and_append(model::compression, model::record_batch);
 
     ss::future<> maybe_keep_offset(
-      const model::record_batch&, const model::record&, std::vector<int32_t>&);
+      const model::record_batch&,
+      const model::record&,
+      bool,
+      std::vector<int32_t>&);
 
     ss::future<std::optional<model::record_batch>> filter(model::record_batch);
 

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -183,12 +183,9 @@ private:
 };
 
 /**
- * Filters out the following record batches from compaction.
- * - Aborted transaction raft data bathes
- * - Transactional control metadata batches (commit/abort etc)
- *
- * Resulting compacted segment includes only committed transaction's
- * data without the transactional markers.
+ * Filters out the aborted transaction data batches from the segment.
+ * Retains the control batches (commit/abort) thus preserving the
+ * transaction boundaries.
  *
  * Note: fence batches are retained to preserve the epochs from pids.
  * The state machine uses this information to preserve the monotonicity

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -148,6 +148,9 @@ private:
 
     ss::future<std::optional<model::record_batch>> filter(model::record_batch);
 
+    // Creates a placeholder batch with same offset range as the input header.
+    model::record_batch make_placeholder_batch(model::record_batch_header&);
+
     filter_t _should_keep_fn;
 
     // Offset to keep in case the index is empty as of getting to this offset.

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -248,6 +248,8 @@ private:
     bool handle_tx_data_batch(const model::record_batch&);
     bool handle_non_tx_control_batch(const model::record_batch&);
     void consume_aborted_txs(model::offset);
+    model::record_batch
+    make_placeholder_batch(model::offset base, model::offset end);
 
     index_rebuilder_reducer _delegate;
     // A min heap of aborted transactions based on begin offset.

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -451,7 +451,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
           *_probe,
           *_readers_cache,
           _manager.resources(),
-          storage::internal::should_apply_delta_time_offset(_feature_table));
+          _feature_table);
 
         vlog(
           gclog.debug,
@@ -549,7 +549,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
           *_probe,
           *_readers_cache,
           _manager.resources(),
-          storage::internal::should_apply_delta_time_offset(_feature_table));
+          _feature_table);
 
         vlog(
           gclog.debug,
@@ -692,8 +692,8 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
               *appender,
               compacted_idx_writer,
               *_probe,
-              storage::internal::should_apply_delta_time_offset(
-                _feature_table));
+              storage::internal::should_apply_delta_time_offset(_feature_table),
+              _feature_table);
 
         } catch (...) {
             eptr = std::current_exception();
@@ -910,7 +910,7 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
       *_probe,
       *_readers_cache,
       _manager.resources(),
-      storage::internal::should_apply_delta_time_offset(_feature_table));
+      _feature_table);
     _probe->delete_segment(*replacement.get());
     vlog(gclog.debug, "Final compacted segment {}", replacement);
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -187,20 +187,29 @@ ss::future<index_state> deduplicate_segment(
   compacted_index_writer& cmp_idx_writer,
   probe& probe,
   offset_delta_time should_offset_delta_times,
-  ss::sharded<features::feature_table>&) {
+  ss::sharded<features::feature_table>& feature_table) {
     auto read_holder = co_await seg->read_lock();
     if (seg->is_closed()) {
         throw segment_closed_exception();
     }
     auto rdr = internal::create_segment_full_reader(
       seg, cfg, probe, std::move(read_holder));
+    auto compaction_placeholder_enabled = feature_table.local().is_active(
+      features::feature::compaction_placeholder_batch);
     auto copy_reducer = internal::copy_data_segment_reducer(
-      [&map, segment_last_offset = seg->offsets().committed_offset](
+      [&map,
+       segment_last_offset = seg->offsets().committed_offset,
+       compaction_placeholder_enabled](
         const model::record_batch& b,
         const model::record& r,
         bool is_last_record_in_batch) {
           auto is_last_batch = b.last_offset() == segment_last_offset;
-          if (is_last_batch && is_last_record_in_batch) {
+          // once compaction placeholder feature is enabled, we are not
+          // worried about empty batches as the reducer then installs a
+          // placeholder batch if all the records are compacted away.
+          if (
+            !compaction_placeholder_enabled
+            && (is_last_batch && is_last_record_in_batch)) {
               vlog(
                 stlog.trace,
                 "retaining last record: {} of segment from batch: {}",

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -186,7 +186,8 @@ ss::future<index_state> deduplicate_segment(
   segment_appender& appender,
   compacted_index_writer& cmp_idx_writer,
   probe& probe,
-  offset_delta_time should_offset_delta_times) {
+  offset_delta_time should_offset_delta_times,
+  ss::sharded<features::feature_table>&) {
     auto read_holder = co_await seg->read_lock();
     if (seg->is_closed()) {
         throw segment_closed_exception();

--- a/src/v/storage/segment_deduplication_utils.h
+++ b/src/v/storage/segment_deduplication_utils.h
@@ -56,6 +56,7 @@ ss::future<index_state> deduplicate_segment(
   segment_appender& appender,
   compacted_index_writer& cmp_idx_writer,
   storage::probe& probe,
-  offset_delta_time should_offset_delta_times);
+  offset_delta_time should_offset_delta_times,
+  ss::sharded<features::feature_table>&);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -411,7 +411,9 @@ ss::future<storage::index_state> do_copy_segment_data(
       tmpname);
 
     auto should_keep = [compacted_list = std::move(compacted_offsets)](
-                         const model::record_batch& b, const model::record& r) {
+                         const model::record_batch& b,
+                         const model::record& r,
+                         bool) {
         const auto o = b.base_offset() + model::offset_delta(r.offset_delta());
         return ss::make_ready_future<bool>(compacted_list.contains(o));
     };
@@ -420,7 +422,8 @@ ss::future<storage::index_state> do_copy_segment_data(
       std::move(should_keep),
       appender.get(),
       seg->path().is_internal_topic(),
-      apply_offset);
+      apply_offset,
+      seg->offsets().committed_offset);
 
     // create the segment, get the in-memory index for the new segment
     auto new_index = co_await create_segment_full_reader(

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -374,7 +374,8 @@ ss::future<storage::index_state> do_copy_segment_data(
   storage::probe& pb,
   ss::rwlock::holder rw_lock_holder,
   storage_resources& resources,
-  offset_delta_time apply_offset) {
+  offset_delta_time apply_offset,
+  ss::sharded<features::feature_table>&) {
     // preserve broker_timestamp from the segment's index
     auto old_broker_timestamp = seg->index().broker_timestamp();
 
@@ -500,7 +501,8 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
   storage::readers_cache& readers_cache,
   storage_resources& resources,
   offset_delta_time apply_offset,
-  ss::rwlock::holder read_holder) {
+  ss::rwlock::holder read_holder,
+  ss::sharded<features::feature_table>& feature_table) {
     vlog(gclog.trace, "self compacting segment {}", s->reader().path());
     auto segment_generation = s->get_generation_id();
 
@@ -517,7 +519,13 @@ ss::future<std::optional<size_t>> do_self_compact_segment(
     auto staging_to_clean = scoped_file_tracker{
       cfg.files_to_cleanup, {staging_file}};
     auto idx = co_await do_copy_segment_data(
-      s, cfg, pb, std::move(read_holder), resources, apply_offset);
+      s,
+      cfg,
+      pb,
+      std::move(read_holder),
+      resources,
+      apply_offset,
+      feature_table);
 
     auto rdr_holder = co_await readers_cache.evict_segment_readers(s);
 
@@ -626,7 +634,7 @@ ss::future<compaction_result> self_compact_segment(
   storage::probe& pb,
   storage::readers_cache& readers_cache,
   storage_resources& resources,
-  offset_delta_time apply_offset) {
+  ss::sharded<features::feature_table>& feature_table) {
     if (s->has_appender()) {
         throw std::runtime_error(fmt::format(
           "Cannot compact an active segment. cfg:{} - segment:{}", cfg, s));
@@ -683,6 +691,7 @@ ss::future<compaction_result> self_compact_segment(
       "Unexpected state {}",
       int(state));
     auto sz_before = s->size_bytes();
+    auto apply_offset = should_apply_delta_time_offset(feature_table);
     auto sz_after = co_await do_self_compact_segment(
       s,
       cfg,
@@ -690,7 +699,8 @@ ss::future<compaction_result> self_compact_segment(
       readers_cache,
       resources,
       apply_offset,
-      std::move(read_holder));
+      std::move(read_holder),
+      feature_table);
     // compaction wasn't executed, return
     if (!sz_after) {
         co_return compaction_result(sz_before);

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -39,7 +39,7 @@ ss::future<compaction_result> self_compact_segment(
   storage::probe&,
   storage::readers_cache&,
   storage::storage_resources&,
-  offset_delta_time apply_offset);
+  ss::sharded<features::feature_table>& feature_table);
 
 /// \brief, rebuilds a given segment's compacted index. This method acquires
 /// locks on the segment.

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -212,6 +212,11 @@ struct clean_segment_value
 };
 
 inline bool is_compactible(const model::record_batch_header& h) {
+    if (h.attrs.is_control()) {
+        // Keep control batches to ensure we maintain transaction boundaries.
+        // They should be rare.
+        return false;
+    }
     static const auto filtered_types = model::offset_translator_batch_types();
     auto n = std::count(filtered_types.begin(), filtered_types.end(), h.type);
     return n == 0;

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -212,7 +212,9 @@ struct clean_segment_value
 };
 
 inline bool is_compactible(const model::record_batch_header& h) {
-    if (h.attrs.is_control()) {
+    if (
+      h.attrs.is_control()
+      || h.type == model::record_batch_type::compaction_placeholder) {
         // Keep control batches to ensure we maintain transaction boundaries.
         // They should be rare.
         return false;

--- a/tests/java/verifiers/src/main/java/io/vectorized/compaction/tx/TxUniqueKeysWorkload.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/compaction/tx/TxUniqueKeysWorkload.java
@@ -26,6 +26,7 @@ public class TxUniqueKeysWorkload extends GatedWorkload {
     public String brokers;
     public String topic;
     public int partitions;
+    public float abort_probability;
   }
 
   static class Partition {
@@ -177,7 +178,8 @@ public class TxUniqueKeysWorkload extends GatedWorkload {
       boolean shouldAbort = false;
 
       if (!shouldRetry) {
-        shouldAbort = random.nextInt(3) == 0;
+        shouldAbort
+            = random.nextInt(100) < Math.round(args.abort_probability * 100);
       }
 
       var txOpId = id;

--- a/tests/java/verifiers/src/main/java/io/vectorized/compaction/tx/TxWorkload.java
+++ b/tests/java/verifiers/src/main/java/io/vectorized/compaction/tx/TxWorkload.java
@@ -27,6 +27,9 @@ public class TxWorkload extends GatedWorkload {
     public String topic;
     public int partitions;
     public int key_set_cardinality;
+    // [0, 1] 0 being no aborts and
+    // 1 being every request is an abort
+    public float abort_probability;
   }
 
   static class WriteInfo {
@@ -208,7 +211,8 @@ public class TxWorkload extends GatedWorkload {
 
       producer.beginTransaction();
 
-      boolean shouldAbort = random.nextInt(3) == 0;
+      boolean shouldAbort
+          = random.nextInt(100) < Math.round(args.abort_probability * 100);
 
       HashMap<String, WriteInfo> batch = new HashMap<>();
 

--- a/tests/rptest/services/compacted_verifier.py
+++ b/tests/rptest/services/compacted_verifier.py
@@ -163,7 +163,8 @@ class CompactedVerifier(Service):
                               connection,
                               topic,
                               partitions,
-                              key_set_cardinality=10):
+                              key_set_cardinality=10,
+                              abort_probability=0.3):
         self._partitions = partitions
         ip = self._node.account.hostname
         r = requests.post(f"http://{ip}:8080/start-producer",
@@ -172,7 +173,8 @@ class CompactedVerifier(Service):
                               "brokers": connection,
                               "topic": topic,
                               "partitions": partitions,
-                              "key_set_cardinality": key_set_cardinality
+                              "key_set_cardinality": key_set_cardinality,
+                              "abort_probability": abort_probability
                           })
         if r.status_code != 200:
             raise Exception(


### PR DESCRIPTION
Control batches (tx_commit, tx_abort) are special data batches that indicate the completion of a transaction. Because these are technically data batches, they participate in deduplication.

It was previously thought that as long as we kept the last control batch in a segment, that deduplicating such records was safe. However, consider the following sequence:

```
node 1:
1. begin tx 1, write data batch in tx 1
2. write many non-tx data batches, up to offset 100
3. abort tx 1
4. begin tx 2, write data batch in tx 2, abort tx 2 which is offset 110
5. begin recovery, replicating data to node 2, sending records [0, 50]
6. roll segment

node 2:
7. receives data [0, 50], including [begin tx 1, data tx 1, data]

node 1:
8. self compact segment: since all abort records have the same key, only abort tx 2 is kept
9. continue recovery, replicating data to node 2, sending records in the range [50, 110], but is missing abort tx 1

node 2:
10. receives data [50, 110], and now has [begin tx 1, data tx 1, data, begin tx 2, data tx 2, abort tx 2]
11. roll segment
12. self compact segment: rm_stm on this node doesn't know that tx 1 is considered aborted
13. data tx 1 is left in the segment as committed
```

If instead, at step 8, we had kept [abort tx 1] as well, this wouldn't have been an issue: node 2 would have replayed the abort and correctly compacted away data tx 1.

This commit does disallows the deduplication of control batches entirely. These batches are only used in transactions, and are expected to be uncommon. This happens in the `is_compactible()` method, which is used at compaction time to determine whether the entire batch should be kept without consulting further record-based maps.

I'm explicilty doing it here rather than e.g. filtering control batches when writing to the compaction index because we'll ultimately need to filter here anyway: older versions of Redpanda will have these control records in their compaction index.

Additionally also fixes a bug where compacting away last aborted data batch in a segment may cause readers to be stuck because of a gap in the segment ranges thus blocking recovery (this issue was exposed by the test)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes

### Bug Fixes

* Fixes a race between compaction and Raft recovery for compacted topics that could result in aborted transactional data batches being visible.
* fixes a bug where compacting away last aborted data batch in a segment may cause readers to be stuck because of a gap in the segment ranges thus blocking raft recovery 
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
