### PR TITLE
rpk/transform/build: enable SIMD

### DIFF
--- a/src/go/rpk/pkg/cli/transform/build.go
+++ b/src/go/rpk/pkg/cli/transform/build.go
@@ -74,6 +74,8 @@ Tinygo - By default tinygo are release builds (-opt=2) for maximum performance.
 					// We want LLVM to use all it's tricks to
 					// make our code fast.
 					"-opt", "2",
+					// Enable SIMD acceleration!
+					"-llvm-features", "+simd128",
 					// Print out an error before aborting, this
 					// greatly aids debugging.
 					"-panic", "print",
@@ -126,6 +128,8 @@ func buildRust(ctx context.Context, fs afero.Fs, cfg project.Config, extraArgs [
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
+	// Enable SIMD acceleration
+	cmd.Env = append(os.Environ(), "RUSTFLAGS=-Ctarget-feature=+simd128")
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("build failed %v", err)
 	}


### PR DESCRIPTION
Both Rust + Tinygo use LLVM toolchains, enable the autovectorizer in
clang to generate SIMD instructions. It looks like the auto vectorizer
is able to recognize some of our record parsing loops and generate SIMD
instructions, so this likely will improve the SDK performance.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* SIMD instructions are generated by default for WebAssembly binaries when building with `rpk`.

