### PR TITLE
Wrapped logging with `vlog` macro in places that missed it

### DIFF
--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -395,7 +395,8 @@ void partition_manager::check_partitions_shutdown_state() {
     const auto now = ss::lowres_clock::now();
     for (auto& state : _partitions_shutting_down) {
         if (state.last_update_timestamp < now - _partition_shutdown_timeout()) {
-            clusterlog.error(
+            vlog(
+              clusterlog.error,
               "partition {} shutdown takes longer than expected, current "
               "shutdown stage: {} time since last update: {} seconds",
               state.partition->ntp(),

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -214,37 +214,46 @@ ss::future<> rpc_server::dispatch_method_once(
                         ctx->pr.set_exception(e);
                         return ss::now();
                     } catch (const ss::timed_out_error& e) {
-                        rpclog.debug("Timing out request on timed_out_error "
-                                     "(shutting down)");
+                        vlog(
+                          rpclog.debug,
+                          "Timing out request on timed_out_error "
+                          "(shutting down)");
                         reply_buf.set_status(rpc::status::request_timeout);
                     } catch (const ss::condition_variable_timed_out& e) {
-                        rpclog.debug(
+                        vlog(
+                          rpclog.debug,
                           "Timing out request on condition_variable_timed_out");
                         reply_buf.set_status(rpc::status::request_timeout);
                     } catch (const ss::gate_closed_exception& e) {
                         // gate_closed is typical during shutdown.  Treat
                         // it like a timeout: request was not erroneous
                         // but we will not give a rseponse.
-                        rpclog.debug(
+                        vlog(
+                          rpclog.debug,
                           "Timing out request on gate_closed_exception "
                           "(shutting down)");
                         reply_buf.set_status(rpc::status::request_timeout);
                     } catch (const ss::broken_condition_variable& e) {
-                        rpclog.debug(
+                        vlog(
+                          rpclog.debug,
                           "Timing out request on broken_condition_variable "
                           "(shutting down)");
                         reply_buf.set_status(rpc::status::request_timeout);
                     } catch (const ss::abort_requested_exception& e) {
-                        rpclog.debug(
+                        vlog(
+                          rpclog.debug,
                           "Timing out request on abort_requested_exception "
                           "(shutting down)");
                         reply_buf.set_status(rpc::status::request_timeout);
                     } catch (const ss::broken_semaphore& e) {
-                        rpclog.debug("Timing out request on broken_semaphore "
-                                     "(shutting down)");
+                        vlog(
+                          rpclog.debug,
+                          "Timing out request on broken_semaphore "
+                          "(shutting down)");
                         reply_buf.set_status(rpc::status::request_timeout);
                     } catch (...) {
-                        rpclog.error(
+                        vlog(
+                          rpclog.error,
                           "Service handler for method {} threw an exception: "
                           "{}",
                           method_id,
@@ -274,7 +283,7 @@ ss::future<> rpc_server::dispatch_method_once(
                 });
           })
           .handle_exception([](const std::exception_ptr& e) {
-              rpclog.error("Error dispatching: {}", e);
+              vlog(rpclog.error, "Error dispatching: {}", e);
           });
 
     return fut;

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -110,12 +110,14 @@ transport::connect(rpc::clock_type::time_point connection_timeout) {
                 } catch (...) {
                     auto e = std::current_exception();
                     if (net::is_disconnect_exception(e)) {
-                        rpc::rpclog.info(
+                        vlog(
+                          rpc::rpclog.info,
                           "Disconnected from server {}: {}",
                           server_address(),
                           e);
                     } else {
-                        rpc::rpclog.error(
+                        vlog(
+                          rpc::rpclog.error,
                           "Error dispatching client reads to {}: {}",
                           server_address(),
                           e);


### PR DESCRIPTION
Added missing `vlog` macros in places where logger was used without it. This way we will have log entry format consistent. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none