### PR TITLE
[v23.3.x] demote ERROR message to DEBUG for timequerys at the edge of spillover retention

### DIFF
--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -249,7 +249,7 @@ bool async_manifest_view_cursor::manifest_in_range(
           auto lo = p.get().get_last_offset();
           vlog(
             _view._ctxlog.debug,
-            "Spill manifest range: [{}/{}], cursor range: [{}/{}]",
+            "STM manifest range: [{}/{}], cursor range: [{}/{}]",
             so,
             lo,
             _begin,
@@ -261,7 +261,7 @@ bool async_manifest_view_cursor::manifest_in_range(
           auto lo = m->manifest.get_last_offset();
           vlog(
             _view._ctxlog.debug,
-            "STM manifest range: [{}/{}], cursor range: [{}/{}]",
+            "Spill manifest range: [{}/{}], cursor range: [{}/{}]",
             so,
             lo,
             _begin,

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -1297,8 +1297,9 @@ async_manifest_view::get_materialized_manifest(
             // Fast path for STM reads
             co_return std::ref(_stm_manifest);
         }
+        // query in not in the stm region
         if (
-          !in_stm(q) && std::holds_alternative<model::timestamp>(q)
+          std::holds_alternative<model::timestamp>(q)
           && _stm_manifest.get_archive_start_offset() == model::offset{}) {
             vlog(_ctxlog.debug, "Using STM manifest for timequery {}", q);
             co_return std::ref(_stm_manifest);

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -524,24 +524,30 @@ private:
 
             if (
               cur.error() == error_outcome::out_of_range
-              && std::holds_alternative<kafka::offset>(query)) {
-                // Special case queries below the start offset of the log.
-                // The start offset may have advanced while the request was
-                // in progress. This is expected, so log at debug level.
-                const auto log_start_offset = _partition->_manifest_view
-                                                ->stm_manifest()
-                                                .full_log_start_kafka_offset();
+              && ss::visit(
+                query,
+                [&](kafka::offset query_offset) {
+                    // Special case queries below the start offset of the log.
+                    // The start offset may have advanced while the request was
+                    // in progress. This is expected, so log at debug level.
+                    const auto log_start_offset
+                      = _partition->_manifest_view->stm_manifest()
+                          .full_log_start_kafka_offset();
 
-                const auto query_offset = std::get<kafka::offset>(query);
-                if (log_start_offset && query_offset < *log_start_offset) {
-                    vlog(
-                      _ctxlog.debug,
-                      "Manifest query below the log's start Kafka offset: {} < "
-                      "{}",
-                      query_offset(),
-                      log_start_offset.value()());
-                    co_return;
-                }
+                    if (log_start_offset && query_offset < *log_start_offset) {
+                        vlog(
+                          _ctxlog.debug,
+                          "Manifest query below the log's start Kafka offset: "
+                          "{} < {}",
+                          query_offset(),
+                          log_start_offset.value()());
+                        return true;
+                    }
+                    return false;
+                },
+                [](auto) { return false; })) {
+                // error was handled
+                co_return;
             }
 
             vlog(

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1156,7 +1156,6 @@ remote_partition::timequery(storage::timequery_config cfg) {
     // Construct a reader that will skip to the requested timestamp
     // by virtue of log_reader_config::start_timestamp
     auto translating_reader = co_await make_reader(config);
-    auto ot_state = std::move(translating_reader.ot_state);
 
     // Read one batch from the reader to learn the offset
     model::record_batch_reader::storage_t data

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -526,6 +526,7 @@ private:
               cur.error() == error_outcome::out_of_range
               && ss::visit(
                 query,
+                [&](model::offset) { return false; },
                 [&](kafka::offset query_offset) {
                     // Special case queries below the start offset of the log.
                     // The start offset may have advanced while the request was
@@ -545,7 +546,32 @@ private:
                     }
                     return false;
                 },
-                [](auto) { return false; })) {
+                [&](model::timestamp query_ts) {
+                    // Special case, it can happen when a timequery falls below
+                    // the clean offset. Caused when the query races with
+                    // retention/gc. log a warning, since the kafka client can
+                    // handle a failed query
+                    auto const& spillovers = _partition->_manifest_view
+                                               ->stm_manifest()
+                                               .get_spillover_map();
+                    if (
+                      spillovers.empty()
+                      || spillovers.get_max_timestamp_column()
+                             .last_value()
+                             .value_or(model::timestamp::max()())
+                           >= query_ts()) {
+                        vlog(
+                          _ctxlog.debug,
+                          "Manifest query raced with retention and the result "
+                          "is below the clean/start offset for {}",
+                          query_ts);
+                        return true;
+                    }
+
+                    // query was not meant for archive region. fallthrough and
+                    // log an error
+                    return false;
+                })) {
                 // error was handled
                 co_return;
             }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16302

Fixes #16306