### PR TITLE
resource_mgmt: disable flaky test

### DIFF
--- a/src/v/resource_mgmt/tests/CMakeLists.txt
+++ b/src/v/resource_mgmt/tests/CMakeLists.txt
@@ -5,6 +5,8 @@ rp_test(
     cpu_profiler_test.cc
     available_memory_test.cc
   LIBRARIES v::seastar_testing_main v::resource_mgmt v::config
+  # TODO: re-enable when https://github.com/redpanda-data/redpanda/issues/16308 is fixed
+  SKIP_BUILD_TYPES "Debug"
   LABELS resource_mgmt
 )
 


### PR DESCRIPTION
This test is consistenly failing by hanging in debug mode for an unknown reason. Let's disable until we track it down.

Related: https://github.com/redpanda-data/redpanda/issues/16308

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
