### PR TITLE
[v23.2.x] demote ERROR message to DEBUG for timequerys at the edge of spillover retention

### DIFF
--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -249,7 +249,7 @@ bool async_manifest_view_cursor::manifest_in_range(
           auto lo = p.get().get_last_offset();
           vlog(
             _view._ctxlog.debug,
-            "Spill manifest range: [{}/{}], cursor range: [{}/{}]",
+            "STM manifest range: [{}/{}], cursor range: [{}/{}]",
             so,
             lo,
             _begin,
@@ -261,7 +261,7 @@ bool async_manifest_view_cursor::manifest_in_range(
           auto lo = m->manifest.get_last_offset();
           vlog(
             _view._ctxlog.debug,
-            "STM manifest range: [{}/{}], cursor range: [{}/{}]",
+            "Spill manifest range: [{}/{}], cursor range: [{}/{}]",
             so,
             lo,
             _begin,

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -1297,8 +1297,9 @@ async_manifest_view::get_materialized_manifest(
             // Fast path for STM reads
             co_return std::ref(_stm_manifest);
         }
+        // query in not in the stm region
         if (
-          !in_stm(q) && std::holds_alternative<model::timestamp>(q)
+          std::holds_alternative<model::timestamp>(q)
           && _stm_manifest.get_archive_start_offset() == model::offset{}) {
             vlog(_ctxlog.debug, "Using STM manifest for timequery {}", q);
             co_return std::ref(_stm_manifest);

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1146,7 +1146,6 @@ remote_partition::timequery(storage::timequery_config cfg) {
     // Construct a reader that will skip to the requested timestamp
     // by virtue of log_reader_config::start_timestamp
     auto translating_reader = co_await make_reader(config);
-    auto ot_state = std::move(translating_reader.ot_state);
 
     // Read one batch from the reader to learn the offset
     model::record_batch_reader::storage_t data


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16302

Fixes https://github.com/redpanda-data/redpanda/issues/16305