### PR TITLE
rptest: add ability to restart pods in `RedpandaServiceCloud`

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -194,13 +194,13 @@ class KubectlTool:
         except subprocess.CalledProcessError as e:
             return False
 
-    def _get_privileged_pod(self):
+    def _get_privileged_pod(self, pod_name=None):
         # kubectl get pod -l name=privileged-pod --no-headers -o custom-columns=NODE:.spec.nodeName,NAME:.metadata.name
         # ip-10-1-1-26.us-west-2.compute.internal    everything-allowed-exec-pod-bkj4m
         # ip-10-1-1-139.us-west-2.compute.internal   everything-allowed-exec-pod-jxk9j
         # ip-10-1-1-101.us-west-2.compute.internal   everything-allowed-exec-pod-pl8sc
         ssh_prefix = self._ssh_prefix()
-        cmd = prefx + [
+        cmd = ssh_prefix + [
             'kubectl',
             'get',
             'pod',
@@ -222,7 +222,6 @@ class KubectlTool:
         # ip-10-1-1-139.us-west-2.compute.internal   rp-ci0motok30vsi89l501g-0
         # ip-10-1-1-101.us-west-2.compute.internal   rp-ci0motok30vsi89l501g-1
         # ip-10-1-1-26.us-west-2.compute.internal    rp-ci0motok30vsi89l501g-2
-        ssh_prefix = self._ssh_prefix()
         cmd = ssh_prefix + [
             'kubectl',
             '-n',
@@ -248,8 +247,9 @@ class KubectlTool:
             redpanda_to_priv_pods[redpanda_pod] = ip_to_priv_pods[ip]
 
         self._redpanda.logger.info(redpanda_to_priv_pods)
-        redpanda_pod = f'rp-{self._cluster_id}-0'
-        return redpanda_to_priv_pods[redpanda_pod]
+        if pod_name is None:
+            pod_name = f'rp-{self._cluster_id}-0'
+        return redpanda_to_priv_pods[pod_name]
 
     def _setup_tbot(self):
         if self._tp_proxy is None or self._tp_token is None:
@@ -286,9 +286,9 @@ class KubectlTool:
             res = subprocess.check_output(apply_cmd)
             self._privileged_pod_installed = True
 
-    def exec_privileged(self, remote_cmd):
+    def exec_privileged(self, remote_cmd, pod_name=None):
         self._setup_privileged_pod()
-        priv_pod = self._get_privileged_pod()
+        priv_pod = self._get_privileged_pod(pod_name)
         ssh_prefix = self._ssh_prefix()
         cmd = ssh_prefix + ['kubectl', 'exec', priv_pod, '--', 'bash', '-c'
                             ] + ['"' + remote_cmd + '"']

--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -165,11 +165,19 @@ class KubectlTool:
         cmd = _kubectl + _kcmd
         return self._cmd(cmd)
 
-    def exec(self, remote_cmd):
+    def exec(self, remote_cmd, pod_name=None):
+        """Execute a command inside of a redpanda pod container.
+
+        :param remote_cmd: string of bash command to run inside of pod container
+        :param pod_name: name of the pod, e.g. 'rp-clo88krkqkrfamptsst0-5', defaults to pod 0
+        """
+
         self._install()
+        if pod_name is None:
+            pod_name = f'rp-{self._cluster_id}-0'
         cmd = [
-            'kubectl', 'exec', '-n', self._namespace, '-c', 'redpanda',
-            f'rp-{self._cluster_id}-0', '--', 'bash', '-c'
+            'kubectl', 'exec', pod_name, f'-n={self._namespace}',
+            '-c=redpanda', '--', 'bash', '-c'
         ] + ['"' + remote_cmd + '"']
         return self._cmd(cmd)
 

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -711,7 +711,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                                   timeout_sec=self.msg_timeout)
 
             # Run a rolling restart.
-            self.stage_rolling_restart()
+            self.redpanda.rolling_restart_pods()
 
             # Hard stop, then restart.
             self.stage_stop_wait_start(forced_stop=True, downtime=0)
@@ -729,15 +729,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                    " detected, code: RequestTimeout"),
         re.compile("cloud_storage - .* - Exceeded cache size limit!"),
     ]
-
-    # Stages for the "test_restarts"
-
-    def stage_rolling_restart(self):
-        self.logger.info(f"Rolling restarting nodes")
-        assert False, "rolling restart not implemented"
-        self.redpanda.rolling_restart_nodes(self.redpanda.nodes,
-                                            start_timeout=600,
-                                            stop_timeout=600)
 
     def stage_block_node_traffic(self):
         wait_time = 120

--- a/tests/rptest/redpanda_cloud_tests/rolling_restart_test.py
+++ b/tests/rptest/redpanda_cloud_tests/rolling_restart_test.py
@@ -1,0 +1,35 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from typing import Any
+from ducktape.tests.test import TestContext
+from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
+from rptest.services.cluster import cluster
+
+
+class RollingRestartTest(RedpandaCloudTest):
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        super().__init__(test_context, *args, **kwargs)
+
+    @cluster(num_nodes=1)
+    def test_restart_pod(self):
+        """Simple test of restart_pod() with a random pod in the cluster.
+        """
+
+        pod = random.choice(self.redpanda.pods)
+        self.logger.info(f'test restart of pod {pod.name}')
+        self.redpanda.restart_pod(pod.name)
+
+    @cluster(num_nodes=1)
+    def test_rolling_restart(self):
+        """Simple test of rolling_restart_pods() with default args."""
+
+        self.logger.info('test rolling restart of all pods in the cluster')
+        self.redpanda.rolling_restart_pods()

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -14,4 +14,5 @@ cloud:
     - redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_decommission_and_add
     - redpanda_cloud_tests/observe_test.py
     - redpanda_cloud_tests/omb_validation_test.py
+    - redpanda_cloud_tests/rolling_restart_test.py
     - tests/services_self_test.py::SimpleSelfTest.test_cloud


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/core-internal/issues/1001

Add `RedpandaServiceCloud.restart_pod()` and `RedpandaServiceCloud.rolling_restart_pods()` to aid in tests that need to simulate a graceful restart of these k8s resources.

Implemented using the `kubectl delete pod` command to allow [k8s to gracefully manage the termination process](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination).

Also added a simple self test of these 2 methods in `redpanda_cloud_tests/rolling_restart_test.py` to the cloud test suite.

verified with a `tier-3-aws-v2-arm` cluster:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  tests/rptest/redpanda_cloud_tests/rolling_restart_test.py::RollingRestartTest
```
output:
```
test_id:    rptest.redpanda_cloud_tests.rolling_restart_test.RollingRestartTest.test_restart_pod
status:     PASS
run time:   1 minute 49.533 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.redpanda_cloud_tests.rolling_restart_test.RollingRestartTest.test_rolling_restart
status:     PASS
run time:   4 minutes 40.765 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
========================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2024-01-30--018
run time:         6 minutes 30.331 seconds
tests run:        2
passed:           2
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
========================================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none