### PR TITLE
Aggregate partition label in `ntp_level_probe`

### DIFF
--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -44,6 +44,9 @@ void ntp_level_probe::setup_ntp_metrics(const model::ntp& ntp) {
       partition_label(ntp.tp.partition()),
     };
 
+    auto aggregate_labels = std::vector<sm::label>{
+      sm::shard_label, partition_label};
+
     _metrics.add_group(
       prometheus_sanitize::metrics_name("ntp_archiver"),
       {
@@ -69,7 +72,7 @@ void ntp_level_probe::setup_ntp_metrics(const model::ntp& ntp) {
           labels),
       },
       {},
-      std::vector<sm::label>{sm::shard_label});
+      aggregate_labels);
 }
 
 void ntp_level_probe::setup_public_metrics(const model::ntp& ntp) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This PR adds the partition label to the aggregated labels in `ntp_level_probe`. This is done to bring the behavior of `ntp_level_probe` in line with other NTP metrics in TS and storage. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
### Bug Fixes
* Aggregates partitions in some cloud storage metrics when the `aggregate_metrics` cluster config is set to true.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
