### PR TITLE
rptest: fix cluster healthy check

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
+++ b/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
@@ -1,0 +1,35 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from typing import Any
+from ducktape.tests.test import TestContext
+from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RedpandaServiceCloud
+
+
+class SelfRedpandaCloudTest(RedpandaCloudTest):
+    """This test verifies RedpandaCloudTest works as expected. It is not a
+    test of redpanda itself. It is for verifying the RedpandaCloudTest class
+    functions as expected for test authors to inherit from the class and
+    create tests against Redpanda Cloud.
+    """
+    def __init__(self, test_context: TestContext, *args: Any, **kwargs: Any):
+        super().__init__(test_context, *args, **kwargs)
+
+        assert isinstance(
+            self.redpanda,
+            RedpandaServiceCloud), 'test should only run on cloud'
+
+    @cluster(num_nodes=1)
+    def test_simple(self):
+        """Simple test of startup()
+        """
+        pass

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -745,7 +745,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         time.sleep(wait_time)
         self.logger.info(
             f"Waiting for the cluster to return to a healthy state")
-        wait_until(self.redpanda.healthy, timeout_sec=600, backoff_sec=1)
+        wait_until(self.redpanda.cluster_healthy(),
+                   timeout_sec=600,
+                   backoff_sec=1)
 
     def stage_stop_wait_start(self, forced_stop: bool, downtime: int):
         node = self.get_node()
@@ -764,7 +766,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         self.logger.info(
             f"Restarting node {node.name} for {restart_timeout} s")
         self.redpanda.start_node(node, timeout=600)
-        wait_until(self.redpanda.healthy,
+        wait_until(self.redpanda.cluster_healthy(),
                    timeout_sec=restart_timeout,
                    backoff_sec=1)
 
@@ -838,7 +840,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                 time.sleep(60)
 
         # make sure nothing is crashed
-        wait_until(self.redpanda.healthy, timeout_sec=60, backoff_sec=1)
+        wait_until(self.redpanda.cluster_healthy(),
+                   timeout_sec=60,
+                   backoff_sec=1)
         self.logger.info(f"Waiting for S3 errors to cease")
         wait_until(lambda: self._cloud_storage_no_new_errors(
             self.redpanda, self.logger),
@@ -1052,7 +1056,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         # skip new node creation so it does not conflict with add via kubectl
         #self.redpanda.clean_node(pod, preserve_logs=True, preserve_current_install=True)
         #self.redpanda.start_node(pod, auto_assign_node_id=False, omit_seeds_on_idx_one=False)
-        #wait_until(self.redpanda.healthy, timeout_sec=600, backoff_sec=1)
+        #wait_until(self.redpanda.cluster_healthy(), timeout_sec=600, backoff_sec=1)
         #new_node_id = self.redpanda.node_id(pod, force_refresh=True)
 
     def _disable_agent_services(self):
@@ -1719,7 +1723,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
         # wait until the cluster is health once more
         self.logger.info("waiting for RP cluster to be healthy")
-        wait_until(self.redpanda.healthy, timeout_sec=900, backoff_sec=1)
+        wait_until(self.redpanda.cluster_healthy(),
+                   timeout_sec=900,
+                   backoff_sec=1)
 
         # verify basic produce and consume operations still work.
 

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -465,6 +465,8 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                                self.msg_size) as _:
             # Test will assert if advertised throughput isn't met
             time.sleep(15)
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
 
     def _get_swarm_connections_count(self, nodes):
         _list = []
@@ -682,7 +684,8 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         assert _hwm >= reasonably_expected, \
             f"Expected >{reasonably_expected} messages, actual {_hwm}"
 
-        return
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
 
     COMBO_PRELOADED_LOG_ALLOW_LIST = [
         re.compile('storage - .* - Stopping parser, short read. .*')
@@ -723,6 +726,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
             # Block traffic to/from one node.
             self.stage_block_node_traffic()
+
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
 
     NOS3_LOG_ALLOW_LIST = [
         re.compile("s3 - .* - Accessing .*, unexpected REST API error "
@@ -800,6 +806,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
 
             # S3 up -> down -> up
             self.stage_block_s3()
+
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
 
     def _cloud_storage_no_new_errors(self, redpanda, logger=None):
         num_errors = redpanda.metric_sum(
@@ -913,6 +922,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         finally:
             producer.stop()
             producer.wait(timeout_sec=600)
+
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
 
     def stage_decommission_and_add(self):
         def cluster_ready_replicas(cluster_name):
@@ -1212,6 +1224,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             producer.stop()
             producer.wait(timeout_sec=600)
 
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
+
     def _stage_add_and_decommission(self):
         cluster_name = f'rp-{self.redpanda._cloud_cluster.cluster_id}'
         orig_replicas = self._get_cluster_replicas(cluster_name)
@@ -1286,6 +1301,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                 consumer.stop()
                 consumer.wait(timeout_sec=600)
 
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
+
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_consume(self):
         # create default topics
@@ -1320,6 +1338,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             producer.wait(timeout_sec=600)
             self.free_preallocated_nodes()
 
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
+
     @ignore
     @cluster(num_nodes=10, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_ts_resource_utilization(self):
@@ -1330,6 +1351,8 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         """
         self._create_topic_spec()
         self.stage_tiered_storage_consuming()
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
 
     def stage_lots_of_failed_consumers(self):
         # This stage sequentially starts 1,000 consumers. Then allows
@@ -1435,6 +1458,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             producer.stop()
             producer.wait(timeout_sec=600)
             self.free_preallocated_nodes()
+
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
 
     def stage_consume_miss_cache(self, producer: KgoVerifierProducer):
         # This stage produces enough data to each RP node to fill up their batch caches
@@ -1829,3 +1855,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             self.logger.info(f"Workload metrics: {_format_metrics(metrics)}")
             # Assert test results
             omb.check_succeed()
+
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -276,6 +276,9 @@ class OMBValidationTest(RedpandaCloudTest):
         finally:
             self.rpk.delete_topic(swarm_topic_name)
 
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
+
     def _warn_metrics(self, metrics, validator):
         """Validates metrics and just warn if any fail."""
 
@@ -379,6 +382,9 @@ class OMBValidationTest(RedpandaCloudTest):
         # fail test if the latency is above expected including fudge factor
         benchmark.check_succeed()
 
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
+
     @cluster(num_nodes=CLUSTER_NODES)
     def test_common_workload(self):
         tier_limits = self.tier_limits
@@ -431,6 +437,8 @@ class OMBValidationTest(RedpandaCloudTest):
         benchmark_time_min = benchmark.benchmark_time() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'
 
     @cluster(num_nodes=CLUSTER_NODES)
     def test_retention(self):
@@ -497,3 +505,5 @@ class OMBValidationTest(RedpandaCloudTest):
         benchmark_time_min = benchmark.benchmark_time() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy at end of test'

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1770,8 +1770,8 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
     def sockets_clear(self, node: RemoteClusterNode):
         return True
 
-    def all_up(self):
-        return self._cloud_cluster.isAlive
+    def all_up(self) -> bool:
+        return self.cluster_healthy()
 
     def metrics(
             self,

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -18,4 +18,5 @@ cloud:
     - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_max_connections
     - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_max_partitions
     - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_common_workload
+    - redpanda_cloud_tests/cloud_self_test.py
     - tests/services_self_test.py::SimpleSelfTest.test_cloud

--- a/tests/rptest/tests/redpanda_cloud_test.py
+++ b/tests/rptest/tests/redpanda_cloud_test.py
@@ -36,5 +36,10 @@ class RedpandaCloudTest(RedpandaTestBase):
         # for easy access but we should fix callers and remove this
         self.config_profile_name = self.redpanda.config_profile_name
 
+    def setup(self):
+        super().setup()
+        assert self.redpanda.cluster_healthy(
+        ), 'cluster unhealthy before start of test'
+
     def client(self):
         return self._client


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/core-internal/issues/1003

New method`RedpandaServiceCloud.cluster_healthy()` according to [instructions](https://docs.redpanda.com/current/manage/kubernetes/k-rolling-restart/#perform-a-rolling-restart) on ensuring cluster is healthy.

Added assertions with `cluster_healthy()` to the start and end of the heavy tests that target cloud clusters.

Also added a simple self test for the new method:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  tests/rptest/redpanda_cloud_tests/cloud_self_test.py
```

output:
```
test_id:    rptest.redpanda_cloud_tests.cloud_self_test.SelfRedpandaCloudTest.test_simple
status:     PASS
run time:   30.319 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
========================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2024-02-08--008
run time:         30.335 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
========================================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none