### PR TITLE
rptest: Bump audit logging scale test run time

### DIFF
--- a/tests/rptest/scale_tests/audit_log_test.py
+++ b/tests/rptest/scale_tests/audit_log_test.py
@@ -21,6 +21,7 @@ from rptest.services.redpanda import SaslCredentials, SecurityConfig, MetricsEnd
 from rptest.tests.cluster_config_test import wait_for_version_sync
 from rptest.util import wait_until_result
 from ducktape.errors import TimeoutError
+from ducktape.mark import ok_to_fail
 
 # How much memory to assign to redpanda per partition. Redpanda will be started
 # with MIB_PER_PARTITION * PARTITIONS_PER_SHARD * CORE_COUNT memory
@@ -269,8 +270,8 @@ class AuditLogTest(RedpandaTest):
                               workers=self._repeater_worker_count(scale),
                               max_buffered_records=max_buffered_records,
                               **repeater_kwargs) as repeater:
-            # soak for two minutes
-            soak_time_seconds = 120
+            # soak for 5 minutes
+            soak_time_seconds = 60 * 5
             soak_await_bytes = soak_time_seconds * scale.expect_bandwidth
             soak_await_msgs = soak_await_bytes / repeater_msg_size
             # Add some leeway to avoid flakiness
@@ -301,6 +302,7 @@ class AuditLogTest(RedpandaTest):
             # to me able to assert on other properties of the test run.
             return make_result_set(t1, repeater)
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/16199
     @cluster(num_nodes=5)
     def test_audit_log(self):
         """


### PR DESCRIPTION
Also marking `@ok_to_fail` until we find the right parameters to reduce the test flakiness.

The underlying issue is that is it difficult to compare latencies between test runs with any meaningful significance since there usually is a large variance between runs, even with identical parameters. This change increases the test run time which is one potential solution to reducing test run variance.

- Referring to initial issue #16199

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
