### PR TITLE
CDT: fix `rpk tune list` test in GCP.

### DIFF
--- a/tests/rptest/tests/rpk_tuner_test.py
+++ b/tests/rptest/tests/rpk_tuner_test.py
@@ -90,6 +90,9 @@ transparent_hugepages  true     true
         # either x86-64 or i386.
         is_not_x86 = "86" not in uname
 
+        r = str(node.account.ssh_output("dmidecode -s system-product-name"))
+        isGCP = "Google Compute Engine" in r
+
         # Clocksource is only available for x86 architectures.
         expected = expected.replace(
             "clocksource            true     true       ",
@@ -98,10 +101,11 @@ transparent_hugepages  true     true
 
         expected = expected.replace(
             "disk_write_cache       true     false      Disk write cache tuner is only supported in GCP",
-            "disk_write_cache       true     true       ") if os.environ.get(
-                'CDT_CLOUD_PROVIDER', None) == 'gcp' else expected
+            "disk_write_cache       true     true       "
+        ) if isGCP else expected
 
         output = rpk.tune("list")
-        self.logger.debug(output)
+        if output != expected:
+            self.logger.debug(f"expected:\n{expected}\ngot:\n{output}")
 
         assert output == expected


### PR DESCRIPTION
The test failure root cause is that the env `CDT_CLOUD_PROVIDER` is no longer present in the image that runs the CDT tests and this was used to determine an expected output. 

This PR introduces a better and more future-proof method of getting the provider.

Work in progress, I'll update once it's done.

Fixes #15215 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [X] v23.2.x
- [X] v23.1.x

## Release Notes
* none
