### PR TITLE
cluster: publish total available reclaim size to balancer

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -711,7 +711,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 },
                 .size_bytes = p.second->size_bytes() + p.second->non_log_disk_size_bytes(),
                 .under_replicated_replicas = p.second->get_under_replicated(),
-                .reclaimable_size_bytes = p.second->reclaimable_local_size_bytes(),
+                .reclaimable_size_bytes = p.second->reclaimable_size_bytes(),
               };
           });
     } else {
@@ -726,7 +726,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 },
                 .size_bytes = partition->size_bytes() + partition->non_log_disk_size_bytes(),
                 .under_replicated_replicas = partition->get_under_replicated(),
-                .reclaimable_size_bytes = partition->reclaimable_local_size_bytes(),
+                .reclaimable_size_bytes = partition->reclaimable_size_bytes(),
                 });
             }
         }

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -68,8 +68,8 @@ struct partition_status
     std::optional<uint8_t> under_replicated_replicas;
 
     /*
-     * estimated amount of data above local retention that is subject to
-     * reclaim under disk pressure. this is useful for the partition balancer
+     * estimated amount of data subject to reclaim under disk pressure without
+     * violating safety guarantees. this is useful for the partition balancer
      * which is interested in free space on a node. a node may have very little
      * physical free space, but have effective free space represented by
      * reclaimable size bytes.

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -284,8 +284,8 @@ public:
 
     size_t size_bytes() const { return _raft->log()->size_bytes(); }
 
-    size_t reclaimable_local_size_bytes() const {
-        return _raft->log()->reclaimable_local_size_bytes();
+    size_t reclaimable_size_bytes() const {
+        return _raft->log()->reclaimable_size_bytes();
     }
 
     uint64_t non_log_disk_size_bytes() const;

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -513,7 +513,7 @@ ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
     cluster::node::local_state::log_data_state monitor_update;
     monitor_update.data_target_size = target_size;
     monitor_update.data_current_size = usage.usage.total();
-    monitor_update.data_reclaimable_size = usage.reclaim.local_retention;
+    monitor_update.data_reclaimable_size = usage.reclaim.available;
     _local_monitor->local().set_log_data_state(monitor_update);
 
     /*

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2547,7 +2547,7 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
     /*
      * cache this for access by the health
      */
-    _reclaimable_local_size_bytes = reclaim.local_retention;
+    _reclaimable_size_bytes = reclaim.available;
 
     co_return std::make_pair(usage, reclaim);
 }
@@ -3029,7 +3029,7 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
     co_return res;
 }
 
-size_t disk_log_impl::reclaimable_local_size_bytes() const {
+size_t disk_log_impl::reclaimable_size_bytes() const {
     /*
      * circumstances/configuration under which this log will be trimming back to
      * local retention size may change. catch these before reporting potentially
@@ -3045,7 +3045,7 @@ size_t disk_log_impl::reclaimable_local_size_bytes() const {
     if (deletion_exempt(config().ntp())) {
         return 0;
     }
-    return _reclaimable_local_size_bytes;
+    return _reclaimable_size_bytes;
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -140,7 +140,7 @@ public:
         return _segments_rolling_lock.get_units();
     }
 
-    size_t reclaimable_local_size_bytes() const override;
+    size_t reclaimable_size_bytes() const override;
 
     std::optional<model::offset> retention_offset(gc_config) const final;
 
@@ -315,7 +315,7 @@ private:
 
     std::optional<model::offset> _cloud_gc_offset;
     std::optional<model::offset> _last_compaction_window_start_offset;
-    size_t _reclaimable_local_size_bytes{0};
+    size_t _reclaimable_size_bytes{0};
 };
 
 } // namespace storage

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -145,10 +145,10 @@ public:
     virtual probe& get_probe() = 0;
 
     /*
-     * estimate amount of data beyond local retention. zero will be returned in
+     * estimate amount of data safely reclaimable. zero will be returned in
      * cases where this is not applicable, such as the log not being TS-enabled.
      */
-    virtual size_t reclaimable_local_size_bytes() const = 0;
+    virtual size_t reclaimable_size_bytes() const = 0;
     /**
      * Returns new log start offset for given retention settings.
      */


### PR DESCRIPTION
SM publishes reclaimable space up to the local retention level to the cluster balancer. However, it may be the case that a disk is nearly full even at the local retention target, causing the balancer to believe that any space is not available for reclaim. This is problematic for decommission which needs to be able to find some place to create new replicas.

This change swaps out the reclaimable space at local retention level for total reclaimable space. The balancer policy will be expanded further to also take into account the local retention targets and optimize decisions. Changes for that are here https://github.com/redpanda-data/redpanda/pull/16372.

Related https://github.com/redpanda-data/core-internal/issues/719

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Publish total reclaimable space to avoid stuck decommission scenario.