### PR TITLE
rptest: clean teleport data dir before use

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -9,6 +9,7 @@
 
 from logging import Logger
 import os
+import shutil
 import subprocess
 
 SUPPORTED_PROVIDERS = ['aws', 'gcp']
@@ -19,6 +20,7 @@ class KubectlTool:
     Wrapper around kubectl for operating on a redpanda cluster.
     """
 
+    TELEPORT_DATA_DIR = '/tmp/tbot-data'
     TELEPORT_DEST_DIR = '/tmp/machine-id'
     TELEPORT_IDENT_FILE = f'{TELEPORT_DEST_DIR}/identity'
 
@@ -252,9 +254,11 @@ class KubectlTool:
         _method = "iam"
         if self._provider == 'gcp':
             _method = "gcp"
+        self._redpanda.logger.info('cleaning teleport data dir')
+        shutil.rmtree(self.TELEPORT_DATA_DIR)
         self._redpanda.logger.info('starting tbot to generate identity')
         cmd = [
-            'tbot', 'start', '--data-dir=/tmp/tbot-data',
+            'tbot', 'start', f'--data-dir={self.TELEPORT_DATA_DIR}',
             f'--destination-dir={self.TELEPORT_DEST_DIR}',
             f'--auth-server={self._tp_proxy}', f'--join-method={_method}',
             f'--token={self._tp_token}', '--certificate-ttl=6h',


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/cloudv2/issues/12090

clean teleport data dir before each use so the expired identity is not reused.

verified with simple test:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  tests/rptest/tests/services_self_test.py::SimpleSelfTest.test_cloud
```
output:
```
...
[INFO  - 2024-01-30 05:06:02,510 - kubectl - _setup_tbot - lineno:257]: cleaning teleport data dir
[INFO  - 2024-01-30 05:06:02,511 - kubectl - _setup_tbot - lineno:259]: starting tbot to generate identity
WARN [TBOT]      CLI parameters are overriding onboarding config from  config/config.go:472
INFO [TBOT]      Created directory "/tmp/tbot-data" config/destination_directory.go:132
...
test_id:    rptest.tests.services_self_test.SimpleSelfTest.test_cloud
status:     PASS
run time:   36.092 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
========================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2024-01-30--004
run time:         36.110 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
========================================================================================================================================================================================
```


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none