### PR TITLE
Added `redpanda.virtual.cluster.id` topic property

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -79,6 +79,7 @@ enum class errc : int16_t {
     invalid_partition_operation,
     concurrent_modification_error,
     transform_count_limit_exceeded,
+    producer_ids_vcluster_limit_exceeded,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -229,6 +230,8 @@ struct errc_category final : public std::error_category {
             return "Concurrent modification error";
         case errc::transform_count_limit_exceeded:
             return "Too many transforms deployed";
+        case errc::producer_ids_vcluster_limit_exceeded:
+            return "To many vclusters registered in producer state cache";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/namespaced_cache.h
+++ b/src/v/cluster/namespaced_cache.h
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "config/property.h"
+
+#include <absl/container/node_hash_map.h>
+#include <boost/intrusive/list_hook.hpp>
+
+#include <exception>
+
+namespace cluster {
+
+/**
+ * Disposer is called after an entry has been evicted from the cache.
+ *
+ * The cache_disposer callable may be used to cleanup some additional state
+ * depending on application. f.e. it may release resources.
+ */
+template<typename PostEvictionHookT, typename Entry>
+concept cache_disposer = requires(const PostEvictionHookT& hook, Entry& entry) {
+    requires noexcept(hook(entry));
+    { hook(entry) } -> std::same_as<void>;
+};
+/**
+ * Simillar to `experimental::io::cache_evictor` it is a callable that is called
+ * when an entry is evicted from the cache.
+ *
+ * If an entry is eligible for eviction the function should return true.
+ *
+ */
+template<typename Predicate, typename Entry>
+concept cache_evictor = requires(const Predicate func, Entry& entry) {
+    requires noexcept(func(entry));
+    { func(entry) } -> std::same_as<bool>;
+};
+
+/**
+ * Default eviction predicate that does not protect entry from being evicted
+ */
+struct default_cache_evictor {
+    bool operator()(const auto&) const noexcept { return true; };
+};
+
+struct noop_disposer {
+    void operator()(const auto&) const noexcept {};
+};
+
+/**
+ * Member type hook to include into an entry to make it possible to use it with
+ * intrusive list
+ */
+using namespaced_cache_hook = boost::intrusive::list_member_hook<
+  boost::intrusive::link_mode<boost::intrusive::safe_link>>;
+
+/**
+ * Thrown if cache if full i.e. no namespaces can be added to the cache
+ */
+class cache_full_error final : public std::exception {
+public:
+    explicit cache_full_error(ss::sstring msg) noexcept
+      : _msg(std::move(msg)) {}
+
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
+
+/**
+ * Internal per namespace cache implementation concept. User can provide
+ * different implementation of caching algorithm f.e. LRU, FIFO or SIEVE.
+ */
+template<
+  typename CacheT,
+  typename EntryT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  typename EvictionPredicate,
+  typename Disposer>
+concept namespace_cache = requires(
+  CacheT& cache,
+  EntryT& entry,
+  const EvictionPredicate& predicate,
+  const Disposer& disposer) {
+    { cache.insert(entry) } -> std::same_as<void>;
+    { cache.evict(predicate, disposer) } -> std::same_as<bool>;
+    { cache.remove(entry) } -> std::same_as<void>;
+    { cache.touch(entry) } -> std::same_as<void>;
+    { cache.size() } -> std::same_as<size_t>;
+};
+
+/**
+ * Simple cache with LRU eviction policy
+ */
+template<
+  typename EntryT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> EvictionPredicate,
+  cache_disposer<EntryT> Disposer>
+struct lru_cache {
+    using list_type = boost::intrusive::list<
+      EntryT,
+      boost::intrusive::member_hook<EntryT, namespaced_cache_hook, HookPtr>,
+      boost::intrusive::constant_time_size<false>>;
+
+    void insert(EntryT&);
+    bool evict(const EvictionPredicate&, const Disposer&);
+    void remove(const EntryT&);
+    void touch(EntryT&);
+    size_t size() const { return _size; }
+
+private:
+    size_t _size{0};
+    list_type _lru;
+};
+
+/**
+ * A simple cache that maintains an LRU per namespace.
+ *
+ * The cache allows to maintain per namespace lru cache with fair distribution
+ * of available cache slots across all namespaces. Cache size is
+ * controlled by setting maximum number of entries. If adding new namespace to
+ * the cache would result in other namespace to have less than
+ * min_slots_per_namespace cache slots an exception is thrown.
+ *
+ * Maximum number of namespaces that cache can handle can be calculated as:
+ *
+ *  floor(_max_size/_min_slots_per_namespace)
+ *
+ * With cache CacheEvictorT template parameter it is possible to prevent some
+ * entries from being evicted. A predicate should return 'false' if an entry is
+ * not evictable.
+ *
+ * Eviction policy can be controlled with the CacheT parameter. The CacheT
+ * parameter allow to tune per namespace caching policy.
+ *
+ * For now the only provided eviction policy is a simple LRU. In future we may
+ * experience with different caching strategies like f.e. SIEVE or S3-FIFO.
+ *
+ */
+template<
+  typename EntryT,
+  typename NamespaceT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> CacheEvictorT = default_cache_evictor,
+  cache_disposer<EntryT> DisposerT = noop_disposer,
+  namespace_cache<EntryT, HookPtr, CacheEvictorT, DisposerT> CacheT
+  = lru_cache<EntryT, HookPtr, CacheEvictorT, DisposerT>>
+class namespaced_cache {
+private:
+    using namespaces_t
+      = absl::node_hash_map<NamespaceT, std::unique_ptr<CacheT>>;
+
+public:
+    struct stats {
+        size_t total_size{0};
+        absl::node_hash_map<NamespaceT, size_t> namespaces;
+    };
+
+    /**
+     * Creates a namespaced cache with desired maximum size and minimal allowed
+     * number of slots per namespace
+     */
+    explicit namespaced_cache(
+      config::binding<size_t> total_max_size,
+      config::binding<size_t> min_slots_per_namespace,
+      const CacheEvictorT& evictor = CacheEvictorT(),
+      const DisposerT& disposer = DisposerT())
+      : _max_size(std::move(total_max_size))
+      , _min_slots_per_namespace(std::move(min_slots_per_namespace))
+      , _evictor(evictor)
+      , _disposer(disposer) {}
+
+    void insert(const NamespaceT& ns, EntryT& entry);
+    void remove(const NamespaceT& ns, const EntryT& entry);
+    void touch(const NamespaceT& ns, EntryT& entry);
+    /**
+     * Evicts next eligible element from the cache, returns true if element was
+     * evicted.
+     */
+    bool evict() {
+        // we use _namespaces.end() to indicate there is no hint what namespace
+        // to evict from
+        return evict(_namespaces.end());
+    }
+
+    /**
+     * Return basic stats about cache size
+     */
+    stats get_stats() const;
+
+    /**
+     * Returns maximum number of namespaces a cache can handle
+     */
+    size_t namespace_capacity() const {
+        return floor(_max_size() / effective_min_slots_per_namespace());
+    }
+
+    void clear() { _namespaces.clear(); }
+
+private:
+    bool evict(namespaces_t::iterator);
+
+    size_t effective_min_slots_per_namespace() const {
+        return std::min(_max_size(), _min_slots_per_namespace());
+    }
+
+    namespaces_t _namespaces;
+
+    size_t _size{0};
+    config::binding<size_t> _max_size;
+    config::binding<size_t> _min_slots_per_namespace;
+    CacheEvictorT _evictor;
+    DisposerT _disposer;
+};
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> CacheEvictorT,
+  cache_disposer<EntryT> DisposerT,
+  namespace_cache<EntryT, HookPtr, CacheEvictorT, DisposerT> CacheT>
+bool namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  CacheEvictorT,
+  DisposerT,
+  CacheT>::evict(namespaces_t::iterator hint) {
+    /**
+     * linear scan over all namespaces to find the one with the largest number
+     * of producers
+     */
+
+    auto max_it = std::max_element(
+      _namespaces.begin(),
+      _namespaces.end(),
+      [](const auto& lhs, const auto& rhs) {
+          return lhs.second->size() < rhs.second->size();
+      });
+
+    /**
+     * If hint is provided and the number of elements in a hint pointed
+     * namespace cache is equal to max element size evict from the hint
+     * namespace
+     */
+    if (
+      hint != _namespaces.end()
+      && max_it->second->size() == hint->second->size()) {
+        max_it = hint;
+    }
+
+    std::unique_ptr<CacheT>& t_state = max_it->second;
+    auto evicted = t_state->evict(_evictor, _disposer);
+    if (evicted) {
+        --_size;
+    }
+    return evicted;
+}
+
+/**
+ * namespaced_cache definitions
+ */
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> CacheEvictorT,
+  cache_disposer<EntryT> DisposerT,
+  namespace_cache<EntryT, HookPtr, CacheEvictorT, DisposerT> CacheT>
+void namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  CacheEvictorT,
+  DisposerT,
+  CacheT>::insert(const NamespaceT& ns, EntryT& entry) {
+    if (
+      _namespaces.size() >= namespace_capacity() && !_namespaces.contains(ns)) {
+        throw cache_full_error(ssx::sformat(
+          "maximum number of tenants reached. Min number of entries per "
+          "tenant: {}, max cache capacity: {}, current tenants: {}",
+          effective_min_slots_per_namespace(),
+          _max_size(),
+          _namespaces.size()));
+    }
+    auto [it, _] = _namespaces.try_emplace(ns, std::make_unique<CacheT>());
+    while (_size >= _max_size()) {
+        evict(it);
+    }
+
+    it->second->insert(entry);
+
+    ++_size;
+}
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> CacheEvictorT,
+  cache_disposer<EntryT> DisposerT,
+  namespace_cache<EntryT, HookPtr, CacheEvictorT, DisposerT> CacheT>
+void namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  CacheEvictorT,
+  DisposerT,
+  CacheT>::remove(const NamespaceT& ns, const EntryT& entry) {
+    auto it = _namespaces.find(ns);
+    if (it == _namespaces.end()) {
+        return;
+    }
+    if (entry._hook.is_linked()) {
+        it->second->remove(entry);
+        _size--;
+    }
+    if (it->second->size() == 0) {
+        _namespaces.erase(it);
+    }
+}
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> CacheEvictorT,
+  cache_disposer<EntryT> DisposerT,
+  namespace_cache<EntryT, HookPtr, CacheEvictorT, DisposerT> CacheT>
+void namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  CacheEvictorT,
+  DisposerT,
+  CacheT>::touch(const NamespaceT& ns, EntryT& entry) {
+    auto it = _namespaces.find(ns);
+    if (it == _namespaces.end()) {
+        return;
+    }
+    it->second->touch(entry);
+}
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> CacheEvictorT,
+  cache_disposer<EntryT> DisposerT,
+  namespace_cache<EntryT, HookPtr, CacheEvictorT, DisposerT> CacheT>
+namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  CacheEvictorT,
+  DisposerT,
+  CacheT>::stats
+namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  CacheEvictorT,
+  DisposerT,
+  CacheT>::get_stats() const {
+    stats ret;
+    for (auto& [k, state] : _namespaces) {
+        ret.namespaces[k] = state->size();
+    }
+    ret.total_size = _size;
+    return ret;
+}
+
+/**
+ * lru_cache definitions
+ */
+
+template<
+  typename EntryT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> EvictionPredicate,
+  cache_disposer<EntryT> DisposerT>
+void lru_cache<EntryT, HookPtr, EvictionPredicate, DisposerT>::insert(
+  EntryT& entry) {
+    _lru.push_back(entry);
+    ++_size;
+}
+
+template<
+  typename EntryT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> EvictionPredicate,
+  cache_disposer<EntryT> DisposerT>
+bool lru_cache<EntryT, HookPtr, EvictionPredicate, DisposerT>::evict(
+  const EvictionPredicate& predicate, const DisposerT& disposer) {
+    for (auto it = _lru.begin(); it != _lru.end(); ++it) {
+        if (predicate(*it)) {
+            auto& entry = *it;
+            _lru.erase(it);
+            --_size;
+            disposer(entry);
+            return true;
+        }
+    }
+    return false;
+}
+
+template<
+  typename EntryT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> EvictionPredicate,
+  cache_disposer<EntryT> DisposerT>
+void lru_cache<EntryT, HookPtr, EvictionPredicate, DisposerT>::remove(
+  const EntryT& entry) {
+    _lru.erase(_lru.iterator_to(entry));
+    --_size;
+}
+
+template<
+  typename EntryT,
+  namespaced_cache_hook EntryT::*HookPtr,
+  cache_evictor<EntryT> EvictionPredicate,
+  cache_disposer<EntryT> DisposerT>
+void lru_cache<EntryT, HookPtr, EvictionPredicate, DisposerT>::touch(
+  EntryT& entry) {
+    const auto& hook = entry.*HookPtr;
+    if (!hook.is_linked()) {
+        return;
+    }
+    _lru.erase(_lru.iterator_to(entry));
+    _lru.push_back(entry);
+}
+} // namespace cluster

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/namespaced_cache.h"
 #include "cluster/types.h"
 #include "container/intrusive_list_helpers.h"
 #include "model/record.h"
@@ -19,6 +20,7 @@
 
 #include <seastar/core/shared_future.hh>
 #include <seastar/util/defer.hh>
+#include <seastar/util/noncopyable_function.hh>
 
 #include <bit>
 
@@ -32,7 +34,6 @@ concept AcceptsUnits = requires(Func f, ssx::semaphore_units units) {
     f(std::move(units));
 };
 
-class producer_state_manager;
 class producer_state;
 struct producer_state_snapshot;
 class request;
@@ -136,33 +137,26 @@ private:
 };
 
 /// Encapsulates all the state of a producer producing batches to
-/// a single raft group. At init, the producer registers itself with
-/// producer_state_manager that manages the lifecycle of all the
-/// producers on a given shard.
+/// a single raft group.
 class producer_state {
 public:
     producer_state(
-      producer_state_manager& mgr,
       model::producer_identity id,
       raft::group_id group,
-      ss::noncopyable_function<void()> hook)
+      ss::noncopyable_function<void()> post_eviction_hook)
       : _id(id)
       , _group(group)
-      , _parent(std::ref(mgr))
       , _last_updated_ts(ss::lowres_system_clock::now())
-      , _post_eviction_hook(std::move(hook)) {
-        register_self();
-    }
+      , _post_eviction_hook(std::move(post_eviction_hook)) {}
     producer_state(
-      producer_state_manager&,
-      ss::noncopyable_function<void()> hook,
+      ss::noncopyable_function<void()> post_eviction_hook,
       producer_state_snapshot) noexcept;
 
     producer_state(const producer_state&) = delete;
     producer_state& operator=(producer_state&) = delete;
     producer_state(producer_state&&) noexcept = delete;
     producer_state& operator=(producer_state&& other) noexcept = delete;
-    ~producer_state() noexcept { deregister_self(); }
+    ~producer_state() noexcept = default;
     bool operator==(const producer_state& other) const;
 
     friend std::ostream& operator<<(std::ostream& o, const producer_state&);
@@ -180,24 +174,18 @@ public:
     ///   considering candidates for eviction.
     template<AcceptsUnits AsyncFunc>
     auto run_with_lock(AsyncFunc&& func) {
-        return ss::with_gate(
-          _gate, [this, func = std::forward<AsyncFunc>(func)]() mutable {
-              return _op_lock.get_units().then(
-                [this, f = std::forward<AsyncFunc>(func)](auto units) {
-                    unlink_self();
-                    _ops_in_progress++;
-                    return ss::futurize_invoke(f, std::move(units))
-                      .then_wrapped([this](auto result) {
-                          _ops_in_progress--;
-                          link_self();
-                          return result;
-                      });
-                });
+        if (_evicted) {
+            throw ss::gate_closed_exception();
+        }
+        return _op_lock.get_units().then(
+          [f = std::forward<AsyncFunc>(func)](auto units) {
+              return ss::futurize_invoke(f, std::move(units))
+                .then_wrapped([](auto result) { return result; });
           });
     }
 
-    ss::future<> shutdown_input();
-    ss::future<> evict();
+    void shutdown_input();
+    bool can_evict();
     bool is_evicted() const { return _evicted; }
 
     /* reset sequences resets the tracking state and skips the sequence
@@ -206,7 +194,7 @@ public:
       const model::batch_identity&,
       model::term_id current_term,
       bool reset_sequences = false);
-    void update(const model::batch_identity&, kafka::offset);
+    bool update(const model::batch_identity&, kafka::offset);
 
     std::optional<seq_t> last_sequence_number() const;
 
@@ -223,16 +211,9 @@ public:
     void update_current_txn_start_offset(std::optional<kafka::offset> offset) {
         _current_txn_start_offset = offset;
     }
+    namespaced_cache_hook _hook;
 
 private:
-    // Register/deregister with manager.
-    void register_self();
-    void deregister_self();
-    // Utilities to temporarily link and unlink from manager
-    // without modifying the producer count.
-    void link_self();
-    void unlink_self();
-
     std::chrono::milliseconds ms_since_last_update() const {
         return std::chrono::duration_cast<std::chrono::milliseconds>(
           ss::lowres_system_clock::now() - _last_updated_ts);
@@ -244,17 +225,12 @@ private:
     raft::group_id _group;
     // serializes all the operations on this producer
     mutex _op_lock;
-    std::reference_wrapper<producer_state_manager> _parent;
 
     requests _requests;
     // Tracks the last time an operation is run with this producer.
     // Used to evict stale producers.
     ss::lowres_system_clock::time_point _last_updated_ts;
-    intrusive_list_hook _hook;
-    ss::gate _gate;
-    // function hook called on eviction
     bool _evicted = false;
-    size_t _ops_in_progress = 0;
     ss::noncopyable_function<void()> _post_eviction_hook;
     std::optional<kafka::offset> _current_txn_start_offset;
     friend class producer_state_manager;

--- a/src/v/cluster/producer_state_manager.cc
+++ b/src/v/cluster/producer_state_manager.cc
@@ -14,6 +14,7 @@
 #include "cluster/logger.h"
 #include "cluster/producer_state.h"
 #include "cluster/types.h"
+#include "config/property.h"
 #include "prometheus/prometheus_sanitize.h"
 
 #include <seastar/core/metrics.hh>
@@ -22,9 +23,12 @@
 namespace cluster {
 
 producer_state_manager::producer_state_manager(
-  config::binding<uint64_t> max_producer_ids)
+  config::binding<uint64_t> max_producer_ids,
+  config::binding<size_t> virtual_cluster_min_producer_ids)
   : _max_ids(std::move(max_producer_ids))
-  , _cache(_max_ids, _max_ids) {
+  , _virtual_cluster_min_producer_ids(
+      std::move(virtual_cluster_min_producer_ids))
+  , _cache(_max_ids, _virtual_cluster_min_producer_ids) {
     setup_metrics();
 }
 

--- a/src/v/cluster/producer_state_manager.h
+++ b/src/v/cluster/producer_state_manager.h
@@ -21,7 +21,9 @@
 namespace cluster {
 class producer_state_manager {
 public:
-    explicit producer_state_manager(config::binding<uint64_t> max_producer_ids);
+    explicit producer_state_manager(
+      config::binding<uint64_t> max_producer_ids,
+      config::binding<size_t> virtual_cluster_min_producer_ids);
 
     ss::future<> start();
     ss::future<> stop();
@@ -65,6 +67,7 @@ private:
     // all partitions. When exceeded, producers are evicted on an
     // LRU basis.
     config::binding<uint64_t> _max_ids;
+    config::binding<size_t> _virtual_cluster_min_producer_ids;
     // cache of all producers on this shard
     cache_t _cache;
     ss::gate _gate;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -14,6 +14,7 @@
 #include "cluster/producer_state_manager.h"
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/tx_snapshot_utils.h"
+#include "cluster/types.h"
 #include "kafka/protocol/wire.h"
 #include "metrics/metrics.h"
 #include "model/fundamental.h"
@@ -206,7 +207,8 @@ rm_stm::rm_stm(
   raft::consensus* c,
   ss::sharded<cluster::tx_gateway_frontend>& tx_gateway_frontend,
   ss::sharded<features::feature_table>& feature_table,
-  ss::sharded<producer_state_manager>& producer_state_manager)
+  ss::sharded<producer_state_manager>& producer_state_manager,
+  std::optional<vcluster_id> vcluster_id)
   : raft::persisted_stm<>(rm_stm_snapshot, logger, c)
   , _tx_locks(
       mt::
@@ -231,6 +233,7 @@ rm_stm::rm_stm(
       config::shard_local_cfg().tx_log_stats_interval_s.bind())
   , _ctx_log(txlog, ssx::sformat("[{}]", c->ntp()))
   , _producer_state_manager(producer_state_manager)
+  , _vcluster_id(vcluster_id)
   , _producers(
       mt::map<absl::btree_map, model::producer_identity, cluster::producer_ptr>(
         _tx_root_tracker.create_child("producers"))) {
@@ -289,7 +292,7 @@ producer_ptr rm_stm::maybe_create_producer(model::producer_identity pid) {
     }
     auto producer = ss::make_lw_shared<producer_state>(
       pid, _raft->group(), [pid, this] { cleanup_producer_state(pid); });
-    _producer_state_manager.local().register_producer(*producer, std::nullopt);
+    _producer_state_manager.local().register_producer(*producer, _vcluster_id);
     _producers.emplace(pid, producer);
 
     return producer;
@@ -320,7 +323,7 @@ ss::future<> rm_stm::reset_producers() {
           auto& producer = it.second;
           producer->shutdown_input();
           _producer_state_manager.local().deregister_producer(
-            *producer, std::nullopt);
+            *producer, _vcluster_id);
           return ss::now();
       });
     _producers.clear();
@@ -1085,7 +1088,7 @@ ss::future<result<kafka_result>> rm_stm::transactional_replicate(
             producer, bid, std::move(rdr), std::move(units));
       })
       .finally([this, producer] {
-          _producer_state_manager.local().touch(*producer, std::nullopt);
+          _producer_state_manager.local().touch(*producer, _vcluster_id);
       });
 }
 
@@ -1212,7 +1215,7 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
             std::move(units));
       })
       .finally([this, producer] {
-          _producer_state_manager.local().touch(*producer, std::nullopt);
+          _producer_state_manager.local().touch(*producer, _vcluster_id);
       });
 }
 
@@ -1781,7 +1784,7 @@ void rm_stm::apply_data(
         auto producer = maybe_create_producer(bid.pid);
         auto needs_touch = producer->update(bid, last_kafka_offset);
         if (needs_touch) {
-            _producer_state_manager.local().touch(*producer, std::nullopt);
+            _producer_state_manager.local().touch(*producer, _vcluster_id);
         }
 
         if (bid.is_transactional) {
@@ -2366,12 +2369,14 @@ rm_stm_factory::rm_stm_factory(
   bool enable_idempotence,
   ss::sharded<tx_gateway_frontend>& tx_gateway_frontend,
   ss::sharded<cluster::producer_state_manager>& producer_state_manager,
-  ss::sharded<features::feature_table>& feature_table)
+  ss::sharded<features::feature_table>& feature_table,
+  ss::sharded<topic_table>& topics)
   : _enable_transactions(enable_transactions)
   , _enable_idempotence(enable_idempotence)
   , _tx_gateway_frontend(tx_gateway_frontend)
   , _producer_state_manager(producer_state_manager)
-  , _feature_table(feature_table) {}
+  , _feature_table(feature_table)
+  , _topics(topics) {}
 
 bool rm_stm_factory::is_applicable_for(const storage::ntp_config& cfg) const {
     const auto& ntp = cfg.ntp();
@@ -2384,12 +2389,18 @@ bool rm_stm_factory::is_applicable_for(const storage::ntp_config& cfg) const {
 void rm_stm_factory::create(
 
   raft::state_machine_manager_builder& builder, raft::consensus* raft) {
+    auto topic_md = _topics.local().get_topic_metadata_ref(
+      model::topic_namespace_view(raft->ntp()));
+
     auto stm = builder.create_stm<cluster::rm_stm>(
       clusterlog,
       raft,
       _tx_gateway_frontend,
       _feature_table,
-      _producer_state_manager);
+      _producer_state_manager,
+      topic_md.has_value()
+        ? topic_md->get().get_configuration().properties.mpx_virtual_cluster_id
+        : std::nullopt);
 
     raft->log()->stm_manager()->add_stm(stm);
 }

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -146,6 +146,19 @@ rp_test(
 rp_test(
   UNIT_TEST
   GTEST
+  BINARY_NAME namespaced_cache_test
+  SOURCES 
+    namespaced_cache_test.cc
+  LIBRARIES 
+    v::gtest_main 
+    v::serde
+  ARGS "-- -c 1"
+  LABELS cluster
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
   BINARY_NAME cluster_recovery_test
   SOURCES
     cluster_recovery_table_test.cc

--- a/src/v/cluster/tests/namespaced_cache_test.cc
+++ b/src/v/cluster/tests/namespaced_cache_test.cc
@@ -1,0 +1,344 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "cluster/namespaced_cache.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <gtest/gtest.h>
+
+struct fixture : public seastar_test {};
+
+struct entry {
+    cluster::namespaced_cache_hook _hook;
+};
+
+TEST_F(fixture, test_basic_operations) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<entry, ss::sstring, &entry::_hook> cache(
+      config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+
+    entry e0;
+    entry e1;
+    entry e2;
+    entry e4;
+
+    cache.insert(t_1, e0);
+    cache.insert(t_2, e1);
+    cache.insert(t_3, e2);
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 1);
+    EXPECT_EQ(cache.get_stats().total_size, 3);
+    /**
+     * Fill the cache up to capacity
+     */
+    std::vector<entry> entries{12, entry{}};
+    for (int i = 0; i < 12; i += 3) {
+        cache.insert(t_1, entries[i]);
+        cache.insert(t_2, entries[i + 1]);
+        cache.insert(t_3, entries[i + 2]);
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 5);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    std::vector<entry> new_entries{3, entry{}};
+    // now each insert will cause eviction
+    cache.insert(t_1, new_entries[0]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 5);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    cache.insert(t_2, new_entries[1]);
+    cache.insert(t_3, new_entries[2]);
+    // when number of entries in for a namespace that requests an insert is
+    // equal to the number of entries of a namespace with largest number of
+    // entries an eviction should happen from the requesting namespace.
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 5);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    // oldest t_2 entry should be evicted
+    EXPECT_FALSE(e0._hook.is_linked());
+    EXPECT_FALSE(e1._hook.is_linked());
+    EXPECT_FALSE(e2._hook.is_linked());
+    /**
+     * Test removal
+     */
+    for (int i = 0; i < 12; i += 3) {
+        cache.remove(t_1, entries[i]);
+        cache.remove(t_2, entries[i + 1]);
+        cache.remove(t_3, entries[i + 2]);
+    }
+
+    for (auto& e : entries) {
+        EXPECT_FALSE(e._hook.is_linked());
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 1);
+    EXPECT_EQ(cache.get_stats().total_size, 3);
+
+    cache.remove(t_1, new_entries[0]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 1);
+    EXPECT_EQ(cache.get_stats().total_size, 2);
+
+    cache.remove(t_1, new_entries[0]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+
+    cache.clear();
+}
+
+TEST_F(fixture, test_asymmetric_namespaces) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<entry, ss::sstring, &entry::_hook> cache(
+      config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+    std::vector<entry> entries{20, entry{}};
+    /**
+     * fill cache with 2 namespaces
+     */
+    for (int i = 0; i < 7; ++i) {
+        cache.insert(t_1, entries[i]);
+    }
+    for (int i = 7; i < 15; ++i) {
+        cache.insert(t_2, entries[i]);
+    }
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 7);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 8);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    // adding a new entry should cause an eviction from the namespace with the
+    // most entries
+    cache.insert(t_1, entries[15]);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 8);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 7);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    // add another namespace
+    cache.insert(t_3, entries[16]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 7);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 7);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 1);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    cache.insert(t_3, entries[17]);
+    cache.insert(t_3, entries[18]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 6);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 6);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    cache.clear();
+}
+
+struct pinable_entry {
+    bool pinned = false;
+    cluster::namespaced_cache_hook _hook;
+};
+struct pinned_entry_evictor {
+    bool operator()(const pinable_entry& e) const noexcept {
+        return !e.pinned;
+    };
+};
+
+TEST_F(fixture, test_eviction_predicate) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<
+      pinable_entry,
+      ss::sstring,
+      &pinable_entry::_hook,
+      pinned_entry_evictor>
+      cache(config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+    std::vector<pinable_entry> entries{18, pinable_entry{}};
+
+    // fill cache, single namespace
+    for (int i = 0; i < 15; ++i) {
+        cache.insert(t_1, entries[i]);
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 1);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    // pin first two entries
+    entries[0].pinned = true;
+    entries[1].pinned = true;
+
+    // insert entry
+    cache.insert(t_2, entries[15]);
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    // verify if pined entries are still in cache
+    EXPECT_TRUE(entries[0]._hook.is_linked());
+    EXPECT_TRUE(entries[1]._hook.is_linked());
+    // next not pinned entry should be evicted
+    EXPECT_FALSE(entries[2]._hook.is_linked());
+    // unpin entry
+    entries[0].pinned = false;
+    cache.insert(t_2, entries[16]);
+    EXPECT_FALSE(entries[0]._hook.is_linked());
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    cache.clear();
+}
+
+TEST_F(fixture, test_touch) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<entry, ss::sstring, &entry::_hook> cache(
+      config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+    std::vector<entry> entries{18, entry{}};
+
+    // fill cache
+    for (int i = 0; i < 15; i += 3) {
+        cache.insert(t_1, entries[i]);
+        cache.insert(t_2, entries[i + 1]);
+        cache.insert(t_3, entries[i + 2]);
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    cache.touch(t_1, entries[0]);
+    cache.touch(t_1, entries[3]);
+    cache.insert(t_1, entries[15]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    // touched items should not be evicted
+    EXPECT_TRUE(entries[0]._hook.is_linked());
+    EXPECT_TRUE(entries[3]._hook.is_linked());
+
+    EXPECT_FALSE(entries[6]._hook.is_linked());
+
+    cache.clear();
+}
+
+TEST_F(fixture, test_disposer) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    struct keyed_entry {
+        explicit keyed_entry(ss::sstring k)
+          : key(std::move(k)) {}
+        ss::sstring key;
+        cluster::namespaced_cache_hook _hook;
+    };
+
+    absl::flat_hash_map<ss::sstring, std::unique_ptr<keyed_entry>> index;
+
+    static auto index_removing_disposer =
+      [&index](keyed_entry& entry) noexcept { index.erase(entry.key); };
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<
+      keyed_entry,
+      ss::sstring,
+      &keyed_entry::_hook,
+      cluster::default_cache_evictor,
+      decltype(index_removing_disposer)>
+      cache(
+        config::mock_binding<size_t>(15),
+        config::mock_binding<size_t>(3),
+        cluster::default_cache_evictor{},
+        index_removing_disposer);
+
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+
+    for (int i = 0; i < 15; ++i) {
+        auto key = ssx::sformat("k-{}", i);
+        index.emplace(key, std::make_unique<keyed_entry>(key));
+    }
+
+    // fill cache
+    for (int i = 0; i < 15; i += 3) {
+        cache.insert(t_1, *index[ssx::sformat("k-{}", i)]);
+        cache.insert(t_2, *index[ssx::sformat("k-{}", i + 1)]);
+        cache.insert(t_3, *index[ssx::sformat("k-{}", i + 2)]);
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    // all the subsequent inserts will result in eviction
+    index.emplace("new-key-t-1", std::make_unique<keyed_entry>("new-key-t-1"));
+    index.emplace("new-key-t-2", std::make_unique<keyed_entry>("new-key-t-2"));
+    index.emplace("new-key-t-3", std::make_unique<keyed_entry>("new-key-t-3"));
+
+    cache.insert(t_1, *index["new-key-t-1"]);
+    cache.insert(t_2, *index["new-key-t-2"]);
+    cache.insert(t_3, *index["new-key-t-3"]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    EXPECT_EQ(index.size(), 15);
+
+    // evicted entries should be removed from cache
+
+    EXPECT_FALSE(index.contains("key-0"));
+    EXPECT_FALSE(index.contains("key-1"));
+    EXPECT_FALSE(index.contains("key-2"));
+
+    cache.clear();
+    index.clear();
+}

--- a/src/v/cluster/tests/producer_state_tests.cc
+++ b/src/v/cluster/tests/producer_state_tests.cc
@@ -11,13 +11,21 @@
 
 #include "cluster/producer_state.h"
 #include "cluster/producer_state_manager.h"
+#include "cluster/types.h"
 #include "config/mock_property.h"
+#include "config/property.h"
 #include "model/tests/randoms.h"
 #include "test_utils/async.h"
 #include "test_utils/fixture.h"
 
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/testing/thread_test_case.hh>
 
+#include <absl/container/flat_hash_map.h>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -26,41 +34,46 @@ using namespace std::chrono_literals;
 ss::logger logger{"producer_state_test"};
 
 struct test_fixture {
+    using psm_ptr = std::unique_ptr<cluster::producer_state_manager>;
+
     static constexpr uint64_t default_max_producers = 10;
 
-    cluster::producer_state_manager& manager() { return _psm.local(); }
-
-    void check_producers(size_t registered) {
+    void validate_producer_count(size_t registered) {
         BOOST_REQUIRE_EQUAL(
           manager()._cache.get_stats().total_size, registered);
     }
 
-    test_fixture() {
-        ss::smp::invoke_on_all([]() {
-            config::shard_local_cfg().disable_metrics.set_value(true);
-        }).get();
-        config::shard_local_cfg().disable_metrics.set_value(true);
-        _max_producers.start(default_max_producers).get();
-        _psm
-          .start(ss::sharded_parameter(
-            [this] { return _max_producers.local().bind(); }))
-          .get();
-        _psm.invoke_on_all(&cluster::producer_state_manager::start).get();
-        check_producers(0);
+    void validate_namespace_count(size_t registered) {
+        BOOST_REQUIRE_EQUAL(
+          manager()._cache.get_stats().namespaces.size(), registered);
+    }
+
+    void create_producer_state_manager(
+      size_t max_producers, size_t min_producers_per_vcluster) {
+        _psm = std::make_unique<cluster::producer_state_manager>(
+          config::mock_binding<size_t>(max_producers),
+          config::mock_binding<size_t>(min_producers_per_vcluster));
+        _psm->start().get();
+        validate_producer_count(0);
+        validate_namespace_count(0);
     }
 
     ~test_fixture() {
-        _max_producers.stop().get();
-        _psm.stop().get();
+        if (_psm) {
+            _psm->stop().get();
+        }
     }
 
-    cluster::producer_ptr new_producer(ss::noncopyable_function<void()> f = [] {
-    }) {
+    cluster::producer_state_manager& manager() { return *_psm; }
+
+    cluster::producer_ptr new_producer(
+      ss::noncopyable_function<void()> f = [] {},
+      std::optional<cluster::vcluster_id> vcluster = std::nullopt) {
         auto p = ss::make_lw_shared<cluster::producer_state>(
           model::random_producer_identity(),
           raft::group_id{_counter++},
           std::move(f));
-        manager().register_producer(*p, std::nullopt);
+        manager().register_producer(*p, vcluster);
         return p;
     }
 
@@ -72,12 +85,12 @@ struct test_fixture {
         producers.clear();
     }
 
-    long _counter = 0;
-    ss::sharded<config::mock_property<uint64_t>> _max_producers;
-    ss::sharded<cluster::producer_state_manager> _psm;
+    int64_t _counter{0};
+    psm_ptr _psm;
 };
 
 FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
+    create_producer_state_manager(10, 10);
     const size_t num_producers = 10;
     std::vector<cluster::producer_ptr> producers;
     producers.reserve(num_producers);
@@ -85,7 +98,7 @@ FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
         producers.push_back(new_producer());
     }
     // Ensure all producers are registered and linked up
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
 
     // run an active operation on producer, should temporarily
     // unlink itself.
@@ -97,10 +110,10 @@ FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
     });
 
     wait_for_func_begin.wait().get();
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
     // create one producer more and to trigger eviction
     auto new_p = new_producer();
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
     // validate that first producer is not evicted
     BOOST_REQUIRE(producers[0]->is_evicted() == false);
     BOOST_REQUIRE(producers[0]->can_evict() == false);
@@ -109,13 +122,14 @@ FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
 
     f.get();
     producers.push_back(new_p);
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
 
     clean(producers);
-    check_producers(0);
+    validate_producer_count(0);
 }
 
 FIXTURE_TEST(test_lru_maintenance, test_fixture) {
+    create_producer_state_manager(10, 10);
     const size_t num_producers = 5;
     std::vector<cluster::producer_ptr> producers;
     producers.reserve(num_producers);
@@ -123,7 +137,7 @@ FIXTURE_TEST(test_lru_maintenance, test_fixture) {
         auto prod = new_producer();
         producers.push_back(prod);
     }
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
 
     // run a function on each producer and ensure that is the
     // moved to the end of LRU list
@@ -132,10 +146,11 @@ FIXTURE_TEST(test_lru_maintenance, test_fixture) {
     }
 
     clean(producers);
-    check_producers(0);
+    validate_producer_count(0);
 }
 
 FIXTURE_TEST(test_eviction_max_pids, test_fixture) {
+    create_producer_state_manager(10, 10);
     int evicted_so_far = 0;
     std::vector<cluster::producer_ptr> producers;
     producers.reserve(default_max_producers);
@@ -150,12 +165,12 @@ FIXTURE_TEST(test_eviction_max_pids, test_fixture) {
         producers.push_back(new_producer([&] { evicted_so_far++; }));
     }
 
-    check_producers(default_max_producers);
+    validate_producer_count(default_max_producers);
 
     RPTEST_REQUIRE_EVENTUALLY(
       10s, [&] { return evicted_so_far == extra_producers; });
 
-    check_producers(default_max_producers);
+    validate_producer_count(default_max_producers);
 
     // producers are evicted on an lru basis, so the prefix
     // set of producers should be evicted first.
@@ -164,4 +179,91 @@ FIXTURE_TEST(test_eviction_max_pids, test_fixture) {
     }
 
     clean(producers);
+}
+
+FIXTURE_TEST(test_state_management_with_multiple_namespaces, test_fixture) {
+    size_t total_producers = 20;
+    cluster::vcluster_id vcluster_1 = cluster::vcluster_id(
+      xid::from_string("00000000000000000100"));
+    cluster::vcluster_id vcluster_2 = cluster::vcluster_id(
+      xid::from_string("00000000000000000200"));
+    cluster::vcluster_id vcluster_3 = cluster::vcluster_id(
+      xid::from_string("00000000000000000300"));
+    cluster::vcluster_id vcluster_4 = cluster::vcluster_id(
+      xid::from_string("00000000000000000400"));
+    cluster::vcluster_id vcluster_5 = cluster::vcluster_id(
+      xid::from_string("00000000000000000500"));
+
+    absl::flat_hash_map<cluster::vcluster_id, size_t> evicted_producers;
+    create_producer_state_manager(total_producers, 5);
+    struct vcluster_producer {
+        cluster::vcluster_id vcluster;
+        cluster::producer_ptr producer;
+    };
+    std::vector<vcluster_producer> producers;
+    producers.reserve(default_max_producers);
+
+    auto new_vcluster_producer = [&](cluster::vcluster_id& vcluster) {
+        auto p = new_producer([&] { evicted_producers[vcluster]++; }, vcluster);
+        producers.push_back(
+          vcluster_producer{.vcluster = vcluster, .producer = p});
+    };
+    /**
+     * Fill producer state manager with producers from one vcluster
+     */
+    for (int i = 0; i < total_producers; ++i) {
+        new_vcluster_producer(vcluster_1);
+    }
+    validate_producer_count(20);
+    validate_namespace_count(1);
+    /**
+     * Add 3 producers in another vcluster
+     */
+    for (int i = 0; i < 3; ++i) {
+        new_vcluster_producer(vcluster_2);
+    }
+    validate_producer_count(20);
+    // namespace count should increase
+    validate_namespace_count(2);
+    // 3 producers should be evicted from vcluster_1
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_1], 3);
+
+    for (int i = 0; i < 10; ++i) {
+        new_vcluster_producer(vcluster_2);
+    }
+
+    validate_producer_count(20);
+    // namespace count should increase
+    validate_namespace_count(2);
+    // 10 producers should be evicted from vcluster_1
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_1], 10);
+    // 3 producers should be evicted from vcluster_2
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_2], 3);
+
+    for (int i = 0; i < 5; ++i) {
+        new_vcluster_producer(vcluster_3);
+        new_vcluster_producer(vcluster_4);
+    }
+    /**
+     * Another five elements should be evicted from each existing vcluster
+     */
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_1], 15);
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_2], 8);
+
+    validate_producer_count(20);
+    // namespace count should increase
+    validate_namespace_count(4);
+
+    /**
+     * No more space in the manager for another vcluster.
+     */
+    BOOST_REQUIRE_EXCEPTION(
+      new_vcluster_producer(vcluster_5),
+      cluster::cache_full_error,
+      [](const auto& ex) { return true; });
+
+    for (auto vp : producers) {
+        manager().deregister_producer(*vp.producer, vp.vcluster);
+        vp.producer->shutdown_input();
+    }
 }

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -23,7 +23,7 @@ struct rm_stm_test_fixture : simple_raft_fixture {
         producer_state_manager
           .start(
             config::mock_binding(std::numeric_limits<uint64_t>::max()),
-            std::chrono::milliseconds::max())
+            config::mock_binding(std::numeric_limits<uint64_t>::max()))
           .get();
         producer_state_manager
           .invoke_on_all(

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -8,15 +8,27 @@
 // by the Apache License, Version 2.0
 
 #pragma once
+#include "cluster/producer_state_manager.h"
 #include "cluster/rm_stm.h"
 #include "config/property.h"
 #include "raft/tests/simple_raft_fixture.h"
+
+#include <seastar/core/sharded.hh>
 
 static ss::logger logger{"rm_stm-test"};
 
 struct rm_stm_test_fixture : simple_raft_fixture {
     void create_stm_and_start_raft(
       storage::ntp_config::default_overrides overrides = {}) {
+        producer_state_manager
+          .start(
+            config::mock_binding(std::numeric_limits<uint64_t>::max()),
+            std::chrono::milliseconds::max())
+          .get();
+        producer_state_manager
+          .invoke_on_all(
+            [](cluster::producer_state_manager& mgr) { return mgr.start(); })
+          .get();
         create_raft(overrides);
         raft::state_machine_manager_builder stm_m_builder;
 
@@ -25,10 +37,17 @@ struct rm_stm_test_fixture : simple_raft_fixture {
           _raft.get(),
           tx_gateway_frontend,
           _feature_table,
-          _producer_state_manager);
+          producer_state_manager);
 
         _raft->start(std::move(stm_m_builder)).get();
         _started = true;
+    }
+
+    ~rm_stm_test_fixture() {
+        if (_started) {
+            stop_all();
+            producer_state_manager.stop().get();
+        }
     }
 
     const cluster::rm_stm::producers_t& producers() const {
@@ -49,5 +68,6 @@ struct rm_stm_test_fixture : simple_raft_fixture {
     }
 
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    ss::sharded<cluster::producer_state_manager> producer_state_manager;
     ss::shared_ptr<cluster::rm_stm> _stm;
 };

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -37,7 +37,8 @@ struct rm_stm_test_fixture : simple_raft_fixture {
           _raft.get(),
           tx_gateway_frontend,
           _feature_table,
-          producer_state_manager);
+          producer_state_manager,
+          std::nullopt);
 
         _raft->start(std::move(stm_m_builder)).get();
         _started = true;

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -777,9 +777,9 @@ cluster::tx_snapshot_v4 make_tx_snapshot_v4() {
         cluster::random_expiration_snapshot)};
 }
 
-cluster::tx_snapshot make_tx_snapshot_v5(cluster::producer_state_manager& mgr) {
+cluster::tx_snapshot make_tx_snapshot_v5() {
     auto producers = tests::random_frag_vector(
-      tests::random_producer_state, 50, mgr);
+      tests::random_producer_state, 50);
     fragmented_vector<cluster::producer_state_snapshot> snapshots;
     for (auto producer : producers) {
         snapshots.push_back(producer->snapshot(kafka::offset{0}));
@@ -905,7 +905,7 @@ FIXTURE_TEST(test_snapshot_v3_v4_v5_equivalence, rm_stm_test_fixture) {
     }
 
     {
-        snap_v5 = make_tx_snapshot_v5(_producer_state_manager.local());
+        snap_v5 = make_tx_snapshot_v5();
         snap_v5.offset = stm.last_applied_offset();
         auto num_producers_from_snapshot = snap_v5.producers.size();
         auto highest_pid_from_snapshot = snap_v5.highest_producer_id;

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -24,6 +24,7 @@ using cluster::tx_executor;
     auto stop = ss::defer([&] {                                                \
         _data_dir = "test_dir_" + random_generators::gen_alphanum_string(6);   \
         stop_all();                                                            \
+        producer_state_manager.stop().get();                                   \
         _stm = nullptr;                                                        \
     });                                                                        \
     wait_for_confirmed_leader();                                               \

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -353,7 +353,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "record_value_subject_name_strategy: {}, "
       "record_value_subject_name_strategy_compat: {}, "
       "initial_retention_local_target_bytes: {}, "
-      "initial_retention_local_target_ms: {}}}",
+      "initial_retention_local_target_ms: {}, "
+      "mpx_virtual_cluster_id: {}}}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -380,7 +381,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.record_value_subject_name_strategy,
       properties.record_value_subject_name_strategy_compat,
       properties.initial_retention_local_target_bytes,
-      properties.initial_retention_local_target_ms);
+      properties.initial_retention_local_target_ms,
+      properties.mpx_virtual_cluster_id);
 
     return o;
 }
@@ -2195,7 +2197,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       tristate<size_t>{std::nullopt},
-      tristate<std::chrono::milliseconds>{std::nullopt}};
+      tristate<std::chrono::milliseconds>{std::nullopt},
+      std::nullopt};
 }
 
 void adl<cluster::cluster_property_kv>::to(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1471,13 +1471,14 @@ struct remote_topic_properties
  * Type representing MPX virtual cluster. MPX uses XID to identify clusters.
  */
 using vcluster_id = named_type<xid, struct v_cluster_id_tag>;
+
 /**
  * Structure holding topic properties overrides, empty values will be replaced
  * with defaults
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<6>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<7>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -1510,7 +1511,8 @@ struct topic_properties
       std::optional<pandaproxy::schema_registry::subject_name_strategy>
         record_value_subject_name_strategy_compat,
       tristate<size_t> initial_retention_local_target_bytes,
-      tristate<std::chrono::milliseconds> initial_retention_local_target_ms)
+      tristate<std::chrono::milliseconds> initial_retention_local_target_ms,
+      std::optional<vcluster_id> mpx_virtual_cluster_id)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -1542,7 +1544,8 @@ struct topic_properties
           record_value_subject_name_strategy_compat)
       , initial_retention_local_target_bytes(
           initial_retention_local_target_bytes)
-      , initial_retention_local_target_ms(initial_retention_local_target_ms) {}
+      , initial_retention_local_target_ms(initial_retention_local_target_ms)
+      , mpx_virtual_cluster_id(mpx_virtual_cluster_id) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -1584,6 +1587,7 @@ struct topic_properties
     tristate<size_t> initial_retention_local_target_bytes{std::nullopt};
     tristate<std::chrono::milliseconds> initial_retention_local_target_ms{
       std::nullopt};
+    std::optional<vcluster_id> mpx_virtual_cluster_id;
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -1620,7 +1624,8 @@ struct topic_properties
           record_value_subject_name_strategy,
           record_value_subject_name_strategy_compat,
           initial_retention_local_target_bytes,
-          initial_retention_local_target_ms);
+          initial_retention_local_target_ms,
+          mpx_virtual_cluster_id);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -34,6 +34,7 @@
 #include "storage/ntp_config.h"
 #include "tristate.h"
 #include "utils/to_string.h"
+#include "utils/xid.h"
 #include "v8_engine/data_policy.h"
 
 #include <seastar/core/chunked_fifo.hh>
@@ -1466,6 +1467,10 @@ struct remote_topic_properties
     operator<<(std::ostream&, const remote_topic_properties&);
 };
 
+/**
+ * Type representing MPX virtual cluster. MPX uses XID to identify clusters.
+ */
+using vcluster_id = named_type<xid, struct v_cluster_id_tag>;
 /**
  * Structure holding topic properties overrides, empty values will be replaced
  * with defaults

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -581,6 +581,14 @@ struct instance_generator<cluster::remote_topic_properties> {
 
 template<>
 struct instance_generator<cluster::topic_properties> {
+    static xid random_xid() {
+        auto data = random_generators::get_bytes(12);
+        xid::data_t array;
+        std::copy(std::begin(data), std::end(data), array.begin());
+
+        return xid{array};
+    }
+
     static cluster::topic_properties random() {
         return {
           tests::random_optional(
@@ -625,7 +633,9 @@ struct instance_generator<cluster::topic_properties> {
           std::nullopt,
           tests::random_tristate(
             [] { return random_generators::get_int<size_t>(); }),
-          tests::random_tristate([] { return tests::random_duration_ms(); })};
+          tests::random_tristate([] { return tests::random_duration_ms(); }),
+          tests::random_optional(
+            [] { return cluster::vcluster_id(random_xid()); })};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }
@@ -659,9 +669,12 @@ template<>
 struct instance_generator<cluster::create_topics_request> {
     static cluster::create_topics_request random() {
         return {
-          .topics = tests::random_vector([] {
-              return instance_generator<cluster::topic_configuration>::random();
-          }),
+          .topics = tests::random_vector(
+            [] {
+                return instance_generator<
+                  cluster::topic_configuration>::random();
+            },
+            5),
           .timeout = tests::random_duration_ms()};
     }
 

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -604,6 +604,13 @@ inline void rjson_serialize(
       w,
       "initial_retention_local_target_ms",
       tps.initial_retention_local_target_ms);
+    if (tps.mpx_virtual_cluster_id) {
+        write_member(
+          w,
+          "virtual_cluster_id",
+          ssx::sformat("{}", tps.mpx_virtual_cluster_id.value()()));
+    }
+
     w.EndObject();
 }
 
@@ -666,6 +673,12 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
       rd,
       "initial_retention_local_target_ms",
       obj.initial_retention_local_target_ms);
+    std::optional<ss::sstring> vcluster_str;
+    read_member(rd, "virtual_cluster_id", vcluster_str);
+    if (vcluster_str) {
+        obj.mpx_virtual_cluster_id = cluster::vcluster_id(
+          xid::from_string(*vcluster_str));
+    }
 }
 
 inline void rjson_serialize(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2978,7 +2978,13 @@ configuration::configuration()
       "are allowed.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       {"BASIC"},
-      validate_http_authn_mechanisms) {}
+      validate_http_authn_mechanisms)
+  , enable_mpx_extensions(
+      *this,
+      "enable_mpx_extensions",
+      "Enables Redpanda MPX extensions",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      false) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2984,7 +2984,14 @@ configuration::configuration()
       "enable_mpx_extensions",
       "Enables Redpanda MPX extensions",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      false) {}
+      false)
+  , virtual_cluster_min_producer_ids(
+      *this,
+      "virtual_cluster_min_producer_ids",
+      "Minium number of active producers per virtual cluster",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::numeric_limits<uint64_t>::max(),
+      {.min = 1}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -558,6 +558,7 @@ struct configuration final : public config_store {
 
     // MPX
     property<bool> enable_mpx_extensions;
+    bounded_property<uint64_t> virtual_cluster_min_producer_ids;
 
     configuration();
 

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -556,6 +556,9 @@ struct configuration final : public config_store {
     // HTTP Authentication
     property<std::vector<ss::sstring>> http_authentication;
 
+    // MPX
+    property<bool> enable_mpx_extensions;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -97,6 +97,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::invalid_partition_operation:
     case cluster::errc::concurrent_modification_error:
     case cluster::errc::transform_count_limit_exceeded:
+    case cluster::errc::producer_ids_vcluster_limit_exceeded:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -10,6 +10,7 @@
 #include "kafka/server/handlers/describe_configs.h"
 
 #include "cluster/metadata_cache.h"
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "config/data_directory_path.h"
 #include "config/node_config.h"
@@ -30,6 +31,7 @@
 
 #include <seastar/core/do_with.hh>
 #include <seastar/core/smp.hh>
+#include <seastar/core/sstring.hh>
 #include <seastar/util/log.hh>
 
 #include <fmt/ranges.h>
@@ -115,7 +117,8 @@ consteval describe_configs_type property_config_type() {
         std::is_same_v<T, model::timestamp_type> ||
         std::is_same_v<T, config::data_directory_path> ||
         std::is_same_v<T, v8_engine::data_policy> ||
-        std::is_same_v<T, pandaproxy::schema_registry::subject_name_strategy>;
+        std::is_same_v<T, pandaproxy::schema_registry::subject_name_strategy> || 
+        std::is_same_v<T, cluster::vcluster_id>;
 
     constexpr auto is_long_type = is_long<T> ||
         // Long type since seconds is atleast a 35-bit signed integral
@@ -261,6 +264,49 @@ static void add_topic_config(
       .documentation = documentation,
     });
 }
+/**
+ * Special overload for topic configuration which does not have the default per
+ * cluster value
+ */
+template<typename T, typename Func>
+static void add_topic_config(
+  describe_configs_result& result,
+  std::string_view override_name,
+  const std::optional<T>& overrides,
+  bool include_synonyms,
+  std::optional<ss::sstring> documentation,
+  Func&& describe_f) {
+    describe_configs_source src = overrides
+                                    ? describe_configs_source::topic
+                                    : describe_configs_source::default_config;
+
+    std::vector<describe_configs_synonym> synonyms;
+    if (include_synonyms) {
+        synonyms.reserve(2);
+        if (overrides) {
+            synonyms.push_back(describe_configs_synonym{
+              .name = ss::sstring(override_name),
+              .value = describe_f(*overrides),
+              .source = static_cast<int8_t>(describe_configs_source::topic),
+            });
+        }
+        synonyms.push_back(describe_configs_synonym{
+          .name = ss::sstring(override_name),
+          .value = std::nullopt,
+          .source = static_cast<int8_t>(
+            describe_configs_source::default_config),
+        });
+    }
+
+    result.configs.push_back(describe_configs_resource_result{
+      .name = ss::sstring(override_name),
+      .value = describe_f(overrides),
+      .config_source = src,
+      .synonyms = std::move(synonyms),
+      .config_type = property_config_type<T>(),
+      .documentation = documentation,
+    });
+}
 
 /**
  * For faking DEFAULT_CONFIG status for properties that are actually
@@ -367,6 +413,26 @@ static void add_topic_config_if_requested(
           overrides,
           include_synonyms,
           documentation);
+    }
+}
+
+template<typename T, typename Func>
+static void add_topic_config_if_requested(
+  const describe_configs_resource& resource,
+  describe_configs_result& result,
+  std::string_view override_name,
+  const std::optional<T>& overrides,
+  bool include_synonyms,
+  std::optional<ss::sstring> documentation,
+  Func&& describe_f) {
+    if (config_property_requested(resource.configuration_keys, override_name)) {
+        add_topic_config(
+          result,
+          override_name,
+          overrides,
+          include_synonyms,
+          documentation,
+          std::forward<Func>(describe_f));
     }
 }
 
@@ -810,6 +876,25 @@ ss::future<response_ptr> describe_configs_handler::handle(
               maybe_make_documentation(
                 request.data.include_documentation,
                 config::shard_local_cfg().log_segment_ms.desc()));
+
+            if (config::shard_local_cfg().enable_mpx_extensions()) {
+                add_topic_config_if_requested(
+                  resource,
+                  result,
+                  topic_property_mpx_virtual_cluster_id,
+                  topic_config->properties.mpx_virtual_cluster_id,
+                  request.data.include_synonyms,
+                  maybe_make_documentation(
+                    request.data.include_documentation,
+                    "Identifier of virtual cluster that the topic is "
+                    "affiliated with"),
+                  [](const std::optional<cluster::vcluster_id> property) {
+                      if (!property) {
+                          return ss::sstring("-");
+                      }
+                      return ssx::sformat("{}", (*property)());
+                  });
+            }
 
             constexpr std::string_view key_validation
               = "Enable validation of the schema id for keys on a record";

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -166,6 +166,8 @@ static error_code map_produce_error_code(std::error_code ec) {
             return error_code::out_of_order_sequence_number;
         case cluster::errc::invalid_request:
             return error_code::invalid_request;
+        case cluster::errc::producer_ids_vcluster_limit_exceeded:
+            return error_code::policy_violation;
         case cluster::errc::generic_tx_error:
             return error_code::unknown_server_error;
         default:

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -194,6 +194,10 @@ to_cluster_type(const creatable_topic& t) {
       = get_tristate_value<std::chrono::milliseconds>(
         config_entries, topic_property_initial_retention_local_target_ms);
 
+    cfg.properties.mpx_virtual_cluster_id
+      = get_config_value<cluster::vcluster_id>(
+        config_entries, topic_property_mpx_virtual_cluster_id);
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 
@@ -363,6 +367,10 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
           = from_config_type(*properties.initial_retention_local_target_ms);
     }
 
+    if (properties.mpx_virtual_cluster_id.has_value()) {
+        config_entries[topic_property_mpx_virtual_cluster_id]
+          = from_config_type(properties.mpx_virtual_cluster_id.value());
+    }
     /// Final topic_property not encoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
     return config_entries;

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -101,6 +101,9 @@ static constexpr std::string_view
   topic_property_initial_retention_local_target_ms
   = "initial.retention.local.target.ms";
 
+static constexpr std::string_view topic_property_mpx_virtual_cluster_id
+  = "redpanda.virtual.cluster.id";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 static constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {

--- a/src/v/raft/tests/simple_raft_fixture.h
+++ b/src/v/raft/tests/simple_raft_fixture.h
@@ -10,7 +10,6 @@
  */
 
 #pragma once
-#include "cluster/producer_state_manager.h"
 #include "config/property.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -67,15 +66,6 @@ struct simple_raft_fixture {
         _feature_table
           .invoke_on_all(
             [](features::feature_table& f) { f.testing_activate_all(); })
-          .get();
-        _producer_state_manager
-          .start(
-            config::mock_binding(std::numeric_limits<uint64_t>::max()),
-            std::chrono::milliseconds::max())
-          .get();
-        _producer_state_manager
-          .invoke_on_all(
-            [](cluster::producer_state_manager& mgr) { return mgr.start(); })
           .get();
 
         _group_mgr
@@ -152,12 +142,13 @@ struct simple_raft_fixture {
             if (_raft) {
                 _raft.release();
             }
-            _producer_state_manager.stop().get();
+
             _connections.stop().get();
             _storage.stop().get();
             _feature_table.stop().get();
             _as.stop().get();
         }
+        _started = false;
     }
 
     storage::log_config default_log_cfg() {
@@ -212,6 +203,5 @@ struct simple_raft_fixture {
     ss::sharded<features::feature_table> _feature_table;
     ss::sharded<raft::group_manager> _group_mgr;
     ss::sharded<raft::coordinated_recovery_throttle> _recovery_throttle;
-    ss::sharded<cluster::producer_state_manager> _producer_state_manager;
     bool _started = false;
 };

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1424,11 +1424,9 @@ void application::wire_up_redpanda_services(
 
     syschecks::systemd_message("Initializing producer state manager").get();
     construct_service(
-      producer_manager,
-      ss::sharded_parameter([]() {
+      producer_manager, ss::sharded_parameter([]() {
           return config::shard_local_cfg().max_concurrent_producer_ids.bind();
-      }),
-      config::shard_local_cfg().transactional_id_expiration_ms.value())
+      }))
       .get();
 
     producer_manager.invoke_on_all(&cluster::producer_state_manager::start)

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1424,8 +1424,13 @@ void application::wire_up_redpanda_services(
 
     syschecks::systemd_message("Initializing producer state manager").get();
     construct_service(
-      producer_manager, ss::sharded_parameter([]() {
+      producer_manager,
+      ss::sharded_parameter([]() {
           return config::shard_local_cfg().max_concurrent_producer_ids.bind();
+      }),
+      ss::sharded_parameter([]() {
+          return config::shard_local_cfg()
+            .virtual_cluster_min_producer_ids.bind();
       }))
       .get();
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2491,7 +2491,8 @@ void application::start_runtime_services(
             config::shard_local_cfg().enable_idempotence.value(),
             tx_gateway_frontend,
             producer_manager,
-            feature_table);
+            feature_table,
+            controller->get_topics_state());
           pm.register_factory<cluster::log_eviction_stm_factory>(
             storage.local().kvs());
           pm.register_factory<cluster::archival_metadata_stm_factory>(

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -180,10 +180,8 @@ inline absl::btree_set<Value> random_btree_set(Fn&& gen, size_t size = 20) {
     return random_set<absl::btree_set, Value>(std::forward<Fn>(gen), size);
 }
 
-inline cluster::producer_ptr
-random_producer_state(cluster::producer_state_manager& psm) {
+inline cluster::producer_ptr random_producer_state() {
     return ss::make_lw_shared<cluster::producer_state>(
-      psm,
       model::producer_identity{
         random_generators::get_int<int64_t>(),
         random_generators::get_int<int16_t>()},

--- a/src/v/utils/CMakeLists.txt
+++ b/src/v/utils/CMakeLists.txt
@@ -14,6 +14,7 @@ v_cc_library(
     uuid.cc
     bottomless_token_bucket.cc
     log_hist.cc
+    xid.cc
   DEPS
     Seastar::seastar
     Hdrhistogram::hdr_histogram

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -102,6 +102,10 @@ public:
         return o << "{" << t() << "}";
     };
 
+    friend std::istream& operator>>(std::istream& i, base_named_type& t) {
+        return i >> t._value;
+    };
+
 protected:
     type _value = std::numeric_limits<T>::min();
 };
@@ -170,6 +174,10 @@ public:
 
     friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
         return o << "{" << t() << "}";
+    };
+
+    friend std::istream& operator>>(std::istream& i, base_named_type& t) {
+        return i >> t._value;
     };
 
 protected:

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ rp_test(
     stable_iterator_test.cc
     tracking_allocator_tests.cc
     tristate_test.cc
+    xid_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::utils absl::flat_hash_map v::random
   LABELS utils

--- a/src/v/utils/tests/xid_test.cc
+++ b/src/v/utils/tests/xid_test.cc
@@ -1,0 +1,43 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "random/generators.h"
+#include "serde/rw/rw.h"
+#include "utils/xid.h"
+
+#include <absl/container/node_hash_map.h>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+
+xid random_xid() {
+    static std::uniform_int_distribution<int> rand_fill('@', '~');
+    xid::data_t array;
+    memset(
+      array.data(), rand_fill(random_generators::internal::gen), array.size());
+
+    return xid(array);
+}
+
+BOOST_AUTO_TEST_CASE(string_formatting_test) {
+    for (int i = 0; i < 1000; ++i) {
+        auto test_xid = random_xid();
+        BOOST_REQUIRE_EQUAL(
+          boost::lexical_cast<xid>(fmt::format("{}", test_xid)), test_xid);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(serde_rt_test) {
+    for (int i = 0; i < 1000; ++i) {
+        auto test_xid = random_xid();
+        BOOST_REQUIRE_EQUAL(
+          serde::from_iobuf<xid>(serde::to_iobuf(test_xid)), test_xid);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(hasing_test) { absl::node_hash_map<xid, int> map; }

--- a/src/v/utils/xid.cc
+++ b/src/v/utils/xid.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/xid.h"
+
+#include "ssx/sformat.h"
+
+#include <fmt/format.h>
+
+namespace {
+static constexpr std::array<char, 32> b32_alphabet{
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a',
+  'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+  'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v'};
+
+using decoder_t = std::array<uint8_t, 256>;
+
+constexpr decoder_t build_decoder_table() {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    std::array<uint8_t, 256> ret = {0xff};
+
+    for (uint8_t i = 0; i < b32_alphabet.size(); ++i) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+        ret[b32_alphabet[i]] = i;
+    }
+    return ret;
+}
+
+static constexpr decoder_t decoder = build_decoder_table();
+} // namespace
+
+invalid_xid::invalid_xid(const ss::sstring& current_string)
+  : _msg(ssx::sformat("String '{}' is not a valid xid", current_string)) {}
+
+xid xid::from_string(const ss::sstring& str) {
+    if (str.size() != str_size) {
+        throw invalid_xid(str);
+    }
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index,
+    // readability-magic-numbers, hicpp-signed-bitwise)
+    data_t data;
+    data[11] = decoder[str[17]] << 6u | decoder[str[18]] << 1u
+               | decoder[str[19]] >> 4u;
+
+    // check the last byte
+    if (b32_alphabet[(data[11] << 4) & 0x1F] != str[19]) {
+        throw invalid_xid(str);
+    }
+
+    data[10] = decoder[str[16]] << 3u | decoder[str[17]] >> 2u;
+    data[9] = decoder[str[14]] << 5u | decoder[str[15]];
+    data[8] = decoder[str[12]] << 7u | decoder[str[13]] << 2u
+              | decoder[str[14]] >> 3u;
+    data[7] = decoder[str[11]] << 4u | decoder[str[12]] >> 1;
+    data[6] = decoder[str[9]] << 6u | decoder[str[10]] << 1u
+              | decoder[str[11]] >> 4u;
+    data[5] = decoder[str[8]] << 3u | decoder[str[9]] >> 2u;
+    data[4] = decoder[str[6]] << 5u | decoder[str[7]];
+    data[3] = decoder[str[4]] << 7u | decoder[str[5]] << 2u
+              | decoder[str[6]] >> 3u;
+    data[2] = decoder[str[3]] << 4u | decoder[str[4]] >> 1u;
+    data[1] = decoder[str[1]] << 6u | decoder[str[2]] << 1
+              | decoder[str[3]] >> 4u;
+    data[0] = decoder[str[0]] << 3u | decoder[str[1]] >> 2u;
+    // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index,
+    // readability-magic-numbers, hicpp-signed-bitwise)
+    return xid(data);
+}
+
+fmt::format_context::iterator
+fmt::formatter<xid>::format(const xid& id, format_context& ctx) const {
+    static constexpr uint8_t mask = 0x1f;
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index,
+    // readability-magic-numbers, hicpp-signed-bitwise)
+    fmt::format_to(
+      ctx.out(),
+      "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+      b32_alphabet[id._data[0] >> 3u],
+      b32_alphabet[((id._data[1] >> 6u) & mask) | ((id._data[0] << 2u) & mask)],
+      b32_alphabet[(id._data[1] >> 1) & mask],
+      b32_alphabet[((id._data[2] >> 4) & mask) | ((id._data[1] << 4) & mask)],
+      b32_alphabet[id._data[3] >> 7 | ((id._data[2] << 1) & mask)],
+      b32_alphabet[(id._data[3] >> 2) & mask],
+      b32_alphabet[id._data[4] >> 5 | ((id._data[3] << 3) & mask)],
+      b32_alphabet[id._data[4] & mask],
+      b32_alphabet[id._data[5] >> 3],
+      b32_alphabet[((id._data[6] >> 6) & mask) | ((id._data[5] << 2) & mask)],
+      b32_alphabet[(id._data[6] >> 1) & mask],
+      b32_alphabet[((id._data[7] >> 4) & mask) | ((id._data[6] << 4) & mask)],
+      b32_alphabet[id._data[8] >> 7 | ((id._data[7] << 1) & mask)],
+      b32_alphabet[(id._data[8] >> 2) & mask],
+      b32_alphabet[(id._data[9] >> 5) | ((id._data[8] << 3) & mask)],
+      b32_alphabet[id._data[9] & mask],
+      b32_alphabet[id._data[10] >> 3],
+      b32_alphabet
+        [((uint8_t)(id._data[11] >> 6) & mask)
+         | ((uint8_t)(id._data[10] << 2) & mask)],
+      b32_alphabet[(id._data[11] >> 1) & mask],
+      b32_alphabet[(id._data[11] << 4) & mask]);
+
+    // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index,
+    // readability-magic-numbers, hicpp-signed-bitwise)
+    return ctx.out();
+}
+
+std::ostream& operator<<(std::ostream& o, const xid& id) {
+    fmt::print(o, "{}", id);
+    return o;
+}
+
+std::istream& operator>>(std::istream& i, xid& id) {
+    ss::sstring s;
+    i >> s;
+    id._data = xid::from_string(s)._data;
+    return i;
+}

--- a/src/v/utils/xid.h
+++ b/src/v/utils/xid.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/bytes.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <fmt/core.h>
+
+#include <array>
+#include <cstdint>
+#include <exception>
+
+class invalid_xid final : public std::exception {
+public:
+    explicit invalid_xid(const ss::sstring&);
+    const char* what() const noexcept final { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
+
+/**
+ * Class representing XID
+ *
+ * Based on (https://github.com/rs/xid)
+ */
+class xid {
+public:
+    // number of bytes in an underlying data structure
+    static constexpr size_t size = 12;
+    // size of xid string representation
+    static constexpr size_t str_size = 20;
+
+    using data_t = std::array<uint8_t, size>;
+
+    explicit constexpr xid(data_t data)
+      : _data(data) {}
+    // default constructor to make the xid type lexically castable from string
+    constexpr xid() = default;
+
+    xid(const xid&) = default;
+    xid(xid&&) = default;
+    xid& operator=(const xid&) = default;
+    xid& operator=(xid&&) = default;
+    ~xid() = default;
+    friend bool operator==(const xid&, const xid&) = default;
+
+    operator bytes_view() { return to_bytes_view(_data); }
+
+    template<typename H>
+    friend H AbslHashValue(H h, const xid& id) {
+        return H::combine(std::move(h), id._data);
+    }
+
+    static xid from_string(const ss::sstring&);
+
+    friend std::ostream& operator<<(std::ostream&, const xid&);
+
+    friend std::istream& operator>>(std::istream&, xid&);
+
+private:
+    friend struct fmt::formatter<xid>;
+    data_t _data;
+};
+
+template<>
+struct fmt::formatter<xid> : fmt::formatter<std::string_view> {
+    fmt::format_context::iterator
+    format(const xid& id, format_context& ctx) const;
+};

--- a/src/v/utils/xid.h
+++ b/src/v/utils/xid.h
@@ -13,6 +13,8 @@
 
 #include "base/seastarx.h"
 #include "bytes/bytes.h"
+#include "serde/rw/array.h"
+#include "serde/rw/rw.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -69,6 +71,15 @@ public:
     friend std::ostream& operator<<(std::ostream&, const xid&);
 
     friend std::istream& operator>>(std::istream&, xid&);
+
+    friend inline void
+    read_nested(iobuf_parser& in, xid& id, size_t const bytes_left_limit) {
+        serde::read_nested(in, id._data, bytes_left_limit);
+    }
+
+    friend inline void write(iobuf& out, xid id) {
+        serde::write(out, id._data);
+    }
 
 private:
     friend struct fmt::formatter<xid>;

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -81,6 +81,7 @@ class TopicSpec:
 
     PROPERTY_INITIAL_RETENTION_LOCAL_TARGET_BYTES = "initial.retention.local.target.bytes"
     PROPERTY_INITIAL_RETENTION_LOCAL_TARGET_MS = "initial.retention.local.target.ms"
+    PROPERTY_VIRTUAL_CLUSTER_ID = "redpanda.virtual.cluster.id"
 
     def __init__(self,
                  *,
@@ -108,7 +109,8 @@ class TopicSpec:
                  record_value_subject_name_strategy=None,
                  record_value_subject_name_strategy_compat=None,
                  initial_retention_local_target_bytes=None,
-                 initial_retention_local_target_ms=None):
+                 initial_retention_local_target_ms=None,
+                 virtual_cluster_id=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -134,6 +136,7 @@ class TopicSpec:
         self.record_value_subject_name_strategy_compat = record_value_subject_name_strategy_compat
         self.initial_retention_local_target_bytes = initial_retention_local_target_bytes
         self.initial_retention_local_target_ms = initial_retention_local_target_ms
+        self.virtual_cluster_id = virtual_cluster_id
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -724,34 +724,25 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         ans = rpk.cluster_config_set("max_concurrent_producer_ids",
                                      str(max_concurrent_producer_ids))
 
-        test_producer = ck.Producer({
-            'bootstrap.servers':
-            self.redpanda.brokers(),
-            'enable.idempotence':
-            True,
-        })
-
         topic = self.topics[0].name
-        test_producer.produce(topic,
-                              '0',
-                              '0',
-                              partition=0,
-                              on_delivery=self.on_delivery)
-        test_producer.flush()
 
-        max_producers = 51
+        def _produce_one(producer, idx):
+            self.logger.debug(f"producing using {idx} producer")
+            producer.produce(topic,
+                             f"record-key-producer-{idx}",
+                             f"record-value-producer-{idx}",
+                             partition=0,
+                             on_delivery=self.on_delivery)
+            producer.flush()
+
+        max_producers = 50
         producers = []
-        for i in range(max_producers - 1):
+        for i in range(max_producers):
             p = ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'enable.idempotence': True,
             })
-            p.produce(topic,
-                      str(i + 1),
-                      str(i + 1),
-                      partition=0,
-                      on_delivery=self.on_delivery)
-            p.flush()
+            _produce_one(p, i)
             producers.append(p)
 
         # Wait until eviction kicks in.
@@ -778,31 +769,23 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                    err_msg="Producers not evicted in time")
 
         try:
-            test_producer.produce(topic,
-                                  'test',
-                                  'test',
-                                  partition=0,
-                                  on_delivery=self.on_delivery)
-            test_producer.flush()
+            _produce_one(producers[0], 0)
             assert False, "We can not produce after cleaning in rm_stm"
         except ck.cimpl.KafkaException as e:
             kafka_error = e.args[0]
             kafka_error.code(
             ) == ck.cimpl.KafkaError.OUT_OF_ORDER_SEQUENCE_NUMBER
 
-        last_worked_producers = max_producers - max_concurrent_producer_ids - 1
-        for i in range(max_concurrent_producer_ids):
-            producers[last_worked_producers + i].produce(
-                topic,
-                str(max_producers + i),
-                str(max_producers + i),
-                partition=0,
-                on_delivery=self.on_delivery)
-            producers[last_worked_producers + i].flush()
+        # validate that the producers are evicted with LRU policy,
+        # starting from this producer there should be no sequence
+        # number errors as those producer state should not be evicted
+        last_not_evicted_producer_idx = max_producers - max_concurrent_producer_ids + 1
+        for i in range(last_not_evicted_producer_idx, len(producers)):
+            _produce_one(producers[i], i)
 
-        should_be_consumed = max_producers + max_concurrent_producer_ids - 1
+        expected_records = len(
+            producers) - last_not_evicted_producer_idx + max_producers
         num_consumed = 0
-        prev_rec = bytes("0", 'UTF-8')
 
         consumer = ck.Consumer({
             'bootstrap.servers': self.redpanda.brokers(),
@@ -812,20 +795,13 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
 
         consumer.subscribe([topic])
 
-        while num_consumed < should_be_consumed:
+        while num_consumed < expected_records:
             self.redpanda.logger.debug(
-                f"Consumed {num_consumed}. Should consume at the end {should_be_consumed}"
-            )
+                f"Consumed {num_consumed} of of {expected_records}")
             records = self.consume(consumer)
-
-            for record in records:
-                assert prev_rec == record.key(
-                ), f"Expected {prev_rec}. Got {record.key()}"
-                prev_rec = bytes(str(int(prev_rec) + 1), 'UTF-8')
-
             num_consumed += len(records)
 
-        assert num_consumed == should_be_consumed
+        assert num_consumed == expected_records
 
 
 @contextmanager

--- a/tests/rptest/tests/vcluster_topic_property_test.py
+++ b/tests/rptest/tests/vcluster_topic_property_test.py
@@ -1,0 +1,78 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from rptest.clients.rpk import RpkException, RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from random import randbytes
+
+BASE32_ALPHABET = "0123456789abcdefghijklmnopqrstuv"
+
+
+def get_vcluster_id(topic_properties: dict):
+    if TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID not in topic_properties:
+        return None
+    return topic_properties[TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID][0]
+
+
+class VirtualClusterTopicPropertyTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(VirtualClusterTopicPropertyTest,
+              self).__init__(test_context=test_context, num_brokers=3)
+
+    def _random_xid_string(self):
+        xid = ''.join([random.choice(BASE32_ALPHABET) for _ in range(19)])
+
+        return xid + random.choice(['0', 'g'])
+
+    @cluster(num_nodes=3)
+    def test_basic_virtual_cluster_property(self):
+        rpk = RpkTool(self.redpanda)
+        # try creating vcluster enabled topic with extensions disabled
+        topic = TopicSpec()
+        vcluster_id = self._random_xid_string()
+        rpk.create_topic(
+            topic=topic.name,
+            partitions=1,
+            replicas=3,
+            config={TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID: vcluster_id})
+
+        configs = rpk.describe_topic_configs(topic.name)
+        assert TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID not in configs, \
+            "When MPX extensions are disabled there should be no virtual cluster property reported"
+        try:
+            configs = rpk.alter_topic_config(
+                topic.name, TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID, vcluster_id)
+            assert False, "Altering topic virtual cluster property should not be supported"
+        except RpkException as e:
+            assert "INVALID_CONFIG" in e.msg
+        rpk.delete_topic(topic.name)
+        # enable mpx extensions
+        self.redpanda.set_cluster_config({"enable_mpx_extensions": True})
+        # create topic with virtual cluster id assigned
+        rpk.create_topic(
+            topic=topic.name,
+            partitions=1,
+            replicas=3,
+            config={TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID: vcluster_id})
+
+        configs = rpk.describe_topic_configs(topic.name)
+
+        assert get_vcluster_id(configs) == vcluster_id, \
+            f"current virtual cluster id {get_vcluster_id(configs)} and expected cluster id {vcluster_id} doesn't match"
+
+        try:
+            rpk.alter_topic_config(topic.name,
+                                   TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID,
+                                   self._random_xid_string())
+            assert False, "Altering topic virtual cluster property should not be supported"
+        except RpkException as e:
+            assert "INVALID_CONFIG" in e.msg

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -99,6 +99,10 @@ def read_topic_properties_serde(rdr: Reader, version):
             'initial_retention_local_target_ms':
             rdr.read_tristate(Reader.read_uint64)
         }
+    if version >= 7:
+        topic_properties |= {
+            'mpx_virtual_cluster_id': rdr.read_optional(Reader.read_bytes)
+        }
 
     return topic_properties
 
@@ -119,7 +123,7 @@ def read_topic_configuration_assignment_serde(rdr: Reader):
                     rdr.read_int16(),
                     'properties':
                     rdr.read_envelope(read_topic_properties_serde,
-                                      max_version=6),
+                                      max_version=7),
                 }, 1),
             'assignments':
             rdr.read_serde_vector(lambda r: r.read_envelope(


### PR DESCRIPTION
### Basic definitions of virtual clusters

Added utilities providing abstractions and algorithms to handle virtual cluster context in Redpanda.

### `redpanda.virtual.cluster.id` topic property
Added `redpanda.virtual.cluster.id` topic property which affiliates the topic with virtual cluster. The property is only settable during topic creation and can not be modified.

### Per virtual cluster producer state management

Added per virtual cluster producer state eviction policy to manager producer sessions. The policy provides fair sharing of total number of producer state slots among the virtual clusters while being able to effectively utilize all slots available if they are available 

### Added configuration enabling MPX specific extensions

Added configuration that allows controlling if MPX specific extensions like per virtual cluster LRUs and additional topic properties are available. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none