### PR TITLE
rptest: Fix race condition in CloudRetentionTest

### DIFF
--- a/tests/rptest/tests/cloud_retention_test.py
+++ b/tests/rptest/tests/cloud_retention_test.py
@@ -103,20 +103,9 @@ class CloudRetentionTest(PreallocNodesTest):
                                        msg_count=msg_count,
                                        custom_node=self.preallocated_nodes)
 
-        consumer = KgoVerifierConsumerGroupConsumer(
-            self.test_context,
-            self.redpanda,
-            self.topic_name,
-            msg_size,
-            readers=3,
-            loop=True,
-            max_msgs=max_read_msgs,
-            nodes=self.preallocated_nodes)
-
         producer.start(clean=False)
 
         producer.wait_for_offset_map()
-        consumer.start(clean=False)
 
         producer.wait_for_acks(msg_count, timeout_sec=600, backoff_sec=5)
         producer.wait()
@@ -191,6 +180,17 @@ class CloudRetentionTest(PreallocNodesTest):
         wait_until(lambda: check_total_size(include_below_start_offset=True),
                    timeout_sec=60,
                    backoff_sec=5)
+
+        consumer = KgoVerifierConsumerGroupConsumer(
+            self.test_context,
+            self.redpanda,
+            self.topic_name,
+            msg_size,
+            readers=3,
+            loop=True,
+            max_msgs=max_read_msgs,
+            nodes=self.preallocated_nodes)
+        consumer.start(clean=False)
 
         consumer.wait()
         self.logger.info("finished consuming")


### PR DESCRIPTION
Fixes #15893

The test has race condition. It starts consumer before all data is produced and before retention kicks in. The original intention was to let the consumer validate the data after retention. Basically, to check that the data is readable. But because of that the consumer were reading data that was removed by retention. It was racing with the producer. Largely simplifed version of what was happening there. 
* The producer produces offsets in range [0...1000]. 
* The retention removes offsets in range [0...500).
* The consumer is started concurrently with the producer with the expectation that it will consume offsets in range [500...1000]. We're validating the number of messages consumed.
* The consumer actually manages to consume offsets in range [0...600]. So the check based on number of messages passes.
* In CDT the consumer doesn't manage to consume enough data because of different performance characteristics. It consumes in range [0...100] and check fails.

This PR fixes this by starting the consumer after retention is confirmed. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none