### PR TITLE
rptest: Create multi-node test with 1k topics and >10M events

### DIFF
--- a/tests/rptest/e2e_tests/flink_scale_test.py
+++ b/tests/rptest/e2e_tests/flink_scale_test.py
@@ -22,6 +22,8 @@ from rptest.services.flink import FlinkService
 from rptest.services.redpanda import MetricsEndpoint, MetricSamples
 from rptest.tests.redpanda_test import RedpandaTest
 
+from rptest.utils.mode_checks import skip_debug_mode
+
 
 class FlinkScaleTests(RedpandaTest):
     def __init__(self, test_context, *args, **kwargs):
@@ -185,6 +187,7 @@ class FlinkScaleTests(RedpandaTest):
         self.logger.debug("Done creating topics ({:>5,.2f}s, {:>5,.2f} "
                           "topics per sec)".format(elapsed, tps))
 
+    @skip_debug_mode
     @cluster(num_nodes=4)
     @parametrize(unique_topics=True)
     @parametrize(unique_topics=False)
@@ -306,6 +309,7 @@ class FlinkScaleTests(RedpandaTest):
 
         return
 
+    @skip_debug_mode
     @cluster(num_nodes=8)
     def test_transactions_scale_swarm(self):
         """

--- a/tests/rptest/e2e_tests/workloads/flink_transactions_topic_swarm.py
+++ b/tests/rptest/e2e_tests/workloads/flink_transactions_topic_swarm.py
@@ -1,0 +1,280 @@
+# Copyright 2023 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import json
+import logging
+import os
+import sys
+
+from dataclasses import dataclass
+
+from pyflink.common import WatermarkStrategy, Types, SimpleStringSchema
+from pyflink.datastream.checkpointing_mode import CheckpointingMode
+from pyflink.datastream.checkpoint_config import ExternalizedCheckpointCleanup
+
+from pyflink.common import Configuration
+from pyflink.datastream import StreamExecutionEnvironment, RuntimeExecutionMode
+from pyflink.datastream.connectors.kafka import KafkaSink, DeliveryGuarantee, \
+    KafkaRecordSerializationSchema, KafkaSource, KafkaOffsetsInitializer
+from pyflink.datastream.connectors import NumberSequenceSource
+
+MODE_PRODUCE = 'produce'
+MODE_CONSUME = 'consume'
+
+
+@dataclass(kw_only=True)
+class WorkloadConfig:
+    # Default values are set for CDT run inside EC2 instance
+    connector_path: str = "File:///opt/flink/connectors/flink-sql-connector-kafka-3.0.1-1.18.jar"
+    python_lib_path: str = "File:///opt/flink/opt/flink-python-1.18.0.jar"
+    python_archive: str = "/opt/flink/flink_venv.tgz"
+    logger_path: str = "/workloads"
+    log_level: str = "DEBUG"
+    producer_group: str = "flink_group"
+    consumer_group: str = "flink_group"
+    number_of_topics: int = 1
+    topic_prefix: str = "flink-transactions-topic"
+    transaction_id_prefix: str = "flink-transaction-prefix"
+    # options are produce/consume
+    mode: str = MODE_PRODUCE
+    # How many events generate
+    count: int = 512
+    # This should be updated to value from self.redpanda.brokers()
+    brokers: str = "localhost:9092"
+
+
+def setup_logger(logfilepath, level):
+    # Simple file logger
+    handler = logging.FileHandler(logfilepath)
+    handler.setFormatter(
+        logging.Formatter(
+            '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    level = logging.getLevelName(level.upper())
+    handler.setLevel(level)
+    logger = logging.getLogger(__name__)
+    logger.addHandler(handler)
+
+    return logger
+
+
+class FlinkWorkloadProduce:
+    def __init__(self, config_override):
+        # Serialize config
+        self.config = WorkloadConfig(**config_override)
+        # Create logger
+        filename = f"{os.path.basename(__file__).split('.')[0]}.log"
+        logfile = os.path.join(self.config.logger_path, filename)
+        self.logger = setup_logger(logfile, self.config.log_level)
+
+    def setup(self):
+        self.logger.info("Initializing Produce workload")
+        # Initialize
+        config = Configuration()
+        # This is required for ducktape EC2 run
+        config.set_string("python.client.executable", "python3")
+        config.set_string("python.executable", "python3")
+        config.set_string("pipeline.jars", self.config.connector_path)
+        # This is needed for Scalar functions work
+        # See https://nightlies.apache.org/flink/flink-docs-master/docs/dev/python/dependency_management/
+        config.set_string("pipeline.classpaths", self.config.python_lib_path)
+
+        # Create flink env
+        # Streaming env is user in order to add kafka connector
+        env = StreamExecutionEnvironment.get_execution_environment()
+        env.set_runtime_mode(RuntimeExecutionMode.STREAMING)
+
+        # Configure jars, alternatively
+        env.add_jars(self.config.connector_path)
+        # Add python venv archive to table_api
+        env.add_python_archive(self.config.python_archive, "venv")
+        env.set_python_executable("venv/bin/python")
+
+        # Checkpoints settings
+        # See: https://nightlies.apache.org/flink/flink-docs-master/api/python/reference/pyflink.datastream/checkpoint.html
+        # and: https://nightlies.apache.org/flink/flink-docs-master/docs/dev/datastream/fault-tolerance/checkpointing/
+
+        # start a checkpoint every 1000 ms
+        env.enable_checkpointing(1000)
+        # advanced options:
+        # set mode to exactly-once (this is the default)
+        env.get_checkpoint_config().set_checkpointing_mode(
+            CheckpointingMode.EXACTLY_ONCE)
+        # make sure 1 ms of progress happen between checkpoints
+        env.get_checkpoint_config().set_min_pause_between_checkpoints(1)
+        # checkpoints have to complete within one minute, or are discarded
+        env.get_checkpoint_config().set_checkpoint_timeout(30000)
+        # only two consecutive checkpoint failures are tolerated
+        env.get_checkpoint_config().set_tolerable_checkpoint_failure_number(2)
+        # allow only one checkpoint to be in progress at the same time
+        env.get_checkpoint_config().set_max_concurrent_checkpoints(1)
+        # enable externalized checkpoints which are retained
+        # after job cancellation
+        env.get_checkpoint_config().enable_externalized_checkpoints(
+            ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
+        # enables the unaligned checkpoints
+        env.get_checkpoint_config().enable_unaligned_checkpoints()
+
+        # Save env
+        self.stream_env = env
+
+    def prepare_produce_mode(self):
+        """
+            Initialized produce mode
+
+            Steps:
+            - Use simple number Sequence as a source
+            - Transform it to str
+            - Send to brokers
+        """
+
+        # NumberSequence produces Types.LONG
+        # Cast it to str
+        def transform(value):
+            yield str(value)
+
+        self.datasources = []
+        self.sinks = []
+
+        for idx in range(self.config.number_of_topics):
+            topic_name = f"{self.config.topic_prefix}-{idx}"
+            self.logger.info(f"Preparing producer for topic '{topic_name}'")
+            tid_prefix = f"{self.config.transaction_id_prefix}-{idx}"
+
+            # Prepare data source
+            source = NumberSequenceSource(0, self.config.count)
+
+            # Create DataStream
+            ds = self.stream_env.from_source(
+                source=source,
+                watermark_strategy=WatermarkStrategy.no_watermarks(),
+                source_name=f"number_sequence_{idx}")
+
+            # Assign transformation
+            self.datasources.append(
+                ds.flat_map(transform, output_type=Types.STRING()))
+
+            # Create simple serializer with String schema
+            record_serializer = KafkaRecordSerializationSchema.builder() \
+                .set_topic(topic_name) \
+                .set_key_serialization_schema(SimpleStringSchema()) \
+                .set_value_serialization_schema(SimpleStringSchema()) \
+                .build()
+
+            # Build KafkaSource class
+            sink = KafkaSink.builder() \
+                .set_bootstrap_servers(self.config.brokers) \
+                .set_record_serializer(record_serializer) \
+                .set_delivery_guarantee(DeliveryGuarantee.EXACTLY_ONCE) \
+                .set_transactional_id_prefix(tid_prefix) \
+                .build()
+            self.sinks.append(sink)
+
+    def produce_sequence(self):
+        for idx in range(self.config.number_of_topics):
+            # Add previously created KafkaSink class as a sink to DataStream
+            self.datasources[idx].sink_to(self.sinks[idx])
+            # Do the sending
+
+        self.stream_env.execute()
+
+        return
+
+    def prepare_consume_mode(self):
+        """
+            Initialize consume mode
+
+            Steps:
+            - Use KafkaSource
+            - Just dump sequence to stdout
+        """
+        self.datasources = []
+        # format topic name
+        for idx in range(self.config.number_of_topics):
+            topic_name = f"{self.config.topic_prefix}-{idx}"
+            self.logger.info("Creating consumer with target topic of "
+                             f"'{topic_name}'")
+            # Create consumer from KafkaSource class
+            source = KafkaSource \
+                .builder() \
+                .set_bootstrap_servers(self.config.brokers) \
+                .set_group_id(self.config.consumer_group) \
+                .set_topics(topic_name) \
+                .set_value_only_deserializer(SimpleStringSchema()) \
+                .set_starting_offsets(KafkaOffsetsInitializer.earliest()) \
+                .set_bounded(KafkaOffsetsInitializer.latest()) \
+                .build()
+
+            ds = self.stream_env.from_source(source,
+                                             WatermarkStrategy.no_watermarks(),
+                                             "Kafka Source")
+            # Just print received message
+            ds.print()
+            self.datasources.append(ds)
+
+    def consume_sequence(self):
+        """
+            Example of a consume task usign Table API
+        """
+        # Run
+        self.logger.info("Runnig consumer")
+        self.stream_env.execute()
+        self.logger.info("Done")
+
+        return
+
+    def run(self):
+        # Run selected mode
+        if self.config.mode == MODE_PRODUCE:
+            self.prepare_produce_mode()
+            self.produce_sequence()
+        elif self.config.mode == MODE_CONSUME:
+            self.prepare_consume_mode()
+            self.consume_sequence()
+        else:
+            self.logger.info(f"Mode '{self.config.mode}' not supported")
+
+        return
+
+    def cleanup(self):
+        """
+            Cleanup placeholder
+        """
+        pass
+
+
+if __name__ == '__main__':
+    # Load config if specified
+    if len(sys.argv) > 1:
+        # Validate arguments in a quick and dirty way.
+        # This will assign one argument to filename and generate exception if
+        # there is more than one argument
+        try:
+            [filename] = sys.argv[1:]
+        except Exception as e:
+            raise RuntimeError("Wrong number of arguments."
+                               "Should be one with path to "
+                               "flink_workload_conf.json") from e
+    else:
+        # No config path provided, just use defaults
+        filename = "/workloads/flink_workload_config.json"
+
+    # Load configuration
+    with open(filename, 'r+t') as f:
+        input_config = json.load(f)
+
+    # All messages past this point is intercepted by task manager
+    # and will be seen in its log
+    workload = FlinkWorkloadProduce(input_config)
+    try:
+        workload.setup()
+        workload.run()
+    except Exception as e:
+        # Do not re-throw not to cause a commoution
+        raise RuntimeError("Workload run failed") from e
+    finally:
+        workload.cleanup()

--- a/tests/rptest/services/flink.py
+++ b/tests/rptest/services/flink.py
@@ -225,15 +225,35 @@ class FlinkService(Service):
         self.service_config['taskmanager.memory.flink.size'] = f"{tm_ram-1}g"
         # Task slots is half cpu cores, 1
         self.service_config['taskmanager.numberOfTaskSlots'] = 1
+        # Set default per-task parallelism to number of vcpus
+        self.service_config['pipeline.max-parallelism'] = specs["vcpus"]
+        # Set maximum default paralel tasks to 2xvcpus
+        self.service_config[
+            'execution.batch.adaptive.auto-parallelism.max-parallelism'] = specs[
+                "vcpus"] * 2
+        # Adaptive scheduler that handles parallelism auto configuration
+        self.service_config['jobmanager.scheduler'] = 'Adaptive'
+        # Task restarts with delay of 30 s if rate per interval exceeded 5
+        # Restarts needed due to discunnects or overloads
+        # Ref: https://nightlies.apache.org/flink/flink-docs-master/docs/ops/state/task_failure_recovery/#failure-rate-restart-strategy
+        self.service_config['restart-strategy.type'] = 'failure-rate'
+        # Delay between restarts
+        self.service_config['restart-strategy.failure-rate.delay'] = '30s'
+        # Rate measuring interval
+        self.service_config[
+            'restart-strategy.failure-rate.failure-rate-interval'] = '10s'
+        # Failures per interval
+        self.service_config[
+            'restart-strategy.failure-rate.max-failures-per-interval'] = 50
 
         self.logger.info("Flink service configufation is:\n"
                          f"{json.dumps(self.service_config, indent=2)}")
-        # No need to tinker with parallelism settings, it is adaptive
+        # No need to further tinker with parallelism settings, it is adaptive
+
         # It is better to run multiple task managers. So, there should be
         # one task manager running for each vcpus. This will provide
         # efficient use of resources
         self.num_taskmanagers = specs["vcpus"]
-
         # internal metric storage
         self._metric = {}
         self.job_idle_threshold_ms = 30000

--- a/tests/rptest/services/flink.py
+++ b/tests/rptest/services/flink.py
@@ -174,6 +174,7 @@ class FlinkService(Service):
     STATE_RUNNING = 'RUNNING'
     STATE_CANCELING = 'CANCELING'
     STATE_DEPLOYING = 'DEPLOYING'
+    STATE_RESTARTING = 'RESTARTING'
 
     STATE_CREATED = 'CREATED'
     STATE_SCHEDULED = 'SCHEDULED'
@@ -194,11 +195,11 @@ class FlinkService(Service):
         # Map statuses
         self.job_active_statuses = [
             self.STATE_INIT, self.STATE_RECONCILING, self.STATE_RUNNING,
-            self.STATE_CANCELING, self.STATE_DEPLOYING
+            self.STATE_CANCELING, self.STATE_DEPLOYING, self.STATE_RESTARTING,
+            self.STATE_CREATED, self.STATE_SCHEDULED
         ]
         self.job_inactive_statuses = [
-            self.STATE_CREATED, self.STATE_SCHEDULED, self.STATE_FAILED,
-            self.STATE_FINISHED, self.STATE_CANCELED
+            self.STATE_FAILED, self.STATE_FINISHED, self.STATE_CANCELED
         ]
 
         # Provider instance/node util class


### PR DESCRIPTION
Goal is to generate as many topics as possible until RP starts to fail.
Flink workload is used with auto-sized task managers and flexible failure rate settings.

Workloads should generate low to low-moderate data to random topics. Data rate should be controllable.

Milestones
- 1k tops

Fixes: redpanda-data/devprod#1013

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none