### PR TITLE
storage/kvstore: remove oversized alloc

### DIFF
--- a/src/v/bytes/include/bytes/bytes.h
+++ b/src/v/bytes/include/bytes/bytes.h
@@ -177,3 +177,9 @@ operator^(const std::array<char, Size>& a, const std::array<char, Size>& b) {
       a.begin(), a.end(), b.begin(), out.begin(), std::bit_xor<>());
     return out;
 }
+
+struct bytes_type_cmp {
+    using is_transparent = std::true_type;
+    bool operator()(const bytes& lhs, const bytes_view& rhs) const;
+    bool operator()(const bytes& lhs, const bytes& rhs) const;
+};

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -347,3 +347,11 @@ std::ostream& operator<<(std::ostream& os, const bytes_view& b) {
     return os;
 }
 } // namespace std
+
+bool bytes_type_cmp::operator()(const bytes& lhs, const bytes_view& rhs) const {
+    return lhs < rhs;
+}
+
+bool bytes_type_cmp::operator()(const bytes& lhs, const bytes& rhs) const {
+    return lhs < rhs;
+}

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -483,7 +483,6 @@ ss::future<> kvstore::load_snapshot_from_reader(snapshot_reader& reader) {
     }
 
     auto lock = co_await _db_mut.get_units();
-    _db.reserve(batch.header().record_count);
     co_await batch.for_each_record_async([this](model::record r) {
         auto key = iobuf_to_bytes(r.release_key());
         _probe.add_cached_bytes(key.size() + r.value().size_bytes());

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -26,7 +26,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/timer.hh>
 
-#include <absl/container/node_hash_map.h>
+#include <absl/container/btree_map.h>
 
 namespace storage {
 
@@ -164,7 +164,7 @@ private:
     // Protect _db and _next_offset across asynchronous mutations.
     mutex _db_mut;
     model::offset _next_offset;
-    absl::node_hash_map<bytes, iobuf, bytes_type_hash, bytes_type_eq> _db;
+    absl::btree_map<bytes, iobuf, bytes_type_cmp> _db;
     std::optional<ntp_sanitizer_config> _ntp_sanitizer_config;
 
     ss::future<> put(key_space ks, bytes key, std::optional<iobuf> value);


### PR DESCRIPTION
It's possible to have enough entries in the kvstore that we run into
oversized allocs. Prevent that by using a btree_map

This was previously discussed in https://github.com/redpanda-data/redpanda/pull/10340

Fixes: https://github.com/redpanda-data/redpanda/issues/16320

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
