### PR TITLE
cloud_storage_clients/client_pool: handle broken _self_config_barrier

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -518,7 +518,6 @@ ss::future<> ntp_archiver::upload_topic_manifest() {
             _topic_manifest_dirty = false;
         }
     } catch (const ss::gate_closed_exception&) {
-    } catch (const ss::broken_named_semaphore&) {
     } catch (const ss::abort_requested_exception&) {
     } catch (...) {
         vlog(
@@ -1221,8 +1220,6 @@ ss::future<cloud_storage::upload_result> ntp_archiver::do_upload_segment(
     } catch (const ss::gate_closed_exception&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const ss::abort_requested_exception&) {
-        response = cloud_storage::upload_result::cancelled;
-    } catch (const ss::broken_named_semaphore&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const std::exception& e) {
         vlog(_rtclog.error, "failed to upload segment {}: {}", path, e);

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -330,6 +330,9 @@ client_pool::acquire(ss::abort_source& as) {
             }
         }
     } catch (const ss::broken_condition_variable&) {
+    } catch (const ss::broken_named_semaphore&) {
+        // this is thrown at shutdown_connections/stop if we are waiting on
+        // _self_config_barrier
     }
     if (_gate.is_closed() || _as.abort_requested()) {
         throw ss::gate_closed_exception();


### PR DESCRIPTION
_self_config_barrier is a semaphore used as a barrier for the self config step.

at shutdown_connections/stop it's broken (like it's done for _cvar the condition_variable), so it's not useful to bubble up the broken_named_semaphore exception.

the code after this will convert it to a gate_closed_exception

see https://github.com/redpanda-data/redpanda/pull/12632/files#r1293657997

This removes some failures from https://github.com/redpanda-data/redpanda/issues/15150
happening because this ERROR line appearing in the log
```
ERROR 2024-01-30 09:22:56,880 [shard 2:au  ] cloud_storage - [fiber76~122|0|29632ms] - remote.cc:1243 - Failed to delete keys: Semaphore broken: self_config_barrier
```
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
