### PR TITLE
[v23.3.x] storage/kvstore: remove oversized alloc

### DIFF
--- a/src/v/bytes/bytes.h
+++ b/src/v/bytes/bytes.h
@@ -177,3 +177,9 @@ operator^(const std::array<char, Size>& a, const std::array<char, Size>& b) {
       a.begin(), a.end(), b.begin(), out.begin(), std::bit_xor<>());
     return out;
 }
+
+struct bytes_type_cmp {
+    using is_transparent = std::true_type;
+    bool operator()(const bytes& lhs, const bytes_view& rhs) const;
+    bool operator()(const bytes& lhs, const bytes& rhs) const;
+};

--- a/src/v/bytes/iobuf.cc
+++ b/src/v/bytes/iobuf.cc
@@ -347,3 +347,11 @@ std::ostream& operator<<(std::ostream& os, const bytes_view& b) {
     return os;
 }
 } // namespace std
+
+bool bytes_type_cmp::operator()(const bytes& lhs, const bytes_view& rhs) const {
+    return lhs < rhs;
+}
+
+bool bytes_type_cmp::operator()(const bytes& lhs, const bytes& rhs) const {
+    return lhs < rhs;
+}

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -483,7 +483,6 @@ ss::future<> kvstore::load_snapshot_from_reader(snapshot_reader& reader) {
     }
 
     auto lock = co_await _db_mut.get_units();
-    _db.reserve(batch.header().record_count);
     co_await batch.for_each_record_async([this](model::record r) {
         auto key = iobuf_to_bytes(r.release_key());
         _probe.add_cached_bytes(key.size() + r.value().size_bytes());

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -26,7 +26,7 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/timer.hh>
 
-#include <absl/container/node_hash_map.h>
+#include <absl/container/btree_map.h>
 
 namespace storage {
 
@@ -164,7 +164,7 @@ private:
     // Protect _db and _next_offset across asynchronous mutations.
     mutex _db_mut;
     model::offset _next_offset;
-    absl::node_hash_map<bytes, iobuf, bytes_type_hash, bytes_type_eq> _db;
+    absl::btree_map<bytes, iobuf, bytes_type_cmp> _db;
     std::optional<ntp_sanitizer_config> _ntp_sanitizer_config;
 
     ss::future<> put(key_space ks, bytes key, std::optional<iobuf> value);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16381
Fixes: https://github.com/redpanda-data/redpanda/issues/16389,