### PR TITLE
kafka: Wrap call to lexical_cast in try block

### DIFF
--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -406,13 +406,17 @@ void parse_and_set_optional(
     }
     // set property value if preset, otherwise do nothing
     if (op == config_resource_operation::set && value) {
-        auto v = boost::lexical_cast<T>(*value);
-        auto v_error = validator(*value, v);
-        if (v_error) {
-            throw validation_error(*v_error);
-        }
-        property.value = std::move(v);
         property.op = cluster::incremental_update_operation::set;
+        try {
+            auto v = boost::lexical_cast<T>(*value);
+            auto v_error = validator(*value, v);
+            if (v_error) {
+                throw validation_error(*v_error);
+            }
+            property.value = std::move(v);
+        } catch (std::runtime_error const&) {
+            throw boost::bad_lexical_cast();
+        }
         return;
     }
 }


### PR DESCRIPTION
- incremental_alter_configs requests were killing connections when requests supplied an invalid string as a compression_type argument.

- The method lexical_cast invokes to convert a compression to a string contains a string_switch method without a default clause, this throws when no matches are found. The solution is to wrap the call to lexical_cast in a try/catch clause.

- Fixes: #16281

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes

### Bug Fixes

* Fixes issue that causes the connection to hang when an unsupported compression type is passed via an incremental_alter_configs request
