### PR TITLE
[v23.3.x] cloud_storage_clients/client_pool: handle broken _self_config_barrier

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -518,7 +518,6 @@ ss::future<> ntp_archiver::upload_topic_manifest() {
             _topic_manifest_dirty = false;
         }
     } catch (const ss::gate_closed_exception&) {
-    } catch (const ss::broken_named_semaphore&) {
     } catch (const ss::abort_requested_exception&) {
     } catch (...) {
         vlog(
@@ -1221,8 +1220,6 @@ ss::future<cloud_storage::upload_result> ntp_archiver::do_upload_segment(
     } catch (const ss::gate_closed_exception&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const ss::abort_requested_exception&) {
-        response = cloud_storage::upload_result::cancelled;
-    } catch (const ss::broken_named_semaphore&) {
         response = cloud_storage::upload_result::cancelled;
     } catch (const std::exception& e) {
         vlog(_rtclog.error, "failed to upload segment {}: {}", path, e);

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -330,6 +330,9 @@ client_pool::acquire(ss::abort_source& as) {
             }
         }
     } catch (const ss::broken_condition_variable&) {
+    } catch (const ss::broken_named_semaphore&) {
+        // this is thrown at shutdown_connections/stop if we are waiting on
+        // _self_config_barrier
     }
     if (_gate.is_closed() || _as.abort_requested()) {
         throw ss::gate_closed_exception();


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16385
