### PR TITLE
rpk: add `cpu_profile` to `rpk debug bundle`

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -44,6 +44,7 @@ type bundleParams struct {
 	metricsInterval         time.Duration
 	partitions              []topicPartitionFilter
 	labelSelector           map[string]string
+	cpuProfilerWait         time.Duration
 }
 
 type topicPartitionFilter struct {
@@ -69,12 +70,19 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 		timeout         time.Duration
 		metricsInterval time.Duration
+		cpuProfilerWait time.Duration
 	)
 	cmd := &cobra.Command{
 		Use:   "bundle",
 		Short: "Collect environment data and create a bundle file for the Redpanda Data support team to inspect",
 		Long:  bundleHelpText,
 		Run: func(cmd *cobra.Command, args []string) {
+			//  Redpanda queries for samples from Seastar every ~13 seconds by
+			//  default. Setting wait_ms to anything less than 13 seconds will
+			//  result in no samples being returned.
+			if cpuProfilerWait < 15*time.Second {
+				out.Die("--cpu-profiler-wait must be higher than 15 seconds")
+			}
 			path, err := determineFilepath(fs, outFile, cmd.Flags().Changed(outputFlag))
 			out.MaybeDie(err, "unable to determine filepath %q: %v", outFile, err)
 
@@ -119,6 +127,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 				timeout:                 timeout,
 				metricsInterval:         metricsInterval,
 				partitions:              partitions,
+				cpuProfilerWait:         cpuProfilerWait,
 			}
 			if len(labelSelector) > 0 {
 				labelsMap, err := labels.ConvertSelectorToLabelsMap(strings.Join(labelSelector, ","))
@@ -148,7 +157,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 	f := cmd.Flags()
 	f.StringVarP(&outFile, outputFlag, "o", "", "The file path where the debug file will be written (default ./<timestamp>-bundle.zip)")
-	f.DurationVar(&timeout, "timeout", 12*time.Second, "How long to wait for child commands to execute (e.g. 30s, 1.5m)")
+	f.DurationVar(&timeout, "timeout", 31*time.Second, "How long to wait for child commands to execute (e.g. 30s, 1.5m)")
 	f.DurationVar(&metricsInterval, "metrics-interval", 10*time.Second, "Interval between metrics snapshots (e.g. 30s, 1.5m)")
 	f.StringVar(&logsSince, "logs-since", "", "Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD")
 	f.StringVar(&logsUntil, "logs-until", "", "Include log entries on or older than the specified date (journalctl date format, e.g. YYYY-MM-DD")
@@ -158,6 +167,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	f.StringVarP(&namespace, "namespace", "n", "redpanda", "The namespace to use to collect the resources from (k8s only)")
 	f.StringArrayVarP(&labelSelector, "label-selector", "l", []string{"app.kubernetes.io/name=redpanda"}, "Comma-separated label selectors to filter your resources. e.g: <label>=<value>,<label>=<value> (k8s only)")
 	f.StringArrayVarP(&partitionFlag, "partition", "p", nil, "Comma-separated partition IDs; when provided, rpk saves extra admin API requests for those partitions. Check help for extended usage")
+	f.DurationVar(&cpuProfilerWait, "cpu-profiler-wait", 30*time.Second, "For how long to collect samples for the cpu profiler (e.g. 30s, 1.5m). Must be higher than 15s")
 
 	return cmd
 }
@@ -243,7 +253,7 @@ COMMON FILES
 
  - Admin API calls: Multiple requests to gather information such as: Cluster and
    broker configurations, cluster health data, balancer status, cloud storage
-   status, and license key information.
+   status, cpu profiles, and license key information.
 
  - Broker metrics: The broker's Prometheus metrics, fetched through its
    admin API (/metrics and /public_metrics).

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -145,7 +145,7 @@ func executeBundle(ctx context.Context, bp bundleParams) error {
 		saveMountedFilesystems(ps),
 		saveNTPDrift(ps),
 		saveResourceUsageData(ps, bp.y),
-		saveSingleAdminAPICalls(ctx, ps, bp.fs, bp.p, addrs, bp.metricsInterval),
+		saveSingleAdminAPICalls(ctx, ps, bp.fs, bp.p, addrs, bp.metricsInterval, bp.cpuProfilerWait),
 		saveSlabInfo(ps),
 		saveSocketData(ctx, ps),
 		saveSysctl(ctx, ps),

--- a/tests/rptest/clients/rpk_remote.py
+++ b/tests/rptest/clients/rpk_remote.py
@@ -34,7 +34,8 @@ class RpkRemoteTool:
             self._rpk_binary(), 'debug', 'bundle', "--output", output_file,
             "--api-urls",
             self._redpanda.admin_endpoints()
-        ])
+        ],
+                             timeout=45)
 
     def cluster_config_force_reset(self, property_name):
         return self._execute([

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -127,6 +127,7 @@ class RpkClusterTest(RedpandaTest):
             # and 1 cluster_view and node_config per node:
             assert f'{root_name}/admin/cluster_view_{n.account.hostname}-9644.json' in files
             assert f'{root_name}/admin/node_config_{n.account.hostname}-9644.json' in files
+            assert f'{root_name}/admin/cpu_profile_{n.account.hostname}-9644.json' in files
 
     @cluster(num_nodes=3)
     def test_get_config(self):


### PR DESCRIPTION
This PR adds the raw response of the CPU profile admin endpoint to the bundle generated by `rpk debug bundle`. 

It introduces a new flag: `--cpu-profiler-wait` with a default of `30s`,  which sets the internal `wait_ms` of the Admin API's `GET /v1/debug/cpu_profile`

**File Location:** `bundle/admin/cpu_profile_<node_address>.json` 


Fixes #13175
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Features

* `rpk debug bundle` now includes a CPU profile of the requested nodes.
