### PR TITLE
slash-cmd: fix /backport command

### DIFF
--- a/.github/workflows/scripts/backport-command/pr_details.sh
+++ b/.github/workflows/scripts/backport-command/pr_details.sh
@@ -31,7 +31,7 @@ fixing_issue_urls=$(gh api graphql -f query='{
       }
     }
   }
-}' --jq .data.resource.closingIssuesReferences.nodes.[].url)
+}' --jq '.data.resource.closingIssuesReferences.nodes | map(.url) | join(" ")')
 
 suffix=$((RANDOM % 1000))
 git config --global user.email "$GIT_EMAIL"

--- a/tests/docker/ducktape-deps/flink
+++ b/tests/docker/ducktape-deps/flink
@@ -7,7 +7,7 @@ FLINK_VERSION=1.18.1
 FLINK_SCALA_VERSION=2.12
 FLINK_FILE=flink-${FLINK_VERSION}-bin-scala_${FLINK_SCALA_VERSION}.tgz
 # Instead of using main download link, use our s3. Alternative is to use archive.apache.org,
-# but it will ban frequent downloads after some time. 
+# but it will ban frequent downloads after some time.
 # This will prevent us from getting an HTTP:404 when new version will be introduced
 # old: FLINK_URL=https://downloads.apache.org/flink/flink-${FLINK_VERSION}/${FLINK_FILE}
 DEPS_BASEURL=https://vectorized-public.s3.us-west-2.amazonaws.com/dependencies


### PR DESCRIPTION
`--jq` arg of gh graphql returns multiline string in case of multiple fixing issues. Fixing by joining the results in a single line string

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
