### PR TITLE
[v23.3.x] Fixed large allocation in `kafka::wait_for_leaders`

### DIFF
--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -178,7 +178,7 @@ void generate_not_controller_errors(Iter begin, Iter end, ErrIter out_it) {
 }
 
 // Wait for leaders of all topic partitons for given set of results
-ss::future<std::vector<model::node_id>> wait_for_leaders(
+ss::future<> wait_for_leaders(
   cluster::metadata_cache&,
   std::vector<cluster::topic_result>,
   model::timeout_clock::time_point);

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -94,6 +94,9 @@ class TopicRecreateTest(RedpandaTest):
         rpk = RpkTool(self.redpanda)
 
         def topic_is_healthy():
+            if not swarm.is_alive(swarm.nodes[0]):
+                swarm.stop()
+                swarm.start()
             partitions = rpk.describe_topic(spec.name)
             hw_offsets = [p.high_watermark for p in partitions]
             offsets_present = [hw > 0 for hw in hw_offsets]
@@ -106,7 +109,10 @@ class TopicRecreateTest(RedpandaTest):
             self.client().delete_topic(spec.name)
             spec.replication_factor = rf
             self.client().create_topic(spec)
-            wait_until(topic_is_healthy, 30, 2)
+            wait_until(topic_is_healthy,
+                       30,
+                       2,
+                       err_msg=f"Topic {spec.name} health")
             sleep(5)
 
         swarm.stop()


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16287
Fixes: https://github.com/redpanda-data/redpanda/issues/16430, Fixes: https://github.com/redpanda-data/redpanda/issues/16431,