### PR TITLE
transform: data path for multiple output topics

### DIFF
--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -257,4 +257,8 @@ iobuf transformed_data::to_serialized_record(
     return out;
 }
 
+size_t transformed_data::memory_usage() const {
+    return sizeof(*this) + _data.size_bytes();
+}
+
 } // namespace model

--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -289,4 +289,8 @@ size_t transformed_data::memory_usage() const {
     return sizeof(*this) + _data.size_bytes();
 }
 
+transformed_data transformed_data::copy() const {
+    return transformed_data(_data.copy());
+}
+
 } // namespace model

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -273,6 +273,11 @@ public:
 
     bool operator==(const transformed_data&) const = default;
 
+    /**
+     * Explicitly make a copy of this transformed data.
+     */
+    transformed_data copy() const;
+
 private:
     explicit transformed_data(iobuf d);
 

--- a/src/v/model/transform.h
+++ b/src/v/model/transform.h
@@ -260,6 +260,13 @@ public:
     iobuf to_serialized_record(
       record_attributes, int64_t timestamp_delta, int32_t offset_delta) &&;
 
+    /**
+     * The memory usage for this struct and it's data.
+     */
+    size_t memory_usage() const;
+
+    bool operator==(const transformed_data&) const = default;
+
 private:
     explicit transformed_data(iobuf d);
 

--- a/src/v/ssx/future-util.h
+++ b/src/v/ssx/future-util.h
@@ -23,6 +23,8 @@
 
 #include <algorithm>
 #include <iterator>
+#include <memory>
+#include <type_traits>
 
 namespace ssx {
 
@@ -426,6 +428,16 @@ seastar::future<T...> with_timeout_abortable(
     });
 
     return result;
+}
+
+// Create a ready future with template deduction.
+//
+// In most cases you should not need specify a template parameter using this
+// function over seastar's make_ready_future function.
+template<typename T>
+seastar::future<std::remove_cvref_t<T>> now(T&& v) noexcept {
+    return seastar::make_ready_future<std::remove_cvref_t<T>>(
+      std::forward<T>(v));
 }
 
 } // namespace ssx

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -43,6 +43,7 @@
 #include "wasm/errc.h"
 
 #include <seastar/core/circular_buffer.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/sharded.hh>
@@ -51,6 +52,9 @@
 #include <seastar/coroutine/as_future.hh>
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/util/optimized_optional.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <boost/range/irange.hpp>
 
 #include <system_error>
 
@@ -251,53 +255,86 @@ public:
     offset_tracker_impl(
       model::transform_id tid,
       model::partition_id pid,
+      uint32_t output_topic_count,
       rpc::client* client,
       commit_batcher<>* batcher)
-      : _key(
-        {.id = tid,
-         .partition = pid,
-         .output_topic = model::output_topic_index{}})
+      : _id(tid)
+      , _partition(pid)
+      , _output_topic_count(output_topic_count)
       , _client(client)
       , _batcher(batcher) {}
 
     ss::future<> start() override { return ss::now(); }
 
     ss::future<> stop() override {
-        model::transform_offsets_key key = _key;
-        key.output_topic = model::output_topic_index{0};
-        _batcher->unload(key);
+        for (auto idx : boost::irange(_output_topic_count)) {
+            model::transform_offsets_key key = {
+              .id = _id,
+              .partition = _partition,
+              .output_topic = idx,
+            };
+            _batcher->unload(key);
+        }
         return ss::now();
     }
 
     ss::future<> wait_for_previous_flushes(ss::abort_source* as) override {
-        return _batcher->wait_for_previous_flushes(_key, as);
+        return ss::parallel_for_each(
+          boost::irange(_output_topic_count),
+          [this, as](model::output_topic_index idx) {
+              model::transform_offsets_key key = {
+                .id = _id,
+                .partition = _partition,
+                .output_topic = idx,
+              };
+              return _batcher->wait_for_previous_flushes(key, as);
+          });
     }
 
-    ss::future<std::optional<kafka::offset>> load_committed_offset() override {
-        model::transform_offsets_key key = _key;
-        key.output_topic = model::output_topic_index{0};
-        auto result = co_await _client->offset_fetch(key);
-        if (result.has_error()) {
-            cluster::errc ec = result.error();
-            throw std::runtime_error(ss::format(
-              "error committing offset: {}",
-              cluster::error_category().message(int(ec))));
-        }
-        auto value = result.value();
-        if (!value) {
-            co_return std::nullopt;
-        }
-        co_return value->offset;
+    ss::future<absl::flat_hash_map<model::output_topic_index, kafka::offset>>
+    load_committed_offsets() override {
+        absl::flat_hash_map<model::output_topic_index, kafka::offset> offsets;
+        offsets.reserve(_output_topic_count);
+        co_await ss::parallel_for_each(
+          boost::irange(_output_topic_count),
+          [this, &offsets](model::output_topic_index idx) {
+              model::transform_offsets_key key = {
+                .id = _id,
+                .partition = _partition,
+                .output_topic = idx,
+              };
+              return _client->offset_fetch(key).then(
+                [&offsets, idx](auto result) {
+                    if (result.has_error()) {
+                        cluster::errc ec = result.error();
+                        throw std::runtime_error(ss::format(
+                          "error loading committed offset: {}",
+                          cluster::error_category().message(int(ec))));
+                    }
+                    auto value = result.value();
+                    if (value) {
+                        offsets[idx] = value->offset;
+                    }
+                    return ss::now();
+                });
+          });
+        co_return offsets;
     }
 
-    ss::future<> commit_offset(kafka::offset offset) override {
-        model::transform_offsets_key key = _key;
-        key.output_topic = model::output_topic_index{0};
+    ss::future<> commit_offset(
+      model::output_topic_index index, kafka::offset offset) override {
+        model::transform_offsets_key key = {
+          .id = _id,
+          .partition = _partition,
+          .output_topic = index,
+        };
         return _batcher->commit_offset(key, {.offset = offset});
     }
 
 private:
-    model::transform_offsets_key _key;
+    model::transform_id _id;
+    model::partition_id _partition;
+    model::output_topic_index _output_topic_count;
     rpc::client* _client;
     commit_batcher<>* _batcher;
 };
@@ -345,7 +382,7 @@ public:
         sinks.push_back(std::move(sink));
 
         auto offset_tracker = std::make_unique<offset_tracker_impl>(
-          id, ntp.tp.partition, _client, _batcher);
+          id, ntp.tp.partition, meta.output_topics.size(), _client, _batcher);
 
         co_return std::make_unique<processor>(
           id,

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -92,16 +92,19 @@ public:
     virtual ss::future<> wait_for_previous_flushes(ss::abort_source*) = 0;
 
     /**
-     * Load the latest offset we've committed.
+     * Load the latest offset for all output topics we've committed.
      */
-    virtual ss::future<std::optional<kafka::offset>>
-    load_committed_offset() = 0;
+    virtual ss::future<
+      absl::flat_hash_map<model::output_topic_index, kafka::offset>>
+    load_committed_offsets() = 0;
 
     /**
-     * Commit progress. The offset here is how far on the input partition we've
-     * transformed and successfully written to the output topic.
+     * Commit progress for a given output topic. The offset here is how far on
+     * the input partition we've transformed and successfully written to the
+     * output topic.
      */
-    virtual ss::future<> commit_offset(kafka::offset) = 0;
+    virtual ss::future<>
+      commit_offset(model::output_topic_index, kafka::offset) = 0;
 };
 
 } // namespace transform

--- a/src/v/transform/probe.h
+++ b/src/v/transform/probe.h
@@ -27,19 +27,19 @@ struct processor_state_change {
 /** A per transform probe. */
 class probe : public wasm::transform_probe {
 public:
-    void setup_metrics(ss::sstring);
+    void setup_metrics(const model::transform_metadata&);
 
     void increment_read_bytes(uint64_t bytes);
     void increment_write_bytes(uint64_t bytes);
     void increment_failure();
     void state_change(processor_state_change);
-    void report_lag(int64_t delta);
+    void report_lag(model::output_topic_index, int64_t delta);
 
 private:
     uint64_t _read_bytes = 0;
     uint64_t _write_bytes = 0;
     uint64_t _failures = 0;
-    uint64_t _lag = 0;
+    std::vector<uint64_t> _lag;
     absl::flat_hash_map<model::transform_report::processor::state, uint64_t>
       _processor_state;
 };

--- a/src/v/transform/probe.h
+++ b/src/v/transform/probe.h
@@ -36,6 +36,8 @@ public:
     void report_lag(model::output_topic_index, int64_t delta);
 
 private:
+    friend class ProcessorTestFixture;
+
     uint64_t _read_bytes = 0;
     std::vector<uint64_t> _write_bytes;
     uint64_t _failures = 0;

--- a/src/v/transform/probe.h
+++ b/src/v/transform/probe.h
@@ -30,14 +30,14 @@ public:
     void setup_metrics(const model::transform_metadata&);
 
     void increment_read_bytes(uint64_t bytes);
-    void increment_write_bytes(uint64_t bytes);
+    void increment_write_bytes(model::output_topic_index, uint64_t bytes);
     void increment_failure();
     void state_change(processor_state_change);
     void report_lag(model::output_topic_index, int64_t delta);
 
 private:
     uint64_t _read_bytes = 0;
-    uint64_t _write_bytes = 0;
+    std::vector<uint64_t> _write_bytes;
     uint64_t _failures = 0;
     std::vector<uint64_t> _lag;
     absl::flat_hash_map<model::transform_report::processor::state, uint64_t>

--- a/src/v/transform/rpc/tests/transform_rpc_test.cc
+++ b/src/v/transform/rpc/tests/transform_rpc_test.cc
@@ -973,6 +973,7 @@ TEST_P(TransformRpcTest, TestTransformOffsetRPCs) {
     for (int i = 0; i < num_transforms; i++) {
         auto request_key = model::transform_offsets_key{};
         request_key.id = model::transform_id{i};
+        request_key.output_topic = model::output_topic_index{0};
         set_errors_to_inject(random_generators::get_int(0, 2));
         for (int32_t j = 0; j < num_src_partitions; j++) {
             request_key.partition = model::partition_id{j};

--- a/src/v/transform/tests/commit_batcher_test.cc
+++ b/src/v/transform/tests/commit_batcher_test.cc
@@ -211,13 +211,22 @@ public:
         auto co = committed_offset::parse(s);
         _batcher
           ->commit_offset(
-            {.id = co.id, .partition = co.partition}, {.offset = co.offset})
+            {
+              .id = co.id,
+              .partition = co.partition,
+              .output_topic = model::output_topic_index{0},
+            },
+            {.offset = co.offset})
           .get();
     }
 
     void unload(std::string_view s) {
         auto co = committed_offset::parse(absl::StrCat(s, "@0"));
-        _batcher->unload({.id = co.id, .partition = co.partition});
+        _batcher->unload({
+          .id = co.id,
+          .partition = co.partition,
+          .output_topic = model::output_topic_index{0},
+        });
     }
 
     void advance(ss::manual_clock::duration d) {

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -103,7 +103,7 @@ ss::future<> fake_wasm_engine::transform(
     case mode::noop: {
         auto it = model::record_batch_iterator::create(batch);
         while (it.has_next()) {
-            cb(model::transformed_data::from_record(it.next()));
+            cb(std::nullopt, model::transformed_data::from_record(it.next()));
         }
         break;
     }

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -30,18 +30,25 @@
 
 namespace transform::testing {
 ss::future<> fake_sink::write(ss::chunked_fifo<model::record_batch> batches) {
+    co_await _cork.wait();
     for (auto& batch : batches) {
         _batches.push_back(std::move(batch));
     }
     _cond_var.broadcast();
-    co_return;
 }
+
 ss::future<model::record_batch> fake_sink::read() {
     co_await _cond_var.wait(1s, [this] { return !_batches.empty(); });
     auto batch = std::move(_batches.front());
     _batches.pop_front();
     co_return batch;
 }
+
+void fake_sink::uncork() {
+    _cork.signal(_cork.max_counter() - _cork.available_units());
+}
+
+void fake_sink::cork() { _cork.consume(std::max(_cork.available_units(), 0L)); }
 
 ss::future<> fake_source::start() { co_return; }
 
@@ -95,26 +102,34 @@ ss::future<> fake_offset_tracker::stop() { co_return; }
 
 ss::future<> fake_offset_tracker::start() { co_return; }
 
-void fake_wasm_engine::set_mode(mode m) { _mode = m; }
+void fake_wasm_engine::set_output_topics(std::vector<model::topic> topics) {
+    _output_topics = std::move(topics);
+}
+
+void fake_wasm_engine::set_use_default_output_topic() {
+    _output_topics = std::nullopt;
+}
 
 ss::future<> fake_wasm_engine::transform(
   model::record_batch batch,
   wasm::transform_probe*,
   wasm::transform_callback cb) {
-    switch (_mode) {
-    case mode::noop: {
-        auto it = model::record_batch_iterator::create(batch);
-        while (it.has_next()) {
-            auto transformed = model::transformed_data::from_record(it.next());
+    auto it = model::record_batch_iterator::create(batch);
+    while (it.has_next()) {
+        auto transformed = model::transformed_data::from_record(it.next());
+        if (!_output_topics.has_value()) {
             auto success = co_await cb(std::nullopt, std::move(transformed));
             if (!success) {
                 throw std::runtime_error("transform write failed!");
             }
+        } else {
+            for (const auto& topic : _output_topics.value()) {
+                auto success = co_await cb(topic, transformed.copy());
+                if (!success) {
+                    throw std::runtime_error("transform write failed!");
+                }
+            }
         }
-        break;
-    }
-    case mode::filter:
-        break;
     }
 }
 
@@ -141,4 +156,5 @@ ss::future<> fake_offset_tracker::wait_for_committed_offset(
 ss::future<> fake_offset_tracker::wait_for_previous_flushes(ss::abort_source*) {
     co_return;
 }
+
 } // namespace transform::testing

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -95,14 +95,17 @@ public:
     ss::future<> stop() override;
     ss::future<> wait_for_previous_flushes(ss::abort_source*) override;
 
-    ss::future<std::optional<kafka::offset>> load_committed_offset() override;
+    ss::future<absl::flat_hash_map<model::output_topic_index, kafka::offset>>
+    load_committed_offsets() override;
 
-    ss::future<> commit_offset(kafka::offset o) override;
+    ss::future<>
+      commit_offset(model::output_topic_index, kafka::offset) override;
 
-    ss::future<> wait_for_committed_offset(kafka::offset);
+    ss::future<>
+      wait_for_committed_offset(model::output_topic_index, kafka::offset);
 
 private:
-    std::optional<kafka::offset> _committed;
+    absl::flat_hash_map<model::output_topic_index, kafka::offset> _committed;
     ss::condition_variable _cond_var;
 };
 

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -51,6 +51,7 @@ public:
         sinks.push_back(std::move(sink));
         auto offset_tracker = std::make_unique<testing::fake_offset_tracker>();
         _offset_tracker = offset_tracker.get();
+        _probe.setup_metrics(testing::my_metadata);
         _p = std::make_unique<transform::processor>(
           testing::my_transform_id,
           testing::my_ntp,

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -172,7 +172,7 @@ public:
             return it->second.probe();
         }
         auto probe = ss::make_lw_shared<transform::probe>();
-        probe->setup_metrics(meta.name());
+        probe->setup_metrics(meta);
         return probe;
     }
 

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -228,8 +228,12 @@ ss::future<> processor::run_transform_loop() {
         co_await _engine->transform(
           std::move(*batch),
           _probe,
-          [&transformed](model::transformed_data data) {
+          [&transformed](
+            std::optional<model::topic_view> topic,
+            model::transformed_data data) {
+              vassert(topic == std::nullopt, "not supported yet 🙂");
               transformed.push_back(std::move(data));
+              return wasm::write_success::yes;
           });
         if (!transformed.empty()) {
             auto b = model::transformed_data::make_batch(

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -120,6 +120,7 @@ private:
         std::unique_ptr<sink> sink;
     };
     absl::flat_hash_map<model::topic, output> _outputs;
+    output* _default_output = nullptr;
 
     ss::abort_source _as;
     ss::future<> _task;

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -94,7 +94,7 @@ private:
     ss::future<> poll_sleep();
     ss::future<absl::flat_hash_map<model::output_topic_index, kafka::offset>>
     load_latest_committed();
-    void report_lag(int64_t);
+    void report_lag(model::output_topic_index, int64_t);
 
     template<typename... Future>
     ss::future<> when_all_shutdown(Future&&...);
@@ -125,6 +125,6 @@ private:
     ss::future<> _task;
     prefix_logger _logger;
 
-    int64_t _last_reported_lag = 0;
+    std::vector<int64_t> _last_reported_lag;
 };
 } // namespace transform

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -27,6 +27,9 @@
 #include <seastar/core/queue.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+#include <absl/container/flat_hash_map.h>
+
+#include <memory>
 #include <variant>
 
 namespace transform {
@@ -36,7 +39,7 @@ namespace transform {
  * committed offset.
  */
 struct transformed_output {
-    std::variant<model::record_batch, kafka::offset> data;
+    std::variant<model::transformed_data, kafka::offset> data;
 
     // How much memory this object is using.
     size_t memory_usage() const;
@@ -81,7 +84,8 @@ public:
 private:
     ss::future<> run_consumer_loop(kafka::offset);
     ss::future<> run_transform_loop();
-    ss::future<> run_producer_loop();
+    ss::future<> run_all_producers();
+    ss::future<> run_producer_loop(transfer_queue<transformed_output>*, sink*);
     ss::future<> poll_sleep();
     ss::future<kafka::offset> load_start_offset();
     void report_lag(int64_t);
@@ -95,16 +99,20 @@ private:
     model::transform_metadata _meta;
     ss::shared_ptr<wasm::engine> _engine;
     std::unique_ptr<source> _source;
-    std::vector<std::unique_ptr<sink>> _sinks;
     std::unique_ptr<offset_tracker> _offset_tracker;
     state_callback _state_callback;
     probe* _probe;
 
     static constexpr size_t buffer_chunk_size = 8;
+
     transfer_queue<model::record_batch, buffer_chunk_size>
       _consumer_transform_pipe;
-    transfer_queue<transformed_output, buffer_chunk_size>
-      _transform_producer_pipe;
+
+    struct output {
+        transfer_queue<transformed_output> queue;
+        std::unique_ptr<sink> sink;
+    };
+    absl::flat_hash_map<model::topic, output> _outputs;
 
     ss::abort_source _as;
     ss::future<> _task;

--- a/src/v/transform/transform_processor.h
+++ b/src/v/transform/transform_processor.h
@@ -84,10 +84,16 @@ public:
 private:
     ss::future<> run_consumer_loop(kafka::offset);
     ss::future<> run_transform_loop();
-    ss::future<> run_all_producers();
-    ss::future<> run_producer_loop(transfer_queue<transformed_output>*, sink*);
+    ss::future<> run_all_producers(
+      absl::flat_hash_map<model::output_topic_index, kafka::offset>);
+    ss::future<> run_producer_loop(
+      model::output_topic_index,
+      transfer_queue<transformed_output>*,
+      sink*,
+      kafka::offset);
     ss::future<> poll_sleep();
-    ss::future<kafka::offset> load_start_offset();
+    ss::future<absl::flat_hash_map<model::output_topic_index, kafka::offset>>
+    load_latest_committed();
     void report_lag(int64_t);
 
     template<typename... Future>
@@ -109,6 +115,7 @@ private:
       _consumer_transform_pipe;
 
     struct output {
+        model::output_topic_index index;
         transfer_queue<transformed_output> queue;
         std::unique_ptr<sink> sink;
     };

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -12,11 +12,13 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "model/fundamental.h"
 #include "model/record.h"
 #include "model/transform.h"
 #include "pandaproxy/schema_registry/fwd.h"
 #include "wasm/fwd.h"
 
+#include <seastar/util/bool_class.hh>
 #include <seastar/util/noncopyable_function.hh>
 
 #include <chrono>
@@ -24,11 +26,16 @@
 
 namespace wasm {
 
+using write_success = ss::bool_class<struct write_success_t>;
+
 /**
  * The callback for when data emitted from the transform.
+ *
+ * The topic is optional, and if omitted, then the "default" output topic should
+ * be assumed.
  */
-using transform_callback
-  = ss::noncopyable_function<void(model::transformed_data)>;
+using transform_callback = ss::noncopyable_function<write_success(
+  std::optional<model::topic_view>, model::transformed_data)>;
 
 /**
  * A wasm engine is a running VM loaded with a user module and capable of

--- a/src/v/wasm/api.h
+++ b/src/v/wasm/api.h
@@ -34,7 +34,7 @@ using write_success = ss::bool_class<struct write_success_t>;
  * The topic is optional, and if omitted, then the "default" output topic should
  * be assumed.
  */
-using transform_callback = ss::noncopyable_function<write_success(
+using transform_callback = ss::noncopyable_function<ss::future<write_success>(
   std::optional<model::topic_view>, model::transformed_data)>;
 
 /**

--- a/src/v/wasm/ffi.h
+++ b/src/v/wasm/ffi.h
@@ -89,6 +89,7 @@ public:
     void append(int32_t);
     void append(uint64_t);
     void append(int64_t);
+    void append_byte(uint8_t);
 
     size_t total() const noexcept { return _offset; };
 
@@ -124,6 +125,7 @@ public:
     void append(int32_t);
     void append(uint64_t);
     void append(int64_t);
+    void append_byte(uint8_t);
 
     size_t total() const noexcept { return _offset; };
 
@@ -152,13 +154,18 @@ public:
     ~reader() = default;
 
     ss::sstring read_string(size_t);
+    std::string_view read_string_view(size_t);
     iobuf read_iobuf(size_t);
     iobuf read_sized_iobuf();
     ss::sstring read_sized_string();
+    std::string_view read_sized_string_view();
     int64_t read_varint();
+    uint8_t read_byte();
+
+    size_t remaining_bytes() const;
 
 private:
-    array<uint8_t> slice_remainder();
+    array<uint8_t> slice_remainder() const;
 
     array<uint8_t> _input;
     size_t _offset{0};

--- a/src/v/wasm/tests/wasm_cache_test.cc
+++ b/src/v/wasm/tests/wasm_cache_test.cc
@@ -277,7 +277,7 @@ TEST_F(WasmCacheTest, CanMultiplexTransforms) {
         ->transform(
           random_batch(),
           nullptr,
-          [](auto, auto) { return write_success::yes; })
+          [](auto, auto) { return ssx::now(write_success::yes); })
         .get(),
       std::runtime_error);
     EXPECT_EQ(state()->engine_restarts, 1);
@@ -286,7 +286,7 @@ TEST_F(WasmCacheTest, CanMultiplexTransforms) {
                       ->transform(
                         random_batch(),
                         nullptr,
-                        [](auto, auto) { return write_success::yes; })
+                        [](auto, auto) { return ssx::now(write_success::yes); })
                       .get());
     EXPECT_EQ(state()->engine_restarts, 1);
     engine_one->stop().get();

--- a/src/v/wasm/tests/wasm_cache_test.cc
+++ b/src/v/wasm/tests/wasm_cache_test.cc
@@ -273,12 +273,21 @@ TEST_F(WasmCacheTest, CanMultiplexTransforms) {
     engine_two->start().get();
     state()->engine_transform_should_throw = true;
     EXPECT_THROW(
-      engine_one->transform(random_batch(), nullptr, [](auto) {}).get(),
+      engine_one
+        ->transform(
+          random_batch(),
+          nullptr,
+          [](auto, auto) { return write_success::yes; })
+        .get(),
       std::runtime_error);
     EXPECT_EQ(state()->engine_restarts, 1);
     state()->engine_transform_should_throw = false;
-    EXPECT_NO_THROW(
-      engine_two->transform(random_batch(), nullptr, [](auto) {}).get());
+    EXPECT_NO_THROW(engine_two
+                      ->transform(
+                        random_batch(),
+                        nullptr,
+                        [](auto, auto) { return write_success::yes; })
+                      .get());
     EXPECT_EQ(state()->engine_restarts, 1);
     engine_one->stop().get();
     engine_two->stop().get();

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -202,8 +202,9 @@ model::record_batch WasmTestFixture::transform(const model::record_batch& b) {
       ->transform(
         b.copy(),
         _probe.get(),
-        [&transformed](model::transformed_data data) {
+        [&transformed](auto, model::transformed_data data) {
             transformed.push_back(std::move(data));
+            return wasm::write_success::yes;
         })
       .get();
     return model::transformed_data::make_batch(

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -29,6 +29,7 @@
 #include "wasm/wasmtime.h"
 
 #include <seastar/core/chunked_fifo.hh>
+#include <seastar/core/future.hh>
 #include <seastar/util/file.hh>
 
 #include <fmt/chrono.h>
@@ -204,7 +205,8 @@ model::record_batch WasmTestFixture::transform(const model::record_batch& b) {
         _probe.get(),
         [&transformed](auto, model::transformed_data data) {
             transformed.push_back(std::move(data));
-            return wasm::write_success::yes;
+            return ss::make_ready_future<wasm::write_success>(
+              wasm::write_success::yes);
         })
       .get();
     return model::transformed_data::make_batch(

--- a/src/v/wasm/tests/wasm_transform_bench.cc
+++ b/src/v/wasm/tests/wasm_transform_bench.cc
@@ -107,7 +107,7 @@ public:
             &_probe,
             [output](auto, auto data) {
                 output->push_back(std::move(data));
-                return wasm::write_success::yes;
+                return ssx::now(wasm::write_success::yes);
             })
           .then([output]() {
               perf_tests::do_not_optimize(model::transformed_data::make_batch(

--- a/src/v/wasm/tests/wasm_transform_bench.cc
+++ b/src/v/wasm/tests/wasm_transform_bench.cc
@@ -105,7 +105,10 @@ public:
           ->transform(
             std::move(batch),
             &_probe,
-            [output](auto data) { output->push_back(std::move(data)); })
+            [output](auto, auto data) {
+                output->push_back(std::move(data));
+                return wasm::write_success::yes;
+            })
           .then([output]() {
               perf_tests::do_not_optimize(model::transformed_data::make_batch(
                 model::timestamp::now(), std::move(*output)));

--- a/src/v/wasm/transform_module.cc
+++ b/src/v/wasm/transform_module.cc
@@ -21,6 +21,7 @@
 #include "model/transform.h"
 #include "utils/named_type.h"
 #include "utils/vint.h"
+#include "wasm/api.h"
 #include "wasm/ffi.h"
 #include "wasm/logger.h"
 #include "wasm/wasi.h"
@@ -35,6 +36,7 @@ namespace wasm {
 
 constexpr int32_t NO_ACTIVE_TRANSFORM = -1;
 constexpr int32_t INVALID_BUFFER = -2;
+constexpr int32_t INVALID_WRITE = -3;
 
 transform_module::transform_module(wasi::preview1_module* m)
   : _wasi_module(m) {}
@@ -203,8 +205,8 @@ int32_t transform_module::write_record(ffi::array<uint8_t> buf) {
     if (!d) {
         return INVALID_BUFFER;
     }
-    _call_ctx->callback->emit(*std::move(d));
-    return int32_t(buf.size());
+    auto result = _call_ctx->callback->emit(std::nullopt, *std::move(d));
+    return result == write_success::yes ? int32_t(buf.size()) : INVALID_WRITE;
 }
 
 void transform_module::start() {

--- a/src/v/wasm/transform_module.h
+++ b/src/v/wasm/transform_module.h
@@ -70,9 +70,8 @@ public:
     // Called before surfacing a record to the VM.
     virtual void pre_record() = 0;
     // Called for each record output from the VM.
-    virtual write_success
-      emit(std::optional<model::topic_view>, model::transformed_data)
-      = 0;
+    virtual ss::future<write_success>
+      emit(std::optional<model::topic_view>, model::transformed_data) = 0;
     // Called after a VM specifies it's done with a record.
     virtual void post_record() = 0;
 };
@@ -154,9 +153,10 @@ public:
       model::offset* offset_delta,
       ffi::array<uint8_t>);
 
-    int32_t write_record(ffi::array<uint8_t>);
+    ss::future<int32_t> write_record(ffi::array<uint8_t>);
 
-    int32_t write_record_with_options(ffi::array<uint8_t>, ffi::array<uint8_t>);
+    ss::future<int32_t>
+      write_record_with_options(ffi::array<uint8_t>, ffi::array<uint8_t>);
 
     // End ABI exports
 

--- a/src/v/wasm/transform_module.h
+++ b/src/v/wasm/transform_module.h
@@ -134,6 +134,7 @@ public:
     // Start ABI exports
 
     void check_abi_version_1();
+    void check_abi_version_2();
 
     ss::future<int32_t> read_batch_header(
       int64_t* base_offset,
@@ -154,6 +155,8 @@ public:
       ffi::array<uint8_t>);
 
     int32_t write_record(ffi::array<uint8_t>);
+
+    int32_t write_record_with_options(ffi::array<uint8_t>, ffi::array<uint8_t>);
 
     // End ABI exports
 

--- a/src/v/wasm/transform_module.h
+++ b/src/v/wasm/transform_module.h
@@ -12,9 +12,11 @@
 #pragma once
 
 #include "bytes/iobuf.h"
+#include "model/fundamental.h"
 #include "model/record.h"
 #include "model/transform.h"
 #include "utils/named_type.h"
+#include "wasm/api.h"
 #include "wasm/ffi.h"
 #include "wasm/wasi.h"
 
@@ -68,7 +70,9 @@ public:
     // Called before surfacing a record to the VM.
     virtual void pre_record() = 0;
     // Called for each record output from the VM.
-    virtual void emit(model::transformed_data) = 0;
+    virtual write_success
+      emit(std::optional<model::topic_view>, model::transformed_data)
+      = 0;
     // Called after a VM specifies it's done with a record.
     virtual void post_record() = 0;
 };

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -754,7 +754,7 @@ private:
                 _measurement = _probe->latency_measurement();
             }
 
-            write_success emit(
+            ss::future<write_success> emit(
               std::optional<model::topic_view> topic,
               model::transformed_data data) final {
                 return _cb(topic, std::move(data));

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -1213,9 +1213,11 @@ void register_transform_module(
 #define REG_HOST_FN(name)                                                      \
     host_function<&transform_module::name>::reg(linker, #name, ssc)
     REG_HOST_FN(check_abi_version_1);
+    REG_HOST_FN(check_abi_version_2);
     REG_HOST_FN(read_batch_header);
     REG_HOST_FN(read_next_record);
     REG_HOST_FN(write_record);
+    REG_HOST_FN(write_record_with_options);
 #undef REG_HOST_FN
 }
 

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -754,8 +754,10 @@ private:
                 _measurement = _probe->latency_measurement();
             }
 
-            void emit(model::transformed_data data) final {
-                _cb(std::move(data));
+            write_success emit(
+              std::optional<model::topic_view> topic,
+              model::transformed_data data) final {
+                return _cb(topic, std::move(data));
             }
 
             void post_record() final { _measurement = nullptr; }


### PR DESCRIPTION

Update the data path of transforms to support multiple output topics, here is a summary of the changes:

- Extend our ABI to add a function that can emit to a specific topic.
- Pass that back from the wasm subsystem to transform subsystem
- Track offsets per output topic, this includes lag metrics.
- Resume from the offset that has the most lag and have other transforms that are ahead suppress duplicates 

Next up we need to support using these new methods in the SDKs, and remove validation in the deploy path that a single output is used. 

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
