### PR TITLE
[v23.2.x] cluster: publish total available reclaim size to balancer

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -711,7 +711,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 },
                 .size_bytes = p.second->size_bytes() + p.second->non_log_disk_size_bytes(),
                 .under_replicated_replicas = p.second->get_under_replicated(),
-                .reclaimable_size_bytes = p.second->reclaimable_local_size_bytes(),
+                .reclaimable_size_bytes = p.second->reclaimable_size_bytes(),
               };
           });
     } else {
@@ -726,7 +726,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 },
                 .size_bytes = partition->size_bytes() + partition->non_log_disk_size_bytes(),
                 .under_replicated_replicas = partition->get_under_replicated(),
-                .reclaimable_size_bytes = partition->reclaimable_local_size_bytes(),
+                .reclaimable_size_bytes = partition->reclaimable_size_bytes(),
                 });
             }
         }

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -68,8 +68,8 @@ struct partition_status
     std::optional<uint8_t> under_replicated_replicas;
 
     /*
-     * estimated amount of data above local retention that is subject to
-     * reclaim under disk pressure. this is useful for the partition balancer
+     * estimated amount of data subject to reclaim under disk pressure without
+     * violating safety guarantees. this is useful for the partition balancer
      * which is interested in free space on a node. a node may have very little
      * physical free space, but have effective free space represented by
      * reclaimable size bytes.

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -276,8 +276,8 @@ public:
 
     size_t size_bytes() const { return _raft->log()->size_bytes(); }
 
-    size_t reclaimable_local_size_bytes() const {
-        return _raft->log()->reclaimable_local_size_bytes();
+    size_t reclaimable_size_bytes() const {
+        return _raft->log()->reclaimable_size_bytes();
     }
 
     uint64_t non_log_disk_size_bytes() const;

--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -520,7 +520,7 @@ ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
     cluster::node::local_state::log_data_state monitor_update;
     monitor_update.data_target_size = target_size;
     monitor_update.data_current_size = usage.usage.total();
-    monitor_update.data_reclaimable_size = usage.reclaim.local_retention;
+    monitor_update.data_reclaimable_size = usage.reclaim.available;
     _local_monitor->local().set_log_data_state(monitor_update);
 
     /*

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2169,7 +2169,7 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
     /*
      * cache this for access by the health
      */
-    _reclaimable_local_size_bytes = reclaim.local_retention;
+    _reclaimable_size_bytes = reclaim.available;
 
     co_return std::make_pair(usage, reclaim);
 }
@@ -2651,7 +2651,7 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
     co_return res;
 }
 
-size_t disk_log_impl::reclaimable_local_size_bytes() const {
+size_t disk_log_impl::reclaimable_size_bytes() const {
     /*
      * circumstances/configuration under which this log will be trimming back to
      * local retention size may change. catch these before reporting potentially
@@ -2667,7 +2667,7 @@ size_t disk_log_impl::reclaimable_local_size_bytes() const {
     if (deletion_exempt(config().ntp())) {
         return 0;
     }
-    return _reclaimable_local_size_bytes;
+    return _reclaimable_size_bytes;
 }
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -143,7 +143,7 @@ public:
         return _segments_rolling_lock.get_units();
     }
 
-    size_t reclaimable_local_size_bytes() const override;
+    size_t reclaimable_size_bytes() const override;
 
 private:
     friend class disk_log_appender; // for multi-term appends
@@ -294,7 +294,7 @@ private:
     mutex _segments_rolling_lock;
 
     std::optional<model::offset> _cloud_gc_offset;
-    size_t _reclaimable_local_size_bytes{0};
+    size_t _reclaimable_size_bytes{0};
 };
 
 } // namespace storage

--- a/src/v/storage/log.h
+++ b/src/v/storage/log.h
@@ -144,10 +144,10 @@ public:
     virtual probe& get_probe() = 0;
 
     /*
-     * estimate amount of data beyond local retention. zero will be returned in
+     * estimate amount of data safely reclaimable. zero will be returned in
      * cases where this is not applicable, such as the log not being TS-enabled.
      */
-    virtual size_t reclaimable_local_size_bytes() const = 0;
+    virtual size_t reclaimable_size_bytes() const = 0;
 
 private:
     ntp_config _config;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16354 
Fixes: https://github.com/redpanda-data/redpanda/issues/16423