### PR TITLE
io: add io queue manager

### DIFF
--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -8,10 +8,12 @@ v_cc_library(
     page_set.cc
     clang-tidy-helper.cc
     logger.cc
+    io_queue.cc
   DEPS
     Seastar::seastar
     absl::btree
     absl::flat_hash_map
+    v::container
 )
 
 add_subdirectory(tests)

--- a/src/v/io/io_queue.cc
+++ b/src/v/io/io_queue.cc
@@ -124,6 +124,11 @@ seastar::future<> io_queue::dispatch() noexcept {
 
         auto units = co_await seastar::get_units(ops_, 1);
 
+        /*
+         * dispatch loop and close() run concurrently, and synchronize ont he
+         * ops_ semaphore. if dispatch wakes up after close() completed, then we
+         * need to identify that case here--we no longer have a file descriptor.
+         */
         if (file_ == nullptr) {
             continue;
         }

--- a/src/v/io/io_queue.cc
+++ b/src/v/io/io_queue.cc
@@ -10,6 +10,7 @@
  */
 #include "io/io_queue.h"
 
+#include "base/vassert.h"
 #include "io/logger.h"
 
 #include <seastar/core/coroutine.hh>
@@ -146,8 +147,7 @@ seastar::future<> io_queue::dispatch() noexcept {
             dispatch_write(page, std::move(units));
 
         } else {
-            assert(false);
-            std::terminate();
+            vassert(false, "Expected a read or write flag");
         }
     }
 }
@@ -172,8 +172,7 @@ void io_queue::dispatch_read(
                 }
             })
             .handle_exception([this](std::exception_ptr eptr) {
-                log.error("Read failed to {}: {}", path_, eptr);
-                std::terminate();
+                vassert(false, "Read failed to {}: {}", path_, eptr);
             });
       });
 }
@@ -203,8 +202,7 @@ void io_queue::dispatch_write(
                 }
             })
             .handle_exception([this](std::exception_ptr eptr) {
-                log.error("Write failed to {}: {}", path_, eptr);
-                std::terminate();
+                vassert(false, "Write failed to {}: {}", path_, eptr);
             });
       });
 }

--- a/src/v/io/io_queue.cc
+++ b/src/v/io/io_queue.cc
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/io_queue.h"
+
+#include "io/logger.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+
+namespace experimental::io {
+
+io_queue::io_queue(
+  persistence* storage,
+  std::filesystem::path path,
+  completion_callback_type complete) noexcept
+  : storage_(storage)
+  , path_(std::move(path))
+  , complete_(std::move(complete)) {}
+
+void io_queue::start() noexcept {
+    log.debug("Starting io queue for {}", path_);
+    dispatcher_ = dispatch();
+}
+
+seastar::future<> io_queue::stop() noexcept {
+    log.debug("Stopping io queue for {}", path_);
+    auto dispatcher = std::exchange(
+      dispatcher_, seastar::make_ready_future<>());
+    stop_ = true;
+    cond_.signal();
+    co_await std::move(dispatcher);
+    co_await gate_.close();
+}
+
+const std::filesystem::path& io_queue::path() const noexcept { return path_; }
+
+seastar::future<> io_queue::open() noexcept {
+    log.debug("Opening {}", path_);
+    assert(!opened());
+    assert(running_.empty());
+    file_ = co_await storage_->open(path_);
+    cond_.signal();
+}
+
+bool io_queue::opened() const noexcept { return file_ != nullptr; }
+
+/*
+ * closing the file always succeeds. once seastar::file::close is invoked the
+ * handle is not longer usable, so we swallow any errors here and release units
+ * to avoid blocking other queues as there isn't much else we can do.
+ *
+ * failure to close a file is quite rare outside of the normal cases like trying
+ * to close an unknown or already closed file handle. these cases won't occur
+ * using the seastar api since it prevents those mistakes. in any case, what we
+ * care about most when closing a file is that its file descriptor resource is
+ * freed in the kernel to avoid reaching an open file limit.
+ */
+seastar::future<> io_queue::close() noexcept {
+    log.debug("Closing {}", path_);
+    assert(opened());
+
+    // ensure all on-going ops have completed
+    auto units = co_await seastar::get_units(
+      ops_, seastar::semaphore::max_counter());
+
+    auto file = std::exchange(file_, nullptr);
+    try {
+        co_await file->close();
+    } catch (...) {
+        log.warn(
+          "Unable to close file {}: {}", path_, std::current_exception());
+    }
+}
+
+void io_queue::submit_read(page& page) noexcept {
+    page.set_flag(page::flags::read);
+    enqueue_pending(page);
+}
+
+void io_queue::submit_write(page& page) noexcept {
+    /*
+     * if the page is not on any list, then in queue it.
+     */
+    if (!page.io_queue_hook.is_linked()) {
+        page.set_flag(page::flags::write);
+        enqueue_pending(page);
+        return;
+    }
+
+    assert(page.test_flag(page::flags::write));
+
+    /*
+     * if it isn't queued, then that means the dispatcher has handled it. in
+     * this case, new data may have arrived into the page. we mark it as queued
+     * as a signal to the I/O completion continuation to requeue the write.
+     */
+    if (!page.test_flag(page::flags::queued)) {
+        log.debug("Marking inflight I/O to be requeued");
+        page.set_flag(page::flags::queued);
+    }
+}
+
+void io_queue::enqueue_pending(page& page) noexcept {
+    pending_.push_back(page);
+    page.set_flag(page::flags::queued);
+    cond_.signal();
+}
+
+seastar::future<> io_queue::dispatch() noexcept {
+    while (true) {
+        co_await cond_.wait([this] { return !pending_.empty() || stop_; });
+
+        if (stop_) {
+            co_return;
+        }
+
+        auto units = co_await seastar::get_units(ops_, 1);
+
+        if (file_ == nullptr) {
+            continue;
+        }
+
+        auto& page = pending_.front();
+        pending_.pop_front();
+        assert(page.test_flag(page::flags::queued));
+        page.clear_flag(page::flags::queued);
+        running_.push_back(page);
+
+        if (page.test_flag(page::flags::read)) {
+            dispatch_read(page, std::move(units));
+
+        } else if (page.test_flag(page::flags::write)) {
+            dispatch_write(page, std::move(units));
+
+        } else {
+            assert(false);
+            std::terminate();
+        }
+    }
+}
+
+void io_queue::dispatch_read(
+  page& page, seastar::semaphore_units<> units) noexcept {
+    log.debug("Reading {} at {}~{}", path_, page.offset(), page.data().size());
+
+    std::ignore = seastar::with_gate(
+      gate_, [this, &page, units = std::move(units)]() mutable {
+          return file_
+            ->dma_read(
+              page.offset(), page.data().get_write(), page.data().size())
+            .then([this, &page, units = std::move(units)](auto) {
+                running_.erase(request_list_type::s_iterator_to(page));
+                if (complete_) {
+                    complete_(page);
+                }
+            })
+            .handle_exception([this](std::exception_ptr eptr) {
+                log.error("Read failed to {}: {}", path_, eptr);
+                std::terminate();
+            });
+      });
+}
+
+void io_queue::dispatch_write(
+  page& page, seastar::semaphore_units<> units) noexcept {
+    log.debug("Writing {} at {}~{}", path_, page.offset(), page.data().size());
+
+    std::ignore = seastar::with_gate(
+      gate_, [this, &page, units = std::move(units)]() mutable {
+          return file_
+            ->dma_write(page.offset(), page.data().get(), page.data().size())
+            .then([this, &page, units = std::move(units)](auto) {
+                running_.erase(request_list_type::s_iterator_to(page));
+                if (page.test_flag(page::flags::queued)) {
+                    pending_.push_back(page);
+                    cond_.signal();
+                }
+                if (complete_) {
+                    complete_(page);
+                }
+            })
+            .handle_exception([this](std::exception_ptr eptr) {
+                log.error("Write failed to {}: {}", path_, eptr);
+                std::terminate();
+            });
+      });
+}
+
+} // namespace experimental::io

--- a/src/v/io/io_queue.cc
+++ b/src/v/io/io_queue.cc
@@ -12,6 +12,7 @@
 
 #include "base/vassert.h"
 #include "io/logger.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
@@ -156,7 +157,7 @@ void io_queue::dispatch_read(
   page& page, seastar::semaphore_units<> units) noexcept {
     log.debug("Reading {} at {}~{}", path_, page.offset(), page.data().size());
 
-    std::ignore = seastar::with_gate(
+    ssx::background = seastar::with_gate(
       gate_, [this, &page, units = std::move(units)]() mutable {
           return file_
             ->dma_read(
@@ -181,7 +182,7 @@ void io_queue::dispatch_write(
   page& page, seastar::semaphore_units<> units) noexcept {
     log.debug("Writing {} at {}~{}", path_, page.offset(), page.data().size());
 
-    std::ignore = seastar::with_gate(
+    ssx::background = seastar::with_gate(
       gate_, [this, &page, units = std::move(units)]() mutable {
           return file_
             ->dma_write(page.offset(), page.data().get(), page.data().size())

--- a/src/v/io/io_queue.h
+++ b/src/v/io/io_queue.h
@@ -79,7 +79,8 @@ public:
     /**
      * Open the queue and begin dispatching pending I/O requests.
      *
-     * Requires that opened() be false.
+     * Requires that opened() be false. The queue will remain in the closed
+     * state if an exceptional future is returned.
      */
     seastar::future<> open() noexcept;
 

--- a/src/v/io/io_queue.h
+++ b/src/v/io/io_queue.h
@@ -68,6 +68,11 @@ public:
 
     /**
      * Stops the I/O queue's background dispatcher.
+     *
+     * It is recommended that close() be invoked prior to stopping the queue.
+     * While Seastar will close the file handle automatically, ensuring that the
+     * queue is drained before the file handle is closed will avoid errors
+     * within Seastar related to closing file handles with pending I/O.
      */
     seastar::future<> stop() noexcept;
 

--- a/src/v/io/io_queue.h
+++ b/src/v/io/io_queue.h
@@ -45,7 +45,8 @@ public:
     /**
      * Callback invoked when the scheduler completes an operation.
      */
-    using completion_callback_type = seastar::noncopyable_function<void(page&)>;
+    using completion_callback_type
+      = seastar::noncopyable_function<void(page&) noexcept>;
 
     /**
      * Construct a new io_queue.

--- a/src/v/io/io_queue.h
+++ b/src/v/io/io_queue.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "io/page.h"
+#include "io/persistence.h"
+
+#include <seastar/core/condition-variable.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/semaphore.hh>
+
+namespace experimental::io {
+
+namespace testing_details {
+class io_queue_accessor;
+}; // namespace testing_details
+
+/**
+ * Manager of I/O requests for a single file.
+ *
+ * An I/O request is added to the queue using the `submit_*` interfaces. For
+ * example, a page may be read or written by passing a reference to the page to
+ * either `submit_read` or `submit_write`.
+ *
+ * There is no guarantee of the order in which I/O requests are processed.
+ *
+ * Submission of I/O requests can be made at any time, but pending I/O requests
+ * are processed only when the queue is in the open state. A new I/O queue is in
+ * the closed state. To open the queue use the `open()` interface which will
+ * open a handle to the underlying file. To close the queue and the file handle
+ * use the `close()` interface. A queue may be opened and closed any number of
+ * times. This is useful if the queue is used in a context that control the
+ * maximum number of open file handles or wants to pause I/O for some reason.
+ */
+class io_queue {
+public:
+    /**
+     * Callback invoked when the scheduler completes an operation.
+     */
+    using completion_callback_type = seastar::noncopyable_function<void(page&)>;
+
+    /**
+     * Construct a new io_queue.
+     */
+    io_queue(
+      persistence* storage,
+      std::filesystem::path path,
+      completion_callback_type complete) noexcept;
+
+    io_queue(const io_queue&) = delete;
+    io_queue& operator=(const io_queue&) = delete;
+    io_queue(io_queue&&) noexcept = delete;
+    io_queue& operator=(io_queue&&) noexcept = delete;
+    ~io_queue() noexcept = default;
+
+    /**
+     * Starts the I/O queue's background dispatcher.
+     */
+    void start() noexcept;
+
+    /**
+     * Stops the I/O queue's background dispatcher.
+     */
+    seastar::future<> stop() noexcept;
+
+    /**
+     * Return the path of the backing file.
+     */
+    [[nodiscard]] const std::filesystem::path& path() const noexcept;
+
+    /**
+     * Open the queue and begin dispatching pending I/O requests.
+     *
+     * Requires that opened() be false.
+     */
+    seastar::future<> open() noexcept;
+
+    /**
+     * Returns true if the queue is open, and false otherwise.
+     */
+    bool opened() const noexcept;
+
+    /**
+     * Close the queue and release the underlying file handle.
+     *
+     * Waits until inflight I/Os are complete. Pending I/Os remain in the
+     * pending state until the queue is re-opened.
+     *
+     * Requires that opened() be true.
+     */
+    seastar::future<> close() noexcept;
+
+    /**
+     * Submit a read I/O request.
+     */
+    void submit_read(page&) noexcept;
+
+    /**
+     * Submit a write I/O request.
+     *
+     * If a write request is submitted for a page that had been dispatched but
+     * not yet completed then it will be requeued to be written again.
+     */
+    void submit_write(page&) noexcept;
+
+private:
+    friend testing_details::io_queue_accessor;
+
+    using request_list_type = intrusive_list<page, &page::io_queue_hook>;
+
+    /*
+     * file always represents path on the storage backend. the file pointer is
+     * set via open() and cleared via close(). this may happen any number of
+     * times during the life time of the queue.
+     */
+    persistence* storage_;
+    std::filesystem::path path_;
+    seastar::shared_ptr<persistence::file> file_;
+
+    /*
+     * submitted requests first land on the pending list. they are moved to the
+     * running list when they are dispatched. when a request is completed it is
+     * removed from the running list, and passed to the completion callback.
+     *
+     * operations are dispatched under the ops semaphore which is used to
+     * synchronize completion of operations with pending calls to close().
+     */
+    request_list_type pending_;
+    request_list_type running_;
+    completion_callback_type complete_;
+    seastar::semaphore ops_{seastar::semaphore::max_counter()};
+    void enqueue_pending(page&) noexcept;
+
+    /*
+     * dispatcher holds the dispatch() fiber which processes the pending list of
+     * requests. stop() will shutdown the dispatcher and wait for it to finish.
+     */
+    bool stop_{false};
+    seastar::condition_variable cond_;
+    seastar::gate gate_;
+    seastar::future<> dispatcher_{seastar::make_ready_future<>()};
+    seastar::future<> dispatch() noexcept;
+    void dispatch_read(page&, seastar::semaphore_units<>) noexcept;
+    void dispatch_write(page&, seastar::semaphore_units<>) noexcept;
+};
+
+} // namespace experimental::io

--- a/src/v/io/io_queue.h
+++ b/src/v/io/io_queue.h
@@ -107,6 +107,9 @@ public:
 
     /**
      * Submit a read I/O request.
+     *
+     * A page submitted for read must not be resubmitted for read or write until
+     * it has completed.
      */
     void submit_read(page&) noexcept;
 

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -27,4 +27,24 @@ const seastar::temporary_buffer<char>& page::data() const noexcept {
     return data_;
 }
 
+template<typename T>
+auto underlying(T type) {
+    return static_cast<std::underlying_type_t<T>>(type);
+}
+
+void page::set_flag(flags flag) noexcept {
+    assert(flag != flags::num_flags);
+    flags_.set(underlying(flag));
+}
+
+void page::clear_flag(flags flag) noexcept {
+    assert(flag != flags::num_flags);
+    flags_.reset(underlying(flag));
+}
+
+bool page::test_flag(flags flag) const noexcept {
+    assert(flag != flags::num_flags);
+    return flags_.test(underlying(flag));
+}
+
 } // namespace experimental::io

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -12,6 +12,7 @@
 
 #include <seastar/core/temporary_buffer.hh>
 
+#include <bitset>
 #include <cstdint>
 
 namespace experimental::io {
@@ -52,10 +53,34 @@ public:
     [[nodiscard]] seastar::temporary_buffer<char>& data() noexcept;
     [[nodiscard]] const seastar::temporary_buffer<char>& data() const noexcept;
 
+    /*
+     * read,write: page is queued for read or write
+     */
+    enum class flags { read, write, num_flags };
+
+    /**
+     * set a page flag.
+     */
+    void set_flag(flags) noexcept;
+
+    /**
+     * clear a page flag.
+     */
+    void clear_flag(flags) noexcept;
+
+    /**
+     * Return true if the flag is set, and false otherwise.
+     */
+    [[nodiscard]] bool test_flag(flags) const noexcept;
+
 private:
+    static constexpr auto num_page_flags
+      = static_cast<std::underlying_type_t<flags>>(flags::num_flags);
+
     uint64_t offset_;
     uint64_t size_;
     seastar::temporary_buffer<char> data_;
+    std::bitset<num_page_flags> flags_;
 };
 
 } // namespace experimental::io

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -10,6 +10,8 @@
  */
 #pragma once
 
+#include "container/intrusive_list_helpers.h"
+
 #include <seastar/core/temporary_buffer.hh>
 
 #include <bitset>
@@ -56,7 +58,7 @@ public:
     /*
      * read,write: page is queued for read or write
      */
-    enum class flags { read, write, num_flags };
+    enum class flags { read, write, queued, num_flags };
 
     /**
      * set a page flag.
@@ -72,6 +74,12 @@ public:
      * Return true if the flag is set, and false otherwise.
      */
     [[nodiscard]] bool test_flag(flags) const noexcept;
+
+    /**
+     * Intrusive list hook for I/O queue membership.
+     */
+    // NOLINTNEXTLINE(*-non-private-member-variables-in-classes)
+    intrusive_list_hook io_queue_hook;
 
 private:
     static constexpr auto num_page_flags

--- a/src/v/io/tests/CMakeLists.txt
+++ b/src/v/io/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ rp_test(
     persistence_test.cc
     page_test.cc
     page_set_test.cc
+    io_queue_test.cc
   LIBRARIES
     v::gtest_main
     v::io

--- a/src/v/io/tests/common.cc
+++ b/src/v/io/tests/common.cc
@@ -12,8 +12,10 @@
 
 #include "base/units.h"
 
+#include <seastar/core/align.hh>
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/sleep.hh>
+#include <seastar/core/thread.hh>
 #include <seastar/util/later.hh>
 
 #include <random>
@@ -80,4 +82,70 @@ make_page(uint64_t offset, std::optional<uint64_t> seed) {
 void sleep_ms(unsigned min, unsigned max) {
     const auto ms = random_generators::get_int(min, max);
     seastar::sleep(std::chrono::milliseconds(ms)).get();
+}
+
+io_queue_workload_generator::io_queue_workload_generator(
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  size_t max_file_size,
+  size_t num_io_ops,
+  std::function<void(io::page&)> submit_read,
+  std::function<void(io::page&)> submit_write,
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  unsigned min_ms,
+  unsigned max_ms)
+  : max_file_size(max_file_size)
+  , num_io_ops(num_io_ops)
+  , submit_read(std::move(submit_read))
+  , submit_write(std::move(submit_write))
+  , min_ms(min_ms)
+  , max_ms(max_ms) {}
+
+seastar::future<> io_queue_workload_generator::run() {
+    std::ignore = seastar::with_gate(
+      gate, [this] { return generate_writes(); });
+    std::ignore = seastar::with_gate(gate, [this] { return generate_reads(); });
+    return gate.close();
+}
+
+void io_queue_workload_generator::handle_complete(io::page& page) {
+    if (page.test_flag(io::page::flags::write)) {
+        completed_writes.emplace(page.offset(), &page);
+        ++completed_writes_count;
+    } else if (page.test_flag(io::page::flags::read)) {
+        completed_reads.push_back(&page);
+    }
+}
+
+seastar::future<> io_queue_workload_generator::generate_writes() {
+    return seastar::async([this] {
+        while (completed_writes_count < num_io_ops) {
+            const auto offset = seastar::align_down<size_t>(
+              random_generators::get_int(max_file_size), 4096);
+            submitted_writes.push_back(make_page(offset, offset));
+            submit_write(*submitted_writes.back());
+            sleep_ms(min_ms, max_ms);
+        }
+    });
+}
+
+seastar::future<> io_queue_workload_generator::generate_reads() {
+    return seastar::async([=] {
+        while (completed_reads.size() < num_io_ops) {
+            if (auto* write = select_random_write(); write != nullptr) {
+                submitted_reads.push_back(make_page(write->offset()));
+                submit_read(*submitted_reads.back());
+            }
+            sleep_ms(min_ms, max_ms);
+        }
+    });
+}
+
+io::page* io_queue_workload_generator::select_random_write() const {
+    auto delta = random_generators::get_int(completed_writes.size());
+    auto it = completed_writes.begin();
+    std::advance(it, delta);
+    if (it != completed_writes.end()) {
+        return it->second;
+    }
+    return nullptr;
 }

--- a/src/v/io/tests/common.h
+++ b/src/v/io/tests/common.h
@@ -19,6 +19,8 @@
 #include <seastar/core/gate.hh>
 #include <seastar/core/temporary_buffer.hh>
 
+#include <gtest/gtest.h>
+
 #include <deque>
 #include <map>
 
@@ -148,4 +150,25 @@ private:
 
     bool stop_{false};
     seastar::future<> injector{seastar::make_ready_future<>()};
+};
+
+/**
+ * Helper test fixture that constructs a persistence instance.
+ */
+class StorageTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        if (disk_persistence()) {
+            storage_ = std::make_unique<io::disk_persistence>();
+        } else {
+            storage_ = std::make_unique<io::memory_persistence>();
+        }
+    }
+
+    io::persistence* storage() { return storage_.get(); }
+
+private:
+    [[nodiscard]] virtual bool disk_persistence() const = 0;
+
+    std::unique_ptr<io::persistence> storage_;
 };

--- a/src/v/io/tests/io_queue_test.cc
+++ b/src/v/io/tests/io_queue_test.cc
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "base/units.h"
+#include "io/io_queue.h"
+#include "io/tests/common.h"
+#include "random/generators.h"
+
+#include <seastar/core/seastar.hh>
+#include <seastar/core/thread.hh>
+
+#include <gtest/gtest.h>
+
+namespace io = experimental::io;
+
+/*
+ * params
+ *  - max file size
+ *  - num io operations
+ *  - disk or memory backend
+ */
+class IOQueueTest
+  : public StorageTest
+  , public ::testing::WithParamInterface<std::tuple<bool, size_t, size_t>> {
+public:
+    [[nodiscard]] static size_t file_size() { return std::get<1>(GetParam()); }
+    [[nodiscard]] static size_t num_io_ops() { return std::get<2>(GetParam()); }
+
+private:
+    [[nodiscard]] bool disk_persistence() const override {
+        return std::get<0>(GetParam());
+    }
+};
+
+/*
+ * helper combining io_queue, workload generator, and fault injection.
+ */
+struct queue_tester {
+    queue_tester(
+      io::persistence* storage,
+      std::filesystem::path path,
+      size_t file_size,
+      size_t num_io_ops)
+      : queue(
+        storage,
+        std::move(path),
+        [this](io::page& page) { generator.handle_complete(page); })
+      , generator(
+          file_size,
+          num_io_ops,
+          [this](auto& page) { queue.submit_read(page); },
+          [this](auto& page) { queue.submit_write(page); })
+      , faulter(storage, &queue) {}
+
+    void run() {
+        // start
+        faulter.start();
+        open_close_looper = open_close_loop();
+        queue.start();
+        generator.run().get();
+
+        // stop
+        stop_ = true;
+        faulter.stop().get();
+        queue.stop().get();
+        std::move(open_close_looper).get();
+    }
+
+    /*
+     * injects open() and close() calls during the test.
+     */
+    seastar::future<> open_close_loop() {
+        return seastar::async([this] {
+            while (!stop_) {
+                try {
+                    queue.open().get();
+                } catch (...) {
+                }
+                sleep_ms(10, 50);
+                if (queue.opened()) {
+                    queue.close().get();
+                    sleep_ms(10, 50);
+                }
+            }
+        });
+    }
+
+    io::io_queue queue;
+    io_queue_workload_generator generator;
+    io_queue_fault_injector faulter;
+
+    bool stop_{false};
+    seastar::future<> open_close_looper{seastar::make_ready_future<>()};
+};
+
+TEST_P(IOQueueTest, WriteRead) {
+    queue_tester qt(storage(), "foo", file_size(), num_io_ops());
+    storage()->create(qt.queue.path()).get();
+    qt.run();
+
+    ASSERT_GE(qt.generator.reads().size(), num_io_ops());
+    ASSERT_FALSE(qt.generator.writes().empty());
+
+    for (const auto& read : qt.generator.reads()) {
+        EXPECT_TRUE(qt.generator.writes().contains(read->offset()));
+        auto* write = qt.generator.writes().at(read->offset());
+        EXPECT_EQ(read->data(), write->data());
+    }
+
+    try {
+        seastar::remove_file(qt.queue.path().string()).get();
+    } catch (...) {
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  IOQueue,
+  IOQueueTest,
+  ::testing::Combine(
+    ::testing::Bool(),                 // disk backend?
+    ::testing::Values(16_KiB, 10_MiB), // backing file size
+    ::testing::Values(10, 3000)));     // number of io operations

--- a/src/v/io/tests/io_queue_test.cc
+++ b/src/v/io/tests/io_queue_test.cc
@@ -51,7 +51,7 @@ struct queue_tester {
       : queue(
         storage,
         std::move(path),
-        [this](io::page& page) { generator.handle_complete(page); })
+        [this](io::page& page) noexcept { generator.handle_complete(page); })
       , generator(
           file_size,
           num_io_ops,

--- a/src/v/io/tests/page_test.cc
+++ b/src/v/io/tests/page_test.cc
@@ -48,3 +48,22 @@ TEST(Page, SetData) {
     EXPECT_EQ(p.data().size(), size);
     EXPECT_EQ(p.data(), d1);
 }
+
+TEST(Page, Flags) {
+    io::page p(1, {});
+
+    EXPECT_FALSE(p.test_flag(io::page::flags::read));
+    p.set_flag(io::page::flags::read);
+    EXPECT_TRUE(p.test_flag(io::page::flags::read));
+
+    EXPECT_FALSE(p.test_flag(io::page::flags::write));
+    p.set_flag(io::page::flags::write);
+    EXPECT_TRUE(p.test_flag(io::page::flags::write));
+    EXPECT_TRUE(p.test_flag(io::page::flags::read));
+
+    p.clear_flag(io::page::flags::read);
+    EXPECT_FALSE(p.test_flag(io::page::flags::read));
+    p.clear_flag(io::page::flags::write);
+    EXPECT_FALSE(p.test_flag(io::page::flags::write));
+    EXPECT_FALSE(p.test_flag(io::page::flags::read));
+}


### PR DESCRIPTION
Adds `io_queue` which manages and dispatches submitted reads and writes. It's underlying file description can safely be closed and re-opened at anytime which forms the basis for enforcing open-file limits (next PR) across all `io_queues`.

Reviewers will observe the complete lack of I/O optimization opportunities such as combining adjacent physical pages into larger I/O requests. The other feature lacking in this version which we will want is some amount of support for retrying failed I/Os and applying backpressure for certain scenarios such as ENOSPC, but that isn't in this version. Failures opening and closing are not fatal, and are used by the scheduler (next PR) to deal with transient issues opening and closing io queue files.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
