### PR TITLE
Data Transforms Schema Registry Rust SDK

### DIFF
--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -61,6 +61,8 @@ jobs:
 
       - name: Publish
         working-directory: src/transform-sdk/rust
-        run: ./scripts/publish.py --version ${{github.ref_name}}
+        run: |
+          pip install tomlkit
+          ./scripts/publish.py --version ${{github.ref_name}}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/src/transform-sdk/go/transform/sr/client.go
+++ b/src/transform-sdk/go/transform/sr/client.go
@@ -42,8 +42,7 @@ const (
 // that use the key "$ref" can refer to another schema via URL. For more details
 // on references, see the following link:
 //
-//	https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#schema-references
-//	https://docs.confluent.io/platform/current/schema-registry/develop/api.html
+//	https://docs.redpanda.com/current/manage/schema-reg/schema-reg-api/#reference-a-schema
 type Reference struct {
 	Name    string
 	Subject string

--- a/src/transform-sdk/rust/Cargo.lock
+++ b/src/transform-sdk/rust/Cargo.lock
@@ -548,11 +548,19 @@ dependencies = [
  "quickcheck",
  "rand",
  "redpanda-transform-sdk-types",
+ "redpanda-transform-sdk-varint",
 ]
 
 [[package]]
 name = "redpanda-transform-sdk-types"
 version = "0.0.0-dev"
+
+[[package]]
+name = "redpanda-transform-sdk-varint"
+version = "0.0.0-dev"
+dependencies = [
+ "quickcheck",
+]
 
 [[package]]
 name = "regex"

--- a/src/transform-sdk/rust/Cargo.lock
+++ b/src/transform-sdk/rust/Cargo.lock
@@ -541,8 +541,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "redpanda-transform-sdk-sr-sys"
+version = "0.0.0-dev"
+dependencies = [
+ "redpanda-transform-sdk-sr-types",
+ "redpanda-transform-sdk-varint",
+]
+
+[[package]]
 name = "redpanda-transform-sdk-sr-types"
 version = "0.0.0-dev"
+dependencies = [
+ "redpanda-transform-sdk-varint",
+]
 
 [[package]]
 name = "redpanda-transform-sdk-sys"

--- a/src/transform-sdk/rust/Cargo.lock
+++ b/src/transform-sdk/rust/Cargo.lock
@@ -541,6 +541,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "redpanda-transform-sdk-sr"
+version = "0.0.0-dev"
+dependencies = [
+ "redpanda-transform-sdk-sr-sys",
+ "redpanda-transform-sdk-sr-types",
+]
+
+[[package]]
 name = "redpanda-transform-sdk-sr-sys"
 version = "0.0.0-dev"
 dependencies = [

--- a/src/transform-sdk/rust/Cargo.lock
+++ b/src/transform-sdk/rust/Cargo.lock
@@ -541,6 +541,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "redpanda-transform-sdk-sr-types"
+version = "0.0.0-dev"
+
+[[package]]
 name = "redpanda-transform-sdk-sys"
 version = "0.0.0-dev"
 dependencies = [

--- a/src/transform-sdk/rust/Cargo.toml
+++ b/src/transform-sdk/rust/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "core-sys",
   "core-types",
   "varint",
+  "sr-types",
   "examples/*",
 ]
 

--- a/src/transform-sdk/rust/Cargo.toml
+++ b/src/transform-sdk/rust/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "varint",
   "sr-types",
   "sr-sys",
+  "sr",
   "examples/*",
 ]
 

--- a/src/transform-sdk/rust/Cargo.toml
+++ b/src/transform-sdk/rust/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "core-types",
   "varint",
   "sr-types",
+  "sr-sys",
   "examples/*",
 ]
 

--- a/src/transform-sdk/rust/Cargo.toml
+++ b/src/transform-sdk/rust/Cargo.toml
@@ -27,6 +27,7 @@ resolver = "2"
 members = [
   "core-sys",
   "core-types",
+  "varint",
   "examples/*",
 ]
 

--- a/src/transform-sdk/rust/core-sys/Cargo.toml
+++ b/src/transform-sdk/rust/core-sys/Cargo.toml
@@ -12,6 +12,7 @@ categories.workspace = true
 
 [dependencies]
 redpanda-transform-sdk-types = { path = "../core-types", version = "=0.0.0-dev" }
+redpanda-transform-sdk-varint = { path = "../varint", version = "=0.0.0-dev" }
 
 [dev-dependencies]
 quickcheck = { workspace = true }

--- a/src/transform-sdk/rust/core-sys/src/lib.rs
+++ b/src/transform-sdk/rust/core-sys/src/lib.rs
@@ -29,9 +29,6 @@ mod stub_abi;
 #[cfg(not(target_os = "wasi"))]
 use stub_abi as abi;
 mod serde;
-mod varint;
-
-extern crate redpanda_transform_sdk_types;
 
 use redpanda_transform_sdk_types::*;
 

--- a/src/transform-sdk/rust/core-types/src/lib.rs
+++ b/src/transform-sdk/rust/core-types/src/lib.rs
@@ -35,7 +35,7 @@ pub struct WriteEvent<'a> {
 /// A [`WrittenRecord`] is handed to `on_record_written` event handlers as the record that Redpanda
 /// wrote. The record contains a key value pair with some headers, along with the record's
 /// timestamp.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct WrittenRecord<'a> {
     record: BorrowedRecord<'a>,
     timestamp: SystemTime,
@@ -143,7 +143,7 @@ impl<'a> RecordWriter<'a> {
 }
 
 /// An error that can occur when writing records to the output topic.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum WriteError {
     /// Unknown error from the broker with the corresponding error code.
@@ -161,7 +161,7 @@ impl std::fmt::Display for WriteError {
 impl std::error::Error for WriteError {}
 
 /// A zero-copy [`BorrowedRecord`] header.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BorrowedHeader<'a> {
     key: &'a [u8],
     value: Option<&'a [u8]>,
@@ -196,7 +196,7 @@ impl<'a> From<&'a BorrowedHeader<'a>> for BorrowedHeader<'a> {
 }
 
 /// A zero-copy representation of a [`Record`] within Redpanda.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BorrowedRecord<'a> {
     key: Option<&'a [u8]>,
     value: Option<&'a [u8]>,
@@ -252,7 +252,7 @@ impl<'a> From<&'a BorrowedRecord<'a>> for BorrowedRecord<'a> {
 ///
 /// Headers are opaque to the broker and are purely a mechanism for the producer and consumers to
 /// pass information.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RecordHeader {
     key: Vec<u8>,
     value: Option<Vec<u8>>,
@@ -296,7 +296,7 @@ impl<'a> From<&'a RecordHeader> for BorrowedHeader<'a> {
 /// A record is a key-value pair of bytes, along with a collection of [`RecordHeader`].
 ///
 /// Records are generated as the result of any transforms that act upon a [`BorrowedRecord`].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Record {
     key: Option<Vec<u8>>,
     value: Option<Vec<u8>>,

--- a/src/transform-sdk/rust/scripts/publish.py
+++ b/src/transform-sdk/rust/scripts/publish.py
@@ -63,7 +63,7 @@ def publish(version: str, dry_run: bool):
 
     # The order matters here so that we get the right versions in the registry
     # before deploying the next crate
-    for pkg in ["-varint", "-sr-types", "-types", "-sys", ""]:
+    for pkg in ["-varint", "-sr-types", "-sr-sys", "-types", "-sys", ""]:
         publish_package(f"redpanda-transform-sdk{pkg}", dry_run)
 
 

--- a/src/transform-sdk/rust/scripts/publish.py
+++ b/src/transform-sdk/rust/scripts/publish.py
@@ -61,9 +61,9 @@ def publish(version: str, dry_run: bool):
         update_dependencies(manifest, version)
         path.write_text(tomlkit.dumps(manifest))
 
-    # The order matters here so that we get the right versions in the registry 
+    # The order matters here so that we get the right versions in the registry
     # before deploying the next crate
-    for pkg in ["-types", "-sys", ""]:
+    for pkg in ["-varint", "-types", "-sys", ""]:
         publish_package(f"redpanda-transform-sdk{pkg}", dry_run)
 
 

--- a/src/transform-sdk/rust/scripts/publish.py
+++ b/src/transform-sdk/rust/scripts/publish.py
@@ -35,6 +35,7 @@ def publish_package(pkg: str, dry_run: bool):
             check=True,
         )
 
+
 def update_dependencies(manifest: tomlkit.TOMLDocument, version: str):
     if "dependencies" not in manifest:
         return
@@ -63,7 +64,9 @@ def publish(version: str, dry_run: bool):
 
     # The order matters here so that we get the right versions in the registry
     # before deploying the next crate
-    for pkg in ["-varint", "-sr-types", "-sr-sys", "-types", "-sys", ""]:
+    for pkg in [
+            "-varint", "-sr-types", "-sr-sys", "-sr", "-types", "-sys", ""
+    ]:
         publish_package(f"redpanda-transform-sdk{pkg}", dry_run)
 
 

--- a/src/transform-sdk/rust/scripts/publish.py
+++ b/src/transform-sdk/rust/scripts/publish.py
@@ -3,59 +3,74 @@
 import argparse
 from pathlib import Path
 import subprocess
-import re
+import tomlkit
 
 CARGO_WORKSPACE_DIR = Path(__file__).resolve().parent.parent
 
 CARGO_TOML_FILE = CARGO_WORKSPACE_DIR / "Cargo.toml"
-SYS_CARGO_TOML_FILE = CARGO_WORKSPACE_DIR / "core-sys" / "Cargo.toml"
 
 
-def publish_package(pkg: str):
+def publish_package(pkg: str, dry_run: bool):
     # must have env CARGO_REGISTRY_TOKEN set or the user must be logged in.
-    subprocess.run(
-        [
-            "cargo",
-            "publish",
-            # We just update the version
-            "--allow-dirty",
-            "--locked",
-            f"--package={pkg}",
-        ],
-        check=True,
-    )
+    cmd = [
+        "cargo",
+        "publish",
+        # We just update the version
+        "--allow-dirty",
+        "--locked",
+        f"--package={pkg}",
+    ]
+    if dry_run:
+        print(f"$ {' '.join(cmd)}")
+    else:
+        subprocess.run(
+            [
+                "cargo",
+                "publish",
+                # We just update the version
+                "--allow-dirty",
+                "--locked",
+                f"--package={pkg}",
+            ],
+            check=True,
+        )
+
+def update_dependencies(manifest: tomlkit.TOMLDocument, version: str):
+    if "dependencies" not in manifest:
+        return
+    for meta in manifest["dependencies"].values():
+        if not meta.is_inline_table():
+            continue
+        meta["version"] = version
 
 
-def publish(version: str):
+def publish(version: str, dry_run: bool):
     # Cargo does not like the prefix we add to tags, so remove it.
     version = version.removeprefix('transform-sdk/v')
-    # Set the version in the TOML file
-    toml = CARGO_TOML_FILE.read_text()
-    toml = re.sub(pattern='^version = "[^"]+"',
-                  repl=f'version = "{version}"',
-                  string=toml,
-                  flags=re.MULTILINE)
-    toml = re.sub(pattern='{ path = "([^"]+)", version = "=[^"]+" }$',
-                  repl=f'{{ path = "\\1", version = "={version}" }}',
-                  string=toml,
-                  flags=re.MULTILINE)
-    CARGO_TOML_FILE.write_text(toml)
 
-    toml = SYS_CARGO_TOML_FILE.read_text()
-    toml = re.sub(pattern='{ path = "([^"]+)", version = "=[^"]+" }$',
-                  repl=f'{{ path = "\\1", version = "={version}" }}',
-                  string=toml,
-                  flags=re.MULTILINE)
-    SYS_CARGO_TOML_FILE.write_text(toml)
+    # Set the workspace version in the TOML file
+    manifest = tomlkit.loads(CARGO_TOML_FILE.read_text())
+    manifest["workspace"]["package"]["version"] = version
+    CARGO_TOML_FILE.write_text(tomlkit.dumps(manifest))
 
-    # The order matters here so that we get the right versions
+    # Update versions everywhere
+    for path in CARGO_WORKSPACE_DIR.glob("**/*.toml"):
+        if "examples" in path.parts:
+            continue
+        manifest = tomlkit.loads(path.read_text())
+        update_dependencies(manifest, version)
+        path.write_text(tomlkit.dumps(manifest))
+
+    # The order matters here so that we get the right versions in the registry 
+    # before deploying the next crate
     for pkg in ["-types", "-sys", ""]:
-        publish_package(f"redpanda-transform-sdk{pkg}")
+        publish_package(f"redpanda-transform-sdk{pkg}", dry_run)
 
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--version', type=str, required=True)
+parser.add_argument('--dry', action='store_true')
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    publish(version=args.version)
+    publish(version=args.version, dry_run=args.dry)

--- a/src/transform-sdk/rust/scripts/publish.py
+++ b/src/transform-sdk/rust/scripts/publish.py
@@ -63,7 +63,7 @@ def publish(version: str, dry_run: bool):
 
     # The order matters here so that we get the right versions in the registry
     # before deploying the next crate
-    for pkg in ["-varint", "-types", "-sys", ""]:
+    for pkg in ["-varint", "-sr-types", "-types", "-sys", ""]:
         publish_package(f"redpanda-transform-sdk{pkg}", dry_run)
 
 

--- a/src/transform-sdk/rust/sr-sys/Cargo.toml
+++ b/src/transform-sdk/rust/sr-sys/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "redpanda-transform-sdk-sr-sys"
+description = "Redpanda Schema Registry ABI contract for redpanda-transform-sdk-sr"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+redpanda-transform-sdk-sr-types = { path = "../sr-types", version = "=0.0.0-dev" }
+redpanda-transform-sdk-varint = { path = "../varint", version = "=0.0.0-dev" }

--- a/src/transform-sdk/rust/sr-sys/README.md
+++ b/src/transform-sdk/rust/sr-sys/README.md
@@ -1,0 +1,5 @@
+# Redpanda Data Transforms Schema Registry Client Rust SDK - ABI Contract
+
+This is an internal crate as part of Redpanda's Data Transforms Schema Registry SDK, and encapsulates the broker's ABI contract with the guest.
+
+If you are looking to use transform's Schema Registry client you probably want crate [redpanda-transform-sdk-sr](https://crates.io/crates/redpanda-transform-sdk).

--- a/src/transform-sdk/rust/sr-sys/src/abi.rs
+++ b/src/transform-sdk/rust/sr-sys/src/abi.rs
@@ -1,0 +1,49 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[link(wasm_import_module = "redpanda_schema_registry")]
+extern "C" {
+
+    #[link_name = "get_schema_definition_len"]
+    pub(crate) fn get_schema_definition_len(schema_id: i32, len: *mut i32) -> i32;
+
+    #[link_name = "get_schema_definition"]
+    pub(crate) fn get_schema_definition(schema_id: i32, buf: *mut u8, len: i32) -> i32;
+
+    #[link_name = "get_schema_subject_len"]
+    pub(crate) fn get_schema_subject_len(
+        subject: *const u8,
+        subject_len: i32,
+        version: i32,
+        len: *mut i32,
+    ) -> i32;
+
+    #[link_name = "get_schema_subject"]
+    pub(crate) fn get_schema_subject(
+        subject: *const u8,
+        subject_len: i32,
+        version: i32,
+        buf: *mut u8,
+        len: i32,
+    ) -> i32;
+
+    #[link_name = "create_subject_schema"]
+    pub(crate) fn create_subject_schema(
+        subject: *const u8,
+        subject_len: i32,
+        buf: *const u8,
+        len: i32,
+        schema_id_out: *mut i32,
+    ) -> i32;
+}

--- a/src/transform-sdk/rust/sr-sys/src/lib.rs
+++ b/src/transform-sdk/rust/sr-sys/src/lib.rs
@@ -1,0 +1,115 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An internal crate providing the ABI contract for Redpanda's Data Transform Schema Registry
+//! Client.
+//!
+//! If you are looking to use transform's schema registry client you probably want crate
+//! [redpanda-transform-sdk-sr](https://crates.io/crates/redpanda-transform-sdk-sr).
+
+#[cfg(target_os = "wasi")]
+mod abi;
+#[cfg(not(target_os = "wasi"))]
+mod stub_abi;
+use abi::{get_schema_definition, get_schema_subject};
+#[cfg(not(target_os = "wasi"))]
+use stub_abi as abi;
+mod serde;
+
+use redpanda_transform_sdk_sr_types::*;
+use redpanda_transform_sdk_varint as varint;
+
+#[derive(Default, Debug)]
+pub struct AbiSchemaRegistryClient {}
+
+impl AbiSchemaRegistryClient {
+    pub fn new() -> AbiSchemaRegistryClient {
+        Self {}
+    }
+}
+
+impl SchemaRegistryClientImpl for AbiSchemaRegistryClient {
+    fn lookup_schema_by_id(&self, id: SchemaId) -> Result<Schema> {
+        let mut length: i32 = 0;
+        let errno = abi::get_schema_definition_len(id.0, &mut length);
+        if errno != 0 {
+            return Err(SchemaRegistryError::Unknown(errno));
+        }
+        let mut buf = vec![0; length as usize];
+        let errno_or_amt = get_schema_definition(id.0, buf.as_mut_ptr(), buf.len() as i32);
+        if errno_or_amt < 0 {
+            return Err(SchemaRegistryError::Unknown(errno_or_amt));
+        }
+        serde::decode_schema_def(&buf[0..errno_or_amt as usize])
+    }
+
+    fn lookup_schema_by_version(
+        &self,
+        subject: &str,
+        version: SchemaVersion,
+    ) -> Result<SubjectSchema> {
+        let mut length: i32 = 0;
+        let errno = abi::get_schema_subject_len(
+            subject.as_ptr(),
+            subject.len() as i32,
+            version.0,
+            &mut length,
+        );
+        if errno != 0 {
+            return Err(SchemaRegistryError::Unknown(errno));
+        }
+        let mut buf = vec![0; length as usize];
+        let errno_or_amt = get_schema_subject(
+            subject.as_ptr(),
+            subject.len() as i32,
+            version.0,
+            buf.as_mut_ptr(),
+            buf.len() as i32,
+        );
+        if errno_or_amt < 0 {
+            return Err(SchemaRegistryError::Unknown(errno_or_amt));
+        }
+        serde::decode_schema(subject, &buf[0..errno_or_amt as usize])
+    }
+
+    fn lookup_latest_schema(&self, subject: &str) -> Result<SubjectSchema> {
+        self.lookup_schema_by_version(subject, SchemaVersion(-1))
+    }
+
+    fn create_schema(&mut self, subject: &str, schema: Schema) -> Result<SubjectSchema> {
+        let mut buf = Vec::with_capacity(schema.schema().len() + (varint::MAX_LENGTH * 2));
+        serde::encode_schema_def(&mut buf, &schema);
+        let mut schema_id: i32 = 0;
+        // TODO: It was currently an oversight that schema registry does not correctly set the
+        // version here (take it as a parameter to this method), we should bump the ABI and
+        // expose that method.
+        let schema_version: i32 = 0;
+        let errno = abi::create_subject_schema(
+            subject.as_ptr(),
+            subject.len() as i32,
+            buf.as_ptr(),
+            buf.len() as i32,
+            &mut schema_id,
+        );
+        if errno != 0 {
+            return Err(SchemaRegistryError::Unknown(errno));
+        }
+        Ok(SubjectSchema::new(
+            schema,
+            subject,
+            SchemaVersion(schema_version),
+            SchemaId(schema_id),
+        ))
+    }
+}

--- a/src/transform-sdk/rust/sr-sys/src/serde.rs
+++ b/src/transform-sdk/rust/sr-sys/src/serde.rs
@@ -1,0 +1,117 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use redpanda_transform_sdk_sr_types::*;
+use redpanda_transform_sdk_varint as varint;
+
+pub(crate) fn decode_schema(subject: &str, buf: &[u8]) -> Result<SubjectSchema> {
+    let decoded = varint::read(buf)?;
+    let id = SchemaId(decoded.value as i32);
+    let buf = &buf[decoded.read..];
+    let decoded = varint::read(buf)?;
+    let version = SchemaVersion(decoded.value as i32);
+    let buf = &buf[decoded.read..];
+    let schema = decode_schema_def(buf)?;
+    Ok(SubjectSchema::new(schema, subject, version, id))
+}
+
+pub(crate) fn decode_schema_def(buf: &[u8]) -> Result<Schema> {
+    let decoded = varint::read(buf)?;
+    let format = match decoded.value {
+        0 => SchemaFormat::Avro,
+        1 => SchemaFormat::Protobuf,
+        2 => SchemaFormat::Json,
+        _ => return Err(SchemaRegistryError::Unknown(-1)),
+    };
+    let buf = &buf[decoded.read..];
+    let decoded = varint::read_sized_buffer(buf)?;
+    let buf = &buf[decoded.read..];
+    let schema = String::from_utf8(decoded.value.unwrap_or_default().into())?;
+    let decoded = varint::read(buf)?;
+    let mut references: Vec<Reference> = Vec::with_capacity(decoded.value as usize);
+    let mut buf = &buf[decoded.read..];
+    for _ in 0..decoded.value {
+        let decoded = varint::read_sized_buffer(buf)?;
+        buf = &buf[decoded.read..];
+        let name = String::from_utf8(decoded.value.unwrap_or_default().into())?;
+        let decoded = varint::read_sized_buffer(buf)?;
+        buf = &buf[decoded.read..];
+        let subject = String::from_utf8(decoded.value.unwrap_or_default().into())?;
+        let decoded = varint::read(buf)?;
+        buf = &buf[decoded.read..];
+        let version = SchemaVersion(decoded.value as i32);
+        references.push(Reference::new(name, subject, version));
+    }
+    Ok(Schema::new(schema, format, references))
+}
+
+pub(crate) fn encode_schema_def(buf: &mut Vec<u8>, schema: &Schema) {
+    varint::write(
+        buf,
+        match schema.format() {
+            SchemaFormat::Avro => 0,
+            SchemaFormat::Protobuf => 1,
+            SchemaFormat::Json => 2,
+        },
+    );
+    varint::write_sized_buffer(buf, Some(schema.schema().as_bytes()));
+    varint::write(buf, schema.references().len() as i64);
+    for reference in schema.references() {
+        varint::write_sized_buffer(buf, Some(reference.name().as_bytes()));
+        varint::write_sized_buffer(buf, Some(reference.subject().as_bytes()));
+        varint::write(buf, reference.version().0 as i64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use redpanda_transform_sdk_sr_types::SchemaFormat;
+
+    use super::{decode_schema_def, encode_schema_def, Reference, Schema, SchemaVersion};
+
+    #[test]
+    fn roundtrip() {
+        let schema = Schema::new(
+            r#"{
+                  "type": "record",
+                  "namespace": "com.example.school",
+                  "name": "Student",
+                  "fields": [
+                    {
+                      "name": "Name",
+                      "type": "string"
+                    },
+                    {
+                      "name": "Age",
+                      "type": "int"
+                    },
+                    {
+                      "name": "Address",
+                      "type": "com.example.school.Address"
+                    }
+                  ]
+                }"#,
+            SchemaFormat::Avro,
+            vec![Reference::new(
+                "com.example.school.Address",
+                "Address",
+                SchemaVersion(1),
+            )],
+        );
+        let mut buf = vec![];
+        encode_schema_def(&mut buf, &schema);
+        let roundtripped = decode_schema_def(&buf).unwrap();
+        assert_eq!(schema, roundtripped);
+    }
+}

--- a/src/transform-sdk/rust/sr-sys/src/stub_abi.rs
+++ b/src/transform-sdk/rust/sr-sys/src/stub_abi.rs
@@ -1,0 +1,50 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub(crate) fn get_schema_definition_len(_schema_id: i32, _len: *mut i32) -> i32 {
+    panic!();
+}
+
+pub(crate) fn get_schema_definition(_schema_id: i32, _buf: *mut u8, _len: i32) -> i32 {
+    panic!();
+}
+
+pub(crate) fn get_schema_subject_len(
+    _subject: *const u8,
+    _subject_len: i32,
+    _version: i32,
+    _len: *mut i32,
+) -> i32 {
+    panic!();
+}
+
+pub(crate) fn get_schema_subject(
+    _subject: *const u8,
+    _subject_len: i32,
+    _version: i32,
+    _buf: *mut u8,
+    _len: i32,
+) -> i32 {
+    panic!();
+}
+
+pub(crate) fn create_subject_schema(
+    _subject: *const u8,
+    _subject_len: i32,
+    _buf: *const u8,
+    _len: i32,
+    _schema_id_out: *mut i32,
+) -> i32 {
+    panic!();
+}

--- a/src/transform-sdk/rust/sr-types/Cargo.toml
+++ b/src/transform-sdk/rust/sr-types/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "redpanda-transform-sdk-sr-types"
+description = "Types for redpanda-transform-sdk-sr"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+redpanda-transform-sdk-varint = { path = "../varint", version = "=0.0.0-dev" }

--- a/src/transform-sdk/rust/sr-types/README.md
+++ b/src/transform-sdk/rust/sr-types/README.md
@@ -1,0 +1,5 @@
+# Redpanda Data Transforms Schema Registry Client Rust SDK - Shared Types
+
+This is an internal crate as part of Redpanda's Data Transforms Schema Registry SDK, to provide shared types to other crates.
+
+If you are looking to use transform's Schema Registry client you probably want crate [redpanda-transform-sdk-sr](https://crates.io/crates/redpanda-transform-sdk).

--- a/src/transform-sdk/rust/sr-types/src/lib.rs
+++ b/src/transform-sdk/rust/sr-types/src/lib.rs
@@ -1,0 +1,250 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! An internal crate providing shared types for Redpanda's Data Transforms Schema Registry client.
+//!
+//! If you are looking to use schema registry within transforms you probably want crate
+//! [redpanda-transform-sdk-sr](https://crates.io/crates/redpanda-transform-sdk-sr). These types are
+//! re-exported there for usage.
+
+use std::string::FromUtf8Error;
+
+use redpanda_transform_sdk_varint as varint;
+
+/// SchemaFormat is an enum that represents the different types of schemas stored in schema registry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SchemaFormat {
+    Avro,
+    Protobuf,
+    Json,
+}
+
+/// SchemaId is a type for the registered ID of a schema.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SchemaId(pub i32);
+
+/// SchemaVersion is the version of a schema under a subject within the schema registry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct SchemaVersion(pub i32);
+
+/// Reference is a way for a one schema to reference another. The details
+/// for how referencing is done are type specific; for example, JSON objects
+/// that use the key "$ref" can refer to another schema via URL. For more details
+/// on references, see the following link:
+///
+///  https://docs.redpanda.com/current/manage/schema-reg/schema-reg-api/#reference-a-schema
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Reference {
+    name: String,
+    subject: String,
+    version: SchemaVersion,
+}
+
+impl Reference {
+    /// Create a new reference from a name, subject and version of a registered schema
+    pub fn new(
+        name: impl Into<String>,
+        subject: impl Into<String>,
+        version: SchemaVersion,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            subject: subject.into(),
+            version,
+        }
+    }
+
+    /// Get the name of the reference
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the subject of the referenced schema
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// Get the version of the referenced schema
+    pub fn version(&self) -> SchemaVersion {
+        self.version
+    }
+}
+
+/// Schema is a schema that can be registered within schema registry
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Schema {
+    schema: String,
+    format: SchemaFormat,
+    references: Vec<Reference>,
+}
+
+impl Schema {
+    /// Create a new schema with a given format and references
+    pub fn new(
+        schema: impl Into<String>,
+        format: SchemaFormat,
+        references: Vec<Reference>,
+    ) -> Self {
+        Self {
+            schema: schema.into(),
+            format,
+            references,
+        }
+    }
+
+    /// Create a new avro schema with the given references
+    pub fn new_avro(schema: String, references: Vec<Reference>) -> Self {
+        Self::new(schema, SchemaFormat::Avro, references)
+    }
+
+    /// Create a new protobuf schema with the given references
+    pub fn new_protobuf(schema: String, references: Vec<Reference>) -> Self {
+        Self::new(schema, SchemaFormat::Protobuf, references)
+    }
+
+    /// Get the textual format of the schema
+    pub fn schema(&self) -> &str {
+        self.schema.as_ref()
+    }
+
+    /// Get the format of this schema
+    pub fn format(&self) -> &SchemaFormat {
+        &self.format
+    }
+
+    /// Get all the schemas that are referenced in this schema
+    pub fn references(&self) -> &[Reference] {
+        self.references.as_ref()
+    }
+}
+
+/// SubjectSchema is a schema along with the subject, version and ID of the schema in the schema
+/// registry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SubjectSchema {
+    schema: Schema,
+
+    subject: String,
+    version: SchemaVersion,
+    id: SchemaId,
+}
+
+impl SubjectSchema {
+    /// Create a new schema that has been registered in the schema registry under the given
+    /// subject/version and ID.
+    pub fn new(
+        schema: Schema,
+        subject: impl Into<String>,
+        version: SchemaVersion,
+        id: SchemaId,
+    ) -> Self {
+        Self {
+            schema,
+            subject: subject.into(),
+            version,
+            id,
+        }
+    }
+
+    /// Get the schema that was registered.
+    pub fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    /// The subject that the schema was registered under.
+    pub fn subject(&self) -> &str {
+        self.subject.as_ref()
+    }
+
+    /// The version that the schema was registered under.
+    pub fn version(&self) -> SchemaVersion {
+        self.version
+    }
+
+    /// The ID that the schema was registered under.
+    pub fn id(&self) -> SchemaId {
+        self.id
+    }
+}
+
+/// An error that can occur interacting with the schema registry
+#[derive(Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SchemaRegistryError {
+    /// Unknown error from the registry with the corresponding error code.
+    Unknown(i32),
+    DecodingError(varint::DecodeError),
+    UnknownFormat(i64),
+    InvalidSchema,
+}
+
+impl std::fmt::Display for SchemaRegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SchemaRegistryError::Unknown(errno) => {
+                write!(f, "writing record failed with errno: {}", errno)
+            }
+            SchemaRegistryError::DecodingError(err) => {
+                write!(f, "unable to decode broker data: {}", err)
+            }
+            SchemaRegistryError::UnknownFormat(id) => {
+                write!(f, "unknown format with ID: {}", id)
+            }
+            SchemaRegistryError::InvalidSchema => {
+                write!(f, "invalid utf8 in schema")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SchemaRegistryError {}
+
+impl From<varint::DecodeError> for SchemaRegistryError {
+    fn from(err: varint::DecodeError) -> Self {
+        SchemaRegistryError::DecodingError(err)
+    }
+}
+
+impl From<FromUtf8Error> for SchemaRegistryError {
+    fn from(_: FromUtf8Error) -> Self {
+        SchemaRegistryError::InvalidSchema
+    }
+}
+
+/// A result type for the schema registry where errors are SchemaRegistryError.
+pub type Result<T> = std::result::Result<T, SchemaRegistryError>;
+
+/// A client for interacting with the schema registry within Redpanda.
+pub trait SchemaRegistryClientImpl {
+    /// Lookup a schema via it's global ID.
+    fn lookup_schema_by_id(&self, id: SchemaId) -> Result<Schema>;
+
+    /// Lookup a schema for a given subject at a specific version.
+    fn lookup_schema_by_version(
+        &self,
+        subject: &str,
+        version: SchemaVersion,
+    ) -> Result<SubjectSchema>;
+
+    /// Lookup the latest schema for a subject.
+    fn lookup_latest_schema(&self, subject: &str) -> Result<SubjectSchema>;
+
+    /// Create a schema in the schema registry under the given subject, returning the version and
+    /// ID.
+    ///
+    /// If an equivalent schema already exists globally, that schema ID will be reused.
+    /// If an equivalent schema already exists within that subject, this will be a noop and the
+    /// existing schema version will be returned.
+    fn create_schema(&mut self, subject: &str, schema: Schema) -> Result<SubjectSchema>;
+}

--- a/src/transform-sdk/rust/sr-types/src/lib.rs
+++ b/src/transform-sdk/rust/sr-types/src/lib.rs
@@ -14,7 +14,7 @@
 
 //! An internal crate providing shared types for Redpanda's Data Transforms Schema Registry client.
 //!
-//! If you are looking to use schema registry within transforms you probably want crate
+//! If you are looking to use Schema Registry within transforms you probably want crate
 //! [redpanda-transform-sdk-sr](https://crates.io/crates/redpanda-transform-sdk-sr). These types are
 //! re-exported there for usage.
 
@@ -22,7 +22,7 @@ use std::string::FromUtf8Error;
 
 use redpanda_transform_sdk_varint as varint;
 
-/// SchemaFormat is an enum that represents the different types of schemas stored in schema registry.
+/// SchemaFormat is an enum that represents the schema formats supported in the Schema Registry.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SchemaFormat {
     Avro,
@@ -34,12 +34,12 @@ pub enum SchemaFormat {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SchemaId(pub i32);
 
-/// SchemaVersion is the version of a schema under a subject within the schema registry.
+/// SchemaVersion is the version of a schema for a subject within the Schema Registry.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SchemaVersion(pub i32);
 
-/// Reference is a way for a one schema to reference another. The details
-/// for how referencing is done are type specific; for example, JSON objects
+/// Reference is a way for one schema to reference another. The details
+/// for how referencing is done are type-specific; for example, JSON objects
 /// that use the key "$ref" can refer to another schema via URL. For more details
 /// on references, see the following link:
 ///
@@ -81,7 +81,7 @@ impl Reference {
     }
 }
 
-/// Schema is a schema that can be registered within schema registry
+/// Schema is a schema that can be registered within Schema Registry
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Schema {
     schema: String,
@@ -141,7 +141,7 @@ pub struct SubjectSchema {
 }
 
 impl SubjectSchema {
-    /// Create a new schema that has been registered in the schema registry under the given
+    /// Create a new schema that has been registered in the Schema Registry under the given
     /// subject/version and ID.
     pub fn new(
         schema: Schema,
@@ -178,7 +178,7 @@ impl SubjectSchema {
     }
 }
 
-/// An error that can occur interacting with the schema registry
+/// An error that can occur when interacting with the Schema Registry
 #[derive(Debug, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum SchemaRegistryError {
@@ -222,12 +222,12 @@ impl From<FromUtf8Error> for SchemaRegistryError {
     }
 }
 
-/// A result type for the schema registry where errors are SchemaRegistryError.
+/// A result type for the Schema Registry where errors are SchemaRegistryError.
 pub type Result<T> = std::result::Result<T, SchemaRegistryError>;
 
-/// A client for interacting with the schema registry within Redpanda.
+/// A client for interacting with the Schema Registry within Redpanda.
 pub trait SchemaRegistryClientImpl {
-    /// Lookup a schema via it's global ID.
+    /// Lookup a schema via its global ID.
     fn lookup_schema_by_id(&self, id: SchemaId) -> Result<Schema>;
 
     /// Lookup a schema for a given subject at a specific version.
@@ -240,7 +240,7 @@ pub trait SchemaRegistryClientImpl {
     /// Lookup the latest schema for a subject.
     fn lookup_latest_schema(&self, subject: &str) -> Result<SubjectSchema>;
 
-    /// Create a schema in the schema registry under the given subject, returning the version and
+    /// Create a schema in the Schema Registry under the given subject, returning the version and
     /// ID.
     ///
     /// If an equivalent schema already exists globally, that schema ID will be reused.

--- a/src/transform-sdk/rust/sr/Cargo.toml
+++ b/src/transform-sdk/rust/sr/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "redpanda-transform-sdk-sr"
+description = "A Schema Registry Client for Redpanda Data Transforms."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dependencies]
+redpanda-transform-sdk-sr-types = { path = "../sr-types", version = "=0.0.0-dev" }
+redpanda-transform-sdk-sr-sys = { path = "../sr-sys", version = "=0.0.0-dev" }

--- a/src/transform-sdk/rust/sr/README.md
+++ b/src/transform-sdk/rust/sr/README.md
@@ -1,0 +1,3 @@
+# Redpanda Data Transforms Schema Registry Client Rust SDK
+
+This crate provides access to Redpanda's Data Transform's Schema Registry Client.

--- a/src/transform-sdk/rust/sr/src/lib.rs
+++ b/src/transform-sdk/rust/sr/src/lib.rs
@@ -1,0 +1,81 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Redpanda Data Transforms Rust Schema Registry Client library.
+//!
+//! Within Data Transforms access is provided to schema registry built-in to Redpanda.
+//! This client is the provided interface to read and write schemas within the registry.
+
+use redpanda_transform_sdk_sr_sys::AbiSchemaRegistryClient;
+pub use redpanda_transform_sdk_sr_types::*;
+
+/// A client for interacting with the schema registry within Redpanda.
+pub struct SchemaRegistryClient {
+    delegate: Box<dyn SchemaRegistryClientImpl>,
+}
+
+impl SchemaRegistryClient {
+    /// Create a new default schema registry client that connects to Redpanda's Schema Registry
+    /// when running within the context of a data transform.
+    pub fn new() -> Self {
+        Self::new_wrapping(Box::new(AbiSchemaRegistryClient::new()))
+    }
+
+    /// Create a new custom schema registry client wrapping the implementation.
+    ///
+    /// This is useful in testing when you want to inject a mock client.
+    pub fn new_wrapping(delegate: Box<dyn SchemaRegistryClientImpl>) -> Self {
+        Self { delegate }
+    }
+
+    /// Lookup a schema via it's global ID.
+    pub fn lookup_schema_by_id(&self, id: SchemaId) -> Result<Schema> {
+        self.delegate.lookup_schema_by_id(id)
+    }
+
+    /// Lookup a schema for a given subject at a specific version.
+    pub fn lookup_schema_by_version(
+        &self,
+        subject: impl AsRef<str>,
+        version: SchemaVersion,
+    ) -> Result<SubjectSchema> {
+        self.delegate
+            .lookup_schema_by_version(subject.as_ref(), version)
+    }
+
+    /// Lookup the latest schema for a subject.
+    pub fn lookup_latest_schema(&self, subject: impl AsRef<str>) -> Result<SubjectSchema> {
+        self.delegate.lookup_latest_schema(subject.as_ref())
+    }
+
+    /// Create a schema in the schema registry under the given subject, returning the version and
+    /// ID.
+    ///
+    /// If an equivalent schema already exists globally, that schema ID will be reused.
+    /// If an equivalent schema already exists within that subject, this will be a noop and the
+    /// existing schema version will be returned.
+    pub fn create_schema(
+        &mut self,
+        subject: impl AsRef<str>,
+        schema: Schema,
+    ) -> Result<SubjectSchema> {
+        self.delegate.create_schema(subject.as_ref(), schema)
+    }
+}
+
+impl Default for SchemaRegistryClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/transform-sdk/rust/sr/src/lib.rs
+++ b/src/transform-sdk/rust/sr/src/lib.rs
@@ -14,32 +14,32 @@
 
 //! Redpanda Data Transforms Rust Schema Registry Client library.
 //!
-//! Within Data Transforms access is provided to schema registry built-in to Redpanda.
+//! Access to the Schema Registry built into Redpanda is available within data transforms.
 //! This client is the provided interface to read and write schemas within the registry.
 
 use redpanda_transform_sdk_sr_sys::AbiSchemaRegistryClient;
 pub use redpanda_transform_sdk_sr_types::*;
 
-/// A client for interacting with the schema registry within Redpanda.
+/// A client for interacting with the Schema Registry within Redpanda.
 pub struct SchemaRegistryClient {
     delegate: Box<dyn SchemaRegistryClientImpl>,
 }
 
 impl SchemaRegistryClient {
-    /// Create a new default schema registry client that connects to Redpanda's Schema Registry
+    /// Create a new default Schema Registry client that connects to Redpanda's Schema Registry
     /// when running within the context of a data transform.
     pub fn new() -> Self {
         Self::new_wrapping(Box::new(AbiSchemaRegistryClient::new()))
     }
 
-    /// Create a new custom schema registry client wrapping the implementation.
+    /// Create a new custom Schema Registry client wrapping the implementation.
     ///
     /// This is useful in testing when you want to inject a mock client.
     pub fn new_wrapping(delegate: Box<dyn SchemaRegistryClientImpl>) -> Self {
         Self { delegate }
     }
 
-    /// Lookup a schema via it's global ID.
+    /// Lookup a schema via its global ID.
     pub fn lookup_schema_by_id(&self, id: SchemaId) -> Result<Schema> {
         self.delegate.lookup_schema_by_id(id)
     }
@@ -59,7 +59,7 @@ impl SchemaRegistryClient {
         self.delegate.lookup_latest_schema(subject.as_ref())
     }
 
-    /// Create a schema in the schema registry under the given subject, returning the version and
+    /// Create a schema in the Schema Registry under the given subject, returning the version and
     /// ID.
     ///
     /// If an equivalent schema already exists globally, that schema ID will be reused.

--- a/src/transform-sdk/rust/varint/Cargo.toml
+++ b/src/transform-sdk/rust/varint/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "redpanda-transform-sdk-varint"
+description = "Varint decoding for redpanda-transform-sdk"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+[dev-dependencies]
+quickcheck = { workspace = true }

--- a/src/transform-sdk/rust/varint/src/lib.rs
+++ b/src/transform-sdk/rust/varint/src/lib.rs
@@ -15,7 +15,7 @@
 use core::fmt;
 use std::error::Error;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum DecodeError {
     Overflow,
     ShortRead,

--- a/src/transform-sdk/rust/varint/src/lib.rs
+++ b/src/transform-sdk/rust/varint/src/lib.rs
@@ -61,7 +61,8 @@ impl<T> Decoded<T> {
     }
 }
 
-const MAX_LENGTH: usize = 10;
+// The maximum encoded size of an i64
+pub const MAX_LENGTH: usize = 10;
 
 fn zigzag_encode(x: i64) -> u64 {
     ((x << 1) ^ (x >> 63)) as u64

--- a/src/transform-sdk/rust/varint/src/lib.rs
+++ b/src/transform-sdk/rust/varint/src/lib.rs
@@ -16,7 +16,7 @@ use core::fmt;
 use std::error::Error;
 
 #[derive(Debug)]
-pub(crate) enum VarintDecodeError {
+pub enum DecodeError {
     Overflow,
     ShortRead,
     ShortReadBuffer {
@@ -25,14 +25,14 @@ pub(crate) enum VarintDecodeError {
     },
 }
 
-impl Error for VarintDecodeError {}
+impl Error for DecodeError {}
 
-impl fmt::Display for VarintDecodeError {
+impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            VarintDecodeError::Overflow => write!(f, "decoded varint would overflow i64::MAX"),
-            VarintDecodeError::ShortRead => write!(f, "short read when decoding varint"),
-            VarintDecodeError::ShortReadBuffer {
+            DecodeError::Overflow => write!(f, "decoded varint would overflow i64::MAX"),
+            DecodeError::ShortRead => write!(f, "short read when decoding varint"),
+            DecodeError::ShortReadBuffer {
                 buf_size,
                 payload_remaining,
             } => write!(
@@ -44,10 +44,10 @@ impl fmt::Display for VarintDecodeError {
     }
 }
 
-type Result<T> = std::result::Result<T, VarintDecodeError>;
+pub type Result<T> = std::result::Result<T, DecodeError>;
 
 #[derive(PartialEq, Eq)]
-pub(crate) struct Decoded<T> {
+pub struct Decoded<T> {
     pub value: T,
     pub read: usize,
 }
@@ -76,7 +76,7 @@ fn read_unsigned(payload: &[u8]) -> Result<Decoded<u64>> {
     let mut shift = 0;
     for (i, b) in payload.iter().enumerate() {
         if i >= MAX_LENGTH {
-            return Err(VarintDecodeError::Overflow);
+            return Err(DecodeError::Overflow);
         }
         decoded |= ((b & 0x7F) as u64) << shift;
         if b & 0x80 == 0 {
@@ -87,14 +87,14 @@ fn read_unsigned(payload: &[u8]) -> Result<Decoded<u64>> {
         }
         shift += 7;
     }
-    Err(VarintDecodeError::ShortRead)
+    Err(DecodeError::ShortRead)
 }
 
-pub(crate) fn read(payload: &[u8]) -> Result<Decoded<i64>> {
+pub fn read(payload: &[u8]) -> Result<Decoded<i64>> {
     read_unsigned(payload).map(|r| r.map(zigzag_decode))
 }
 
-pub(crate) fn read_sized_buffer(payload: &[u8]) -> Result<Decoded<Option<&[u8]>>> {
+pub fn read_sized_buffer(payload: &[u8]) -> Result<Decoded<Option<&[u8]>>> {
     let result = read(payload)?;
     if result.value < 0 {
         return Ok(result.map(|_| None));
@@ -102,7 +102,7 @@ pub(crate) fn read_sized_buffer(payload: &[u8]) -> Result<Decoded<Option<&[u8]>>
     let payload = &payload[result.read..];
     let buf_size = result.value as usize;
     if buf_size > payload.len() {
-        return Err(VarintDecodeError::ShortReadBuffer {
+        return Err(DecodeError::ShortReadBuffer {
             buf_size,
             payload_remaining: payload.len(),
         });
@@ -122,11 +122,11 @@ fn write_unsigned(payload: &mut Vec<u8>, mut v: u64) {
     payload.push(v as u8);
 }
 
-pub(crate) fn write(payload: &mut Vec<u8>, v: i64) {
+pub fn write(payload: &mut Vec<u8>, v: i64) {
     write_unsigned(payload, zigzag_encode(v))
 }
 
-pub(crate) fn write_sized_buffer(payload: &mut Vec<u8>, buf: Option<&[u8]>) {
+pub fn write_sized_buffer(payload: &mut Vec<u8>, buf: Option<&[u8]>) {
     match buf {
         Some(b) => {
             write(payload, b.len() as i64);
@@ -142,6 +142,8 @@ mod tests {
         read, read_sized_buffer, read_unsigned, write, write_sized_buffer, write_unsigned,
         zigzag_decode, zigzag_encode,
     };
+
+    use quickcheck::quickcheck;
 
     quickcheck! {
         fn zigzag(n: i64) -> bool {


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/redpanda/issues/16075

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Features

* Data Transform's Rust SDK now supports a Schema Registry Client.

