### PR TITLE
cloud_storage: Add watchdog utility and use it to detect stuck eviction loop

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1054,6 +1054,9 @@ remote_partition::aborted_transactions(offset_range offsets) {
 
 ss::future<> remote_partition::stop() {
     vlog(_ctxlog.debug, "remote partition stop {} segments", _segments.size());
+    watchdog wd(300s, [ntp = get_ntp()] {
+        vlog(cst_log.error, "remote_partition {} stop operation stuck", ntp);
+    });
 
     // Prevent further segment materialization, readers, etc.
     _as.request_abort();

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -850,13 +850,13 @@ ss::future<> remote_partition::start() {
 
 void remote_partition::evict_segment_reader(
   std::unique_ptr<remote_segment_batch_reader> reader) {
-    _eviction_pending.push_back(std::move(reader));
+    _eviction_pending.emplace_back(std::move(reader));
     _has_evictions_cvar.signal();
 }
 
 void remote_partition::evict_segment(
   ss::lw_shared_ptr<remote_segment> segment) {
-    _eviction_pending.push_back(std::move(segment));
+    _eviction_pending.emplace_back(std::move(segment));
     _has_evictions_cvar.signal();
 }
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -832,7 +832,8 @@ remote_partition::remote_partition(
   cache& c,
   cloud_storage_clients::bucket_name bucket,
   partition_probe& probe)
-  : _rtc(_as)
+  : _ntp(m->get_ntp())
+  , _rtc(_as)
   , _ctxlog(cst_log, _rtc, m->get_ntp().path())
   , _api(api)
   , _cache(c)
@@ -870,7 +871,7 @@ ss::future<> remote_partition::run_eviction_loop() {
         // got stuck. The deadline is set to 5 minutes to avoid false positives.
         // The callback is self sufficient and can outlive the remote_partition
         // instance.
-        watchdog wd(300s, [ntp = get_ntp()] {
+        watchdog wd(300s, [ntp = _ntp] {
             vlog(cst_log.error, "Eviction loop for partition {} stuck", ntp);
         });
         auto eviction_in_flight = std::exchange(_eviction_pending, {});
@@ -898,7 +899,7 @@ kafka::offset remote_partition::first_uploaded_offset() {
     vassert(
       _manifest_view->stm_manifest().size() > 0,
       "The manifest for {} is not expected to be empty",
-      _manifest_view->stm_manifest().get_ntp());
+      _ntp);
     auto so
       = _manifest_view->stm_manifest().full_log_start_kafka_offset().value();
     vlog(_ctxlog.trace, "remote partition first_uploaded_offset: {}", so);
@@ -909,15 +910,13 @@ kafka::offset remote_partition::next_kafka_offset() {
     vassert(
       _manifest_view->stm_manifest().size() > 0,
       "The manifest for {} is not expected to be empty",
-      _manifest_view->get_ntp());
+      _ntp);
     auto next = _manifest_view->stm_manifest().get_next_kafka_offset().value();
     vlog(_ctxlog.debug, "remote partition next_kafka_offset: {}", next);
     return next;
 }
 
-const model::ntp& remote_partition::get_ntp() const {
-    return _manifest_view->get_ntp();
-}
+const model::ntp& remote_partition::get_ntp() const { return _ntp; }
 
 bool remote_partition::is_data_available() const {
     const auto& stmm = _manifest_view->stm_manifest();
@@ -1309,7 +1308,7 @@ void remote_partition::finalize() {
     auto serialized_manifest = stm_manifest.to_iobuf();
 
     finalize_data data{
-      .ntp = stm_manifest.get_ntp(),
+      .ntp = get_ntp(),
       .revision = stm_manifest.get_revision_id(),
       .bucket = _bucket,
       .key

--- a/src/v/cloud_storage/remote_partition.h
+++ b/src/v/cloud_storage/remote_partition.h
@@ -217,6 +217,7 @@ private:
     iterator get_or_materialize_segment(
       const remote_segment_path& path, const segment_meta&, segment_units);
 
+    model::ntp _ntp;
     retry_chain_node _rtc;
     retry_chain_logger _ctxlog;
     ss::gate _gate;

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -28,6 +28,7 @@
 #include "resource_mgmt/io_priority.h"
 #include "ssx/future-util.h"
 #include "ssx/sformat.h"
+#include "ssx/watchdog.h"
 #include "storage/parser.h"
 #include "storage/segment_index.h"
 #include "utils/retry_chain_node.h"
@@ -242,6 +243,10 @@ ss::future<> remote_segment::stop() {
         vlog(_ctxlog.warn, "remote segment {} already stopped", _path);
         co_return;
     }
+
+    watchdog wd(300s, [path = _path] {
+        vlog(cst_log.error, "remote_segment {} stop operation stuck", path);
+    });
 
     vlog(_ctxlog.debug, "remote segment stop");
     _bg_cvar.broken();

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1465,6 +1465,13 @@ ss::future<> remote_segment_batch_reader::stop() {
         co_return;
     }
 
+    watchdog wd(300s, [path = _seg->get_segment_path()] {
+        vlog(
+          cst_log.error,
+          "remote_segment_batch_reader {} stop operation stuck",
+          path);
+    });
+
     vlog(
       _ctxlog.debug,
       "[{}] remote_segment_batch_reader::stop",

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ rp_test(
     thread_worker.cc
     sleep_abortable_test.cc
     task_local_ptr_test.cc
+    watchdog_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v::ssx
   LABELS ssx

--- a/src/v/ssx/tests/watchdog_test.cc
+++ b/src/v/ssx/tests/watchdog_test.cc
@@ -1,0 +1,41 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "ssx/watchdog.h"
+
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/manual_clock.hh>
+#include <seastar/testing/thread_test_case.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+using namespace std::chrono_literals;
+
+SEASTAR_THREAD_TEST_CASE(watchdog_test_defuse) {
+    bool watchdog_triggered = false;
+    {
+        watchdog wd(100ms, [&] { watchdog_triggered = true; });
+        // to allow some async code to run
+        ss::sleep(1ms).get();
+    }
+    ss::sleep(1ms).get();
+    BOOST_REQUIRE(watchdog_triggered == false);
+    // watchdog timeout passed
+    ss::sleep(200ms).get();
+    BOOST_REQUIRE(watchdog_triggered == false);
+}
+
+SEASTAR_THREAD_TEST_CASE(watchdog_test_trigger) {
+    bool watchdog_triggered = false;
+    {
+        watchdog wd(100ms, [&] { watchdog_triggered = true; });
+        ss::sleep(200ms).get();
+    }
+    BOOST_REQUIRE(watchdog_triggered == true);
+}

--- a/src/v/ssx/watchdog.h
+++ b/src/v/ssx/watchdog.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/vassert.h"
+#include "ssx/future-util.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/util/noncopyable_function.hh>
+
+/// This tool can be used to detect anomalously long
+/// running operations or stuck async loops.
+/// You can create an instance of 'watchdog' and pass
+/// a timestamp and a callback. The callback will be
+/// invoked when the timeout expires.
+///
+/// Code sample below:
+/// \code
+///   ss::future<> service::close() {
+///     watchdog wd(10s, [] { vlog(log.error, "service::close hang"); });
+///     _as.request_abort();
+///     co_await _gate.close(); // op. can potentially hang
+///   }
+/// \endcode
+///
+/// Note that you can't pass an abort_source. It's expected that when
+/// the subsystem protected by the watchdog is shutting down using its
+/// own abort_source the 'watchdog' instance will be quickly disposed.
+/// If the shutdown process is broken we want the 'watchdog' to detect
+/// this.
+///
+/// \warning The watchdog is not supposed to be used to invoke a lot of
+/// logic inside the callback (e.g. for general control flow). Its supposed to
+/// trigger logging or metric update. The lifetime of the underlying background
+/// fiber is not restricted by the lifetime of the watchdog so the callback
+/// should either be very simple (logging) or implement concurrency control
+/// externally using gate. Also, note that it's not possible to pass the
+/// abort_source. This is by design because we don't want to defuse the watchdog
+/// during shutdown because a lot of hangs happen during shutdown.
+class watchdog {
+public:
+    /// Create watchdog instance
+    ///
+    /// \param timeout defines time interval after which the watchdog will be
+    ///                triggered
+    /// \param deadline_reached is a callback that will be called when
+    ///                         the watchdog is triggered
+    /// \note The callback may outlive the watchdog
+    /// instance. To prevent lifetime issues one could use external
+    /// synchronization (hold a gate in the callback and close the gate outside
+    /// of the callback) or alternatively (and preferably) the callback should
+    /// be very simple, for instance, it should just log an error message.
+    watchdog(
+      seastar::lowres_clock::duration timeout,
+      seastar::noncopyable_function<void()> deadline_reached) {
+        start_waiting(timeout, std::move(deadline_reached));
+    }
+    // D-tor defuses the watchdog. The callback won't be called after this.
+    ~watchdog() {
+        // Cancellation happens asynchronously but its guaranteed that
+        // a. The background task never touches any fields of the 'watchdog'
+        //    which allows it to outlive the 'watchdog' instance.
+        // b. After cancellation it will never invoke any code other than code
+        //    which is used to ignore exceptions.
+        cancel();
+    }
+    watchdog(const watchdog&) = delete;
+    watchdog(watchdog&&) = delete;
+    watchdog& operator=(const watchdog&) = delete;
+    watchdog& operator=(watchdog&&) = delete;
+
+private:
+    void start_waiting(
+      seastar::lowres_clock::duration timeout,
+      seastar::noncopyable_function<void()> deadline_reached) {
+        ssx::background = ssx::ignore_shutdown_exceptions(
+          seastar::sleep_abortable(timeout, _as)
+            // copy the callback to the local state of the background fiber
+            .then([cb = std::move(deadline_reached)] { cb(); }));
+    }
+    void cancel() { _as.request_abort(); }
+    seastar::abort_source _as;
+};


### PR DESCRIPTION
Sometimes we want to detect situations when things are get stuck. Every
Redpanda service usually have a stop method which is invoked during
shutdown and which could prevent graceful shutdown when it hangs.
Another example is all types of eviction/housekeeping loops in the code.
When these loops are stuck Redpanda is running out of resources. We want
to be able to detect this.

The 'watchdog' utitily is a simple safeguard. When the object is created
it takes a timeout and a callback. When timeut expires the callback is
invoked. The watchdog can be created on a stack before the asynchronous
operation that can potentially get stuck.

Usage:
```
ss::future<> service: stop() {
  watchdog wd(10s, [] {
    vlog(logger.error, "service::stop hang");
  });
  _as.request_abort();
  co_await _gate.close();  //<-- operation that can potentially get stuck
}
```

This utility is used in the `remote_partition::run_eviction_loop` method. This is a background fiber that disposes the segments and readers asynchronously (it eliminates the need for the active reader to wait for the previous reader to stop). When this loop can't make progress we can run out of resources and all readers will get stuck. To detect this the `watchdog` is created. The callback of the watchdog logs error message.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Improves observability by allowing Redpanda to detect that some internal processes are stuck.