### PR TITLE
DNM: debug manifest content before spillover

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2470,9 +2470,10 @@ ss::future<> ntp_archiver::apply_spillover() {
     if (manifest_size_limit.has_value()) {
         vlog(
           _rtclog.debug,
-          "Manifest size: {}, manifest size limit (x2): {}",
+          "Manifest size: {}, manifest size limit (x2): {}, start offset: {}",
           manifest().segments_metadata_bytes(),
-          manifest_size_limit.value() * 2);
+          manifest_size_limit.value() * 2,
+          manifest().get_start_offset());
     } else {
         vlog(
           _rtclog.debug,


### PR DESCRIPTION
Debugging spillover error during `test_scrubber`

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* None