### PR TITLE
Improved handling of truncation with ACKS=1

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2028,10 +2028,13 @@ consensus::do_append_entries(append_entries_request&& r) {
         vlog(
           _ctxlog.info,
           "Truncating log in term: {}, Request previous log index: {} is "
-          "earlier than log end offset: {}. Truncating to: {}",
+          "earlier than log end offset: {}, last visible index: {}, leader "
+          "last visible index: {}. Truncating to: {}",
           request_metadata.term,
           request_metadata.prev_log_index,
           lstats.dirty_offset,
+          last_visible_index(),
+          _last_leader_visible_offset,
           truncate_at);
         _probe->log_truncated();
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2008,11 +2008,11 @@ consensus::do_append_entries(append_entries_request&& r) {
 
     // section 3
     if (request_metadata.prev_log_index < last_log_offset) {
-        if (unlikely(request_metadata.prev_log_index < _commit_index)) {
+        if (unlikely(request_metadata.prev_log_index < last_visible_index())) {
             reply.result = reply_result::success;
             // clamp dirty offset to the current commit index not to allow
             // leader reasoning about follower log beyond that point
-            reply.last_dirty_log_index = _commit_index;
+            reply.last_dirty_log_index = last_visible_index();
             reply.last_flushed_log_index = _commit_index;
             vlog(
               _ctxlog.info,


### PR DESCRIPTION
If an offset was already visible a follower must not be allowed to
truncate it as it may lead to a situation in which an offset is visible
and not readable.

Visible batches has the same replication guarantees as committed batches
as leader still waits for the majority to acknowledge message at given
offset before making it visible to the readers. This makes it possible
not to truncate offsets which were previously visible.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- Improved handling of follower fetching offset validation when used with relaxed consistency