### PR TITLE
transform/logging/test: deflake TransformLogManagerTest.LargeBuffer

### DIFF
--- a/src/v/transform/logging/tests/log_manager_test.cc
+++ b/src/v/transform/logging/tests/log_manager_test.cc
@@ -196,6 +196,10 @@ TEST_F(TransformLogManagerTest, LargeBuffer) {
         ss::maybe_yield().get();
     }
 
+    // Drain the task queue so that we don't get races where this advance should
+    // trigger the flush, but there is currently a pending flush, which doesn't
+    // acuse the advance_clock to actually trigger a flush.
+    tests::drain_task_queue().get();
     advance_clock();
 
     EXPECT_EQ(logs().size(), N);


### PR DESCRIPTION
I saw a test flake in CI for another PR and dove in to debug this test
via: `transform_logging_rpunit --gtest_repeat=1000 --gtest_break_on_failure`

Running that I quickly saw failures, and after turning on logs and added
a couple logs of my own, I saw that in debug mode because the scheduler
can reorder tasks, that there is a concurrent flush running when we
advance our manual clock (from the LWM flush), so the clock advance
doesn't do anything. Fix that by always awaiting for pending tasks to
finish before triggering the next flush.

After performing this change, I can now run 1000 iterations of this
test on debug mode without failures.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
