### PR TITLE
[v23.3.x] transform/logging/test: deflake TransformLogManagerTest.LargeBuffer

### DIFF
--- a/src/v/transform/logging/tests/log_manager_test.cc
+++ b/src/v/transform/logging/tests/log_manager_test.cc
@@ -196,6 +196,10 @@ TEST_F(TransformLogManagerTest, LargeBuffer) {
         ss::maybe_yield().get();
     }
 
+    // Drain the task queue so that we don't get races where this advance should
+    // trigger the flush, but there is currently a pending flush, which doesn't
+    // acuse the advance_clock to actually trigger a flush.
+    tests::drain_task_queue().get();
     advance_clock();
 
     EXPECT_EQ(logs().size(), N);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16478
