### PR TITLE
Wire `transform::logging::manager` into transform API, rpc client

### DIFF
--- a/src/transform-sdk/go/transform/internal/testdata/identity_logging/transform.go
+++ b/src/transform-sdk/go/transform/internal/testdata/identity_logging/transform.go
@@ -1,0 +1,31 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/transform"
+	"os"
+)
+
+func main() {
+	transform.OnRecordWritten(identityTransform)
+}
+
+func identityTransform(e transform.WriteEvent, w transform.RecordWriter) error {
+	fmt.Fprintf(os.Stderr,
+		"%s:%s\n", e.Record().Key[:], e.Record().Value[:])
+	return w.Write(e.Record())
+}

--- a/src/v/cluster/health_manager.cc
+++ b/src/v/cluster/health_manager.cc
@@ -198,6 +198,11 @@ ss::future<> health_manager::do_tick() {
             ok = co_await ensure_topic_replication(
               model::kafka_audit_logging_nt);
         }
+
+        if (ok) {
+            ok = co_await ensure_topic_replication(
+              model::transform_log_internal_nt);
+        }
     }
 
     _timer.arm(_tick_interval);

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -512,13 +512,19 @@ produce_topic(produce_ctx& octx, produce_request::topic& topic) {
                   .error_code = errc}));
         };
 
+        const bool is_transform_logs_topic
+          = topic.name == model::transform_log_internal_topic;
+
         const auto& kafka_noproduce_topics
           = config::shard_local_cfg().kafka_noproduce_topics();
-        const bool is_noproduce_topic = std::find(
-                                          kafka_noproduce_topics.begin(),
-                                          kafka_noproduce_topics.end(),
-                                          topic.name)
-                                        != kafka_noproduce_topics.end();
+
+        const bool is_noproduce_topic = is_transform_logs_topic
+                                        || std::find(
+                                             kafka_noproduce_topics.begin(),
+                                             kafka_noproduce_topics.end(),
+                                             topic.name)
+                                             != kafka_noproduce_topics.end();
+
         const bool audit_produce_restricted
           = !octx.rctx.authorized_auditor()
             && topic.name == model::kafka_audit_logging_topic();

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -1312,6 +1312,9 @@ delete_topics_handler::handle(request_context ctx, ss::smp_service_group) {
     if (config::shard_local_cfg().audit_enabled()) {
         kafka_nodelete_topics.push_back(model::kafka_audit_logging_topic());
     }
+    if (config::shard_local_cfg().data_transforms_enabled()) {
+        kafka_nodelete_topics.push_back(model::transform_log_internal_topic());
+    }
     auto nodelete_it = std::partition(
       request.data.topic_names.begin(),
       request.data.topic_names.end(),

--- a/src/v/model/namespace.h
+++ b/src/v/model/namespace.h
@@ -72,11 +72,18 @@ inline const model::ntp wasm_binaries_internal_ntp(
   model::topic("wasm_binaries"),
   model::partition_id(0));
 
+inline const model::topic
+  transform_log_internal_topic("_redpanda.transform_logs");
+
+inline const model::topic_namespace transform_log_internal_nt(
+  model::kafka_namespace, model::transform_log_internal_topic);
+
 inline bool is_user_topic(topic_namespace_view tp_ns) {
     return tp_ns.ns == kafka_namespace
            && tp_ns.tp != kafka_consumer_offsets_topic
            && tp_ns.tp != schema_registry_internal_tp.topic
-           && tp_ns.tp != kafka_audit_logging_topic;
+           && tp_ns.tp != kafka_audit_logging_topic
+           && tp_ns.tp != transform_log_internal_topic;
 }
 
 inline bool is_user_topic(const ntp& ntp) {

--- a/src/v/model/record.h
+++ b/src/v/model/record.h
@@ -614,7 +614,6 @@ private:
     iobuf_const_parser _parser;
 };
 
-// 57 bytes
 constexpr uint32_t packed_record_batch_header_size
   = sizeof(model::record_batch_header::header_crc)          // 4
     + sizeof(model::record_batch_header::size_bytes)        // 4
@@ -629,6 +628,7 @@ constexpr uint32_t packed_record_batch_header_size
     + sizeof(model::record_batch_header::producer_epoch)    // 2
     + sizeof(model::record_batch_header::base_sequence)     // 4
     + sizeof(model::record_batch_header::record_count);     // 4
+static_assert(packed_record_batch_header_size == 61);
 
 class record_batch
   : public serde::envelope<

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1260,6 +1260,7 @@ void application::wire_up_runtime_services(
           &controller->get_topics_state(),
           &partition_manager,
           &_transform_rpc_client,
+          &metadata_cache,
           sched_groups.transforms_sg())
           .get();
     }

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -21,6 +21,7 @@ v_cc_library(
     v::wasm
     v::model
     v::transform_rpc
+    v::transform_logging
 )
 
 add_subdirectory(tests)

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -30,6 +30,8 @@
 #include "transform/commit_batcher.h"
 #include "transform/io.h"
 #include "transform/logger.h"
+#include "transform/logging/log_manager.h"
+#include "transform/logging/rpc_client.h"
 #include "transform/rpc/client.h"
 #include "transform/rpc/deps.h"
 #include "transform/transform_logger.h"
@@ -412,6 +414,7 @@ service::service(
   ss::sharded<cluster::topic_table>* topic_table,
   ss::sharded<cluster::partition_manager>* partition_manager,
   ss::sharded<rpc::client>* rpc_client,
+  ss::sharded<cluster::metadata_cache>* metadata_cache,
   ss::scheduling_group sg)
   : _runtime(runtime)
   , _self(self)
@@ -421,6 +424,7 @@ service::service(
   , _topic_table(topic_table)
   , _partition_manager(partition_manager)
   , _rpc_client(rpc_client)
+  , _metadata_cache(metadata_cache)
   , _sg(sg) {}
 
 service::~service() = default;
@@ -446,6 +450,23 @@ ss::future<> service::start() {
     co_await _batcher->start();
     co_await _manager->start();
     register_notifications();
+
+    _log_manager = std::make_unique<logging::manager<ss::lowres_clock>>(
+      _self,
+      std::make_unique<logging::rpc_client>(
+        &_rpc_client->local(), &_metadata_cache->local()),
+      config::shard_local_cfg().data_transforms_logging_buffer_capacity_bytes(),
+      config::shard_local_cfg().data_transforms_logging_line_max_bytes.bind(),
+      config::shard_local_cfg()
+        .data_transforms_logging_flush_interval_ms.bind());
+    auto fut = co_await ss::coroutine::as_future(_log_manager->start());
+    if (fut.failed()) {
+        vlog(
+          tlog.error,
+          "Failed to start transform::logging::manager: {}",
+          fut.get_exception());
+    }
+    co_return co_await std::move(fut);
 }
 
 void service::register_notifications() {
@@ -526,6 +547,12 @@ ss::future<> service::stop() {
     }
     if (_batcher) {
         co_await _batcher->stop();
+    }
+    if (_log_manager) {
+        co_await _log_manager->stop();
+        // destroy the existing manager to clear out any residual state or
+        // unflushed log data
+        _log_manager.reset();
     }
 }
 
@@ -642,7 +669,8 @@ ss::future<> service::cleanup_wasm_binary(uuid_t key) {
 
 ss::future<ss::optimized_optional<ss::shared_ptr<wasm::engine>>>
 service::create_engine(model::transform_metadata meta) {
-    auto logger = std::make_unique<transform::logger>(meta.name, &tlog);
+    auto logger = std::make_unique<transform::logger>(
+      meta.name, _log_manager.get());
     auto factory = co_await get_factory(std::move(meta));
     if (!factory) {
         co_return ss::shared_ptr<wasm::engine>(nullptr);

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -19,6 +19,7 @@
 #include "model/transform.h"
 #include "raft/fwd.h"
 #include "transform/fwd.h"
+#include "transform/logging/fwd.h"
 #include "wasm/fwd.h"
 
 #include <seastar/core/lowres_clock.hh>
@@ -53,6 +54,7 @@ public:
       ss::sharded<cluster::topic_table>* topic_table,
       ss::sharded<cluster::partition_manager>* partition_manager,
       ss::sharded<rpc::client>* rpc_client,
+      ss::sharded<cluster::metadata_cache>* metadata_cache,
       ss::scheduling_group sg);
     service(const service&) = delete;
     service(service&&) = delete;
@@ -120,11 +122,13 @@ private:
     ss::sharded<cluster::topic_table>* _topic_table;
     ss::sharded<cluster::partition_manager>* _partition_manager;
     ss::sharded<rpc::client>* _rpc_client;
+    ss::sharded<cluster::metadata_cache>* _metadata_cache;
     std::unique_ptr<manager<ss::lowres_clock>> _manager;
     std::unique_ptr<commit_batcher<ss::lowres_clock>> _batcher;
     std::vector<ss::deferred_action<ss::noncopyable_function<void()>>>
       _notification_cleanups;
     ss::scheduling_group _sg;
+    std::unique_ptr<logging::manager<ss::lowres_clock>> _log_manager;
 };
 
 } // namespace transform

--- a/src/v/transform/logging/CMakeLists.txt
+++ b/src/v/transform/logging/CMakeLists.txt
@@ -1,11 +1,13 @@
 v_cc_library(
   NAME transform_logging
   HDRS
+    record_batcher.h
     event.h
     io.h
     log_manager.h
     logger.h
   SRCS
+    record_batcher.cc
     event.cc
     log_manager.cc
     logger.cc

--- a/src/v/transform/logging/CMakeLists.txt
+++ b/src/v/transform/logging/CMakeLists.txt
@@ -6,14 +6,18 @@ v_cc_library(
     io.h
     log_manager.h
     logger.h
+    rpc_client.h
   SRCS
     record_batcher.cc
     event.cc
     log_manager.cc
     logger.cc
+    rpc_client.cc
   DEPS
     v::config
+    v::cluster
     v::model
+    v::transform_rpc
 )
 
 add_subdirectory(tests)

--- a/src/v/transform/logging/errc.h
+++ b/src/v/transform/logging/errc.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include <system_error>
+
+namespace transform::logging {
+
+enum class errc {
+    success = 0,
+    // When logs topic creation fails
+    topic_creation_failure,
+    // When logs topic metadata lookup fails
+    topic_not_found,
+    // When we can't compute a partition ID for some transform's logs
+    partition_lookup_failure,
+    // When producing logs batches fails
+    write_failure,
+};
+
+struct errc_category final : public std::error_category {
+    const char* name() const noexcept final {
+        return "transform::logging::errc";
+    }
+
+    std::string message(int c) const final {
+        switch (static_cast<errc>(c)) {
+        case errc::success:
+            return "transform::logging::success";
+        case errc::topic_creation_failure:
+            return "Failed to create transform logs topic";
+        case errc::topic_not_found:
+            return "Transform logs topic metadata lookup failed";
+        case errc::partition_lookup_failure:
+            return "Failed to compute output partition ID for transform logs";
+        case errc::write_failure:
+            return "Failed write to transform logs topic";
+        default:
+            return "transform::logging::errc::unknown(" + std::to_string(c)
+                   + ")";
+        }
+    }
+};
+
+inline const std::error_category& error_category() noexcept {
+    static errc_category e;
+    return e;
+}
+inline std::error_code make_error_code(errc e) noexcept {
+    return {static_cast<int>(e), error_category()};
+}
+
+} // namespace transform::logging
+
+namespace std {
+template<>
+struct is_error_code_enum<transform::logging::errc> : true_type {};
+} // namespace std

--- a/src/v/transform/logging/fwd.h
+++ b/src/v/transform/logging/fwd.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+namespace transform::logging {
+template<typename ClockType>
+class manager;
+class client;
+} // namespace transform::logging

--- a/src/v/transform/logging/io.h
+++ b/src/v/transform/logging/io.h
@@ -20,15 +20,12 @@ namespace transform::logging {
 
 namespace io {
 struct json_batch {
-    json_batch(
-      model::transform_name n,
-      ss::chunked_fifo<iobuf> e,
-      ssx::semaphore_units units)
+    json_batch(iobuf n, ss::chunked_fifo<iobuf> e, ssx::semaphore_units units)
       : name(std::move(n))
       , events(std::move(e))
       , _units(std::move(units)) {}
 
-    model::transform_name name;
+    iobuf name;
     ss::chunked_fifo<iobuf> events;
 
 private:

--- a/src/v/transform/logging/io.h
+++ b/src/v/transform/logging/io.h
@@ -9,9 +9,11 @@
  * by the Apache License, Version 2.0
  */
 
+#include "base/outcome.h"
 #include "cluster/errc.h"
 #include "model/record.h"
 #include "ssx/semaphore.h"
+#include "transform/logging/errc.h"
 #include "transform/logging/event.h"
 
 #pragma once
@@ -53,16 +55,17 @@ public:
     client& operator=(client&&) = delete;
     virtual ~client() = default;
 
+    virtual ss::future<errc> initialize() = 0;
+
     /*
      * Collect io::json_batches into model::record_batch(es) and publish
      *
      * Implementations should aim to batch outgoing records maximally and
      * respect cluster-wide batch size limits.
      */
-    virtual ss::future<> write(model::partition_id, io::json_batches) = 0;
+    virtual ss::future<errc> write(model::partition_id, io::json_batches) = 0;
 
-    virtual model::partition_id
-    compute_output_partition(model::transform_name_view name)
-      = 0;
+    virtual result<model::partition_id, errc>
+    compute_output_partition(model::transform_name_view name) = 0;
 };
 } // namespace transform::logging

--- a/src/v/transform/logging/log_manager.cc
+++ b/src/v/transform/logging/log_manager.cc
@@ -26,6 +26,8 @@
 #include <seastar/core/smp.hh>
 #include <seastar/coroutine/as_future.hh>
 
+#include <absl/strings/escaping.h>
+
 namespace transform::logging {
 namespace {
 using namespace std::chrono_literals;
@@ -250,7 +252,7 @@ void manager<ClockType>::enqueue_log(
             return std::nullopt;
         } else if (contains_control_character(sub_view)) {
             // escape control chars and truncate (again, if necessary)
-            auto res = replace_control_chars_in_string(sub_view);
+            auto res = absl::CHexEscape(sub_view);
             return res.substr(0, msg_len(res));
         }
         return ss::sstring{sub_view.data(), sub_view.size()};

--- a/src/v/transform/logging/log_manager.cc
+++ b/src/v/transform/logging/log_manager.cc
@@ -49,6 +49,7 @@ public:
       , _jitter(_interval_ms(), jitter_amt) {
         _interval_ms.watch([this]() {
             _jitter = simple_time_jitter<ClockType>{_interval_ms(), jitter_amt};
+            wakeup();
         });
     }
 

--- a/src/v/transform/logging/log_manager.cc
+++ b/src/v/transform/logging/log_manager.cc
@@ -152,10 +152,10 @@ private:
             co_await ss::maybe_yield();
         }
 
+        iobuf nb;
+        nb.append(name().data(), name().size());
         co_return io::json_batch{
-          model::transform_name{name().data(), name().size()},
-          std::move(ev_json),
-          std::move(*buffer_units)};
+          std::move(nb), std::move(ev_json), std::move(*buffer_units)};
     }
 
     ss::future<> do_flush(model::partition_id pid, io::json_batches events) {

--- a/src/v/transform/logging/log_manager.cc
+++ b/src/v/transform/logging/log_manager.cc
@@ -17,6 +17,7 @@
 #include "model/namespace.h"
 #include "random/simple_time_jitter.h"
 #include "strings/utf8.h"
+#include "transform/logging/errc.h"
 #include "transform/logging/io.h"
 #include "transform/logging/logger.h"
 
@@ -70,6 +71,7 @@ public:
     }
 
 private:
+    bool _inited{false};
     template<typename BuffersT>
     ss::future<> flush_loop(BuffersT* bufs) {
         while (!_as->abort_requested()) {
@@ -89,6 +91,10 @@ private:
             } catch (const ss::broken_condition_variable&) {
                 break;
             } catch (const ss::condition_variable_timed_out&) {
+            }
+            if (!_inited) {
+                _inited = co_await _client->initialize()
+                          == logging::errc::success;
             }
             co_await flush(bufs);
         }
@@ -111,13 +117,23 @@ private:
           local_bufs, MAX_CONCURRENCY, [this, &batches](auto& pr) {
               auto& [name, events] = pr;
               model::transform_name_view nv{name};
-              auto pid = _client->compute_output_partition(nv);
+              auto pid_res = _client->compute_output_partition(nv);
+              if (pid_res.has_error()) {
+                  vlog(
+                    tlg_log.warn,
+                    "Partition lookup failed for transform '{}': {}",
+                    name,
+                    std::error_code{pid_res.assume_error()}.message());
+                  return ss::now();
+              }
 
               return do_serialize_log_events(nv, std::move(events))
-                .then([pid, &batches](auto batch) -> ss::future<> {
-                    batches[pid].emplace_back(std::move(batch));
-                    return ss::now();
-                });
+                .then(
+                  [pid = pid_res.assume_value(),
+                   &batches](auto batch) -> ss::future<> {
+                      batches[pid].emplace_back(std::move(batch));
+                      return ss::now();
+                  });
           });
 
         co_await ss::max_concurrent_for_each(
@@ -164,7 +180,10 @@ private:
         // capacity have been adopted by `json_batch`es. These units will be
         // released (i.e. buffer capacity freed) only once those records have
         // been produced.
-        co_await _client->write(pid, std::move(events));
+        std::error_code ec = co_await _client->write(pid, std::move(events));
+        if (ec != errc::success) {
+            vlog(tlg_log.warn, "Flush failed: {}", ec.message());
+        }
     }
     ss::abort_source* _as = nullptr;
     transform::logging::client* _client = nullptr;
@@ -200,7 +219,7 @@ manager<ClockType>::~manager() = default;
 
 template<typename ClockType>
 ss::future<> manager<ClockType>::start() {
-    return _flusher->template start<>(&_log_buffers);
+    co_return co_await _flusher->template start<>(&_log_buffers);
 }
 
 template<typename ClockType>

--- a/src/v/transform/logging/record_batcher.cc
+++ b/src/v/transform/logging/record_batcher.cc
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/logging/record_batcher.h"
+
+#include "absl/algorithm/container.h"
+#include "model/record.h"
+#include "storage/record_batch_builder.h"
+#include "transform/logging/logger.h"
+#include "utils/human.h"
+
+namespace transform::logging {
+
+namespace detail {
+class batcher_impl {
+public:
+    batcher_impl() = delete;
+    explicit batcher_impl(size_t batch_max_bytes)
+      : _batch_max_bytes(batch_max_bytes) {}
+    ~batcher_impl() = default;
+    batcher_impl(const batcher_impl&) = delete;
+    batcher_impl& operator=(const batcher_impl&) = delete;
+    batcher_impl(batcher_impl&&) = delete;
+    batcher_impl& operator=(batcher_impl&&) = delete;
+
+    model::record_batch make_batch_of_one(iobuf k, iobuf v) {
+        return std::move(bb_init().add_raw_kv(std::move(k), std::move(v)))
+          .build();
+    }
+
+    void append(iobuf k, iobuf v) {
+        auto record = model::record(
+          /*attributes*/ {},
+          /*ts_delta*/ 0,
+          /*offset_delta*/ std::numeric_limits<int32_t>::max(),
+          std::move(k),
+          std::move(v),
+          /*headers*/ {});
+        size_t record_size = record.size_bytes();
+        if (record_size > max_records_bytes()) {
+            vlog(
+              tlg_log.info,
+              "Dropped record: size exceeds configured batch max "
+              "size: {} > {}",
+              human::bytes{static_cast<double>(record_size)},
+              human::bytes{static_cast<double>(max_records_bytes())});
+            return;
+        } else if (record_size >= curr_batch_headroom_bytes()) {
+            roll_batch();
+        }
+        _curr_batch_size += record_size;
+        _builder.add_raw_kv(record.release_key(), record.release_value());
+    }
+
+    size_t total_size_bytes() {
+        return absl::c_accumulate(
+          _record_batches, 0, [](size_t acc, const model::record_batch& b) {
+              return acc + b.size_bytes();
+          });
+    }
+
+    ss::chunked_fifo<model::record_batch> finish() {
+        if (!_builder.empty()) {
+            roll_batch();
+        }
+        return std::exchange(_record_batches, {});
+    }
+
+private:
+    size_t curr_batch_headroom_bytes() const {
+        return max_records_bytes() - curr_records_bytes();
+    }
+    size_t batch_size_bytes() const {
+        return curr_records_bytes() + model::packed_record_batch_header_size;
+    }
+    size_t curr_records_bytes() const { return _curr_batch_size; }
+    size_t max_records_bytes() const {
+        return _batch_max_bytes - model::packed_record_batch_header_size;
+    }
+
+    void roll_batch() {
+        auto batch = std::exchange(_builder, bb_init()).build();
+        auto diff = static_cast<int64_t>(batch_size_bytes())
+                    - static_cast<int64_t>(batch.size_bytes());
+        if (diff < 0) {
+            vlog(
+              tlg_log.debug,
+              "Underestimaged batch size {} - {} = {}",
+              human::bytes{static_cast<double>(batch_size_bytes())},
+              human::bytes{static_cast<double>(batch.size_bytes())},
+              diff);
+        } else {
+            vlog(
+              tlg_log.trace,
+              "Building record batch. Actual size: {} (estimated: {}, err:{})",
+              human::bytes{static_cast<double>(batch.size_bytes())},
+              human::bytes{static_cast<double>(batch_size_bytes())},
+              diff);
+        }
+        // NOTE(oren): We could drop a batch here if it's too large to save
+        // bandwidth, but this should happen very rarely if ever (estimates are
+        // deliberately conservative). The most important thing is that we roll
+        // the batch builder to make room for subsequent records.
+        _curr_batch_size = 0;
+        _record_batches.push_back(std::move(batch));
+    }
+
+    static storage::record_batch_builder bb_init() {
+        return storage::record_batch_builder{
+          model::record_batch_type::raft_data, model::offset{0}};
+    }
+
+    size_t _batch_max_bytes;
+    storage::record_batch_builder _builder{bb_init()};
+    ss::chunked_fifo<model::record_batch> _record_batches;
+    size_t _curr_batch_size{0};
+};
+
+} // namespace detail
+
+record_batcher::record_batcher(size_t max_batch_size)
+  : _impl(std::make_unique<detail::batcher_impl>(max_batch_size)) {}
+
+record_batcher::~record_batcher() = default;
+
+void record_batcher::append(iobuf k, iobuf v) {
+    _impl->append(std::move(k), std::move(v));
+}
+size_t record_batcher::total_size_bytes() { return _impl->total_size_bytes(); }
+
+ss::chunked_fifo<model::record_batch> record_batcher::finish() {
+    return _impl->finish();
+}
+
+} // namespace transform::logging

--- a/src/v/transform/logging/record_batcher.h
+++ b/src/v/transform/logging/record_batcher.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/record.h"
+
+namespace transform::logging {
+
+namespace detail {
+class batcher_impl;
+}
+
+/**
+ * A class for collecting arbitrarily many key-value pairs (as iobufs) into a
+ * collection of model::record_batches, attempting to enforce a maximum size
+ * in bytes for each such batch by estimating a running total of serialized
+ * record size and rolling over to a new batch when an incoming record would
+ * otherwise meet or exceed the specified max.
+ *
+ * The functions of this class are synchronous and do not perform any I/O.
+ */
+class record_batcher {
+public:
+    record_batcher() = delete;
+    explicit record_batcher(size_t batch_max_bytes);
+    ~record_batcher();
+    record_batcher(const record_batcher&) = delete;
+    record_batcher& operator=(const record_batcher&) = delete;
+    record_batcher(record_batcher&&) = delete;
+    record_batcher& operator=(record_batcher&&) = delete;
+
+    /**
+     * Add a record to the current batch, possibly rolling over to a
+     * new batch if the serialized record would exceed batch_max_bytes.
+     */
+    void append(iobuf k, iobuf v);
+
+    /**
+     * Return the total size in bytes of all record_batches, exclusive of any
+     * batch still being built.
+     */
+    size_t total_size_bytes();
+
+    /**
+     * Move the collection of batches from the batcher and leave it in a
+     * useable (i.e. empty) state.
+     */
+    ss::chunked_fifo<model::record_batch> finish();
+
+private:
+    std::unique_ptr<detail::batcher_impl> _impl;
+};
+} // namespace transform::logging

--- a/src/v/transform/logging/rpc_client.cc
+++ b/src/v/transform/logging/rpc_client.cc
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "rpc_client.h"
+
+#include "hashing/murmur.h"
+#include "model/namespace.h"
+#include "transform/logging/logger.h"
+#include "transform/logging/record_batcher.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+
+namespace transform::logging {
+
+rpc_client::rpc_client(
+  rpc::client* rpc_client, cluster::metadata_cache* metadata_cache)
+  : _rpc_client(rpc_client)
+  , _metadata_cache(metadata_cache) {}
+
+ss::future<errc>
+rpc_client::write(model::partition_id pid, io::json_batches batches) {
+    model::topic_namespace_view ns_tp{model::transform_log_internal_nt};
+    auto cfg = _metadata_cache->get_topic_cfg(ns_tp);
+    if (!cfg.has_value()) {
+        co_return errc::topic_not_found;
+    }
+
+    auto max_batch_size = cfg->properties.batch_max_bytes.value_or(
+      config::shard_local_cfg().kafka_batch_max_bytes());
+
+    record_batcher batcher{max_batch_size};
+
+    while (!batches.empty()) {
+        auto json_batch = std::move(batches.front());
+        batches.pop_front();
+        while (!json_batch.events.empty()) {
+            auto ev = std::move(json_batch.events.front());
+            json_batch.events.pop_front();
+            batcher.append(json_batch.name.copy(), std::move(ev));
+            co_await ss::coroutine::maybe_yield();
+        }
+    }
+
+    auto total_request_size = batcher.total_size_bytes();
+    auto record_batches = batcher.finish();
+
+    model::topic_partition tp{model::transform_log_internal_topic, pid};
+    vlog(
+      tlg_log.debug,
+      "Producing logs for {{ {} }} total size: {}B",
+      tp,
+      total_request_size);
+
+    auto res = co_await _rpc_client->produce(
+      std::move(tp), std::move(record_batches));
+    if (res != cluster::errc::success) {
+        vlog(
+          tlg_log.debug, "Produce error: {}", std::error_code{res}.message());
+        co_return errc::write_failure;
+    }
+    co_return errc::success;
+}
+
+result<model::partition_id, errc>
+rpc_client::compute_output_partition(model::transform_name_view name) {
+    model::topic_namespace_view ns_tp{model::transform_log_internal_nt};
+    const auto& config = _metadata_cache->get_topic_cfg(ns_tp);
+    if (!config) {
+        return errc::topic_not_found;
+    }
+    auto n_partitions = static_cast<uint32_t>(config->partition_count);
+    if (n_partitions == 0) {
+        return errc::partition_lookup_failure;
+    }
+    return model::partition_id{static_cast<int32_t>(
+      murmur2(name().data(), name().size()) % n_partitions)};
+}
+
+ss::future<errc> rpc_client::initialize() {
+    auto fut = co_await ss::coroutine::as_future<errc>(create_topic());
+    if (fut.failed()) {
+        vlog(tlg_log.warn, "Init error: {}", fut.get_exception());
+        co_return errc::topic_creation_failure;
+    }
+    co_return fut.get();
+}
+
+ss::future<errc> rpc_client::create_topic() {
+    auto ec = co_await _rpc_client->create_transform_logs_topic();
+    co_return (
+      ec == cluster::errc::success || ec == cluster::errc::topic_already_exists
+        ? errc::success
+        : errc::topic_creation_failure);
+}
+
+} // namespace transform::logging

--- a/src/v/transform/logging/rpc_client.h
+++ b/src/v/transform/logging/rpc_client.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/outcome.h"
+#include "transform/logging/errc.h"
+#include "transform/logging/io.h"
+#include "transform/rpc/client.h"
+
+namespace transform::logging {
+
+/**
+ * transform::logging::client implementation for managing and producing record
+ * batches to _redpanda.transform_logs.
+ *
+ * Encapsulates a transform::rpc::client, which does the heavy lifing of
+ * implementing an internal RPC interface to the rest of Redpanda, and a
+ * cluster::metadata_cache for computing the output partition for a certain
+ * named transform's logs.
+ *
+ * See transform::logging::client for more general information about the
+ * interface.
+ */
+class rpc_client final : public client {
+public:
+    explicit rpc_client(
+      rpc::client* rpc_client, cluster::metadata_cache* metadata_cache);
+    rpc_client() = delete;
+    rpc_client(const rpc_client&) = delete;
+    rpc_client& operator=(const rpc_client&) = delete;
+    rpc_client(rpc_client&&) = delete;
+    rpc_client& operator=(rpc_client&&) = delete;
+    ~rpc_client() override = default;
+
+    ss::future<errc> initialize() override;
+    ss::future<errc> write(model::partition_id, io::json_batches) override;
+    result<model::partition_id, errc>
+      compute_output_partition(model::transform_name_view) override;
+
+private:
+    ss::future<errc> create_topic();
+    rpc::client* _rpc_client;
+    cluster::metadata_cache* _metadata_cache;
+};
+
+} // namespace transform::logging

--- a/src/v/transform/logging/tests/CMakeLists.txt
+++ b/src/v/transform/logging/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ rp_test(
   SOURCES
     model_test.cc
     log_manager_test.cc
+    record_batcher_test.cc
   LIBRARIES
     v::transform_logging
     v::transform_logging_test_utils

--- a/src/v/transform/logging/tests/log_manager_test.cc
+++ b/src/v/transform/logging/tests/log_manager_test.cc
@@ -14,6 +14,7 @@
 #include <seastar/core/manual_clock.hh>
 #include <seastar/core/shared_ptr.hh>
 
+#include <absl/strings/escaping.h>
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
@@ -298,7 +299,7 @@ TEST_F(TransformLogManagerTest, MessageTruncation) {
 
     // test that truncation occurs _after_ control char escaping
     ss::sstring in_msg(line_max, char{0x7f});
-    auto escaped = replace_control_chars_in_string(in_msg);
+    auto escaped = absl::CHexEscape(in_msg);
     EXPECT_GT(escaped.length(), line_max);
 
     enqueue_log(in_msg);
@@ -332,7 +333,7 @@ TEST_F(TransformLogManagerTest, IllegalMessages) {
     EXPECT_EQ(logs().size(), 1);
 
     auto msg = testing::get_message_body(logs().front().copy());
-    EXPECT_EQ(msg, replace_control_chars_in_string(control_char_msg.data()));
+    EXPECT_EQ(msg, absl::CHexEscape(control_char_msg.data()));
 }
 
 TEST_F(TransformLogManagerTest, ConfigTuning) {

--- a/src/v/transform/logging/tests/log_manager_test.cc
+++ b/src/v/transform/logging/tests/log_manager_test.cc
@@ -1,9 +1,11 @@
+#include "base/outcome.h"
 #include "base/units.h"
 #include "config/mock_property.h"
 #include "model/namespace.h"
 #include "model/transform.h"
 #include "strings/utf8.h"
 #include "test_utils/async.h"
+#include "transform/logging/errc.h"
 #include "transform/logging/event.h"
 #include "transform/logging/io.h"
 #include "transform/logging/log_manager.h"
@@ -38,7 +40,7 @@ class fake_client final : public transform::logging::client {
 public:
     fake_client() = default;
 
-    ss::future<>
+    ss::future<errc>
     write(model::partition_id pid, io::json_batches batches) override {
         while (!batches.empty()) {
             auto events = std::move(batches.front());
@@ -50,21 +52,30 @@ public:
               std::back_inserter(_logs));
         }
 
-        return ss::now();
+        co_return errc::success;
     }
 
-    model::partition_id
+    result<model::partition_id, errc>
     compute_output_partition(model::transform_name_view name) override {
+        if (_partition_ec.has_value()) {
+            return *_partition_ec;
+        }
         size_t h = std::hash<model::transform_name>{}(
           model::transform_name{name().data(), name().size()});
         return model::partition_id{static_cast<int>(h % 4)};
     }
 
+    ss::future<errc> initialize() override { co_return errc::success; }
+
     const ss::chunked_fifo<iobuf>& logs() const { return _logs; }
+
+    void set_partition_ec(std::optional<errc> ec) { _partition_ec = ec; }
 
 private:
     ss::chunked_fifo<iobuf> _logs;
     absl::flat_hash_map<model::partition_id, size_t> _pid_event_counts;
+
+    std::optional<errc> _partition_ec{};
 };
 
 } // namespace
@@ -84,6 +95,10 @@ public:
           _line_limit.bind(),
           _flush_ms.bind());
         start_manager();
+    }
+
+    void set_find_partition_ec(std::optional<errc> ec) {
+        _client->set_partition_ec(ec);
     }
 
     void TearDown() override {
@@ -355,6 +370,41 @@ TEST_F(TransformLogManagerTest, ConfigTuning) {
     // reflect the new line limit
     EXPECT_EQ(logs().size(), 2);
     EXPECT_EQ(last_log_msg().size(), lim2);
+}
+
+TEST_F(TransformLogManagerTest, ComputePartitionError) {
+    constexpr int N = 100;
+    set_find_partition_ec(errc::topic_not_found);
+    auto names = get_random_transform_names(4);
+
+    for (int i = 0; i < N; ++i) {
+        enqueue_log(
+          ss::log_level::info,
+          model::transform_name_view{names.at(i % names.size())()},
+          ss::sstring(i + 1, 'a'));
+    }
+
+    advance_clock();
+
+    // logs should all have been dropped prior to hitting the client
+    EXPECT_EQ(logs().size(), 0);
+
+    set_find_partition_ec(std::nullopt);
+
+    advance_clock();
+
+    EXPECT_EQ(logs().size(), 0);
+
+    for (int i = 0; i < N; ++i) {
+        enqueue_log(
+          ss::log_level::info,
+          model::transform_name_view{names.at(i % names.size())()},
+          ss::sstring(i + 1, 'a'));
+    }
+
+    advance_clock();
+
+    EXPECT_EQ(logs().size(), N);
 }
 
 } // namespace transform::logging

--- a/src/v/transform/logging/tests/record_batcher_test.cc
+++ b/src/v/transform/logging/tests/record_batcher_test.cc
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/units.h"
+#include "transform/logging/record_batcher.h"
+#include "transform/logging/tests/utils.h"
+
+#include <gtest/gtest.h>
+
+namespace transform::logging {
+
+TEST(TransformLoggingRecordBatcherTest, TestMaxBytes) {
+    constexpr size_t batch_max_bytes = 1_KiB;
+    constexpr size_t total_bytes = batch_max_bytes * 10;
+    record_batcher batcher{batch_max_bytes};
+
+    // General goal here is to generate enough data that we'll need several
+    // batches.
+    auto bytes_remain = static_cast<ssize_t>(total_bytes);
+    while (bytes_remain > 0) {
+        auto k = testing::random_length_iobuf(batch_max_bytes / 2);
+        bytes_remain -= static_cast<ssize_t>(k.size_bytes());
+        auto v = testing::random_length_iobuf(batch_max_bytes / 2);
+        bytes_remain -= static_cast<ssize_t>(v.size_bytes());
+        batcher.append(std::move(k), std::move(v));
+    }
+
+    auto batches = batcher.finish();
+    auto tot = batches.size();
+    EXPECT_TRUE(!batches.empty());
+    int i = 1;
+    for (auto& b : batches) {
+        EXPECT_LE(static_cast<size_t>(b.size_bytes()), batch_max_bytes)
+          << fmt::format("Batch {}/{} size {}", i, tot, b.size_bytes());
+        ++i;
+    }
+}
+
+TEST(TransformLoggingRecordBatcherTest, TestReuseBatcher) {
+    constexpr size_t batch_max_bytes = 1_KiB;
+    record_batcher batcher{batch_max_bytes};
+
+    for (int i = 0; i < 4; ++i) {
+        auto k = testing::random_length_iobuf(batch_max_bytes / 4);
+        auto v = testing::random_length_iobuf(batch_max_bytes / 4);
+        auto ks = k.size_bytes();
+        auto vs = v.size_bytes();
+        batcher.append(std::move(k), std::move(v));
+
+        // we haven't finalized any batches yet
+        EXPECT_EQ(batcher.total_size_bytes(), 0);
+
+        auto batches = batcher.finish();
+        EXPECT_EQ(batches.size(), 1);
+        EXPECT_GT(batches.back().size_bytes(), ks + vs);
+    }
+}
+
+} // namespace transform::logging

--- a/src/v/transform/logging/tests/utils.cc
+++ b/src/v/transform/logging/tests/utils.cc
@@ -38,4 +38,16 @@ model::transform_name random_transform_name(size_t len) {
     return model::transform_name{random_generators::gen_alphanum_string(len)};
 }
 
+iobuf random_length_iobuf(size_t data_max) {
+    assert(data_max > 0);
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::uniform_int_distribution<std::mt19937::result_type> dist(1, data_max);
+
+    auto data = random_generators::gen_alphanum_string(dist(rng));
+    iobuf b;
+    b.append(data.data(), data.size());
+    return b;
+}
+
 } // namespace transform::logging::testing

--- a/src/v/transform/logging/tests/utils.h
+++ b/src/v/transform/logging/tests/utils.h
@@ -24,4 +24,6 @@ std::string get_message_body(iobuf);
 
 model::transform_name random_transform_name(size_t len = 12);
 
+iobuf random_length_iobuf(size_t data_max);
+
 } // namespace transform::logging::testing

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -84,6 +84,8 @@ public:
 
     ss::future<model::cluster_transform_report> generate_report();
 
+    ss::future<cluster::errc> create_transform_logs_topic();
+
     /**
      * List all the tracked offsets for all transforms within the cluster.
      */
@@ -129,6 +131,8 @@ private:
     ss::future<std::optional<model::node_id>> compute_wasm_binary_ntp_leader();
     ss::future<bool> try_create_wasm_binary_ntp();
     ss::future<bool> try_create_transform_offsets_topic();
+
+    ss::future<cluster::errc> try_create_transform_logs_topic();
 
     ss::future<result<model::partition_id, cluster::errc>>
       find_coordinator_once(model::transform_offsets_key);

--- a/tests/docker/ducktape-deps/tinygo-wasi-transforms
+++ b/tests/docker/ducktape-deps/tinygo-wasi-transforms
@@ -10,6 +10,10 @@ tinygo build -target wasi -opt=z \
   -panic print -scheduler none \
   -o "/opt/transforms/tinygo/identity.wasm" ./identity
 
+tinygo build -target wasi -opt=z \
+  -panic print -scheduler none \
+  -o "/opt/transforms/tinygo/identity_logging.wasm" ./identity_logging
+
 # The following are some invalid wasm binarys for Redpanda, they either are invalid
 # as they are invalid bytes, or don't adhere to our ABI contract somehow
 #

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -10,6 +10,7 @@
 import typing
 import time
 import random
+import json
 
 from requests.exceptions import RequestException
 
@@ -23,6 +24,8 @@ from rptest.services.admin import Admin, CommittedWasmOffset
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.tests.cluster_config_test import wait_for_version_sync
+from rptest.utils.utf8 import CONTROL_CHARS_VALS, generate_string_with_control_character
+from rptest.util import expect_exception
 
 
 class WasmException(Exception):
@@ -46,13 +49,19 @@ class BaseDataTransformsTest(RedpandaTest):
         self._rpk = RpkTool(self.redpanda)
         self._admin = Admin(self.redpanda)
 
-    def _deploy_wasm(self, name: str, input_topic: TopicSpec,
-                     output_topic: TopicSpec):
+    def _deploy_wasm(self,
+                     name: str,
+                     input_topic: TopicSpec,
+                     output_topic: TopicSpec,
+                     file="tinygo/identity.wasm"):
         """
         Deploy a wasm transform and wait for all processors to be running.
         """
         def do_deploy():
-            self._rpk.deploy_wasm(name, input_topic.name, output_topic.name)
+            self._rpk.deploy_wasm(name,
+                                  input_topic.name,
+                                  output_topic.name,
+                                  file=file)
             return True
 
         wait_until(
@@ -433,3 +442,234 @@ class DataTransformsLeadershipChangingTest(BaseDataTransformsTest):
                                                      timeout_sec=60)
         self.logger.info(f"{consumer_status}")
         assert consumer_status.invalid_records == 0, f"transform verification failed with invalid records: {consumer_status}"
+
+
+class DataTransformsLoggingTest(BaseDataTransformsTest):
+    """
+    Tests for data transforms logging
+    """
+
+    topics = [TopicSpec(partition_count=9), TopicSpec(partition_count=9)]
+
+    logs_topic = TopicSpec(name='_redpanda.transform_logs', partition_count=4)
+
+    # TODO(oren): be nice to actually use the OTel protobufs here
+    class LogRecord:
+        class Attribute:
+            def __init__(self, attr: dict):
+                self.key = attr['key']
+                assert len(attr['value']) == 1
+                self.value_type = list(attr['value'].keys())[0]
+                self.value = attr['value'][self.value_type]
+
+            # don't really care about the value, just the correct key and value _type_
+            def __eq__(self, other):
+                return (self.key == other.key
+                        and self.value_type == other.value_type
+                        and type(self.value) == type(other.value))
+
+        EXPECTED_ATTRS = [
+            Attribute({
+                'key': 'transform_name',
+                'value': {
+                    'stringValue': 'any'  # don't care for validation
+                }
+            }),
+            Attribute({
+                'key': 'node',
+                'value': {
+                    'intValue': 23  # don't care for validation
+                }
+            })
+        ]
+
+        BODY_FIELD = 'body'
+        TS_FIELD = 'timeUnixNano'
+        SEVERITY_FIELD = 'severityNumber'
+        ATTRS_FIELD = 'attributes'
+
+        def __init__(self, raw: str):
+            self._record = json.loads(raw)
+            self._record['value'] = json.loads(self._record['value'])
+
+            # Redpanda bits
+            self.offset = self._record['offset']
+            self.key = self._record['key']
+
+            # OTel bits
+            self._rep = self._record['value']
+            self.body = self._rep.get(self.BODY_FIELD, None)
+            self.timestamp_ns = self._rep.get(self.TS_FIELD, None)
+            self.severity = self._rep.get(self.SEVERITY_FIELD, None)
+            self.attributes = [
+                self.Attribute(attr)
+                for attr in self._rep.get(self.ATTRS_FIELD, [])
+            ]
+
+        def __str__(self):
+            return json.dumps(self._record, indent=1)
+
+        def validate(
+                self,
+                offset: typing.Optional[int] = None
+        ) -> typing.Optional[list[str]]:
+            errors = []
+            if offset is not None and offset != self.offset:
+                errors.append(f"Expected offset {offset} got {self.offset}")
+            if self.body is None:
+                errors.append(f"Missing {self.BODY_FIELD}")
+            if self.timestamp_ns is None:
+                errors.append(f"Missing {self.TS_FIELD}")
+            if self.severity is None:
+                errors.append(f"Missing {self.SEVERITY_FIELD}")
+            if self.ATTRS_FIELD not in self._rep:
+                errors.append(f"Missing {self.ATTRS_FIELD}")
+
+            if len(self.attributes) != 2:
+                errors.append(
+                    f"Expected 2 attributes, got {len(self.attributes)}")
+
+            for attr in self.EXPECTED_ATTRS:
+                if attr not in self.attributes:
+                    errors.append(f"Missing attribute '{attr.key}'")
+
+            if len(errors) > 0:
+                return errors
+
+            return None
+
+    def setup_identity_xform(self):
+        it, ot = self.topics
+        self._deploy_wasm(name="identity-logging-xform",
+                          input_topic=self.topics[0],
+                          output_topic=self.topics[1],
+                          file="tinygo/identity_logging.wasm")
+        return self.topics
+
+    def consume_one_log_record(self, offset=0, timeout=10) -> LogRecord:
+        return self.LogRecord(
+            self._rpk.consume(self.logs_topic.name,
+                              n=1,
+                              offset=offset,
+                              timeout=timeout))
+
+    @cluster(num_nodes=4)
+    def test_logs_volume(self):
+        input_topic, output_topic = self.setup_identity_xform()
+        producer_status = self._produce_input_topic(topic=input_topic,
+                                                    transactional=False)
+        consumer_status = self._consume_output_topic(topic=output_topic,
+                                                     status=producer_status)
+        seqnos = consumer_status.latest_seqnos
+
+        # NOTE(oren): all logs for a given transform should go to the same
+        # partition assuming the partition count of the logs topic doesn't change.
+        # Therefore the sum of the highest sequence numbers for each output partition
+        # is a fine proxy for expected high water mark on the transform logs topic
+        log_hwm = sum([seqnos[p] for p in seqnos])
+
+        self.logger.debug(
+            f"Expect to find log offsets up to the total # of records {log_hwm}"
+        )
+        test_offsets = [0, log_hwm // 2, log_hwm]
+        for i in test_offsets:
+            log = self.consume_one_log_record(offset=i)
+            validation_errs = log.validate(offset=i)
+            assert (
+                validation_errs is None
+            ), f"Validation failed, errors: {json.dumps(validation_errs, indent=1)}"
+
+    @cluster(num_nodes=3)
+    def test_logs_otel(self):
+        """
+        Verify that log events conform to a subset OTel logging spec as laid out in our RFC
+        """
+        input_topic, output_topic = self.setup_identity_xform()
+
+        self._rpk.produce(input_topic.name, 'foo', 'bar')
+        log = self.consume_one_log_record()
+        validation_errors = log.validate()
+        assert (
+            validation_errors is None
+        ), f"Log record validation failed, errors: {json.dumps(validation_errors, indent=1)}"
+
+    @cluster(num_nodes=3)
+    def test_logs_cc_escaping(self):
+        input_topic, output_topic = self.setup_identity_xform()
+
+        val = generate_string_with_control_character(12)
+        buf = bytearray()
+        buf.extend(map(ord, val))
+        assert any([b in CONTROL_CHARS_VALS
+                    for b in buf]), f"Expected control char(s) in {buf}"
+
+        self._rpk.produce(input_topic.name, 'foo', val)
+
+        log = self.consume_one_log_record()
+        buf = bytearray()
+        buf.extend(map(ord, log.body))
+        assert all([b not in CONTROL_CHARS_VALS for b in buf
+                    ]), f"Found control char(s) in log output: {buf}"
+
+    @cluster(num_nodes=3)
+    def test_log_topic_integrity(self):
+        self.setup_identity_xform()
+
+        self.logger.debug(
+            f"{self.logs_topic.name}: delete topic should fail (empty response table)"
+        )
+        with expect_exception(RpkException,
+                              lambda e: "expected one row; found 0" in str(e)):
+            self._rpk.delete_topic(self.logs_topic.name)
+
+        self.logger.debug(
+            f"{self.logs_topic.name}: produce should fail (authZ error)")
+        with expect_exception(
+                RpkException,
+                lambda e: "Topic authorization failed" in str(e)):
+            self._rpk.produce(self.logs_topic.name, "hardy", "har har")
+
+    @cluster(num_nodes=3)
+    def test_tunable_configs(self):
+        it, ot = self.setup_identity_xform()
+
+        self.logger.debug(
+            "See that we can consume a log message w/in 5s with the default interval"
+        )
+        self._rpk.produce(it.name, 'foo', 'bar')
+        self.consume_one_log_record(offset=0, timeout=5)
+
+        self.logger.debug(
+            "Consume operations should time out if the flush interval is very long"
+        )
+
+        # 1h
+        self.redpanda.set_cluster_config(
+            {'data_transforms_logging_flush_interval_ms': 1000 * 60 * 60})
+
+        self._rpk.produce(it.name, 'foo', 'bar')
+        with expect_exception(RpkException, lambda e: "timed out" in str(e)):
+            self.consume_one_log_record(offset=1, timeout=5)
+
+        self.logger.debug(
+            "Log messages should be truncated to the configured max line")
+
+        max_line = 10
+        self.redpanda.set_cluster_config({
+            'data_transforms_logging_flush_interval_ms':
+            500,
+            'data_transforms_logging_line_max_bytes':
+            max_line
+        })
+
+        self._rpk.produce(it.name, 'a' * max_line, 'b' * max_line)
+
+        # ignore the record at offset{0} b/c it was already in the buffers
+        # by the time we updated the max line length.
+        log = self.consume_one_log_record(offset=2)
+
+        assert len(
+            log.body
+        ) == max_line, f"Expected {max_line}B, got {len(log.body)}B ({log.body})"
+
+    # TODO(oren): some tests based on metrics would probably be good

--- a/tests/rptest/tests/scram_test.py
+++ b/tests/rptest/tests/scram_test.py
@@ -28,7 +28,7 @@ from rptest.services.admin import Admin
 from rptest.services.redpanda import SecurityConfig, SaslCredentials, SecurityConfig
 from rptest.tests.sasl_reauth_test import get_sasl_metrics, REAUTH_METRIC, EXPIRATION_METRIC
 from rptest.util import expect_http_error
-from rptest.utils.utf8 import CONTROL_CHARS, CONTROL_CHARS_MAP
+from rptest.utils.utf8 import CONTROL_CHARS, CONTROL_CHARS_MAP, generate_string_with_control_character
 
 
 class BaseScramTest(RedpandaTest):
@@ -454,22 +454,13 @@ class InvalidNewUserStrings(BaseScramTest):
                              security=security,
                              extra_node_conf={'developer_mode': True})
 
-    @staticmethod
-    def generate_string_with_control_character(length: int):
-        rv = ''.join(
-            random.choices(string.ascii_letters + CONTROL_CHARS, k=length))
-        while not any(char in rv for char in CONTROL_CHARS):
-            rv = ''.join(
-                random.choices(string.ascii_letters + CONTROL_CHARS, k=length))
-        return rv
-
     @cluster(num_nodes=3)
     def test_invalid_user_name(self):
         """
         Validates that usernames that contain control characters and usernames which
         do not match the SCRAM regex are properly rejected
         """
-        username = self.generate_string_with_control_character(15)
+        username = generate_string_with_control_character(15)
 
         self.create_user(
             username=username,
@@ -493,7 +484,7 @@ class InvalidNewUserStrings(BaseScramTest):
         """
         Validates that algorithms that contain control characters are properly rejected
         """
-        algorithm = self.generate_string_with_control_character(10)
+        algorithm = generate_string_with_control_character(10)
 
         self.create_user(
             username="test",
@@ -508,7 +499,7 @@ class InvalidNewUserStrings(BaseScramTest):
         """
         Validates that passwords that contain control characters are properly rejected
         """
-        password = self.generate_string_with_control_character(15)
+        password = generate_string_with_control_character(15)
         self.create_user(
             username="test",
             algorithm="SCRAM-SHA-256",

--- a/tests/rptest/utils/utf8.py
+++ b/tests/rptest/utils/utf8.py
@@ -1,3 +1,6 @@
+import random
+import string
+
 # List of every control character except the null character
 CONTROL_CHARS = ''.join((chr(x) for x in range(1, 32))) + '\x7f'
 # List of control character numerical value
@@ -10,3 +13,12 @@ CONTROL_CHARS_MAP = dict(
         [(lambda c: b'\xe2\x90\xa1'.decode('utf-8')
           if c == 0x7f else bytes([0xe2, 0x90, 0x80 + c]).decode('utf-8'))(c)
          for c in CONTROL_CHARS_VALS]))
+
+
+def generate_string_with_control_character(length: int) -> str:
+    rv = ''.join(random.choices(string.ascii_letters + CONTROL_CHARS,
+                                k=length))
+    while not any(char in rv for char in CONTROL_CHARS):
+        rv = ''.join(
+            random.choices(string.ascii_letters + CONTROL_CHARS, k=length))
+    return rv


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This commit implements the end-to-end plumbing for data transform logging. This includes:
- Implementation of `wasm::logger` that encapsulates a `manager` instance
- Log manager initialization in `transform::service`
- `logging::client` implementation to perform record batching, forward writes to `rpc::client`, create the transform logging topic, and compute output partition IDs for partiticular transforms. 
- Delete/write protection and health_manager update for logs topic integrity
- Integration tests for transform logging

Closes https://github.com/redpanda-data/core-internal/issues/1057
Closes https://github.com/redpanda-data/core-internal/issues/1058

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Features

* Publish log (i.e. stderr/stdout) output from data transforms exclusively to an internally managed Redpanda topic (`_redpanda.transform_logs`). Data transform logs will no longer appear in broker logs.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
