### PR TITLE
rptest: exclude OMBValidationTest.test_retention

### DIFF
--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -13,6 +13,9 @@ cloud:
     - redpanda_cloud_tests/config_profile_verify_test.py
     - redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_decommission_and_add
     - redpanda_cloud_tests/observe_test.py
-    - redpanda_cloud_tests/omb_validation_test.py
     - redpanda_cloud_tests/rolling_restart_test.py
+    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_max_connections
+    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_max_partitions
+    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_common_workload
+    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_retention
     - tests/services_self_test.py::SimpleSelfTest.test_cloud

--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -17,5 +17,4 @@ cloud:
     - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_max_connections
     - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_max_partitions
     - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_common_workload
-    - redpanda_cloud_tests/omb_validation_test.py::OMBValidationTest.test_retention
     - tests/services_self_test.py::SimpleSelfTest.test_cloud


### PR DESCRIPTION
exclude just `OMBValidationTest.test_retention` from cdt cloud runs for now while it is being investigated

related to issue https://github.com/redpanda-data/redpanda/issues/15334

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none