### PR TITLE
[v23.3.x] k/metadata: guesstimate leader when information is not yet present

### DIFF
--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -82,11 +82,12 @@ std::optional<cluster::leader_term> get_leader_term(
     auto leader_term = md_cache.get_leader_term(tp_ns, p_id);
     /**
      * If current broker do not yet have any information about leadership we
-     * simply return random node to force the client metadata update.
+     * fallback to leader guesstimating. We return first replica from the
+     * replica set and term 0. (This is the same logic that has been a part of
+     * cluster::topic_dispatcher before)
      */
     if (!leader_term) {
-        auto idx = fast_prng_source() % replicas.size();
-        leader_term.emplace(replicas[idx], model::term_id(-1));
+        leader_term.emplace(replicas[0], model::term_id(0));
         return leader_term;
     }
     if (!leader_term->leader.has_value()) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/15981
Fixes: https://github.com/redpanda-data/redpanda/issues/16490, Fixes: https://github.com/redpanda-data/redpanda/issues/16491,