### PR TITLE
tests: disable snapshots when testing partial controller deletion

### DIFF
--- a/tests/rptest/tests/controller_erase_test.py
+++ b/tests/rptest/tests/controller_erase_test.py
@@ -42,6 +42,11 @@ class ControllerEraseTest(RedpandaTest):
         """
 
         admin = Admin(self.redpanda)
+        # disable controller snapshot in partial removal test to make sure that
+        # the deleted segment is not snapshot before restarting the node
+        if partial:
+            self.redpanda.set_cluster_config(
+                {"controller_snapshot_max_age_sec": 3600})
 
         # Do a bunch of metadata operations to put something in the controller log
         transfers_leadership_count = 4


### PR DESCRIPTION
When testing partial deletion the test selects a segment to remove from controller log. Before deleting the segment but after it was selected it may be accounted in the controller snapshot.

Disabled controller snapshot to prevent the test racing with snapshot creation.

Fixes: #8217

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none