### PR TITLE
rptest: Ignore error logs generated by anomaly injection

### DIFF
--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -18,6 +18,8 @@ from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.mark._mark import Mark
 from ducktape.tests.test import TestContext
 
+from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
+
 
 def cluster(log_allow_list=None,
             check_allowed_error_logs=True,
@@ -95,6 +97,10 @@ def cluster(log_allow_list=None,
 
             t_initial = time.time()
             disk_stats_initial = psutil.disk_io_counters()
+            if log_allow_list is not None:
+                for entry in log_allow_list:
+                    if isinstance(entry, AllowLogsOnPredicate):
+                        entry.initialize(self)
             try:
                 r = f(self, *args, **kwargs)
             except:

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -8,16 +8,15 @@
 # by the Apache License, Version 2.0
 
 import functools
-from itertools import chain
 import time
 from typing import Protocol
-import psutil
 
-from rptest.services.redpanda import RedpandaService, RedpandaServiceBase, RedpandaServiceCloud
-from ducktape.mark.resource import ClusterUseMetadata
+import psutil
 from ducktape.mark._mark import Mark
+from ducktape.mark.resource import ClusterUseMetadata
 from ducktape.tests.test import TestContext
 
+from rptest.services.redpanda import RedpandaServiceBase, RedpandaServiceCloud
 from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
 
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -66,6 +66,7 @@ from rptest.services.storage import ClusterStorage, NodeStorage, NodeCacheStorag
 from rptest.services.storage_failure_injection import FailureInjectionConfig
 from rptest.services.utils import BadLogLines, NodeCrash
 from rptest.util import inject_remote_script, ssh_output_stderr, wait_until_result
+from rptest.utils.allow_logs_on_predicate import AllowLogsOnPredicate
 
 Partition = collections.namedtuple('Partition',
                                    ['topic', 'index', 'leader', 'replicas'])
@@ -289,6 +290,12 @@ def is_redpanda_cloud(context: TestContext):
     # global signal that it's a cloud run
     return bool(
         context.globals.get(RedpandaServiceCloud.GLOBAL_CLOUD_CLUSTER_CONFIG))
+
+
+def should_compile(
+        allow_list_element: str | AllowLogsOnPredicate | re.Pattern) -> bool:
+    return not isinstance(allow_list_element, re.Pattern) and not isinstance(
+        allow_list_element, AllowLogsOnPredicate)
 
 
 class ResourceSettings:
@@ -1331,7 +1338,7 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
             combined_allow_list = DEFAULT_LOG_ALLOW_LIST.copy()
             # Accept either compiled or string regexes
             for a in allow_list:
-                if not isinstance(a, re.Pattern):
+                if should_compile(a):
                     a = re.compile(a)
                 combined_allow_list.append(a)
             allow_list = combined_allow_list
@@ -2752,7 +2759,7 @@ class RedpandaService(RedpandaServiceBase):
         allow_list = []
         if log_allow_list:
             for a in log_allow_list:
-                if not isinstance(a, re.Pattern):
+                if should_compile(a):
                     a = re.compile(a)
                 allow_list.append(a)
 

--- a/tests/rptest/utils/allow_logs_on_predicate.py
+++ b/tests/rptest/utils/allow_logs_on_predicate.py
@@ -1,0 +1,52 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+from typing import Callable, Optional, Protocol
+
+
+class ConvertableToBool(Protocol):
+    def __bool__(self) -> bool:
+        ...
+
+
+PredicateT = Callable[[str], ConvertableToBool]
+
+
+class AllowLogsOnPredicate:
+    """
+    Calls the supplied test method to determine if ERROR logs should be allowed
+    """
+    def __init__(self, method: str):
+        """
+        predicate_method: The name of the method on the test which will accept a log entry,
+        and return a truthy value to signal if the ERROR log is allowed.
+        """
+        self.method = method
+        self.predicate: Optional[PredicateT] = None
+
+    def initialize(self, test_case):
+        """
+        Called with the test case during the `cluster` decorator run, after this object
+        has been constructed with the method name. Validates and sets the method to be
+        called per log entry.
+        """
+        assert hasattr(
+            test_case, self.method
+        ), f"Test {test_case} does not have expected method {self.method}"
+        self.predicate = getattr(test_case, self.method)
+        assert callable(
+            self.predicate), f"{self.predicate} is not a callable method"
+
+    def search(self, log_line: str) -> ConvertableToBool:
+        """
+        Explicitly convert falsy values to None. This matches semantics of `re.search` which this method is
+        expected to be called with, where None is returned for failed searches. This conversion allows
+        the predicate to return falsy values to reject a log from being allowed.
+        """
+        assert self.predicate is not None, f"Log predicate method {self.method} is not initialized"
+        return self.predicate(log_line) or None

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -143,7 +143,8 @@ SegmentMetadata = namedtuple(
     'SegmentMetadata',
     ['ntp', 'revision', 'base_offset', 'term', 'md5', 'size'])
 
-SegmentPathComponents = namedtuple('SegmentPathComponents', ['ntpr', 'name'])
+SegmentPathComponents = namedtuple('SegmentPathComponents',
+                                   ['ntpr', 'name', 'base_offset'])
 
 MISSING_DATA_ERRORS = [
     "No segments found. Empty partition manifest generated",
@@ -313,8 +314,11 @@ def parse_s3_segment_path(path) -> SegmentPathComponents:
     partition = int(part_rev[0])
     revision = int(part_rev[1])
     fname = items[4]
+    base_offset = int(fname.split('-')[0])
     ntpr = NTPR(ns=ns, topic=topic, partition=partition, revision=revision)
-    return SegmentPathComponents(ntpr=ntpr, name=fname)
+    return SegmentPathComponents(ntpr=ntpr,
+                                 name=fname,
+                                 base_offset=base_offset)
 
 
 def _parse_checksum_entry(path, value, ignore_rev):


### PR DESCRIPTION
FIXES https://github.com/redpanda-data/redpanda/issues/16474

This test removes a segment from the manifest to generate anomalies. A side effect of this is that the validation in manifest done during spillover which checks that the start of the manifest and the start of spillover must match can fail, because the first segment of the manifest has been force reset away.

Effectively, spillover manifest is creating by iterating over segment list in main manifest. This main manifest is missing its first segment because of the anomaly injection.

When applying the spillover command, the manifest compares the start offsets of the spillover meta and the main manifest. The start offset has not changed during the anomaly injection. As a result the apply-spillover command fails.

This is acceptable because the anomaly injection should cause this failure, and this change adds the error to allow list.

Additionally, a utility is added which can allow logs using information from a test run.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
