### PR TITLE
rptest: enable test_add_and_decommission

### DIFF
--- a/tests/rptest/test_suite_cloud.yml
+++ b/tests/rptest/test_suite_cloud.yml
@@ -11,6 +11,7 @@
 cloud:
   included:
     - redpanda_cloud_tests/config_profile_verify_test.py
+    - redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_add_and_decommission
     - redpanda_cloud_tests/high_throughput_test.py::HighThroughputTest.test_decommission_and_add
     - redpanda_cloud_tests/observe_test.py
     - redpanda_cloud_tests/omb_validation_test.py


### PR DESCRIPTION
follow on to PR #15701

enable test to run on the scheduled jobs

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none