### PR TITLE
container: chunked_vector improvements

### DIFF
--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -152,7 +152,7 @@ public:
         --_size;
         if (_frags.back().empty()) {
             _frags.pop_back();
-            _capacity -= elems_per_frag;
+            _capacity -= std::min(elems_per_frag, _capacity);
         }
         update_generation();
     }

--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -140,10 +140,10 @@ public:
     template<class... Args>
     T& emplace_back(Args&&... args) {
         maybe_add_capacity();
-        _frags.back().emplace_back(std::forward<Args>(args)...);
+        T& emplaced = _frags.back().emplace_back(std::forward<Args>(args)...);
         ++_size;
         update_generation();
-        return _frags.back().back();
+        return emplaced;
     }
 
     void pop_back() {

--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -112,8 +112,11 @@ public:
     requires std::input_iterator<Iter>
     fragmented_vector(Iter begin, Iter end)
       : fragmented_vector() {
+        if constexpr (std::random_access_iterator<Iter>) {
+            reserve(std::distance(begin, end));
+        }
         // Improvement: Write a more efficient implementation for
-        // random_access_iterators
+        // std::contiguous_iterator<Iter>
         for (auto it = begin; it != end; ++it) {
             push_back(*it);
         }

--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -273,7 +273,7 @@ public:
      * Returns the approximate in-memory size of this vector in bytes.
      */
     size_t memory_size() const {
-        return _frags.size() * (sizeof(_frags[0]) + elems_per_frag * sizeof(T));
+        return (_frags.size() * sizeof(_frags[0])) + (_capacity * sizeof(T));
     }
 
     /**

--- a/src/v/container/tests/fragmented_vector_test.cc
+++ b/src/v/container/tests/fragmented_vector_test.cc
@@ -399,6 +399,38 @@ TEST(Vector, FromIterRangeConstructor) {
     EXPECT_THAT(fv, ElementsAre(1, 2, 3));
 }
 
+TEST(ChunkedVector, PushPop) {
+    for (int i = 0; i < 100; ++i) {
+        chunked_vector<int32_t> vec;
+        for (int i = 0; i < vec.elements_per_fragment(); ++i) {
+            bool push_back = vec.empty() || bool(random_generators::get_int(1));
+            if (push_back) {
+                vec.push_back(i);
+            } else {
+                vec.pop_back();
+            }
+            EXPECT_TRUE(fragmented_vector_validator::validate(vec));
+        }
+    }
+}
+
+TEST(ChunkedVector, PushPopN) {
+    for (int i = 0; i < 100; ++i) {
+        chunked_vector<int32_t> vec;
+        for (int i = 0; i < vec.elements_per_fragment(); ++i) {
+            // Slight preference to make larger vectors because we could be
+            // popping back multiple
+            bool push_back = vec.empty() || bool(random_generators::get_int(2));
+            if (push_back) {
+                vec.push_back(i);
+            } else {
+                vec.pop_back_n(random_generators::get_int(vec.size()));
+            }
+            EXPECT_TRUE(fragmented_vector_validator::validate(vec));
+        }
+    }
+}
+
 TEST(ChunkedVector, FirstChunkCapacityDoubles) {
     chunked_vector<int32_t> vec;
     for (int i = 0; i < vec.elements_per_fragment(); ++i) {


### PR DESCRIPTION
The main thing this patch does is catch a bug with `pop_back` in chunked vector now that we don't always use full fragment sizes when there is only a single fragment.

There are also a couple of other small improvements and fixes for `chunked_vector`, such as calling `reserve` for the iterator constructor, making `memory_size` more accurate.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
