### PR TITLE
cloud_storage: Fix timequery bug that triggers full scan

### DIFF
--- a/src/v/cloud_storage/read_path_probes.h
+++ b/src/v/cloud_storage/read_path_probes.h
@@ -23,11 +23,26 @@ public:
     explicit partition_probe(const model::ntp& ntp);
 
     void add_bytes_read(uint64_t read) { _bytes_read += read; }
+    void add_bytes_skip(uint64_t skip) { _bytes_skip += skip; }
+    void add_bytes_accept(uint64_t accept) { _bytes_accept += accept; }
     void add_records_read(uint64_t read) { _records_read += read; }
     void chunk_size(uint64_t size) { _chunk_size = size; }
 
+    uint64_t get_bytes_read() const noexcept { return _bytes_read; }
+    uint64_t get_bytes_skip() const noexcept { return _bytes_skip; }
+    uint64_t get_bytes_accept() const noexcept { return _bytes_accept; }
+    uint64_t get_records_read() const noexcept { return _records_read; }
+    uint64_t get_chunk_size() const noexcept { return _chunk_size; }
+
 private:
+    // Number of bytes that partition reader have received
     uint64_t _bytes_read = 0;
+    // This is used in tests and not exposed to the metrics endpoint
+    // Number of bytes skipped by the segment batch reader
+    uint64_t _bytes_skip = 0;
+    // This is used in tests and not exposed to the metrics endpoint
+    // Number of bytes accepted by the segment batch reader
+    uint64_t _bytes_accept = 0;
     uint64_t _records_read = 0;
     uint64_t _chunk_size = 0;
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -113,7 +113,7 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
     auto ko = model::offset_cast(config.start_offset);
     // Two level lookup:
     // - find segment meta based on kafka offset
-    //   this allow us to avoid any abiguity in case if the segment
+    //   this allow us to avoid any ambiguity in case if the segment
     //   doesn't have any data. The 'segment_containing' method of the
     //   manifest takes this into account.
     // - find materialized segment or materialize the new one
@@ -127,24 +127,24 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
                 mit = manifest.segment_containing(maybe_meta->base_offset);
             }
         } else {
-            // In this case the lookup is perfomed by kafka offset.
+            // In this case the lookup is performed by kafka offset.
             // Normally, this would be the first lookup done by the
             // partition_record_batch_reader_impl. This lookup will
             // skip segments without data batches (the logic is implemented
             // inside the partition_manifest).
             mit = manifest.segment_containing(ko);
-        }
-        if (mit == manifest.end()) {
-            // Segment that matches exactly can't be found in the manifest. In
-            // this case we want to start scanning from the begining of the
-            // partition if the start of the manifest is contained by the scan
-            // range.
-            auto so = manifest.get_start_kafka_offset().value_or(
-              kafka::offset::min());
-            if (
-              model::offset_cast(config.start_offset) < so
-              && model::offset_cast(config.max_offset) > so) {
-                mit = manifest.begin();
+            if (mit == manifest.end()) {
+                // Segment that matches exactly can't be found in the manifest.
+                // In this case we want to start scanning from the beginning of
+                // the partition if the start of the manifest is contained by
+                // the scan range.
+                auto so = manifest.get_start_kafka_offset().value_or(
+                  kafka::offset::min());
+                if (
+                  model::offset_cast(config.start_offset) < so
+                  && model::offset_cast(config.max_offset) > so) {
+                    mit = manifest.begin();
+                }
             }
         }
     } else {

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1197,6 +1197,7 @@ public:
               "[{}] accept_batch_start skip because record batch type is {}",
               _config.client_address,
               header.type);
+            _parent._probe.add_bytes_skip(header.size_bytes);
             return batch_consumer::consume_result::skip_batch;
         }
 
@@ -1214,6 +1215,7 @@ public:
               rp_to_kafka(header.last_offset()),
               header.last_offset(),
               _config.start_offset);
+            _parent._probe.add_bytes_skip(header.size_bytes);
             return batch_consumer::consume_result::skip_batch;
         }
 
@@ -1234,8 +1236,10 @@ public:
               "[{}] accept_batch_start skip because header timestamp is {}",
               _config.client_address,
               header.first_timestamp);
+            _parent._probe.add_bytes_skip(header.size_bytes);
             return batch_consumer::consume_result::skip_batch;
         }
+        _parent._probe.add_bytes_accept(header.size_bytes);
         // we want to consume the batch
         return batch_consumer::consume_result::accept_batch;
     }

--- a/src/v/cloud_storage/tests/common_def.h
+++ b/src/v/cloud_storage/tests/common_def.h
@@ -73,6 +73,7 @@ struct batch_t {
     /// Set to true to completely erase the batch from the segment
     /// to check compacted segments.
     bool hole{false};
+    std::optional<model::timestamp> timestamp{std::nullopt};
 };
 
 /// \returns generated batches and committed offset + 1
@@ -92,7 +93,8 @@ make_random_batches(model::offset o, const std::vector<batch_t>& batches) {
           batch.type,
           batch.record_sizes.size() != batch.num_records
             ? std::nullopt
-            : std::make_optional(batch.record_sizes));
+            : std::make_optional(batch.record_sizes),
+          batch.timestamp);
         o = b.last_offset() + model::offset(1);
         b.set_term(model::term_id(0));
         ret.push_back(std::move(b));


### PR DESCRIPTION
Timequery can trigger full partition scan if the query overshoots the last segment. In this case if `log_reader_config.start_offset` is below the first segment in the manifest and `log_reader_config.max_offset` is above last offset in the manifest we will initialize the scan from the beginning which is very expensive.

This PR adds
- New partition level metrics which are used to detect skipped bytes generated by futile partition scan. This metrics are not exposed to metrics endpoint and only used internally (mostly for testing and will be used for alerts).
- New test suite in the `remote_partition_test` that performs timequery (TODO: add fuzz test).
- One line fix for the bug.

Fixes #16479

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix timequery error that triggered full partition scan
