### PR TITLE
config: update bindings when properties are reset

### DIFF
--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -751,7 +751,7 @@ FIXTURE_TEST(test_segments_pending_deletion_limit, archiver_fixture) {
       [] { config::shard_local_cfg().log_retention_ms.reset(); });
 
     config::shard_local_cfg()
-      .cloud_storage_max_segments_pending_deletion_per_partition(2);
+      .cloud_storage_max_segments_pending_deletion_per_partition.set_value(2);
 
     auto [arch_conf, remote_conf] = get_configurations();
     auto amv = ss::make_shared<cloud_storage::async_manifest_view>(

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -38,12 +38,13 @@ scan_remote_partition_incrementally_with_reuploads(
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {
         config::shard_local_cfg()
-          .cloud_storage_max_materialized_segments_per_shard(
+          .cloud_storage_max_materialized_segments_per_shard.set_value(
             maybe_max_segments);
     }
     if (maybe_max_readers) {
-        config::shard_local_cfg().cloud_storage_max_segment_readers_per_shard(
-          maybe_max_readers);
+        config::shard_local_cfg()
+          .cloud_storage_max_segment_readers_per_shard.set_value(
+            maybe_max_readers);
     }
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -1885,12 +1885,13 @@ std::vector<model::record_batch_header> scan_remote_partition_with_replacements(
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {
         config::shard_local_cfg()
-          .cloud_storage_max_materialized_segments_per_shard(
+          .cloud_storage_max_materialized_segments_per_shard.set_value(
             maybe_max_segments);
     }
     if (maybe_max_readers) {
-        config::shard_local_cfg().cloud_storage_max_segment_readers_per_shard(
-          maybe_max_readers);
+        config::shard_local_cfg()
+          .cloud_storage_max_segment_readers_per_shard.set_value(
+            maybe_max_readers);
     }
     storage::log_reader_config read_one(
       base, model::next_offset(base), ss::default_priority_class());

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -647,12 +647,13 @@ std::vector<model::record_batch_header> scan_remote_partition_incrementally(
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {
         config::shard_local_cfg()
-          .cloud_storage_max_materialized_segments_per_shard(
+          .cloud_storage_max_materialized_segments_per_shard.set_value(
             maybe_max_segments);
     }
     if (maybe_max_readers) {
-        config::shard_local_cfg().cloud_storage_max_segment_readers_per_shard(
-          maybe_max_readers);
+        config::shard_local_cfg()
+          .cloud_storage_max_segment_readers_per_shard.set_value(
+            maybe_max_readers);
     }
     auto manifest = hydrate_manifest(imposter.api.local(), bucket);
     partition_probe probe(manifest.get_ntp());
@@ -727,12 +728,13 @@ std::vector<model::record_batch_header> scan_remote_partition(
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {
         config::shard_local_cfg()
-          .cloud_storage_max_materialized_segments_per_shard(
+          .cloud_storage_max_materialized_segments_per_shard.set_value(
             maybe_max_segments);
     }
     if (maybe_max_readers) {
-        config::shard_local_cfg().cloud_storage_max_segment_readers_per_shard(
-          maybe_max_readers);
+        config::shard_local_cfg()
+          .cloud_storage_max_segment_readers_per_shard.set_value(
+            maybe_max_readers);
     }
     storage::log_reader_config reader_config(
       base, max, ss::default_priority_class());
@@ -777,12 +779,13 @@ scan_result scan_remote_partition(
     static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {
         config::shard_local_cfg()
-          .cloud_storage_max_materialized_segments_per_shard(
+          .cloud_storage_max_materialized_segments_per_shard.set_value(
             maybe_max_segments);
     }
     if (maybe_max_readers) {
-        config::shard_local_cfg().cloud_storage_max_segment_readers_per_shard(
-          maybe_max_readers);
+        config::shard_local_cfg()
+          .cloud_storage_max_segment_readers_per_shard.set_value(
+            maybe_max_readers);
     }
     auto manifest = hydrate_manifest(imposter.api.local(), bucket);
     storage::log_reader_config reader_config(

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -187,11 +187,6 @@ public:
 
     void reset() override { _value = default_value(); }
 
-    property<T>& operator()(T v) {
-        _value = std::move(v);
-        return *this;
-    }
-
     base_property& operator=(const base_property& pr) override {
         _value = dynamic_cast<const property<T>&>(pr)._value;
         return *this;

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -265,8 +265,10 @@ protected:
 
     bool update_value(T&& new_value) {
         if (new_value != _value) {
-            notify_watchers(new_value);
+            // Update the main value first, in case one of the binding updates
+            // throws.
             _value = std::move(new_value);
+            notify_watchers(_value);
 
             return true;
         } else {

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -185,10 +185,14 @@ public:
         return validate(v);
     }
 
-    void reset() override { _value = default_value(); }
+    void reset() override {
+        auto v = default_value();
+        update_value(std::move(v));
+    }
 
     base_property& operator=(const base_property& pr) override {
-        _value = dynamic_cast<const property<T>&>(pr)._value;
+        auto v = dynamic_cast<const property<T>&>(pr)._value;
+        update_value(std::move(v));
         return *this;
     }
 

--- a/src/v/config/tests/config_store_test.cc
+++ b/src/v/config/tests/config_store_test.cc
@@ -450,6 +450,13 @@ SEASTAR_THREAD_TEST_CASE(property_bind) {
     BOOST_TEST(bind2() == "newvalue4");
     BOOST_TEST(bind3() == "newvalue4");
     BOOST_TEST(watch_count == 6);
+
+    // Check that the bindings are updated when the property is reset to its
+    // default value.
+    cfg2.required_string.reset();
+    BOOST_TEST(bind2() == "");
+    BOOST_TEST(bind3() == "");
+    BOOST_TEST(watch_count == 8);
 }
 
 SEASTAR_THREAD_TEST_CASE(property_conversion_bind) {


### PR DESCRIPTION
Previously we just set the value without notifying bindings. This led to ignoring property value updates when the property was reset to its default value as a result of a patch_cluster_config request with non-empty "remove" section.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [x] v23.1.x

## Release Notes

### Bug Fixes

* Fix a bug that resulted in Redpanda ignoring until the next restart config values that were reset to their defaults.