### PR TITLE
rptest: use okta auth for teleport

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -72,12 +72,14 @@ class KubectlTool:
                 'tsh',
                 'ssh',
                 f'--proxy={self._tp_proxy}',
+                '--auth=okta',
                 self._remote_uri,
             ]
         return [
             'tsh',
             'ssh',
             f'--proxy={self._tp_proxy}',
+            '--auth=okta'
             f'--identity={self.TELEPORT_IDENT_FILE}',
             self._remote_uri,
         ]
@@ -97,9 +99,12 @@ class KubectlTool:
         if self._tp_proxy is None:
             return ['scp', src, dest]
         if self._tp_token is None:
-            return ['tsh', 'scp', f'--proxy={self._tp_proxy}', src, dest]
+            return [
+                'tsh', 'scp', f'--proxy={self._tp_proxy}', '--auth=okta', src,
+                dest
+            ]
         return [
-            'tsh', 'scp', f'--proxy={self._tp_proxy}',
+            'tsh', 'scp', f'--proxy={self._tp_proxy}', '--auth=okta',
             f'--identity={self.TELEPORT_IDENT_FILE}', src, dest
         ]
 


### PR DESCRIPTION
without this fix, will get error:
```
ERROR: no github connectors found
```
validated fix with test:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  tests/rptest/tests/services_self_test.py::SimpleSelfTest.test_cloud
```
output:
```
test_id:    rptest.tests.services_self_test.SimpleSelfTest.test_cloud
status:     PASS
run time:   54.454 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
========================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2024-02-06--004
run time:         54.472 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
========================================================================================================================================================================================
```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none