### PR TITLE
Fix missing comma in kubectl.py

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -79,7 +79,7 @@ class KubectlTool:
             'tsh',
             'ssh',
             f'--proxy={self._tp_proxy}',
-            '--auth=okta'
+            '--auth=okta',
             f'--identity={self.TELEPORT_IDENT_FILE}',
             self._remote_uri,
         ]


### PR DESCRIPTION
Follow on to PR #16505

Fix missing comma. The code "works" because the strings get just appended to each
other but then form an invalid cli arg.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

