### PR TITLE
[v23.2.x] cloud_storage: Fix timequery bug that triggers full scan

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -97,7 +97,7 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
     auto ko = model::offset_cast(config.start_offset);
     // Two level lookup:
     // - find segment meta based on kafka offset
-    //   this allow us to avoid any abiguity in case if the segment
+    //   this allow us to avoid any ambiguity in case if the segment
     //   doesn't have any data. The 'segment_containing' method of the
     //   manifest takes this into account.
     // - find materialized segment or materialize the new one
@@ -111,22 +111,24 @@ remote_partition::borrow_result_t remote_partition::borrow_next_segment_reader(
                 mit = manifest.segment_containing(maybe_meta->base_offset);
             }
         } else {
-            // In this case the lookup is perfomed by kafka offset.
+            // In this case the lookup is performed by kafka offset.
             // Normally, this would be the first lookup done by the
             // partition_record_batch_reader_impl. This lookup will
             // skip segments without data batches (the logic is implemented
             // inside the partition_manifest).
             mit = manifest.segment_containing(ko);
-        }
-        if (mit == manifest.end()) {
-            // Segment that matches exactly can't be found in the manifest. In
-            // this case we want to start scanning from the begining of the
-            // partition if the start of the manifest is contained by the scan
-            // range.
-            auto so = manifest.get_start_kafka_offset().value_or(
-              kafka::offset::min());
-            if (config.start_offset < so && config.max_offset > so) {
-                mit = manifest.begin();
+            if (mit == manifest.end()) {
+                // Segment that matches exactly can't be found in the manifest.
+                // In this case we want to start scanning from the beginning of
+                // the partition if the start of the manifest is contained by
+                // the scan range.
+                auto so = manifest.get_start_kafka_offset().value_or(
+                  kafka::offset::min());
+                if (
+                  model::offset_cast(config.start_offset) < so
+                  && model::offset_cast(config.max_offset) > so) {
+                    mit = manifest.begin();
+                }
             }
         }
     } else {


### PR DESCRIPTION
Timequery can trigger full partition scan if the query overshoots the last segment. In this case if `log_reader_config.start_offset` is below the first segment in the manifest and `log_reader_config.max_offset` is above last offset in the manifest we will initialize the scan from the beginning which is very expensive.

Fixes #16479 #16516

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix timequery error that triggered full partition scan
