### PR TITLE
rpc: Add config flag to enable/disable compression for replies

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -143,6 +143,12 @@ configuration::configuration()
       {.example = "8"},
       8,
       {.min = 8})
+  , rpc_server_compress_replies(
+      *this,
+      "rpc_server_compress_replies",
+      "Enable compression for internal rpc server replies",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
   , enable_coproc(*this, "enable_coproc")
   , coproc_max_inflight_bytes(*this, "coproc_max_inflight_bytes")
   , coproc_max_ingest_bytes(*this, "coproc_max_ingest_bytes")

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -60,6 +60,7 @@ struct configuration final : public config_store {
     bounded_property<std::optional<int>> rpc_server_tcp_recv_buf;
     bounded_property<std::optional<int>> rpc_server_tcp_send_buf;
     bounded_property<int> rpc_client_connections_per_peer;
+    property<bool> rpc_server_compress_replies;
     // Coproc
     deprecated_property enable_coproc;
     deprecated_property coproc_max_inflight_bytes;

--- a/src/v/rpc/rpc_server.cc
+++ b/src/v/rpc/rpc_server.cc
@@ -9,6 +9,7 @@
 
 #include "rpc/rpc_server.h"
 
+#include "config/configuration.h"
 #include "rpc/logger.h"
 #include "rpc/types.h"
 #include "ssx/semaphore.h"
@@ -75,8 +76,10 @@ ss::future<> rpc_server::apply(ss::lw_shared_ptr<net::connection> conn) {
 
 ss::future<>
 rpc_server::send_reply(ss::lw_shared_ptr<server_context_impl> ctx, netbuf buf) {
-    buf.set_min_compression_bytes(reply_min_compression_bytes);
-    buf.set_compression(rpc::compression_type::zstd);
+    if (config::shard_local_cfg().rpc_server_compress_replies()) {
+        buf.set_min_compression_bytes(reply_min_compression_bytes);
+        buf.set_compression(rpc::compression_type::zstd);
+    }
     buf.set_correlation_id(ctx->get_header().correlation_id);
 
     auto view = co_await std::move(buf).as_scattered();


### PR DESCRIPTION
Add a flag to allow disabling internal rpc reply compression.

Right now we unconditionally enable compression for rpc replies if they
are above the min compression size (1Kib).

In this commit we don't change the default and keep compression on but
we might change that in a follow up commit as the cpu overhead from
compressing/uncompressing larger messages has shown to be detrimental to
overall performance.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
* none