### PR TITLE
transform: gc committed offsets

### DIFF
--- a/src/v/cluster/distributed_kv_stm_types.h
+++ b/src/v/cluster/distributed_kv_stm_types.h
@@ -200,17 +200,20 @@ make_kv_data_batch(absl::btree_map<Key, Value> kvs) {
 }
 
 template<class Key, class Value>
-static simple_batch_builder make_kv_data_batch_remove_key(Key k) {
+static simple_batch_builder
+make_kv_data_batch_remove_all(absl::btree_set<Key> ks) {
     simple_batch_builder builder(
       model::record_batch_type::raft_data, model::offset(0));
-    iobuf key_buf;
-    serde::write(key_buf, kv_data_key<Key>{k});
-    iobuf value_buf;
-    serde::write(value_buf, kv_data_value<Value>{});
+    for (auto& k : ks) {
+        iobuf key_buf;
+        serde::write(key_buf, kv_data_key<Key>{k});
+        iobuf value_buf;
+        serde::write(value_buf, kv_data_value<Value>{});
 
-    builder.add_kv(
-      record_key{record_type::kv_data, std::move(key_buf)},
-      record_value_wrapper{std::move(value_buf)});
+        builder.add_kv(
+          record_key{record_type::kv_data, std::move(key_buf)},
+          record_value_wrapper{std::move(value_buf)});
+    }
     return builder;
 }
 

--- a/src/v/cluster/tests/distributed_kv_stm_tests.cc
+++ b/src/v/cluster/tests/distributed_kv_stm_tests.cc
@@ -97,7 +97,7 @@ FIXTURE_TEST(test_stm_list, stm_test_fixture) {
     }
 }
 
-FIXTURE_TEST(test_batched_put, stm_test_fixture) {
+FIXTURE_TEST(test_batched_actions, stm_test_fixture) {
     create_stm_and_start_raft(1);
     auto& stm = *_stm;
     stm.start().get0();
@@ -117,6 +117,16 @@ FIXTURE_TEST(test_batched_put, stm_test_fixture) {
 
     for (int i = 0; i < 30; i++) {
         BOOST_REQUIRE_EQUAL(stm.get(i).get0().value(), test_value{i});
+    }
+
+    // Delete the even keys
+    stm.remove_all([](int key) { return key % 2 == 0; }).get();
+    for (int i = 0; i < 30; i++) {
+        if (i % 2 == 0) {
+            BOOST_REQUIRE(!stm.get(i).get().value().has_value());
+        } else {
+            BOOST_REQUIRE_EQUAL(stm.get(i).get().value(), test_value{i});
+        }
     }
 }
 

--- a/src/v/redpanda/admin/api-doc/transform.json
+++ b/src/v/redpanda/admin/api-doc/transform.json
@@ -78,6 +78,19 @@
           ]
         }
       ]
+    },
+    {
+      "path": "/v1/transform/debug/committed_offsets/garbage_collect",
+      "operations": [
+        {
+          "method": "POST",
+          "summary": "Cleanup unknown commits for transforms that where deleted.",
+          "nickname": "garbage_collect_committed_offsets",
+          "produces": [
+            "application/json"
+          ]
+        }
+      ]
     }
   ],
   "models": {

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -610,6 +610,8 @@ private:
       delete_transform(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
       list_committed_offsets(std::unique_ptr<ss::http::request>);
+    ss::future<ss::json::json_return_type>
+      garbage_collect_committed_offsets(std::unique_ptr<ss::http::request>);
 
     ss::future<> throw_on_error(
       ss::http::request& req,

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -79,11 +79,26 @@ public:
 
     /**
      * List the committed offsets for each transform/partition.
+     *
+     * NOTE: This information is **not** guarenteed to be consistent and may
+     * provide an information for different offsets at different points in time.
      */
     ss::future<result<
       ss::chunked_fifo<model::transform_committed_offset>,
       cluster::errc>>
       list_committed_offsets(list_committed_offsets_options);
+
+    /**
+     * Delete all offsets from transforms that do not exist.
+     *
+     * NOTE: This should only be ran while new transforms are not deploying, as
+     * it is possible to delete transforms for newly deployed transforms as our
+     * control plane operations are eventually consistent, so the shard that is
+     * performing the garbage collection may have out of date information (and
+     * gathering all the offsets that exist can result in an inconsistent view
+     * of information anyways).
+     */
+    ss::future<std::error_code> garbage_collect_committed_offsets();
 
     /**
      * Create a reporter of the transform subsystem.

--- a/src/v/transform/api.h
+++ b/src/v/transform/api.h
@@ -29,7 +29,10 @@
 
 namespace transform {
 
+/** Request options for listing committed offsets. */
 struct list_committed_offsets_options {
+    // If true, show transforms that we don't have metadata for, these likely
+    // represent transforms that have been deleted.
     bool show_unknown = false;
 };
 
@@ -37,6 +40,10 @@ struct list_committed_offsets_options {
  * The transform service is responsible for intersecting the current state of
  * plugins and topic partitions and ensures that the corresponding wasm
  * transform is running for each leader partition (on the input topic).
+ *
+ * This service is mostly responsible for interfacing the rest of the system
+ * with the transform control plane (transform::manager), and forwarding the
+ * correct events from the rest of the system into the control plane.
  *
  * Instances on every shard.
  */

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -90,6 +90,12 @@ public:
     ss::future<result<model::transform_offsets_map, cluster::errc>>
     list_committed_offsets();
 
+    /**
+     * Delete all committed offsets for this transform ID.
+     */
+    ss::future<cluster::errc>
+    delete_committed_offsets(absl::btree_set<model::transform_id> ids);
+
     ss::future<> start();
     ss::future<> stop();
 
@@ -165,6 +171,18 @@ private:
     do_remote_list_committed_offsets(
       model::node_id,
       model::partition_id,
+      model::timeout_clock::duration timeout);
+
+    ss::future<cluster::errc> do_delete_committed_offsets(
+      model::partition_id, absl::btree_set<model::transform_id>);
+    ss::future<cluster::errc> do_delete_committed_offsets_once(
+      model::partition_id, absl::btree_set<model::transform_id>);
+    ss::future<cluster::errc> do_local_delete_committed_offsets(
+      model::partition_id, absl::btree_set<model::transform_id>);
+    ss::future<cluster::errc> do_remote_delete_committed_offsets(
+      model::node_id,
+      model::partition_id,
+      absl::btree_set<model::transform_id>,
       model::timeout_clock::duration timeout);
 
     template<typename Func>

--- a/src/v/transform/rpc/deps.h
+++ b/src/v/transform/rpc/deps.h
@@ -200,6 +200,10 @@ public:
 
     virtual ss::future<result<model::transform_offsets_map, cluster::errc>>
     list_committed_offsets_on_shard(ss::shard_id, const model::ntp&) = 0;
+
+    virtual ss::future<cluster::errc> delete_committed_offsets_on_shard(
+      ss::shard_id, const model::ntp&, absl::btree_set<model::transform_id>)
+      = 0;
 };
 
 }; // namespace transform::rpc

--- a/src/v/transform/rpc/rpc.json
+++ b/src/v/transform/rpc/rpc.json
@@ -49,6 +49,11 @@
             "name": "list_committed_offsets",
             "input_type": "list_commits_request",
             "output_type": "list_commits_reply"
+        },
+        {
+            "name": "delete_committed_offsets",
+            "input_type": "delete_commits_request",
+            "output_type": "delete_commits_reply"
         }
     ]
 }

--- a/src/v/transform/rpc/serde.cc
+++ b/src/v/transform/rpc/serde.cc
@@ -186,4 +186,18 @@ std::ostream& operator<<(std::ostream& os, const list_commits_reply& reply) {
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const delete_commits_request& req) {
+    fmt::print(
+      os,
+      "{{ partition: {}, transform_ids_size: {} }}",
+      req.partition,
+      req.ids.size());
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, const delete_commits_reply& reply) {
+    fmt::print(os, "{{ ec: {} }}", reply.errc);
+    return os;
+}
+
 } // namespace transform::rpc

--- a/src/v/transform/rpc/serde.h
+++ b/src/v/transform/rpc/serde.h
@@ -456,4 +456,52 @@ struct list_commits_reply
     cluster::errc errc{cluster::errc::success};
     model::transform_offsets_map map;
 };
+
+/**
+ * A request to delete commits for a given set of transform IDs on a single
+ * partition.
+ *
+ * Transform IDs that are not found for this are noops.
+ */
+struct delete_commits_request
+  : serde::envelope<
+      delete_commits_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    delete_commits_request() = default;
+    delete_commits_request(
+      model::partition_id partition, absl::btree_set<model::transform_id> ids)
+      : partition(partition)
+      , ids(std::move(ids)) {}
+
+    auto serde_fields() { return std::tie(partition, ids); }
+
+    friend std::ostream&
+    operator<<(std::ostream&, const delete_commits_request&);
+
+    model::partition_id partition;
+    absl::btree_set<model::transform_id> ids;
+};
+
+/**
+ * The response to `delete_commits_request`, and the overall status of the
+ * operation.
+ */
+struct delete_commits_reply
+  : serde::envelope<
+      delete_commits_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    delete_commits_reply() = default;
+
+    auto serde_fields() { return std::tie(errc); }
+
+    friend std::ostream& operator<<(std::ostream&, const delete_commits_reply&);
+
+    cluster::errc errc{cluster::errc::success};
+};
 } // namespace transform::rpc

--- a/src/v/transform/rpc/service.h
+++ b/src/v/transform/rpc/service.h
@@ -58,6 +58,9 @@ public:
     ss::future<result<model::transform_offsets_map, cluster::errc>>
       list_committed_offsets(list_commits_request);
 
+    ss::future<cluster::errc> delete_committed_offsets(
+      model::partition_id, absl::btree_set<model::transform_id>);
+
 private:
     ss::future<transformed_topic_data_result>
       produce(transformed_topic_data, model::timeout_clock::duration);
@@ -110,6 +113,9 @@ public:
 
     ss::future<list_commits_reply> list_committed_offsets(
       list_commits_request, ::rpc::streaming_context&) override;
+
+    ss::future<delete_commits_reply> delete_committed_offsets(
+      delete_commits_request, ::rpc::streaming_context&) override;
 
     ss::future<generate_report_reply> generate_report(
       generate_report_request, ::rpc::streaming_context&) override;

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1266,3 +1266,8 @@ class Admin:
             CommittedWasmOffset(c["transform_name"], c["partition"],
                                 c["offset"]) for c in raw
         ]
+
+    def transforms_gc_committed_offsets(self,
+                                        node: Optional[ClusterNode] = None):
+        path = "transform/debug/committed_offsets/garbage_collect"
+        return self._request("POST", path, node=node)


### PR DESCRIPTION
Prior to this patch set - it was not possible to cleanup committed offsets. This means that if lots of transforms were created and then deleted one could run into the limit with no escape hatch. This patch set implements an escape hatch to cleanup offsets.

This is implemented as a manual GC mechanism because this can race with deploys and delete offsets that are still in use. A way to get around that is to expose a max transform id or something from the controller log so that we don't ever delete any ids that the target shard has not yet seen. Since IDs are assigned from the first deploy and their offset within the controller log, we could do this by the committed offset of the controller log. However, instead of implementing that and running it periodically, we just make it a manual endpoint to hit, the automatic GC could happen at a later date.

This is a followup to: https://github.com/redpanda-data/redpanda/pull/16185

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
