### PR TITLE
schemata: use chunked_vector for createable_topic

### DIFF
--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -19,6 +19,7 @@
 #include <climits>
 #include <compare>
 #include <cstddef>
+#include <initializer_list>
 #include <iterator>
 #include <span>
 #include <stdexcept>
@@ -93,6 +94,35 @@ public:
     fragmented_vector(fragmented_vector&& other) noexcept {
         *this = std::move(other);
     }
+
+    /**
+     * @brief Create a vector from a begin, end iterator pair.
+     *
+     * This has the same semantics as the corresponding std::vector
+     * constructor.
+     */
+    template<typename Iter>
+    requires std::input_iterator<Iter>
+    fragmented_vector(Iter begin, Iter end)
+      : fragmented_vector() {
+        if constexpr (std::random_access_iterator<Iter>) {
+            reserve(std::distance(begin, end));
+        }
+        // Improvement: Write a more efficient implementation for
+        // std::contiguous_iterator<Iter>
+        for (auto it = begin; it != end; ++it) {
+            push_back(*it);
+        }
+    }
+
+    /**
+     * @brief Construct a new vector using an initializer list
+     *
+     * In the same manner as the corresponding std::vector method.
+     */
+    fragmented_vector(std::initializer_list<value_type> elems)
+      : fragmented_vector(elems.begin(), elems.end()) {}
+
     fragmented_vector& operator=(fragmented_vector&& other) noexcept {
         if (this != &other) {
             this->_size = other._size;
@@ -107,20 +137,6 @@ public:
         return *this;
     }
     ~fragmented_vector() noexcept = default;
-
-    template<typename Iter>
-    requires std::input_iterator<Iter>
-    fragmented_vector(Iter begin, Iter end)
-      : fragmented_vector() {
-        if constexpr (std::random_access_iterator<Iter>) {
-            reserve(std::distance(begin, end));
-        }
-        // Improvement: Write a more efficient implementation for
-        // std::contiguous_iterator<Iter>
-        for (auto it = begin; it != end; ++it) {
-            push_back(*it);
-        }
-    }
 
     fragmented_vector copy() const noexcept { return *this; }
 

--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -324,6 +324,21 @@ public:
 
         iter() = default;
 
+        /**
+         * Conversion operator allowing iterator to be converted to
+         * const_iterator, as required by the general iterator contract.
+         */
+        operator iter<true>() const { // NOLINT(hicpp-explicit-conversions)
+            check_generation();
+            iter<true> ret;
+            ret._vec = _vec;
+            ret._index = _index;
+#ifndef NDEBUG
+            ret._my_generation = _my_generation;
+#endif
+            return ret;
+        }
+
         reference operator*() const {
             check_generation();
             return _vec->operator[](_index);
@@ -433,6 +448,11 @@ public:
 
     const_iterator cbegin() const { return const_iterator(this, 0); }
     const_iterator cend() const { return const_iterator(this, _size); }
+
+    /**
+     * @brief Erases all elements from begin to the end of the vector.
+     */
+    void erase_to_end(const_iterator begin) { pop_back_n(cend() - begin); }
 
     friend std::ostream&
     operator<<(std::ostream& os, const fragmented_vector& v) {

--- a/src/v/container/tests/fragmented_vector_test.cc
+++ b/src/v/container/tests/fragmented_vector_test.cc
@@ -399,6 +399,32 @@ TEST(Vector, FromIterRangeConstructor) {
     EXPECT_THAT(fv, ElementsAre(1, 2, 3));
 }
 
+TEST(Vector, FromInitializerListConstructor) {
+    {
+        fragmented_vector<int> fv({});
+
+        EXPECT_THAT(fv, IsValid());
+        EXPECT_THAT(fv, ElementsAre());
+    }
+
+    {
+        fragmented_vector<int> fv({1, 2, 3});
+
+        EXPECT_THAT(fv, IsValid());
+        EXPECT_THAT(fv, ElementsAre(1, 2, 3));
+    }
+
+    {
+        chunked_vector<int> fv({1, 2, 3});
+
+        EXPECT_THAT(fv, IsValid());
+        EXPECT_THAT(fv, ElementsAre(1, 2, 3));
+        // chunked_vector should have a "tight" capacity when constructed
+        // from a list
+        EXPECT_EQ(fv.capacity(), 3);
+    }
+}
+
 TEST(ChunkedVector, PushPop) {
     for (int i = 0; i < 100; ++i) {
         chunked_vector<int32_t> vec;

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -468,6 +468,7 @@ override_member_container = {
     'metadata_response_topic': 'small_fragment_vector',
     'fetchable_partition_response': 'small_fragment_vector',
     'offset_fetch_response_partition': 'small_fragment_vector',
+    'creatable_topic': 'chunked_vector'
 }
 
 

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -199,7 +199,7 @@ ss::future<response_ptr> create_topics_handler::handle(
     }
 
     if (!ctx.audit()) {
-        request.data.topics.erase(valid_range_end, request.data.topics.end());
+        request.data.topics.erase_to_end(valid_range_end);
         create_topics_response err_resp(
           error_code::broker_not_available,
           "Broker not available - audit system failure",

--- a/src/v/kafka/server/tests/delete_topics_test.cc
+++ b/src/v/kafka/server/tests/delete_topics_test.cc
@@ -41,10 +41,8 @@ public:
         topic.num_partitions = partitions;
         topic.replication_factor = rf;
 
-        std::vector<kafka::creatable_topic> topics;
-        topics.push_back(std::move(topic));
         auto req = kafka::create_topics_request{.data{
-          .topics = std::move(topics),
+          .topics = {topic},
           .timeout_ms = 10s,
           .validate_only = false,
         }};

--- a/src/v/kafka/server/tests/topic_recreate_test.cc
+++ b/src/v/kafka/server/tests/topic_recreate_test.cc
@@ -46,10 +46,8 @@ public:
           .replication_factor = rf,
         };
 
-        std::vector<kafka::creatable_topic> topics;
-        topics.push_back(std::move(topic));
         auto req = kafka::create_topics_request{.data{
-          .topics = std::move(topics),
+          .topics = {topic},
           .timeout_ms = 10s,
           .validate_only = false,
         }};


### PR DESCRIPTION
Override the decode path to use chunked_vector for createable_topic as we may have 10,000s of these in a single API request.

Arguably, we could use chunked_vector everywhere now in schemata and get rid of this override, but let's do that later.

Fixes #16521.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug Fixes

* Avoid a large contiguous allocation when creating thousands of topics in a single CreateTopics request.

