### PR TITLE
[v23.3.x] Increase default value of `rpc_client_connections_per_peer` to 32

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -141,7 +141,7 @@ configuration::configuration()
       "The maximum number of connections a broker will open to each of its "
       "peers",
       {.example = "8"},
-      8,
+      32,
       {.min = 8})
   , enable_coproc(*this, "enable_coproc")
   , coproc_max_inflight_bytes(*this, "coproc_max_inflight_bytes")


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16527
