### PR TITLE
Introduced `cluster::vcluster_id` type underlied by XID

### DIFF
--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -34,6 +34,7 @@
 #include "storage/ntp_config.h"
 #include "tristate.h"
 #include "utils/to_string.h"
+#include "utils/xid.h"
 #include "v8_engine/data_policy.h"
 
 #include <seastar/core/chunked_fifo.hh>
@@ -1466,6 +1467,10 @@ struct remote_topic_properties
     operator<<(std::ostream&, const remote_topic_properties&);
 };
 
+/**
+ * Type representing MPX virtual cluster. MPX uses XID to identify clusters.
+ */
+using vcluster_id = named_type<xid, struct v_cluster_id_tag>;
 /**
  * Structure holding topic properties overrides, empty values will be replaced
  * with defaults

--- a/src/v/utils/CMakeLists.txt
+++ b/src/v/utils/CMakeLists.txt
@@ -14,6 +14,7 @@ v_cc_library(
     uuid.cc
     bottomless_token_bucket.cc
     log_hist.cc
+    xid.cc
   DEPS
     Seastar::seastar
     Hdrhistogram::hdr_histogram

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -102,6 +102,10 @@ public:
         return o << "{" << t() << "}";
     };
 
+    friend std::istream& operator>>(std::istream& i, base_named_type& t) {
+        return i >> t._value;
+    };
+
 protected:
     type _value = std::numeric_limits<T>::min();
 };
@@ -170,6 +174,10 @@ public:
 
     friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
         return o << "{" << t() << "}";
+    };
+
+    friend std::istream& operator>>(std::istream& i, base_named_type& t) {
+        return i >> t._value;
     };
 
 protected:

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -53,6 +53,17 @@ rp_test(
   LABELS utils
 )
 
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_utils
+  SOURCES     
+    xid_test.cc
+  LIBRARIES v::utils absl::flat_hash_map v::random v::gtest_main
+  LABELS utils
+)
+
 rp_test(
   BENCHMARK_TEST
   BINARY_NAME seastar_histogram

--- a/src/v/utils/tests/named_type_tests.cc
+++ b/src/v/utils/tests/named_type_tests.cc
@@ -80,6 +80,16 @@ BOOST_AUTO_TEST_CASE(named_type_rvalue_overload) {
     BOOST_REQUIRE_EQUAL(str, r);
 }
 
+BOOST_AUTO_TEST_CASE(named_type_stream_operators) {
+    using int_alias = named_type<uint64_t, struct int_t_alias_test_module>;
+    int_alias value{123};
+    std::stringstream stream;
+    fmt::print(stream, "{}", value);
+    int_alias from_str_value;
+    stream >> from_str_value;
+    BOOST_REQUIRE_EQUAL(from_str_value, value);
+}
+
 static_assert(
   !std::equality_comparable_with<
     named_type<int, struct tag_0>,

--- a/src/v/utils/tests/xid_test.cc
+++ b/src/v/utils/tests/xid_test.cc
@@ -1,0 +1,65 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "random/generators.h"
+#include "serde/rw/rw.h"
+#include "test_utils/test.h"
+#include "utils/xid.h"
+
+#include <absl/container/node_hash_map.h>
+#include <gtest/gtest.h>
+
+xid random_xid() {
+    static std::uniform_int_distribution<int> rand_fill('@', '~');
+    xid::data_t array;
+    memset(
+      array.data(), rand_fill(random_generators::internal::gen), array.size());
+
+    return xid(array);
+}
+
+TEST(xid, string_formatting_test) {
+    for (int i = 0; i < 1000; ++i) {
+        auto test_xid = random_xid();
+        ASSERT_EQ(
+          boost::lexical_cast<xid>(fmt::format("{}", test_xid)), test_xid);
+    }
+}
+
+TEST(xid, hashing_test) {
+    absl::node_hash_map<xid, int> map;
+    for (int i = 0; i < 100; ++i) {
+        auto r_xid = random_xid();
+        map[r_xid] = i;
+        ASSERT_EQ(map[r_xid], i);
+    }
+}
+
+TEST(xid, string_round_trip_test) {
+    for (int i = 0; i < 100; ++i) {
+        auto test_xid = random_xid();
+        ASSERT_EQ(xid::from_string(fmt::format("{}", test_xid)), test_xid);
+    }
+}
+
+TEST(xid, serde_round_trip_test) {
+    for (int i = 0; i < 1000; ++i) {
+        auto test_xid = random_xid();
+        ASSERT_EQ(serde::from_iobuf<xid>(serde::to_iobuf(test_xid)), test_xid);
+    }
+}
+
+TEST(xid, test_xid_string_validation) {
+    // invalid length 21 characters
+    ASSERT_THROW(xid::from_string("ccc0a2mn6i1e6brmdbip0"), invalid_xid);
+    // invalid length 19 characters
+    ASSERT_THROW(xid::from_string("c0a2mn6i1e6brmdbip0"), invalid_xid);
+    // invalid value of last character
+    ASSERT_THROW(xid::from_string("cc0a2mn6i1e6brmdbipa"), invalid_xid);
+}

--- a/src/v/utils/xid.cc
+++ b/src/v/utils/xid.cc
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "utils/xid.h"
+
+#include "serde/rw/array.h"
+#include "serde/rw/rw.h"
+#include "ssx/sformat.h"
+
+#include <fmt/format.h>
+
+namespace {
+static constexpr std::array<char, 32> b32_alphabet{
+  '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a',
+  'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l',
+  'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v'};
+
+using decoder_t = std::array<uint8_t, 256>;
+
+constexpr decoder_t build_decoder_table() {
+    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
+    std::array<uint8_t, 256> ret = {0xff};
+
+    for (uint8_t i = 0; i < b32_alphabet.size(); ++i) {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
+        ret[b32_alphabet[i]] = i;
+    }
+    return ret;
+}
+
+static constexpr decoder_t decoder = build_decoder_table();
+} // namespace
+
+invalid_xid::invalid_xid(const ss::sstring& current_string)
+  : _msg(ssx::sformat("String '{}' is not a valid xid", current_string)) {}
+
+xid xid::from_string(const ss::sstring& str) {
+    if (str.size() != str_size) {
+        throw invalid_xid(str);
+    }
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index,
+    // readability-magic-numbers, hicpp-signed-bitwise)
+    data_t data;
+    data[11] = decoder[str[17]] << 6u | decoder[str[18]] << 1u
+               | decoder[str[19]] >> 4u;
+
+    // check the last byte
+    if (b32_alphabet[(data[11] << 4) & 0x1F] != str[19]) {
+        throw invalid_xid(str);
+    }
+
+    data[10] = decoder[str[16]] << 3u | decoder[str[17]] >> 2u;
+    data[9] = decoder[str[14]] << 5u | decoder[str[15]];
+    data[8] = decoder[str[12]] << 7u | decoder[str[13]] << 2u
+              | decoder[str[14]] >> 3u;
+    data[7] = decoder[str[11]] << 4u | decoder[str[12]] >> 1;
+    data[6] = decoder[str[9]] << 6u | decoder[str[10]] << 1u
+              | decoder[str[11]] >> 4u;
+    data[5] = decoder[str[8]] << 3u | decoder[str[9]] >> 2u;
+    data[4] = decoder[str[6]] << 5u | decoder[str[7]];
+    data[3] = decoder[str[4]] << 7u | decoder[str[5]] << 2u
+              | decoder[str[6]] >> 3u;
+    data[2] = decoder[str[3]] << 4u | decoder[str[4]] >> 1u;
+    data[1] = decoder[str[1]] << 6u | decoder[str[2]] << 1
+              | decoder[str[3]] >> 4u;
+    data[0] = decoder[str[0]] << 3u | decoder[str[1]] >> 2u;
+    // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index,
+    // readability-magic-numbers, hicpp-signed-bitwise)
+    return xid(data);
+}
+
+fmt::format_context::iterator
+fmt::formatter<xid>::format(const xid& id, format_context& ctx) const {
+    static constexpr uint8_t mask = 0x1f;
+    // NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index,
+    // readability-magic-numbers, hicpp-signed-bitwise)
+    fmt::format_to(
+      ctx.out(),
+      "{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}{}",
+      b32_alphabet[id._data[0] >> 3u],
+      b32_alphabet[((id._data[1] >> 6u) & mask) | ((id._data[0] << 2u) & mask)],
+      b32_alphabet[(id._data[1] >> 1) & mask],
+      b32_alphabet[((id._data[2] >> 4) & mask) | ((id._data[1] << 4) & mask)],
+      b32_alphabet[id._data[3] >> 7 | ((id._data[2] << 1) & mask)],
+      b32_alphabet[(id._data[3] >> 2) & mask],
+      b32_alphabet[id._data[4] >> 5 | ((id._data[3] << 3) & mask)],
+      b32_alphabet[id._data[4] & mask],
+      b32_alphabet[id._data[5] >> 3],
+      b32_alphabet[((id._data[6] >> 6) & mask) | ((id._data[5] << 2) & mask)],
+      b32_alphabet[(id._data[6] >> 1) & mask],
+      b32_alphabet[((id._data[7] >> 4) & mask) | ((id._data[6] << 4) & mask)],
+      b32_alphabet[id._data[8] >> 7 | ((id._data[7] << 1) & mask)],
+      b32_alphabet[(id._data[8] >> 2) & mask],
+      b32_alphabet[(id._data[9] >> 5) | ((id._data[8] << 3) & mask)],
+      b32_alphabet[id._data[9] & mask],
+      b32_alphabet[id._data[10] >> 3],
+      b32_alphabet
+        [((uint8_t)(id._data[11] >> 6) & mask)
+         | ((uint8_t)(id._data[10] << 2) & mask)],
+      b32_alphabet[(id._data[11] >> 1) & mask],
+      b32_alphabet[(id._data[11] << 4) & mask]);
+
+    // NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index,
+    // readability-magic-numbers, hicpp-signed-bitwise)
+    return ctx.out();
+}
+
+void read_nested(iobuf_parser& in, xid& id, size_t const bytes_left_limit) {
+    serde::read_nested(in, id._data, bytes_left_limit);
+}
+
+void write(iobuf& out, xid id) { serde::write(out, id._data); }
+
+std::istream& operator>>(std::istream& i, xid& id) {
+    ss::sstring s;
+    i >> s;
+    id._data = xid::from_string(s)._data;
+    return i;
+}

--- a/src/v/utils/xid.h
+++ b/src/v/utils/xid.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/iobuf_parser.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <fmt/core.h>
+
+#include <array>
+#include <cstdint>
+#include <exception>
+
+/**
+ * Exception indicating that provided XID isn't valid f.e. incorrect length of
+ * invalid characters
+ */
+class invalid_xid final : public std::exception {
+public:
+    explicit invalid_xid(const ss::sstring&);
+    const char* what() const noexcept final { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
+
+/**
+ * Class representing an XID.
+ *
+ * The binary representation of the id has 12 bytes. String representation is
+ * using base32 encoding (w/o padding) for better space efficiency when stored
+ * in that form (20 bytes).
+ *
+ * Based on (https://github.com/rs/xid)
+ */
+class xid {
+public:
+    // number of bytes in an underlying data structure
+    static constexpr size_t size = 12;
+    // size of xid string representation
+    static constexpr size_t str_size = 20;
+
+    using data_t = std::array<uint8_t, size>;
+
+    explicit constexpr xid(data_t data)
+      : _data(data) {}
+
+    // default constructor to make the xid type lexically castable from string
+    constexpr xid() = default;
+
+    xid(const xid&) = default;
+    xid(xid&&) = default;
+    xid& operator=(const xid&) = default;
+    xid& operator=(xid&&) = default;
+    ~xid() = default;
+
+    /**
+     * Creates an XID from string.
+     *
+     * The function parse and validate the string representation of XID.
+     *
+     * @return an xid decoded from the string provided
+     */
+    static xid from_string(const ss::sstring&);
+
+    friend bool operator==(const xid&, const xid&) = default;
+
+    friend std::istream& operator>>(std::istream&, xid&);
+
+    friend void
+    read_nested(iobuf_parser& in, xid& id, size_t const bytes_left_limit);
+
+    friend void write(iobuf& out, xid id);
+
+    template<typename H>
+    friend H AbslHashValue(H h, const xid& id) {
+        return H::combine(std::move(h), id._data);
+    }
+
+private:
+    friend struct fmt::formatter<xid>;
+    data_t _data{0};
+};
+
+template<>
+struct fmt::formatter<xid> : fmt::formatter<std::string_view> {
+    fmt::format_context::iterator
+    format(const xid& id, format_context& ctx) const;
+};


### PR DESCRIPTION
Defined a type representing a virtual cluster label. The `vcluster_id` is going to be used to identify partitions and connections and enrich  them with virtual cluster context.

Virtual cluster id is underlaid by XID type as defined in https://github.com/rs/xid.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none