### PR TITLE
c/namespaced_cache: added implementation of namespaced cache

### DIFF
--- a/src/v/cluster/namespaced_cache.h
+++ b/src/v/cluster/namespaced_cache.h
@@ -1,0 +1,501 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "config/property.h"
+#include "container/intrusive_list_helpers.h"
+
+#include <absl/container/node_hash_map.h>
+#include <boost/intrusive/list_hook.hpp>
+
+#include <algorithm>
+#include <exception>
+
+namespace cluster {
+
+/**
+ * Post eviction hook is called after an entry has been evicted from the cache.
+ *
+ * The post_eviction_hook callable may be used to cleanup some additional state
+ * depending on application. f.e. it may release resources.
+ */
+template<typename PostEvictionHookT, typename Entry>
+concept post_eviction_hook = requires(
+  const PostEvictionHookT& hook, Entry& entry) {
+    requires noexcept(hook(entry));
+    { hook(entry) } -> std::same_as<void>;
+};
+/**
+ * Simillar to `experimental::io::cache_evictor` it is a callable that is
+ * called before an entry is evicted. When the callable returns `true` it may
+ * assume that entry is evicted.
+ *
+ * If an entry is eligible for eviction the function should return true.
+ *
+ */
+template<typename PreEvictionHookT, typename Entry>
+concept pre_eviction_hook = requires(
+  const PreEvictionHookT func, Entry& entry) {
+    requires noexcept(func(entry));
+    { func(entry) } -> std::same_as<bool>;
+};
+
+/**
+ * Default eviction predicate that does not protect entry from being evicted
+ */
+struct always_allow_to_evict {
+    bool operator()(const auto&) const noexcept { return true; };
+};
+
+struct noop_post_eviction_hook {
+    void operator()(const auto&) const noexcept {};
+};
+
+/**
+ * Thrown if cache if full i.e. no namespaces can be added to the cache
+ */
+class cache_full_error final : public std::exception {
+public:
+    explicit cache_full_error(ss::sstring msg) noexcept
+      : _msg(std::move(msg)) {}
+
+    const char* what() const noexcept override { return _msg.c_str(); }
+
+private:
+    ss::sstring _msg;
+};
+
+/**
+ * Internal per namespace cache implementation concept. User can provide
+ * different implementation of caching algorithm f.e. LRU, FIFO or SIEVE.
+ */
+template<
+  typename CacheT,
+  typename EntryT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  typename PreEvictionHookT,
+  typename PostEvictionHookT>
+concept namespace_cache = requires(
+  CacheT& cache,
+  EntryT& entry,
+  const PreEvictionHookT& pre_eviction_hook,
+  const PostEvictionHookT& post_eviction_hook) {
+    { cache.insert(entry) } -> std::same_as<void>;
+    {
+        cache.evict(pre_eviction_hook, post_eviction_hook)
+    } -> std::same_as<bool>;
+    { cache.remove(entry) } -> std::same_as<void>;
+    { cache.touch(entry) } -> std::same_as<void>;
+    { cache.size() } -> std::same_as<size_t>;
+};
+
+/**
+ * Simple cache with LRU eviction policy
+ */
+template<
+  typename EntryT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> PreEvictionHookT,
+  post_eviction_hook<EntryT> PostEvictionHookT>
+struct lru_cache {
+    using list_type = uncounted_intrusive_list<EntryT, HookPtr>;
+
+    void insert(EntryT&);
+    bool evict(const PreEvictionHookT&, const PostEvictionHookT&);
+    void remove(const EntryT&);
+    void touch(EntryT&);
+    size_t size() const { return _size; }
+
+private:
+    size_t _size{0};
+    list_type _lru;
+};
+
+/**
+ * A simple cache that maintains an LRU per namespace.
+ *
+ * The cache allows to maintain per namespace lru cache with fair distribution
+ * of available cache slots across all namespaces. Cache size is
+ * controlled by setting maximum number of entries. If adding new namespace to
+ * the cache would result in other namespace to have less than
+ * min_slots_per_namespace cache slots an exception is thrown.
+ *
+ * Maximum number of namespaces that cache can handle can be calculated as:
+ *
+ *  floor(_max_size/_min_slots_per_namespace)
+ *
+ * With cache PreEvictionHookT template parameter it is possible to prevent some
+ * entries from being evicted. A predicate should return 'false' if an entry is
+ * not evictable.
+ *
+ * Eviction policy can be controlled with the CacheT parameter. The CacheT
+ * parameter allow to tune per namespace caching policy.
+ *
+ * For now the only provided eviction policy is a simple LRU. In future we may
+ * experience with different caching strategies like f.e. SIEVE or S3-FIFO.
+ *
+ */
+template<
+  typename EntryT,
+  typename NamespaceT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> PreEvictionHookT = always_allow_to_evict,
+  post_eviction_hook<EntryT> PostEvictionHookT = noop_post_eviction_hook,
+  namespace_cache<EntryT, HookPtr, PreEvictionHookT, PostEvictionHookT> CacheT
+  = lru_cache<EntryT, HookPtr, PreEvictionHookT, PostEvictionHookT>>
+class namespaced_cache {
+private:
+    using namespaces_t
+      = absl::node_hash_map<NamespaceT, std::unique_ptr<CacheT>>;
+
+public:
+    struct stats {
+        size_t total_size{0};
+        absl::node_hash_map<NamespaceT, size_t> namespaces;
+    };
+
+    /**
+     * Creates a namespaced cache with desired maximum size and minimal allowed
+     * number of slots per namespace
+     */
+    explicit namespaced_cache(
+      config::binding<size_t> total_max_size,
+      config::binding<size_t> min_slots_per_namespace,
+      const PreEvictionHookT& pre_eviction_hook = PreEvictionHookT(),
+      const PostEvictionHookT& post_eviction_hook = PostEvictionHookT())
+      : _max_size(std::move(total_max_size))
+      , _min_slots_per_namespace(std::move(min_slots_per_namespace))
+      , _pre_eviction_hook(pre_eviction_hook)
+      , _post_eviction_hook(post_eviction_hook) {
+        _max_size.watch([this] { handle_max_size_change(); });
+    }
+    /**
+     * Inserts an entry into given namespace cache, if there are no slots
+     * available this may result in an eviction.
+     */
+    void insert(const NamespaceT& ns, EntryT& entry);
+    /**
+     * Explicitly remove an entry from the cache.
+     */
+    void remove(const NamespaceT& ns, const EntryT& entry);
+
+    /**
+     * When touched entry is marked as being used, potentially preventing it
+     * from being evicted.
+     */
+    void touch(const NamespaceT& ns, EntryT& entry);
+
+    /**
+     * Evicts next eligible element from the cache, returns true if element was
+     * evicted.
+     */
+    bool evict() {
+        // we use _namespaces.end() to indicate there is no hint what namespace
+        // to evict from
+        return evict(_namespaces.end());
+    }
+
+    /**
+     * Return basic stats about cache size
+     */
+    stats get_stats() const;
+
+    /**
+     * Returns maximum number of namespaces a cache can handle
+     */
+    size_t namespace_capacity() const {
+        return floor(_max_size() / effective_min_slots_per_namespace());
+    }
+
+    void clear() { _namespaces.clear(); }
+
+private:
+    /**
+     * An evict method with an iterator being a hint indicating a namespace that
+     * the entry should be evicted from if all the namespaces has the same
+     * number of entries in a cache.
+     *
+     * The hint is added to prevent situation in which the entry is evicted from
+     * other namespace cache when all eviction eligible namespaces has the same
+     * number of entries as the one the entry was inserted to. If this happens
+     * the hint is used to evict entry from the same namespace that insert
+     * caused the eviction event.
+     */
+    bool evict(namespaces_t::iterator);
+
+    size_t effective_min_slots_per_namespace() const {
+        return std::min(_max_size(), _min_slots_per_namespace());
+    }
+
+    void handle_max_size_change();
+
+    namespaces_t _namespaces;
+
+    size_t _size{0};
+    config::binding<size_t> _max_size;
+    config::binding<size_t> _min_slots_per_namespace;
+    PreEvictionHookT _pre_eviction_hook;
+    PostEvictionHookT _post_eviction_hook;
+};
+
+/**
+ * namespaced_cache definitions
+ */
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> PreEvictionHookT,
+  post_eviction_hook<EntryT> PostEvictionHookT,
+  namespace_cache<EntryT, HookPtr, PreEvictionHookT, PostEvictionHookT> CacheT>
+bool namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  PreEvictionHookT,
+  PostEvictionHookT,
+  CacheT>::evict(namespaces_t::iterator hint) {
+    /**
+     * linear scan over all namespaces to find the one with the largest number
+     * entries in an LRU
+     */
+    auto max_it = std::max_element(
+      _namespaces.begin(),
+      _namespaces.end(),
+      [](const auto& lhs, const auto& rhs) {
+          return lhs.second->size() < rhs.second->size();
+      });
+
+    /**
+     * If hint is provided and the number of elements in a hint pointed
+     * namespace cache is equal to max element size evict from the hint
+     * namespace
+     */
+    if (
+      hint != _namespaces.end()
+      && max_it->second->size() == hint->second->size()) {
+        max_it = hint;
+    }
+
+    std::unique_ptr<CacheT>& t_state = max_it->second;
+    auto evicted = t_state->evict(_pre_eviction_hook, _post_eviction_hook);
+    if (evicted) {
+        --_size;
+    }
+    return evicted;
+}
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> PreEvictionHookT,
+  post_eviction_hook<EntryT> PostEvictionHookT,
+  namespace_cache<EntryT, HookPtr, PreEvictionHookT, PostEvictionHookT> CacheT>
+void namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  PreEvictionHookT,
+  PostEvictionHookT,
+  CacheT>::insert(const NamespaceT& ns, EntryT& entry) {
+    if (
+      _namespaces.size() >= namespace_capacity() && !_namespaces.contains(ns)) {
+        throw cache_full_error(ssx::sformat(
+          "maximum number of namespaces reached. Min number of entries per "
+          "namespace: {}, max cache capacity: {}, current namespaces: {}",
+          effective_min_slots_per_namespace(),
+          _max_size(),
+          _namespaces.size()));
+    }
+    auto [it, _] = _namespaces.try_emplace(ns, std::make_unique<CacheT>());
+
+    /**
+     * It is very unlikely that this loop will take more than few iterations to
+     * find the eviction spot. Therefore we do not yield here.
+     */
+    size_t iteration = 0;
+    while (_size >= _max_size() && iteration++ < _size) {
+        evict(it);
+    }
+    /**
+     * If there was no entry to evict from cache, throw cache full error
+     */
+    if (_size >= _max_size()) {
+        throw cache_full_error(
+          "unable to evict entry from cache, cache is at capacity");
+    }
+
+    it->second->insert(entry);
+
+    ++_size;
+}
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> PreEvictionHookT,
+  post_eviction_hook<EntryT> PostEvictionHookT,
+  namespace_cache<EntryT, HookPtr, PreEvictionHookT, PostEvictionHookT> CacheT>
+void namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  PreEvictionHookT,
+  PostEvictionHookT,
+  CacheT>::remove(const NamespaceT& ns, const EntryT& entry) {
+    auto it = _namespaces.find(ns);
+    if (it == _namespaces.end()) {
+        return;
+    }
+    if (entry._hook.is_linked()) {
+        it->second->remove(entry);
+        _size--;
+    }
+    if (it->second->size() == 0) {
+        _namespaces.erase(it);
+    }
+}
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> PreEvictionHookT,
+  post_eviction_hook<EntryT> PostEvictionHookT,
+  namespace_cache<EntryT, HookPtr, PreEvictionHookT, PostEvictionHookT> CacheT>
+void namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  PreEvictionHookT,
+  PostEvictionHookT,
+  CacheT>::touch(const NamespaceT& ns, EntryT& entry) {
+    auto it = _namespaces.find(ns);
+    if (it == _namespaces.end()) {
+        return;
+    }
+    it->second->touch(entry);
+}
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> PreEvictionHookT,
+  post_eviction_hook<EntryT> PostEvictionHookT,
+  namespace_cache<EntryT, HookPtr, PreEvictionHookT, PostEvictionHookT> CacheT>
+namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  PreEvictionHookT,
+  PostEvictionHookT,
+  CacheT>::stats
+namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  PreEvictionHookT,
+  PostEvictionHookT,
+  CacheT>::get_stats() const {
+    stats ret;
+    for (auto& [k, state] : _namespaces) {
+        ret.namespaces[k] = state->size();
+    }
+    ret.total_size = _size;
+    return ret;
+}
+
+template<
+  typename EntryT,
+  typename NamespaceT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> PreEvictionHookT,
+  post_eviction_hook<EntryT> PostEvictionHookT,
+  namespace_cache<EntryT, HookPtr, PreEvictionHookT, PostEvictionHookT> CacheT>
+void namespaced_cache<
+  EntryT,
+  NamespaceT,
+  HookPtr,
+  PreEvictionHookT,
+  PostEvictionHookT,
+  CacheT>::handle_max_size_change() {
+    /**
+     * Evict entries immediately after max size changed and it is smaller than
+     * current size
+     */
+    size_t iteration = 0;
+    while (_size > _max_size() && iteration++ < _size) {
+        evict(_namespaces.end());
+    }
+}
+/**
+ * lru_cache definitions
+ */
+
+template<
+  typename EntryT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> EvictionPredicate,
+  post_eviction_hook<EntryT> PostEvictionHookT>
+void lru_cache<EntryT, HookPtr, EvictionPredicate, PostEvictionHookT>::insert(
+  EntryT& entry) {
+    _lru.push_back(entry);
+    ++_size;
+}
+
+template<
+  typename EntryT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> EvictionPredicate,
+  post_eviction_hook<EntryT> PostEvictionHookT>
+bool lru_cache<EntryT, HookPtr, EvictionPredicate, PostEvictionHookT>::evict(
+  const EvictionPredicate& predicate, const PostEvictionHookT& disposer) {
+    for (auto it = _lru.begin(); it != _lru.end(); ++it) {
+        if (predicate(*it)) {
+            auto& entry = *it;
+            _lru.erase(it);
+            --_size;
+            disposer(entry);
+            return true;
+        }
+    }
+    return false;
+}
+
+template<
+  typename EntryT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> EvictionPredicate,
+  post_eviction_hook<EntryT> PostEvictionHookT>
+void lru_cache<EntryT, HookPtr, EvictionPredicate, PostEvictionHookT>::remove(
+  const EntryT& entry) {
+    _lru.erase(_lru.iterator_to(entry));
+    --_size;
+}
+
+template<
+  typename EntryT,
+  safe_intrusive_list_hook EntryT::*HookPtr,
+  pre_eviction_hook<EntryT> EvictionPredicate,
+  post_eviction_hook<EntryT> PostEvictionHookT>
+void lru_cache<EntryT, HookPtr, EvictionPredicate, PostEvictionHookT>::touch(
+  EntryT& entry) {
+    const auto& hook = entry.*HookPtr;
+    if (!hook.is_linked()) {
+        return;
+    }
+    _lru.erase(_lru.iterator_to(entry));
+    _lru.push_back(entry);
+}
+} // namespace cluster

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -146,6 +146,20 @@ rp_test(
 rp_test(
   UNIT_TEST
   GTEST
+  BINARY_NAME namespaced_cache_test
+  SOURCES 
+    namespaced_cache_test.cc
+  LIBRARIES 
+    v::gtest_main 
+    v::serde
+    v::config
+  ARGS "-- -c 1"
+  LABELS cluster
+)
+
+rp_test(
+  UNIT_TEST
+  GTEST
   BINARY_NAME cluster_recovery_test
   SOURCES
     cluster_recovery_table_test.cc

--- a/src/v/cluster/tests/namespaced_cache_test.cc
+++ b/src/v/cluster/tests/namespaced_cache_test.cc
@@ -1,0 +1,454 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "cluster/namespaced_cache.h"
+#include "config/config_store.h"
+#include "config/property.h"
+#include "container/intrusive_list_helpers.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <absl/container/flat_hash_map.h>
+#include <gtest/gtest.h>
+
+struct fixture : public seastar_test {};
+
+struct entry {
+    explicit entry(ss::sstring k)
+      : key(std::move(k)) {}
+    bool pinned = false;
+    ss::sstring key;
+    safe_intrusive_list_hook _hook;
+};
+
+TEST_F(fixture, test_basic_operations) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<entry, ss::sstring, &entry::_hook> cache(
+      config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+
+    entry e0{"e-0"};
+    entry e1{"e-1"};
+    entry e2{"e-2"};
+
+    cache.insert(t_1, e0);
+    cache.insert(t_2, e1);
+    cache.insert(t_3, e2);
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 1);
+    EXPECT_EQ(cache.get_stats().total_size, 3);
+    /**
+     * Fill the cache up to capacity
+     */
+    std::vector<entry> entries{12, entry{"key"}};
+    for (int i = 0; i < 12; i += 3) {
+        cache.insert(t_1, entries[i]);
+        cache.insert(t_2, entries[i + 1]);
+        cache.insert(t_3, entries[i + 2]);
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 5);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    std::vector<entry> new_entries{3, entry{"key"}};
+    // now each insert will cause eviction
+    cache.insert(t_1, new_entries[0]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 5);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    cache.insert(t_2, new_entries[1]);
+    cache.insert(t_3, new_entries[2]);
+    // when number of entries in for a namespace that requests an insert is
+    // equal to the number of entries of a namespace with largest number of
+    // entries an eviction should happen from the requesting namespace.
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 5);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 5);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    // oldest t_2 entry should be evicted
+    EXPECT_FALSE(e0._hook.is_linked());
+    EXPECT_FALSE(e1._hook.is_linked());
+    EXPECT_FALSE(e2._hook.is_linked());
+    /**
+     * Test removal
+     */
+    for (int i = 0; i < 12; i += 3) {
+        cache.remove(t_1, entries[i]);
+        cache.remove(t_2, entries[i + 1]);
+        cache.remove(t_3, entries[i + 2]);
+    }
+
+    for (auto& e : entries) {
+        EXPECT_FALSE(e._hook.is_linked());
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 1);
+    EXPECT_EQ(cache.get_stats().total_size, 3);
+
+    cache.remove(t_1, new_entries[0]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 1);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 1);
+    EXPECT_EQ(cache.get_stats().total_size, 2);
+
+    cache.remove(t_1, new_entries[0]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+
+    cache.clear();
+}
+
+TEST_F(fixture, test_asymmetric_namespaces) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<entry, ss::sstring, &entry::_hook> cache(
+      config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+    std::vector<entry> entries{20, entry{"key"}};
+    /**
+     * fill cache with 2 namespaces
+     */
+    for (int i = 0; i < 7; ++i) {
+        cache.insert(t_1, entries[i]);
+    }
+    for (int i = 7; i < 15; ++i) {
+        cache.insert(t_2, entries[i]);
+    }
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 7);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 8);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    // adding a new entry should cause an eviction from the namespace with the
+    // most entries
+    cache.insert(t_1, entries[15]);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 8);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 7);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    // add another namespace
+    cache.insert(t_3, entries[16]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 7);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 7);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 1);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    cache.insert(t_3, entries[17]);
+    cache.insert(t_3, entries[18]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().namespaces[t_1], 6);
+    EXPECT_EQ(cache.get_stats().namespaces[t_2], 6);
+    EXPECT_EQ(cache.get_stats().namespaces[t_3], 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    cache.clear();
+}
+
+struct pinned_entry_evictor {
+    bool operator()(const entry& e) const noexcept { return !e.pinned; };
+};
+
+TEST_F(fixture, test_eviction_predicate) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::
+      namespaced_cache<entry, ss::sstring, &entry::_hook, pinned_entry_evictor>
+        cache(
+          config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+    std::vector<entry> entries{18, entry{"pinnable"}};
+
+    // fill cache, single namespace
+    for (int i = 0; i < 15; ++i) {
+        cache.insert(t_1, entries[i]);
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 1);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    // pin first two entries
+    entries[0].pinned = true;
+    entries[1].pinned = true;
+
+    // insert entry
+    cache.insert(t_2, entries[15]);
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    // verify if pined entries are still in cache
+    EXPECT_TRUE(entries[0]._hook.is_linked());
+    EXPECT_TRUE(entries[1]._hook.is_linked());
+    // next not pinned entry should be evicted
+    EXPECT_FALSE(entries[2]._hook.is_linked());
+    // unpin entry
+    entries[0].pinned = false;
+    cache.insert(t_2, entries[16]);
+    EXPECT_FALSE(entries[0]._hook.is_linked());
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 2);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    cache.clear();
+}
+
+TEST_F(fixture, test_insertion_when_all_entries_are_pinned) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::
+      namespaced_cache<entry, ss::sstring, &entry::_hook, pinned_entry_evictor>
+        cache(
+          config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+    std::vector<entry> entries{16, entry{"pinnable"}};
+
+    // fill cache
+    for (int i = 0; i < 15; i += 3) {
+        cache.insert(t_1, entries[i]);
+        cache.insert(t_2, entries[i + 1]);
+        cache.insert(t_3, entries[i + 2]);
+    }
+
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    // pin all entries
+    for (auto& e : entries) {
+        e.pinned = true;
+    }
+
+    // eviction should fail as there are no entries we can evict
+    EXPECT_FALSE(cache.evict());
+
+    // insertion should still be possible even if no entries are evictable
+    EXPECT_THROW(cache.insert(t_2, entries[15]), cluster::cache_full_error);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    // unpin some entries
+    for (int i = 3; i < 10; ++i) {
+        entries[i].pinned = false;
+    }
+
+    cache.insert(t_2, entries[15]);
+
+    ASSERT_EQ(cache.get_stats().total_size, 15);
+    cache.clear();
+}
+
+TEST_F(fixture, test_touch) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<entry, ss::sstring, &entry::_hook> cache(
+      config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+    std::vector<entry> entries{18, entry{"default"}};
+
+    // fill cache
+    for (int i = 0; i < 15; i += 3) {
+        cache.insert(t_1, entries[i]);
+        cache.insert(t_2, entries[i + 1]);
+        cache.insert(t_3, entries[i + 2]);
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    cache.touch(t_1, entries[0]);
+    cache.touch(t_1, entries[3]);
+    cache.insert(t_1, entries[15]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    // touched items should not be evicted
+    EXPECT_TRUE(entries[0]._hook.is_linked());
+    EXPECT_TRUE(entries[3]._hook.is_linked());
+
+    EXPECT_FALSE(entries[6]._hook.is_linked());
+
+    cache.clear();
+}
+
+TEST_F(fixture, test_post_eviction_hook) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+
+    absl::flat_hash_map<ss::sstring, std::unique_ptr<entry>> index;
+
+    static auto index_removing_disposer = [&index](entry& entry) noexcept {
+        index.erase(entry.key);
+    };
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<
+      entry,
+      ss::sstring,
+      &entry::_hook,
+      cluster::always_allow_to_evict,
+      decltype(index_removing_disposer)>
+      cache(
+        config::mock_binding<size_t>(15),
+        config::mock_binding<size_t>(3),
+        cluster::always_allow_to_evict{},
+        index_removing_disposer);
+
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+
+    for (int i = 0; i < 15; ++i) {
+        auto key = ssx::sformat("k-{}", i);
+        index.emplace(key, std::make_unique<entry>(key));
+    }
+
+    // fill cache
+    for (int i = 0; i < 15; i += 3) {
+        cache.insert(t_1, *index[ssx::sformat("k-{}", i)]);
+        cache.insert(t_2, *index[ssx::sformat("k-{}", i + 1)]);
+        cache.insert(t_3, *index[ssx::sformat("k-{}", i + 2)]);
+    }
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    // all the subsequent inserts will result in eviction
+    index.emplace("new-key-t-1", std::make_unique<entry>("new-key-t-1"));
+    index.emplace("new-key-t-2", std::make_unique<entry>("new-key-t-2"));
+    index.emplace("new-key-t-3", std::make_unique<entry>("new-key-t-3"));
+
+    cache.insert(t_1, *index["new-key-t-1"]);
+    cache.insert(t_2, *index["new-key-t-2"]);
+    cache.insert(t_3, *index["new-key-t-3"]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+    EXPECT_EQ(index.size(), 15);
+
+    // evicted entries should be removed from cache
+
+    EXPECT_FALSE(index.contains("key-0"));
+    EXPECT_FALSE(index.contains("key-1"));
+    EXPECT_FALSE(index.contains("key-2"));
+
+    cache.clear();
+    index.clear();
+}
+
+TEST_F(fixture, test_cache_full) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+    ss::sstring t_4 = "t_4";
+    ss::sstring t_5 = "t_5";
+    ss::sstring t_6 = "t_6";
+
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<entry, ss::sstring, &entry::_hook> cache(
+      config::mock_binding<size_t>(15), config::mock_binding<size_t>(3));
+
+    // verify initial state
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 0);
+    EXPECT_EQ(cache.get_stats().total_size, 0);
+    std::vector<entry> entries{6, entry{"default"}};
+
+    cache.insert(t_1, entries[0]);
+    cache.insert(t_2, entries[1]);
+    cache.insert(t_3, entries[2]);
+    cache.insert(t_4, entries[3]);
+    cache.insert(t_5, entries[4]);
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 5);
+    EXPECT_EQ(cache.get_stats().total_size, 5);
+
+    ASSERT_THROW(cache.insert(t_6, entries[5]), cluster::cache_full_error);
+
+    cache.clear();
+}
+
+TEST_F(fixture, test_changing_max_size) {
+    ss::sstring t_1 = "t_1";
+    ss::sstring t_2 = "t_2";
+    ss::sstring t_3 = "t_3";
+    config::config_store store;
+    config::property<size_t> max_size_property(
+      store,
+      "max_size",
+      "test_max_size",
+      {.needs_restart = config::needs_restart::no,
+       .visibility = config::visibility::user},
+      15);
+    /**
+     * Create cache with capacity of 15 and min 3 entries per namespace
+     */
+    cluster::namespaced_cache<entry, ss::sstring, &entry::_hook> cache(
+      max_size_property.bind(), config::mock_binding<size_t>(3));
+
+    std::vector<entry> entries{15, entry{"default"}};
+
+    // fill cache
+    for (int i = 0; i < 15; i += 3) {
+        cache.insert(t_1, entries[i]);
+        cache.insert(t_2, entries[i + 1]);
+        cache.insert(t_3, entries[i + 2]);
+    }
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().total_size, 15);
+
+    max_size_property.set_value(10);
+
+    EXPECT_EQ(cache.get_stats().namespaces.size(), 3);
+    EXPECT_EQ(cache.get_stats().total_size, 10);
+
+    cache.clear();
+}


### PR DESCRIPTION
The cache allows to maintain per namespace lru cache with fair distribution of available cache slots across all namespaces. Cache size is controlled by setting maximum number of entries. If adding new namespace to the cache would result in other namespace to have less than min_slots_per_namespace cache slots an exception is thrown.

Maximum number of namespaces that cache can handle can be calculated as:

```
floor(_max_size/_min_slots_per_namespace)
```

With cache EvictionPredT template parameter it is possible to prevent some entries from being evicted. A predicate should return 'false' if an entry is not evictable.

Eviction policy can be controlled with the CacheT parameter. The CacheT parameter allow to tune per namespace caching policy.

For now the only provided eviction policy is a simple LRU. In future we may experience with different caching strategies like f.e. SIEVE or S3-FIFO.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none