### PR TITLE
rptest: force cleaning of teleport data dir

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -9,7 +9,6 @@
 
 from logging import Logger
 import os
-import shutil
 import subprocess
 
 SUPPORTED_PROVIDERS = ['aws', 'gcp']
@@ -268,7 +267,7 @@ class KubectlTool:
         if self._provider == 'gcp':
             _method = "gcp"
         self._redpanda.logger.info('cleaning teleport data dir')
-        shutil.rmtree(self.TELEPORT_DATA_DIR)
+        subprocess.check_output(['rm', '-f', '-r', self.TELEPORT_DATA_DIR])
         self._redpanda.logger.info('starting tbot to generate identity')
         cmd = [
             'tbot', 'start', f'--data-dir={self.TELEPORT_DATA_DIR}',


### PR DESCRIPTION
following on PR #16359, this PR fixes [error](https://buildkite.com/redpanda/vtools/builds/11765) in running ducktape tests on cloudv2:
```
...
  File "/home/ubuntu/redpanda/tests/rptest/clients/kubectl.py", line 271, in _setup_tbot
    shutil.rmtree(self.TELEPORT_DATA_DIR)
  File "/usr/lib/python3.10/shutil.py", line 715, in rmtree
    onerror(os.lstat, path, sys.exc_info())
  File "/usr/lib/python3.10/shutil.py", line 713, in rmtree
    orig_st = os.lstat(path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tbot-data'
```

by forcing deletion of the teleport data dir.

i validated this by running test without `/tmp/tbot-data` dir to simulate buildkite's scheduled job scenario:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  tests/rptest/tests/services_self_test.py::SimpleSelfTest.test_cloud
```
output:
```
test_id:    rptest.tests.services_self_test.SimpleSelfTest.test_cloud
status:     PASS
run time:   54.107 seconds
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
========================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2024-02-08--006
run time:         54.125 seconds
tests run:        1
passed:           1
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
========================================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
