### PR TITLE
redpanda/kafka: add consumer groups committed offset timestamp metrics

### DIFF
--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -184,7 +184,7 @@ public:
           const model::topic_partition& tp,
           enable_group_metrics enable_metrics)
           : metadata(std::move(_metadata))
-          , probe(metadata.offset) {
+          , probe(metadata.offset, metadata.commit_timestamp) {
             if (enable_metrics) {
                 probe.setup_metrics(group_id, tp);
                 probe.setup_public_metrics(group_id, tp);


### PR DESCRIPTION
our application must consume all messages, we can't afford to loose one by cleanup retention. Alongside with disk usage metrics, we need to measure the age of the lag to measure, time wise, the lateness we are having on each topic/partition.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes
### Improvements
* add `redpanda_kafka_consumer_group_committed_offset_timestamp_seconds` and `redpanda_kafka_consumer_group_committed_offset_age_seconds` public metrics