### PR TITLE
rpc: Disable compression for internal rpc replies

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -148,7 +148,7 @@ configuration::configuration()
       "rpc_server_compress_replies",
       "Enable compression for internal rpc server replies",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      true)
+      false)
   , enable_coproc(*this, "enable_coproc")
   , coproc_max_inflight_bytes(*this, "coproc_max_inflight_bytes")
   , coproc_max_ingest_bytes(*this, "coproc_max_ingest_bytes")


### PR DESCRIPTION
On the internal rpc send side compression is enabled selectively via
opts parameters but on the reply side we compress all replies that are
above 1Kib unconditionally by default.

Compression is usually useful for trading compute for IO. There seems
little point in doing this for internal rpc. Brokers are mostly
connected on low latency/high throughput links so compression just adds
needless CPU overhead.

In the higher cloud tiers at the partition limits we see the health
report infra cause overhead and latency degregation in higher
percentiles.

A large chunk of this comes from compressing and decoding the massive
health report messages.

This patch disables compression which measurably improves the situation
as per above reasoning.

This change has little impact on normal append_entries flow as the
replies don't make the 1Kib min boundary anyway.

Ref https://github.com/redpanda-data/core-internal/issues/1047

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix (might manually backport later)
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
