### PR TITLE
[v23.3.x] tests: disable snapshots when testing partial controller deletion

### DIFF
--- a/tests/rptest/tests/controller_erase_test.py
+++ b/tests/rptest/tests/controller_erase_test.py
@@ -42,6 +42,11 @@ class ControllerEraseTest(RedpandaTest):
         """
 
         admin = Admin(self.redpanda)
+        # disable controller snapshot in partial removal test to make sure that
+        # the deleted segment is not snapshot before restarting the node
+        if partial:
+            self.redpanda.set_cluster_config(
+                {"controller_snapshot_max_age_sec": 3600})
 
         # Do a bunch of metadata operations to put something in the controller log
         transfers_leadership_count = 4


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16495
Fixes: https://github.com/redpanda-data/redpanda/issues/16555,