### PR TITLE
Metrics for transform logging

### DIFF
--- a/src/v/transform/logging/CMakeLists.txt
+++ b/src/v/transform/logging/CMakeLists.txt
@@ -6,6 +6,7 @@ v_cc_library(
     io.h
     log_manager.h
     logger.h
+    probes.h
     rpc_client.h
   SRCS
     record_batcher.cc
@@ -13,6 +14,7 @@ v_cc_library(
     log_manager.cc
     logger.cc
     rpc_client.cc
+    probes.cc
   DEPS
     v::config
     v::cluster

--- a/src/v/transform/logging/fwd.h
+++ b/src/v/transform/logging/fwd.h
@@ -15,4 +15,6 @@ namespace transform::logging {
 template<typename ClockType>
 class manager;
 class client;
+class logger_probe;
+class manager_probe;
 } // namespace transform::logging

--- a/src/v/transform/logging/log_manager.cc
+++ b/src/v/transform/logging/log_manager.cc
@@ -20,6 +20,7 @@
 #include "transform/logging/errc.h"
 #include "transform/logging/io.h"
 #include "transform/logging/logger.h"
+#include "transform/logging/probes.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/manual_clock.hh>
@@ -45,10 +46,12 @@ public:
     explicit flusher(
       ss::abort_source* as,
       transform::logging::client* c,
-      config::binding<std::chrono::milliseconds> fi)
+      config::binding<std::chrono::milliseconds> fi,
+      manager_probe* probe)
       : _as(as)
       , _client(c)
       , _interval_ms(std::move(fi))
+      , _probe(probe)
       , _jitter(_interval_ms(), jitter_amt) {
         _interval_ms.watch([this]() {
             _jitter = simple_time_jitter<ClockType>{_interval_ms(), jitter_amt};
@@ -184,12 +187,14 @@ private:
         // been produced.
         std::error_code ec = co_await _client->write(pid, std::move(events));
         if (ec != errc::success) {
+            _probe->write_error();
             vlog(tlg_log.warn, "Flush failed: {}", ec.message());
         }
     }
     ss::abort_source* _as = nullptr;
     transform::logging::client* _client = nullptr;
     config::binding<std::chrono::milliseconds> _interval_ms;
+    manager_probe* _probe;
     simple_time_jitter<ClockType> _jitter;
     ss::condition_variable _wakeup_signal{};
     ss::gate _gate{};
@@ -213,21 +218,32 @@ manager<ClockType>::manager(
   , _buffer_limit_bytes(bc)
   , _buffer_low_water_mark(_buffer_limit_bytes / lwm_denom)
   , _buffer_sem(_buffer_limit_bytes, "Log manager buffer semaphore")
-  , _flusher(std::make_unique<detail::flusher<ClockType>>(
-      &_as, _client.get(), std::move(fi))) {}
+  , _flush_interval(std::move(fi)) {}
 
 template<typename ClockType>
 manager<ClockType>::~manager() = default;
 
 template<typename ClockType>
 ss::future<> manager<ClockType>::start() {
+    _probe = std::make_unique<manager_probe>();
+    _probe->setup_metrics([this] {
+        return 1.0
+               - (static_cast<double>(_buffer_sem.available_units()) / static_cast<double>(_buffer_limit_bytes));
+    });
+    _flusher = std::make_unique<detail::flusher<ClockType>>(
+      &_as, _client.get(), _flush_interval, _probe.get());
     co_return co_await _flusher->template start<>(&_log_buffers);
 }
 
 template<typename ClockType>
 ss::future<> manager<ClockType>::stop() {
     _as.request_abort();
-    co_await _flusher->stop();
+    if (_flusher != nullptr) {
+        co_await _flusher->stop();
+    }
+    _flusher.reset(nullptr);
+    _probe.reset(nullptr);
+    std::exchange(_logger_probes, probe_map_t{});
 }
 
 template<typename ClockType>
@@ -274,10 +290,25 @@ void manager<ClockType>::enqueue_log(
         return res;
     };
 
+    auto get_probe = [this](std::string_view name) -> logger_probe* {
+        auto res = _logger_probes.find(name);
+        if (res == _logger_probes.end()) {
+            auto [it, _] = _logger_probes.emplace(
+              ss::sstring{name.data(), name.size()},
+              std::make_unique<logger_probe>());
+            it->second->setup_metrics(model::transform_name_view{name});
+            return it->second.get();
+        }
+        return res->second.get();
+    };
+
     auto it = get_queue(transform_name);
     if (it == _log_buffers.end()) {
         return;
     }
+
+    auto probe = get_probe(transform_name);
+    probe->log_event();
 
     // Unfortunately, we don't know how long an escaped string will be
     // until we've allocated memory for it. So we optimistically grab
@@ -289,6 +320,7 @@ void manager<ClockType>::enqueue_log(
     message = message.substr(0, msg_len(message));
     auto units = ss::try_get_units(_buffer_sem, message.size());
     if (!units) {
+        probe->dropped_log_event();
         vlog(tlg_log.debug, "Failed to enqueue transform log: Buffer full");
         return;
     }

--- a/src/v/transform/logging/log_manager.h
+++ b/src/v/transform/logging/log_manager.h
@@ -15,6 +15,7 @@
 #include "model/transform.h"
 #include "ssx/semaphore.h"
 #include "transform/logging/event.h"
+#include "transform/logging/fwd.h"
 #include "transform/logging/io.h"
 #include "utils/absl_sstring_hash.h"
 #include "wasm/logger.h"
@@ -116,6 +117,7 @@ private:
     size_t _buffer_limit_bytes;
     ssize_t _buffer_low_water_mark;
     ssx::semaphore _buffer_sem;
+    config::binding<std::chrono::milliseconds> _flush_interval;
 
     ss::abort_source _as{};
 
@@ -133,7 +135,11 @@ private:
     // lands
     using buffer_t = ss::chunked_fifo<buffer_entry>;
     absl::btree_map<ss::sstring, buffer_t, sstring_less> _log_buffers;
+    using probe_map_t = absl::
+      btree_map<ss::sstring, std::unique_ptr<logger_probe>, sstring_less>;
+    probe_map_t _logger_probes;
 
+    std::unique_ptr<manager_probe> _probe{};
     std::unique_ptr<detail::flusher<ClockType>> _flusher{};
 };
 

--- a/src/v/transform/logging/probes.cc
+++ b/src/v/transform/logging/probes.cc
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "transform/logging/probes.h"
+
+#include "base/seastarx.h"
+#include "config/configuration.h"
+#include "prometheus/prometheus_sanitize.h"
+
+#include <seastar/core/metrics_registration.hh>
+
+namespace transform::logging {
+
+void logger_probe::setup_metrics(model::transform_name_view transform_name) {
+    namespace sm = ss::metrics;
+
+    const auto name_label = sm::label("function_name");
+    const std::vector<sm::label_instance> labels = {
+      name_label(transform_name()),
+    };
+
+    auto setup_common = [this, &labels]() {
+        std::vector<sm::impl::metric_definition_impl> defs;
+        defs.emplace_back(sm::make_counter(
+          "events_total",
+          [this]() { return _total_log_events; },
+          sm::description("Running count of transform log events"),
+          labels));
+        defs.emplace_back(sm::make_counter(
+          "events_dropped_total",
+          [this]() { return _total_dropped_log_events; },
+          sm::description("Running count of dropped transform log events"),
+          labels));
+        return defs;
+    };
+
+    auto group_name = prometheus_sanitize::metrics_name(
+      "data_transforms_logger");
+
+    if (!config::shard_local_cfg().disable_metrics()) {
+        _metrics.add_group(
+          group_name, setup_common(), {}, {sm::shard_label, name_label});
+    }
+
+    if (!config::shard_local_cfg().disable_public_metrics()) {
+        auto defs_impl = setup_common();
+        std::vector<sm::metric_definition> defs;
+        defs.reserve(defs_impl.size());
+        std::transform(
+          std::make_move_iterator(defs_impl.begin()),
+          std::make_move_iterator(defs_impl.end()),
+          std::back_inserter(defs),
+          [](auto def) {
+              return sm::metric_definition{def.aggregate({sm::shard_label})};
+          });
+
+        _public_metrics.add_group(group_name, defs);
+    }
+}
+
+void manager_probe::setup_metrics(std::function<double()> get_usage_ratio) {
+    namespace sm = ss::metrics;
+
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    auto group_name = prometheus_sanitize::metrics_name(
+      "data_transforms_log_manager");
+
+    std::vector<ss::metrics::impl::metric_definition_impl> defs{
+      sm::make_gauge(
+        "buffer_usage_ratio",
+        [fn = std::move(get_usage_ratio)] { return fn(); },
+        sm::description("Transform log manager buffer usage ratio")),
+      sm::make_counter(
+        "write_errors_total",
+        [this] { return _total_write_errors; },
+        sm::description("Running count of errors while writing to the "
+                        "transform logs topic")),
+    };
+
+    _metrics.add_group(group_name, std::move(defs), {}, {sm::shard_label});
+}
+} // namespace transform::logging

--- a/src/v/transform/logging/probes.h
+++ b/src/v/transform/logging/probes.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "metrics/metrics.h"
+#include "model/transform.h"
+
+#include <seastar/core/smp.hh>
+
+namespace transform::logging {
+
+class logger_probe {
+public:
+    logger_probe() = default;
+    logger_probe(const logger_probe&) = delete;
+    logger_probe& operator=(const logger_probe&) = delete;
+    logger_probe(logger_probe&&) = delete;
+    logger_probe& operator=(logger_probe&&) = delete;
+    ~logger_probe() {}
+
+    void setup_metrics(model::transform_name_view transform_name);
+
+    void log_event() { ++_total_log_events; }
+    void dropped_log_event() { ++_total_dropped_log_events; }
+
+private:
+    uint64_t _total_log_events{0};
+    uint64_t _total_dropped_log_events{0};
+    metrics::internal_metric_groups _metrics;
+    metrics::public_metric_groups _public_metrics;
+};
+
+class manager_probe {
+public:
+    manager_probe() = default;
+    manager_probe(const manager_probe&) = delete;
+    manager_probe& operator=(const manager_probe&) = delete;
+    manager_probe(manager_probe&&) = delete;
+    manager_probe& operator=(manager_probe&&) = delete;
+    ~manager_probe() = default;
+
+    void setup_metrics(std::function<double()> get_usage_ratio);
+
+    void write_error() { ++_total_write_errors; }
+
+private:
+    uint64_t _total_write_errors{0};
+    metrics::internal_metric_groups _metrics;
+};
+
+} // namespace transform::logging

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -10,13 +10,17 @@
 import typing
 import time
 import random
+import string
 import json
+from typing import Optional
 
 from requests.exceptions import RequestException
 
+from ducktape.cluster.cluster import ClusterNode
 from ducktape.mark import matrix
 from rptest.clients.rpk import RpkException, RpkTool
 from rptest.services.cluster import cluster
+from rptest.services.redpanda import MetricSamples, MetricsEndpoint
 from ducktape.utils.util import wait_until
 from rptest.services.transform_verifier_service import TransformVerifierProduceConfig, TransformVerifierProduceStatus, TransformVerifierService, TransformVerifierConsumeConfig, TransformVerifierConsumeStatus
 from rptest.services.admin import Admin, CommittedWasmOffset
@@ -25,7 +29,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.clients.types import TopicSpec
 from rptest.tests.cluster_config_test import wait_for_version_sync
 from rptest.utils.utf8 import CONTROL_CHARS_VALS, generate_string_with_control_character
-from rptest.util import expect_exception
+from rptest.util import expect_exception, wait_until_result
 
 
 class WasmException(Exception):
@@ -444,118 +448,123 @@ class DataTransformsLeadershipChangingTest(BaseDataTransformsTest):
         assert consumer_status.invalid_records == 0, f"transform verification failed with invalid records: {consumer_status}"
 
 
-class DataTransformsLoggingTest(BaseDataTransformsTest):
+# TODO(oren): be nice to actually use the OTel protobufs here
+class LogRecord:
+    class Attribute:
+        def __init__(self, attr: dict):
+            self.key = attr['key']
+            assert len(attr['value']) == 1
+            self.value_type = list(attr['value'].keys())[0]
+            self.value = attr['value'][self.value_type]
+
+        # don't really care about the value, just the correct key and value _type_
+        def __eq__(self, other):
+            return (self.key == other.key
+                    and self.value_type == other.value_type
+                    and type(self.value) == type(other.value))
+
+    EXPECTED_ATTRS = [
+        Attribute({
+            'key': 'transform_name',
+            'value': {
+                'stringValue': 'any'  # don't care for validation
+            }
+        }),
+        Attribute({
+            'key': 'node',
+            'value': {
+                'intValue': 23  # don't care for validation
+            }
+        })
+    ]
+
+    BODY_FIELD = 'body'
+    TS_FIELD = 'timeUnixNano'
+    SEVERITY_FIELD = 'severityNumber'
+    ATTRS_FIELD = 'attributes'
+
+    def __init__(self, raw: str):
+        self._record = json.loads(raw)
+        self._record['value'] = json.loads(self._record['value'])
+
+        # Redpanda bits
+        self.offset = self._record['offset']
+        self.key = self._record['key']
+
+        # OTel bits
+        self._rep = self._record['value']
+        self.body = self._rep.get(self.BODY_FIELD, None)
+        self.timestamp_ns = self._rep.get(self.TS_FIELD, None)
+        self.severity = self._rep.get(self.SEVERITY_FIELD, None)
+        self.attributes = [
+            self.Attribute(attr)
+            for attr in self._rep.get(self.ATTRS_FIELD, [])
+        ]
+
+    def __str__(self):
+        return json.dumps(self._record, indent=1)
+
+    def validate(
+            self,
+            offset: typing.Optional[int] = None) -> typing.Optional[list[str]]:
+        errors = []
+        if offset is not None and offset != self.offset:
+            errors.append(f"Expected offset {offset} got {self.offset}")
+        if self.body is None:
+            errors.append(f"Missing {self.BODY_FIELD}")
+        if self.timestamp_ns is None:
+            errors.append(f"Missing {self.TS_FIELD}")
+        if self.severity is None:
+            errors.append(f"Missing {self.SEVERITY_FIELD}")
+        if self.ATTRS_FIELD not in self._rep:
+            errors.append(f"Missing {self.ATTRS_FIELD}")
+
+        if len(self.attributes) != 2:
+            errors.append(f"Expected 2 attributes, got {len(self.attributes)}")
+
+        for attr in self.EXPECTED_ATTRS:
+            if attr not in self.attributes:
+                errors.append(f"Missing attribute '{attr.key}'")
+
+        if len(errors) > 0:
+            return errors
+
+        return None
+
+
+class BaseDataTransformsLoggingTest(BaseDataTransformsTest):
     """
     Tests for data transforms logging
     """
 
-    topics = [TopicSpec(partition_count=9), TopicSpec(partition_count=9)]
-
     logs_topic = TopicSpec(name='_redpanda.transform_logs', partition_count=4)
 
-    # TODO(oren): be nice to actually use the OTel protobufs here
-    class LogRecord:
-        class Attribute:
-            def __init__(self, attr: dict):
-                self.key = attr['key']
-                assert len(attr['value']) == 1
-                self.value_type = list(attr['value'].keys())[0]
-                self.value = attr['value'][self.value_type]
-
-            # don't really care about the value, just the correct key and value _type_
-            def __eq__(self, other):
-                return (self.key == other.key
-                        and self.value_type == other.value_type
-                        and type(self.value) == type(other.value))
-
-        EXPECTED_ATTRS = [
-            Attribute({
-                'key': 'transform_name',
-                'value': {
-                    'stringValue': 'any'  # don't care for validation
-                }
-            }),
-            Attribute({
-                'key': 'node',
-                'value': {
-                    'intValue': 23  # don't care for validation
-                }
-            })
-        ]
-
-        BODY_FIELD = 'body'
-        TS_FIELD = 'timeUnixNano'
-        SEVERITY_FIELD = 'severityNumber'
-        ATTRS_FIELD = 'attributes'
-
-        def __init__(self, raw: str):
-            self._record = json.loads(raw)
-            self._record['value'] = json.loads(self._record['value'])
-
-            # Redpanda bits
-            self.offset = self._record['offset']
-            self.key = self._record['key']
-
-            # OTel bits
-            self._rep = self._record['value']
-            self.body = self._rep.get(self.BODY_FIELD, None)
-            self.timestamp_ns = self._rep.get(self.TS_FIELD, None)
-            self.severity = self._rep.get(self.SEVERITY_FIELD, None)
-            self.attributes = [
-                self.Attribute(attr)
-                for attr in self._rep.get(self.ATTRS_FIELD, [])
-            ]
-
-        def __str__(self):
-            return json.dumps(self._record, indent=1)
-
-        def validate(
-                self,
-                offset: typing.Optional[int] = None
-        ) -> typing.Optional[list[str]]:
-            errors = []
-            if offset is not None and offset != self.offset:
-                errors.append(f"Expected offset {offset} got {self.offset}")
-            if self.body is None:
-                errors.append(f"Missing {self.BODY_FIELD}")
-            if self.timestamp_ns is None:
-                errors.append(f"Missing {self.TS_FIELD}")
-            if self.severity is None:
-                errors.append(f"Missing {self.SEVERITY_FIELD}")
-            if self.ATTRS_FIELD not in self._rep:
-                errors.append(f"Missing {self.ATTRS_FIELD}")
-
-            if len(self.attributes) != 2:
-                errors.append(
-                    f"Expected 2 attributes, got {len(self.attributes)}")
-
-            for attr in self.EXPECTED_ATTRS:
-                if attr not in self.attributes:
-                    errors.append(f"Missing attribute '{attr.key}'")
-
-            if len(errors) > 0:
-                return errors
-
-            return None
-
-    def setup_identity_xform(self):
-        it, ot = self.topics
-        self._deploy_wasm(name="identity-logging-xform",
-                          input_topic=self.topics[0],
-                          output_topic=self.topics[1],
+    def setup_identity_xform(self, it, ot, name="identity-logging_xform"):
+        self._deploy_wasm(name=name,
+                          input_topic=it,
+                          output_topic=ot,
                           file="tinygo/identity_logging.wasm")
-        return self.topics
+        return [it, ot]
 
     def consume_one_log_record(self, offset=0, timeout=10) -> LogRecord:
-        return self.LogRecord(
+        return LogRecord(
             self._rpk.consume(self.logs_topic.name,
                               n=1,
                               offset=offset,
                               timeout=timeout))
 
+
+class DataTransformsLoggingTest(BaseDataTransformsLoggingTest):
+
+    topics = [
+        TopicSpec(partition_count=9),
+        TopicSpec(partition_count=9),
+    ]
+
     @cluster(num_nodes=4)
     def test_logs_volume(self):
-        input_topic, output_topic = self.setup_identity_xform()
+        input_topic, output_topic = self.setup_identity_xform(
+            self.topics[0], self.topics[1])
         producer_status = self._produce_input_topic(topic=input_topic,
                                                     transactional=False)
         consumer_status = self._consume_output_topic(topic=output_topic,
@@ -584,7 +593,8 @@ class DataTransformsLoggingTest(BaseDataTransformsTest):
         """
         Verify that log events conform to a subset OTel logging spec as laid out in our RFC
         """
-        input_topic, output_topic = self.setup_identity_xform()
+        input_topic, _ = self.setup_identity_xform(self.topics[0],
+                                                   self.topics[1])
 
         self._rpk.produce(input_topic.name, 'foo', 'bar')
         log = self.consume_one_log_record()
@@ -595,7 +605,8 @@ class DataTransformsLoggingTest(BaseDataTransformsTest):
 
     @cluster(num_nodes=3)
     def test_logs_cc_escaping(self):
-        input_topic, output_topic = self.setup_identity_xform()
+        input_topic, output_topic = self.setup_identity_xform(
+            self.topics[0], self.topics[1])
 
         val = generate_string_with_control_character(12)
         buf = bytearray()
@@ -613,7 +624,7 @@ class DataTransformsLoggingTest(BaseDataTransformsTest):
 
     @cluster(num_nodes=3)
     def test_log_topic_integrity(self):
-        self.setup_identity_xform()
+        self.setup_identity_xform(self.topics[0], self.topics[1])
 
         self.logger.debug(
             f"{self.logs_topic.name}: delete topic should fail (empty response table)"
@@ -631,7 +642,7 @@ class DataTransformsLoggingTest(BaseDataTransformsTest):
 
     @cluster(num_nodes=3)
     def test_tunable_configs(self):
-        it, ot = self.setup_identity_xform()
+        it, _ = self.setup_identity_xform(self.topics[0], self.topics[1])
 
         self.logger.debug(
             "See that we can consume a log message w/in 5s with the default interval"
@@ -672,4 +683,209 @@ class DataTransformsLoggingTest(BaseDataTransformsTest):
             log.body
         ) == max_line, f"Expected {max_line}B, got {len(log.body)}B ({log.body})"
 
-    # TODO(oren): some tests based on metrics would probably be good
+
+class DataTransformsLoggingMetricsTest(BaseDataTransformsLoggingTest):
+
+    topics = [
+        TopicSpec(partition_count=9),
+        TopicSpec(partition_count=9),
+        TopicSpec(partition_count=9),
+        TopicSpec(partition_count=9),
+        TopicSpec(partition_count=9),
+        TopicSpec(partition_count=9),
+        TopicSpec(partition_count=9),
+        TopicSpec(partition_count=9),
+    ]
+
+    LOGGER_METRICS = ["events_total", "events_dropped_total"]
+    LOGGER_LABELS = ["function_name", "shard"]
+    MANAGER_METRICS = [
+        "log_manager_buffer_usage_ratio", "log_manager_write_errors_total"
+    ]
+    MANAGER_LABELS = ["shard"]
+
+    def get_metrics_from_node(
+        self,
+        node: ClusterNode,
+        patterns: list[str],
+        endpoint=MetricsEndpoint.METRICS
+    ) -> Optional[dict[str, MetricSamples]]:
+        def get_metrics_from_node_sync(patterns: list[str]):
+            samples = self.redpanda.metrics_samples(
+                patterns,
+                [node],
+                endpoint,
+            )
+            success = samples is not None
+            return success, samples
+
+        try:
+            return wait_until_result(
+                lambda: get_metrics_from_node_sync(patterns),
+                timeout_sec=2,
+                backoff_sec=.1)
+        except TimeoutError as e:
+            return None
+
+    def unpack_samples(self, metric_samples):
+        return {
+            k: [{
+                'value': s.value,
+                'labels': s.labels
+            } for s in metric_samples[k].samples]
+            for k in metric_samples.keys()
+        }
+
+    def random_ascii_string(self, min_len, max_len) -> str:
+        return ''.join(
+            random.choices(string.ascii_letters + string.digits,
+                           k=random.randint(min_len, max_len)))
+
+    @cluster(num_nodes=3)
+    def test_logger_metrics_present(self):
+        it, _ = self.setup_identity_xform(self.topics[0], self.topics[1])
+        self._rpk.produce(it.name, 'foo', 'bar')
+        self.consume_one_log_record()
+
+        def has_logger_metrics(node, endpoint):
+            metrics_samples = self.get_metrics_from_node(node,
+                                                         self.LOGGER_METRICS,
+                                                         endpoint=endpoint)
+            assert metrics_samples is not None, "get_metrics timed out"
+            return sorted(metrics_samples.keys()) == sorted(
+                self.LOGGER_METRICS)
+
+        assert any(
+            [
+                has_logger_metrics(n, MetricsEndpoint.METRICS)
+                for n in self.redpanda.nodes
+            ]
+        ), "Expected some node to export logger metrics on the internal endpoint"
+
+        assert any(
+            [
+                has_logger_metrics(n, MetricsEndpoint.PUBLIC_METRICS)
+                for n in self.redpanda.nodes
+            ]
+        ), "Expected some node to export logger metrics on the public endpoint"
+
+    @cluster(num_nodes=3)
+    def test_logger_metrics_values(self):
+        n_xform = len(self.topics) // 2
+
+        its = []
+        for i in range(0, n_xform):
+            its.append(
+                self.setup_identity_xform(
+                    self.topics[2 * i],
+                    self.topics[2 * i + 1],
+                    name=f"logger{i+1}",
+                )[0])
+        N_PER_TP = 100
+        for i in range(0, N_PER_TP):
+            for it in its:
+                self._rpk.produce(
+                    it.name,
+                    self.random_ascii_string(10, 100),
+                    self.random_ascii_string(10, 100),
+                )
+
+        def get_total_events_per_xform() -> tuple[dict[str, int], int]:
+            totals = {}
+            dropped = 0
+            for node in self.redpanda.nodes:
+                samples = self.unpack_samples(
+                    self.get_metrics_from_node(
+                        node,
+                        self.LOGGER_METRICS,
+                        endpoint=MetricsEndpoint.METRICS))
+                for m in samples['events_total']:
+                    xfm_name = m['labels']['function_name']
+                    totals[xfm_name] = totals.get(xfm_name, 0) + m['value']
+                dropped += sum(
+                    [m['value'] for m in samples["events_dropped_total"]])
+            self.logger.debug(json.dumps(totals, indent=1))
+            return (totals, dropped)
+
+        def get_total_events() -> tuple[int, int]:
+            tot = 0
+            totals, dropped = get_total_events_per_xform()
+            for k in totals:
+                tot += totals[k]
+            self.logger.debug(f"Cluster total log events: {tot}")
+            return (tot, dropped)
+
+        n_events_expected = N_PER_TP * len(its)
+        wait_until(lambda: get_total_events()[0] >= n_events_expected,
+                   timeout_sec=30,
+                   backoff_sec=5,
+                   err_msg=f"never got all the events")
+
+        totals, dropped = get_total_events_per_xform()
+        assert len(totals) == len(its)
+        for name in totals:
+            assert totals[
+                name] >= N_PER_TP, f"Expected {N_PER_TP} log events from transform {name}, got{totals[name]}"
+        assert dropped == 0, f"Expected no dropped events, got {dropped}"
+
+    @cluster(num_nodes=3)
+    def test_manager_metrics_present(self):
+        it, _ = self.setup_identity_xform(self.topics[0], self.topics[1])
+
+        def has_manager_metrics(node, endpoint):
+            metrics_samples = self.get_metrics_from_node(node,
+                                                         self.MANAGER_METRICS,
+                                                         endpoint=endpoint)
+            assert metrics_samples is not None, "Get_metrics timed out"
+            return sorted(metrics_samples.keys()) == sorted(
+                self.MANAGER_METRICS)
+
+        assert all(
+            [
+                has_manager_metrics(n, MetricsEndpoint.METRICS)
+                for n in self.redpanda.nodes
+            ]
+        ), "Expected all nodes to export manager metrics on the internal endpoint"
+
+        assert not any([
+            has_manager_metrics(n, MetricsEndpoint.PUBLIC_METRICS)
+            for n in self.redpanda.nodes
+        ]), "Expected no node to export manager metrics on the public endpoint"
+
+    @cluster(num_nodes=3)
+    def test_manager_metrics_values(self):
+        self.logger.debug("Set flush interval to 1h so buffers fill up")
+        self.redpanda.set_cluster_config(
+            {'data_transforms_logging_flush_interval_ms': 60 * 60 * 1000})
+
+        it, ot = self.setup_identity_xform(
+            self.topics[0],
+            self.topics[1],
+            name=f"logger-xform",
+        )
+
+        N_PER_TP = 32
+        for _ in range(0, N_PER_TP):
+            self._rpk.produce(
+                it.name,
+                self.random_ascii_string(128, 128),
+                self.random_ascii_string(128, 128),
+            )
+
+        self._rpk.consume(ot.name, n=1, offset=N_PER_TP - 1)
+
+        all_nodes_usage = []
+        for node in self.redpanda.nodes:
+            samples = self.unpack_samples(
+                self.get_metrics_from_node(
+                    node,
+                    ["log_manager_buffer_usage"],
+                    endpoint=MetricsEndpoint.METRICS,
+                ))
+
+            for s in samples['log_manager_buffer_usage']:
+                all_nodes_usage.append(s['value'])
+
+        assert any(
+            bu > 0.0 for bu in all_nodes_usage
+        ), f"Expected some non-zero buffer usage, got {all_nodes_usage}"


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR introduces some metrics for transform logging:

logger_probe for tracking metrics specific to individual transform
 loggers:
 - data_transforms_logger_events_total
    - Total # of log events emitted by some transform.
 - data_transforms_logger_events_dropped_total
    - Total # of some transform's log events that were dropped due
        to buffer capacity constraint.
    - exported to BOTH /metrics and /public_metrics

manager_probe for tracking metrics generic to the logging::manager:
- data_transforms_log_manager_buffer_usage_ratio
   - Current occupancy of the logging::manager's queues as a fraction
      of total capacity. [0.0..1.0]
- data_transforms_log_manager_write_errors_total
   - Total number of failures to produce log events to the transform
       logs topic.
    - exported ONLY to /metrics

Closes https://github.com/redpanda-data/core-internal/issues/1059

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Features

* Add Prometheus metrics for data transforms logging

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
