### PR TITLE
rpk: Improve tuner output script

### DIFF
--- a/src/go/rpk/.golangci.yml
+++ b/src/go/rpk/.golangci.yml
@@ -6,7 +6,8 @@ run:
 # those tools ever.
 issues:
   exclude-use-default: false
-
+  new-from-rev: HEAD
+  
 # We opt out of all suggested linters and manually pick what we want.
 # Please do not use enable-all.
 linters:

--- a/src/go/rpk/pkg/cli/redpanda/tune/tune.go
+++ b/src/go/rpk/pkg/cli/redpanda/tune/tune.go
@@ -93,6 +93,13 @@ To learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.
 			out.MaybeDie(err, "unable to load config: %v", err)
 			var tunerFactory factory.TunersFactory
 			if outTuneScriptFile != "" {
+				exists, err := afero.Exists(fs, outTuneScriptFile)
+				out.MaybeDie(err, "unable to determine if file %q exists: %v", outTuneScriptFile, err)
+				if !exists {
+					zap.L().Sugar().Debugf("provided output-script file %q does not exists, creating one", outTuneScriptFile)
+					_, err = fs.Create(outTuneScriptFile)
+					out.MaybeDie(err, "unable to create file %q: %v", outTuneScriptFile, err)
+				}
 				isDir, err := afero.IsDir(fs, outTuneScriptFile)
 				out.MaybeDie(err, "unable to check if %q is a dir or a file: %v", outTuneScriptFile, err)
 				if isDir {
@@ -111,7 +118,7 @@ To learn more about a tuner, run 'rpk redpanda tune help <tuner name>'.
 	}
 	addTunerParamsFlags(cmd, &tunerParams)
 	cmd.Flags().StringVar(&cpuSet, "cpu-set", "all", "Set of CPUs for tuners to use in cpuset(7) format; if not specified, tuners will use all available CPUs")
-	cmd.Flags().StringVar(&outTuneScriptFile, "output-script", "", "Generate a tuning file that can later be used to tune the system")
+	cmd.Flags().StringVar(&outTuneScriptFile, "output-script", "", "If a filename is provided, it will generate a tuning file that can later be used to tune the system")
 	cmd.Flags().DurationVar(&timeout, "timeout", 10*time.Second, "The maximum time to wait for the tune processes to complete (e.g. 300ms, 1.5s, 2h45m)")
 	// Deprecated
 	cmd.Flags().BoolVar(new(bool), "interactive", false, "Ask for confirmation on every step (e.g. configuration generation)")

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file.go
@@ -78,7 +78,7 @@ func (c *writeSizedFileCommand) RenderScript(w *bufio.Writer) error {
 	// See 'man truncate'.
 	fmt.Fprintf(
 		w,
-		"truncate -s %d %s",
+		"truncate -s %d %s\n",
 		c.sizeBytes,
 		c.path,
 	)

--- a/src/go/rpk/pkg/tuners/executors/commands/write_sized_file_test.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/write_sized_file_test.go
@@ -27,7 +27,7 @@ func TestWriteSizedFileCmdRender(t *testing.T) {
 		int64(1),
 	)
 
-	expected := "truncate -s 1 /some/made/up/filepath.txt"
+	expected := "truncate -s 1 /some/made/up/filepath.txt\n"
 	var buf bytes.Buffer
 
 	w := bufio.NewWriter(&buf)


### PR DESCRIPTION
This PR fixes:

- Missing new line in output script.
- Improves the file handling behavior, now it creates a file if the provided string does not exist. 

Fixes #16552 
Fixes #16064 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes


### Bug Fixes

* `rpk tune --output-script`: Add a missing new line in the ballast file tuner when using the `--output-script` flag

### Improvements

* `rpk tune --output-script`: rpk now creates a file for you if the provided file does not exist.
