### PR TITLE
Set KAFKA_OPTS to empty in OMB

### DIFF
--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -68,12 +68,15 @@ class OpenMessagingBenchmarkWorkers(Service):
 
         node.account.mkdirs(OpenMessagingBenchmarkWorkers.PERSISTENT_ROOT)
 
-        start_cmd = f"cd /opt/openmessaging-benchmark; \
-                      HEAP_OPTS=\" \" \
-                      bin/benchmark-worker \
-                      --port {OpenMessagingBenchmarkWorkers.PORT} \
-                      --stats-port {OpenMessagingBenchmarkWorkers.STATS_PORT} \
-                      >> {OpenMessagingBenchmarkWorkers.STDOUT_STDERR_CAPTURE} 2>&1 & disown"
+        start_cmd = (
+            f"cd /opt/openmessaging-benchmark; "
+            f"HEAP_OPTS=\" \" "
+            f"KAFKA_OPTS=\" \" "
+            f"bin/benchmark-worker "
+            f"--port {OpenMessagingBenchmarkWorkers.PORT} "
+            f"--stats-port {OpenMessagingBenchmarkWorkers.STATS_PORT} "
+            f">> {OpenMessagingBenchmarkWorkers.STDOUT_STDERR_CAPTURE} 2>&1 & disown"
+        )
 
         with node.account.monitor_log(OpenMessagingBenchmarkWorkers.
                                       STDOUT_STDERR_CAPTURE) as monitor:


### PR DESCRIPTION
Set KAFKA_OPTS to a single space in OMB, which is required to use newer OMB versions as otherwise we try to use a -javaagent from a location that doesn't exist in DT OMB setup (see
bin/benchmark-workers script).

Single empty space is because a totally empty KAFKA_OPTS will still be overridden by the bin/benchmark-workers script.

Issue redpanda-data/core-internal#1016.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
