### PR TITLE
cloud_storage: update upload_object api

### DIFF
--- a/src/v/archival/purger.cc
+++ b/src/v/archival/purger.cc
@@ -539,12 +539,13 @@ ss::future<cloud_storage::upload_result> purger::write_remote_lifecycle_marker(
     };
     auto marker_key = remote_marker.get_key();
 
-    co_return co_await _api.upload_object(
-      bucket,
-      marker_key,
-      serde::to_iobuf(std::move(remote_marker)),
-      marker_rtc,
-      "remote_lifecycle_marker");
+    co_return co_await _api.upload_object({
+      .bucket_name = bucket,
+      .key = marker_key,
+      .payload = serde::to_iobuf(std::move(remote_marker)),
+      .parent_rtc = marker_rtc,
+      .upload_type = cloud_storage::upload_object_type::remote_lifecycle_marker,
+    });
 }
 
 ss::future<> purger::stop() {

--- a/src/v/cloud_storage/recovery_utils.cc
+++ b/src/v/cloud_storage/recovery_utils.cc
@@ -67,11 +67,11 @@ ss::future<> place_download_result(
     retry_chain_node fib{&parent};
     auto result_path = generate_result_path(ntp_cfg, result_completed);
     auto result = co_await remote.upload_object(
-      bucket,
-      cloud_storage_clients::object_key{result_path},
-      iobuf{},
-      fib,
-      "download result file");
+      {.bucket_name = bucket,
+       .key = cloud_storage_clients::object_key{result_path},
+       .payload = iobuf{},
+       .parent_rtc = fib,
+       .upload_type = upload_object_type::download_result_file});
     if (result != upload_result::success) {
         vlog(
           cst_log.error,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -397,16 +397,8 @@ public:
     /// \brief Upload small objects to bucket. Suitable for uploading simple
     /// strings, does not check for leadership before upload like the segment
     /// upload function.
-    ///
-    /// \param bucket The bucket to upload to
-    /// \param object_path The path to upload to
-    /// \param payload The data to place in the bucket
-    ss::future<upload_result> upload_object(
-      const cloud_storage_clients::bucket_name& bucket,
-      const cloud_storage_clients::object_key& object_path,
-      iobuf payload,
-      retry_chain_node& parent,
-      const char* log_object_type = "object");
+    ss::future<upload_result>
+    upload_object(upload_object_request upload_request);
 
     ss::future<download_result> do_download_manifest(
       const cloud_storage_clients::bucket_name& bucket,

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1297,11 +1297,11 @@ ss::future<> finalize_background(remote& api, finalize_data data) {
           data.insync_offset);
 
         auto manifest_put_result = co_await api.upload_object(
-          data.bucket,
-          data.key,
-          std::move(data.serialized_manifest),
-          local_rtc,
-          "manifest");
+          {.bucket_name = data.bucket,
+           .key = data.key,
+           .payload = std::move(data.serialized_manifest),
+           .parent_rtc = local_rtc,
+           .upload_type = upload_object_type::manifest});
 
         if (manifest_put_result != upload_result::success) {
             vlog(

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -195,14 +195,15 @@ void upload_index(
     builder->consume().get();
     builder->close().get();
     auto ixbuf = ix.to_iobuf();
-    auto upload_res = f.api.local()
-                        .upload_object(
-                          bucket,
-                          cloud_storage_clients::object_key{
-                            path().native() + ".index"},
-                          std::move(ixbuf),
-                          fib)
-                        .get();
+    auto upload_res
+      = f.api.local()
+          .upload_object(
+            {.bucket_name = bucket,
+             .key
+             = cloud_storage_clients::object_key{path().native() + ".index"},
+             .payload = std::move(ixbuf),
+             .parent_rtc = fib})
+          .get();
     BOOST_REQUIRE(upload_res == upload_result::success);
 }
 

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -603,7 +603,11 @@ FIXTURE_TEST(test_list_bucket, remote_fixture) {
                 cloud_storage_clients::object_key path{
                   fmt::format("{}/{}/{}", i, j, k)};
                 auto result = remote.local()
-                                .upload_object(bucket, path, iobuf{}, fib)
+                                .upload_object(
+                                  {.bucket_name = bucket,
+                                   .key = path,
+                                   .payload = iobuf{},
+                                   .parent_rtc = fib})
                                 .get();
                 BOOST_REQUIRE_EQUAL(
                   cloud_storage::upload_result::success, result);
@@ -649,8 +653,13 @@ FIXTURE_TEST(test_list_bucket_with_prefix, remote_fixture) {
         for (const char second : {'a', 'b'}) {
             cloud_storage_clients::object_key path{
               fmt::format("{}/{}", first, second)};
-            auto result
-              = remote.local().upload_object(bucket, path, iobuf{}, fib).get();
+            auto result = remote.local()
+                            .upload_object(
+                              {.bucket_name = bucket,
+                               .key = path,
+                               .payload = iobuf{},
+                               .parent_rtc = fib})
+                            .get();
             BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
         }
     }
@@ -676,8 +685,13 @@ FIXTURE_TEST(test_list_bucket_with_filter, remote_fixture) {
     retry_chain_node fib(never_abort, 100ms, 20ms);
     cloud_storage_clients::bucket_name bucket{"test"};
     cloud_storage_clients::object_key path{"b"};
-    auto upl_result
-      = remote.local().upload_object(bucket, path, iobuf{}, fib).get();
+    auto upl_result = remote.local()
+                        .upload_object(
+                          {.bucket_name = bucket,
+                           .key = path,
+                           .payload = iobuf{},
+                           .parent_rtc = fib})
+                        .get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, upl_result);
 
     auto result = remote.local()
@@ -704,7 +718,10 @@ FIXTURE_TEST(test_put_string, remote_fixture) {
     cloud_storage_clients::object_key path{"p"};
     auto result = remote.local()
                     .upload_object(
-                      bucket, path, make_iobuf_from_string("p"), fib)
+                      {.bucket_name = bucket,
+                       .key = path,
+                       .payload = make_iobuf_from_string("p"),
+                       .parent_rtc = fib})
                     .get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
 
@@ -845,19 +862,19 @@ FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
-          bucket,
-          cloud_storage_clients::object_key{"p"},
-          make_iobuf_from_string("p"),
-          fib)
+          {.bucket_name = bucket,
+           .key = cloud_storage_clients::object_key{"p"},
+           .payload = make_iobuf_from_string("p"),
+           .parent_rtc = fib})
         .get());
     BOOST_REQUIRE_EQUAL(
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
-          bucket,
-          cloud_storage_clients::object_key{"q"},
-          make_iobuf_from_string("q"),
-          fib)
+          {.bucket_name = bucket,
+           .key = cloud_storage_clients::object_key{"q"},
+           .payload = make_iobuf_from_string("q"),
+           .parent_rtc = fib})
         .get());
 
     std::vector<cloud_storage_clients::object_key> to_delete{
@@ -890,10 +907,10 @@ FIXTURE_TEST(
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
-          bucket,
-          cloud_storage_clients::object_key{"p"},
-          make_iobuf_from_string("p"),
-          fib)
+          {.bucket_name = bucket,
+           .key = cloud_storage_clients::object_key{"p"},
+           .payload = make_iobuf_from_string("p"),
+           .parent_rtc = fib})
         .get());
 
     std::vector<cloud_storage_clients::object_key> to_delete{

--- a/src/v/cluster/cloud_metadata/offsets_uploader.cc
+++ b/src/v/cluster/cloud_metadata/offsets_uploader.cc
@@ -70,7 +70,12 @@ ss::future<offsets_upload_result> offsets_uploader::upload(
 
         try {
             auto upload_res = co_await _remote.local().upload_object(
-              _bucket, remote_key, std::move(buf), retry_node);
+              {.bucket_name = _bucket,
+               .key = remote_key,
+               .payload = std::move(buf),
+               .parent_rtc = retry_node,
+               .upload_type
+               = cloud_storage::upload_object_type::group_offsets_snapshot});
             if (upload_res == cloud_storage::upload_result::success) {
                 paths.paths.emplace_back(remote_key().c_str());
             }


### PR DESCRIPTION
This is a refactor of the `upload_object` api in remote.cc. This method is used to upload small files to cloud storage as an iobuf payload. The method is a little rough in that it accepts strings to classify the upload kind and has code paths to update metrics of the remote probe depending on which object kind was uploaded (this is checked via string comparison).

The changes here are a pre-requisite to being able to use this API to create inventory configuration objects which are a PUT request with an XML payload. 

The following changes are made:

* scoped enum values are used to represent upload kind
* The caller specifies callbacks to use (optionally) when the upload succeeds, fails or backs off, with the remote probe supplied as argument
* The many arguments are collected into a POD struct for aggregate initialization and the resulting readability. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
