### PR TITLE
cloud_storage/inventory: Add inventory create-config API for AWS

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -42,6 +42,8 @@ v_cc_library(
     async_manifest_view.cc
     materialized_manifest_cache.cc
     anomalies_detector.cc
+    inventory/aws_ops.cc
+    inventory/types.cc
   DEPS
     Seastar::seastar
     v::bytes
@@ -55,4 +57,6 @@ v_cc_library(
     v::raft
     # NOTE: do not add v::cloud as a dependency
 )
+
 add_subdirectory(tests)
+add_subdirectory(inventory/tests)

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -42,6 +42,7 @@ v_cc_library(
     async_manifest_view.cc
     materialized_manifest_cache.cc
     anomalies_detector.cc
+    inventory/inv_ops.cc
     inventory/aws_ops.cc
     inventory/types.cc
   DEPS

--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -92,7 +92,8 @@ aws_ops::create_inventory_configuration(
       {.bucket_name = _bucket,
        .key = cloud_storage_clients::object_key{key},
        .payload = to_xml(cfg),
-       .parent_rtc = parent_rtc});
+       .parent_rtc = parent_rtc,
+       .upload_type = upload_object_type::inventory_configuration});
 }
 
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/inventory/aws_ops.h"
+
+#include "cloud_storage/remote.h"
+
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+
+using boost::property_tree::ptree;
+
+namespace {
+
+struct aws_report_configuration {
+    static constexpr auto xmlns = "http://s3.amazonaws.com/doc/2006-03-01/";
+    static constexpr auto destination_path = "Destination.S3BucketDestination";
+    static constexpr auto frequency_path = "Schedule.Frequency";
+
+    cloud_storage_clients::bucket_name bucket;
+    cloud_storage::inventory::inventory_config_id inventory_id;
+
+    cloud_storage::inventory::report_format format;
+    ss::sstring prefix;
+
+    cloud_storage::inventory::report_generation_frequency frequency;
+};
+
+ptree destination_node(const aws_report_configuration& cfg) {
+    ptree destination;
+    destination.add("Format", cfg.format);
+    destination.add("Prefix", cfg.prefix);
+    destination.add("Bucket", fmt::format("arn::aws::s3:::{}", cfg.bucket()));
+    return destination;
+}
+
+iobuf to_xml(const aws_report_configuration& cfg) {
+    ptree inv_cfg;
+    inv_cfg.put("<xmlattr>.xmlns", cfg.xmlns);
+    inv_cfg.add_child(cfg.destination_path, destination_node(cfg));
+
+    inv_cfg.add("IsEnabled", "true");
+    inv_cfg.add("Id", cfg.inventory_id());
+
+    inv_cfg.add(cfg.frequency_path, cfg.frequency);
+
+    ptree root;
+    root.put_child("InventoryConfiguration", inv_cfg);
+
+    std::stringstream sstr;
+    boost::property_tree::xml_parser::write_xml(sstr, root);
+
+    iobuf b;
+    b.append(sstr.str().data(), sstr.str().size());
+    return b;
+}
+
+} // namespace
+
+namespace cloud_storage::inventory {
+
+aws_ops::aws_ops(
+  cloud_storage_clients::bucket_name bucket,
+  inventory_config_id inventory_config_id,
+  ss::sstring inventory_prefix)
+  : _bucket(std::move(bucket))
+  , _inventory_config_id(std::move(inventory_config_id))
+  , _prefix(std::move(inventory_prefix)) {}
+
+ss::future<cloud_storage::upload_result>
+aws_ops::create_inventory_configuration(
+  cloud_storage::cloud_storage_api& remote,
+  retry_chain_node& parent_rtc,
+  report_generation_frequency frequency,
+  report_format format) {
+    const aws_report_configuration cfg{
+      .bucket = _bucket,
+      .inventory_id = _inventory_config_id,
+      .format = format,
+      .prefix = _prefix,
+      .frequency = frequency};
+
+    const auto key = fmt::format("?inventory&id={}", _inventory_config_id());
+    co_return co_await remote.upload_object(
+      {.bucket_name = _bucket,
+       .key = cloud_storage_clients::object_key{key},
+       .payload = to_xml(cfg),
+       .parent_rtc = parent_rtc});
+}
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/aws_ops.h
+++ b/src/v/cloud_storage/inventory/aws_ops.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/inventory/types.h"
+#include "model/fundamental.h"
+
+namespace cloud_storage::inventory {
+
+/// \brief AWS specific inventory API calls
+class aws_ops {
+public:
+    aws_ops(
+      cloud_storage_clients::bucket_name bucket,
+      inventory_config_id inventory_config_id,
+      ss::sstring inventory_prefix);
+
+    ss::future<cloud_storage::upload_result> create_inventory_configuration(
+      cloud_storage::cloud_storage_api&,
+      retry_chain_node&,
+      report_generation_frequency,
+      report_format);
+
+private:
+    cloud_storage_clients::bucket_name _bucket;
+    inventory_config_id _inventory_config_id;
+    ss::sstring _prefix;
+};
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/aws_ops.h
+++ b/src/v/cloud_storage/inventory/aws_ops.h
@@ -16,7 +16,7 @@
 namespace cloud_storage::inventory {
 
 /// \brief AWS specific inventory API calls
-class aws_ops {
+class aws_ops final : public base_ops {
 public:
     aws_ops(
       cloud_storage_clients::bucket_name bucket,
@@ -27,7 +27,7 @@ public:
       cloud_storage::cloud_storage_api&,
       retry_chain_node&,
       report_generation_frequency,
-      report_format);
+      report_format) override;
 
 private:
     cloud_storage_clients::bucket_name _bucket;

--- a/src/v/cloud_storage/inventory/inv_ops.cc
+++ b/src/v/cloud_storage/inventory/inv_ops.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/inventory/inv_ops.h"
+
+#include "cloud_storage/types.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/util/variant_utils.hh>
+
+#include <utility>
+
+namespace {
+// TODO (abhijat) - cluster config
+constexpr auto frequency
+  = cloud_storage::inventory::report_generation_frequency::daily;
+constexpr auto format = cloud_storage::inventory::report_format::csv;
+} // namespace
+
+namespace cloud_storage::inventory {
+
+inv_ops::inv_ops(ops_t ops)
+  : _inv_ops{std::move(ops)} {}
+
+ss::future<cloud_storage::upload_result>
+inv_ops::create_inventory_configuration(
+  cloud_storage_api& remote, retry_chain_node& parent) {
+    return ss::visit(_inv_ops, [&remote, &parent](auto& ops) {
+        return ops.create_inventory_configuration(
+          remote, parent, frequency, format);
+    });
+}
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/inv_ops.h
+++ b/src/v/cloud_storage/inventory/inv_ops.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/inventory/aws_ops.h"
+
+namespace cloud_storage::inventory {
+
+using ops_t = inv_ops_variant<aws_ops>;
+
+/// \brief A wrapper for vendor specific inventory API calls.
+class inv_ops {
+public:
+    explicit inv_ops(ops_t ops);
+
+    ss::future<cloud_storage::upload_result> create_inventory_configuration(
+      cloud_storage_api& remote, retry_chain_node&);
+
+private:
+    ops_t _inv_ops;
+};
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/inventory/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME create_inv_cfg
+  SOURCES
+    create_inventory_config_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES
+    Boost::unit_test_framework
+    v::cloud_storage
+    v::gtest_main
+  ARGS "-- -c 1"
+  LABELS cloud_storage
+)

--- a/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
+++ b/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
@@ -9,6 +9,7 @@
  */
 
 #include "cloud_storage/inventory/aws_ops.h"
+#include "cloud_storage/inventory/inv_ops.h"
 #include "cloud_storage/remote.h"
 
 #include <gmock/gmock.h>
@@ -81,4 +82,11 @@ TEST(CreateInvCfg, LowLevelApi) {
         prefix},
       frequency,
       format);
+}
+
+TEST(CreateInvCfg, HighLevelApi) {
+    test_create(cst::inventory::inv_ops{cst::inventory::aws_ops{
+      cloud_storage_clients::bucket_name{bucket},
+      cst::inventory::inventory_config_id{id},
+      prefix}});
 }

--- a/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
+++ b/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
@@ -50,7 +50,8 @@ std::string iobuf_to_xml(iobuf buf) {
 
 ss::future<cst::upload_result>
 validate_request(cst::upload_object_request request) {
-    EXPECT_EQ(request.upload_type, cst::upload_object_type::object);
+    EXPECT_EQ(
+      request.upload_type, cst::upload_object_type::inventory_configuration);
     EXPECT_EQ(request.bucket_name(), bucket);
     EXPECT_EQ(request.key(), expected_key);
     EXPECT_EQ(iobuf_to_xml(std::move(request.payload)), expected_xml_payload);

--- a/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
+++ b/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/inventory/aws_ops.h"
+#include "cloud_storage/remote.h"
+
+#include <gmock/gmock.h>
+
+namespace cst = cloud_storage;
+namespace t = ::testing;
+
+constexpr auto id = "redpanda-inv-weekly";
+constexpr auto bucket = "test-bucket";
+constexpr auto prefix = "inv-prefix";
+constexpr auto format = cst::inventory::report_format::csv;
+constexpr auto frequency = cst::inventory::report_generation_frequency::daily;
+const auto expected_key = fmt::format("?inventory&id={}", id);
+const auto expected_xml_payload = fmt::format(
+  R"({header}
+<InventoryConfiguration {ns}><Destination><S3BucketDestination><Format>{format}</Format><Prefix>{prefix}</Prefix><Bucket>arn::aws::s3:::{bucket}</Bucket></S3BucketDestination></Destination><IsEnabled>true</IsEnabled><Id>{id}</Id><Schedule><Frequency>{schedule}</Frequency></Schedule></InventoryConfiguration>)",
+  fmt::arg("header", R"(<?xml version="1.0" encoding="utf-8"?>)"),
+  fmt::arg("ns", R"(xmlns="http://s3.amazonaws.com/doc/2006-03-01/")"),
+  fmt::arg("format", format),
+  fmt::arg("prefix", prefix),
+  fmt::arg("bucket", bucket),
+  fmt::arg("schedule", frequency),
+  fmt::arg("id", id));
+
+class MockRemote : public cst::cloud_storage_api {
+public:
+    MOCK_METHOD(
+      ss::future<cst::upload_result>,
+      upload_object,
+      (cst::upload_object_request),
+      (override));
+};
+
+std::string iobuf_to_xml(iobuf buf) {
+    iobuf_parser p{std::move(buf)};
+    return p.read_string(p.bytes_left());
+}
+
+ss::future<cst::upload_result>
+validate_request(cst::upload_object_request request) {
+    EXPECT_EQ(request.upload_type, cst::upload_object_type::object);
+    EXPECT_EQ(request.bucket_name(), bucket);
+    EXPECT_EQ(request.key(), expected_key);
+    EXPECT_EQ(iobuf_to_xml(std::move(request.payload)), expected_xml_payload);
+    return ss::make_ready_future<cst::upload_result>(
+      cst::upload_result::success);
+}
+
+template<typename T, typename... Ts>
+void test_create(T t, Ts... args) {
+    MockRemote remote;
+    EXPECT_CALL(remote, upload_object(t::_))
+      .Times(1)
+      .WillOnce(t::Invoke(validate_request));
+
+    ss::abort_source as;
+    retry_chain_node parent{as};
+
+    const auto result
+      = t.create_inventory_configuration(remote, parent, args...).get();
+
+    ASSERT_EQ(result, cst::upload_result::success);
+}
+
+TEST(CreateInvCfg, LowLevelApi) {
+    test_create(
+      cst::inventory::aws_ops{
+        cloud_storage_clients::bucket_name{bucket},
+        cst::inventory::inventory_config_id{id},
+        prefix},
+      frequency,
+      format);
+}

--- a/src/v/cloud_storage/inventory/types.cc
+++ b/src/v/cloud_storage/inventory/types.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/inventory/types.h"
+
+namespace cloud_storage::inventory {
+std::ostream& operator<<(std::ostream& os, report_generation_frequency rgf) {
+    switch (rgf) {
+    case report_generation_frequency::daily:
+        return os << "Daily";
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, report_format rf) {
+    switch (rf) {
+    case report_format::csv:
+        return os << "CSV";
+    }
+}
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sharded.hh>
+
+#include <type_traits>
+#include <variant>
+
+class retry_chain_node;
+
+namespace cloud_storage {
+class cloud_storage_api;
+enum class upload_result;
+} // namespace cloud_storage
+
+namespace cloud_storage::inventory {
+
+// The identifier for a specific report configuration scheduled to run at a
+// fixed frequency and producing files of a fixed format.
+using inventory_config_id = named_type<ss::sstring, struct inventory_config>;
+
+enum class report_generation_frequency { daily };
+std::ostream& operator<<(std::ostream&, report_generation_frequency);
+
+enum class report_format { csv };
+std::ostream& operator<<(std::ostream&, report_format);
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -37,4 +37,25 @@ std::ostream& operator<<(std::ostream&, report_generation_frequency);
 enum class report_format { csv };
 std::ostream& operator<<(std::ostream&, report_format);
 
+/// \brief This class is not directly used for runtime polymorphism, it exists
+/// as a convenience to define constraints for inv_ops_variant, to make sure
+/// that the classes set as variants of inv_ops_variant have the expected set of
+/// methods defined in base_ops.
+class base_ops {
+public:
+    virtual ss::future<cloud_storage::upload_result>
+    create_inventory_configuration(
+      cloud_storage::cloud_storage_api&,
+      retry_chain_node&,
+      report_generation_frequency,
+      report_format)
+      = 0;
+};
+
+template<typename T>
+concept vendor_ops_provider = std::is_base_of_v<base_ops, T>;
+
+template<vendor_ops_provider... Ts>
+using inv_ops_variant = std::variant<Ts...>;
+
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -510,25 +510,20 @@ configuration::get_bucket_config() {
 std::ostream& operator<<(std::ostream& os, upload_object_type upload) {
     switch (upload) {
     case upload_object_type::object:
-        os << "object";
-        break;
+        return os << "object";
     case upload_object_type::segment_index:
-        os << "segment-index";
-        break;
+        return os << "segment-index";
     case upload_object_type::manifest:
-        os << "manifest";
-        break;
+        return os << "manifest";
     case upload_object_type::group_offsets_snapshot:
-        os << "group-offsets-snapshot";
-        break;
+        return os << "group-offsets-snapshot";
     case upload_object_type::download_result_file:
-        os << "download-result-file";
-        break;
+        return os << "download-result-file";
     case upload_object_type::remote_lifecycle_marker:
-        os << "remote-lifecycle-marker";
-        break;
+        return os << "remote-lifecycle-marker";
+    case upload_object_type::inventory_configuration:
+        return os << "inventory-configuration";
     }
-    return os;
 }
 
 void upload_object_request::on_success(remote_probe& probe) {

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -427,6 +427,7 @@ enum class upload_object_type {
     group_offsets_snapshot,
     download_result_file,
     remote_lifecycle_marker,
+    inventory_configuration,
 };
 
 std::ostream& operator<<(std::ostream&, upload_object_type);


### PR DESCRIPTION
The inventory API is introduced for AWS. The primary object introduced here is `cloud_storage::inventory::inv_ops` which is not wired into any service yet. Eventually it will be used by the scrubber-inventory download service (yet to be created) to schedule and download reports.

This PR contains the `create_inventory_configuration` method. The method added here schedules reports to be created for the given frequency and format by creating a report configuration. It calls [PutBucketInventoryConfiguration](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketInventoryConfiguration.html)

The API is divided into high level (vendor agnostic router) and low level (vendor specific) objects. The low level APIs, of which only AWS is implemented here, will hide the vendor specific actions required to perform tasks such as:

* creating an inventory config (implemented in this PR)
* ascertaining if the latest report is ready
* downloading the latest report
* cleaning up old reports

The high level API contains a variant to the low level API, and visits methods in the low level API depending on which vendor redpanda is deployed for. The variant will be extended to Azure and GCP as these are implemented.

__Why not add methods directly to `cloud_storage::remote` instead of adding a new abstraction layer__: remote can already call the right vendor HTTP verbs using specific clients, so potentially the create-inventory call could be added there without much overhead. 

However, remote generally deals with single, retryable HTTP calls (except for a couple of bulk operation cases), and it is built around segment/manifest operations. Only a couple of general purpose methods are exposed there. 

While the current inventory config creation maps to a single PUT call, the next methods which will be implemented in future PRs such as finding the latest report, checking if latest report is ready etc. will span multiple HTTP calls, for example downloading a JSON manifest, parsing paths in it and downloading those paths, and generally require logic which is inventory API specific. 

It is easier to add a high level API to manage these operations than to push these down into the s3 client or the abs client. 

Also, the GCS and AWS APIs are exactly similar for cloud storage operations so the same s3 client caters to both, but these two vendors differ in the inventory management calls. If we try to push down the details into the S3 client, it will need to be aware of the backend and call different implementations for GCS and AWS. 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
