### PR TITLE
cloud_storage: Add `download_object` method for downloading small objects

### DIFF
--- a/src/v/archival/purger.cc
+++ b/src/v/archival/purger.cc
@@ -538,13 +538,11 @@ ss::future<cloud_storage::upload_result> purger::write_remote_lifecycle_marker(
       .status = status,
     };
     auto marker_key = remote_marker.get_key();
-
     co_return co_await _api.upload_object({
-      .bucket_name = bucket,
-      .key = marker_key,
+      .transfer_details
+      = {.bucket = bucket, .key = marker_key, .parent_rtc = marker_rtc},
+      .type = cloud_storage::upload_type::remote_lifecycle_marker,
       .payload = serde::to_iobuf(std::move(remote_marker)),
-      .parent_rtc = marker_rtc,
-      .upload_type = cloud_storage::upload_object_type::remote_lifecycle_marker,
     });
 }
 

--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -122,6 +122,7 @@ ss::future<> upload_housekeeping_service::bg_idle_loop() {
         case cloud_storage::api_activity_type::manifest_upload:
         case cloud_storage::api_activity_type::segment_upload:
         case cloud_storage::api_activity_type::segment_delete:
+        case cloud_storage::api_activity_type::object_upload:
             weight = 1;
             if (event.is_retry) {
                 slow_down_weight = 1;
@@ -130,6 +131,7 @@ ss::future<> upload_housekeeping_service::bg_idle_loop() {
         // Read path events
         case cloud_storage::api_activity_type::manifest_download:
         case cloud_storage::api_activity_type::segment_download:
+        case cloud_storage::api_activity_type::object_download:
             weight = 1;
             if (event.is_retry) {
                 slow_down_weight = 1;

--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -89,11 +89,10 @@ aws_ops::create_inventory_configuration(
 
     const auto key = fmt::format("?inventory&id={}", _inventory_config_id());
     co_return co_await remote.upload_object(
-      {.bucket_name = _bucket,
-       .key = cloud_storage_clients::object_key{key},
-       .payload = to_xml(cfg),
-       .parent_rtc = parent_rtc,
-       .upload_type = upload_object_type::inventory_configuration});
+      {.transfer_details
+       = {.bucket = _bucket, .key = cloud_storage_clients::object_key{key}, .parent_rtc = parent_rtc},
+       .type = upload_type::inventory_configuration,
+       .payload = to_xml(cfg)});
 }
 
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
+++ b/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
@@ -39,7 +39,7 @@ public:
     MOCK_METHOD(
       ss::future<cst::upload_result>,
       upload_object,
-      (cst::upload_object_request),
+      (cst::upload_request),
       (override));
 };
 
@@ -48,12 +48,10 @@ std::string iobuf_to_xml(iobuf buf) {
     return p.read_string(p.bytes_left());
 }
 
-ss::future<cst::upload_result>
-validate_request(cst::upload_object_request request) {
-    EXPECT_EQ(
-      request.upload_type, cst::upload_object_type::inventory_configuration);
-    EXPECT_EQ(request.bucket_name(), bucket);
-    EXPECT_EQ(request.key(), expected_key);
+ss::future<cst::upload_result> validate_request(cst::upload_request request) {
+    EXPECT_EQ(request.type, cst::upload_type::inventory_configuration);
+    EXPECT_EQ(request.transfer_details.bucket(), bucket);
+    EXPECT_EQ(request.transfer_details.key(), expected_key);
     EXPECT_EQ(iobuf_to_xml(std::move(request.payload)), expected_xml_payload);
     return ss::make_ready_future<cst::upload_result>(
       cst::upload_result::success);

--- a/src/v/cloud_storage/recovery_utils.cc
+++ b/src/v/cloud_storage/recovery_utils.cc
@@ -66,12 +66,12 @@ ss::future<> place_download_result(
   retry_chain_node& parent) {
     retry_chain_node fib{&parent};
     auto result_path = generate_result_path(ntp_cfg, result_completed);
-    auto result = co_await remote.upload_object(
-      {.bucket_name = bucket,
-       .key = cloud_storage_clients::object_key{result_path},
-       .payload = iobuf{},
-       .parent_rtc = fib,
-       .upload_type = upload_object_type::download_result_file});
+    auto result = co_await remote.upload_object({
+      .transfer_details
+      = {.bucket = bucket, .key = cloud_storage_clients::object_key{result_path}, .parent_rtc = fib},
+      .type = upload_type::download_result_file,
+      .payload = iobuf{},
+    });
     if (result != upload_result::success) {
         vlog(
           cst_log.error,

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -845,7 +845,7 @@ remote::download_object(cloud_storage::download_request download_request) {
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         notify_external_subscribers(
           api_activity_notification{
-            .type = api_activity_type::segment_download,
+            .type = api_activity_type::object_download,
             .is_retry = fib.retry_count() > 1},
           transfer_details.parent_rtc);
         auto resp = co_await lease.client->get_object(
@@ -1420,6 +1420,12 @@ ss::future<upload_result> remote::upload_object(upload_request upload_request) {
           upload_type,
           path,
           content_length);
+
+        notify_external_subscribers(
+          api_activity_notification{
+            .type = api_activity_type::object_upload,
+            .is_retry = fib.retry_count() > 1},
+          transfer_details.parent_rtc);
 
         auto to_upload = upload_request.payload.copy();
         auto res = co_await lease.client->put_object(

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -345,6 +345,13 @@ public:
       offset_index& ix,
       retry_chain_node& parent);
 
+    /// \brief Download object small enough to fit in memory
+    /// \param download_request holds a reference to an iobuf in the `payload`
+    /// field which will hold the downloaded object if the download was
+    /// successful
+    ss::future<download_result>
+    download_object(download_request download_request);
+
     /// Checks if the segment exists in the bucket
     ss::future<download_result> segment_exists(
       const cloud_storage_clients::bucket_name& bucket,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -121,7 +121,7 @@ struct api_activity_notification {
 // references/pointers to this interface instead of remote to enable testing.
 class cloud_storage_api {
 public:
-    virtual ss::future<upload_result> upload_object(upload_object_request) = 0;
+    virtual ss::future<upload_result> upload_object(upload_request) = 0;
     virtual ~cloud_storage_api() = default;
 };
 
@@ -409,7 +409,7 @@ public:
     /// strings, does not check for leadership before upload like the segment
     /// upload function.
     ss::future<upload_result>
-    upload_object(upload_object_request upload_request) override;
+    upload_object(upload_request upload_request) override;
 
     ss::future<download_result> do_download_manifest(
       const cloud_storage_clients::bucket_name& bucket,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -109,6 +109,8 @@ enum class api_activity_type {
     manifest_download,
     controller_snapshot_upload,
     controller_snapshot_download,
+    object_upload,
+    object_download
 };
 
 struct api_activity_notification {

--- a/src/v/cloud_storage/tests/remote_segment_test.cc
+++ b/src/v/cloud_storage/tests/remote_segment_test.cc
@@ -197,12 +197,11 @@ void upload_index(
     auto ixbuf = ix.to_iobuf();
     auto upload_res
       = f.api.local()
-          .upload_object(
-            {.bucket_name = bucket,
-             .key
-             = cloud_storage_clients::object_key{path().native() + ".index"},
-             .payload = std::move(ixbuf),
-             .parent_rtc = fib})
+          .upload_object({
+            .transfer_details
+            = {.bucket = bucket, .key = cloud_storage_clients::object_key{path().native() + ".index"}, .parent_rtc = fib},
+            .payload = std::move(ixbuf),
+          })
           .get();
     BOOST_REQUIRE(upload_res == upload_result::success);
 }

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -602,13 +602,13 @@ FIXTURE_TEST(test_list_bucket, remote_fixture) {
             for (int k = 0; k < third; k++) {
                 cloud_storage_clients::object_key path{
                   fmt::format("{}/{}/{}", i, j, k)};
-                auto result = remote.local()
-                                .upload_object(
-                                  {.bucket_name = bucket,
-                                   .key = path,
-                                   .payload = iobuf{},
-                                   .parent_rtc = fib})
-                                .get();
+                auto result
+                  = remote.local()
+                      .upload_object(
+                        {.transfer_details
+                         = {.bucket = bucket, .key = path, .parent_rtc = fib},
+                         .payload = iobuf{}})
+                      .get();
                 BOOST_REQUIRE_EQUAL(
                   cloud_storage::upload_result::success, result);
             }
@@ -653,13 +653,13 @@ FIXTURE_TEST(test_list_bucket_with_prefix, remote_fixture) {
         for (const char second : {'a', 'b'}) {
             cloud_storage_clients::object_key path{
               fmt::format("{}/{}", first, second)};
-            auto result = remote.local()
-                            .upload_object(
-                              {.bucket_name = bucket,
-                               .key = path,
-                               .payload = iobuf{},
-                               .parent_rtc = fib})
-                            .get();
+            auto result
+              = remote.local()
+                  .upload_object(
+                    {.transfer_details
+                     = {.bucket = bucket, .key = path, .parent_rtc = fib},
+                     .payload = iobuf{}})
+                  .get();
             BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
         }
     }
@@ -687,10 +687,9 @@ FIXTURE_TEST(test_list_bucket_with_filter, remote_fixture) {
     cloud_storage_clients::object_key path{"b"};
     auto upl_result = remote.local()
                         .upload_object(
-                          {.bucket_name = bucket,
-                           .key = path,
-                           .payload = iobuf{},
-                           .parent_rtc = fib})
+                          {.transfer_details
+                           = {.bucket = bucket, .key = path, .parent_rtc = fib},
+                           .payload = iobuf{}})
                         .get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, upl_result);
 
@@ -718,10 +717,9 @@ FIXTURE_TEST(test_put_string, remote_fixture) {
     cloud_storage_clients::object_key path{"p"};
     auto result = remote.local()
                     .upload_object(
-                      {.bucket_name = bucket,
-                       .key = path,
-                       .payload = make_iobuf_from_string("p"),
-                       .parent_rtc = fib})
+                      {.transfer_details
+                       = {.bucket = bucket, .key = path, .parent_rtc = fib},
+                       .payload = make_iobuf_from_string("p")})
                     .get();
     BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
 
@@ -862,19 +860,17 @@ FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
-          {.bucket_name = bucket,
-           .key = cloud_storage_clients::object_key{"p"},
-           .payload = make_iobuf_from_string("p"),
-           .parent_rtc = fib})
+          {.transfer_details
+           = {.bucket = bucket, .key = cloud_storage_clients::object_key{"p"}, .parent_rtc = fib},
+           .payload = make_iobuf_from_string("p")})
         .get());
     BOOST_REQUIRE_EQUAL(
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
-          {.bucket_name = bucket,
-           .key = cloud_storage_clients::object_key{"q"},
-           .payload = make_iobuf_from_string("q"),
-           .parent_rtc = fib})
+          {.transfer_details
+           = {.bucket = bucket, .key = cloud_storage_clients::object_key{"q"}, .parent_rtc = fib},
+           .payload = make_iobuf_from_string("q")})
         .get());
 
     std::vector<cloud_storage_clients::object_key> to_delete{
@@ -907,10 +903,9 @@ FIXTURE_TEST(
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
-          {.bucket_name = bucket,
-           .key = cloud_storage_clients::object_key{"p"},
-           .payload = make_iobuf_from_string("p"),
-           .parent_rtc = fib})
+          {.transfer_details
+           = {.bucket = bucket, .key = cloud_storage_clients::object_key{"p"}, .parent_rtc = fib},
+           .payload = make_iobuf_from_string("p")})
         .get());
 
     std::vector<cloud_storage_clients::object_key> to_delete{

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -715,6 +715,7 @@ FIXTURE_TEST(test_put_string, remote_fixture) {
     retry_chain_node fib(never_abort, 100ms, 20ms);
 
     cloud_storage_clients::object_key path{"p"};
+    auto subscription = remote.local().subscribe(allow_all);
     auto result = remote.local()
                     .upload_object(
                       {.transfer_details
@@ -726,6 +727,9 @@ FIXTURE_TEST(test_put_string, remote_fixture) {
     auto request = get_requests()[0];
     BOOST_REQUIRE(request.method == "PUT");
     BOOST_REQUIRE(request.content == "p");
+
+    BOOST_REQUIRE(subscription.available());
+    BOOST_REQUIRE(subscription.get().type == api_activity_type::object_upload);
 }
 
 FIXTURE_TEST(test_delete_objects, remote_fixture) {
@@ -1246,6 +1250,7 @@ FIXTURE_TEST(test_get_object, remote_fixture) {
     retry_chain_node fib(never_abort, 1s, 20ms);
 
     cloud_storage_clients::object_key path{"p"};
+
     BOOST_REQUIRE_EQUAL(
       cloud_storage::upload_result::success,
       remote.local()
@@ -1256,6 +1261,7 @@ FIXTURE_TEST(test_get_object, remote_fixture) {
         })
         .get());
 
+    auto subscription = remote.local().subscribe(allow_all);
     iobuf buf;
     auto dl_res = remote.local()
                     .download_object(
@@ -1273,4 +1279,7 @@ FIXTURE_TEST(test_get_object, remote_fixture) {
 
     BOOST_REQUIRE(dl_res == download_result::success);
     BOOST_REQUIRE_EQUAL(iobuf_to_bytes(buf), "p");
+    BOOST_REQUIRE(subscription.available());
+    BOOST_REQUIRE(
+      subscription.get().type == api_activity_type::object_download);
 }

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -39,7 +39,7 @@ cloud_storage_clients::default_overrides get_default_overrides() {
 }
 
 void run_callback(
-  std::optional<cloud_storage::upload_object_request::probe_callback_t>& cb,
+  std::optional<cloud_storage::probe_callback_t>& cb,
   cloud_storage::remote_probe& probe) {
     if (cb.has_value()) {
         cb.value()(probe);
@@ -507,32 +507,43 @@ configuration::get_bucket_config() {
     }
 }
 
-std::ostream& operator<<(std::ostream& os, upload_object_type upload) {
+std::ostream& operator<<(std::ostream& os, upload_type upload) {
     switch (upload) {
-    case upload_object_type::object:
+        using enum cloud_storage::upload_type;
+    case object:
         return os << "object";
-    case upload_object_type::segment_index:
+    case segment_index:
         return os << "segment-index";
-    case upload_object_type::manifest:
+    case manifest:
         return os << "manifest";
-    case upload_object_type::group_offsets_snapshot:
+    case group_offsets_snapshot:
         return os << "group-offsets-snapshot";
-    case upload_object_type::download_result_file:
+    case download_result_file:
         return os << "download-result-file";
-    case upload_object_type::remote_lifecycle_marker:
+    case remote_lifecycle_marker:
         return os << "remote-lifecycle-marker";
-    case upload_object_type::inventory_configuration:
+    case inventory_configuration:
         return os << "inventory-configuration";
     }
 }
 
-void upload_object_request::on_success(remote_probe& probe) {
+std::ostream& operator<<(std::ostream& os, download_type download) {
+    switch (download) {
+        using enum cloud_storage::download_type;
+    case object:
+        return os << "object";
+    case segment_index:
+        return os << "segment-index";
+    }
+}
+
+void transfer_details::on_success(remote_probe& probe) {
     run_callback(success_cb, probe);
 }
-void upload_object_request::on_failure(remote_probe& probe) {
+void transfer_details::on_failure(remote_probe& probe) {
     run_callback(failure_cb, probe);
 }
-void upload_object_request::on_backoff(remote_probe& probe) {
+void transfer_details::on_backoff(remote_probe& probe) {
     run_callback(backoff_cb, probe);
 }
 

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -463,6 +463,12 @@ struct upload_request {
     iobuf payload;
 };
 
+struct download_request {
+    transfer_details transfer_details;
+    download_type type;
+    iobuf& payload;
+};
+
 } // namespace cloud_storage
 
 namespace std {

--- a/src/v/cluster/cloud_metadata/offsets_uploader.cc
+++ b/src/v/cluster/cloud_metadata/offsets_uploader.cc
@@ -69,13 +69,12 @@ ss::future<offsets_upload_result> offsets_uploader::upload(
           uuid, meta_id, ntp.tp.partition, snap_idx++);
 
         try {
-            auto upload_res = co_await _remote.local().upload_object(
-              {.bucket_name = _bucket,
-               .key = remote_key,
-               .payload = std::move(buf),
-               .parent_rtc = retry_node,
-               .upload_type
-               = cloud_storage::upload_object_type::group_offsets_snapshot});
+            auto upload_res = co_await _remote.local().upload_object({
+              .transfer_details
+              = {.bucket = _bucket, .key = remote_key, .parent_rtc = retry_node},
+              .type = cloud_storage::upload_type::group_offsets_snapshot,
+              .payload = std::move(buf),
+            });
             if (upload_res == cloud_storage::upload_result::success) {
                 paths.paths.emplace_back(remote_key().c_str());
             }


### PR DESCRIPTION
A `download_object` method is added to `cloud_storage::remote` to download small objects intended to remain in memory and not written to disk via a stream etc.

The upload_object_request is generalized into a transfer_request type with variants for upload and download.

The download_index method is refactored to use download_object.

The new method will be used in a follow up PR to check if an inventory configuration is present or not.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
