### PR TITLE
io: add scheduler

### DIFF
--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -9,6 +9,7 @@ v_cc_library(
     clang-tidy-helper.cc
     logger.cc
     io_queue.cc
+    scheduler.cc
   DEPS
     Seastar::seastar
     absl::btree

--- a/src/v/io/README.md
+++ b/src/v/io/README.md
@@ -1,0 +1,17 @@
+The `io` module implements a page-based write-back cache.
+
+### `cache`
+
+S3-FIFO cache eviction algorithm.
+
+### `io_queue`
+
+Per-file I/O request submission queue and scheduler.
+
+### `scheduler`
+
+High-level scheduling across I/O queues.
+
+### `persistence`
+
+Abstract storage interface with disk and memory backends.

--- a/src/v/io/cache.h
+++ b/src/v/io/cache.h
@@ -18,10 +18,6 @@
 #include <algorithm>
 #include <optional>
 
-namespace testing_details {
-class cache_hook_accessor;
-}; // namespace testing_details
-
 /**
  * \defgroup cache Cache
  *
@@ -180,6 +176,10 @@ class cache_hook_accessor;
  */
 
 namespace experimental::io {
+
+namespace testing_details {
+class cache_hook_accessor;
+}; // namespace testing_details
 
 /**
  * Specifies that a callable type can be used as a cache eviction function.

--- a/src/v/io/scheduler.cc
+++ b/src/v/io/scheduler.cc
@@ -18,7 +18,7 @@
 namespace experimental::io {
 
 scheduler::scheduler(size_t num_files) noexcept
-  : open_file_limit_(num_files) {}
+  : open_file_limit_(num_files, "io::open_file_limit") {}
 
 void scheduler::add_queue(queue* queue) noexcept {
     queues_.push_back(*queue);

--- a/src/v/io/scheduler.cc
+++ b/src/v/io/scheduler.cc
@@ -81,6 +81,10 @@ seastar::future<> scheduler::monitor(queue* queue) noexcept {
          * because an io queue needs to wake up to be closed there is a delay
          * before the eviction is visible. this delay is why we track waiters_
          * separately rather than using the nofiles_ semaphore state.
+         *
+         * another way to look at this is that waiters_ is used to handle the
+         * case that we adjust the open_file_limit at runtime. currently it is a
+         * static value but will later be adjustable.
          */
         while (waiters_ > 0 && !lru_.empty()) {
             waiters_--;

--- a/src/v/io/scheduler.cc
+++ b/src/v/io/scheduler.cc
@@ -104,6 +104,11 @@ seastar::future<> scheduler::monitor(queue* queue) noexcept {
             co_return;
         }
 
+        /*
+         * semaphore is used instead of a condition variable because we don't
+         * want to miss a wake-up. the normal way to handle this would be to add
+         * a predicate, but the condition isn't a simple boolean flag or two.
+         */
         co_await queue->monitor_work_.wait(
           std::max<size_t>(queue->monitor_work_.current(), 1));
 

--- a/src/v/io/scheduler.cc
+++ b/src/v/io/scheduler.cc
@@ -99,7 +99,7 @@ seastar::future<> scheduler::monitor(queue* queue) noexcept {
                     queue->cache_hook_.unlink();
                 }
                 co_await queue->io_queue_.close();
-                queue->units_.return_all();
+                queue->open_file_limit_units_.return_all();
             }
             co_return;
         }
@@ -117,7 +117,7 @@ seastar::future<> scheduler::monitor(queue* queue) noexcept {
         if (queue->io_queue_.opened()) {
             if (!queue->cache_hook_.is_linked()) {
                 co_await queue->io_queue_.close();
-                queue->units_.return_all();
+                queue->open_file_limit_units_.return_all();
             }
             continue;
         }
@@ -148,7 +148,7 @@ seastar::future<> scheduler::monitor(queue* queue) noexcept {
 
         try {
             co_await queue->io_queue_.open();
-            queue->units_ = std::move(units.value());
+            queue->open_file_limit_units_ = std::move(units.value());
             lru_.push_back(*queue);
 
         } catch (...) {

--- a/src/v/io/scheduler.cc
+++ b/src/v/io/scheduler.cc
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/scheduler.h"
+
+#include "io/logger.h"
+#include "io/persistence.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace experimental::io {
+
+scheduler::scheduler(size_t nofiles) noexcept
+  : nofiles_(nofiles) {}
+
+void scheduler::add_queue(queue* queue) noexcept {
+    queues_.push_back(*queue);
+    queue->io_queue_.start();
+    queue->monitor_ = monitor(queue);
+}
+
+seastar::future<> scheduler::remove_queue(queue* queue) noexcept {
+    queue->sched_hook_.unlink();
+    queue->stop_ = true;
+    queue->sem_.signal();
+    auto monitor = std::exchange(
+      queue->monitor_, seastar::make_ready_future<>());
+    co_await std::move(monitor);
+    co_await queue->io_queue_.stop();
+}
+
+void scheduler::submit_read(queue* queue, page* page) noexcept {
+    queue->io_queue_.submit_read(*page);
+    if (!queue->io_queue_.opened()) {
+        queue->sem_.signal();
+    } else if (queue->cache_hook_.is_linked()) {
+        queue->cache_hook_.unlink();
+        lru_.push_back(*queue);
+    }
+}
+
+void scheduler::submit_write(queue* queue, page* page) noexcept {
+    queue->io_queue_.submit_write(*page);
+    if (!queue->io_queue_.opened()) {
+        queue->sem_.signal();
+    } else if (queue->cache_hook_.is_linked()) {
+        queue->cache_hook_.unlink();
+        lru_.push_back(*queue);
+    }
+}
+
+scheduler::queue::queue(
+  persistence* storage,
+  std::filesystem::path path,
+  io_queue::completion_callback_type complete)
+  : io_queue_(storage, std::move(path), std::move(complete)) {}
+
+const std::filesystem::path& scheduler::queue::path() const noexcept {
+    return io_queue_.path();
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+seastar::future<> scheduler::monitor(queue* queue) noexcept {
+    while (true) {
+        /*
+         * cooperative scheduling for cache eviction. consider the case when
+         * nofiles_ semaphore is initialized with 0 units (weird, but ok, maybe
+         * we want to be able to pause all I/O). two queues block on nofiles_
+         * semaphore. later a unit is deposited into the semaphore and the first
+         * wakes up and opens its underlying io_queue. at this point the running
+         * queue monitor could be suspended, but we'd like to be able for all
+         * queues to make progress. to handle this the active queue monitor will
+         * evict one or more other queues before suspending itself. however,
+         * because an io queue needs to wake up to be closed there is a delay
+         * before the eviction is visible. this delay is why we track waiters_
+         * separately rather than using the nofiles_ semaphore state.
+         */
+        while (waiters_ > 0 && !lru_.empty()) {
+            waiters_--;
+            auto& queue = lru_.front();
+            lru_.pop_front();
+            queue.sem_.signal();
+        }
+
+        /*
+         * when stopping the queue clean it up fully including removing it from
+         * the cache and closing the underlying io-queue.
+         */
+        if (queue->stop_) {
+            if (queue->io_queue_.opened()) {
+                if (queue->cache_hook_.is_linked()) {
+                    queue->cache_hook_.unlink();
+                }
+                co_await queue->io_queue_.close();
+                queue->units_.return_all();
+            }
+            co_return;
+        }
+
+        co_await queue->sem_.wait(std::max<size_t>(queue->sem_.current(), 1));
+
+        /*
+         * in the common case the queue is already open so there is nothing else
+         * to do and the monitor can loop around to suspend itself. however, if
+         * the queue has also been removed from the lru cache list then this is
+         * a signal that the opened queue should be closed and nofiles_ units
+         * released.
+         */
+        if (queue->io_queue_.opened()) {
+            if (!queue->cache_hook_.is_linked()) {
+                co_await queue->io_queue_.close();
+                queue->units_.return_all();
+            }
+            continue;
+        }
+
+        /*
+         * open the queue. if we can't get nofiles units then we'll try to
+         * evict another queue and wait for units to become available.
+         */
+        auto units = seastar::try_get_units(nofiles_, 1);
+        if (!units.has_value()) {
+            if (lru_.empty()) {
+                /*
+                 * this case is possible, if for example, `nofiles_` was
+                 * initialized with 0 units.
+                 */
+                waiters_++;
+            } else {
+                /*
+                 * signal another queue to be closed. once closed this queue
+                 * will acquire a nofiles_ unit and be allowed to open.
+                 */
+                auto& queue = lru_.front();
+                lru_.pop_front();
+                queue.sem_.signal();
+            }
+            units = co_await seastar::get_units(nofiles_, 1);
+        }
+
+        try {
+            co_await queue->io_queue_.open();
+            queue->units_ = std::move(units.value());
+            lru_.push_back(*queue);
+
+        } catch (...) {
+            log.warn(
+              "Unable to open file {}: {}",
+              queue->path(),
+              std::current_exception());
+        }
+    }
+}
+
+} // namespace experimental::io

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -79,7 +79,7 @@ public:
         // used to signal work for the queue monitor
         ssx::semaphore monitor_work_{0, "io::scheduler::queue::monitor_work"};
         // holds units from scheduler::open_file_limit
-        ssx::semaphore_units units_;
+        ssx::semaphore_units open_file_limit_units_;
         bool stop_{false};
     };
 

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -12,6 +12,7 @@
 
 #include "container/intrusive_list_helpers.h"
 #include "io/io_queue.h"
+#include "ssx/semaphore.h"
 
 #include <seastar/core/future.hh>
 
@@ -76,7 +77,8 @@ public:
          */
         seastar::future<> monitor_{seastar::make_ready_future<>()};
         seastar::semaphore sem_{0};
-        seastar::semaphore_units<> units_;
+        // holds units from scheduler::open_file_limit
+        ssx::semaphore_units units_;
         bool stop_{false};
     };
 
@@ -118,7 +120,7 @@ private:
     seastar::future<> monitor(queue*) noexcept;
 
     size_t waiters_{0};
-    seastar::semaphore open_file_limit_;
+    ssx::semaphore open_file_limit_;
     intrusive_list<queue, &queue::cache_hook_> lru_;
 };
 

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "container/intrusive_list_helpers.h"
+#include "io/io_queue.h"
+
+#include <seastar/core/future.hh>
+
+#include <filesystem>
+
+namespace experimental::io {
+
+class persistence;
+
+/**
+ * Manager of all file I/O queues.
+ *
+ * The scheduler tracks and controls the lifecycle of each I/O queue. The role
+ * of the scheduler is to implement high-level policies to accompolish goals
+ * like avoiding I/O queue starvation, or providing I/O priority.
+ *
+ * Currently the only policy that is implemented in the scheduler is maintaining
+ * a maximum number of open files by limiting the number of I/O queues that are
+ * open at any given time.
+ */
+class scheduler {
+public:
+    /**
+     * The queue is a wrapper around the low-level `io_queue`, and provides
+     * hooks and metadata for being managed by the scheduler.
+     */
+    class queue {
+    public:
+        /**
+         * Construct a new queue.
+         */
+        queue(
+          persistence* storage,
+          std::filesystem::path path,
+          io_queue::completion_callback_type complete);
+
+        /**
+         * Return the path of the backing file.
+         */
+        [[nodiscard]] const std::filesystem::path& path() const noexcept;
+
+    private:
+        friend class scheduler;
+
+        io_queue io_queue_;
+
+        /*
+         * all queues are tracked by the scheduler, as well as a cache to select
+         * a queue to close in order to enforce the maximum open queue limit.
+         */
+        intrusive_list_hook sched_hook_;
+        intrusive_list_hook cache_hook_;
+
+        /*
+         * a queue monitor controls the open/close lifecycle of the I/O queue.
+         * see scheduler::monitor implementation for more details.
+         */
+        seastar::future<> monitor_{seastar::make_ready_future<>()};
+        seastar::semaphore sem_{0};
+        seastar::semaphore_units<> units_;
+        bool stop_{false};
+    };
+
+    /**
+     * Construct a new scheduler.
+     *
+     * The scheduler will limit the number of concurrent open queues to a
+     * maximum of \p nofiles.
+     */
+    explicit scheduler(size_t nofiles) noexcept;
+
+    /**
+     * Add a queue to the scheduler.
+     *
+     * The queue must not have been previously added.
+     */
+    void add_queue(queue*) noexcept;
+
+    /**
+     * Remove a queue from the scheduler.
+     *
+     * The returned future completes when the background monitor has exited.
+     */
+    static seastar::future<> remove_queue(queue*) noexcept;
+
+    /**
+     * Submit an I/O request to a queue.
+     */
+    void submit_read(queue* queue, page* page) noexcept;
+    void submit_write(queue* queue, page* page) noexcept;
+
+private:
+    intrusive_list<queue, &queue::sched_hook_> queues_;
+
+    /*
+     * maximum open file handling. see implementation of `monitor` for more
+     * detailed description.
+     */
+    size_t waiters_{0};
+    seastar::semaphore nofiles_;
+    intrusive_list<queue, &queue::cache_hook_> lru_;
+    seastar::future<> monitor(queue*) noexcept;
+};
+
+} // namespace experimental::io

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -76,7 +76,8 @@ public:
          * see scheduler::monitor implementation for more details.
          */
         seastar::future<> monitor_{seastar::make_ready_future<>()};
-        seastar::semaphore sem_{0};
+        // used to signal work for the queue monitor
+        ssx::semaphore monitor_work_{0, "io::scheduler::queue::monitor_work"};
         // holds units from scheduler::open_file_limit
         ssx::semaphore_units units_;
         bool stop_{false};

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -84,9 +84,9 @@ public:
      * Construct a new scheduler.
      *
      * The scheduler will limit the number of concurrent open queues to a
-     * maximum of \p nofiles.
+     * maximum of \p num_files.
      */
-    explicit scheduler(size_t nofiles) noexcept;
+    explicit scheduler(size_t num_files) noexcept;
 
     /**
      * Add a queue to the scheduler.
@@ -118,7 +118,7 @@ private:
     seastar::future<> monitor(queue*) noexcept;
 
     size_t waiters_{0};
-    seastar::semaphore nofiles_;
+    seastar::semaphore open_file_limit_;
     intrusive_list<queue, &queue::cache_hook_> lru_;
 };
 

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -115,10 +115,11 @@ private:
      * maximum open file handling. see implementation of `monitor` for more
      * detailed description.
      */
+    seastar::future<> monitor(queue*) noexcept;
+
     size_t waiters_{0};
     seastar::semaphore nofiles_;
     intrusive_list<queue, &queue::cache_hook_> lru_;
-    seastar::future<> monitor(queue*) noexcept;
 };
 
 } // namespace experimental::io

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -122,6 +122,7 @@ private:
 
     size_t waiters_{0};
     ssx::semaphore open_file_limit_;
+    // LRU-ordered list of currently opened queues
     intrusive_list<queue, &queue::lru_hook_> lru_;
 };
 

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -19,6 +19,10 @@
 
 namespace experimental::io {
 
+namespace testing_details {
+class scheduler_queue_accessor;
+}; // namespace testing_details
+
 class persistence;
 
 /**
@@ -55,6 +59,7 @@ public:
 
     private:
         friend class scheduler;
+        friend class testing_details::scheduler_queue_accessor;
 
         io_queue io_queue_;
 

--- a/src/v/io/scheduler.h
+++ b/src/v/io/scheduler.h
@@ -69,7 +69,7 @@ public:
          * a queue to close in order to enforce the maximum open queue limit.
          */
         intrusive_list_hook sched_hook_;
-        intrusive_list_hook cache_hook_;
+        intrusive_list_hook lru_hook_;
 
         /*
          * a queue monitor controls the open/close lifecycle of the I/O queue.
@@ -122,7 +122,7 @@ private:
 
     size_t waiters_{0};
     ssx::semaphore open_file_limit_;
-    intrusive_list<queue, &queue::cache_hook_> lru_;
+    intrusive_list<queue, &queue::lru_hook_> lru_;
 };
 
 } // namespace experimental::io

--- a/src/v/io/tests/CMakeLists.txt
+++ b/src/v/io/tests/CMakeLists.txt
@@ -12,8 +12,13 @@ rp_test(
     page_test.cc
     page_set_test.cc
     io_queue_test.cc
+    scheduler_test.cc
   LIBRARIES
     v::gtest_main
     v::io
     absl::btree
+  # scheduler and io-queue test are memory hungary since they track copies of
+  # all dispatched and completed ios. scaling down cpus give CI tests a bit more
+  # breathing room to run.
+  ARGS "-- -c2"
 )

--- a/src/v/io/tests/cache_test.cc
+++ b/src/v/io/tests/cache_test.cc
@@ -13,9 +13,7 @@
 
 #include <map>
 
-namespace io = experimental::io;
-
-namespace testing_details {
+namespace experimental::io::testing_details {
 class cache_hook_accessor {
 public:
     static std::optional<size_t>
@@ -30,7 +28,9 @@ public:
 
     static uint8_t get_hook_freq(io::cache_hook& hook) { return hook.freq_; }
 };
-} // namespace testing_details
+} // namespace experimental::io::testing_details
+
+namespace io = experimental::io;
 
 class CacheTest : public ::testing::Test {
 public:
@@ -78,18 +78,19 @@ public:
     }
 
     static std::optional<size_t> get_hook_insertion_time(const entry& entry) {
-        return testing_details::cache_hook_accessor::get_hook_insertion_time(
-          entry.hook);
+        return io::testing_details::cache_hook_accessor::
+          get_hook_insertion_time(entry.hook);
     }
 
     static void
     set_hook_insertion_time(entry& entry, std::optional<size_t> time) {
-        testing_details::cache_hook_accessor::set_hook_insertion_time(
+        io::testing_details::cache_hook_accessor::set_hook_insertion_time(
           entry.hook, time);
     }
 
     static uint8_t get_hook_freq(entry& entry) {
-        return testing_details::cache_hook_accessor::get_hook_freq(entry.hook);
+        return io::testing_details::cache_hook_accessor::get_hook_freq(
+          entry.hook);
     }
 
     template<typename... Entries>

--- a/src/v/io/tests/io_queue_test.cc
+++ b/src/v/io/tests/io_queue_test.cc
@@ -22,9 +22,9 @@ namespace io = experimental::io;
 
 /*
  * params
+ *  - disk or memory backend
  *  - max file size
  *  - num io operations
- *  - disk or memory backend
  */
 class IOQueueTest
   : public StorageTest

--- a/src/v/io/tests/scheduler_test.cc
+++ b/src/v/io/tests/scheduler_test.cc
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "base/units.h"
+#include "io/scheduler.h"
+#include "io/tests/common.h"
+#include "random/generators.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/core/when_all.hh>
+#include <seastar/util/later.hh>
+
+#include <boost/range/irange.hpp>
+
+namespace experimental::io::testing_details {
+class scheduler_queue_accessor {
+public:
+    static auto get_queue(io::scheduler::queue* queue) {
+        return &queue->io_queue_;
+    }
+};
+} // namespace experimental::io::testing_details
+
+namespace io = experimental::io;
+
+/*
+ * params
+ *  - disk or memory backend
+ *  - max file size
+ *  - num io operations
+ *  - num of queues
+ *  - max number of open files
+ */
+class SchedulerTest
+  : public StorageTest
+  , public ::testing::WithParamInterface<
+      std::tuple<bool, size_t, size_t, size_t, size_t>> {
+public:
+    [[nodiscard]] static size_t file_size() { return std::get<1>(GetParam()); }
+    [[nodiscard]] static size_t num_io_ops() { return std::get<2>(GetParam()); }
+    [[nodiscard]] static size_t num_queues() { return std::get<3>(GetParam()); }
+    [[nodiscard]] static size_t open_files() { return std::get<4>(GetParam()); }
+
+    void SetUp() override {
+        StorageTest::SetUp();
+        scheduler_ = std::make_unique<io::scheduler>(open_files());
+    }
+
+    io::scheduler* scheduler() { return scheduler_.get(); }
+
+private:
+    [[nodiscard]] bool disk_persistence() const override {
+        return std::get<0>(GetParam());
+    }
+
+    std::unique_ptr<io::scheduler> scheduler_;
+};
+
+/*
+ * combines scheduler, queue, load generator, and fault injection.
+ */
+struct scheduler_tester {
+    scheduler_tester(
+      io::scheduler* scheduler,
+      io::persistence* storage,
+      std::filesystem::path path,
+      size_t file_size,
+      size_t num_io_ops)
+      : scheduler(scheduler)
+      , queue(
+          storage,
+          std::move(path),
+          [this](auto& page) noexcept { generator.handle_complete(page); })
+      , generator(
+          file_size,
+          num_io_ops,
+          [this, scheduler](auto& page) {
+              scheduler->submit_read(&queue, &page);
+          },
+          [this, scheduler](auto& page) {
+              scheduler->submit_write(&queue, &page);
+          })
+      , faulter{
+          storage,
+          io::testing_details::scheduler_queue_accessor::get_queue(&queue),
+          10,
+          100 // min,max delay between faults
+        } {}
+
+    seastar::future<> run() {
+        scheduler->add_queue(&queue);
+        faulter.start();
+        return generator.run();
+    }
+
+    void stop() {
+        faulter.stop().get();
+        io::scheduler::remove_queue(&queue).get();
+    }
+
+    io::scheduler* scheduler;
+    io::scheduler::queue queue;
+    io_queue_workload_generator generator;
+    io_queue_fault_injector faulter;
+};
+
+/*
+ * This test uses a load generator to run reads and writes against multiple I/O
+ * queues while limiting the maximum number of open file handles. Faults are
+ * injected during execution.
+ */
+TEST_P(SchedulerTest, WriteRead) {
+    // paths for test files. one per queue.
+    std::vector<std::filesystem::path> paths;
+    for (auto i : boost::irange(num_queues())) {
+        paths.emplace_back(fmt::format("foo.{}", i));
+    }
+
+    // test driver for each queue
+    std::vector<std::unique_ptr<scheduler_tester>> drivers;
+    drivers.reserve(paths.size());
+    for (const auto& path : paths) {
+        storage()->create(path).get();
+        drivers.push_back(std::make_unique<scheduler_tester>(
+          scheduler(), storage(), path, file_size(), num_io_ops()));
+    }
+
+    // start the driver for each io queue
+    std::vector<seastar::future<>> runners;
+    runners.reserve(drivers.size());
+    for (auto& driver : drivers) {
+        runners.push_back(driver->run());
+    }
+
+    seastar::when_all_succeed(runners.begin(), runners.end()).get();
+
+    for (auto& driver : drivers) {
+        driver->stop();
+    }
+
+    // verify
+    for (auto& driver : drivers) {
+        const auto& gen = driver->generator;
+        ASSERT_GE(gen.reads().size(), num_io_ops());
+        ASSERT_FALSE(gen.writes().empty());
+        for (const auto& read : gen.reads()) {
+            EXPECT_TRUE(gen.writes().contains(read->offset()));
+            auto* write = gen.writes().at(read->offset());
+            EXPECT_EQ(read->data(), write->data());
+        }
+    }
+
+    for (auto& driver : drivers) {
+        try {
+            seastar::remove_file(driver->queue.path().string()).get();
+        } catch (...) {
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  Scheduler,
+  SchedulerTest,
+  ::testing::Combine(
+    ::testing::Bool(),               // disk backend?
+    ::testing::Values(10_MiB),       // backing file size
+    ::testing::Values(1000),         // number of io operations
+    ::testing::Range<size_t>(1, 5),  // num submission queues
+    ::testing::Values(1, 2, 5, 6))); // max open files
+
+/*
+ * memory persistence is disabled in this test. some ci environments have
+ * limited memory and this has exhausted it.
+ */
+INSTANTIATE_TEST_SUITE_P(
+  SchedulerManyQueues,
+  SchedulerTest,
+  ::testing::Combine(
+    ::testing::Bool(),           // disk backend
+    ::testing::Values(1_MiB),    // backing file size
+    ::testing::Values(500),      // number of io operations
+    ::testing::Values(60),       // num submission queues
+    ::testing::Values(60, 61))); // max open files


### PR DESCRIPTION
Adds a simple scheduler to the I/O subsystem. The purpose of the scheduler is to manage all of the active I/O queues (e.g. implementing global policies like preventing starvation or priority). However, this initial version of the scheduler only implements a policy that limits the total number of open file handles.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
