### PR TITLE
cst/inv: Create helpers to conditionally create inventory config

### DIFF
--- a/src/v/cloud_storage/inventory/aws_ops.h
+++ b/src/v/cloud_storage/inventory/aws_ops.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/inventory/types.h"
+#include "cloud_storage_clients/types.h"
 #include "model/fundamental.h"
 
 namespace cloud_storage::inventory {
@@ -29,9 +30,13 @@ public:
       report_generation_frequency,
       report_format) override;
 
+    ss::future<bool> inventory_configuration_exists(
+      cloud_storage::cloud_storage_api&, retry_chain_node&) override;
+
 private:
     cloud_storage_clients::bucket_name _bucket;
     inventory_config_id _inventory_config_id;
+    cloud_storage_clients::object_key _inventory_key;
     ss::sstring _prefix;
 };
 

--- a/src/v/cloud_storage/inventory/inv_ops.cc
+++ b/src/v/cloud_storage/inventory/inv_ops.cc
@@ -38,4 +38,10 @@ inv_ops::create_inventory_configuration(
     });
 }
 
+ss::future<bool> inv_ops::inventory_configuration_exists(
+  cloud_storage_api& remote, retry_chain_node& parent) {
+    return ss::visit(_inv_ops, [&remote, &parent](auto& ops) {
+        return ops.inventory_configuration_exists(remote, parent);
+    });
+}
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/inv_ops.cc
+++ b/src/v/cloud_storage/inventory/inv_ops.cc
@@ -44,4 +44,34 @@ ss::future<bool> inv_ops::inventory_configuration_exists(
         return ops.inventory_configuration_exists(remote, parent);
     });
 }
+
+ss::future<inventory_creation_result>
+inv_ops::maybe_create_inventory_configuration(
+  cloud_storage_api& remote, retry_chain_node& parent) {
+    if (const auto exists = co_await inventory_configuration_exists(
+          remote, parent);
+        exists) {
+        co_return inventory_creation_result::already_exists;
+    }
+
+    const auto create_res = co_await create_inventory_configuration(
+      remote, parent);
+
+    switch (create_res) {
+    case upload_result::success:
+        co_return inventory_creation_result::success;
+    case upload_result::timedout:
+    case upload_result::cancelled:
+        co_return inventory_creation_result::failed;
+    case upload_result::failed:
+        // If config creation failed, check if some other node raced to create
+        // it first.
+        if (co_await inventory_configuration_exists(remote, parent)) {
+            co_return inventory_creation_result::already_exists;
+        } else {
+            co_return inventory_creation_result::failed;
+        }
+    }
+}
+
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/inv_ops.h
+++ b/src/v/cloud_storage/inventory/inv_ops.h
@@ -27,6 +27,9 @@ public:
     ss::future<bool>
     inventory_configuration_exists(cloud_storage_api&, retry_chain_node&);
 
+    ss::future<inventory_creation_result>
+    maybe_create_inventory_configuration(cloud_storage_api&, retry_chain_node&);
+
 private:
     ops_t _inv_ops;
 };

--- a/src/v/cloud_storage/inventory/inv_ops.h
+++ b/src/v/cloud_storage/inventory/inv_ops.h
@@ -21,8 +21,11 @@ class inv_ops {
 public:
     explicit inv_ops(ops_t ops);
 
-    ss::future<cloud_storage::upload_result> create_inventory_configuration(
-      cloud_storage_api& remote, retry_chain_node&);
+    ss::future<cloud_storage::upload_result>
+    create_inventory_configuration(cloud_storage_api&, retry_chain_node&);
+
+    ss::future<bool>
+    inventory_configuration_exists(cloud_storage_api&, retry_chain_node&);
 
 private:
     ops_t _inv_ops;

--- a/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
+++ b/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
@@ -41,6 +41,11 @@ public:
       upload_object,
       (cst::upload_request),
       (override));
+    MOCK_METHOD(
+      ss::future<cst::download_result>,
+      download_object,
+      (cst::download_request),
+      (override));
 };
 
 std::string iobuf_to_xml(iobuf buf) {
@@ -48,7 +53,8 @@ std::string iobuf_to_xml(iobuf buf) {
     return p.read_string(p.bytes_left());
 }
 
-ss::future<cst::upload_result> validate_request(cst::upload_request request) {
+ss::future<cst::upload_result>
+validate_create_request(cst::upload_request request) {
     EXPECT_EQ(request.type, cst::upload_type::inventory_configuration);
     EXPECT_EQ(request.transfer_details.bucket(), bucket);
     EXPECT_EQ(request.transfer_details.key(), expected_key);
@@ -62,7 +68,7 @@ void test_create(T t, Ts... args) {
     MockRemote remote;
     EXPECT_CALL(remote, upload_object(t::_))
       .Times(1)
-      .WillOnce(t::Invoke(validate_request));
+      .WillOnce(t::Invoke(validate_create_request));
 
     ss::abort_source as;
     retry_chain_node parent{as};
@@ -88,4 +94,28 @@ TEST(CreateInvCfg, HighLevelApi) {
       cloud_storage_clients::bucket_name{bucket},
       cst::inventory::inventory_config_id{id},
       prefix}});
+}
+
+ss::future<cst::download_result>
+validate_inventory_exists_request(cst::download_request request) {
+    EXPECT_EQ(request.transfer_details.bucket, bucket);
+    EXPECT_EQ(request.transfer_details.key, expected_key);
+    co_return cst::download_result::success;
+}
+
+TEST(InvCfgExists, HighLevelApi) {
+    MockRemote remote;
+    EXPECT_CALL(remote, download_object(t::_))
+      .Times(1)
+      .WillOnce(t::Invoke(validate_inventory_exists_request));
+
+    ss::abort_source as;
+    retry_chain_node parent{as};
+
+    cst::inventory::inv_ops ops{cst::inventory::aws_ops{
+      cloud_storage_clients::bucket_name{bucket},
+      cst::inventory::inventory_config_id{id},
+      prefix}};
+
+    ASSERT_TRUE(ops.inventory_configuration_exists(remote, parent).get());
 }

--- a/src/v/cloud_storage/inventory/types.cc
+++ b/src/v/cloud_storage/inventory/types.cc
@@ -25,4 +25,16 @@ std::ostream& operator<<(std::ostream& os, report_format rf) {
     }
 }
 
+std::ostream& operator<<(std::ostream& os, inventory_creation_result icr) {
+    switch (icr) {
+        using enum cloud_storage::inventory::inventory_creation_result;
+    case success:
+        return os << "success";
+    case failed:
+        return os << "failed";
+    case already_exists:
+        return os << "already-exists";
+    }
+}
+
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -62,4 +62,12 @@ concept vendor_ops_provider = std::is_base_of_v<base_ops, T>;
 template<vendor_ops_provider... Ts>
 using inv_ops_variant = std::variant<Ts...>;
 
+enum class inventory_creation_result {
+    success,
+    failed,
+    already_exists,
+};
+
+std::ostream& operator<<(std::ostream&, inventory_creation_result);
+
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -50,6 +50,10 @@ public:
       report_generation_frequency,
       report_format)
       = 0;
+
+    virtual ss::future<bool> inventory_configuration_exists(
+      cloud_storage::cloud_storage_api& remote, retry_chain_node& parent_rtc)
+      = 0;
 };
 
 template<typename T>

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -124,6 +124,7 @@ struct api_activity_notification {
 class cloud_storage_api {
 public:
     virtual ss::future<upload_result> upload_object(upload_request) = 0;
+    virtual ss::future<download_result> download_object(download_request) = 0;
     virtual ~cloud_storage_api() = default;
 };
 
@@ -352,7 +353,7 @@ public:
     /// field which will hold the downloaded object if the download was
     /// successful
     ss::future<download_result>
-    download_object(download_request download_request);
+    download_object(download_request download_request) override;
 
     /// Checks if the segment exists in the bucket
     ss::future<download_result> segment_exists(


### PR DESCRIPTION
Introduces helpers to check if inventory configuration exists, and to conditionally create one. Maps the result of the individual calls to `inventory_creation_result` states: 
* `success`
* `failure`
* `already_exists`

The creation of config is expected to be performed by any node in cluster at startup. Instead of simply attempting to create and relying on the server side validation to prevent duplicates, we first do a check before creating the config. One node creates the config and the others see that the config is present and move on.

#### Handling races while creation

It is possible that multiple nodes try to create the config after they observe that the config is missing, since the calls to check and create are separate. In this case all but one nodes will fail to create the config. The failing nodes should return the status as `already_exists` rather than `failed`. To achieve this, on failure the nodes once again check if the config exists and they lost the race to create it.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* None