### PR TITLE
Added timeout to `gtest_raft_rpunit`

### DIFF
--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ set(gsrcs
 rp_test(
   UNIT_TEST
   GTEST
+  TIMEOUT 500
   BINARY_NAME gtest_raft
   SOURCES ${gsrcs}
   LIBRARIES  v::raft v::storage_test_utils v::model_test_utils v::features v::gtest_main

--- a/src/v/test_utils/test.h
+++ b/src/v/test_utils/test.h
@@ -142,6 +142,8 @@ private:
  */
 #define GTEST_FATAL_FAILURE_CORO_(message)                                     \
     co_return GTEST_MESSAGE_(message, ::testing::TestPartResult::kFatalFailure)
+#define GTEST_SKIP_CORO_(message)                                              \
+    co_return GTEST_MESSAGE_(message, ::testing::TestPartResult::kSkip)
 #define ASSERT_PRED_FORMAT2_CORO(pred_format, v1, v2)                          \
     GTEST_PRED_FORMAT2_(pred_format, v1, v2, GTEST_FATAL_FAILURE_CORO_)
 #define GTEST_ASSERT_EQ_CORO(val1, val2)                                       \
@@ -173,4 +175,7 @@ private:
 #define ASSERT_LT_CORO(val1, val2) GTEST_ASSERT_LT_CORO(val1, val2)
 #define ASSERT_LE_CORO(val1, val2) GTEST_ASSERT_LE_CORO(val1, val2)
 #define ASSERT_NE_CORO(val1, val2) GTEST_ASSERT_NE_CORO(val1, val2)
+
+#define GTEST_SKIP_CORO() GTEST_SKIP_CORO_("")
+
 // NOLINTEND(cppcoreguidelines-macro-usage,bugprone-macro-parentheses)


### PR DESCRIPTION
Added timeout to for the `gtest_raft_rpunit`. This will allow us to retrieve logs from failed test. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...
tbd
If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none