### PR TITLE
storage: Use fragmented_vector in OT-state

### DIFF
--- a/src/v/storage/offset_translator_state.cc
+++ b/src/v/storage/offset_translator_state.cc
@@ -13,6 +13,7 @@
 
 #include "base/vassert.h"
 #include "base/vlog.h"
+#include "container/fragmented_vector.h"
 #include "model/fundamental.h"
 #include "storage/logger.h"
 
@@ -348,7 +349,7 @@ struct persisted_batches_map
       serde::version<0>,
       serde::compat_version<0>> {
     int64_t start_delta = 0;
-    std::vector<persisted_batch> batches;
+    chunked_vector<persisted_batch> batches;
 };
 
 } // namespace
@@ -359,7 +360,7 @@ iobuf offset_translator_state::serialize_map() const {
       "ntp {}: offsets map shouldn't be empty",
       _ntp);
 
-    std::vector<persisted_batch> batches;
+    chunked_vector<persisted_batch> batches;
     batches.reserve(_last_offset2batch.size());
     for (const auto& [o, b] : _last_offset2batch) {
         int32_t length = int32_t(o - b.base_offset) + 1;


### PR DESCRIPTION
offset_translator_state uses vector to store entries. This may create oversized allocations when the struct is serialized/deserialized. This commit replaces vector with chunked_vector.

Both serialized data structure and serialization code path are updated. The version of the data structure is not changed because serde treats any vector-like structure the same and uses the same format.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix oversized allocation in storage.