### PR TITLE
cloud_storage: skip over segments below archive start

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -356,6 +356,16 @@ partition_manifest::full_log_start_kafka_offset() const {
     return get_start_kafka_offset();
 }
 
+std::optional<model::offset> partition_manifest::full_log_start_offset() const {
+    if (_archive_start_offset != model::offset{}) {
+        return _archive_start_offset;
+    }
+    if (_start_offset == model::offset{}) {
+        return std::nullopt;
+    }
+    return _start_offset;
+}
+
 std::optional<kafka::offset>
 partition_manifest::get_start_kafka_offset() const {
     if (_start_offset == model::offset{}) {

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -252,6 +252,10 @@ public:
     /// manifest, start kafka offset override and start offset of the archive.
     std::optional<kafka::offset> full_log_start_kafka_offset() const;
 
+    /// Return start offset that takes into account the STM manifest's start
+    /// and the archive start offsets.
+    std::optional<model::offset> full_log_start_offset() const;
+
     /// Get starting offset of the current manifest (doesn't take into account
     /// spillover manifests)
     std::optional<model::offset> get_start_offset() const;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This fixes a bug for timequeries that could result in a removed segment being
unsuccessfully downloaded during a timequery. The sequence of events is as
follows:

    1. Spillover manifest [7278, 8592]
    2. Spillover more manifests... [...13574]
    3. Eventually our stm manifest is [13875, 15802]
    4. We housekeep and truncate to 7804. This is the new archive start offset and
       archive clean offset
    5. A timequery comes in whose timestamp falls in manifest [7278, 8592]
    6. Segment [7278-7410] is attempted to be downloaded, which has already been
       removed

To fix this, as we're seeking within a given manifest, we'll now check against
the overall start offset of the partition, skipping any segments that fall
below the start.

Fixes #15042

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug fix

* Fixes a bug in the tiered storage time-based query implementation that could result in a consumer hang when consuming very old data.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
