### PR TITLE
cloud_storage: protect atime writes with a mutex

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -319,6 +319,8 @@ private:
     cache_probe probe;
     access_time_tracker _access_time_tracker;
     ss::timer<ss::lowres_clock> _tracker_timer;
+    ssx::semaphore _access_tracker_writer_sm{
+      1, "cloud/cache/access_tracker_writer"};
 
     /// Remember when we last finished clean_up_cache, in order to
     /// avoid wastefully running it again soon after.


### PR DESCRIPTION
Fixes a potential cloud storage cache access time tracker file corruption which can happen during redpanda shutdown.

This corruption is negligible as the file doesn't store any important data. We ignore parsing failures during startup. Only the file header contains variable sized fields and corruption in this section of the file is impossible.  The remaining contents of the file are read using fixed size buffers. At most we would have read a bogus file hash or a bogus timestamp. None of which could do harm.

`cache::save_access_time_tracker` can run concurrently during redpanda shutdown sequence.

`cache::start` starts a timer which calls
`cache::maybe_save_access_time_tracker`, then `cache::stop` call `cache::save_access_time_tracker` unconditionally.

It is possible that stop invokes `cache::save_access_time_tracker` while this method is running in a fiber started by the timer. If that's the case, in `save_access_time_tracker` method we didn't have any mutual exclusion mechanism when writing to the temporary file and the subsequent rename.

During a particular ordering of events, the following error gets logged:

```
ERROR 2024-02-20 13:47:13,188 [shard 0:main] cloud_storage -
cache_service.cc:893 - failed to save access time tracker during auto
cloud_storage::cache::stop()::(anonymous class)::operator()(auto) const
[eptr:auto = std::exception_ptr]:
std::__1::__fs::filesystem::filesystem_error (error system:2, filesystem
error: rename failed: No such file or directory
["/var/lib/redpanda/data/cloud_storage_cache/accesstime.tmp"]
["/var/lib/redpanda/data/cloud_storage_cache/accesstime"])
```

The best explanation is the following ordering of events:

1: f1, f2: calls save_access_time_tracker
2: f1, f2: opens accesstime.tmp
3: f1, f2: calls _save_access_time_tracker
4: f1, f2: co_await ss::rename_file(tmp_path.string(),
   final_path.string())

In the step 4, only 1 fiber can succeed and the other will fail with the exception.

This is a benign race-condition. However, another less pleasant race-condition is also possible:

1: f1, f2: calls save_access_time_tracker
2: f1, f2: opens accesstime.tmp
3: f1, f2: calls _save_access_time_tracker
4: f1, f2: auto out = co_await ss::make_file_output_stream(std::move(f))
   note: make_file_out_stream creates a buffered stream with 8K buffer
5: f1: co_await _access_time_tracker.write(out) note: write does acquire
   a exclusive lock so nothing to worry about there
6: f2: co_await _access_time_tracker.write(out);
7: f2: co_await out.flush();
8: f1: co_await out.flush();

Notice that f1 wrote first to the file, then f2 did and flushed the in-memory buffers, then (!) f1 flushed its in-memory buffers.

It is possible that the flush invoked by f1 will overwrite up to 8K bytes at an arbitrary position in the file initially written by f2. Thus, f2 will become corrupted.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Bug Fixes

* Fix a potential cloud storage cache access time tracker file corruption during shutdown.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
