### PR TITLE
Throughput shared token bucket hackery

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2782,7 +2782,7 @@ configuration::configuration()
       "kafka_quota_balancer_v2",
       "Use the new, improved, super-awesome quota balancer",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
-      false)
+      true)
   , kafka_throughput_replenish_threshold(
       *this,
       "kafka_throughput_replenish_threshold",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2777,6 +2777,12 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       std::nullopt,
       {.min = 1})
+  , kafka_quota_balancer_v2(
+      *this,
+      "kafka_quota_balancer_v2",
+      "Use the new, improved, super-awesome quota balancer",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      false)
   , kafka_quota_balancer_window(
       *this,
       "kafka_quota_balancer_window_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2783,6 +2783,14 @@ configuration::configuration()
       "Use the new, improved, super-awesome quota balancer",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , kafka_throughput_replenish_threshold(
+      *this,
+      "kafka_throughput_replenish_threshold",
+      "Threshold for refilling the token bucket. Will be clamped between 1 and "
+      "rate.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      {.min = 1})
   , kafka_quota_balancer_window(
       *this,
       "kafka_quota_balancer_window_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -518,6 +518,8 @@ struct configuration final : public config_store {
     bounded_property<std::optional<int64_t>>
       kafka_throughput_limit_node_out_bps;
     property<bool> kafka_quota_balancer_v2;
+    bounded_property<std::optional<int64_t>>
+      kafka_throughput_replenish_threshold;
     bounded_property<std::chrono::milliseconds> kafka_quota_balancer_window;
     bounded_property<std::chrono::milliseconds>
       kafka_quota_balancer_node_period;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -517,6 +517,7 @@ struct configuration final : public config_store {
     bounded_property<std::optional<int64_t>> kafka_throughput_limit_node_in_bps;
     bounded_property<std::optional<int64_t>>
       kafka_throughput_limit_node_out_bps;
+    property<bool> kafka_quota_balancer_v2;
     bounded_property<std::chrono::milliseconds> kafka_quota_balancer_window;
     bounded_property<std::chrono::milliseconds>
       kafka_quota_balancer_node_period;

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -138,7 +138,9 @@ auto make_node_bucket(auto const& cfg) {
     // if the rate is created as 0 and is then increased
     int64_t limit = rate;
     // TODO: A threshold of 1 too small, but allows profiling the atomic ops
-    int64_t threshold = 1;
+    int64_t threshold = config::shard_local_cfg()
+                          .kafka_throughput_replenish_threshold()
+                          .value_or(1);
     return std::make_unique<kafka::snc_quota_manager::bucket_t>(
       rate, limit, threshold);
 };

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -14,6 +14,7 @@
 #include "config/property.h"
 #include "config/throughput_control_group.h"
 #include "metrics/metrics.h"
+#include "ssx/sharded_ptr.h"
 #include "utils/bottomless_token_bucket.h"
 #include "utils/mutex.h"
 
@@ -102,10 +103,10 @@ public:
       ss::internal::capped_release::no,
       clock>;
     using buckets_t = kafka::ingress_egress_state<
-      std::unique_ptr<kafka::snc_quota_manager::bucket_t>>;
+      ssx::sharded_ptr<kafka::snc_quota_manager::bucket_t>>;
     static buckets_t make_node_buckets();
 
-    explicit snc_quota_manager(const buckets_t& node_quota);
+    explicit snc_quota_manager(buckets_t& node_quota);
     snc_quota_manager(const snc_quota_manager&) = delete;
     snc_quota_manager& operator=(const snc_quota_manager&) = delete;
     snc_quota_manager(snc_quota_manager&&) = delete;
@@ -235,7 +236,7 @@ private:
     ingress_egress_state<std::optional<quota_t>> _node_quota_default;
     ingress_egress_state<quota_t> _shard_quota_minimum;
     ingress_egress_state<bottomless_token_bucket> _shard_quota;
-    ingress_egress_state<bucket_t*> _node_quota;
+    buckets_t& _node_quota;
 
     // service
     snc_quotas_probe _probe;

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -33,26 +33,39 @@ using std::vector;
 using tests::kv_t;
 
 struct prod_consume_fixture : public redpanda_thread_fixture {
-    void start() {
-        consumer = std::make_unique<kafka::client::transport>(
-          make_kafka_client().get0());
-        producer = std::make_unique<kafka::client::transport>(
-          make_kafka_client().get0());
-        consumer->connect().get0();
-        producer->connect().get0();
-        model::topic_namespace tp_ns(model::ns("kafka"), test_topic);
-        add_topic(tp_ns).get0();
-        model::ntp ntp(tp_ns.ns, tp_ns.tp, model::partition_id(0));
-        tests::cooperative_spin_wait_with_timeout(2s, [ntp, this] {
-            auto shard = app.shard_table.local().shard_for(ntp);
-            if (!shard) {
-                return ss::make_ready_future<bool>(false);
-            }
-            return app.partition_manager.invoke_on(
-              *shard, [ntp](cluster::partition_manager& pm) {
-                  return pm.get(ntp)->is_leader();
-              });
-        }).get0();
+    void start(unsigned int count = 1) {
+        producers.reserve(count);
+        consumers.reserve(count);
+        fetch_offsets.resize(count, model::offset{0});
+
+        add_topic(test_tp_ns, static_cast<int>(count)).get();
+
+        ss::parallel_for_each(boost::irange(0u, count), [&](auto i) {
+            consumers.emplace_back(make_kafka_client().get());
+            auto& consumer = consumers.back();
+
+            producers.emplace_back(make_kafka_client().get());
+            auto& producer = producers.back();
+
+            model::ntp ntp(
+              test_tp_ns.ns, test_tp_ns.tp, model::partition_id(i));
+            return ss::when_all_succeed(
+                     producer.connect(),
+                     consumer.connect(),
+                     tests::cooperative_spin_wait_with_timeout(
+                       2s,
+                       [ntp, this] {
+                           auto shard = app.shard_table.local().shard_for(ntp);
+                           if (!shard) {
+                               return ss::make_ready_future<bool>(false);
+                           }
+                           return app.partition_manager.invoke_on(
+                             *shard, [ntp](cluster::partition_manager& pm) {
+                                 return pm.get(ntp)->is_leader();
+                             });
+                       }))
+              .discard_result();
+        }).get();
     }
 
     std::vector<kafka::produce_request::partition> small_batches(size_t count) {
@@ -74,8 +87,9 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         return res;
     }
 
-    ss::future<kafka::produce_response>
-    produce_raw(std::vector<kafka::produce_request::partition>&& partitions) {
+    ss::future<kafka::produce_response> produce_raw(
+      kafka::client::transport& producer,
+      std::vector<kafka::produce_request::partition>&& partitions) {
         kafka::produce_request::topic tp;
         tp.partitions = std::move(partitions);
         tp.name = test_topic;
@@ -85,7 +99,12 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         req.data.timeout_ms = std::chrono::seconds(2);
         req.has_idempotent = false;
         req.has_transactional = false;
-        return producer->dispatch(std::move(req));
+        return producer.dispatch(std::move(req));
+    }
+
+    ss::future<kafka::produce_response>
+    produce_raw(std::vector<kafka::produce_request::partition>&& partitions) {
+        return produce_raw(producers.front(), std::move(partitions));
     }
 
     template<typename T>
@@ -98,10 +117,11 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
           });
     }
 
-    ss::future<kafka::fetch_response> fetch_next() {
+    ss::future<kafka::fetch_response>
+    fetch_next(kafka::client::transport& consumer, model::partition_id p_id) {
         kafka::fetch_request::partition partition;
-        partition.fetch_offset = fetch_offset;
-        partition.partition_index = model::partition_id(0);
+        partition.fetch_offset = fetch_offsets[p_id()];
+        partition.partition_index = p_id;
         partition.log_start_offset = model::offset(0);
         partition.max_bytes = 1_MiB;
         kafka::fetch_request::topic topic;
@@ -114,8 +134,8 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
         req.data.max_wait_ms = 1000ms;
         req.data.topics.push_back(std::move(topic));
 
-        return consumer->dispatch(std::move(req), kafka::api_version(4))
-          .then([this](kafka::fetch_response resp) {
+        return consumer.dispatch(std::move(req), kafka::api_version(4))
+          .then([this, p_id](kafka::fetch_response resp) {
               if (resp.data.topics.empty()) {
                   return resp;
               }
@@ -125,18 +145,24 @@ struct prod_consume_fixture : public redpanda_thread_fixture {
                   const auto& data = part.partitions.begin()->records;
                   if (data && !data->empty()) {
                       // update next fetch offset the same way as Kafka clients
-                      fetch_offset = ++data->last_offset();
+                      fetch_offsets[p_id()] = ++data->last_offset();
                   }
               }
               return resp;
           });
     }
 
-    model::offset fetch_offset{0};
-    std::unique_ptr<kafka::client::transport> consumer;
-    std::unique_ptr<kafka::client::transport> producer;
+    ss::future<kafka::fetch_response> fetch_next() {
+        return fetch_next(consumers.front(), model::partition_id{0});
+    }
+
+    std::vector<model::offset> fetch_offsets;
+    std::vector<kafka::client::transport> consumers;
+    std::vector<kafka::client::transport> producers;
     ss::abort_source as;
-    const model::topic test_topic = model::topic("test-topic");
+    const model::topic_namespace test_tp_ns = {
+      model::ns("kafka"), model::topic("test-topic")};
+    const model::topic& test_topic = test_tp_ns.tp;
 };
 
 /**
@@ -184,8 +210,8 @@ FIXTURE_TEST(test_version_handler, prod_consume_fixture) {
     const auto unsupported_version = kafka::api_version(
       kafka::produce_handler::max_supported() + 1);
     BOOST_CHECK_THROW(
-      producer
-        ->dispatch(
+      producers.front()
+        .dispatch(
           // NOLINTNEXTLINE(bugprone-use-after-move)
           kafka::produce_request(std::nullopt, 1, std::move(topics)),
           unsupported_version)
@@ -194,7 +220,7 @@ FIXTURE_TEST(test_version_handler, prod_consume_fixture) {
 }
 
 static std::vector<kafka::produce_request::partition>
-single_batch(const size_t volume) {
+single_batch(model::partition_id p_id, const size_t volume) {
     storage::record_batch_builder builder(
       model::record_batch_type::raft_data, model::offset(0));
     {
@@ -205,7 +231,7 @@ single_batch(const size_t volume) {
     }
 
     kafka::produce_request::partition partition;
-    partition.partition_index = model::partition_id(0);
+    partition.partition_index = p_id;
     partition.records.emplace(std::move(builder).build());
 
     std::vector<kafka::produce_request::partition> res;
@@ -216,6 +242,9 @@ single_batch(const size_t volume) {
 namespace ch = std::chrono;
 
 struct throughput_limits_fixure : prod_consume_fixture {
+    static constexpr size_t kafka_packet_in_overhead = 127;
+    static constexpr size_t kafka_packet_eg_overhead = 62;
+
     ch::milliseconds _window_width;
     ch::milliseconds _balancer_period;
     int64_t _rate_minimum;
@@ -273,18 +302,17 @@ struct throughput_limits_fixure : prod_consume_fixture {
       const size_t batch_size,
       const int tolerance_percent) {
         size_t kafka_in_data_len = 0;
-        constexpr size_t kafka_packet_overhead = 127;
         // do not divide rate by smp::count because
         // - balanced case: TP will be balanced and  the entire quota will end
         // up in one shard
         // - static case: rate_limit is per shard
         const auto batches_cnt = /* 1s * */ rate_limit_in
-                                 / (batch_size + kafka_packet_overhead);
+                                 / (batch_size + kafka_packet_in_overhead);
         ch::steady_clock::time_point start;
         ch::milliseconds throttle_time{};
 
         for (int k = -warmup_cycles(
-               rate_limit_in, batch_size + kafka_packet_overhead);
+               rate_limit_in, batch_size + kafka_packet_in_overhead);
              k != batches_cnt;
              ++k) {
             if (k == 0) {
@@ -294,7 +322,8 @@ struct throughput_limits_fixure : prod_consume_fixture {
                   false,
                   "Ingress measurement starts. batches: " << batches_cnt);
             }
-            throttle_time += produce_raw(single_batch(batch_size))
+            throttle_time += produce_raw(
+                               single_batch(model::partition_id{0}, batch_size))
                                .then([](const kafka::produce_response& r) {
                                    return r.data.throttle_time_ms;
                                })
@@ -302,7 +331,7 @@ struct throughput_limits_fixure : prod_consume_fixture {
             kafka_in_data_len += batch_size;
         }
         const auto stop = ch::steady_clock::now();
-        const auto wire_data_length = (batch_size + kafka_packet_overhead)
+        const auto wire_data_length = (batch_size + kafka_packet_in_overhead)
                                       * batches_cnt;
         const auto rate_estimated = rate_limit_in
                                     - _rate_minimum * (ss::smp::count - 1);
@@ -324,7 +353,6 @@ struct throughput_limits_fixure : prod_consume_fixture {
       const size_t batch_size,
       const int tolerance_percent) {
         size_t kafka_out_data_len = 0;
-        constexpr size_t kafka_packet_overhead = 62;
         ch::steady_clock::time_point start;
         size_t total_size{};
         ch::milliseconds throttle_time{};
@@ -334,7 +362,7 @@ struct throughput_limits_fixure : prod_consume_fixture {
         // to fetch. We only can consume almost as much as have been produced:
         const auto kafka_data_cap = kafka_data_available - batch_size * 2;
         for (int k = -warmup_cycles(
-               rate_limit_out, batch_size + kafka_packet_overhead);
+               rate_limit_out, batch_size + kafka_packet_eg_overhead);
              kafka_out_data_len < kafka_data_cap;
              ++k) {
             if (k == 0) {
@@ -356,7 +384,7 @@ struct throughput_limits_fixure : prod_consume_fixture {
                                           .partitions[0]
                                           .records.value()
                                           .size_bytes();
-            total_size += kafka_data_len + kafka_packet_overhead;
+            total_size += kafka_data_len + kafka_packet_eg_overhead;
             throttle_time += fetch_resp.data.throttle_time_ms;
             kafka_out_data_len += kafka_data_len;
         }
@@ -558,22 +586,9 @@ FIXTURE_TEST(test_quota_balancer_config_balancer_period, prod_consume_fixture) {
 // TODO: move producer utilities somewhere else and give this test a proper
 // home.
 FIXTURE_TEST(test_offset_for_leader_epoch, prod_consume_fixture) {
-    producer = std::make_unique<kafka::client::transport>(
-      make_kafka_client().get0());
-    producer->connect().get0();
-    model::topic_namespace tp_ns(model::ns("kafka"), test_topic);
-    add_topic(tp_ns).get0();
-    model::ntp ntp(tp_ns.ns, tp_ns.tp, model::partition_id(0));
-    tests::cooperative_spin_wait_with_timeout(10s, [ntp, this] {
-        auto shard = app.shard_table.local().shard_for(ntp);
-        if (!shard) {
-            return ss::make_ready_future<bool>(false);
-        }
-        return app.partition_manager.invoke_on(
-          *shard, [ntp](cluster::partition_manager& pm) {
-              return pm.get(ntp)->is_leader();
-          });
-    }).get0();
+    wait_for_controller_leadership().get();
+    start();
+    model::ntp ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
     auto shard = app.shard_table.local().shard_for(ntp);
     for (int i = 0; i < 3; i++) {
         // Refresh leadership.
@@ -613,8 +628,7 @@ FIXTURE_TEST(test_offset_for_leader_epoch, prod_consume_fixture) {
 
     // Make a request getting the offset from a term below the start of the
     // log.
-    auto client = make_kafka_client().get0();
-    client.connect().get();
+    auto& client = consumers.front();
     auto current_term = app.partition_manager
                           .invoke_on(
                             *shard,
@@ -659,9 +673,8 @@ FIXTURE_TEST(test_offset_for_leader_epoch, prod_consume_fixture) {
 FIXTURE_TEST(test_basic_delete_around_batch, prod_consume_fixture) {
     wait_for_controller_leadership().get0();
     start();
-    const model::topic_namespace tp_ns(model::ns("kafka"), test_topic);
     const model::partition_id pid(0);
-    const model::ntp ntp(tp_ns.ns, tp_ns.tp, pid);
+    const model::ntp ntp(test_tp_ns.ns, test_tp_ns.tp, pid);
     auto partition = app.partition_manager.local().get(ntp);
     auto log = partition->log();
 
@@ -796,8 +809,7 @@ FIXTURE_TEST(test_produce_bad_timestamps, prod_consume_fixture) {
 
     wait_for_controller_leadership().get0();
     start();
-    auto ntp = model::ntp(
-      model::ns("kafka"), test_topic, model::partition_id(0));
+    auto ntp = model::ntp(test_tp_ns.ns, test_tp_ns.tp, model::partition_id(0));
 
     auto producer = tests::kafka_produce_transport(make_kafka_client().get());
     producer.start().get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1596,7 +1596,6 @@ void application::wire_up_redpanda_services(
     syschecks::systemd_message("Adding kafka quota managers").get();
     construct_service(quota_mgr).get();
 
-    snc_node_quota = kafka::snc_quota_manager::make_node_buckets();
     construct_service(snc_quota_mgr, std::ref(snc_node_quota)).get();
 
     syschecks::systemd_message("Creating auditing subsystem").get();

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1595,7 +1595,9 @@ void application::wire_up_redpanda_services(
     // metrics and quota management
     syschecks::systemd_message("Adding kafka quota managers").get();
     construct_service(quota_mgr).get();
-    construct_service(snc_quota_mgr).get();
+
+    snc_node_quota = kafka::snc_quota_manager::make_node_buckets();
+    construct_service(snc_quota_mgr, std::ref(snc_node_quota)).get();
 
     syschecks::systemd_message("Creating auditing subsystem").get();
     construct_service(

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -30,6 +30,7 @@
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
 #include "kafka/server/fwd.h"
+#include "kafka/server/snc_quota_manager.h"
 #include "metrics/aggregate_metrics_watcher.h"
 #include "metrics/metrics.h"
 #include "net/conn_quota.h"
@@ -152,6 +153,7 @@ public:
     ss::sharded<kafka::coordinator_ntp_mapper> coordinator_ntp_mapper;
     ss::sharded<kafka::group_router> group_router;
     ss::sharded<kafka::quota_manager> quota_mgr;
+    kafka::snc_quota_manager::buckets_t snc_node_quota;
     ss::sharded<kafka::snc_quota_manager> snc_quota_mgr;
     ss::sharded<kafka::rm_group_frontend> rm_group_frontend;
     ss::sharded<kafka::usage_manager> usage_manager;

--- a/src/v/ssx/sharded_ptr.h
+++ b/src/v/ssx/sharded_ptr.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "base/vassert.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+
+#include <memory>
+
+namespace ssx {
+
+/// A pointer that is shared between shards.
+/// reset() must be called on the home shard.
+/// The pointer is stable until the fiber yields.
+template<typename T>
+class sharded_ptr {
+public:
+    sharded_ptr()
+      : _shard{ss::this_shard_id()} {}
+    ~sharded_ptr() {
+        if (*this) {
+            std::default_delete<T>{}(_state.local());
+        }
+    }
+
+    sharded_ptr(sharded_ptr&& other) noexcept = delete;
+    sharded_ptr(sharded_ptr const&) noexcept = delete;
+    sharded_ptr& operator=(sharded_ptr const&) = delete;
+    sharded_ptr& operator=(sharded_ptr&&) = delete;
+
+    T& operator*() const { return *_state.local(); }
+    T* operator->() const { return _state.local(); }
+    explicit operator bool() const {
+        return _state.local_is_initialized() && _state.local() != nullptr;
+    }
+
+    ss::future<> reset(std::unique_ptr<T> u = nullptr) {
+        assert_shard();
+        auto up = u.get();
+
+        if (!_state.local_is_initialized()) {
+            if (u == nullptr) {
+                co_return;
+            }
+            co_await _state.start(up).finally(
+              [this, u{std::move(u)}]() mutable {
+                  if (u.get() == _state.local()) {
+                      void(u.release());
+                  }
+              });
+
+            co_return;
+        }
+
+        co_await _state
+          .invoke_on_others(
+            [up, gh{_gate.hold()}](auto& state) noexcept { state = up; })
+          .finally([this, u{std::move(u)}]() mutable noexcept {
+              std::default_delete<T>{}(_state.local());
+              _state.local() = u.release();
+          });
+    }
+
+    template<typename... Args>
+    ss::future<> reset(Args&&... args) {
+        return reset(std::make_unique<T>(std::forward<Args>(args)...));
+    }
+
+    ss::future<> stop() {
+        co_await reset();
+        co_await _gate.close();
+        co_await _state.stop();
+    }
+
+private:
+    void assert_shard() const {
+        vassert(
+          ss::this_shard_id() == _shard,
+          "reset must be called on home shard: ",
+          _shard);
+    }
+    unsigned int _shard;
+    ss::sharded<T*> _state;
+    ss::gate _gate;
+};
+
+} // namespace ssx

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ rp_test(
   BINARY_NAME ssx_multi_thread
   SOURCES
     abort_source_test.cc
+    sharded_ptr_test.cc
   LIBRARIES v::seastar_testing_main
   ARGS "-- -c 2"
   LABELS ssx

--- a/src/v/ssx/tests/sharded_ptr_test.cc
+++ b/src/v/ssx/tests/sharded_ptr_test.cc
@@ -1,0 +1,33 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "ssx/sharded_ptr.h"
+
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/tools/old/interface.hpp>
+
+SEASTAR_THREAD_TEST_CASE(sharded_ptr) {
+    ssx::sharded_ptr<int> p0;
+    BOOST_REQUIRE(!p0);
+
+    for (auto i : boost::irange(0u, ss::smp::count)) {
+        ss::smp::submit_to(i, [&]() { BOOST_REQUIRE(!p0); }).get();
+    }
+    p0.reset(std::make_unique<int>(43)).get();
+    for (auto i : boost::irange(0u, ss::smp::count)) {
+        ss::smp::submit_to(i, [&]() { BOOST_REQUIRE(p0 && *p0 == 43); }).get();
+    }
+    p0.stop().get();
+    for (auto i : boost::irange(0u, ss::smp::count)) {
+        ss::smp::submit_to(i, [&]() { BOOST_REQUIRE(!p0); }).get();
+    }
+}


### PR DESCRIPTION
Just want to run ducktape. The final PR will have a cleaner history, more tests, and probably remove the old implementation (~1600 lines)

### Cluster configuration - probably temporary
|config|description|default|
|---|---|---|
| `kafka_quota_balancer_v2` |   Use the new, improved, super-awesome quota balancer | `true` |
| `kafka_throughput_replenish_threshold` | Threshold for refilling the token bucket.<br>Will be clamped between 1 and rate. | `1` |

### Metrics (prefix `vectorized_kafka_quotas_`)
| name | type | description | new? |
| --- | --------- | --- | ---- |
| `balancer_runs` | counter | Number of times throughput quota balancer has been run | no |
|`quota_effective` | counter | Currently effective quota, in bytes/s | no |
| `traffic_intake` | counter | Amount of Kafka traffic received from the clients that is <br> taken into processing, in bytes | no |
| `traffic_egress` | counter | Amount of Kafka traffic published to the clients that was <br> taken into processing, in bytes | yes |
| `throttle_time` | histogram | Throttle time histogram (in seconds) | yes |

### Artefacts
A built container exists on [hub.docker/benpope](https://hub.docker.com/layers/benpope81/redpanda/v24.1.0-throughput/images/sha256-80065c1feb2c40a32314e0867a3ed3bf8913360366712644666346a130bdae59?context=explore&tab=vulnerabilities)

[Published](https://buildkite.com/redpanda/cloudv2/builds/47234#018dc979-31db-424e-93e0-066b032dbd8f) install-pack `24.1.20240221022259` to cloudv2-integration


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none