### PR TITLE
rpk: support advertised addresses in `rpk redpanda config bootstrap`

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/config.go
@@ -292,6 +292,9 @@ func parseAdvertisedKafka(adv string, defHost string) (config.NamedSocketAddress
 		}
 		host, port = vnet.SplitHostPortDefault(hostport, config.DefaultKafkaPort)
 	}
+	if host == "0.0.0.0" {
+		return config.NamedSocketAddress{}, errors.New("unexpected kafka advertised address '0.0.0.0' this will cause the broker to fail during startup validation")
+	}
 	return config.NamedSocketAddress{
 		Address: host,
 		Port:    port,
@@ -306,6 +309,9 @@ func parseAdvertisedRPC(adv string, defHost string) (*config.SocketAddress, erro
 			return nil, err
 		}
 		host, port = vnet.SplitHostPortDefault(hostport, config.DefaultRPCPort)
+	}
+	if host == "0.0.0.0" {
+		return nil, errors.New("unexpected rpc advertised address '0.0.0.0' this will cause the broker to fail during startup validation")
 	}
 	return &config.SocketAddress{
 		Address: host,

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -23,6 +23,7 @@ const (
 	DefaultAdminPort     = 9644
 	DefaultRPCPort       = 33145
 	DefaultListenAddress = "0.0.0.0"
+	LoopbackIP           = "127.0.0.1"
 
 	DefaultBallastFilePath = "/var/lib/redpanda/data/ballast"
 	DefaultBallastFileSize = "1GiB"

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -128,7 +128,9 @@ class RpkRedpandaStartTest(RedpandaTest):
             node.account.ssh(f"{rpk} redpanda config bootstrap {seeds_arg} && " \
                     f"{rpk} redpanda config set redpanda.empty_seed_starts_cluster false && " \
                     f"{rpk} redpanda config set redpanda.rpc_server " \
-                    f"'{{\"address\":\"{node.account.hostname}\",\"port\":33145}}'")
+                    f"'{{\"address\":\"{node.account.hostname}\",\"port\":33145}}' &&" \
+                    f"{rpk} redpanda config set redpanda.advertised_rpc_api " \
+                    f"'{{\"address\":\"{node.account.hostname}\",\"port\":33145}}'" )
 
         self.redpanda.for_nodes(self.redpanda.nodes, config_bootstrap_with_rpk)
 


### PR DESCRIPTION
Fixes #16623 

This PR introduces both Advertised RPC and Kafka addresses to our defaults. Given that these values are now added to our default config file (see #14600) we must handle them properly during bootstrap.

Now `bootstrap` supports overriding the default address with the private IP or the one passed via `--self` flag.

Also, it adds flags to override this behavior and lets the user select which `address:port` to use in the advertised addresses.

rpk will preemptively fail if the resulting advertised host is `0.0.0.0` to avoid a validation error during startup.

**Example**:

Starting with the default Redpanda configuration file (https://github.com/redpanda-data/redpanda/blob/dev/conf/redpanda.yaml):
```
$ rpk redpanda config bootstrap --self 192.168.1.70 --advertised-kafka "redpanda-0.redpanda.redpanda.svc.cluster.local.:9093"

$ cat /etc/redpanda/redpanda.yaml
redpanda:
    data_directory: /var/lib/redpanda/data
    seed_servers: []
    rpc_server:
        address: 192.168.1.70
        port: 33145
    kafka_api:
        - address: 192.168.1.70
          port: 9092
    admin:
        - address: 192.168.1.70
          port: 9644
    advertised_rpc_api:
        address: 192.168.1.70
        port: 33145
    advertised_kafka_api:
        - address: redpanda-0.redpanda.redpanda.svc.cluster.local.
          port: 9093
    developer_mode: true
rpk:
    coredump_dir: /var/lib/redpanda/coredump
pandaproxy: {}
schema_registry: {}
```
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Features

* `rpk redpanda config bootstrap` now support bootstrapping your advertised addresses configuration.
