### PR TITLE
serde: Add node_health_report ser/de benchmark

### DIFF
--- a/src/v/serde/test/CMakeLists.txt
+++ b/src/v/serde/test/CMakeLists.txt
@@ -10,7 +10,7 @@ rp_test(
   BENCHMARK_TEST
   BINARY_NAME serde
   SOURCES bench.cc
-  LIBRARIES Seastar::seastar_perf_testing v::serde
+  LIBRARIES Seastar::seastar_perf_testing v::serde v::cluster
   LABELS serde
 )
 

--- a/src/v/serde/test/bench.cc
+++ b/src/v/serde/test/bench.cc
@@ -7,6 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/iobuf.h"
+#include "cluster/health_monitor_types.h"
+#include "cluster/node/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
 #include "serde/serde.h"
 
 #include <seastar/core/reactor.hh>
@@ -87,4 +92,101 @@ PERF_TEST(big_10mb, serialize) {
 
 PERF_TEST(big_10mb, deserialize) {
     return deserialize_big(10 << 20 /*10MB*/, 1 << 15 /*32KB*/);
+}
+
+cluster::topic_status make_topic_status(size_t id, size_t num_partitions) {
+    cluster::topic_status ts;
+    ts.tp_ns = model::topic_namespace(
+      model::ns("foo"), model::topic("bar" + std::to_string(id)));
+
+    for (size_t i = 0; i < num_partitions; ++i) {
+        cluster::partition_status part_status;
+        part_status.id = model::partition_id(i);
+        part_status.leader_id = model::node_id(1);
+        part_status.reclaimable_size_bytes = 100;
+        part_status.revision_id = model::revision_id(1);
+        part_status.term = model::term_id(1);
+
+        ts.partitions.push_back(part_status);
+    }
+
+    return ts;
+}
+
+cluster::node_health_report
+make_node_health_report(size_t num_topics, size_t partitions_per_topic) {
+    cluster::node_health_report hr;
+    hr.id = model::node_id(1);
+
+    hr.local_state.redpanda_version = cluster::node::application_version(
+      "v21.1.1");
+    hr.local_state.logical_version = cluster::cluster_version(1);
+    hr.local_state.uptime = std::chrono::milliseconds(100);
+
+    hr.local_state.data_disk.path = "/bar/baz/foo/foo/foo/foo/foo/foo/foo/bar";
+    hr.local_state.data_disk.total = 1000;
+    hr.local_state.data_disk.free = 500;
+
+    for (size_t i = 0; i < num_topics; ++i) {
+        hr.topics.push_back(make_topic_status(i, partitions_per_topic));
+    }
+
+    return hr;
+}
+
+[[gnu::noinline]] void do_bench_serialize_node_health_report(
+  iobuf& buf, cluster::node_health_report& hr) {
+    return serde::write(buf, std::move(hr));
+}
+
+void bench_serialize_node_health_report(
+  size_t num_topics, size_t partitions_per_topic) {
+    auto hr = make_node_health_report(num_topics, partitions_per_topic);
+    auto buf = iobuf();
+
+    perf_tests::start_measuring_time();
+    do_bench_serialize_node_health_report(buf, hr);
+    perf_tests::do_not_optimize(buf);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(node_health_report, serialize_many_partitions) {
+    bench_serialize_node_health_report(10, 5000);
+}
+
+PERF_TEST(node_health_report, serialize_many_topics) {
+    bench_serialize_node_health_report(50000, 1);
+}
+
+PERF_TEST(node_health_report, serialize_many_topics_replicated_partitions) {
+    bench_serialize_node_health_report(50000, 3);
+}
+
+[[gnu::noinline]] cluster::node_health_report
+do_bench_deserialize_node_health_report(iobuf buf) {
+    return serde::from_iobuf<cluster::node_health_report>(std::move(buf));
+}
+
+void bench_deserialize_node_health_report(
+  size_t num_topics, size_t partitions_per_topic) {
+    auto hr = make_node_health_report(num_topics, partitions_per_topic);
+    auto buf = iobuf();
+    serde::write(buf, std::move(hr));
+
+    perf_tests::start_measuring_time();
+    auto result = do_bench_deserialize_node_health_report(std::move(buf));
+    perf_tests::do_not_optimize(result);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(node_health_report, deserialize_many_partitions) {
+    bench_deserialize_node_health_report(10, 5000);
+}
+
+PERF_TEST(node_health_report, deserialize_many_topics) {
+    bench_deserialize_node_health_report(50000, 1);
+}
+
+PERF_TEST(node_health_report, deserialize_many_topics_replicated_partitions) {
+    bench_deserialize_node_health_report(50000, 3);
 }


### PR DESCRIPTION
Adds a benchmark for `node_health_report` de-serialization across the
topic and partitions dimensions.

| test                                                             |  iterations |      median |         mad |         min |         max |      allocs |       tasks |        inst |
| -                                                                |           - |           - |           - |           - |           - |           - |           - |           - |
| node_health_report.serialize_many_partitions                     |         824 |     1.040ms |     3.470us |     1.036ms |     1.068ms |      66.000 |       0.000 |  23326378.6 |
| node_health_report.serialize_many_topics                         |         214 |     2.865ms |   510.776ns |     2.865ms |     2.870ms |      90.000 |       0.000 |  55992409.2 |
| node_health_report.serialize_many_topics_replicated_partitions   |         143 |     5.004ms |     6.824us |     4.995ms |     5.014ms |     158.000 |       0.000 | 101505687.9 |
| node_health_report.deserialize_many_partitions                   |         362 |     1.483ms |   903.525ns |     1.481ms |     1.484ms |    6258.000 |       0.000 |  42209025.2 |
| node_health_report.deserialize_many_topics                       |         113 |     3.552ms |   629.637ns |     3.550ms |     3.558ms |   50398.000 |       0.000 |  84158327.6 |
| node_health_report.deserialize_many_topics_replicated_partitions |          70 |     6.474ms |     3.465us |     6.468ms |     6.489ms |   50398.000 |       0.000 | 167368490.8 |



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

