### PR TITLE
ci: Bump client-swarm to latest commit

### DIFF
--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -6,7 +6,7 @@ pushd /tmp
 git clone https://github.com/redpanda-data/client-swarm.git
 
 pushd client-swarm
-git reset --hard d20bbf6aa9451fd1d725146c05799b675ab20084
+git reset --hard 21e5d183d56b2a773724ad9741f9fedd0e3a2a53
 cargo build --release
 cp target/release/client-swarm /usr/local/bin
 popd


### PR DESCRIPTION
Latest changes needed in large topic numbers tests that being developed.
See history: https://github.com/redpanda-data/client-swarm/commits/main/

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none