### PR TITLE
PESDLC-109 rptest: add metrics gathering methods to `RedpandaServiceCloud`

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
+++ b/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
@@ -47,3 +47,13 @@ class SelfRedpandaCloudTest(RedpandaCloudTest):
         vectorized_application_uptime = self.redpanda.metrics_sample(
             sample_pattern='vectorized_application_uptime')
         assert vectorized_application_uptime is not None, 'expected some metrics'
+
+    @cluster(num_nodes=1)
+    def test_metrics_samples(self):
+        """Test metrics_samples() can retrieve internal metrics.
+        """
+        sample_patterns = [
+            'vectorized_application_uptime', 'vectorized_reactor_utilization'
+        ]
+        samples = self.redpanda.metrics_samples(sample_patterns)
+        assert samples is not None, 'expected sample patterns to match'

--- a/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
+++ b/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
@@ -57,3 +57,11 @@ class SelfRedpandaCloudTest(RedpandaCloudTest):
         ]
         samples = self.redpanda.metrics_samples(sample_patterns)
         assert samples is not None, 'expected sample patterns to match'
+
+    @cluster(num_nodes=1)
+    def test_metric_sum(self):
+        """Test metric_sum() can retrieve internal metrics.
+        """
+
+        count = self.redpanda.metric_sum('vectorized_application_uptime')
+        assert count > 0, 'expected count greater than 0'

--- a/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
+++ b/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
@@ -39,3 +39,11 @@ class SelfRedpandaCloudTest(RedpandaCloudTest):
         assert r is None, r
         assert self.redpanda.cluster_healthy()
         self.redpanda.assert_cluster_is_reusable()
+
+    @cluster(num_nodes=1)
+    def test_metrics_sample(self):
+        """Test metrics_sample() can retrieve internal metrics.
+        """
+        vectorized_application_uptime = self.redpanda.metrics_sample(
+            sample_pattern='vectorized_application_uptime')
+        assert vectorized_application_uptime is not None, 'expected some metrics'

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1797,10 +1797,15 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
 
     def metrics(
             self,
-            node,
+            pod_name: str = None,
             metrics_endpoint: MetricsEndpoint = MetricsEndpoint.PUBLIC_METRICS
     ):
-        text = self._cloud_cluster.get_public_metrics()
+        if metrics_endpoint == MetricsEndpoint.PUBLIC_METRICS:
+            text = self._cloud_cluster.get_public_metrics()
+        else:
+            text = self.__kubectl.exec(
+                'curl -f -s -S http://localhost:9644/metrics',
+                pod_name).decode()
         return text_string_to_metric_families(text)
 
     def metric_sum(

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -987,7 +987,7 @@ class RedpandaServiceABC(ABC):
     def _metrics_sample(
         self,
         sample_pattern: str,
-        ns,
+        ns: list[Any],
         metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS,
     ) -> Optional[MetricSamples]:
         '''Does the main work of the metrics_sample() implementation given a list of ns to iterate over.
@@ -1020,7 +1020,7 @@ class RedpandaServiceABC(ABC):
     def _metrics_samples(
         self,
         sample_patterns: list[str],
-        ns,
+        ns: list[Any],
         metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS,
     ) -> dict[str, MetricSamples]:
         '''Does the main work of the metrics_samples() implementation given a list of ns to iterate over.
@@ -1058,10 +1058,10 @@ class RedpandaServiceABC(ABC):
     def _metric_sum(
             self,
             metric_name: str,
+            ns: list[Any],
             metrics_endpoint: MetricsEndpoint = MetricsEndpoint.METRICS,
             namespace: str = None,
-            topic: str = None,
-            ns=None):
+            topic: str = None):
         '''Does the main work of the metric_sum() implementation given a list of ns to iterate over.
         '''
 
@@ -1313,8 +1313,8 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
         if nodes is None:
             nodes = self.nodes
 
-        return self._metric_sum(metric_name, metrics_endpoint, namespace,
-                                topic, nodes)
+        return self._metric_sum(metric_name, nodes, metrics_endpoint,
+                                namespace, topic)
 
     def healthy(self):
         """
@@ -2040,8 +2040,8 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         if pods is None:
             pods = self.pods
 
-        return self._metric_sum(metric_name, metrics_endpoint, namespace,
-                                topic, pods)
+        return self._metric_sum(metric_name, pods, metrics_endpoint, namespace,
+                                topic)
 
     @staticmethod
     def get_cloud_globals(globals: dict[str, Any]) -> dict[str, Any]:

--- a/tests/rptest/tests/follower_fetching_test.py
+++ b/tests/rptest/tests/follower_fetching_test.py
@@ -67,7 +67,7 @@ class FollowerFetchingTest(PreallocNodesTest):
         producer.free()
 
     def get_node_metric(self, node, topic, metric):
-        return self.redpanda.metric_sum(ns="kafka",
+        return self.redpanda.metric_sum(namespace="kafka",
                                         nodes=[node],
                                         topic=topic,
                                         metric_name=metric)


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/core-internal/issues/993

added metrics gathering methods to `RedpandaServiceCloud` that complement the metrics gathering methods in `RedpandaService`:
* `RedpandaServiceCloud.metrics_sample()`
* `RedpandaServiceCloud.metrics_samples()`
* `RedpandaServiceCloud.metric_sum()`

also added simple self tests to verify each of these.

verified with:
```console
ducktape \
  --debug \
  --globals=/home/ubuntu/redpanda/tests/globals.json \
  --cluster=ducktape.cluster.json.JsonCluster \
  --cluster-file=/home/ubuntu/redpanda/tests/cluster.json \
  tests/rptest/redpanda_cloud_tests/cloud_self_test.py::SelfRedpandaCloudTest
```
output:
```
test_id:    rptest.redpanda_cloud_tests.cloud_self_test.SelfRedpandaCloudTest.test_metric_sum
status:     PASS
run time:   41.296 seconds
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.redpanda_cloud_tests.cloud_self_test.SelfRedpandaCloudTest.test_metrics_sample
status:     PASS
run time:   37.044 seconds
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.redpanda_cloud_tests.cloud_self_test.SelfRedpandaCloudTest.test_metrics_samples
status:     PASS
run time:   52.362 seconds
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.redpanda_cloud_tests.cloud_self_test.SelfRedpandaCloudTest.test_simple
status:     PASS
run time:   24.468 seconds
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_id:    rptest.redpanda_cloud_tests.cloud_self_test.SelfRedpandaCloudTest.test_healthy
status:     PASS
run time:   38.856 seconds
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
================================================================================================================================================================================================
SESSION REPORT (ALL TESTS)
ducktape version: 0.8.18
session_id:       2024-03-01--007
run time:         3 minutes 14.122 seconds
tests run:        5
passed:           5
flaky:            0
failed:           0
ignored:          0
opassed:          0
ofailed:          0
================================================================================================================================================================================================
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
