### PR TITLE
test: retry on readyReplicas test

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -1166,6 +1166,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             lambda: cluster_ready_replicas(cluster_name) == replicas,
             timeout_sec=600,
             backoff_sec=1,
+            retry_on_exc=True,
             err_msg=
             f'number of ready replicas for {cluster_name} did not arrive at {replicas}'
         )


### PR DESCRIPTION
Presumably if the cluster isn't yet fully initialized then jsonpath query for readyReplicas will return an empty string and converting that to an integer will fail. The entire process is in a wait_until, so we'll just ignore these errors.

    test_id:    HighThroughputTest.test_add_and_decommission
    status:     FAIL
    run time:   2629.113 seconds

    ValueError("invalid literal for int() with base 10: ''")
    Traceback (most recent call last):
      File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 184, in _do_run
        data = self.run_test()
      File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 269, in run_test
        return self.test_context.function(self.test)
      File "/home/ubuntu/redpanda/tests/rptest/services/cluster.py", line 104, in wrapped
        r = f(self, *args, **kwargs)
      File "/home/ubuntu/redpanda/tests/rptest/redpanda_cloud_tests/high_throughput_test.py", line 1221, in test_add_and_decommission
        self._stage_add_and_decommission()
      File "/home/ubuntu/redpanda/tests/rptest/redpanda_cloud_tests/high_throughput_test.py", line 1251, in _stage_add_and_decommission
        self._patch_cluster_replicas(cluster_name, orig_replicas)
      File "/home/ubuntu/redpanda/tests/rptest/redpanda_cloud_tests/high_throughput_test.py", line 1165, in _patch_cluster_replicas
        wait_until(
      File "/usr/local/lib/python3.10/dist-packages/ducktape/utils/util.py", line 53, in wait_until
        raise e
      File "/usr/local/lib/python3.10/dist-packages/ducktape/utils/util.py", line 44, in wait_until
        if condition():
      File "/home/ubuntu/redpanda/tests/rptest/redpanda_cloud_tests/high_throughput_test.py", line 1166, in <lambda>
        lambda: cluster_ready_replicas(cluster_name) == replicas,
      File "/home/ubuntu/redpanda/tests/rptest/redpanda_cloud_tests/high_throughput_test.py", line 1144, in cluster_ready_replicas
        return int(
    ValueError: invalid literal for int() with base 10: ''

Fixes: https://github.com/redpanda-data/redpanda/issues/16631

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
