### PR TITLE
test: check for non-empty samples from any core

### DIFF
--- a/tests/rptest/tests/cpu_profiler_admin_api_test.py
+++ b/tests/rptest/tests/cpu_profiler_admin_api_test.py
@@ -69,9 +69,9 @@ class CPUProfilerAdminAPITest(RedpandaTest):
             profile = self.admin.get_cpu_profile(wait_ms=30 * 1_000)
 
             assert len(profile) > 0, "At least one shard should exist"
-            assert len(
-                profile[0]["samples"]
-            ) > 0, "At least one cpu profile should've been collected."
+            assert any(
+                len(p["samples"]) > 0 for p in
+                profile), "At least one cpu profile should've been collected."
 
     @cluster(num_nodes=3)
     def test_get_cpu_profile_with_override_limits(self):


### PR DESCRIPTION
Only core 0 was checked for samples in the test. We can see here in the result of querying the cpu profiler endpoint that only core 1 had samples.
```
    [DEBUG - 2024-02-16 02:04:02,865 - admin - _request - lineno:383]: Response OK, JSON: [{'shard_id': 0, 'dropped_samples': 0}, {'shard_id': 1, 'dropped_samples': 0, 'samples': [{'user_backtrace': '0xef666 /opt/redpanda_installs/ci/lib/libseastar.so+0x597c482 /opt/r
```
```
        KeyError('samples')
    Traceback (most recent call last):
      File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 184, in _do_run
        data = self.run_test()
      File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 269, in run_test
        return self.test_context.function(self.test)
      File "/root/tests/rptest/services/cluster.py", line 104, in wrapped
        r = f(self, *args, **kwargs)
      File "/root/tests/rptest/tests/cpu_profiler_admin_api_test.py", line 73, in test_get_cpu_profile_with_override
        profile[0]["samples"]
    KeyError: 'samples'
```
Fixes: https://github.com/redpanda-data/redpanda/issues/16618

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
