### PR TITLE
test: wait for cluster to become healthy after setup

### DIFF
--- a/tests/rptest/tests/redpanda_cloud_test.py
+++ b/tests/rptest/tests/redpanda_cloud_test.py
@@ -38,8 +38,10 @@ class RedpandaCloudTest(RedpandaTestBase):
 
     def setup(self):
         super().setup()
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy before start of test'
+        wait_until(lambda: self.redpanda.cluster_healthy(),
+                   timeout_sec=20,
+                   backoff_sec=5,
+                   err_msg='cluster unhealthy before start of test')
 
     def client(self):
         return self._client


### PR DESCRIPTION
Immediately after the test starts up and the initial topics are created the cluster health is tested. In this case the cluster was unhealth because of:

    reasons:                [leaderless_partitions under_replicated_partitions]',

But these aren't really indications of an _unhealthy_ cluster, but rather normal states that should be considered unhealthy if they persist. In the test that failed 100s of partitions were being created in a single topic, so perhaps something went out for coffee temproarily.

Anyway, we can give some grace period to becoming healthy rather than failing.

    AssertionError('cluster unhealthy before start of test')
    Traceback (most recent call last):
      File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 182, in _do_run
        self.setup_test()
      File "/usr/local/lib/python3.10/dist-packages/ducktape/tests/runner_client.py", line 260, in setup_test
        self.test.setup()
      File "/home/ubuntu/redpanda/tests/rptest/redpanda_cloud_tests/high_throughput_test.py", line 357, in setup
        super().setup()
      File "/home/ubuntu/redpanda/tests/rptest/tests/redpanda_cloud_test.py", line 41, in setup
        assert self.redpanda.cluster_healthy(
    AssertionError: cluster unhealthy before start of test

Fixes: https://github.com/redpanda-data/redpanda/issues/16670

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
