### PR TITLE
test: give ready grace period to compacted verifier startup

### DIFF
--- a/tests/rptest/services/compacted_verifier.py
+++ b/tests/rptest/services/compacted_verifier.py
@@ -114,7 +114,7 @@ class CompactedVerifier(Service):
 
     ### Service overrides
 
-    def start_node(self, node, timeout_sec=10):
+    def start_node(self, node, timeout_sec=20):
         node.account.ssh(
             f"bash /opt/remote/control/start.sh rw \"java -cp /opt/verifiers/verifiers.jar io.vectorized.compaction.App\""
         )

--- a/tests/rptest/services/compacted_verifier.py
+++ b/tests/rptest/services/compacted_verifier.py
@@ -157,6 +157,7 @@ class CompactedVerifier(Service):
         ip = self._node.account.hostname
         r = requests.get(f"http://{ip}:8080/ping")
         if r.status_code != 200:
+            self.logger.debug(f"Ping {ip} failed: {r}: {r.status_code}")
             raise Exception(f"unexpected status code: {r.status_code}")
 
     def remote_start_producer(self,


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/redpanda/issues/16613

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

