### PR TITLE
[v23.3.x] Implement async_for_each

### DIFF
--- a/src/v/ssx/async_algorithm.h
+++ b/src/v/ssx/async_algorithm.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+
+#include <iterator>
+#include <limits>
+
+//
+// async_algorithms.h
+//
+// These are implementations of a few algorithms, similar in nature to those in
+// <algorithm>, but which are async-friendly in the sense that they yield
+// periodically.
+//
+// For the simplest use cases we offer free functions like async_for_each, which
+// is the same as for_each except that it yields every Traits::interval
+// iterations: every call starts the counter anew.
+//
+// For more complicated cases, like nested loops, it may be convenient to carry
+// the counter from one iteration to the next, in order to yield at the correct
+// times. For example, in a doubly nested loop where the inner loop always ran
+// for less than interval iterations, we would not yield with the simple
+// functions.
+
+namespace ssx {
+
+struct async_counter {
+    // internal details, don't rely on the values
+    ssize_t count = 0;
+};
+
+struct async_algo_traits {
+    // The number of elements processed before trying to yield
+    constexpr static ssize_t interval = 100;
+    // Called every time after we call maybe_yield, useful to
+    // introspect the behavior in tests.
+    static void yield_called() {}
+};
+
+namespace detail {
+
+// value-semantic counter for when no external counter was passed
+struct internal_counter {
+    ssize_t count;
+};
+
+// ref-semantic counter for when an external counter was passed
+// we need to jump though these semantics since using a ref-counter
+// for the internal case would lead to a lifetime issue as the counter
+// lives in the stack frame of a non-coroutine and is passed into a
+// coroutine, which will UAF on suspension
+struct ref_counter {
+    ssize_t& count;
+};
+
+template<typename Traits, typename C>
+static ssize_t remaining(const C& c) {
+    // amount of work we can do before yielding
+    return std::max(Traits::interval - c.count, (ssize_t)0);
+}
+
+/**
+ * The fixed cost of just calling the async helper methods: it is
+ * mostly important that this is non-zero so if you call the counter
+ * version of the async methods on tons of empty containers, you do
+ * yield: otherwise we would never yield in this case.
+ *
+ */
+constexpr ssize_t FIXED_COST = 1;
+
+template<
+  typename Traits,
+  typename Counter,
+  typename Fn,
+  std::random_access_iterator Iterator>
+ss::future<>
+async_for_each_coro(Counter counter, Iterator begin, Iterator end, Fn f) {
+    do {
+        auto chunk_size = std::min(remaining<Traits>(counter), end - begin);
+        Iterator chunk_end = begin + chunk_size;
+        std::for_each(begin, chunk_end, f);
+        begin = chunk_end;
+        counter.count += chunk_size;
+        if (counter.count >= Traits::interval) {
+            co_await ss::coroutine::maybe_yield();
+            counter.count = 0;
+            Traits::yield_called();
+        }
+    } while (begin != end);
+
+    counter.count += FIXED_COST;
+}
+
+/**
+ * Helper to combine the internal and external counter implementations.
+ */
+template<
+  typename Traits = async_algo_traits,
+  typename Counter,
+  typename Fn,
+  std::random_access_iterator Iterator>
+ss::future<>
+async_for_each_fast(Counter counter, Iterator begin, Iterator end, Fn f) {
+    // This first part is an important optimization: if the input range is small
+    // enough, we don't want to create a coroutine frame as that's costly, so
+    // this function is not coroutine and we do the whole iteration here (as we
+    // won't yield), otherwise we defer to the coroutine-based helper.
+    if (auto total_size = (end - begin) + FIXED_COST;
+        total_size <= detail::remaining<Traits>(counter)) {
+        std::for_each(begin, end, std::move(f));
+        counter.count += total_size;
+        return ss::make_ready_future();
+    }
+
+    return async_for_each_coro<Traits>(counter, begin, end, std::move(f));
+}
+
+} // namespace detail
+
+/**
+ * @brief Call f on every element, yielding occasionally.
+ *
+ * This is equivalent to std::for_each, except that the computational
+ * loop yields every Traits::interval (default 100) iterations in order
+ * to avoid reactor stalls. The returned future resolves when all elements
+ * have been processed.
+ *
+ * The function is taken by value.
+ *
+ * The iterators must remain valid until the returned future resolves.
+ *
+ * @param begin the beginning of the range to process
+ * @param end the end of the range to process
+ * @param f the function to call on each element
+ * @return ss::future<> a future which resolves when all elements have been
+ * processed
+ */
+template<
+  typename Traits = async_algo_traits,
+  typename Fn,
+  std::random_access_iterator Iterator>
+ss::future<> async_for_each(Iterator begin, Iterator end, Fn f) {
+    return async_for_each_fast<Traits>(
+      detail::internal_counter{}, begin, end, std::move(f));
+}
+
+/**
+ * @brief Call f on every element, yielding occasionally and accepting
+ * an externally provided counter for yield control.
+ *
+ * This is equivalent to std::for_each, except that the computational
+ * loop yields every Traits::interval (default 100) iterations in order
+ * to avoid reactor stalls. The returned future resolves when all elements
+ * have been processed.
+ *
+ * This behaves similarly to async_for_each except that the counter used to
+ * track how much work as been done since the last attempted yield is passed
+ * in by the caller. This allows use in more complex cases such as nested loops
+ * where the inner loop may itself not do sufficient work to ever trigger the
+ * yield condition, even though the total amount of work done across all
+ iterations
+ * is very high.
+ *
+ * Use case:
+ *
+ * Replace something like:
+ *
+ * for (... outer loop ...) {
+ *   for (... inner loop ...) {
+ *      f(elem);
+ *   }
+ * }
+ * with:
+ *
+ * async_counter counter;
+ * for (... outer loop ...) {
+ *    co_await async_for_each(counter, begin, end, f);
+ * }
+ *
+ * The counter is taken by reference and must live at least until the
+ * returned future resolves: this usually trivial when the caller is a
+ * coroutine but may require some care when continuation style is used.
+ *
+ * The function is taken by value.
+ *
+ * The iterators must remain valid until the returned future resolves.
+ *
+ * @param begin the beginning of the range to process
+ * @param end the end of the range to process
+ * @param f the function to call on each element
+ * @return ss::future<> a future which resolves when all elements have been
+ * processed
+ */
+template<
+  typename Traits = async_algo_traits,
+  typename Fn,
+  std::random_access_iterator Iterator>
+ss::future<> async_for_each_counter(
+  async_counter& counter, Iterator begin, Iterator end, Fn f) {
+    return detail::async_for_each_fast<Traits>(
+      detail::ref_counter{counter.count}, begin, end, std::move(f));
+}
+
+} // namespace ssx

--- a/src/v/ssx/tests/CMakeLists.txt
+++ b/src/v/ssx/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ rp_test(
   GTEST
   BINARY_NAME ssx_gunit
   SOURCES
+    async_algorithm_test.cc
     work_queue_test.cc
   LIBRARIES v::gtest_main v::ssx
   LABELS ssx

--- a/src/v/ssx/tests/async_algorithm_test.cc
+++ b/src/v/ssx/tests/async_algorithm_test.cc
@@ -1,0 +1,228 @@
+// Copyright 2023 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "gmock/gmock.h"
+#include "seastarx.h"
+#include "ssx/async-clear.h"
+#include "ssx/async_algorithm.h"
+#include "ssx/future-util.h"
+#include "utils/move_canary.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/core/thread.hh>
+#include <seastar/coroutine/maybe_yield.hh>
+
+#include <algorithm>
+#include <cstdint>
+#include <iterator>
+
+namespace ssx {
+
+namespace {
+
+static ss::future<>
+async_push_back(auto& container, ssize_t n, const auto& val) {
+    constexpr ssize_t batch = 1000;
+
+    while (n > 0) {
+        std::fill_n(std::back_inserter(container), std::min(n, batch), val);
+        n -= batch;
+        co_await ss::coroutine::maybe_yield();
+    }
+}
+
+const auto add_one = [](int& x) { x++; };
+[[maybe_unused]] const auto add_one_slow = [](int& x) {
+    static volatile int sink = 0;
+    for (int i = 0; i < 100; i++) {
+        sink = sink + 1;
+    }
+    x++;
+};
+
+static thread_local int yields;
+
+template<ssize_t I>
+struct test_traits : async_algo_traits {
+    constexpr static ssize_t interval = I;
+    static void yield_called() { yields++; }
+};
+
+static void check_same_result(const auto& container, auto fn) {
+    auto std_input = container, async_input0 = container,
+         async_input1 = container, async_input2 = container,
+         async_input3 = container;
+
+    std::for_each(std_input.begin(), std_input.end(), fn);
+
+    // vanilla
+    ssx::async_for_each(async_input0.begin(), async_input0.end(), fn).get();
+
+    // interval 1
+    ssx::async_for_each<test_traits<1>>(
+      async_input1.begin(), async_input1.end(), fn)
+      .get();
+
+    // vanilla with counter
+    async_counter c;
+    ssx::async_for_each_counter(c, async_input2.begin(), async_input2.end(), fn)
+      .get();
+
+    // interval 1 with counter
+    ssx::async_for_each_counter<test_traits<1>>(
+      c, async_input3.begin(), async_input3.end(), fn)
+      .get();
+
+    EXPECT_EQ(std_input, async_input0);
+    EXPECT_EQ(std_input, async_input1);
+    EXPECT_EQ(std_input, async_input2);
+    EXPECT_EQ(std_input, async_input3);
+};
+
+struct task_counter {
+    static int64_t tasks() {
+        return (int64_t)ss::engine().get_sched_stats().tasks_processed;
+    }
+
+    int64_t task_start = tasks();
+    ssize_t yield_start = yields;
+
+    int64_t task_delta() { return tasks() - task_start; }
+    ssize_t yield_delta() { return yields - yield_start; }
+};
+
+} // namespace
+
+TEST(AsyncAlgo, async_for_each_same_result) {
+    // basic checks
+    check_same_result(std::vector<int>{}, add_one);
+    check_same_result(std::vector<int>{1, 2, 3, 4}, add_one);
+}
+
+TEST(AsyncAlgo, yield_count) {
+    // helper to check that async_for_each results in the same final state
+    // as std::for_each
+
+    std::vector<int> v{1, 2, 3, 4, 5};
+
+    task_counter c;
+    ssx::async_for_each<test_traits<1>>(v.begin(), v.end(), add_one).get();
+    EXPECT_EQ(5, c.yield_delta());
+
+    c = {};
+    ssx::async_for_each<test_traits<2>>(v.begin(), v.end(), add_one).get();
+    // floor(5/2), as we don't yield on partial intervals
+    EXPECT_EQ(2, c.yield_delta());
+}
+
+TEST(AsyncAlgo, yield_count_counter) {
+    async_counter a_counter;
+
+    std::vector<int> v{1, 2};
+
+    task_counter t_counter;
+    ssx::async_for_each_counter<test_traits<3>>(
+      a_counter, v.begin(), v.end(), add_one)
+      .get();
+    EXPECT_EQ(0, t_counter.yield_delta());
+    EXPECT_EQ(3, a_counter.count);
+
+    // now we should get a yield since we carry over the 2 ops
+    // from above
+    t_counter = {};
+    ssx::async_for_each_counter<test_traits<3>>(
+      a_counter, v.begin(), v.end(), add_one)
+      .get();
+    EXPECT_EQ(1, t_counter.yield_delta());
+
+    v = {1, 2, 3};
+    t_counter = {};
+    a_counter = {};
+    ssx::async_for_each_counter<test_traits<2>>(
+      a_counter, v.begin(), v.end(), add_one)
+      .get();
+    // 3 elems - 2 interval, overflow by 1 + FIXED_COST = 2
+    EXPECT_EQ(2, a_counter.count);
+    EXPECT_EQ(1, t_counter.yield_delta());
+
+    t_counter = {};
+    ssx::async_for_each_counter<test_traits<2>>(
+      a_counter, v.begin(), v.end(), add_one)
+      .get();
+    EXPECT_EQ(2, a_counter.count);
+    EXPECT_EQ(2, t_counter.yield_delta());
+}
+
+TEST(AsyncAlgo, yield_count_counter_empty) {
+    async_counter a_counter;
+    task_counter t_counter;
+
+    std::vector<int> empty;
+
+    auto call = [&] {
+        ssx::async_for_each_counter<test_traits<2>>(
+          a_counter, empty.begin(), empty.end(), add_one)
+          .get();
+    };
+
+    call();
+    EXPECT_EQ(1, a_counter.count);
+    EXPECT_EQ(0, t_counter.yield_delta());
+
+    call();
+    EXPECT_EQ(2, a_counter.count);
+    EXPECT_EQ(0, t_counter.yield_delta());
+
+    call();
+    EXPECT_EQ(1, a_counter.count);
+    EXPECT_EQ(1, t_counter.yield_delta());
+
+    a_counter = {};
+    t_counter = {};
+    constexpr auto iters = 101;
+    for (int i = 0; i < iters; i++) {
+        call();
+    }
+
+    // here we check that even though the vector is empty, we do yield 50 times
+    // (100 iterations / work interval of 2), since always assume 1 unit of work
+    // has been performed
+    EXPECT_EQ(iters / 2, t_counter.yield_delta());
+}
+
+TEST(AsyncAlgo, async_for_each_large_container) {
+    constexpr size_t size = 1'000'000;
+    constexpr int answer = 42;
+
+    std::deque<int> v;
+    async_push_back(v, size, answer).get();
+
+    task_counter tasks;
+
+    async_for_each(v.begin(), v.end(), add_one_slow).get();
+
+    EXPECT_GT(tasks.task_delta(), 2); // in practice it's > 100
+}
+
+TEST(AsyncAlgo, async_for_each_move_correctness) {
+    std::deque<int> v;
+    async_push_back(v, 10, 0).get();
+
+    auto func = [canary = move_canary{}](const int& i) {
+        if (i != -1) {
+            EXPECT_FALSE(canary.is_moved_from());
+        }
+        return canary.is_moved_from();
+    };
+
+    ASSERT_FALSE(func(0));
+
+    async_for_each<test_traits<2>>(v.begin(), v.end(), func).get();
+}
+
+} // namespace ssx


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/16662.

Fixes #16673.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
