### PR TITLE
rpk: update help text of decommission-status

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
+++ b/src/go/rpk/pkg/cli/redpanda/admin/brokers/decommission-status.go
@@ -61,10 +61,6 @@ ALLOCATION FAILURES
 ==================
 kafka/foo/2
 kafka/test/0
-
-Note that the command reports allocation failed partitions only when
-'partition_autobalancing_mode' is set to 'continuous'. See the current value
-using 'rpk cluster config get partition_autobalancing_mode'.
 `,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
Since 23.3, the ALLOCATION FAILURE field is available with any values in `partition_autobalancing_mode`. Prior to that, it was available only with `continuous`. This PR removes the following help text:

```
Note that the command reports allocation failed partitions only when
'partition_autobalancing_mode' is set to 'continuous'. See the current value
using 'rpk cluster config get partition_autobalancing_mode'.
```

https://redpandadata.slack.com/archives/C03GJ5HV8P9/p1704387906405199?thread_ts=1704384519.063189&cid=C03GJ5HV8P9
https://redpandadata.slack.com/archives/C01ND4SVB6Z/p1708664638156689?thread_ts=1708652713.078249&cid=C01ND4SVB6Z


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none


