### PR TITLE
http/client: add request interface that takes an iobuf

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -639,4 +639,13 @@ client::request_header redacted_header(client::request_header original) {
     return h;
 }
 
+seastar::future<client::response_stream_ref> client::request(
+  request_header header, iobuf body, seastar::lowres_clock::duration timeout) {
+    auto [request, response] = co_await make_request(
+      std::move(header), timeout);
+    co_await request->send_some(std::move(body));
+    co_await request->send_eof();
+    co_return response;
+}
+
 } // namespace http

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -82,6 +82,10 @@ void client::check() const {
 
 ss::future<client::request_response_t> client::make_request(
   client::request_header&& header, ss::lowres_clock::duration timeout) {
+    // Set request HTTP-version to 1.1
+    constexpr unsigned http_version = 11;
+    header.version(http_version);
+
     auto verb = header.method();
     auto target = header.target();
     ss::sstring target_str(target.data(), target.size());

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -601,15 +601,7 @@ ss::future<client::response_stream_ref> client::request(
 
 ss::future<client::response_stream_ref> client::request(
   client::request_header&& header, ss::lowres_clock::duration timeout) {
-    return make_request(std::move(header), timeout)
-      .then([](request_response_t reqresp) mutable {
-          auto [request, response] = std::move(reqresp);
-          return request->send_some(iobuf())
-            .then([request = request]() { return request->send_eof(); })
-            .then([response = response] {
-                return ss::make_ready_future<response_stream_ref>(response);
-            });
-      });
+    return request(std::move(header), iobuf(), timeout);
 }
 
 ss::output_stream<char> client::request_stream::as_output_stream() {

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -215,6 +215,16 @@ public:
       request_header&& header,
       ss::lowres_clock::duration timeout = default_connect_timeout);
 
+    /**
+     * Dispatch a request with the provided headers and body.
+     *
+     * Returns the response stream.
+     */
+    seastar::future<response_stream_ref> request(
+      request_header header,
+      iobuf body,
+      ss::lowres_clock::duration timeout = default_connect_timeout);
+
 private:
     template<class BufferSeq>
     static ss::future<> forward(client* client, BufferSeq&& seq);

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -193,12 +193,6 @@ public:
     using request_response_t
       = std::tuple<request_stream_ref, response_stream_ref>;
 
-    // Make http_request, if the transport is not yet connected it will connect
-    // first otherwise the future will resolve immediately.
-    ss::future<request_response_t> make_request(
-      request_header&& header,
-      ss::lowres_clock::duration timeout = default_connect_timeout);
-
     /// Utility function that executes request with the body and returns
     /// stream. Returned future becomes ready when the body is sent.
     /// Using the stream returned by the future client can pull response.
@@ -228,6 +222,11 @@ public:
 private:
     template<class BufferSeq>
     static ss::future<> forward(client* client, BufferSeq&& seq);
+
+    // Make http_request, if the transport is not yet connected it will connect
+    // first otherwise the future will resolve immediately.
+    ss::future<request_response_t>
+    make_request(request_header&& header, ss::lowres_clock::duration timeout);
 
     /// Receive bytes from the remote endpoint
     ss::future<ss::temporary_buffer<char>> receive();

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -58,10 +58,6 @@ enum class reconnect_result_t {
 
 /// Http client
 class client : protected net::base_transport {
-    enum {
-        protocol_version = 11,
-    };
-
 public:
     using request_header = boost::beast::http::request_header<>;
     using response_header = boost::beast::http::response_header<>;

--- a/src/v/http/demo/client.cc
+++ b/src/v/http/demo/client.cc
@@ -109,10 +109,8 @@ http::client::request_header make_header(const test_conf& cfg) {
 ss::future<> send_post_request(
   http::client& cli, http::client::request_header&& header, iobuf&& body) {
     vlog(test_log.info, "send POST request");
-    auto [req, resp] = cli.make_request(std::move(header)).get0();
+    auto resp = cli.request(std::move(header), std::move(body)).get0();
     // send request
-    req->send_some(std::move(body)).get();
-    req->send_eof().get();
     while (!resp->is_done()) {
         iobuf buf = resp->recv_some().get0();
         for (auto& fragm : buf) {

--- a/src/v/pandaproxy/test/utils.h
+++ b/src/v/pandaproxy/test/utils.h
@@ -70,9 +70,7 @@ inline consumed_response do_request(
   serialization_format content,
   serialization_format accept) {
     auto hdr = make_header(method, target, body, content, accept);
-    auto [req, res] = client.make_request(std::move(hdr)).get();
-    req->send_some(std::move(body)).get();
-    req->send_eof().get();
+    auto res = client.request(std::move(hdr), std::move(body)).get();
     auto bdy = consume_body(*res);
     vassert(res->is_header_done(), "Header isn't done");
     return {res->get_headers(), std::move(bdy)};


### PR DESCRIPTION
* Adds request() method that takes an iobuf
* Updates users of make_request() to use the new interface
* Sets HTTP/1.1 version explicitly

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

