### PR TITLE
tests: Fix missing include in redpanda_cloud_test

### DIFF
--- a/tests/rptest/tests/redpanda_cloud_test.py
+++ b/tests/rptest/tests/redpanda_cloud_test.py
@@ -10,6 +10,7 @@
 import os
 from typing import Sequence
 
+from ducktape.utils.util import wait_until
 from ducktape.tests.test import Test, TestContext
 from rptest.services.redpanda import CloudTierName, SISettings, make_redpanda_cloud_service, make_redpanda_service, CloudStorageType
 from rptest.clients.kafka_cli_tools import KafkaCliTools


### PR DESCRIPTION
Fixup for cfe28f5b23dabd73db35fc3268f1349daba8b11c


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

