### PR TITLE
c/p_leaders: check if leaders table was modified after async iteration

### DIFF
--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -198,9 +198,8 @@ void partition_leaders_table::do_update_partition_leader(
         if (p_it->second.update_term > term) {
             vlog(
               clusterlog.trace,
-              "skip update for partition {}/{} with previous term {} current "
-              "term "
-              "{}",
+              "skip update for partition {}/{}/{} with previous term {} "
+              "current term {}",
               t_it->first.ns,
               t_it->first.tp,
               p_id,

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -117,6 +117,7 @@ public:
                     p.second.current_leader,
                     p.second.update_term);
               });
+            throw_if_modified(version_snapshot);
         }
     }
 


### PR DESCRIPTION
Since leaders table might have been modified during the execution of iteration over the topic partitions we must check the version of topics table after the asynchronous iteration finished.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none