### PR TITLE
Added `redpanda.virtual.cluster.id` topic property

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -470,6 +470,7 @@ static cloud_storage::manifest_topic_configuration convert_topic_configuration(
         .segment_size = cfg.properties.segment_size,
         .retention_bytes = cfg.properties.retention_bytes,
         .retention_duration = cfg.properties.retention_duration,
+        .virtual_cluster_id = cfg.properties.mpx_virtual_cluster_id,
       },
     };
     return result;

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -138,6 +138,7 @@ struct manifest_topic_configuration {
         std::optional<size_t> segment_size;
         tristate<size_t> retention_bytes{std::nullopt};
         tristate<std::chrono::milliseconds> retention_duration{std::nullopt};
+        std::optional<model::vcluster_id> virtual_cluster_id;
         bool operator==(const topic_properties& other) const = default;
     };
     topic_properties properties;

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -393,6 +393,7 @@ static cluster::topic_configuration make_topic_config(
     topic_properties.timestamp_type = manifest_props.timestamp_type;
     topic_properties.shadow_indexing = model::shadow_indexing_mode::full;
     topic_properties.recovery = true;
+    topic_properties.mpx_virtual_cluster_id = manifest_props.virtual_cluster_id;
 
     if (request.retention_bytes().has_value()) {
         topic_properties.retention_local_target_bytes = tristate<size_t>{

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -353,7 +353,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "record_value_subject_name_strategy: {}, "
       "record_value_subject_name_strategy_compat: {}, "
       "initial_retention_local_target_bytes: {}, "
-      "initial_retention_local_target_ms: {}}}",
+      "initial_retention_local_target_ms: {}, "
+      "mpx_virtual_cluster_id: {}}}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -380,7 +381,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.record_value_subject_name_strategy,
       properties.record_value_subject_name_strategy_compat,
       properties.initial_retention_local_target_bytes,
-      properties.initial_retention_local_target_ms);
+      properties.initial_retention_local_target_ms,
+      properties.mpx_virtual_cluster_id);
 
     return o;
 }
@@ -2195,7 +2197,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       std::nullopt,
       tristate<size_t>{std::nullopt},
-      tristate<std::chrono::milliseconds>{std::nullopt}};
+      tristate<std::chrono::milliseconds>{std::nullopt},
+      std::nullopt};
 }
 
 void adl<cluster::cluster_property_kv>::to(

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1468,10 +1468,6 @@ struct remote_topic_properties
 };
 
 /**
- * Type representing MPX virtual cluster. MPX uses XID to identify clusters.
- */
-using vcluster_id = named_type<xid, struct v_cluster_id_tag>;
-/**
  * Structure holding topic properties overrides, empty values will be replaced
  * with defaults
  */
@@ -1510,7 +1506,8 @@ struct topic_properties
       std::optional<pandaproxy::schema_registry::subject_name_strategy>
         record_value_subject_name_strategy_compat,
       tristate<size_t> initial_retention_local_target_bytes,
-      tristate<std::chrono::milliseconds> initial_retention_local_target_ms)
+      tristate<std::chrono::milliseconds> initial_retention_local_target_ms,
+      std::optional<vcluster_id> mpx_virtual_cluster_id)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -1584,6 +1581,7 @@ struct topic_properties
     tristate<size_t> initial_retention_local_target_bytes{std::nullopt};
     tristate<std::chrono::milliseconds> initial_retention_local_target_ms{
       std::nullopt};
+    std::optional<vcluster_id> mpx_virtual_cluster_id;
 
     bool is_compacted() const;
     bool has_overrides() const;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1473,7 +1473,7 @@ struct remote_topic_properties
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<6>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<7>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -1507,7 +1507,7 @@ struct topic_properties
         record_value_subject_name_strategy_compat,
       tristate<size_t> initial_retention_local_target_bytes,
       tristate<std::chrono::milliseconds> initial_retention_local_target_ms,
-      std::optional<vcluster_id> mpx_virtual_cluster_id)
+      std::optional<model::vcluster_id> mpx_virtual_cluster_id)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -1539,7 +1539,8 @@ struct topic_properties
           record_value_subject_name_strategy_compat)
       , initial_retention_local_target_bytes(
           initial_retention_local_target_bytes)
-      , initial_retention_local_target_ms(initial_retention_local_target_ms) {}
+      , initial_retention_local_target_ms(initial_retention_local_target_ms)
+      , mpx_virtual_cluster_id(mpx_virtual_cluster_id) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -1581,7 +1582,7 @@ struct topic_properties
     tristate<size_t> initial_retention_local_target_bytes{std::nullopt};
     tristate<std::chrono::milliseconds> initial_retention_local_target_ms{
       std::nullopt};
-    std::optional<vcluster_id> mpx_virtual_cluster_id;
+    std::optional<model::vcluster_id> mpx_virtual_cluster_id;
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -1618,7 +1619,8 @@ struct topic_properties
           record_value_subject_name_strategy,
           record_value_subject_name_strategy_compat,
           initial_retention_local_target_bytes,
-          initial_retention_local_target_ms);
+          initial_retention_local_target_ms,
+          mpx_virtual_cluster_id);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -350,6 +350,7 @@ struct compat_check<cluster::topic_properties> {
         json_write(record_value_subject_name_strategy_compat);
         json_write(initial_retention_local_target_bytes);
         json_write(initial_retention_local_target_ms);
+        json_write(mpx_virtual_cluster_id);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -381,6 +382,7 @@ struct compat_check<cluster::topic_properties> {
         json_read(record_value_subject_name_strategy_compat);
         json_read(initial_retention_local_target_bytes);
         json_read(initial_retention_local_target_ms);
+        json_read(mpx_virtual_cluster_id);
         return obj;
     }
 
@@ -407,6 +409,7 @@ struct compat_check<cluster::topic_properties> {
           std::nullopt};
         obj.initial_retention_local_target_ms
           = tristate<std::chrono::milliseconds>{std::nullopt};
+        obj.mpx_virtual_cluster_id = std::nullopt;
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -482,6 +485,8 @@ struct compat_check<cluster::topic_configuration> {
         obj.properties.initial_retention_local_target_ms
           = tristate<std::chrono::milliseconds>{std::nullopt};
 
+        obj.properties.mpx_virtual_cluster_id = std::nullopt;
+
         if (cfg != obj) {
             throw compat_error(fmt::format(
               "Verify of {{cluster::topic_property}} decoding "
@@ -544,6 +549,7 @@ struct compat_check<cluster::create_topics_request> {
               = tristate<size_t>{std::nullopt};
             topic.properties.initial_retention_local_target_ms
               = tristate<std::chrono::milliseconds>{std::nullopt};
+            topic.properties.mpx_virtual_cluster_id = std::nullopt;
         }
         if (req != obj) {
             throw compat_error(fmt::format(
@@ -606,6 +612,7 @@ struct compat_check<cluster::create_topics_reply> {
               = tristate<size_t>{std::nullopt};
             topic.properties.initial_retention_local_target_ms
               = tristate<std::chrono::milliseconds>{std::nullopt};
+            topic.properties.mpx_virtual_cluster_id = std::nullopt;
         }
         if (reply != obj) {
             throw compat_error(fmt::format(

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -604,6 +604,8 @@ inline void rjson_serialize(
       w,
       "initial_retention_local_target_ms",
       tps.initial_retention_local_target_ms);
+    write_member(w, "mpx_virtual_cluster_id", tps.mpx_virtual_cluster_id);
+
     w.EndObject();
 }
 
@@ -666,6 +668,7 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
       rd,
       "initial_retention_local_target_ms",
       obj.initial_retention_local_target_ms);
+    read_member(rd, "mpx_virtual_cluster_id", obj.mpx_virtual_cluster_id);
 }
 
 inline void rjson_serialize(

--- a/src/v/compat/json.h
+++ b/src/v/compat/json.h
@@ -503,6 +503,12 @@ inline void read_value(json::Value const& rd, security::acl_host& host) {
     host = security::acl_host(address);
 }
 
+inline void read_value(json::Value const& rd, model::vcluster_id& v) {
+    ss::sstring xid_str;
+    read_value(rd, xid_str);
+    v = model::vcluster_id(xid::from_string(xid_str));
+}
+
 inline void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const security::acl_host& host) {
     w.StartObject();
@@ -808,6 +814,11 @@ void rjson_serialize(
         rjson_serialize(w, t.value());
     }
     w.EndObject();
+}
+
+inline void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::vcluster_id& v) {
+    rjson_serialize(w, ssx::sformat("{}", v));
 }
 
 #define json_write(_fname) json::write_member(wr, #_fname, obj._fname)

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -194,6 +194,10 @@ to_cluster_type(const creatable_topic& t) {
       = get_tristate_value<std::chrono::milliseconds>(
         config_entries, topic_property_initial_retention_local_target_ms);
 
+    cfg.properties.mpx_virtual_cluster_id
+      = get_config_value<model::vcluster_id>(
+        config_entries, topic_property_mpx_virtual_cluster_id);
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 
@@ -363,6 +367,10 @@ config_map_t from_cluster_type(const cluster::topic_properties& properties) {
           = from_config_type(*properties.initial_retention_local_target_ms);
     }
 
+    if (properties.mpx_virtual_cluster_id.has_value()) {
+        config_entries[topic_property_mpx_virtual_cluster_id]
+          = from_config_type(properties.mpx_virtual_cluster_id.value());
+    }
     /// Final topic_property not encoded here is \ref remote_topic_properties,
     /// is more of an implementation detail no need to ever show user
     return config_entries;

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -101,6 +101,9 @@ static constexpr std::string_view
   topic_property_initial_retention_local_target_ms
   = "initial.retention.local.target.ms";
 
+static constexpr std::string_view topic_property_mpx_virtual_cluster_id
+  = "redpanda.virtual.cluster.id";
+
 // Kafka topic properties that is not relevant for Redpanda
 // Or cannot be altered with kafka alter handler
 static constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -10,6 +10,7 @@
  */
 
 #pragma once
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "kafka/protocol/schemata/create_topics_request.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
@@ -299,6 +300,30 @@ struct configuration_value_validator {
 
         try {
             boost::lexical_cast<typename T::validated_type>(iter->second);
+            return true;
+        } catch (...) {
+            return false;
+        }
+    }
+};
+struct vcluster_id_validator {
+    static constexpr const char* error_message = "invalid virtual cluster id";
+    static constexpr error_code ec = error_code::invalid_config;
+
+    static bool is_valid(const creatable_topic& c) {
+        if (!config::shard_local_cfg().enable_mpx_extensions()) {
+            return true;
+        }
+        auto config_entries = config_map(c.configs);
+
+        auto it = config_entries.find(topic_property_mpx_virtual_cluster_id);
+
+        if (it == config_entries.end()) {
+            return true;
+        }
+
+        try {
+            model::vcluster_id::type::from_string(it->second);
             return true;
         } catch (...) {
             return false;

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -17,6 +17,7 @@
 #include "net/unresolved_address.h"
 #include "serde/envelope.h"
 #include "utils/named_type.h"
+#include "utils/xid.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -557,6 +558,11 @@ constexpr const char* fetch_read_strategy_to_string(fetch_read_strategy s) {
 
 std::ostream& operator<<(std::ostream&, fetch_read_strategy);
 std::istream& operator>>(std::istream&, fetch_read_strategy&);
+
+/**
+ * Type representing MPX virtual cluster. MPX uses XID to identify clusters.
+ */
+using vcluster_id = named_type<xid, struct v_cluster_id_tag>;
 
 namespace internal {
 /*

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -81,6 +81,7 @@ class TopicSpec:
 
     PROPERTY_INITIAL_RETENTION_LOCAL_TARGET_BYTES = "initial.retention.local.target.bytes"
     PROPERTY_INITIAL_RETENTION_LOCAL_TARGET_MS = "initial.retention.local.target.ms"
+    PROPERTY_VIRTUAL_CLUSTER_ID = "redpanda.virtual.cluster.id"
 
     def __init__(self,
                  *,
@@ -108,7 +109,8 @@ class TopicSpec:
                  record_value_subject_name_strategy=None,
                  record_value_subject_name_strategy_compat=None,
                  initial_retention_local_target_bytes=None,
-                 initial_retention_local_target_ms=None):
+                 initial_retention_local_target_ms=None,
+                 virtual_cluster_id=None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -134,6 +136,7 @@ class TopicSpec:
         self.record_value_subject_name_strategy_compat = record_value_subject_name_strategy_compat
         self.initial_retention_local_target_bytes = initial_retention_local_target_bytes
         self.initial_retention_local_target_ms = initial_retention_local_target_ms
+        self.virtual_cluster_id = virtual_cluster_id
 
     def __str__(self):
         return self.name

--- a/tests/rptest/tests/vcluster_topic_property_test.py
+++ b/tests/rptest/tests/vcluster_topic_property_test.py
@@ -1,0 +1,78 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+from rptest.clients.rpk import RpkException, RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from random import randbytes
+
+BASE32_ALPHABET = "0123456789abcdefghijklmnopqrstuv"
+
+
+def get_vcluster_id(topic_properties: dict):
+    if TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID not in topic_properties:
+        return None
+    return topic_properties[TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID][0]
+
+
+class VirtualClusterTopicPropertyTest(RedpandaTest):
+    def __init__(self, test_context):
+        super(VirtualClusterTopicPropertyTest,
+              self).__init__(test_context=test_context, num_brokers=3)
+
+    def _random_xid_string(self):
+        xid = ''.join([random.choice(BASE32_ALPHABET) for _ in range(19)])
+
+        return xid + random.choice(['0', 'g'])
+
+    @cluster(num_nodes=3)
+    def test_basic_virtual_cluster_property(self):
+        rpk = RpkTool(self.redpanda)
+        # try creating vcluster enabled topic with extensions disabled
+        topic = TopicSpec()
+        vcluster_id = self._random_xid_string()
+        rpk.create_topic(
+            topic=topic.name,
+            partitions=1,
+            replicas=3,
+            config={TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID: vcluster_id})
+
+        configs = rpk.describe_topic_configs(topic.name)
+        assert TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID not in configs, \
+            "When MPX extensions are disabled there should be no virtual cluster property reported"
+        try:
+            configs = rpk.alter_topic_config(
+                topic.name, TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID, vcluster_id)
+            assert False, "Altering topic virtual cluster property should not be supported"
+        except RpkException as e:
+            assert "INVALID_CONFIG" in e.msg
+        rpk.delete_topic(topic.name)
+        # enable mpx extensions
+        self.redpanda.set_cluster_config({"enable_mpx_extensions": True})
+        # create topic with virtual cluster id assigned
+        rpk.create_topic(
+            topic=topic.name,
+            partitions=1,
+            replicas=3,
+            config={TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID: vcluster_id})
+
+        configs = rpk.describe_topic_configs(topic.name)
+
+        assert get_vcluster_id(configs) == vcluster_id, \
+            f"current virtual cluster id {get_vcluster_id(configs)} and expected cluster id {vcluster_id} doesn't match"
+
+        try:
+            rpk.alter_topic_config(topic.name,
+                                   TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID,
+                                   self._random_xid_string())
+            assert False, "Altering topic virtual cluster property should not be supported"
+        except RpkException as e:
+            assert "INVALID_CONFIG" in e.msg

--- a/tools/offline_log_viewer/controller.py
+++ b/tools/offline_log_viewer/controller.py
@@ -99,6 +99,10 @@ def read_topic_properties_serde(rdr: Reader, version):
             'initial_retention_local_target_ms':
             rdr.read_tristate(Reader.read_uint64)
         }
+    if version >= 7:
+        topic_properties |= {
+            'mpx_virtual_cluster_id': rdr.read_optional(Reader.read_bytes)
+        }
 
     return topic_properties
 
@@ -119,7 +123,7 @@ def read_topic_configuration_assignment_serde(rdr: Reader):
                     rdr.read_int16(),
                     'properties':
                     rdr.read_envelope(read_topic_properties_serde,
-                                      max_version=6),
+                                      max_version=7),
                 }, 1),
             'assignments':
             rdr.read_serde_vector(lambda r: r.read_envelope(


### PR DESCRIPTION
Added redpanda.virtual.cluster.id topic property which affiliates the topic with virtual cluster. The property is only settable during topic creation and can not be modified.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none