### PR TITLE
http/client: add `post()` method helper

### DIFF
--- a/src/v/cluster/metrics_reporter.h
+++ b/src/v/cluster/metrics_reporter.h
@@ -98,7 +98,6 @@ public:
 
 private:
     void report_metrics();
-    http::client::request_header make_header(const iobuf&);
     ss::future<> do_report_metrics();
     ss::future<result<metrics_snapshot>> build_metrics_snapshot();
 

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -72,6 +72,8 @@ client::client(
   ss::shared_ptr<client_probe> probe,
   ss::lowres_clock::duration max_idle_time)
   : net::base_transport(cfg)
+  , _host_with_port(
+      fmt::format("{}:{}", cfg.server_addr.host(), cfg.server_addr.port()))
   , _connect_gate()
   , _as(as)
   , _probe(std::move(probe))
@@ -92,6 +94,11 @@ ss::future<client::request_response_t> client::make_request(
     // Set request HTTP-version to 1.1
     constexpr unsigned http_version = 11;
     header.version(http_version);
+
+    // The default host is derived from the transport configuration
+    if (header.find(boost::beast::http::field::host) == header.end()) {
+        header.insert(boost::beast::http::field::host, _host_with_port);
+    }
 
     auto verb = header.method();
     auto target = header.target();

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -41,6 +41,13 @@
 
 namespace http {
 
+std::string_view content_type_string(content_type type) {
+    switch (type) {
+    case content_type::json:
+        return "application/json";
+    }
+}
+
 const std::unordered_set<std::variant<boost::beast::http::field, std::string>>
 redacted_fields() {
     return {

--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -658,4 +658,21 @@ seastar::future<client::response_stream_ref> client::request(
     co_return response;
 }
 
+seastar::future<client::response_stream_ref> client::post(
+  std::string_view path,
+  iobuf body,
+  content_type type,
+  seastar::lowres_clock::duration timeout) {
+    request_header header;
+    header.method(boost::beast::http::verb::post);
+    header.target(std::string(path));
+    header.insert(
+      boost::beast::http::field::content_length,
+      fmt::format("{}", body.size_bytes()));
+    header.insert(
+      boost::beast::http::field::content_type,
+      std::string(content_type_string(type)));
+    return request(std::move(header), std::move(body), timeout);
+}
+
 } // namespace http

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -241,6 +241,7 @@ private:
     /// Throw exception if _as is aborted
     void check() const;
 
+    std::string _host_with_port;
     ss::gate _connect_gate;
     const ss::abort_source* _as;
     ss::shared_ptr<http::client_probe> _probe;

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -224,6 +224,20 @@ public:
       iobuf body,
       ss::lowres_clock::duration timeout = default_connect_timeout);
 
+    /**
+     * Dispach a POST request to the provided path.
+     *
+     * @param path request target path
+     * @param body body the request
+     * @param type content type (e.g. json)
+     * @return the response stream
+     */
+    seastar::future<response_stream_ref> post(
+      std::string_view path,
+      iobuf body,
+      content_type type,
+      ss::lowres_clock::duration timeout = default_connect_timeout);
+
 private:
     template<class BufferSeq>
     static ss::future<> forward(client* client, BufferSeq&& seq);

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -56,6 +56,15 @@ enum class reconnect_result_t {
     timed_out,
 };
 
+enum class content_type {
+    json,
+};
+
+/**
+ * Return the HTTP content-type string for the given type.
+ */
+std::string_view content_type_string(content_type type);
+
 /// Http client
 class client : protected net::base_transport {
 public:

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -872,3 +872,8 @@ SEASTAR_THREAD_TEST_CASE(test_header_redacted) {
       s.find("capetown") == std::string::npos
       && s.find("x-amz-security-token") != std::string::npos);
 }
+
+SEASTAR_THREAD_TEST_CASE(content_type_string) {
+    BOOST_REQUIRE_EQUAL(
+      http::content_type_string(http::content_type::json), "application/json");
+}

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -14,6 +14,7 @@
 #include "http/chunk_encoding.h"
 #include "http/client.h"
 #include "http/logger.h"
+#include "json/document.h"
 #include "net/dns.h"
 #include "net/transport.h"
 
@@ -93,6 +94,24 @@ void set_routes(ss::httpd::routes& r) {
         return ss::sstring();
     });
     r.add(operation_type::PUT, url("/empty"), empty_handler);
+
+    auto get_headers_handler = new function_handler(
+      [](ss::httpd::const_req req, ss::http::reply& reply) {
+          json::StringBuffer str_buf;
+          json::Writer<json::StringBuffer> writer(str_buf);
+          writer.StartObject();
+          for (const auto& e : req._headers) {
+              writer.Key(e.first);
+              writer.String(e.second);
+          }
+          writer.EndObject();
+          reply.set_status(
+            ss::http::reply::status_type::ok, str_buf.GetString());
+          return "";
+      },
+      "json");
+
+    r.add(operation_type::GET, url("/headers"), get_headers_handler);
 }
 
 /// Http server and client
@@ -876,4 +895,77 @@ SEASTAR_THREAD_TEST_CASE(test_header_redacted) {
 SEASTAR_THREAD_TEST_CASE(content_type_string) {
     BOOST_REQUIRE_EQUAL(
       http::content_type_string(http::content_type::json), "application/json");
+}
+
+/*
+ * Test that the `Host` header is automatically set on a request.
+ */
+SEASTAR_THREAD_TEST_CASE(default_host_request_header) {
+    auto config = transport_configuration();
+    auto [server, client] = started_client_and_server(config);
+
+    // don't set host header, it should be set automatically
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/headers");
+
+    BOOST_REQUIRE(header.find(boost::beast::http::field::host) == header.end());
+    auto response = client->request(std::move(header)).get();
+    iobuf body;
+    while (!response->is_done()) {
+        body.append(response->recv_some().get());
+    }
+
+    BOOST_REQUIRE_EQUAL(
+      response->get_headers().result(), boost::beast::http::status::ok);
+
+    iobuf_const_parser parser(body);
+    const auto body_str = parser.read_string(parser.bytes_left());
+
+    rapidjson::Document doc;
+    doc.Parse(body_str);
+    BOOST_REQUIRE(!doc.HasParseError());
+    BOOST_REQUIRE(doc.IsObject());
+    BOOST_REQUIRE_EQUAL(
+      doc["Host"].GetString(),
+      fmt::format("{}:{}", httpd_host_name, httpd_port_number));
+
+    server->stop().get();
+}
+
+/*
+ * Test that the `Host` header on a request may be customized.
+ */
+SEASTAR_THREAD_TEST_CASE(custom_host_request_header) {
+    auto config = transport_configuration();
+    auto [server, client] = started_client_and_server(config);
+
+    // don't set host header, it should be set automatically
+    http::client::request_header header;
+    header.method(boost::beast::http::verb::get);
+    header.target("/headers");
+    header.insert(boost::beast::http::field::host, "asdf:333");
+
+    BOOST_REQUIRE(header.find(boost::beast::http::field::host) != header.end());
+    auto response = client->request(std::move(header)).get();
+    iobuf body;
+    while (!response->is_done()) {
+        body.append(response->recv_some().get());
+    }
+
+    BOOST_REQUIRE_EQUAL(
+      response->get_headers().result(), boost::beast::http::status::ok);
+
+    iobuf_const_parser parser(body);
+    const auto body_str = parser.read_string(parser.bytes_left());
+
+    rapidjson::Document doc;
+    doc.Parse(body_str);
+    BOOST_REQUIRE(!doc.HasParseError());
+    BOOST_REQUIRE(doc.IsObject());
+    BOOST_REQUIRE_EQUAL(doc["Host"].GetString(), "asdf:333");
+    BOOST_REQUIRE_NE(
+      fmt::format("{}:{}", httpd_host_name, httpd_port_number), "asdf:333");
+
+    server->stop().get();
 }


### PR DESCRIPTION
Adds a `http::client::post` method which handles preparation of a post request as a convenience for the metrics reporter which is switched over to use this method.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
