### PR TITLE
io: add input stream equality test helper

### DIFF
--- a/src/v/io/tests/common.h
+++ b/src/v/io/tests/common.h
@@ -17,6 +17,7 @@
 
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
 #include <seastar/core/temporary_buffer.hh>
 
 #include <gtest/gtest.h>
@@ -172,3 +173,9 @@ private:
 
     std::unique_ptr<io::persistence> storage_;
 };
+
+/**
+ * Test that two input streams yield the same data.
+ */
+testing::AssertionResult
+EqualInputStreams(seastar::input_stream<char>&, seastar::input_stream<char>&);


### PR DESCRIPTION
Adds an io input stream comparison utility for testing.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
