### PR TITLE
producer_state_manager: add a metric for eviction

### DIFF
--- a/src/v/cluster/producer_state_manager.h
+++ b/src/v/cluster/producer_state_manager.h
@@ -45,6 +45,7 @@ private:
     bool can_evict_producer(const producer_state&) const;
 
     size_t _num_producers = 0;
+    size_t _eviction_counter = 0;
     // if a producer is inactive for this long, it will be gc-ed
     std::chrono::milliseconds _producer_expiration_ms;
     // maximum # of active producers allowed on this shard across


### PR DESCRIPTION
When the producer count is at peak, there could be a heavy churn of producers due to constant eviction which is not reflected by total # of producers alone. Adds a counter that tracks total number of evictions separately.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Adds observability into producer evictions in each shard.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
