### PR TITLE
u/named_type: use fmt to format named type

### DIFF
--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -710,7 +710,7 @@ SEASTAR_THREAD_TEST_CASE(test_no_size_bytes_segment_meta) {
       std::runtime_error,
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
-                   "Missing size_bytes value in {10-1-v1.log} segment meta")
+                   "Missing size_bytes value in 10-1-v1.log segment meta")
                  != std::string::npos;
       });
 }
@@ -791,8 +791,8 @@ SEASTAR_THREAD_TEST_CASE(test_no_closing_bracket_meta) {
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
                    "Failed to parse partition manifest "
-                   "{\"b0000000/meta///-2147483648_-9223372036854775808/"
-                   "manifest.json\"}: Missing a comma or '}' after an object "
+                   "\"b0000000/meta///-2147483648_-9223372036854775808/"
+                   "manifest.json\": Missing a comma or '}' after an object "
                    "member. at offset 325")
                  != std::string::npos;
       });

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -313,8 +313,8 @@ SEASTAR_THREAD_TEST_CASE(wrong_compaction_strategy_throws) {
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
                    "Failed to parse topic manifest "
-                   "{\"30000000/meta/full-test-namespace/full-test-topic/"
-                   "topic_manifest.json\"}: Invalid compaction_strategy: "
+                   "\"30000000/meta/full-test-namespace/full-test-topic/"
+                   "topic_manifest.json\": Invalid compaction_strategy: "
                    "wrong_value")
                  != std::string::npos;
       });

--- a/src/v/cluster/cloud_metadata/tests/cluster_manifest_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_manifest_test.cc
@@ -52,7 +52,7 @@ SEASTAR_THREAD_TEST_CASE(test_basic_serialization) {
     cluster_metadata_manifest manifest;
     manifest.update(make_manifest_stream(simple_manifest_json)).get();
     BOOST_CHECK_EQUAL(100, manifest.upload_time_since_epoch.count());
-    auto uuid_str = "{01234567-89ab-cdef-0123-456789abcdef}";
+    auto uuid_str = "01234567-89ab-cdef-0123-456789abcdef";
     BOOST_CHECK_EQUAL(fmt::to_string(manifest.cluster_uuid), uuid_str);
     BOOST_CHECK_EQUAL(7, manifest.metadata_id());
     BOOST_CHECK_EQUAL(42, manifest.controller_snapshot_offset());

--- a/src/v/kafka/server/tests/group_test.cc
+++ b/src/v/kafka/server/tests/group_test.cc
@@ -481,7 +481,7 @@ SEASTAR_THREAD_TEST_CASE(generate_member_id) {
 SEASTAR_THREAD_TEST_CASE(group_output) {
     auto g = get();
     auto s = fmt::format("{}", g);
-    BOOST_TEST(s.find("id={g}") != std::string::npos);
+    BOOST_TEST(s.find("id=g") != std::string::npos);
 }
 
 SEASTAR_THREAD_TEST_CASE(group_state_output) {

--- a/src/v/kafka/server/tests/member_test.cc
+++ b/src/v/kafka/server/tests/member_test.cc
@@ -160,7 +160,7 @@ SEASTAR_THREAD_TEST_CASE(vote_for_protocols) {
 SEASTAR_THREAD_TEST_CASE(output_stream) {
     auto m = get_member();
     auto s = fmt::format("{}", m);
-    BOOST_TEST(s.find("id={m}") != std::string::npos);
+    BOOST_TEST(s.find("id=m") != std::string::npos);
 }
 
 SEASTAR_THREAD_TEST_CASE(member_serde) {

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -9,6 +9,8 @@
  * by the Apache License, Version 2.0
  */
 #pragma once
+#include <fmt/ostream.h>
+
 #include <cstdint>
 #include <limits>
 #include <ostream>
@@ -99,7 +101,8 @@ public:
     }
 
     friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
-        return o << "{" << t() << "}";
+        fmt::print(o, "{{{}}}", t._value);
+        return o;
     };
 
     friend std::istream& operator>>(std::istream& i, base_named_type& t) {
@@ -173,7 +176,8 @@ public:
     constexpr operator type() && { return std::move(_value); }
 
     friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
-        return o << "{" << t() << "}";
+        fmt::print(o, "{{{}}}", t._value);
+        return o;
     };
 
     friend std::istream& operator>>(std::istream& i, base_named_type& t) {

--- a/src/v/utils/named_type.h
+++ b/src/v/utils/named_type.h
@@ -101,7 +101,7 @@ public:
     }
 
     friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
-        fmt::print(o, "{{{}}}", t._value);
+        fmt::print(o, "{}", t._value);
         return o;
     };
 
@@ -176,7 +176,7 @@ public:
     constexpr operator type() && { return std::move(_value); }
 
     friend std::ostream& operator<<(std::ostream& o, const base_named_type& t) {
-        fmt::print(o, "{{{}}}", t._value);
+        fmt::print(o, "{}", t._value);
         return o;
     };
 


### PR DESCRIPTION
`named_type` was previously using a standard stream operator when being printed. This required any type wrapped with `named_type` to have `opertor<<` defined instead of relaying on `fmt::formatter` like a lot of types does. Changed the implementation of named type stream output operator to use `fmt` library.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none