### PR TITLE
Introduce RBAC data model

### DIFF
--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -27,6 +27,7 @@ v_cc_library(
     krb5.cc
     krb5_configurator.cc
     gssapi_principal_mapper.cc
+    role.cc
   DEPS
     v::http
     v::security_config

--- a/src/v/security/fwd.h
+++ b/src/v/security/fwd.h
@@ -17,6 +17,7 @@ class acl_store;
 class authorizer;
 class credential_store;
 class ephemeral_credential_store;
+class role_store;
 
 namespace oidc {
 

--- a/src/v/security/role.cc
+++ b/src/v/security/role.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "security/role.h"
+
+namespace security {
+std::ostream& operator<<(std::ostream& os, role_member_type t) {
+    switch (t) {
+    case role_member_type::user:
+        return os << "user";
+    }
+    __builtin_unreachable();
+}
+
+std::ostream& operator<<(std::ostream& os, const role_member& m) {
+    fmt::print(os, "{{{}}}:{{{}}}", m.type(), m.name());
+    return os;
+}
+
+// TODO(oren): maybe we should have the role name on the role?
+std::ostream& operator<<(std::ostream& os, const role& r) {
+    fmt::print(os, "role members: {{{}}}", fmt::join(r.members(), ","));
+    return os;
+}
+} // namespace security

--- a/src/v/security/role.h
+++ b/src/v/security/role.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "absl/container/flat_hash_set.h"
+#include "security/types.h"
+#include "serde/envelope.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <iosfwd>
+
+namespace security {
+
+enum class role_member_type {
+    user = 0,
+};
+
+std::ostream& operator<<(std::ostream&, role_member_type);
+
+class role_member
+  : public serde::
+      envelope<role_member, serde::version<0>, serde::compat_version<0>> {
+public:
+    // NOTE(oren): Default constructor is for serde tag_invoke only.
+    // A default constructed `role_member` is not meaningful and you shouldn't
+    // construct them.
+    role_member() = default;
+    role_member(role_member_type type, ss::sstring name)
+      : _type(type)
+      , _name(std::move(name)) {}
+
+    std::string_view name() const { return _name; }
+    role_member_type type() const { return _type; }
+
+    auto serde_fields() { return std::tie(_type, _name); }
+
+private:
+    friend bool operator==(const role_member&, const role_member&) = default;
+    friend std::ostream& operator<<(std::ostream&, const role_member&);
+
+    template<typename H>
+    friend H AbslHashValue(H h, const role_member& e) {
+        return H::combine(std::move(h), e._type, e._name);
+    }
+
+    role_member_type _type{};
+    ss::sstring _name;
+};
+
+class role
+  : public serde::envelope<role, serde::version<0>, serde::compat_version<0>> {
+public:
+    using container_type = absl::flat_hash_set<role_member>;
+
+    role() = default;
+
+    explicit role(container_type members)
+      : _members(std::move(members)) {}
+
+    const container_type& members() const& { return _members; }
+    container_type&& members() && { return std::move(_members); }
+
+    auto serde_fields() { return std::tie(_members); }
+
+    auto begin() const { return _members.begin(); }
+    auto end() const { return _members.end(); }
+    auto cbegin() const { return _members.cbegin(); }
+    auto cend() const { return _members.cend(); }
+
+private:
+    friend bool operator==(const role&, const role&) = default;
+    friend std::ostream& operator<<(std::ostream&, const role&);
+
+    container_type _members;
+};
+
+} // namespace security

--- a/src/v/security/role_store.h
+++ b/src/v/security/role_store.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_map.h"
+#include "absl/container/node_hash_set.h"
+#include "security/role.h"
+#include "security/types.h"
+
+#include <absl/algorithm/container.h>
+#include <boost/range/iterator_range.hpp>
+
+#include <ranges>
+#include <string_view>
+#include <type_traits>
+
+namespace security {
+
+/*
+ * Store for roles and role members.
+ *
+ * This store is subject to two distinct usage cases:
+ *   1. Retrieve the list of roles assigned to some user
+ *      - Used inline as part of the request authorization flow
+ *   2. Read and write from  the set of all roles
+ *      - Used for servicing role management requests in the Admin API
+ *
+ * The internal structure of role_store is geared toward servicing
+ * (1) as efficiently as possible with the primary goal of avoiding
+ * performance regression in the authorizer.
+ *
+ */
+class role_store {
+    struct role_name_view
+      : public named_type<std::string_view, struct role_name_view_tag> {
+        explicit role_name_view(const role_name& r)
+          : named_type<std::string_view, struct role_name_view_tag>(r()) {}
+    };
+    using role_set_type = absl::node_hash_set<role_name>;
+    using name_view_set_type = absl::flat_hash_set<role_name_view>;
+    using members_store_type
+      = absl::node_hash_map<role_member, name_view_set_type>;
+
+public:
+    role_store() noexcept = default;
+    role_store(const role_store&) = delete;
+    role_store& operator=(const role_store&) = delete;
+    role_store(role_store&&) noexcept = default;
+    role_store& operator=(role_store&&) noexcept = default;
+    ~role_store() noexcept = default;
+
+    // Add the given role and members range iff it is not already present.
+    template<typename T>
+    requires std::ranges::range<T>
+             && std::convertible_to<std::ranges::range_value_t<T>, role_member>
+    bool put(role_name name, T&& role) {
+        auto [it, inserted] = _roles.insert(std::move(name));
+        if (inserted) {
+            for (const auto& m : role) {
+                _members_store[m].emplace(*it);
+            }
+        }
+        return inserted;
+    }
+
+    std::optional<role> get(const role_name& name) const {
+        if (!_roles.contains(name)) {
+            return std::nullopt;
+        }
+        auto member_rng = _members_store
+                          | std::views::filter(
+                            [&name](const members_store_type::value_type& e) {
+                                return e.second.contains(role_name_view{name});
+                            })
+                          | std::views::keys;
+        return role{{member_rng.begin(), member_rng.end()}};
+    }
+
+    boost::iterator_range<name_view_set_type::const_iterator>
+    roles_for_member(const role_member& user) const {
+        if (auto it = _members_store.find(user); it != _members_store.end()) {
+            return it->second;
+        }
+        return {};
+    }
+
+    bool remove(const role_name& name) {
+        absl::c_for_each(
+          _members_store, [&name](members_store_type::value_type& e) {
+              e.second.erase(role_name_view{name});
+          });
+        return _roles.erase(name) > 0;
+    }
+
+    bool contains(const role_name& name) const { return _roles.contains(name); }
+
+    void clear() {
+        _members_store.clear();
+        _roles.clear();
+    }
+
+    // Retrieve a list of role_names that satisfy some predicate
+    //
+    // e.g.:
+    // store.range([](const auto& r) {
+    //     role_member mem{role_member_type::user, "user"};
+    //     return role_store::has_member(r, mem) &&
+    //       role_store::name_prefix_filter(e, "foo");
+    // });
+    auto range(auto&& pred) const {
+        return _roles | std::views::transform([this](const auto& e) {
+                   return std::make_pair(
+                     role_name_view{e}, [this]() -> const members_store_type& {
+                         return _members_store;
+                     });
+               })
+               | std::views::filter(std::forward<decltype(pred)>(pred))
+               | std::views::keys;
+    }
+
+    static constexpr auto name_prefix_filter =
+      [](
+        const std::pair<
+          role_name_view, /* role_name */
+          std::function<const members_store_type&(void)>>& e,
+        std::string_view filter) {
+          const auto [name, _] = e;
+          return filter.empty() || name().starts_with(filter);
+      };
+
+    static constexpr auto has_member =
+      [](
+        const std::pair<
+          role_name_view, /* role_name  */
+          std::function<const members_store_type&(void)>>& e,
+        const security::role_member& member) {
+          const auto [name, get_ms] = e;
+          const auto& ms = get_ms();
+          if (auto it = ms.find(member); it != ms.end()) {
+              return it->second.contains(name);
+          }
+          return false;
+      };
+
+private:
+    members_store_type _members_store;
+    role_set_type _roles;
+};
+
+} // namespace security

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -30,3 +30,11 @@ rp_test(
   LABELS
     kafka
 )
+
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME role_store_bench
+  SOURCES role_store_bench.cc
+  LIBRARIES Seastar::seastar_perf_testing v::utils v::security
+  LABELS security
+)

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ rp_test(
     jwt_test.cc
     url_test.cc
     oidc_principal_mapping_test.cc
+    role_store_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka_protocol v::storage v::security
   LABELS kafka

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "random/generators.h"
+#include "security/role.h"
+#include "security/role_store.h"
+
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/util/later.hh>
+
+#include <boost/range/irange.hpp>
+
+#include <vector>
+
+namespace {
+
+using role_name = security::role_name;
+using role_member = security::role_member;
+using role_member_type = security::role_member_type;
+using role = security::role;
+using role_store = security::role_store;
+
+constexpr size_t N_MEMBERS = 1024ul;
+constexpr size_t N_ROLES = 512ul;
+
+static const std::vector<role_member> members_data = [](size_t N) {
+    std::vector<role_member> mems;
+    mems.reserve(N);
+    absl::c_for_each(boost::irange(0ul, N), [&mems](auto) {
+        mems.emplace_back(
+          role_member_type::user, random_generators::gen_alphanum_string(32));
+    });
+    return mems;
+}(N_MEMBERS);
+
+static const std::vector<role_name> role_names_data = [](size_t N) {
+    std::vector<role_name> roles;
+    roles.reserve(N);
+    absl::c_for_each(boost::irange(0ul, N), [&roles](auto) {
+        roles.emplace_back(random_generators::gen_alphanum_string(32));
+    });
+    return roles;
+}(N_ROLES);
+
+role_store make_store() {
+    role_store store;
+    for (auto n : role_names_data) {
+        role::container_type role_mems;
+        for (const auto& m : members_data) {
+            if (random_generators::get_int(0, 1)) {
+                role_mems.insert(m);
+            }
+        }
+        store.put(std::move(n), std::move(role_mems));
+    }
+    return store;
+}
+
+static const role_store store_data = make_store();
+
+template<bool materialize>
+void run_get_member_roles() {
+    perf_tests::start_measuring_time();
+    for (const auto& m : members_data) {
+        auto rng = store_data.roles_for_member(m);
+        perf_tests::do_not_optimize(rng);
+        if constexpr (materialize) {
+            bool is_empty = rng.empty();
+            perf_tests::do_not_optimize(is_empty);
+        }
+    }
+    perf_tests::stop_measuring_time();
+}
+
+template<bool materialize>
+void run_range_queries() {
+    perf_tests::start_measuring_time();
+    for (const auto& m : members_data) {
+        auto rng = store_data.range(
+          [&m](const auto& e) { return role_store::has_member(e, m); });
+        perf_tests::do_not_optimize(rng);
+        if constexpr (materialize) {
+            bool is_empty = rng.empty();
+            perf_tests::do_not_optimize(is_empty);
+        }
+    }
+    perf_tests::stop_measuring_time();
+}
+
+} // namespace
+
+PERF_TEST(role_store_bench, get_member_roles) { run_get_member_roles<true>(); }
+
+PERF_TEST(role_store_bench, get_member_roles_bare_query) {
+    run_get_member_roles<false>();
+}
+
+PERF_TEST(role_store_bench, user_range_query) { run_range_queries<true>(); }
+
+PERF_TEST(role_store_bench, user_range_query_bare_query) {
+    run_range_queries<false>();
+}
+
+PERF_TEST(role_store_bench, remove_role) {
+    auto store = make_store();
+    size_t i = random_generators::get_int(role_names_data.size() - 1);
+    perf_tests::start_measuring_time();
+    store.remove(role_names_data[i]);
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(role_store_bench, update_role) {
+    auto store = make_store();
+    std::vector<std::string_view> membership;
+    role_member m;
+    while (membership.empty()) {
+        m = members_data[random_generators::get_int(members_data.size() - 1)];
+        auto rng = store.roles_for_member(m);
+        std::copy(rng.begin(), rng.end(), std::back_inserter(membership));
+    }
+
+    role_name n{membership[random_generators::get_int(membership.size() - 1)]};
+    perf_tests::start_measuring_time();
+    auto r = store.get(n).value();
+    auto mems = std::move(r).members();
+    store.remove(n);
+    mems.erase(m);
+    store.put(n, std::move(mems));
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(role_store_bench, put_role) {
+    role_store store = make_store();
+    role_name name{random_generators::gen_alphanum_string(32)};
+    std::vector<role_member> all_members;
+    all_members.reserve(N_MEMBERS);
+    absl::c_copy(members_data, std::back_inserter(all_members));
+    perf_tests::start_measuring_time();
+    store.put(std::move(name), std::move(all_members));
+    perf_tests::stop_measuring_time();
+}

--- a/src/v/security/tests/role_store_test.cc
+++ b/src/v/security/tests/role_store_test.cc
@@ -1,0 +1,327 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "absl/container/node_hash_set.h"
+#include "random/generators.h"
+#include "security/role.h"
+#include "security/role_store.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/range/irange.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fmt/ostream.h>
+
+#include <vector>
+
+namespace security {
+
+BOOST_AUTO_TEST_CASE(role_test) {
+    const role_member mem0{role_member_type::user, "member0"};
+    const role_member mem1{role_member_type::user, "member1"};
+
+    std::vector<role_member> mems{mem0, mem1, mem0};
+    role::container_type members{mems.begin(), mems.end()};
+    const role rol{std::move(members)};
+
+    for (const auto& m : mems) {
+        BOOST_CHECK(rol.members().contains(m));
+        BOOST_CHECK_EQUAL(rol.members().count(m), 1);
+    }
+
+    auto rep = fmt::format("{}", rol);
+    BOOST_CHECK(rep.find("{user}:{member0}") != std::string::npos);
+    BOOST_CHECK(rep.find("{user}:{member1}") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(role_store_test) {
+    const role_member mem0{role_member_type::user, "m0"};
+    const role_member mem1{role_member_type::user, "m1"};
+
+    std::vector<role_member> mems{mem0, mem1};
+    const role role0{{mem0, mem1}};
+    const role role1{{mem1}};
+
+    auto role0_copy = role0;
+    auto role1_copy = role1;
+
+    BOOST_CHECK_NE(role0, role1);
+    BOOST_CHECK_NE(role0_copy, role1_copy);
+
+    const role_name copied("copied");
+    const role_name moved("moved");
+
+    role_store store;
+    BOOST_CHECK(store.put(copied, role0));
+    store.put(moved, std::move(role0_copy));
+
+    BOOST_REQUIRE(store.get(copied).has_value());
+    BOOST_CHECK_EQUAL(store.get(copied).value(), role0);
+
+    BOOST_REQUIRE(store.get(moved).has_value());
+    BOOST_CHECK_EQUAL(store.get(moved).value(), role0);
+
+    // update roles
+    BOOST_CHECK(store.remove(copied));
+    BOOST_CHECK(store.remove(moved));
+    BOOST_CHECK(store.put(copied, role1));
+    store.put(moved, std::move(role1_copy));
+
+    BOOST_REQUIRE(store.get(copied).has_value());
+    BOOST_CHECK_EQUAL(store.get(copied).value(), role1);
+
+    BOOST_REQUIRE(store.get(moved).has_value());
+    BOOST_CHECK_EQUAL(store.get(moved).value(), role1);
+
+    // remove a role
+    BOOST_CHECK(store.contains(copied));
+    BOOST_CHECK(store.remove(copied));
+    BOOST_CHECK(!store.remove(copied));
+    BOOST_CHECK(!store.contains(copied));
+    BOOST_REQUIRE(!store.get(copied).has_value());
+    BOOST_CHECK(store.contains(moved));
+    store.clear();
+    BOOST_CHECK(!store.contains(moved));
+}
+
+BOOST_AUTO_TEST_CASE(role_store_no_update) {
+    const role_member m{role_member_type::user, "m0"};
+    const role r{{m}};
+    const role_name n{"r"};
+
+    role_store store;
+
+    {
+        BOOST_CHECK(store.put(n, r));
+        auto o = store.get(n);
+        BOOST_REQUIRE(o.has_value());
+        BOOST_CHECK(o.value() == r);
+    }
+
+    {
+        BOOST_CHECK(!store.put(n, role{}));
+        auto o = store.get(n);
+        BOOST_REQUIRE(o.has_value());
+        BOOST_CHECK(o.value() == r);
+    }
+
+    BOOST_CHECK(store.remove(n));
+
+    {
+        BOOST_CHECK(store.put(n, role{}));
+        auto o = store.get(n);
+        BOOST_REQUIRE(o.has_value());
+        BOOST_CHECK(o.value() == role{});
+    }
+}
+
+BOOST_AUTO_TEST_CASE(role_store_empty_role_test) {
+    role_store store;
+    const role r0;
+    const role_name r0_name("r0");
+    BOOST_CHECK(r0.members().empty());
+    BOOST_CHECK(store.put(r0_name, r0));
+    BOOST_CHECK(!store.put(r0_name, r0));
+    auto r = store.get(r0_name);
+    BOOST_REQUIRE(r.has_value());
+    BOOST_CHECK_EQUAL(r.value(), r0);
+}
+
+BOOST_AUTO_TEST_CASE(role_store_empty_store) {
+    role_store store;
+    const role_name n{"foo"};
+    const role_member m{role_member_type::user, "bar"};
+
+    BOOST_CHECK(!store.get(n).has_value());
+    BOOST_CHECK(store.roles_for_member(m).empty());
+    BOOST_CHECK(store
+                  .range([&m](const auto& e) {
+                      return role_store::has_member(e, m)
+                             || role_store::name_prefix_filter(e, "f");
+                  })
+                  .empty());
+    BOOST_CHECK(!store.remove(n));
+    BOOST_CHECK(!store.contains(n));
+}
+
+BOOST_AUTO_TEST_CASE(role_store_range_test) {
+    const role_member mem0{role_member_type::user, "member0"};
+    const role_member mem1{role_member_type::user, "member1"};
+
+    std::vector<role_member> mems{mem0, mem1};
+    const role role0{{mem0, mem1}};
+    const role role1{{mem0, mem1}};
+
+    BOOST_CHECK_EQUAL(role0, role1);
+
+    const role_name r0_name("role0");
+    const role_name r1_name("role1");
+
+    role_store store;
+    store.put(r0_name, role0);
+    store.put(r1_name, role1);
+
+    auto prefix_pred = [](std::string_view pfx) {
+        return [pfx](const auto& e) {
+            return role_store::name_prefix_filter(e, pfx);
+        };
+    };
+
+    auto member_prefix_pred =
+      [](const role_member& mem, std::string_view filter) {
+          return [&mem, filter](const auto& e) {
+              return role_store::has_member(e, mem)
+                     && role_store::name_prefix_filter(e, filter);
+          };
+      };
+
+    auto check_range_query =
+      [](auto& rng, absl::node_hash_set<role_name> expected) -> bool {
+        absl::node_hash_set<role_name> got{rng.begin(), rng.end()};
+        return got == expected;
+    };
+
+    {
+        auto res = store.range(prefix_pred("rol"));
+        BOOST_CHECK(check_range_query(res, {r0_name, r1_name}));
+    }
+
+    {
+        auto res = store.range(prefix_pred(""));
+        BOOST_CHECK(check_range_query(res, {r0_name, r1_name}));
+    }
+
+    {
+        // both roles contain mem1 but we also filter on the name
+        auto res = store.range(member_prefix_pred(mem1, r0_name()));
+        BOOST_CHECK(check_range_query(res, {r0_name}));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(role_store_roles_for_member) {
+    const role_member mem0{role_member_type::user, "m0"};
+    const role_member mem1{role_member_type::user, "m1"};
+    const role_member mem2{role_member_type::user, "m2"};
+
+    const role role0{{mem0, mem1, mem2}};
+    const role role1{{mem1, mem2}};
+    const role role2{{mem2}};
+
+    const role_name r0_name("role0");
+    const role_name r1_name("role1");
+    const role_name r2_name("role2");
+
+    BOOST_CHECK_NE(role0, role1);
+    BOOST_CHECK_NE(role0, role2);
+    BOOST_CHECK_NE(role1, role2);
+
+    role_store store;
+    BOOST_CHECK(store.put(r0_name, role0));
+    BOOST_CHECK(store.put(r1_name, role1));
+    BOOST_CHECK(store.put(r2_name, role2));
+
+    auto check_membership =
+      [](const auto& rng, absl::node_hash_set<role_name> expected) {
+          absl::node_hash_set<role_name> got{rng.begin(), rng.end()};
+          return got == expected;
+      };
+
+    {
+        auto itr = store.roles_for_member(mem0);
+        BOOST_CHECK(check_membership(itr, {r0_name}));
+    }
+
+    {
+        auto itr = store.roles_for_member(mem1);
+        BOOST_CHECK(check_membership(itr, {r0_name, r1_name}));
+    }
+
+    {
+        auto itr = store.roles_for_member(mem2);
+        BOOST_CHECK(check_membership(itr, {r0_name, r1_name, r2_name}));
+    }
+
+    store.remove(r0_name);
+
+    {
+        auto itr = store.roles_for_member(mem0);
+        BOOST_CHECK(check_membership(itr, {}));
+    }
+
+    {
+        auto itr = store.roles_for_member(mem1);
+        BOOST_CHECK(check_membership(itr, {r1_name}));
+    }
+
+    {
+        auto itr = store.roles_for_member(mem2);
+        BOOST_CHECK(check_membership(itr, {r1_name, r2_name}));
+    }
+
+    store.clear();
+    for (const auto& m : {mem0, mem1, mem2}) {
+        auto itr = store.roles_for_member(m);
+        BOOST_CHECK(itr.empty());
+    };
+}
+
+BOOST_AUTO_TEST_CASE(role_store_big_store) {
+    role_member stable_member{role_member_type::user, "stable"};
+    role_name stable_name{"stable"};
+
+    constexpr size_t N_MEMBERS = 1024ul << 3u;
+    constexpr size_t N_ROLES = 1024ul;
+
+    const std::vector<role_member> members_data = [extra = stable_member]() {
+        std::vector<role_member> mems{extra};
+        mems.reserve(N_MEMBERS);
+        absl::c_for_each(boost::irange(0ul, N_MEMBERS), [&mems](auto) {
+            mems.emplace_back(
+              role_member_type::user,
+              random_generators::gen_alphanum_string(32));
+        });
+        return mems;
+    }();
+
+    const std::vector<role_name> role_names_data = [extra = stable_name]() {
+        std::vector<role_name> roles{extra};
+        roles.reserve(N_ROLES);
+        absl::c_for_each(boost::irange(0ul, N_ROLES), [&roles](auto) {
+            roles.emplace_back(random_generators::gen_alphanum_string(32));
+        });
+        return roles;
+    }();
+
+    const role_store store =
+      [&stable_member, &members_data, &role_names_data]() {
+          role_store store;
+          for (auto n : role_names_data) {
+              role::container_type role_mems;
+              for (const auto& m : members_data) {
+                  if (random_generators::get_int(0, 1) || m == stable_member) {
+                      role_mems.insert(m);
+                  }
+              }
+              store.put(std::move(n), std::move(role_mems));
+          }
+          return store;
+      }();
+
+    auto r = store.get(stable_name);
+    BOOST_REQUIRE(r.has_value());
+    BOOST_CHECK(r.value().members().contains(stable_member));
+
+    auto rls = store.roles_for_member(stable_member);
+    absl::node_hash_set<std::string_view> membership{rls.begin(), rls.end()};
+    BOOST_CHECK(!membership.empty());
+    BOOST_CHECK(membership.contains(stable_name()));
+}
+
+} // namespace security

--- a/src/v/security/types.h
+++ b/src/v/security/types.h
@@ -22,4 +22,6 @@ using credential_user = named_type<ss::sstring, struct credential_user_type>;
 using credential_password
   = named_type<ss::sstring, struct credential_password_type>;
 
+using role_name = named_type<ss::sstring, struct role_name_type>;
+
 } // namespace security


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR introduces the backing in-memory store for Redpanda Roles Based Access Control (RBAC). Not yet consumed anywhere outside unit tests.

Closes https://github.com/redpanda-data/core-internal/issues/1098

```
$ llvm-cov report ./vbuild/debug/clang/bin/test_kafka_security_rpunit --instr-profile=/tmp/test_kafka_security_rpunit.profdata  -sources src/v/security/role*
Filename                      Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
role.cc                             5                 1    80.00%           3                 0   100.00%          15                 1    93.33%           4                 2    50.00%
role.h                             10                 2    80.00%          10                 2    80.00%          12                 2    83.33%           0                 0         -
role_store.h                       18                 0   100.00%          11                 0   100.00%          28                 0   100.00%          10                 2    80.00%
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                              33                 3    90.91%          24                 2    91.67%          55                 3    94.55%          14                 4    71.43%
```

benchmark:
```
| test                                         | iterations | median    | mad       | min       | max       | allocs  | tasks | inst |
| -------------------------------------------- | ---------- | --------- | --------- | --------- | --------- | ------- | ----- | ---- |
| role_store_bench.get_member_roles            | 36715      | 28.032us  | 67.716ns  | 27.382us  | 28.677us  | 0.000   | 0.000 | 0.0  |
| role_store_bench.get_member_roles_bare_query | 35869      | 28.635us  | 40.650ns  | 28.591us  | 28.684us  | 0.000   | 0.000 | 0.0  |
| role_store_bench.user_range_query            | 13443      | 73.122us  | 78.264ns  | 72.985us  | 73.278us  | 0.000   | 0.000 | 0.0  |
| role_store_bench.user_range_query_bare_query | 1919014    | 497.044ns | 0.071ns   | 496.907ns | 497.154ns | 0.000   | 0.000 | 0.0  |
| role_store_bench.remove_role                 | 40         | 18.568us  | 35.775ns  | 18.505us  | 18.618us  | 0.000   | 0.000 | 0.0  |
| role_store_bench.update_role                 | 40         | 68.332us  | 282.900ns | 68.049us  | 69.150us  | 524.725 | 0.000 | 0.0  |
| role_store_bench.put_role                    | 41         | 37.798us  | 256.268ns | 37.542us  | 38.251us  | 1.683   | 0.000 | 0.0  |
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
