### PR TITLE
rptest: better health check

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -10,8 +10,14 @@
 from logging import Logger
 import os
 import subprocess
+from typing import Any
 
 SUPPORTED_PROVIDERS = ['aws', 'gcp']
+
+
+def is_redpanda_pod(pod_obj: dict[str, Any], cluster_id: str) -> bool:
+    """Returns true if the pod API object name matches the Redpanda pattern."""
+    return pod_obj['metadata']['name'].startswith(f'rp-{cluster_id}')
 
 
 class KubectlTool:
@@ -158,7 +164,7 @@ class KubectlTool:
                 f'--------- stderr -----------\n{e.stderr.decode()}')
             raise
 
-    def cmd(self, kcmd: list[str]):
+    def cmd(self, kcmd: list[str] | str):
         """Execute a kubectl command on the agent node.
         """
         # prepare

--- a/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
+++ b/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
@@ -7,7 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-import random
 from typing import Any
 from ducktape.tests.test import TestContext
 from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
@@ -33,3 +32,9 @@ class SelfRedpandaCloudTest(RedpandaCloudTest):
         """Simple test of startup()
         """
         pass
+
+    @cluster(num_nodes=0)
+    def test_healthy(self):
+        r = self.redpanda.cluster_unhealthy_reason()
+        assert r is None, r
+        assert self.redpanda.cluster_healthy()

--- a/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
+++ b/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
@@ -38,3 +38,4 @@ class SelfRedpandaCloudTest(RedpandaCloudTest):
         r = self.redpanda.cluster_unhealthy_reason()
         assert r is None, r
         assert self.redpanda.cluster_healthy()
+        self.redpanda.assert_cluster_is_reusable()

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -249,15 +249,8 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         self.logger.info(f"Loaded install pack '{install_pack['version']}': "
                          f"Redpanda v{install_pack['redpanda_version']}, "
                          f"created at '{install_pack['created_at']}'")
-        if self.config_profile_name not in install_pack['config_profiles']:
-            # throw user friendly error
-            _profiles = ", ".join(
-                [f"'{k}'" for k in install_pack['config_profiles']])
-            raise RuntimeError(
-                f"'{self.config_profile_name}' not found among config profiles: {_profiles}"
-            )
-        config_profile = install_pack['config_profiles'][
-            self.config_profile_name]
+
+        config_profile = self.redpanda.config_profile
         cluster_config = config_profile['cluster_config']
 
         self._num_brokers = config_profile['nodes_count']

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -493,8 +493,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                                self.msg_size) as _:
             # Test will assert if advertised throughput isn't met
             time.sleep(15)
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     def _get_swarm_connections_count(self, nodes):
         _list = []
@@ -712,8 +711,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         assert _hwm >= reasonably_expected, \
             f"Expected >{reasonably_expected} messages, actual {_hwm}"
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     COMBO_PRELOADED_LOG_ALLOW_LIST = [
         re.compile('storage - .* - Stopping parser, short read. .*')
@@ -755,8 +753,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             # Block traffic to/from one node.
             self.stage_block_node_traffic()
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     NOS3_LOG_ALLOW_LIST = [
         re.compile("s3 - .* - Accessing .*, unexpected REST API error "
@@ -835,8 +832,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             # S3 up -> down -> up
             self.stage_block_s3()
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     def _cloud_storage_no_new_errors(self, redpanda, logger=None):
         num_errors = redpanda.metric_sum(
@@ -959,8 +955,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             producer.stop()
             producer.wait(timeout_sec=600)
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     def stage_decommission_and_add(self):
         def cluster_ready_replicas(cluster_name):
@@ -1261,8 +1256,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             producer.stop()
             producer.wait(timeout_sec=600)
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     def _stage_add_and_decommission(self):
         cluster_name = f'rp-{self.redpanda._cloud_cluster.cluster_id}'
@@ -1338,8 +1332,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                 consumer.stop()
                 consumer.wait(timeout_sec=600)
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     @cluster(num_nodes=7, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_consume(self):
@@ -1375,8 +1368,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             producer.wait(timeout_sec=600)
             self.free_preallocated_nodes()
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     @ignore
     @cluster(num_nodes=10, log_allow_list=RESTART_LOG_ALLOW_LIST)
@@ -1388,8 +1380,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         """
         self._create_topic_spec()
         self.stage_tiered_storage_consuming()
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     def stage_lots_of_failed_consumers(self):
         # This stage sequentially starts 1,000 consumers. Then allows
@@ -1496,8 +1487,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             producer.wait(timeout_sec=600)
             self.free_preallocated_nodes()
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     def stage_consume_miss_cache(self, producer: KgoVerifierProducer):
         # This stage produces enough data to each RP node to fill up their batch caches
@@ -1893,5 +1883,4 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             # Assert test results
             omb.check_succeed()
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -886,11 +886,11 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                        backoff_sec=5.0)
             self.logger.info(
                 f"{acked} messages produced in {time.time() - start_time}s")
-        except TimeoutException as e:
-            _throughput = producer.produce_status.acked * self.msg_size // timeout
+        except TimeoutException:
+            _throughput = producer.produce_status.acked * self.msg_size / timeout / 1e6
             raise RuntimeError(
-                f"Low throughput while preparing for the test: {_throughput}: {e}"
-            )
+                f"Low throughput while preparing for the test: {_throughput} MB/s"
+            ) from None
 
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_and_add(self):

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -276,8 +276,7 @@ class OMBValidationTest(RedpandaCloudTest):
         finally:
             self.rpk.delete_topic(swarm_topic_name)
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     def _warn_metrics(self, metrics, validator):
         """Validates metrics and just warn if any fail."""
@@ -382,8 +381,7 @@ class OMBValidationTest(RedpandaCloudTest):
         # fail test if the latency is above expected including fudge factor
         benchmark.check_succeed()
 
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     @cluster(num_nodes=CLUSTER_NODES)
     def test_common_workload(self):
@@ -437,8 +435,7 @@ class OMBValidationTest(RedpandaCloudTest):
         benchmark_time_min = benchmark.benchmark_time() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()
 
     @cluster(num_nodes=CLUSTER_NODES)
     def test_retention(self):
@@ -505,5 +502,4 @@ class OMBValidationTest(RedpandaCloudTest):
         benchmark_time_min = benchmark.benchmark_time() + 5
         benchmark.wait(timeout_sec=benchmark_time_min * 60)
         benchmark.check_succeed()
-        assert self.redpanda.cluster_healthy(
-        ), 'cluster unhealthy at end of test'
+        self.redpanda.assert_cluster_is_reusable()

--- a/tests/rptest/services/openmessaging_benchmark.py
+++ b/tests/rptest/services/openmessaging_benchmark.py
@@ -197,7 +197,7 @@ class OpenMessagingBenchmark(Service):
         if node:
             self.nodes = [node]
 
-        self._metrics = []
+        self._metrics: dict[str, Any] = {}
         self._ctx = ctx
         self.topology = topology
         self.redpanda = redpanda

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -773,8 +773,8 @@ class SecurityConfig:
     # sasl is required
     def sasl_enabled(self):
         return (self.kafka_enable_authorization is None and self.enable_sasl
-                and self.endpoint_authn_method is None
-                ) or self.endpoint_authn_method == "sasl"
+                and self.endpoint_authn_method
+                is None) or self.endpoint_authn_method == "sasl"
 
     # principal is extracted from mtls distinguished name
     def mtls_identity_enabled(self):
@@ -1180,8 +1180,10 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
         the health of a node after a restart.
         """
         counts: dict[int, int
-                     | None] = {self.idx(node): None
-                                for node in self.nodes}
+                     | None] = {
+                         self.idx(node): None
+                         for node in self.nodes
+                     }
         for node in self.nodes:
             try:
                 metrics = self.metrics(node)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1678,8 +1678,13 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
 
     @cached_property
     def config_profile(self) -> dict[str, Any]:
-        return self.get_install_pack()['config_profiles'][
-            self.config_profile_name]
+        profiles: dict[str, Any] = self.get_install_pack()['config_profiles']
+        if self.config_profile_name not in profiles:
+            # throw user friendly error
+            raise RuntimeError(
+                f"'{self.config_profile_name}' not found among config profiles: {profiles.keys()}"
+            )
+        return profiles[self.config_profile_name]
 
     def restart_pod(self, pod_name: str, timeout: int = 180):
         """Restart a pod by name

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -56,7 +56,7 @@ from rptest.clients.rpk_remote import RpkRemoteTool
 from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.clients.installpack import InstallPackClient
 from rptest.clients.rp_storage_tool import RpStorageTool
-from rptest.services import tls
+from rptest.services import redpanda_types, tls
 from rptest.services.admin import Admin
 from rptest.services.redpanda_installer import RedpandaInstaller, VERSION_RE as RI_VERSION_RE, int_tuple as ri_int_tuple
 from rptest.services.redpanda_cloud import CloudCluster, CloudTierName, get_config_profile_name
@@ -74,8 +74,8 @@ Partition = collections.namedtuple('Partition',
 MetricSample = collections.namedtuple(
     'MetricSample', ['family', 'sample', 'node', 'value', 'labels'])
 
-SaslCredentials = collections.namedtuple("SaslCredentials",
-                                         ["username", "password", "algorithm"])
+SaslCredentials = redpanda_types.SaslCredentials
+
 # Map of path -> (checksum, size)
 FileToChecksumSize = dict[str, Tuple[str, int]]
 

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -18,11 +18,10 @@ from rptest.services.provider_clients.ec2_client import RTBS_LABEL
 from rptest.services.provider_clients.rpcloud_client import RpCloudApiClient
 from urllib.parse import urlparse
 
+from rptest.services.redpanda_types import SaslCredentials
+
 ns_name_prefix = "rp-ducktape-ns-"
 ns_name_date_fmt = "%Y-%m-%d-%H%M%S-"
-
-SaslCredentials = collections.namedtuple("SaslCredentials",
-                                         ["username", "password", "algorithm"])
 
 CLOUD_TYPE_FMC = 'FMC'
 CLOUD_TYPE_BYOC = 'BYOC'

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -1,0 +1,6 @@
+import collections
+
+# Basic types shared between various redpanda service and test modes.
+
+SaslCredentials = collections.namedtuple("SaslCredentials",
+                                         ["username", "password", "algorithm"])


### PR DESCRIPTION
This series mostly deals with better health checks to catch cases where test failures (or tests that don't clean up after themselves even on success) may leave the cluster in an unusable state.

Individual commit messages have more details.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - cloud DT test
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
