### PR TITLE
Introduce `principal_type::role`

### DIFF
--- a/src/go/rpk/pkg/cli/acl/common.go
+++ b/src/go/rpk/pkg/cli/acl/common.go
@@ -36,6 +36,8 @@ const (
 	operationFlag      = "operation"
 
 	kafkaCluster = "kafka-cluster"
+
+	rolePrefix = "RedpandaRole:"
 )
 
 var (
@@ -282,7 +284,7 @@ func (a *acls) createCreations() (*kadm.ACLBuilder, error) {
 		Deny(a.denyPrincipals...).
 		DenyHosts(a.denyHosts...)
 
-	b.PrefixUserExcept() // add "User:" prefix to everything if needed
+	b.PrefixUserExcept(rolePrefix) // add "User:" prefix to everything if needed
 
 	return b, b.ValidateCreate()
 }
@@ -329,7 +331,7 @@ func (a *acls) createDeletionsAndDescribes(
 		b.DenyHosts()
 	}
 
-	b.PrefixUserExcept() // add "User:" prefix to everything if needed
+	b.PrefixUserExcept(rolePrefix) // add "User:" prefix to everything if needed
 
 	return b, b.ValidateFilter()
 }

--- a/src/v/kafka/server/handlers/details/security.h
+++ b/src/v/kafka/server/handlers/details/security.h
@@ -31,21 +31,32 @@ struct acl_conversion_error : std::exception {
 
 inline security::acl_principal to_acl_principal(const ss::sstring& principal) {
     std::string_view view(principal);
-    if (unlikely(!view.starts_with("User:"))) {
+    constexpr std::string_view user_prefix{"User:"};
+    constexpr std::string_view role_prefix{"RedpandaRole:"};
+    auto usr = view.starts_with(user_prefix);
+    auto rol = !usr && view.starts_with(role_prefix);
+
+    if (unlikely(!usr && !rol)) {
         throw acl_conversion_error(
           fmt::format("Invalid principal name: {{{}}}", principal));
     }
-    // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers)
-    auto user = principal.substr(5);
-    if (unlikely(user.empty())) {
+
+    auto name = principal.substr(usr ? user_prefix.size() : role_prefix.size());
+    if (unlikely(name.empty())) {
         throw acl_conversion_error(
           fmt::format("Principal name cannot be empty"));
     }
-    if (user == "*") {
-        return security::acl_wildcard_user;
+    if (name == "*") {
+        if (usr) {
+            return security::acl_wildcard_user;
+        } else {
+            throw acl_conversion_error(
+              fmt::format("Illegal wildcard role: {{{}}}", principal));
+        }
     }
     return security::acl_principal(
-      security::principal_type::user, std::move(user));
+      usr ? security::principal_type::user : security::principal_type::role,
+      std::move(name));
 }
 
 inline security::acl_host to_acl_host(const ss::sstring& host) {
@@ -303,6 +314,8 @@ inline ss::sstring to_kafka_principal(const security::acl_principal& p) {
         return fmt::format("User:{}", p.name());
     case security::principal_type::ephemeral_user:
         return fmt::format("Ephemeral user:{}", p.name());
+    case security::principal_type::role:
+        return fmt::format("RedpandaRole:{}", p.name());
     }
     __builtin_unreachable();
 }

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -317,6 +317,8 @@ std::ostream& operator<<(std::ostream& os, principal_type type) {
         return os << "user";
     case principal_type::ephemeral_user:
         return os << "ephemeral user";
+    case principal_type::role:
+        return os << "role";
     }
     __builtin_unreachable();
 }

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -116,6 +116,7 @@ std::ostream& operator<<(std::ostream&, acl_permission);
 enum class principal_type : int8_t {
     user = 0,
     ephemeral_user = 1,
+    role = 2,
 };
 
 std::ostream& operator<<(std::ostream&, resource_type);

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -275,12 +275,12 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
         args = ["--list"]
         return self._run("kafka-acls.sh", args)
 
-    def create_cluster_acls(self, username, op):
+    def create_cluster_acls(self, username, op, ptype: str = "User"):
         """
         Add allow+describe+cluster ACL
         """
         args = ["--add"]
-        args += ["--allow-principal", f"User:{username}"]
+        args += ["--allow-principal", f"{ptype}:{username}"]
         args += ["--operation", op, "--cluster"]
         return self._run("kafka-acls.sh", args)
 


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR introduces a new type of security principal for RBAC. 
Updates `security::to_acl_principal` and `security::to_kafka_principal` to support "Role:" prefix.
Includes a small `rpk` update to respect the "Role:" prefix when creating/deleting ACLs

Closes https://github.com/redpanda-data/core-internal/issues/1100

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
