### PR TITLE
archival: Improve archival STM concurrency control

### DIFF
--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -802,6 +802,26 @@ ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
 
     const auto current_term = _insync_term;
 
+    // If the caller didn't invoke `sync` before calling `replicate` we
+    // might have some batches which are not applied to the STM yet. These
+    // batches could potentially set _active_operation_res and therefore
+    // mask the actual failure.
+    {
+        auto commit = _raft->committed_offset();
+        auto insync = _manifest->get_insync_offset();
+        if (insync < commit) {
+            vlog(_logger.debug, "Replicate is called while STM is catching up");
+            auto sync_res = co_await do_sync(
+              config::shard_local_cfg()
+                .cloud_storage_metadata_sync_timeout_ms.value(),
+              &as);
+            if (!sync_res) {
+                vlog(_logger.warn, "Failed to catch up");
+                co_return errc::timeout;
+            }
+        }
+    }
+
     // Create a promise to deliver the result of the batch application
     _active_operation_res.emplace();
     auto broken_promise_to_shutdown = [](const ss::broken_promise&) {

--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -192,6 +192,16 @@ struct archival_metadata_stm::update_highest_producer_id_cmd {
     using value = model::producer_id;
 };
 
+struct archival_metadata_stm::read_write_fence_cmd
+  : public serde::envelope<
+      read_write_fence_cmd,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    static constexpr cmd_key key{14};
+
+    model::offset last_applied_offset;
+};
+
 // Serde format description
 // v5
 //  - add apply_offset field
@@ -414,6 +424,17 @@ command_batch_builder& command_batch_builder::cleanup_archive(
       archival_metadata_stm::truncate_archive_commit_cmd::key);
     auto record_val = archival_metadata_stm::truncate_archive_commit_cmd::value{
       .start_offset = start_rp_offset, .bytes_removed = bytes_removed};
+    iobuf val_buf = serde::to_iobuf(record_val);
+    _builder.add_raw_kv(std::move(key_buf), std::move(val_buf));
+    return *this;
+}
+
+command_batch_builder&
+command_batch_builder::read_write_fence(model::offset offset) {
+    iobuf key_buf = serde::to_iobuf(
+      archival_metadata_stm::read_write_fence_cmd::key);
+    auto record_val = archival_metadata_stm::read_write_fence_cmd{
+      .last_applied_offset = offset};
     iobuf val_buf = serde::to_iobuf(record_val);
     _builder.add_raw_kv(std::move(key_buf), std::move(val_buf));
     return *this;
@@ -962,8 +983,10 @@ ss::future<> archival_metadata_stm::apply(const model::record_batch& b) {
                                 model::record&& r) {
                 auto key = serde::from_iobuf<cmd_key>(r.release_key());
 
-                _manifest->advance_applied_offset(
-                  base_offset + model::offset{r.offset_delta()});
+                if (key != read_write_fence_cmd::key) {
+                    _manifest->advance_applied_offset(
+                      base_offset + model::offset{r.offset_delta()});
+                }
 
                 if (key != mark_clean_cmd::key) {
                     // All keys other than mark clean make the manifest dirty
@@ -1030,12 +1053,23 @@ ss::future<> archival_metadata_stm::apply(const model::record_batch& b) {
                       serde::from_iobuf<update_highest_producer_id_cmd::value>(
                         r.release_value()));
                     break;
+                case read_write_fence_cmd::key:
+                    if (apply_read_write_fence(
+                          serde::from_iobuf<read_write_fence_cmd>(
+                            r.release_value()))) {
+                        // This means that there is a concurrency violation. The
+                        // fence was created before some other command was
+                        // applied. We can't apply the commands from this batch.
+                        return ss::stop_iteration::yes;
+                    }
+                    break;
                 default:
                     throw std::runtime_error(fmt_with_ctx(
                       fmt::format,
                       "Unknown archival metadata STM command {}",
                       static_cast<int>(key)));
                 };
+                return ss::stop_iteration::no;
             });
         } catch (...) {
             vlog(
@@ -1380,6 +1414,21 @@ void archival_metadata_stm::apply_update_start_kafka_offset(kafka::offset so) {
 void archival_metadata_stm::apply_reset_metadata() {
     vlog(_logger.info, "Resetting manifest");
     _manifest->unsafe_reset();
+}
+
+bool archival_metadata_stm::apply_read_write_fence(
+  const archival_metadata_stm::read_write_fence_cmd& cmd) noexcept {
+    if (_manifest->get_applied_offset() != cmd.last_applied_offset) {
+        vlog(
+          _logger.warn,
+          "Concurrent modification error detected, current applied offset: {}, "
+          "read-write fence: {}",
+          _manifest->get_applied_offset(),
+          cmd.last_applied_offset);
+        maybe_notify_waiter(errc::concurrent_modification_error);
+        return true;
+    }
+    return false;
 }
 
 void archival_metadata_stm::apply_update_highest_producer_id(

--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -440,6 +440,17 @@ command_batch_builder::read_write_fence(model::offset offset) {
     return *this;
 }
 
+command_batch_builder& command_batch_builder::update_highest_producer_id(
+  model::producer_id highest_pid) {
+    if (highest_pid != model::producer_id{}) {
+        iobuf key_buf = serde::to_iobuf(
+          archival_metadata_stm::update_highest_producer_id_cmd::key);
+        iobuf val_buf = serde::to_iobuf(highest_pid());
+        _builder.add_raw_kv(std::move(key_buf), std::move(val_buf));
+    }
+    return *this;
+}
+
 ss::future<std::error_code> command_batch_builder::replicate() {
     _as.check();
     return _stm.get()._lock.with([this]() {

--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -235,8 +235,9 @@ public:
 
     /// This method guarantees that the STM applied all changes
     /// in the log to the in-memory state.
-    ss::future<bool> sync(model::timeout_clock::duration timeout);
-    ss::future<bool>
+    ss::future<std::optional<model::offset>>
+    sync(model::timeout_clock::duration timeout);
+    ss::future<std::optional<model::offset>>
     sync(model::timeout_clock::duration timeout, ss::abort_source* as);
 
     model::offset get_start_offset() const;

--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -102,6 +102,10 @@ public:
     /// concurrency-control mechanism.
     command_batch_builder& read_write_fence(model::offset offset);
 
+    /// Add update_highest_producer_id_cmd command
+    command_batch_builder&
+    update_highest_producer_id(model::producer_id highest_pid);
+
     /// Replicate the configuration batch
     ss::future<std::error_code> replicate();
 

--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -14,20 +14,26 @@
 #include "cloud_storage/fwd.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
+#include "cluster/errc.h"
 #include "cluster/state_machine_registry.h"
 #include "features/fwd.h"
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "model/timeout_clock.h"
 #include "raft/persisted_stm.h"
 #include "storage/record_batch_builder.h"
 #include "utils/mutex.h"
 #include "utils/prefix_logger.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/circular_buffer.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/weak_ptr.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+#include <exception>
 #include <functional>
 #include <system_error>
 
@@ -36,6 +42,7 @@ namespace cluster {
 namespace details {
 /// This class is supposed to be implemented in unit tests.
 class archival_metadata_stm_accessor;
+class command_batch_builder_accessor;
 } // namespace details
 
 class archival_metadata_stm;
@@ -45,6 +52,8 @@ using segment_validated = ss::bool_class<struct segment_validated_tag>;
 /// Batch builder allows to combine different archival_metadata_stm commands
 /// together in a single record batch
 class command_batch_builder {
+    friend class command_batch_builder_accessor;
+
 public:
     command_batch_builder(
       archival_metadata_stm& stm,
@@ -85,6 +94,7 @@ public:
       cloud_storage::scrub_status status,
       cloud_storage::anomalies detected);
     command_batch_builder& reset_scrubbing_metadata();
+
     /// Replicate the configuration batch
     ss::future<std::error_code> replicate();
 
@@ -212,10 +222,11 @@ public:
       model::term_id term,
       const cloud_storage::partition_manifest& manifest);
 
-    // Attempts to bring the archival STM in sync with the log.
-    // Returns "true" if it has synced succesfully *and* the replica
-    // is still the leader with the correct term.
+    /// This method guarantees that the STM applied all changes
+    /// in the log to the in-memory state.
     ss::future<bool> sync(model::timeout_clock::duration timeout);
+    ss::future<bool>
+    sync(model::timeout_clock::duration timeout, ss::abort_source* as);
 
     model::offset get_start_offset() const;
     model::offset get_last_offset() const;
@@ -228,7 +239,7 @@ public:
     fragmented_vector<cloud_storage::partition_manifest::lw_segment_meta>
     get_segments_to_cleanup() const;
 
-    /// Create batch builder that can be used to combine and replicate multipe
+    /// Create batch builder that can be used to combine and replicate multiple
     /// STM commands together
     command_batch_builder
     batch_start(ss::lowres_clock::time_point deadline, ss::abort_source&);
@@ -251,6 +262,9 @@ public:
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 private:
+    ss::future<bool>
+    do_sync(model::timeout_clock::duration timeout, ss::abort_source* as);
+
     ss::future<std::error_code> do_add_segments(
       std::vector<cloud_storage::segment_meta>,
       std::optional<model::offset> clean_offset,
@@ -317,6 +331,10 @@ private:
     void apply_reset_scrubbing_metadata();
     void apply_update_highest_producer_id(model::producer_id pid);
 
+    // Notify current waiter in the 'do_replicate'
+    void maybe_notify_waiter(cluster::errc) noexcept;
+    void maybe_notify_waiter(std::exception_ptr) noexcept;
+
 private:
     prefix_logger _logger;
 
@@ -332,12 +350,7 @@ private:
     // The offset of the last record that modified this stm
     model::offset _last_dirty_at;
 
-    // The last replication future
-    struct last_replicate {
-        model::term_id term;
-        ss::shared_future<result<raft::replicate_result>> result;
-    };
-    std::optional<last_replicate> _last_replicate;
+    std::optional<ss::promise<errc>> _active_operation_res;
 
     cloud_storage::remote& _cloud_storage_api;
     features::feature_table& _feature_table;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -362,9 +362,9 @@ ss::future<> ntp_archiver::upload_until_abort() {
         vlog(_rtclog.debug, "upload loop starting in term {}", _start_term);
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
-        bool is_synced = co_await _parent.archival_meta_stm()->sync(
+        auto is_synced = co_await _parent.archival_meta_stm()->sync(
           sync_timeout);
-        if (!is_synced) {
+        if (!is_synced.has_value()) {
             continue;
         }
         vlog(_rtclog.debug, "upload loop synced in term {}", _start_term);
@@ -667,9 +667,9 @@ ss::future<> ntp_archiver::upload_until_term_change() {
 
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
-        bool is_synced = co_await _parent.archival_meta_stm()->sync(
+        auto is_synced = co_await _parent.archival_meta_stm()->sync(
           sync_timeout);
-        if (!is_synced) {
+        if (!is_synced.has_value()) {
             // This can happen on leadership changes, or on timeouts waiting
             // for stm to catch up: in either case, we should re-check our
             // loop condition: we will drop out if lost leadership, otherwise

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -494,6 +494,7 @@ FIXTURE_TEST(
         pm.add(name, s);
     }
     pm.advance_insync_offset(model::offset{4});
+    pm.advance_applied_offset(model::offset{4});
     archival_stm
       ->add_segments(
         m,

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -45,9 +45,14 @@ ss::logger logger{"archival_metadata_stm_test"};
 
 static ss::abort_source never_abort;
 
+namespace cluster::details {
+class command_batch_builder_accessor {};
+} // namespace cluster::details
+
 struct archival_metadata_stm_base_fixture
   : simple_raft_fixture
-  , http_imposter_fixture {
+  , http_imposter_fixture
+  , cluster::details::command_batch_builder_accessor {
     using simple_raft_fixture::start_raft;
     using simple_raft_fixture::wait_for_becoming_leader;
     using simple_raft_fixture::wait_for_confirmed_leader;

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1193,7 +1193,8 @@ partition_manifest partition_manifest::clone() const {
       _last_partition_scrub,
       _last_scrubbed_offset,
       _detected_anomalies,
-      _highest_producer_id);
+      _highest_producer_id,
+      _applied_offset);
     return tmp;
 }
 
@@ -2053,7 +2054,8 @@ void partition_manifest::do_update(partition_manifest_handler&& handler) {
     if (
       handler._version != to_underlying(manifest_version::v1)
       && handler._version != to_underlying(manifest_version::v2)
-      && handler._version != to_underlying(manifest_version::v3)) {
+      && handler._version != to_underlying(manifest_version::v3)
+      && handler._version != to_underlying(manifest_version::v4)) {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "partition manifest version {} is not supported",
@@ -2626,7 +2628,7 @@ partition_manifest::timequery(model::timestamp t) const {
 struct partition_manifest_serde
   : public serde::envelope<
       partition_manifest_serde,
-      serde::version<to_underlying(manifest_version::v3)>,
+      serde::version<to_underlying(manifest_version::v4)>,
       serde::compat_version<0>> {
     model::ntp _ntp;
     model::initial_revision_id _rev;
@@ -2650,6 +2652,7 @@ struct partition_manifest_serde
     model::timestamp _last_partition_scrub;
     std::optional<model::offset> _last_scrubbed_offset;
     model::producer_id _highest_producer_id;
+    model::offset _applied_offset;
 };
 
 static_assert(

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -83,6 +83,7 @@ enum class manifest_version : int32_t {
     v1 = 1,
     v2 = 2,
     v3 = 3, // v23.3.x
+    v4 = 4, // add applied_offset field
 };
 
 enum class tx_range_manifest_version : int32_t {

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -81,6 +81,7 @@ enum class errc : int16_t {
     transform_count_limit_exceeded,
     role_exists,
     role_does_not_exist,
+    inconsistent_stm_update,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -235,6 +236,8 @@ struct errc_category final : public std::error_category {
             return "Role already exists";
         case errc::role_does_not_exist:
             return "Role does not exist";
+        case errc::inconsistent_stm_update:
+            return "STM command can't be applied";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1007,6 +1007,11 @@ partition::replicate_unsafe_reset(cloud_storage::partition_manifest manifest) {
     auto replication_deadline = ss::lowres_clock::now() + sync_timeout;
     std::vector<cluster::command_batch_builder> builders;
 
+    // TODO: move this logic to the ntp_archiver
+    // currently, the 'batch_start' method will work even if there is an
+    // active input queue instance. The batch replicated here may interrupt
+    // some operation in the archiver but the correctness will not be
+    // compromised.
     auto reset_builder = _archival_meta_stm->batch_start(
       replication_deadline, _as);
     reset_builder.replace_manifest(manifest.to_iobuf());

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1121,7 +1121,7 @@ partition::unsafe_reset_remote_partition_manifest_from_cloud(bool force) {
                           .cloud_storage_metadata_sync_timeout_ms.value();
     auto sync_result = co_await ss::coroutine::as_future(
       _archival_meta_stm->sync(sync_timeout));
-    if (sync_result.failed() || sync_result.get() == false) {
+    if (sync_result.failed() || sync_result.get() == std::nullopt) {
         vlog(
           clusterlog.warn,
           "[{}] Could not sync with log. Skipping unsafe reset ...",

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -99,6 +99,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::transform_count_limit_exceeded:
     case cluster::errc::role_exists:
     case cluster::errc::role_does_not_exist:
+    case cluster::errc::inconsistent_stm_update:
         break;
     }
     return error_code::unknown_server_error;


### PR DESCRIPTION
Currently, the archival STM doesn't propagate errors from the background loop to the caller. The background loop applies record batches to the in-memory state of the STM. Recently, the admission control mechanism was introduced. The background loop checks if the batch can be safely applied and only after that it can apply any changes to the in-memory state of the STM. This is needed to avoid metadata inconsistencies. If the batch can't be safely applied it gets discarded. The problem is that the caller is not receiving the error code.

This PR fixes error propagation. The caller now receives an `inconsistent_stm_update` error in case if metadata inconsistency have been detected. 

Apart from this the PR changes the `sync` method implementation. The `sync` method of the `persisted_stm` assumes that it will be called once in the beginning of the term. If the STM is responsible for creating its own commands (provides the write interface) it guarantees that no commands were replicated in the current term so `sync` guarantees that the in-memory state of the STM is up to date.

The archival STM maintains a complex data structure (the manifest) and the `ntp_archiver` makes decisions based on this state. Because of that it's crucial to guarantee that the state is up to date. Otherwise the `ntp_archiver` may try to replicate inconsistent metadata. Previously, we called `sync` in the beginning of the upload loop which was started in the beginning of the term.

Since then the mid-term restart was added to the `ntp_archiver`. In some cases we can restart the archiver which may lead to the metadata inconsistencies (they `sync` call doesn't help in this case because it only guarantees that all batches from previous terms are applied). We modified the `sync` so it would work as expected after mid-term restart. The archival STM stored the current `replicate` future (implemented as shared future). In the `sync` call we would check if there is an ongoing `replicate` call and wait for the future to be ready and apply some other logic based on current term/offset of the raft group.

This PR changes the implementation of the `sync`. It removes cached `shared_future` from the archival STM. To guarantee that there is no in-flight replication request the code acquires the lock (all replication operations related to the STM are performed under the lock). Then it waits until current `committed_offset` of the Raft group is applied to the in-memory state of the STM.

There is another concurrency control improvement in this PR. To guarantee that we can't apply inconsistent metadata even if it passes the check for some reason the `read-write-fence` command was added. First, the manifest is now tracking the offset of the last applied STM command in the `applied_offset` field. The `read-write-fence` command contains the applied offset from the manifest. When the background loop processes this command it compares the offset in the manifest to the offset in the command and if it's different it skips the batch. The idea is that the `ntp_archiver` should cache the applied offset before upload is created. When the upload is completed it should add `read-write-fence` command to the batch that contains archival metadata. This will guarantee that the metadata update will happen only if the manifest didn't change concurrently during the upload operation.

### Updates
[Force push](https://github.com/redpanda-data/redpanda/compare/25e0cd3209dd4f6c4d9f03dee68c1554508e2bc4..2dc4dbcadc9077894a2c106b87dc7f4e07f60735) - rebase with dev
[Force push](https://github.com/redpanda-data/redpanda/commit/ac9714485b94c8544e1fa761375b20df2cb47c60) - make `sync` method return `optional<offset>` that contains `nullopt` on failure or read-write-fence offset on success. The offset is supposed to be used to add a fence to the command batch.
[Force push](https://github.com/redpanda-data/redpanda/pull/16774/commits/a07f8fbba9661b0b25e3e6a459e8fa87db0ca67a) - avoid triggering the per-operation promise when STM is catching up (commit has detailed description)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Improve concurrency control and metadata consistency in Tiered-Storage.