### PR TITLE
tests: refactor consumer group balancing test

### DIFF
--- a/tests/rptest/tests/consumer_group_balancing_test.py
+++ b/tests/rptest/tests/consumer_group_balancing_test.py
@@ -7,195 +7,63 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
-from rptest.services.cluster import cluster
-
+from collections import defaultdict
+from math import floor
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
-from rptest.services.kafka_cli_consumer import KafkaCliConsumer
-from rptest.services.rpk_producer import RpkProducer
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+
 from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.utils.util import wait_until
-from xxhash import xxh64
-import jump  # package jump-consistent-hash
-from math import ceil, floor
 
-cgroup_balancing_test_num_brokers = 3
-cgroup_balancing_test_num_groups = 3
+consumer_group_topic_partitions = 64
 
 
 class ConsumerGroupBalancingTest(RedpandaTest):
     def __init__(self, test_ctx, *args, **kwargs):
-        self._ctx = test_ctx
-        self.producer = None
-        super(ConsumerGroupBalancingTest, self).__init__(
-            test_ctx,
-            num_brokers=cgroup_balancing_test_num_brokers,
-            *args,
-            extra_rp_conf={
-                # disable leader balancer until even distribution control
-                # of __consumer_offsets leaders is implemented
-                "enable_leader_balancer": False,
-                # only partition distribution is tested yet, so we need
-                # a sigle replica per __consumer_offsets partition.
-                # this will change with implementation of
-                # even distribution control of __consumer_offsets leaders
-                "internal_topic_replication_factor": 1,
-                # a __consumer_offsets partiton per cgroup
-                "group_topic_partitions": cgroup_balancing_test_num_groups,
-            },
-            **kwargs)
+        super(ConsumerGroupBalancingTest,
+              self).__init__(test_ctx,
+                             num_brokers=5,
+                             *args,
+                             extra_rp_conf={
+                                 "group_topic_partitions":
+                                 consumer_group_topic_partitions,
+                             },
+                             **kwargs)
 
-    def make_consumer_properties(base_properties, instance_id=None):
-        properties = {}
-        properties.update(base_properties)
-        if instance_id:
-            properties['group.instance.id'] = instance_id
-        return properties
-
-    def create_consumer(self,
-                        topic,
-                        group,
-                        instance_id=None,
-                        consumer_properties={}):
-        return KafkaCliConsumer(self.test_context,
-                                self.redpanda,
-                                topic=topic,
-                                group=group,
-                                from_beginning=True,
-                                formatter_properties={
-                                    'print.value': 'false',
-                                    'print.key': 'false',
-                                    'print.partition': 'true',
-                                    'print.offset': 'true',
-                                },
-                                consumer_properties=ConsumerGroupBalancingTest.
-                                make_consumer_properties(
-                                    consumer_properties, instance_id))
-
-    def consumed_at_least(consumers, count):
-        return all([c._message_cnt > count for c in consumers])
-
-    def validate_group_state(self,
-                             group,
-                             expected_state,
-                             static_members,
-                             group_members: int = 2):
-        rpk = RpkTool(self.redpanda)
-        # validate group state
-        rpk_group = rpk.group_describe(group)
-
-        assert rpk_group.members == group_members
-        assert rpk_group.state == expected_state
-
-        for p in rpk_group.partitions:
-            if static_members:
-                assert 'panda-consumer' in p.instance_id
-            else:
-                assert p.instance_id is None
-
-    def setup_producer(self, p_cnt):
-        # create topic
-        self.topic_spec = TopicSpec(partition_count=p_cnt,
-                                    replication_factor=3)
-        self.client().create_topic(specs=self.topic_spec)
-        # produce some messages to the topic
-        self.producer = RpkProducer(self._ctx, self.redpanda,
-                                    self.topic_spec.name, 128, 5000, -1)
-        self.producer.start()
-
-    @cluster(num_nodes=cgroup_balancing_test_num_brokers +
-             cgroup_balancing_test_num_groups + 1)
+    @cluster(num_nodes=5)
     def test_coordinator_nodes_balance(self):
         """
         Test checking that consumer group coordinators are distributed evenly across nodes
         """
-        static_members = True
-        self.logger.info(
-            f"brokers: {len(self.redpanda.cluster_spec)} / {len(self.cluster)}"
-        )
 
-        # verify that the names of the groups used will map to different
-        # partitions internally
-        groups = []
-        group_hashes = set()
-        partition_ids = set()
-        for i in range(cgroup_balancing_test_num_groups):
-            group_name = f"cgrp-{i}"  # only tested for 1..3 yet
-            group_hash = xxh64(group_name).intdigest()
-            assert not group_hash in group_hashes
-            partition_id = jump.hash(group_hash,
-                                     cgroup_balancing_test_num_groups)
-            assert not partition_id in partition_ids
-            groups.append(group_name)
-            group_hashes.add(group_hash)
-            partition_ids.add(partition_id)
+        topic = TopicSpec(partition_count=1)
+        self.client().create_topic(topic)
 
-        self.logger.info(f"starting producers and consumers, groups: {groups}")
-
-        # partition count in data topics does not matter
-        self.setup_producer(1)
-
-        # create 1 consumer per group
-        consumers_all = []
-        consumers_by_group = {}
-        for group in groups:
-            instance_id = f"panda-consumer-{group}" if static_members else None
-            consumer = self.create_consumer(self.topic_spec.name,
-                                            group=group,
-                                            instance_id=instance_id)
-            consumer.start()
-            consumers_by_group[group] = [consumer]
-            consumers_all.append(consumer)
-
-        # wait for some messages
-        self.logger.info(f"waiting for some messages")
-        wait_until(
-            lambda: ConsumerGroupBalancingTest.consumed_at_least(
-                consumers_all, 50), 30, 2)
-        # all groups should be stable
-        self.logger.info(f"checking groups are stable")
-        for group in groups:
-            self.validate_group_state(group,
-                                      expected_state="Stable",
-                                      static_members=static_members,
-                                      group_members=1)
-        # stop consumers
-        self.logger.info(f"stopping producers and consumers")
-        for c in consumers_all:
-            c.stop()
-        for c in consumers_all:
-            c.wait()
-            c.free()
-        self.producer.wait()
-        self.producer.free()
-
+        # execute a single produce/consume to initialize __consumer_group topic
         rpk = RpkTool(self.redpanda)
-        coord_groups = {}
-        # find coordinator of each group
-        for group in groups:
-            group_desc = rpk.group_describe(group)
-            self.logger.info(f"group {group}: {group_desc}")
-            coord_groups[group_desc.coordinator] = coord_groups.get(
-                group_desc.coordinator, 0) + 1
+        rpk.produce(topic=topic.name,
+                    key="test_key",
+                    msg="test_msg",
+                    partition=0)
 
-        # model the ideal cgroup coordinators distribution
-        coord_density = sorted(coord_groups.values(), reverse=True)
-        expected_coord_density = [
-            ceil(len(groups) / len(self.redpanda.nodes))
-            for _ in range(len(groups) % len(self.redpanda.nodes))
-        ] + [
-            floor(len(groups) / len(self.redpanda.nodes)) for _ in range(
-                len(groups) %
-                len(self.redpanda.nodes), len(self.redpanda.nodes))
-        ]
+        rpk.consume(topic=topic.name, n=1, group="test-group")
 
-        # actual distribution must match the model
-        if coord_density != expected_coord_density:
-            self.logger.error(
-                "Uneven distribution of group coordinators across nodes. "
-                f"coordinators of groups: {coord_groups}, "
-                f"groups: {len(groups)}, brokers: {len(self.redpanda.nodes)}, "
-                f"coord_density: {coord_density}, expected_coord_density: {expected_coord_density}"
+        admin = Admin(self.redpanda)
+        partitions = admin.get_partitions("__consumer_offsets")
+        replicas_per_node = defaultdict(lambda: 0)
+
+        expected_number_of_replicas = floor(
+            (consumer_group_topic_partitions * 3) / 5)
+
+        for p in partitions:
+            for node in p['replicas']:
+                replicas_per_node[node['node_id']] += 1
+
+        for node, replicas in replicas_per_node.items():
+            self.logger.info(
+                f"__consumer_offsets partition has: {replicas} replicas on node: {node}"
             )
-            raise RuntimeError(
-                "Uneven distribution of group coordinators across brokers")
+            assert replicas in range(expected_number_of_replicas - 1,
+                                     expected_number_of_replicas + 2)


### PR DESCRIPTION
Refactor consumer group balancing test to directly validate `__consumer_offsets` partition replicas placement instead of validating consumer groups coordinators.

Fixes: #9697

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none