### PR TITLE
Cloud Storage: Ignore abort_requested_exception on shutdown

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -1268,6 +1268,8 @@ ss::future<upload_result> remote::delete_objects_sequentially(
                              results.push_back(result);
                          });
                    })
+            .handle_exception_type(
+              [](const ss::abort_requested_exception& /* ignore */) {})
             .handle_exception_type([ctxlog](const std::exception& ex) {
                 vlog(ctxlog.error, "Failed to delete keys: {}", ex.what());
             })

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -19,6 +19,7 @@
 #include "cloud_storage_clients/types.h"
 #include "cloud_storage_clients/util.h"
 #include "model/metadata.h"
+#include "ssx/future-util.h"
 #include "ssx/semaphore.h"
 #include "utils/retry_chain_node.h"
 
@@ -1268,10 +1269,16 @@ ss::future<upload_result> remote::delete_objects_sequentially(
                              results.push_back(result);
                          });
                    })
-            .handle_exception_type(
-              [](const ss::abort_requested_exception& /* ignore */) {})
             .handle_exception_type([ctxlog](const std::exception& ex) {
-                vlog(ctxlog.error, "Failed to delete keys: {}", ex.what());
+                if (ssx::is_shutdown_exception(std::make_exception_ptr(ex))) {
+                    vlog(
+                      ctxlog.debug,
+                      "Failed to delete keys during shutdown: {}",
+                      ex.what());
+
+                } else {
+                    vlog(ctxlog.error, "Failed to delete keys: {}", ex.what());
+                }
             })
             .then([&results] { return results; });
       });


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Looked like the partition was being moved and we were letting an abort error leak out.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none

Fixes: https://github.com/redpanda-data/redpanda/issues/16726

Fixes: https://github.com/redpanda-data/redpanda/issues/16635

