### PR TITLE
[v23.3.x] c/leaders: trigger leadership notification when term changes

### DIFF
--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -223,7 +223,7 @@ ss::future<> config_manager::start() {
     _raft0_leader_changed_notification
       = _leaders.local().register_leadership_change_notification(
         model::controller_ntp,
-        [this](model::ntp, model::term_id, std::optional<model::node_id>) {
+        [this](model::ntp, model::term_id, model::node_id) {
             _reconcile_wait.signal();
         });
 

--- a/src/v/cluster/partition_leaders_table.cc
+++ b/src/v/cluster/partition_leaders_table.cc
@@ -192,6 +192,7 @@ void partition_leaders_table::do_update_partition_leader(
               revision_id_valid
               && revision_id > p_it->second.partition_revision) {
                 p_it->second.update_term = model::term_id{};
+                p_it->second.last_stable_leader_term = model::term_id{};
             }
         }
 
@@ -255,10 +256,10 @@ void partition_leaders_table::do_update_partition_leader(
         return;
     }
     // update stable leader term
+    const auto needs_notification = term > p_it->second.last_stable_leader_term;
     p_it->second.last_stable_leader_term = term;
 
-    // Ensure leadership has changed before notifying watchers
-    if (leader_id != p_it->second.previous_leader) {
+    if (needs_notification) {
         _watchers.notify(
           t_it->first.ns,
           t_it->first.tp,

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -161,7 +161,7 @@ public:
     }
 
     using leader_change_cb_t = ss::noncopyable_function<void(
-      model::ntp, model::term_id, std::optional<model::node_id>)>;
+      model::ntp, model::term_id, model::node_id)>;
 
     // Register a callback for all leadership changes
     notification_id_type

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -80,7 +80,7 @@ leader_balancer::leader_balancer(
 }
 
 void leader_balancer::check_if_controller_leader(
-  model::ntp, model::term_id, std::optional<model::node_id>) {
+  model::ntp, model::term_id, model::node_id) {
     // Don't bother doing anything if it's not enabled
     if (!_enabled()) {
         return;
@@ -109,7 +109,7 @@ void leader_balancer::check_if_controller_leader(
 }
 
 void leader_balancer::on_leadership_change(
-  model::ntp ntp, model::term_id, std::optional<model::node_id>) {
+  model::ntp ntp, model::term_id, model::node_id) {
     if (!_enabled()) {
         return;
     }

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -116,11 +116,9 @@ private:
 
     void on_enable_changed();
 
-    void check_if_controller_leader(
-      model::ntp, model::term_id, std::optional<model::node_id>);
+    void check_if_controller_leader(model::ntp, model::term_id, model::node_id);
 
-    void on_leadership_change(
-      model::ntp, model::term_id, std::optional<model::node_id>);
+    void on_leadership_change(model::ntp, model::term_id, model::node_id);
 
     void on_maintenance_change(model::node_id, model::maintenance_state);
 

--- a/src/v/cluster/tests/partition_leaders_table_test.cc
+++ b/src/v/cluster/tests/partition_leaders_table_test.cc
@@ -181,10 +181,9 @@ TEST_F_CORO(test_fixture, test_leadership_notification) {
     absl::flat_hash_map<model::ntp, int> notifies{{p_0, 0}, {p_1, 0}, {p_2, 0}};
 
     leaders.register_leadership_change_notification(
-      [&](
-        const model::ntp& ntp,
-        model::term_id term,
-        std::optional<model::node_id> leader_id) { notifies[ntp] += 1; });
+      [&](const model::ntp& ntp, model::term_id, model::node_id) {
+          notifies[ntp] += 1;
+      });
 
     // notification should not be triggered when leader_id is set to nullopt
     leaders.update_partition_leader(p_0, model::term_id{1}, std::nullopt);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16776
Fixes: https://github.com/redpanda-data/redpanda/issues/16783,