### PR TITLE
[v23.3.x] c/topic_table_probe: use btree_map in topic table probe

### DIFF
--- a/src/v/cluster/topic_table_probe.h
+++ b/src/v/cluster/topic_table_probe.h
@@ -13,6 +13,7 @@
 #include "cluster/fwd.h"
 #include "metrics/metrics.h"
 
+#include <absl/container/btree_map.h>
 #include <absl/container/flat_hash_set.h>
 
 namespace cluster {
@@ -49,7 +50,7 @@ private:
 
     const topic_table& _topic_table;
     model::node_id _node_id;
-    absl::flat_hash_map<model::topic_namespace, ss::metrics::metric_groups>
+    absl::btree_map<model::topic_namespace, ss::metrics::metric_groups>
       _topics_metrics;
     metrics::internal_metric_groups _internal_metrics;
     metrics::public_metric_groups _public_metrics;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16798
Fixes: https://github.com/redpanda-data/redpanda/issues/16800,