### PR TITLE
[v23.3.x] lint: fix linter error

### DIFF
--- a/tests/docker/ducktape-deps/flink
+++ b/tests/docker/ducktape-deps/flink
@@ -30,7 +30,7 @@ wget ${DEPS_BASEURL}/${KAFKA_CONNECTOR} -O /opt/flink/connectors/${KAFKA_CONNECT
 # At this point, for ARM64 there is no JAVA_HOME, but java is installed
 # So get the folder from java itself
 if [[ -z $JAVA_HOME ]]; then
-  export JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 > /dev/null | grep 'java.home' | cut -d'=' -f2 | xargs);
+  export JAVA_HOME=$(java -XshowSettings:properties -version 2>&1 >/dev/null | grep 'java.home' | cut -d'=' -f2 | xargs)
 fi
 echo "Using Java home folder at $JAVA_HOME"
 
@@ -44,4 +44,4 @@ pip uninstall -y virtualenv
 cd flink_venv
 tar -zcvf ../flink_venv.tgz ./*
 cd ..
-rm -rf flink_venv   
+rm -rf flink_venv


### PR DESCRIPTION
[Manual Backport of #16260]

This was missed in a force merge

Signed-off-by: Tyler Rockwood <rockwood@redpanda.com>
(cherry picked from commit 6f274dc24f80016818d52e9899dfe55a2073ba4a)

Fixes #16262 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [X] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes



* none
