### PR TITLE
PESDLC-895 Split produce/consume methods

### DIFF
--- a/tests/rptest/clients/python_librdkafka.py
+++ b/tests/rptest/clients/python_librdkafka.py
@@ -105,7 +105,9 @@ class PythonLibrdkafka:
                 conf.update({
                     'security.protocol': 'ssl',
                 })
-        self._redpanda.logger.info(conf)
+        # log as debug to eliminate log spamming
+        # when creating a lot of producers
+        self._redpanda.logger.debug(conf)
         return conf
 
     def _get_oauth_config(self):


### PR DESCRIPTION
Splits methods for native python produce/consume to separate method for reusability. Also makes logger in get_config in librdkafka interface to debug to avoid spamming of info log

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none