### PR TITLE
rpk: add debug logs to BYOC

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
+++ b/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/plugin"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 const (
@@ -111,6 +112,9 @@ func parseBYOCFlags(fs afero.Fs, p *config.Params, cmd *cobra.Command, args []st
 	if err != nil {
 		return nil, "", nil, err
 	}
+	// Since we are manually parsing the flags, we need to force building the
+	// logger again.
+	zap.ReplaceGlobals(p.BuildLogger())
 	return cfg, redpandaID, keepForPlugin, nil
 }
 

--- a/src/go/rpk/pkg/oauth/load.go
+++ b/src/go/rpk/pkg/oauth/load.go
@@ -7,6 +7,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	rpkos "github.com/redpanda-data/redpanda/src/go/rpk/pkg/os"
 	"github.com/spf13/afero"
+	"go.uber.org/zap"
 )
 
 // LoadFlow loads or creates a config at default path, and validates and
@@ -28,8 +29,10 @@ func LoadFlow(ctx context.Context, fs afero.Fs, cfg *config.Config, cl Client, n
 
 	var resp Token
 	if authVir.HasClientCredentials() {
+		zap.L().Sugar().Debug("logging in using client credential flow")
 		resp, err = ClientCredentialFlow(ctx, cl, authVir)
 	} else {
+		zap.L().Sugar().Debug("logging in using OAUTH flow")
 		resp, err = DeviceFlow(ctx, cl, authVir, noUI)
 	}
 	if err != nil {


### PR DESCRIPTION
This PR solves a bug that prevented `rpk` to show debug logs when executing `rpk cloud byoc` and adds extra debug logs to the login and plugin download process.

Example:
```
$ rpk cloud byoc aws apply --redpanda-id <my-id> -v 
20:34:39.809  DEBUG  logging in using OAUTH flow
20:34:39.809  DEBUG  using existing authorization token
20:34:39.815  DEBUG  looking for existing byoc plugin  {"exists": false}
20:34:39.815  DEBUG  requesting https://cloud-api.prd.cloud.redpanda.com/api/v1/clusters/<my-id>
20:34:40.899  DEBUG  got response for https://cloud-api.prd.cloud.redpanda.com/api/v1/clusters/<my-id>
20:34:40.899  DEBUG  requesting https://cloud-api.prd.cloud.redpanda.com/api/v1/clusters-resources/install-pack-versions/23.3.xxx
20:34:41.003  DEBUG  got response for https://cloud-api.prd.cloud.redpanda.com/api/v1/clusters-resources/install-pack-versions/23.3.xxx
20:34:41.073  DEBUG  downloading byoc plugin  {"version": "23.3.xxx-sha256.xxx"}
20:34:41.073  DEBUG  requesting https://dl.redpanda.com/public/rpk-plugins/raw/names/byoc-linux-amd64/versions/23.3.xxx-sha256.xxx/byoc-linux-amd64-23.3.xxx-sha256.xxx.tar.gz
20:34:41.165  DEBUG  got response for https://dl.redpanda.com/public/rpk-plugins/raw/names/byoc-linux-amd64/versions/23.3.xxx-sha256.xxx/byoc-linux-amd64-23.3.xxx-sha256.xxxtar.gz
20:34:42.493  DEBUG  writing byoc plugin to /home/rvasquez/.local/bin
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
