### PR TITLE
Alternative `role_store` interface (strictly additive)

### DIFF
--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -27,6 +27,7 @@ v_cc_library(
     krb5.cc
     krb5_configurator.cc
     gssapi_principal_mapper.cc
+    role.cc
   DEPS
     v::http
     v::security_config

--- a/src/v/security/fwd.h
+++ b/src/v/security/fwd.h
@@ -17,6 +17,7 @@ class acl_store;
 class authorizer;
 class credential_store;
 class ephemeral_credential_store;
+class role_store;
 
 namespace oidc {
 

--- a/src/v/security/role.cc
+++ b/src/v/security/role.cc
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "security/role.h"
+
+namespace security {
+std::ostream& operator<<(std::ostream& os, role_member_type t) {
+    switch (t) {
+    case role_member_type::user:
+        return os << "user";
+    }
+    __builtin_unreachable();
+}
+
+std::ostream& operator<<(std::ostream& os, const role_member& m) {
+    fmt::print(os, "{{{}}}:{{{}}}", m.type(), m.name());
+    return os;
+}
+
+// TODO(oren): maybe we should have the role name on the role?
+std::ostream& operator<<(std::ostream& os, const role& r) {
+    fmt::print(os, "role members: {{{}}}", fmt::join(r.members(), ","));
+    return os;
+}
+} // namespace security

--- a/src/v/security/role.h
+++ b/src/v/security/role.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "absl/container/flat_hash_set.h"
+#include "security/types.h"
+#include "serde/envelope.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <iosfwd>
+
+namespace security {
+
+enum class role_member_type {
+    user = 0,
+};
+
+std::ostream& operator<<(std::ostream&, role_member_type);
+
+class role_member
+  : public serde::
+      envelope<role_member, serde::version<0>, serde::compat_version<0>> {
+public:
+    role_member() = default;
+    role_member(role_member_type type, ss::sstring name)
+      : _type(type)
+      , _name(std::move(name)) {}
+
+    bool operator==(const role_member&) const = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const role_member& e) {
+        return H::combine(std::move(h), e._type, e._name);
+    }
+
+    const ss::sstring& name() const { return _name; }
+    role_member_type type() const { return _type; }
+
+    auto serde_fields() { return std::tie(_type, _name); }
+
+private:
+    friend std::ostream& operator<<(std::ostream&, const role_member&);
+    role_member_type _type{};
+    ss::sstring _name;
+};
+
+class role
+  : public serde::envelope<role, serde::version<0>, serde::compat_version<0>> {
+public:
+    // NOTE(oren): flat_hash_set chosen here because the set of members is
+    // effectively immutable between construction and destruction/move
+    using container_type = absl::flat_hash_set<role_member>;
+
+    role() = default;
+
+    explicit role(container_type members)
+      : _members(std::move(members)) {}
+
+    const container_type& members() const { return _members; }
+
+    bool operator==(const role&) const = default;
+
+    auto serde_fields() { return std::tie(_members); }
+
+private:
+    friend std::ostream& operator<<(std::ostream&, const role&);
+    container_type _members;
+};
+
+} // namespace security

--- a/src/v/security/role_store.h
+++ b/src/v/security/role_store.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "absl/container/flat_hash_set.h"
+#include "absl/container/node_hash_map.h"
+#include "security/role.h"
+#include "security/types.h"
+
+#include <seastar/util/variant_utils.hh>
+
+#include <ranges>
+#include <type_traits>
+
+namespace security {
+
+/* container for Roles */
+class role_store {
+    using role_types = std::variant<role>;
+    using container_type = absl::node_hash_map<role_name, role_types>;
+    using member_cache_type
+      = absl::node_hash_map<role_member, absl::flat_hash_set<role_name>>;
+
+public:
+    role_store() noexcept = default;
+    role_store(const role_store&) = delete;
+    role_store& operator=(const role_store&) = delete;
+    role_store(role_store&&) noexcept = default;
+    role_store& operator=(role_store&&) noexcept = default;
+    ~role_store() noexcept = default;
+
+    template<typename T>
+    bool put(const role_name& name, T&& role) {
+        auto res = _roles.insert_or_assign(name, std::forward<T>(role));
+        using v_type = typename std::remove_cv<
+          typename std::remove_reference<T>::type>::type;
+        for (const auto& m : std::get<v_type>(res.first->second).members()) {
+            _member_cache[m].insert(name);
+        }
+        return res.second;
+    }
+
+    template<typename T>
+    std::optional<T> get(const role_name& name) const {
+        if (auto it = _roles.find(name); it != _roles.end()) {
+            return std::get<T>(it->second);
+        }
+        return std::nullopt;
+    }
+
+    std::optional<const member_cache_type::value_type::second_type*>
+    get_member_roles(const role_member& user) const {
+        auto it = _member_cache.find(user);
+        if (it != _member_cache.end()) {
+            return &it->second;
+        }
+        return std::nullopt;
+    }
+
+    bool remove(const role_name& name) {
+        absl::c_for_each(
+          _member_cache, [&name](auto& e) { e.second.erase(name); });
+        return _roles.erase(name) > 0;
+    }
+
+    bool contains(const role_name& name) const { return _roles.contains(name); }
+
+    auto range(auto&& pred) const {
+        return _roles | std::views::filter(std::forward<decltype(pred)>(pred));
+    }
+
+    void clear() {
+        _member_cache.clear();
+        _roles.clear();
+    }
+
+    static constexpr auto name_prefix_filter =
+      [](
+        const security::role_store::container_type::value_type& t,
+        std::string_view filter) {
+          return filter.empty() || t.first().starts_with(filter);
+      };
+
+    static constexpr auto has_member =
+      [](
+        const security::role_store::container_type::value_type& t,
+        const security::role_member& member) {
+          return ss::visit(t.second, [&member](security::role const& r) {
+              return member.name().empty() || r.members().contains(member);
+          });
+      };
+
+private:
+    container_type _roles;
+    member_cache_type _member_cache;
+};
+
+} // namespace security

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -30,3 +30,11 @@ rp_test(
   LABELS
     kafka
 )
+
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME role_store_bench
+  SOURCES role_store_bench.cc
+  LIBRARIES Seastar::seastar_perf_testing v::utils v::security
+  LABELS security
+)

--- a/src/v/security/tests/CMakeLists.txt
+++ b/src/v/security/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ rp_test(
     jwt_test.cc
     url_test.cc
     oidc_principal_mapping_test.cc
+    role_store_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka_protocol v::storage v::security
   LABELS kafka

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "random/generators.h"
+#include "security/role.h"
+#include "security/role_store.h"
+
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/util/later.hh>
+
+#include <utility>
+
+using namespace security;
+
+const std::vector<role_member>& get_mems(int n) {
+    static std::vector<role_member> mems;
+    if (!mems.empty()) {
+        return mems;
+    }
+    for (int i = 0; i < n; ++i) {
+        mems.emplace_back(
+          role_member_type::user, random_generators::gen_alphanum_string(32));
+    }
+    return mems;
+}
+
+const std::vector<std::pair<role_name, role>>&
+get_roles(int n, const std::vector<role_member>& mems) {
+    static std::vector<std::pair<role_name, role>> roles;
+    if (!roles.empty()) {
+        return roles;
+    }
+    for (int i = 0; i < n; ++i) {
+        role::container_type role_mems;
+        for (const auto& m : mems) {
+            auto ri = random_generators::get_int(0, 1);
+            if (ri) {
+                role_mems.insert(m);
+            }
+        }
+        roles.emplace_back(
+          role_name{random_generators::gen_alphanum_string(32)},
+          std::move(role_mems));
+    }
+    return roles;
+}
+
+void run_member_queries(int n, bool iter) {
+    security::role_store store;
+    const auto& mems = get_mems(n);
+    const auto& roles = get_roles(n, mems);
+    for (const auto& [n, r] : roles) {
+        store.put(n, r);
+    }
+    perf_tests::start_measuring_time();
+    for (const auto& m : mems) {
+        auto rng = store.get_member_roles(m);
+        if (!rng.has_value() || !iter) {
+            continue;
+        }
+        for (const auto& r : *rng.value()) {
+            perf_tests::do_not_optimize(r);
+        }
+    }
+    perf_tests::stop_measuring_time();
+}
+
+void run_range_queries(int n, bool iter) {
+    security::role_store store;
+    const auto& mems = get_mems(n);
+    const auto& roles = get_roles(n, mems);
+    for (const auto& [n, r] : roles) {
+        store.put(n, r);
+    }
+    perf_tests::start_measuring_time();
+    for (const auto& m : mems) {
+        auto rng = store.range(
+          [&m](const auto& e) { return role_store::has_member(e, m); });
+        if (rng.empty() || !iter) {
+            continue;
+        }
+        for (const auto& r : rng) {
+            perf_tests::do_not_optimize(r);
+        }
+    }
+    perf_tests::stop_measuring_time();
+}
+
+PERF_TEST(role_store_bench, member_get_query) {
+    run_member_queries(1000, true);
+}
+
+// PERF_TEST(role_store_bench, member_get_query_no_iter) {
+//     run_member_queries(1000, false);
+// }
+
+PERF_TEST(role_store_bench, user_range_query) { run_range_queries(1000, true); }
+
+// PERF_TEST(role_store_bench, user_range_query_no_iter) {
+//     run_range_queries(1000, false);
+// }

--- a/src/v/security/tests/role_store_test.cc
+++ b/src/v/security/tests/role_store_test.cc
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "security/role.h"
+#include "security/role_store.h"
+
+#include <boost/algorithm/string.hpp>
+#include <boost/test/tools/old/interface.hpp>
+#include <boost/test/unit_test.hpp>
+#include <fmt/ostream.h>
+
+#include <vector>
+
+namespace security {
+
+BOOST_AUTO_TEST_CASE(role_test) {
+    const role_member mem0{role_member_type::user, "member0"};
+    const role_member mem1{role_member_type::user, "member1"};
+
+    std::vector<role_member> mems{mem0, mem1, mem0};
+    role::container_type members{mems.begin(), mems.end()};
+    const role rol{std::move(members)};
+
+    for (const auto& m : mems) {
+        BOOST_REQUIRE(rol.members().contains(m));
+        BOOST_REQUIRE_EQUAL(rol.members().count(m), 1);
+    }
+
+    auto rep = fmt::format("{}", rol);
+    BOOST_REQUIRE(rep.find("{user}:{member0}") != std::string::npos);
+    BOOST_REQUIRE(rep.find("{user}:{member1}") != std::string::npos);
+}
+
+BOOST_AUTO_TEST_CASE(role_store_test) {
+    const role_member mem0{role_member_type::user, "member0"};
+    const role_member mem1{role_member_type::user, "member1"};
+
+    std::vector<role_member> mems{mem0, mem1};
+    const role role0{{mems.begin(), mems.end()}};
+    const role role1{{mems.begin(), mems.begin() + 1}};
+
+    auto role0_copy = role0;
+    auto role1_copy = role1;
+
+    BOOST_REQUIRE_NE(role0, role1);
+    BOOST_REQUIRE_NE(role0_copy, role1_copy);
+
+    const role_name copied("copied");
+    const role_name moved("moved");
+
+    role_store store;
+    store.put(copied, role0);
+    store.put(moved, std::move(role0_copy));
+
+    BOOST_REQUIRE(store.get<role>(copied).has_value());
+    BOOST_REQUIRE_EQUAL(store.get<role>(copied).value(), role0);
+
+    BOOST_REQUIRE(store.get<role>(moved).has_value());
+    BOOST_REQUIRE_EQUAL(store.get<role>(moved).value(), role0);
+
+    // update roles
+    store.put(copied, role1);
+    store.put(moved, std::move(role1_copy));
+
+    BOOST_REQUIRE(store.get<role>(copied).has_value());
+    BOOST_REQUIRE_EQUAL(store.get<role>(copied).value(), role1);
+
+    BOOST_REQUIRE(store.get<role>(moved).has_value());
+    BOOST_REQUIRE_EQUAL(store.get<role>(moved).value(), role1);
+
+    // remove a role
+    BOOST_REQUIRE(store.contains(copied));
+    BOOST_REQUIRE(store.remove(copied));
+    BOOST_REQUIRE(!store.remove(copied));
+    BOOST_REQUIRE(!store.contains(copied));
+    BOOST_REQUIRE(!store.get<role>(copied).has_value());
+    BOOST_REQUIRE(store.contains(moved));
+    store.clear();
+    BOOST_REQUIRE(!store.contains(moved));
+}
+
+BOOST_AUTO_TEST_CASE(role_store_range_test) {
+    const role_member mem0{role_member_type::user, "member0"};
+    const role_member mem1{role_member_type::user, "member1"};
+
+    std::vector<role_member> mems{mem0, mem1};
+    const role role0{{mems.begin(), mems.end()}};
+    const role role1{{mems.begin(), mems.begin() + 1}};
+
+    BOOST_REQUIRE_NE(role0, role1);
+
+    const role_name r0_name("role0");
+    const role_name r1_name("role1");
+
+    role_store store;
+    store.put(r0_name, role0);
+    store.put(r1_name, role1);
+
+    auto prefix_pred = [](std::string_view pfx) {
+        return [pfx](const auto& e) {
+            return role_store::name_prefix_filter(e, pfx);
+        };
+    };
+
+    {
+        auto res = store.range(prefix_pred("rol"));
+        BOOST_REQUIRE_EQUAL(std::distance(res.begin(), res.end()), 2);
+    }
+
+    {
+        auto res = store.range(prefix_pred(""));
+        BOOST_REQUIRE_EQUAL(std::distance(res.begin(), res.end()), 2);
+    }
+
+    auto member_pred = [](const role_member& mem) {
+        return [&mem](const auto& e) { return role_store::has_member(e, mem); };
+    };
+
+    {
+        // only one role contains mem1
+        auto res = store.range(member_pred(mem1));
+        BOOST_REQUIRE_EQUAL(std::distance(res.begin(), res.end()), 1);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(role_store_member_query_test) {
+    const role_member mem0{role_member_type::user, "member0"};
+    const role_member mem1{role_member_type::user, "member1"};
+    const role_member mem2{role_member_type::user, "member2"};
+
+    std::vector<role_member> mems{mem0, mem1, mem2};
+    const role role0{{mems.begin(), mems.end()}};
+    const role role1{{mems.begin() + 1, mems.end()}};
+    const role role2{{mems.begin() + 2, mems.end()}};
+
+    const role_name r0_name("role0");
+    const role_name r1_name("role1");
+    const role_name r2_name("role2");
+
+    BOOST_REQUIRE_NE(role0, role1);
+    BOOST_REQUIRE_NE(role0, role2);
+    BOOST_REQUIRE_NE(role1, role2);
+
+    role_store store;
+    store.put(r0_name, role0);
+    store.put(r1_name, role1);
+    store.put(r2_name, role2);
+
+    {
+        auto mem0_roles = store.get_member_roles(mem0);
+        BOOST_REQUIRE(mem0_roles.has_value());
+        BOOST_REQUIRE(mem0_roles.value()->contains(r0_name));
+        BOOST_REQUIRE(!mem0_roles.value()->contains(r1_name));
+        BOOST_REQUIRE(!mem0_roles.value()->contains(r2_name));
+    }
+
+    {
+        auto mem1_roles = store.get_member_roles(mem1);
+        BOOST_REQUIRE(mem1_roles.has_value());
+        BOOST_REQUIRE(mem1_roles.value()->contains(r0_name));
+        BOOST_REQUIRE(mem1_roles.value()->contains(r1_name));
+        BOOST_REQUIRE(!mem1_roles.value()->contains(r2_name));
+    }
+
+    {
+        auto mem2_roles = store.get_member_roles(mem2);
+        BOOST_REQUIRE(mem2_roles.has_value());
+        BOOST_REQUIRE(mem2_roles.value()->contains(r0_name));
+        BOOST_REQUIRE(mem2_roles.value()->contains(r1_name));
+        BOOST_REQUIRE(mem2_roles.value()->contains(r2_name));
+    }
+
+    store.remove(r0_name);
+
+    {
+        auto mem0_roles = store.get_member_roles(mem0);
+        BOOST_REQUIRE(mem0_roles.has_value());
+        BOOST_REQUIRE(!mem0_roles.value()->contains(r0_name));
+        BOOST_REQUIRE(!mem0_roles.value()->contains(r1_name));
+        BOOST_REQUIRE(!mem0_roles.value()->contains(r2_name));
+    }
+
+    {
+        auto mem1_roles = store.get_member_roles(mem1);
+        BOOST_REQUIRE(mem1_roles.has_value());
+        BOOST_REQUIRE(!mem1_roles.value()->contains(r0_name));
+        BOOST_REQUIRE(mem1_roles.value()->contains(r1_name));
+        BOOST_REQUIRE(!mem1_roles.value()->contains(r2_name));
+    }
+
+    {
+        auto mem2_roles = store.get_member_roles(mem2);
+        BOOST_REQUIRE(mem2_roles.has_value());
+        BOOST_REQUIRE(!mem2_roles.value()->contains(r0_name));
+        BOOST_REQUIRE(mem2_roles.value()->contains(r1_name));
+        BOOST_REQUIRE(mem2_roles.value()->contains(r2_name));
+    }
+
+    store.clear();
+    absl::c_for_each(mems, [&store](const auto& m) {
+        BOOST_REQUIRE(!store.get_member_roles(m).has_value());
+    });
+}
+
+} // namespace security

--- a/src/v/security/types.h
+++ b/src/v/security/types.h
@@ -22,4 +22,6 @@ using credential_user = named_type<ss::sstring, struct credential_user_type>;
 using credential_password
   = named_type<ss::sstring, struct credential_password_type>;
 
+using role_name = named_type<ss::sstring, struct role_name_type>;
+
 } // namespace security


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Introduces an additional associative container mapping `role_member -> set<role_name>` and a lookup interface for same. put/remove role operations now also mutate the member cache.

This PR is mainly for discussion.

Quick benchmark:


| test                                     |  iterations |      median |         mad |         min |         max |      allocs |       tasks |        inst |
| -                                        |           - |           - |           - |           - |           - |           - |           - |           - |
| role_store_bencb.member_get_query        |         111 |     1.503ms |     1.317us |     1.501ms |     1.505ms |       0.000 |       0.000 |         0.0 |
| role_store_bencb.user_range_query        |          58 |    84.049ms |   164.863us |    83.834ms |    85.156ms |       0.000 |       0.000 |         0.0 |

Each iteration is 1000 queries over the same store (1000 distinct roles). Not quite sure it's apples to apples, but the order of magnitude difference seems appropriate given all the set lookups we can avoid. Obviously there's a memory cost to store both representations; the alternative one is convenient for the management interface, but those operations are rare so we could probably just fake it - construct convenient objects on demand or w/e.

## Backports Required


<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
