### PR TITLE
Enable large alloc warnings above 128KiB by default 

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -158,7 +158,7 @@ node_config::node_config() noexcept
       "memory_allocation_warning_threshold",
       "Enables log messages for allocations greater than the given size.",
       {.visibility = visibility::tunable},
-      std::nullopt)
+      128_KiB + 1) // 128 KiB is the largest allowed allocation size
   , storage_failure_injection_enabled(
       *this,
       "storage_failure_injection_enabled",

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3432,12 +3432,6 @@ class RedpandaService(RedpandaServiceBase):
         except:
             cur_ver = None
 
-        # This node property isn't available on versions of RP older than 23.2.
-        if cur_ver and cur_ver >= (23, 2, 0):
-            memory_allocation_warning_threshold_bytes = 256 * 1024  # 256 KiB
-        else:
-            memory_allocation_warning_threshold_bytes = None
-
         conf = self.render("redpanda.yaml",
                            node=node,
                            data_dir=RedpandaService.DATA_DIR,
@@ -3456,9 +3450,7 @@ class RedpandaService(RedpandaServiceBase):
                            superuser=self._superuser,
                            sasl_enabled=self.sasl_enabled(),
                            endpoint_authn_method=self.endpoint_authn_method(),
-                           auto_auth=self._security.auto_auth,
-                           memory_allocation_warning_threshold=
-                           memory_allocation_warning_threshold_bytes)
+                           auto_auth=self._security.auto_auth)
 
         if override_cfg_params or node in self._extra_node_conf:
             doc = yaml.full_load(conf)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -13,9 +13,6 @@ redpanda:
 {% if node_id is not none %}
   node_id: {{node_id}}
 {% endif %}
-{% if memory_allocation_warning_threshold is not none %}
-  memory_allocation_warning_threshold: {{memory_allocation_warning_threshold}}
-{% endif %}
   rpc_server:
     address: "{{node.account.hostname}}"
     port: 33145


### PR DESCRIPTION
We already have the reactor stall warnings on in "prod" and arguably the
large allocs are more important as they actually might result in a
crash.

Further the large alloc threshold automatically increases after each
warning so it's unlikely for this to be very spamy.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* Large allocations are now logged by default (similar to reactor stalls)


