### PR TITLE
[v23.3.x] admin/server: fix get_cluster_id response formatting

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3377,7 +3377,7 @@ void admin_server::register_cluster_routes() {
             = _controller->get_storage().local().get_cluster_uuid();
           if (cluster_uuid) {
               ss::httpd::cluster_json::uuid ret;
-              ret.cluster_uuid = ssx::sformat("{}", cluster_uuid);
+              ret.cluster_uuid = ssx::sformat("{}", cluster_uuid.value());
               return ss::json::json_return_type(std::move(ret));
           }
           return ss::json::json_return_type(ss::json::json_void());

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3377,7 +3377,7 @@ void admin_server::register_cluster_routes() {
             = _controller->get_storage().local().get_cluster_uuid();
           if (cluster_uuid) {
               ss::httpd::cluster_json::uuid ret;
-              ret.cluster_uuid = ssx::sformat("{}", cluster_uuid.value());
+              ret.cluster_uuid = ssx::sformat("{}", cluster_uuid.value()());
               return ss::json::json_return_type(std::move(ret));
           }
           return ss::json::json_return_type(ss::json::json_void());

--- a/tests/rptest/tests/cluster_metadata_upload_test.py
+++ b/tests/rptest/tests/cluster_metadata_upload_test.py
@@ -161,7 +161,7 @@ class ClusterMetadataUploadTest(RedpandaTest):
         s3_snapshot = BucketView(self.redpanda, topics=self.topics)
         orig_cluster_uuid, orig_highest_manifest_id = \
             check_cluster_metadata_is_consistent(s3_snapshot)
-        assert orig_cluster_uuid in orig_cluster_uuid_resp, \
+        assert orig_cluster_uuid == orig_cluster_uuid_resp, \
             f"{orig_cluster_uuid_resp} vs {orig_cluster_uuid}"
         for n in self.redpanda.nodes:
             self.redpanda.remove_local_data(n)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16183
Fixes: https://github.com/redpanda-data/redpanda/issues/16831,