### PR TITLE
rpk: replace web UI url for cloud clusters

### DIFF
--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -372,7 +372,7 @@ them in rpk with
 func CloudClusterMessage(p config.RpkProfile, clusterName, clusterID string) string {
 	return fmt.Sprintf(`
 Cluster %s
-  Web UI: https://cloudv2.redpanda.com/clusters/%s/overview
+  Web UI: https://cloud.redpanda.com/clusters/%s/overview
   Redpanda Seed Brokers: [%s]
 `, clusterName, clusterID, strings.Join(p.KafkaAPI.Brokers, ", "))
 }


### PR DESCRIPTION
We are migrating from cloudv2 -> cloud.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [X] v23.2.x
- [ ] v23.1.x

## Release Notes


* none
