### PR TITLE
rpk: remove timeout for profile create

### DIFF
--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -22,6 +22,7 @@ import (
 	container "github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cloudapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/httpapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/oauth/providers/auth0"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
@@ -104,9 +105,7 @@ rpk always switches to the newly created profile.
 				out.Die("profile name cannot be empty unless using %v or %v", fromCloudFlag, fromContainerFlag)
 			}
 
-			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
-			defer cancel()
-			name, msg, err := createProfile(ctx, fs, y, cfg, fromRedpanda, fromProfile, fromCloud, fromContainer, set, name, description)
+			name, msg, err := createProfile(cmd.Context(), fs, y, cfg, fromRedpanda, fromProfile, fromCloud, fromContainer, set, name, description)
 			out.MaybeDieErr(err)
 
 			fmt.Printf("Created and switched to new profile %q.\n", name)
@@ -272,7 +271,7 @@ func createCloudProfile(ctx context.Context, y *config.RpkYaml, cfg *config.Conf
 	if expired {
 		return CloudClusterOutputs{}, fmt.Errorf("token for %q has expired, please login again", y.CurrentCloudAuth)
 	}
-	cl := cloudapi.NewClient(overrides.CloudAPIURL, a.AuthToken)
+	cl := cloudapi.NewClient(overrides.CloudAPIURL, a.AuthToken, httpapi.ReqTimeout(10*time.Second))
 
 	if clusterID == "prompt" {
 		return PromptCloudClusterProfile(ctx, cl)


### PR DESCRIPTION
Instead, we will add a timeout to the client
that requests all the information needed to
populate the client

This is to avoid erroring `request context deadline exceeded` after the user took more than 10 seconds to pick their Cluster.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [ ] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

* rpk: Remove 10s timeout in `rpk profile create`
