### PR TITLE
raft/recovery: better metric for recovery bandwidth consumption

### DIFF
--- a/src/v/raft/coordinated_recovery_throttle.cc
+++ b/src/v/raft/coordinated_recovery_throttle.cc
@@ -91,11 +91,22 @@ void coordinated_recovery_throttle::setup_metrics() {
         namespace sm = ss::metrics;
         _public_metrics.add_group(
           prometheus_sanitize::metrics_name("raft:recovery"),
-          {sm::make_gauge(
-            "partition_movement_available_bandwidth",
-            [this] { return _throttler.available(); },
-            sm::description(
-              "Bandwidth available for partition movement. bytes/sec"))});
+          {// note: deprecate partition_movement_available_bandwidth
+           // in favor of partition_movement_consumed_bandwidth when
+           // possible.
+           sm::make_gauge(
+             "partition_movement_available_bandwidth",
+             [this] { return _throttler.available(); },
+             sm::description(
+               "Bandwidth available for partition movement. bytes/sec")),
+           sm::make_gauge(
+             "partition_movement_consumed_bandwidth",
+             [this] {
+                 return _throttler.last_reset_capacity()
+                        - _throttler.available();
+             },
+             sm::description(
+               "Bandwidth consumed for partition movement. bytes/sec"))});
     }
 }
 


### PR DESCRIPTION
Adds a new public metric `redpanda_raft_recovery_partition_movement_consumed_bandwidth`  for recovery throttle that tracks how much bandwidth is consumed for raft recovery.

This is more useful because it helps tune raft_learner_recovery_rate. If the entire bandwidth is in use, time to bump recovery rate.

With this change, `partition_movement_available_bandwidth` is obsolete but retaining it so we donot break the public metrics contract. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x
- [ ] v23.1.x

## Release Notes

### Improvements

*  Adds a new public metric redpanda_raft_recovery_partition_movement_consumed_bandwidth that tracks how much bandwidth is currently in use for raft recovery.  This helps tune raft_learner_recovery_rate.


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
