### PR TITLE
[v23.3.x] Enable large alloc warnings above 128KiB by default 

### DIFF
--- a/src/v/config/node_config.cc
+++ b/src/v/config/node_config.cc
@@ -158,7 +158,7 @@ node_config::node_config() noexcept
       "memory_allocation_warning_threshold",
       "Enables log messages for allocations greater than the given size.",
       {.visibility = visibility::tunable},
-      std::nullopt)
+      128_KiB + 1) // 128 KiB is the largest allowed allocation size
   , storage_failure_injection_enabled(
       *this,
       "storage_failure_injection_enabled",

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3145,12 +3145,6 @@ class RedpandaService(RedpandaServiceBase):
         except:
             cur_ver = None
 
-        # This node property isn't available on versions of RP older than 23.2.
-        if cur_ver and cur_ver >= (23, 2, 0):
-            memory_allocation_warning_threshold_bytes = 256 * 1024  # 256 KiB
-        else:
-            memory_allocation_warning_threshold_bytes = None
-
         conf = self.render("redpanda.yaml",
                            node=node,
                            data_dir=RedpandaService.DATA_DIR,
@@ -3169,9 +3163,7 @@ class RedpandaService(RedpandaServiceBase):
                            superuser=self._superuser,
                            sasl_enabled=self.sasl_enabled(),
                            endpoint_authn_method=self.endpoint_authn_method(),
-                           auto_auth=self._security.auto_auth,
-                           memory_allocation_warning_threshold=
-                           memory_allocation_warning_threshold_bytes)
+                           auto_auth=self._security.auto_auth)
 
         if override_cfg_params or node in self._extra_node_conf:
             doc = yaml.full_load(conf)

--- a/tests/rptest/services/templates/redpanda.yaml
+++ b/tests/rptest/services/templates/redpanda.yaml
@@ -13,9 +13,6 @@ redpanda:
 {% if node_id is not none %}
   node_id: {{node_id}}
 {% endif %}
-{% if memory_allocation_warning_threshold is not none %}
-  memory_allocation_warning_threshold: {{memory_allocation_warning_threshold}}
-{% endif %}
   rpc_server:
     address: "{{node.account.hostname}}"
     port: 33145


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16828
