### PR TITLE
Made `storage::readers_cache` size limitted

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -86,6 +86,15 @@ configuration::configuration()
       "Duration after which inactive readers will be evicted from cache",
       {.visibility = visibility::tunable},
       30s)
+  , readers_cache_target_max_size(
+      *this,
+      "readers_cache_target_max_size",
+      "Maximum desired number of readers cached per ntp. This a soft limit, a "
+      "number of readers in cache may temporary increase as cleanup is done in "
+      "background",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      200,
+      {.min = 0, .max = 10000})
   , log_segment_ms(
       *this,
       "log_segment_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -51,6 +51,8 @@ struct configuration final : public config_store {
     bounded_property<uint16_t> log_segment_size_jitter_percent;
     bounded_property<uint64_t> compacted_log_segment_size;
     property<std::chrono::milliseconds> readers_cache_eviction_timeout_ms;
+    bounded_property<size_t> readers_cache_target_max_size;
+
     bounded_property<std::optional<std::chrono::milliseconds>> log_segment_ms;
     bounded_property<std::chrono::milliseconds> log_segment_ms_min;
     bounded_property<std::chrono::milliseconds> log_segment_ms_max;

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -121,7 +121,9 @@ disk_log_impl::disk_log_impl(
   , _probe(std::make_unique<storage::probe>())
   , _max_segment_size(compute_max_segment_size())
   , _readers_cache(std::make_unique<readers_cache>(
-      config().ntp(), _manager.config().readers_cache_eviction_timeout)) {
+      config().ntp(),
+      _manager.config().readers_cache_eviction_timeout,
+      config::shard_local_cfg().readers_cache_target_max_size.bind())) {
     const bool is_compacted = config().is_compacted();
     for (auto& s : _segs) {
         _probe->add_initial_segment(*s);

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -11,6 +11,7 @@
 #include "storage/readers_cache.h"
 
 #include "base/vlog.h"
+#include "container/intrusive_list_helpers.h"
 #include "model/fundamental.h"
 #include "ssx/future-util.h"
 #include "storage/types.h"
@@ -26,9 +27,12 @@
 namespace storage {
 
 readers_cache::readers_cache(
-  model::ntp ntp, std::chrono::milliseconds eviction_timeout)
+  model::ntp ntp,
+  std::chrono::milliseconds eviction_timeout,
+  config::binding<size_t> target_max_size)
   : _ntp(std::move(ntp))
-  , _eviction_timeout(eviction_timeout) {
+  , _eviction_timeout(eviction_timeout)
+  , _target_max_size(std::move(target_max_size)) {
     _probe.setup_metrics(_ntp);
     // setup eviction timer
     _eviction_timer.set_callback([this] {
@@ -76,6 +80,7 @@ readers_cache::put(std::unique_ptr<log_reader> reader) {
     auto ptr = new entry{.reader = std::move(reader)}; // NOLINT
     _in_use.push_back(*ptr);
     _probe.reader_added();
+    maybe_evict_size();
     return ptr->make_cached_reader(this);
 }
 
@@ -103,7 +108,7 @@ readers_cache::get_reader(const log_reader_config& cfg) {
       _ntp,
       cfg);
     vlog(stlog.trace, "{} - trying to get reader for: {}", _ntp, cfg);
-    intrusive_list<entry, &entry::_hook> to_evict;
+    uncounted_intrusive_list<entry, &entry::_hook> to_evict;
     /**
      * We use linear search since _readers intrusive list is small.
      */
@@ -141,7 +146,7 @@ readers_cache::get_reader(const log_reader_config& cfg) {
 
     // we use cached_reader wrapper to track reader usage, when cached_reader is
     // destroyed we unlock reader and trigger eviction
-    e._hook.unlink();
+    _readers.erase(_readers.iterator_to(e));
     _in_use.push_back(e);
     return e.make_cached_reader(this);
 }
@@ -281,8 +286,8 @@ readers_cache::~readers_cache() {
       "readers cache have to be closed before destorying");
 }
 
-ss::future<>
-readers_cache::dispose_entries(intrusive_list<entry, &entry::_hook> entries) {
+ss::future<> readers_cache::dispose_entries(
+  uncounted_intrusive_list<entry, &entry::_hook> entries) {
     for (auto& e : entries) {
         co_await e.reader->finally();
     }
@@ -301,7 +306,7 @@ readers_cache::dispose_entries(intrusive_list<entry, &entry::_hook> entries) {
 }
 
 void readers_cache::dispose_in_background(
-  intrusive_list<entry, &entry::_hook> entries) {
+  uncounted_intrusive_list<entry, &entry::_hook> entries) {
     ssx::spawn_with_gate(_gate, [this, entries = std::move(entries)]() mutable {
         return dispose_entries(std::move(entries));
     });
@@ -344,6 +349,31 @@ ss::future<> readers_cache::maybe_evict() {
         const auto outdated = e.last_used + _eviction_timeout < now;
         return invalid || outdated;
     });
+}
+
+inline bool readers_cache::over_size_limit() const {
+    return !_readers.empty()
+           && _readers.size() + _in_use.size() > _target_max_size();
+}
+
+void readers_cache::maybe_evict_size() {
+    /**
+     * exit early if there is nothing to clean
+     */
+    if (!over_size_limit()) [[likely]] {
+        return;
+    }
+
+    uncounted_intrusive_list<entry, &entry::_hook> to_evict;
+    _readers.pop_front_and_dispose(
+      [&to_evict](entry* e) { to_evict.push_back(*e); });
+
+    dispose_in_background(std::move(to_evict));
+}
+
+readers_cache::stats readers_cache::get_stats() const {
+    return readers_cache::stats{
+      .in_use_readers = _in_use.size(), .cached_readers = _readers.size()};
 }
 
 } // namespace storage

--- a/src/v/storage/readers_cache.h
+++ b/src/v/storage/readers_cache.h
@@ -16,6 +16,7 @@
 #include "model/record.h"
 #include "model/record_batch_reader.h"
 #include "random/generators.h"
+#include "random/simple_time_jitter.h"
 #include "storage/log_reader.h"
 #include "storage/readers_cache_probe.h"
 #include "storage/types.h"
@@ -205,5 +206,7 @@ private:
      */
     std::vector<offset_range> _locked_offset_ranges;
     ss::condition_variable _in_use_reader_destroyed;
+
+    simple_time_jitter<ss::lowres_clock> _eviction_jitter;
 };
 } // namespace storage

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -31,7 +31,6 @@ rp_test(
     timequery_test.cc
     kvstore_test.cc
     backlog_controller_test.cc
-    readers_cache_test.cc
     concat_segment_reader_test.cc
     offset_to_filepos_test.cc
     offset_translator_state_test.cc
@@ -142,6 +141,7 @@ rp_test(
   SOURCES
     scoped_file_tracker_test.cc
     segment_deduplication_test.cc
+    readers_cache_test.cc
   LIBRARIES  v::storage v::storage_test_utils v::gtest_main
   LABELS storage
   ARGS "-- -c 1"

--- a/src/v/storage/tests/readers_cache_test.cc
+++ b/src/v/storage/tests/readers_cache_test.cc
@@ -8,17 +8,20 @@
 // by the Apache License, Version 2.0
 
 #include "base/seastarx.h"
+#include "config/property.h"
 #include "model/fundamental.h"
 #include "storage/readers_cache.h"
-#include "test_utils/fixture.h"
+#include "test_utils/test.h"
 
 #include <fmt/ostream.h>
+#include <gtest/gtest.h>
 
 namespace storage {
-struct readers_cache_test_fixture {
+struct readers_cache_test_fixture : seastar_test {
     readers_cache_test_fixture()
       : cache(
-        model::ntp("test", "test", 0), std::chrono::milliseconds(360000)) {}
+        model::ntp("test", "test", 0),
+        std::chrono::milliseconds(360000)) {}
 
     bool intersects_locked_range(model::offset begin, model::offset end) {
         return cache.intersects_with_locked_range(begin, end);
@@ -26,7 +29,7 @@ struct readers_cache_test_fixture {
 
     void test_intersects_locked(
       model::offset::type begin, model::offset::type end, bool in_range) {
-        BOOST_REQUIRE_EQUAL(
+        ASSERT_EQ(
           intersects_locked_range(model::offset(begin), model::offset(end)),
           in_range);
     }
@@ -37,7 +40,7 @@ struct readers_cache_test_fixture {
 } // namespace storage
 using namespace storage;
 
-FIXTURE_TEST(test_range_is_correctly_locked, readers_cache_test_fixture) {
+TEST_F(readers_cache_test_fixture, test_range_is_correctly_locked) {
     {
         /**
          * Evict truncate locks range starting from give offset up to max

--- a/src/v/storage/tests/readers_cache_test.cc
+++ b/src/v/storage/tests/readers_cache_test.cc
@@ -8,39 +8,103 @@
 // by the Apache License, Version 2.0
 
 #include "base/seastarx.h"
+#include "config/base_property.h"
+#include "config/config_store.h"
 #include "config/property.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
+#include "storage/fs_utils.h"
+#include "storage/log_reader.h"
+#include "storage/probe.h"
 #include "storage/readers_cache.h"
+#include "storage/segment.h"
+#include "storage/storage_resources.h"
+#include "storage/types.h"
+#include "test_utils/async.h"
 #include "test_utils/test.h"
 
+#include <seastar/util/defer.hh>
+
 #include <fmt/ostream.h>
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 namespace storage {
 struct readers_cache_test_fixture : seastar_test {
-    readers_cache_test_fixture()
-      : cache(
-        model::ntp("test", "test", 0),
-        std::chrono::milliseconds(360000)) {}
-
-    bool intersects_locked_range(model::offset begin, model::offset end) {
+    using segment_ptr = ss::lw_shared_ptr<storage::segment>;
+    bool intersects_locked_range(
+      const readers_cache& cache, model::offset begin, model::offset end) {
         return cache.intersects_with_locked_range(begin, end);
     }
 
     void test_intersects_locked(
-      model::offset::type begin, model::offset::type end, bool in_range) {
+      const readers_cache& cache,
+      model::offset::type begin,
+      model::offset::type end,
+      bool in_range) {
         ASSERT_EQ(
-          intersects_locked_range(model::offset(begin), model::offset(end)),
+          intersects_locked_range(
+            cache, model::offset(begin), model::offset(end)),
           in_range);
     }
 
-    readers_cache cache;
+    readers_cache make_cache(
+      std::chrono::milliseconds max_age, config::property<size_t> max_size) {
+        return storage::readers_cache(
+          model::ntp("test", "test", 0), max_age, max_size);
+    }
+
+    config::property<size_t> make_max_size_property(size_t default_value) {
+        return config::property<size_t>(
+          store,
+          "max_cache_size",
+          "max_cache_size",
+          {.needs_restart = config::needs_restart::no,
+           .visibility = config::visibility::tunable},
+          default_value);
+    }
+
+    std::unique_ptr<storage::log_reader>
+    make_reader(ss::circular_buffer<segment_ptr> segments = {}) {
+        auto lease = std::make_unique<lock_manager::lease>(
+          segment_set(std::move(segments)));
+        return std::make_unique<log_reader>(
+          std::move(lease),
+          storage::log_reader_config(
+            model::offset(0),
+            model::offset::max(),
+            ss::default_priority_class()),
+          probe);
+    }
+
+    segment_ptr make_segment(model::offset base_offset) {
+        segment_index idx(
+          segment_full_path::mock("mocked"),
+          base_offset,
+          1024,
+          features,
+          std::nullopt);
+        return ss::make_lw_shared<storage::segment>(
+          storage::segment::offset_tracker(model::term_id(0), base_offset),
+          nullptr,
+          std::move(idx),
+          nullptr,
+          std::nullopt,
+          std::nullopt,
+          resources);
+    }
+
+    storage::storage_resources resources;
+    ss::sharded<features::feature_table> features;
+    config::config_store store;
+    storage::probe probe;
 };
 
 } // namespace storage
 using namespace storage;
 
 TEST_F(readers_cache_test_fixture, test_range_is_correctly_locked) {
+    readers_cache cache = make_cache(1h, make_max_size_property(10));
     {
         /**
          * Evict truncate locks range starting from give offset up to max
@@ -48,19 +112,19 @@ TEST_F(readers_cache_test_fixture, test_range_is_correctly_locked) {
         auto holder = cache.evict_truncate(model::offset(10)).get();
 
         // [0,1] is not in [10,inf]
-        test_intersects_locked(0, 1, false);
+        test_intersects_locked(cache, 0, 1, false);
 
         // [0,10] is in range [10,inf]
-        test_intersects_locked(0, 10, true);
+        test_intersects_locked(cache, 0, 10, true);
 
         // [9,12] is in range [10, inf]
-        test_intersects_locked(9, 12, true);
+        test_intersects_locked(cache, 9, 12, true);
 
         // [10,12] is in range [10, inf]
-        test_intersects_locked(10, 12, true);
+        test_intersects_locked(cache, 10, 12, true);
 
         // [20,25] is in range [10, inf]
-        test_intersects_locked(20, 25, true);
+        test_intersects_locked(cache, 20, 25, true);
     }
 
     {
@@ -70,19 +134,19 @@ TEST_F(readers_cache_test_fixture, test_range_is_correctly_locked) {
         auto holder = cache.evict_prefix_truncate(model::offset(10)).get();
 
         // [0,1] is in [0,10]
-        test_intersects_locked(0, 1, true);
+        test_intersects_locked(cache, 0, 1, true);
 
         // [0,10] is in range [0,10]
-        test_intersects_locked(0, 10, true);
+        test_intersects_locked(cache, 0, 10, true);
 
         // [9,12] is in range [0, 10]
-        test_intersects_locked(9, 12, true);
+        test_intersects_locked(cache, 9, 12, true);
 
         // [10,12] is in range [0, 10]
-        test_intersects_locked(10, 12, true);
+        test_intersects_locked(cache, 10, 12, true);
 
         // [20,25] is not in range [0, 10]
-        test_intersects_locked(20, 25, false);
+        test_intersects_locked(cache, 20, 25, false);
     }
 
     {
@@ -93,24 +157,78 @@ TEST_F(readers_cache_test_fixture, test_range_is_correctly_locked) {
           = cache.evict_range(model::offset(5), model::offset(10)).get();
 
         // [0,1] is not in [5,10]
-        test_intersects_locked(0, 1, false);
+        test_intersects_locked(cache, 0, 1, false);
 
         // [0,20] is not in range [5,10] but [5,10] is in [0,20]
-        test_intersects_locked(0, 20, true);
+        test_intersects_locked(cache, 0, 20, true);
 
         // [9,12] is in range [5,10]
-        test_intersects_locked(9, 12, true);
+        test_intersects_locked(cache, 9, 12, true);
 
         // [10,12] is in range [5,10]
-        test_intersects_locked(10, 12, true);
+        test_intersects_locked(cache, 10, 12, true);
 
         // [20,25] is not in range [5,10]
-        test_intersects_locked(20, 25, false);
+        test_intersects_locked(cache, 20, 25, false);
 
         // [4,5] is in range [5,10]
-        test_intersects_locked(4, 5, true);
+        test_intersects_locked(cache, 4, 5, true);
 
         // [6,7] is in range [5,10]
-        test_intersects_locked(6, 7, true);
+        test_intersects_locked(cache, 6, 7, true);
     }
+}
+
+TEST_F(readers_cache_test_fixture, test_reader_with_no_lease_is_not_cached) {
+    readers_cache cache = make_cache(30s, make_max_size_property(10));
+    for (int i = 0; i < 10; ++i) {
+        cache.put(make_reader());
+    }
+
+    EXPECT_EQ(cache.get_stats().cached_readers, 0);
+    EXPECT_EQ(cache.get_stats().in_use_readers, 0);
+}
+
+TEST_F(readers_cache_test_fixture, test_size_based_eviction) {
+    readers_cache cache = make_cache(30s, make_max_size_property(10));
+
+    auto close = ss::defer([&cache] { cache.stop().get(); });
+
+    for (int i = 0; i < 10; ++i) {
+        ss::circular_buffer<segment_ptr> set;
+        set.push_back(make_segment(model::offset(i)));
+        cache.put(make_reader(std::move(set)));
+    }
+    /**
+     * We are not using the reader. It should be returned to the cache
+     * immediately.
+     */
+    EXPECT_EQ(cache.get_stats().cached_readers, 10);
+    EXPECT_EQ(cache.get_stats().in_use_readers, 0);
+
+    /**
+     * Add few more readers, the cache should grow temporally as cleanup is done
+     * in a background.
+     */
+    for (int i = 10; i < 15; ++i) {
+        ss::circular_buffer<segment_ptr> set;
+        set.push_back(make_segment(model::offset(i)));
+        cache.put(make_reader(std::move(set)));
+    }
+
+    EXPECT_EQ(cache.get_stats().in_use_readers, 0);
+
+    RPTEST_REQUIRE_EVENTUALLY(
+      5s, [&] { return cache.get_stats().cached_readers == 10; });
+
+    ss::circular_buffer<segment_ptr> set;
+    set.push_back(make_segment(model::offset(100)));
+    auto reader = cache.put(make_reader(std::move(set)));
+    EXPECT_EQ(cache.get_stats().in_use_readers, 1);
+    /**
+     * Since one of the readers in in use, one of the additional cached readers
+     * should eventually be evicted
+     */
+    RPTEST_REQUIRE_EVENTUALLY(
+      5s, [&] { return cache.get_stats().cached_readers == 9; });
 }


### PR DESCRIPTION
Added size based eviction to `storage::readers_cache`. Previously the
eviction was only time based which may lead to a problem when multiple
readers were created for the same NTP. Now with the size based eviction
the readers cache size is bounded and will not grow indefinitely.

Note on backward compatibility:

Previously the size of cache was unbounded. In this commit we change the
policy to keep up to 200 readers per ntp. This number is still large
enough not cause any issues as it would mean that there are 200
concurrent readers reading a single partition at the same time.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- better control of memory usage in storage layer.
