### PR TITLE
Fixed background apply fiber race condition in `raft::state_machine_manager`

### DIFF
--- a/src/v/raft/state_machine_manager.cc
+++ b/src/v/raft/state_machine_manager.cc
@@ -387,14 +387,15 @@ void state_machine_manager::maybe_start_background_apply(
         return entry->background_apply_mutex.get_units().then(
           [this, entry](auto u) {
               return ss::with_scheduling_group(
-                       _apply_sg,
-                       [this, entry] { return background_apply_fiber(entry); })
-                .finally([u = std::move(u)] {});
+                _apply_sg, [this, entry, u = std::move(u)]() mutable {
+                    return background_apply_fiber(entry, std::move(u));
+                });
           });
     });
 }
 
-ss::future<> state_machine_manager::background_apply_fiber(entry_ptr entry) {
+ss::future<> state_machine_manager::background_apply_fiber(
+  entry_ptr entry, ssx::semaphore_units units) {
     while (!_as.abort_requested() && entry->stm->next() < _next) {
         storage::log_reader_config config(
           entry->stm->next(), _next, ss::default_priority_class());
@@ -425,6 +426,7 @@ ss::future<> state_machine_manager::background_apply_fiber(entry_ptr entry) {
             co_await ss::sleep_abortable(1s, _as);
         }
     }
+    units.return_all();
     vlog(
       _log.debug,
       "finished background apply for '{}' state machine",

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -149,7 +149,7 @@ private:
       = absl::flat_hash_map<ss::sstring, entry_ptr, sstring_hash, sstring_eq>;
 
     void maybe_start_background_apply(const entry_ptr&);
-    ss::future<> background_apply_fiber(entry_ptr);
+    ss::future<> background_apply_fiber(entry_ptr, ssx::semaphore_units);
 
     ss::future<> apply_raft_snapshot();
     ss::future<> do_apply_raft_snapshot(

--- a/src/v/raft/tests/stm_test_fixture.h
+++ b/src/v/raft/tests/stm_test_fixture.h
@@ -34,6 +34,7 @@
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/coroutine/parallel_for_each.hh>
+#include <seastar/util/bool_class.hh>
 #include <seastar/util/log.hh>
 
 #include <ostream>
@@ -142,6 +143,7 @@ struct simple_kv : public raft::state_machine_base {
     state_t state;
     raft_node_instance& raft_node;
 };
+using wait_for_each_batch = ss::bool_class<struct wait_for_each_tag>;
 
 struct state_machine_fixture : raft_fixture {
     ss::future<result<raft::replicate_result>>
@@ -172,7 +174,8 @@ struct state_machine_fixture : raft_fixture {
     }
 
     ss::future<absl::flat_hash_map<ss::sstring, value_entry>>
-    build_random_state(int op_cnt) {
+    build_random_state(
+      int op_cnt, wait_for_each_batch wait_for_each = wait_for_each_batch::no) {
         absl::flat_hash_map<ss::sstring, value_entry> state;
 
         for (int i = 0; i < op_cnt;) {
@@ -213,6 +216,10 @@ struct state_machine_fixture : raft_fixture {
               logger().debug,
               "replication result: [last_offset: {}]",
               result.value().last_offset);
+
+            if (wait_for_each) {
+                co_await wait_for_apply();
+            }
         }
         co_return state;
     }


### PR DESCRIPTION
`raft::state_machine_manager` uses background apply fiber to
individually apply batches to state machines which are behind the main
apply fiber. When background apply fiber is active it reads and apply
batches up to current committed offset. When background apply fiber is
active it acquires the mutex. When mutex is acquired the main apply
fiber do not consider the stm as up to date.

The code was prone to very rare race condition as the background apply
was finished in one continuation but the units were release in
subsequent `finally` block. Normally this approach is harmless as the
semaphore is waited for and it will be signalled after the `finally`
fiber is executed. In `state_machine_manager` we only check if the
semaphore is available, this makes the solution vulnerable to timing.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none