### PR TITLE
cloud_storage: Improve stale_reader test

### DIFF
--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -1987,11 +1987,19 @@ FIXTURE_TEST(test_stale_reader, cloud_storage_fixture) {
     batch_t data = {
       .num_records = 1, .type = model::record_batch_type::raft_data};
 
+    batch_t merged = {
+      .num_records = 2, .type = model::record_batch_type::raft_data};
+
     // offsets 0-29
     const std::vector<std::vector<batch_t>> batch_types = {
       {data, data, data, data, data, data, data, data, data, data},
       {data, data, data, data, data, data, data, data, data, data},
       {data, data, data, data, data, data, data, data, data, data},
+    };
+    const std::vector<std::vector<batch_t>> merged_batch_types = {
+      {merged, merged, merged, merged, merged},
+      {merged, merged, merged, merged, merged},
+      {merged, merged, merged, merged, merged},
     };
 
     auto segments = setup_s3_imposter(
@@ -2000,9 +2008,9 @@ FIXTURE_TEST(test_stale_reader, cloud_storage_fixture) {
     print_segments(segments);
 
     auto headers_read = scan_remote_partition_with_replacements(
-      *this, model::offset(0), model::offset(29), batch_types, 0, 0);
+      *this, model::offset(0), model::offset(29), merged_batch_types, 0, 0);
 
-    BOOST_REQUIRE_EQUAL(headers_read.size(), 30);
+    BOOST_REQUIRE_EQUAL(headers_read.size(), 15);
 }
 
 // Returns true if a kafka::offset scan returns the expected number of records.

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -564,7 +564,6 @@ std::vector<in_memory_segment> replace_segments(
         auto bo = s.base_offset;
         auto it = manifest.find(bo);
         BOOST_REQUIRE(it != manifest.end());
-        BOOST_REQUIRE(it->size_bytes != s.bytes.size());
         auto path = manifest.generate_segment_path(*it);
         segments_to_remove.push_back(ss::sstring("/") + path().native());
     }


### PR DESCRIPTION
The test failed ocasionally when the test suite generated replacement segments with the same size as original. The test replaced segments 1:1. 30 segments were replaced with 30 new randomly generated segments. This caused the test to fail ocasionally when the size of the replacment matced the size of the original segment.

This PR fixes that by replacing and merging segments. Every two old segments are replaced with one new. The manifest allows replacement segments to have any size if they are replacing more than one segment so the test can no longer fail this way.

Fixes #15679 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none