### PR TITLE
admin/transform/delete: path decode names

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_transform.go
+++ b/src/go/rpk/pkg/adminapi/api_transform.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 const (
@@ -35,7 +36,7 @@ func (a *AdminAPI) DeployWasmTransform(ctx context.Context, t TransformMetadata,
 
 // DeleteWasmTransform deletes a wasm transform in a cluster.
 func (a *AdminAPI) DeleteWasmTransform(ctx context.Context, name string) error {
-	return a.sendToLeader(ctx, http.MethodDelete, baseTransformEndpoint+name, nil, nil)
+	return a.sendToLeader(ctx, http.MethodDelete, baseTransformEndpoint+url.PathEscape(name), nil, nil)
 }
 
 // PartitionTransformStatus is the status of a single transform that is running on an input partition.

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -51,7 +51,11 @@ admin_server::delete_transform(std::unique_ptr<ss::http::request> req) {
     if (!_transform_service->local_is_initialized()) {
         throw transforms_not_enabled();
     }
-    auto name = model::transform_name(req->param["name"]);
+    ss::sstring raw_name;
+    if (!admin::path_decode(req->param["name"], raw_name)) {
+        throw seastar::httpd::bad_request_exception("invalid transform name");
+    }
+    auto name = model::transform_name(std::move(raw_name));
     std::error_code ec = co_await _transform_service->local().delete_transform(
       std::move(name));
     co_await throw_on_error(*req, ec, model::controller_ntp);


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/redpanda/issues/16643, https://github.com/redpanda-data/redpanda/issues/16810

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fixed deleting Data Transforms with names that had URL unsafe characters
