### PR TITLE
cloud_storage: various non-functional changes

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -245,15 +245,15 @@ public:
             _partition_reader_as = config.abort_source;
             auto sub = config.abort_source->get().subscribe([this]() noexcept {
                 vlog(_ctxlog.debug, "abort requested via config.abort_source");
-                if (_reader) {
-                    _partition->evict_segment_reader(std::move(_reader));
+                if (_seg_reader) {
+                    _partition->evict_segment_reader(std::move(_seg_reader));
                 }
             });
             if (sub) {
                 _as_sub = std::move(*sub);
             } else {
                 vlog(_ctxlog.debug, "abort_source is triggered in c-tor");
-                _reader = {};
+                _seg_reader = {};
             }
         }
 
@@ -273,7 +273,7 @@ public:
         auto ntp = _partition->get_ntp();
         vlog(_ctxlog.trace, "Destructing reader {}", ntp);
         _partition->_ts_probe.reader_destroyed();
-        if (_reader) {
+        if (_seg_reader) {
             // We must not destroy this reader: it is not safe to do so
             // without calling stop() on it.  The remote_partition is
             // responsible for cleaning up readers, including calling
@@ -312,7 +312,7 @@ public:
     operator=(const partition_record_batch_reader_impl& o)
       = delete;
 
-    bool is_end_of_stream() const override { return _reader == nullptr; }
+    bool is_end_of_stream() const override { return _seg_reader == nullptr; }
 
     void throw_on_external_abort() {
         _partition->_as.check();
@@ -333,11 +333,11 @@ public:
                   "empty");
                 co_return storage_t{};
             }
-            if (_reader->config().over_budget) {
+            if (_seg_reader->config().over_budget) {
                 vlog(
                   _ctxlog.debug,
                   "We're over-budget, stopping, config: {}",
-                  _reader->config());
+                  _seg_reader->config());
                 // We need to stop in such way that will keep the
                 // reader in the reusable state, so we could reuse
                 // it on next iteration
@@ -353,7 +353,7 @@ public:
                 }
 
                 throw_on_external_abort();
-                auto reader_delta = _reader->current_delta();
+                auto reader_delta = _seg_reader->current_delta();
                 if (
                   !_ot_state->empty()
                   && _ot_state->last_delta() > reader_delta) {
@@ -385,7 +385,7 @@ public:
                       "of the current reader: {}, delta offset of the offset "
                       "translator: {}, first offset produced by this reader: "
                       "{}",
-                      _reader->config(),
+                      _seg_reader->config(),
                       reader_delta,
                       _ot_state->last_delta(),
                       _first_produced_offset);
@@ -400,10 +400,10 @@ public:
                   _ctxlog.debug,
                   "Invoking 'read_some' on current log reader with config: "
                   "{}",
-                  _reader->config());
+                  _seg_reader->config());
 
                 try {
-                    auto result = co_await _reader->read_some(
+                    auto result = co_await _seg_reader->read_some(
                       deadline, *_ot_state);
                     throw_on_external_abort();
 
@@ -433,7 +433,7 @@ public:
                       _ctxlog.warn,
                       "stuck reader: current rp offset: {}, max rp offset: {}",
                       ex.rp_offset,
-                      _reader->max_rp_offset());
+                      _seg_reader->max_rp_offset());
 
                     // If the reader is stuck because of a mismatch between
                     // segment data and manifest entry, set reader to EOF and
@@ -448,7 +448,7 @@ public:
                     if (
                       model::next_offset(ex.rp_offset)
                         >= _next_segment_base_offset
-                      && !_reader->is_eof()) {
+                      && !_seg_reader->is_eof()) {
                         vlog(
                           _ctxlog.info,
                           "mismatch between current segment end and manifest "
@@ -457,10 +457,10 @@ public:
                           "set EOF on reader and try to "
                           "reset",
                           ex.rp_offset,
-                          _reader->max_rp_offset(),
+                          _seg_reader->max_rp_offset(),
                           _next_segment_base_offset,
-                          _reader->is_eof());
-                        _reader->set_eof();
+                          _seg_reader->is_eof());
+                        _seg_reader->set_eof();
                         continue;
                     }
                     throw;
@@ -486,7 +486,7 @@ public:
         // we've thrown an exception. Regardless of which error, the reader may
         // have been left in an indeterminate state. Re-set the pointer to it
         // to ensure that it will not be reused.
-        if (_reader) {
+        if (_seg_reader) {
             co_await set_end_of_stream();
         }
         if (unknown_exception_ptr) {
@@ -496,7 +496,7 @@ public:
         vlog(
           _ctxlog.debug,
           "EOS reached, reader available: {}, is end of stream: {}",
-          static_cast<bool>(_reader),
+          static_cast<bool>(_seg_reader),
           is_end_of_stream());
         co_return storage_t{};
     }
@@ -508,8 +508,8 @@ public:
 private:
     /// Return or evict currently referenced reader
     void dispose_current_reader() {
-        if (_reader) {
-            _partition->return_segment_reader(std::move(_reader));
+        if (_seg_reader) {
+            _partition->return_segment_reader(std::move(_seg_reader));
         }
     }
 
@@ -629,7 +629,7 @@ private:
           std::move(segment_unit),
           std::move(segment_reader_unit));
         if (reader) {
-            _reader = std::move(reader);
+            _seg_reader = std::move(reader);
             _next_segment_base_offset = next_offset;
             return;
         }
@@ -639,7 +639,7 @@ private:
           "segment not "
           "found, config: {}",
           config);
-        _reader = {};
+        _seg_reader = {};
         _next_segment_base_offset = {};
     }
 
@@ -677,17 +677,19 @@ private:
     /// attached.
     ss::future<bool> maybe_reset_reader() {
         vlog(_ctxlog.debug, "maybe_reset_reader called");
-        if (!_reader) {
+        if (!_seg_reader) {
             co_return false;
         }
-        if (_reader->config().start_offset > _reader->config().max_offset) {
+        if (
+          _seg_reader->config().start_offset
+          > _seg_reader->config().max_offset) {
             vlog(
               _ctxlog.debug,
               "maybe_reset_stream called - stream already consumed, start "
               "{}, "
               "max {}",
-              _reader->config().start_offset,
-              _reader->config().max_offset);
+              _seg_reader->config().start_offset,
+              _seg_reader->config().max_offset);
             // Entire range is consumed, detach from remote_partition and
             // close the reader.
             co_await set_end_of_stream();
@@ -697,16 +699,16 @@ private:
           _ctxlog.debug,
           "maybe_reset_reader, config start_offset: {}, reader max_offset: "
           "{}",
-          _reader->config().start_offset,
-          _reader->max_rp_offset());
+          _seg_reader->config().start_offset,
+          _seg_reader->max_rp_offset());
 
         // The next offset should be below the next segment base offset if the
         // reader has not finished. If the next offset to be read from has
         // reached the next segment but the reader is not finished, then the
         // state is inconsistent.
-        if (_reader->is_eof()) {
-            auto prev_max_offset = _reader->max_rp_offset();
-            auto config = _reader->config();
+        if (_seg_reader->is_eof()) {
+            auto prev_max_offset = _seg_reader->max_rp_offset();
+            auto config = _seg_reader->config();
             vlog(
               _ctxlog.debug,
               "maybe_reset_stream condition triggered after offset: {}, "
@@ -714,12 +716,12 @@ private:
               "reader's max log offset: {}, is EOF: {}, next base_offset "
               "estimate: {}",
               prev_max_offset,
-              _reader->current_rp_offset(),
+              _seg_reader->current_rp_offset(),
               config.start_offset,
-              _reader->max_rp_offset(),
-              _reader->is_eof(),
+              _seg_reader->max_rp_offset(),
+              _seg_reader->is_eof(),
               _next_segment_base_offset);
-            _partition->evict_segment_reader(std::move(_reader));
+            _partition->evict_segment_reader(std::move(_seg_reader));
             vlog(
               _ctxlog.debug,
               "initializing new segment reader {}, next offset {}, manifest "
@@ -798,32 +800,32 @@ private:
                     std::move(segment_reader_unit),
                     _next_segment_base_offset);
                 _next_segment_base_offset = new_next_offset;
-                _reader = std::move(new_reader);
+                _seg_reader = std::move(new_reader);
             }
-            if (maybe_manifest.has_value() && _reader != nullptr) {
+            if (maybe_manifest.has_value() && _seg_reader != nullptr) {
                 vassert(
-                  prev_max_offset != _reader->max_rp_offset(),
+                  prev_max_offset != _seg_reader->max_rp_offset(),
                   "Progress stall detected, ntp: {}, max offset of prev "
                   "reader: {}, max offset of the new reader {}",
                   _partition->get_ntp(),
                   prev_max_offset,
-                  _reader->max_rp_offset());
+                  _seg_reader->max_rp_offset());
             }
         }
         vlog(
           _ctxlog.debug,
           "maybe_reset_reader completed, reader is present: {}, is end of "
           "stream: {}",
-          static_cast<bool>(_reader),
+          static_cast<bool>(_seg_reader),
           is_end_of_stream());
-        co_return static_cast<bool>(_reader);
+        co_return static_cast<bool>(_seg_reader);
     }
 
     /// Transition reader to the completed state. Stop tracking state in
     /// the 'remote_partition'
     ss::future<> set_end_of_stream() {
-        co_await _reader->stop();
-        _reader = {};
+        co_await _seg_reader->stop();
+        _seg_reader = {};
     }
 
     retry_chain_node _rtc;
@@ -852,7 +854,7 @@ private:
 
     ss::lw_shared_ptr<storage::offset_translator_state> _ot_state;
     /// Reader state that was borrowed from the materialized_segment_state
-    std::unique_ptr<remote_segment_batch_reader> _reader;
+    std::unique_ptr<remote_segment_batch_reader> _seg_reader;
     /// Cancellation subscription
     ss::abort_source::subscription _as_sub;
     /// Reference to the abort source of the partition reader

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1148,13 +1148,6 @@ public:
         return k - _parent._cur_delta;
     }
 
-    /// Translate kafka offset to redpanda offset
-    ///
-    /// \note this can only be applied to current record batch
-    model::offset kafka_to_rp(kafka::offset k) const noexcept {
-        return k + _parent._cur_delta;
-    }
-
     /// Point config.start_offset to the next record batch
     ///
     /// \param header is a record batch header with redpanda offset

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -1130,7 +1130,7 @@ public:
       const model::ntp& ntp,
       retry_chain_node& rtc)
       : _config(conf)
-      , _parent(parent)
+      , _seg_reader(parent)
       , _term(term)
       , _rtc(&rtc)
       , _ctxlog(cst_log, _rtc, ntp.path())
@@ -1141,11 +1141,11 @@ public:
     /// \note this can only be applied to current record batch
     kafka::offset rp_to_kafka(model::offset k) const noexcept {
         vassert(
-          k() >= _parent._cur_delta(),
+          k() >= _seg_reader._cur_delta(),
           "Redpanda offset {} is smaller than the delta {}",
           k,
-          _parent._cur_delta);
-        return k - _parent._cur_delta;
+          _seg_reader._cur_delta);
+        return k - _seg_reader._cur_delta;
     }
 
     /// Point config.start_offset to the next record batch
@@ -1154,7 +1154,7 @@ public:
     /// \note this can only be applied to current record batch
     void
     advance_config_offsets(const model::record_batch_header& header) noexcept {
-        _parent._cur_rp_offset = header.last_offset() + model::offset{1};
+        _seg_reader._cur_rp_offset = header.last_offset() + model::offset{1};
 
         if (header.type == model::record_batch_type::raft_data) {
             auto next = rp_to_kafka(header.last_offset()) + model::offset(1);
@@ -1171,7 +1171,7 @@ public:
           "[{}] accept_batch_start {}, current delta: {}",
           _config.client_address,
           header,
-          _parent._cur_delta);
+          _seg_reader._cur_delta);
 
         if (
           rp_to_kafka(header.base_offset)
@@ -1195,7 +1195,7 @@ public:
               "[{}] accept_batch_start skip because record batch type is {}",
               _config.client_address,
               header.type);
-            _parent._probe.add_bytes_skip(header.size_bytes);
+            _seg_reader._probe.add_bytes_skip(header.size_bytes);
             return batch_consumer::consume_result::skip_batch;
         }
 
@@ -1213,7 +1213,7 @@ public:
               rp_to_kafka(header.last_offset()),
               header.last_offset(),
               _config.start_offset);
-            _parent._probe.add_bytes_skip(header.size_bytes);
+            _seg_reader._probe.add_bytes_skip(header.size_bytes);
             return batch_consumer::consume_result::skip_batch;
         }
 
@@ -1234,10 +1234,10 @@ public:
               "[{}] accept_batch_start skip because header timestamp is {}",
               _config.client_address,
               header.first_timestamp);
-            _parent._probe.add_bytes_skip(header.size_bytes);
+            _seg_reader._probe.add_bytes_skip(header.size_bytes);
             return batch_consumer::consume_result::skip_batch;
         }
-        _parent._probe.add_bytes_accept(header.size_bytes);
+        _seg_reader._probe.add_bytes_accept(header.size_bytes);
         // we want to consume the batch
         return batch_consumer::consume_result::accept_batch;
     }
@@ -1275,21 +1275,22 @@ public:
             _filtered_types.begin(), _filtered_types.end(), header.type)
           > 0) {
             vassert(
-              _parent._cur_ot_state,
+              _seg_reader._cur_ot_state,
               "ntp {}: offset translator state for "
               "remote_segment_batch_consumer not initialized",
-              _parent._seg->get_ntp());
+              _seg_reader._seg->get_ntp());
 
             vlog(
               _ctxlog.debug,
               "added offset translation gap [{}-{}], current state: {}",
               header.base_offset,
               header.last_offset(),
-              _parent._cur_ot_state);
+              _seg_reader._cur_ot_state);
 
-            _parent._cur_ot_state->get().add_gap(
+            _seg_reader._cur_ot_state->get().add_gap(
               header.base_offset, header.last_offset());
-            _parent._cur_delta += header.last_offset_delta + model::offset(1);
+            _seg_reader._cur_delta += header.last_offset_delta
+                                      + model::offset(1);
         }
     }
 
@@ -1313,7 +1314,7 @@ public:
         batch.header().header_crc = model::internal_header_only_crc(
           batch.header());
 
-        size_t sz = _parent.produce(std::move(batch));
+        size_t sz = _seg_reader.produce(std::move(batch));
 
         if (_config.over_budget) {
             co_return stop_parser::yes;
@@ -1332,7 +1333,7 @@ public:
 
 private:
     storage::log_reader_config& _config;
-    remote_segment_batch_reader& _parent;
+    remote_segment_batch_reader& _seg_reader;
     model::record_batch_header _header;
     iobuf _records;
     model::term_id _term;


### PR DESCRIPTION
Some non-functional changes that I noticed while reading through the read path:

- renames segment readers to `_seg_reader`, rather than `_parent` or `_reader`
- removes some dead code

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
