### PR TITLE
raft: remove full_raft_configuration_recovery_pattern config property

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2440,11 +2440,7 @@ configuration::configuration()
       {.visibility = visibility::tunable},
       8_MiB)
   , full_raft_configuration_recovery_pattern(
-      *this,
-      "full_raft_configuration_recovery_pattern",
-      "Recover raft configuration on start for NTPs matching pattern",
-      {.visibility = visibility::tunable},
-      {})
+      *this, "full_raft_configuration_recovery_pattern")
   , enable_auto_rebalance_on_node_add(
       *this,
       "enable_auto_rebalance_on_node_add",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -446,7 +446,7 @@ struct configuration final : public config_store {
     property<size_t> kafka_qdc_max_depth;
     property<std::chrono::milliseconds> kafka_qdc_depth_update_ms;
     property<size_t> zstd_decompress_workspace_bytes;
-    one_or_many_property<ss::sstring> full_raft_configuration_recovery_pattern;
+    deprecated_property full_raft_configuration_recovery_pattern;
     property<bool> enable_auto_rebalance_on_node_add;
 
     enum_property<model::partition_autobalancing_mode>


### PR DESCRIPTION
The property was added as a workaround to a bug, but has since (presumably) gone unused.

I have some upcoming changes to bring offset translation into the storage layer, and this property raises a complication since it allows Raft to start up with a mismatch between the storage log and Raft state. Maintaining the property moving forward would make startup a bit more difficult to reason about, and the property itself doesn't seem particularly safe nonetheless.

This commit removes it outright.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* The `full_raft_configuration_recovery_pattern` cluster config property is now deprecated and will be ignored by Redpanda.