### PR TITLE
cst/inv: Download latest report

### DIFF
--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -12,8 +12,10 @@
 
 #include "cloud_storage/remote.h"
 
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#include <re2/re2.h>
 
 using boost::property_tree::ptree;
 
@@ -60,6 +62,22 @@ iobuf to_xml(const aws_report_configuration& cfg) {
     iobuf b;
     b.append(sstr.str().data(), sstr.str().size());
     return b;
+}
+
+// YYYY-MM-DDTHH-MMZ/
+const re2::RE2 trailing_date_expression{R"(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}Z/)"};
+
+bool is_datetime(std::string_view path) {
+    return RE2::FullMatch(path, trailing_date_expression);
+}
+
+ss::sstring checksum_path(std::string_view path) {
+    return fmt::format("{}manifest.checksum", path);
+}
+
+ss::sstring manifest_path(std::string path) {
+    boost::replace_last(path, "checksum", "json");
+    return path;
 }
 
 } // namespace
@@ -109,6 +127,58 @@ ss::future<bool> aws_ops::inventory_configuration_exists(
        = {.bucket = _bucket, .key = _inventory_key, .parent_rtc = parent_rtc},
        .payload = buf});
     co_return dl_res == download_result::success;
+}
+
+ss::future<result<report_metadata_path, cloud_storage_clients::error_outcome>>
+aws_ops::latest_report_path(
+  cloud_storage::cloud_storage_api& remote, retry_chain_node& parent_rtc) {
+    // The prefix is generated according to
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-inventory-location.html
+    const auto prefix = cloud_storage_clients::object_key{
+      fmt::format("{}/{}/{}/", _prefix, _bucket, _inventory_config_id)};
+    const auto list_result = co_await remote.list_objects(
+      _bucket, parent_rtc, prefix, '/');
+
+    if (list_result.has_error()) {
+        co_return list_result.error();
+    }
+
+    // The prefix may contain non-datetime folders such as hive data, which we
+    // ignore. The datetime folders are normalized with the prefix, and then the
+    // checksum file path is appended to them. The final result is a series of
+    // paths to checksums which we need to probe.
+    auto filtered = list_result.value().common_prefixes
+                    | std::views::filter(is_datetime)
+                    | std::views::transform([&prefix](const auto& date_string) {
+                          return fmt::format(
+                            "{}{}", prefix().native(), date_string);
+                      })
+                    | std::views::transform(checksum_path);
+
+    std::vector<std::string> cksum_paths{filtered.begin(), filtered.end()};
+    // The datetime strings (YYYY-MM-DDTHH-MMZ) can be sorted by lexical
+    // comparison
+    std::ranges::sort(cksum_paths, std::ranges::greater());
+
+    // A checksum appears in the bucket at the designated location only once the
+    // inventory is ready, so we probe the checksum files from latest to
+    // earliest. We stop at the first checksum we find.
+    for (auto& checksum_path : cksum_paths) {
+        if (const auto result = co_await remote.object_exists(
+              _bucket,
+              cloud_storage_clients::object_key{checksum_path},
+              parent_rtc,
+              existence_check_type::object);
+            result == download_result::success) {
+            // Since the actual report paths will be embedded within the
+            // manifest, and the manifest and the report is guaranteed to exist
+            // once the checksum is found, we return the path to manifest.
+            co_return report_metadata_path{
+              manifest_path(std::move(checksum_path))};
+        }
+    }
+
+    co_return cloud_storage_clients::error_outcome::key_not_found;
 }
 
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -129,7 +129,7 @@ ss::future<bool> aws_ops::inventory_configuration_exists(
     co_return dl_res == download_result::success;
 }
 
-ss::future<result<report_metadata_path, cloud_storage_clients::error_outcome>>
+ss::future<result<report_metadata_path, client_error>>
 aws_ops::latest_report_path(
   cloud_storage::cloud_storage_api& remote, retry_chain_node& parent_rtc) {
     // The prefix is generated according to

--- a/src/v/cloud_storage/inventory/aws_ops.h
+++ b/src/v/cloud_storage/inventory/aws_ops.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "base/outcome.h"
 #include "cloud_storage/inventory/types.h"
 #include "cloud_storage_clients/types.h"
 #include "model/fundamental.h"
@@ -32,6 +33,12 @@ public:
 
     ss::future<bool> inventory_configuration_exists(
       cloud_storage::cloud_storage_api&, retry_chain_node&) override;
+
+    /// Returns the manifest path to the latest available report for the
+    /// inventory configuration assigned to this object
+    ss::future<
+      result<report_metadata_path, cloud_storage_clients::error_outcome>>
+    latest_report_path(cloud_storage::cloud_storage_api&, retry_chain_node&);
 
 private:
     cloud_storage_clients::bucket_name _bucket;

--- a/src/v/cloud_storage/inventory/inv_ops.cc
+++ b/src/v/cloud_storage/inventory/inv_ops.cc
@@ -74,4 +74,12 @@ inv_ops::maybe_create_inventory_configuration(
     }
 }
 
+ss::future<result<report_metadata_path, cloud_storage_clients::error_outcome>>
+inv_ops::latest_report_path(
+  cloud_storage_api& remote, retry_chain_node& parent) {
+    return ss::visit(_inv_ops, [&remote, &parent](auto& ops) {
+        return ops.latest_report_path(remote, parent);
+    });
+}
+
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/inv_ops.h
+++ b/src/v/cloud_storage/inventory/inv_ops.h
@@ -30,6 +30,9 @@ public:
     ss::future<inventory_creation_result>
     maybe_create_inventory_configuration(cloud_storage_api&, retry_chain_node&);
 
+    ss::future<result<report_metadata_path, client_error>>
+    latest_report_path(cloud_storage_api&, retry_chain_node&);
+
 private:
     ops_t _inv_ops;
 };

--- a/src/v/cloud_storage/inventory/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/inventory/tests/CMakeLists.txt
@@ -1,9 +1,10 @@
 rp_test(
   UNIT_TEST
   GTEST
-  BINARY_NAME create_inv_cfg
+  BINARY_NAME inv_api
   SOURCES
     create_inventory_config_test.cc
+    fetch_report_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     Boost::unit_test_framework

--- a/src/v/cloud_storage/inventory/tests/common.h
+++ b/src/v/cloud_storage/inventory/tests/common.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/remote.h"
+
+#include <gmock/gmock.h>
+
+namespace cloud_storage::inventory {
+
+class MockRemote : public cloud_storage::cloud_storage_api {
+public:
+    MOCK_METHOD(
+      ss::future<cloud_storage::upload_result>,
+      upload_object,
+      (cloud_storage::upload_request),
+      (override));
+    MOCK_METHOD(
+      ss::future<cloud_storage::download_result>,
+      download_object,
+      (cloud_storage::download_request),
+      (override));
+    MOCK_METHOD(
+      ss::future<cloud_storage::cloud_storage_api::list_result>,
+      list_objects,
+      (const cloud_storage_clients::bucket_name&,
+       retry_chain_node&,
+       std::optional<cloud_storage_clients::object_key>,
+       std::optional<char>,
+       std::optional<cloud_storage_clients::client::item_filter>),
+      (override));
+    MOCK_METHOD(
+      ss::future<cloud_storage::download_result>,
+      object_exists,
+      (const cloud_storage_clients::bucket_name&,
+       const cloud_storage_clients::object_key&,
+       retry_chain_node&,
+       existence_check_type),
+      (override));
+};
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/inventory/aws_ops.h"
+#include "cloud_storage/inventory/tests/common.h"
+
+namespace cst = cloud_storage;
+namespace cl = cloud_storage_clients;
+namespace t = ::testing;
+
+const auto id = cst::inventory::inventory_config_id{"redpanda-inv-weekly"};
+const auto bucket = cl::bucket_name{"test-bucket"};
+constexpr auto prefix = "inv-prefix";
+const auto list_prefix = fmt::format("{}/{}/{}/", prefix, bucket, id);
+
+void validate_list_objects(
+  cst::inventory::MockRemote& remote,
+  retry_chain_node& parent,
+  cl::client::list_bucket_result result) {
+    EXPECT_CALL(
+      remote,
+      list_objects(
+        t::Eq(bucket),
+        t::Ref(parent),
+        t::Eq(list_prefix),
+        t::Optional('/'),
+        t::Eq(std::nullopt)))
+      .Times(1)
+      .WillOnce(
+        t::Return(ss::make_ready_future<cst::cloud_storage_api::list_result>(
+          std::move(result))));
+}
+
+TEST(FindLatestReport, NoReportsExist) {
+    ss::abort_source as;
+    retry_chain_node parent{as};
+
+    cst::inventory::MockRemote remote;
+    validate_list_objects(remote, parent, {});
+
+    cst::inventory::aws_ops ops{bucket, id, prefix};
+    const auto result = ops.latest_report_path(remote, parent).get();
+
+    EXPECT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), cl::error_outcome::key_not_found);
+}
+
+TEST(FindLatestReport, LatestReportPathReturned) {
+    ss::abort_source as;
+    retry_chain_node parent{as};
+
+    constexpr auto latest_date = "1945-05-07T23-23Z/";
+    constexpr auto latest_date_which_has_report = "1757-06-23T00-02Z/";
+
+    // We expect the following prefixes to be checked, in order from latest to
+    // earliest.
+    // The scanning will stop once the first manifest checksum is found
+    const auto dates = cl::client::list_bucket_result{
+      .common_prefixes = {
+        "1215-06-15T01-02Z/",
+        latest_date_which_has_report,
+        latest_date,
+        "1337-05-24T02-01Z/"}};
+
+    cst::inventory::MockRemote remote;
+    validate_list_objects(remote, parent, dates);
+
+    // The latest date does not have a manifest checksum, so it will be checked
+    // and then discarded
+    EXPECT_CALL(
+      remote,
+      object_exists(
+        t::Eq(bucket),
+        t::Eq(fmt::format("{}{}manifest.checksum", list_prefix, latest_date)),
+        t::Ref(parent),
+        t::Eq(cst::existence_check_type::object)))
+      .Times(1)
+      .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
+        cst::download_result::notfound)));
+
+    // The next latest date does have a checksum file, so it becomes the result
+    EXPECT_CALL(
+      remote,
+      object_exists(
+        t::Eq(bucket),
+        t::Eq(fmt::format(
+          "{}{}manifest.checksum", list_prefix, latest_date_which_has_report)),
+        t::Ref(parent),
+        t::Eq(cst::existence_check_type::object)))
+      .Times(1)
+      .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
+        cst::download_result::success)));
+
+    cst::inventory::aws_ops ops{bucket, id, prefix};
+    const auto result = ops.latest_report_path(remote, parent).get();
+
+    EXPECT_TRUE(result.has_value());
+    EXPECT_EQ(
+      result.value(),
+      fmt::format(
+        "{}{}manifest.json", list_prefix, latest_date_which_has_report));
+}
+
+TEST(FindLatestReport, NonDatePathsIgnored) {
+    ss::abort_source as;
+    retry_chain_node parent{as};
+
+    const auto dates = cl::client::list_bucket_result{
+      .common_prefixes = {"1215-06/", "133701Z/"}};
+
+    cst::inventory::MockRemote remote;
+    validate_list_objects(remote, parent, dates);
+
+    cst::inventory::aws_ops ops{bucket, id, prefix};
+    const auto result = ops.latest_report_path(remote, parent).get();
+
+    EXPECT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), cl::error_outcome::key_not_found);
+}

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -70,4 +70,15 @@ enum class inventory_creation_result {
 
 std::ostream& operator<<(std::ostream&, inventory_creation_result);
 
+// The report metadata path is the path in bucket to a manifest JSON file which
+// contains directions to the report. For some vendors such as AWS there is a
+// simple path to the report in the manifest. For Google the report may be split
+// into shards, and the manifest will contain paths to all the shards. Vendor
+// specific APIs will parse this metadata object and download the actual
+// reports. The presence of this path also guarantees that the report has been
+// fully generated.
+
+using report_metadata_path
+  = named_type<ss::sstring, struct report_metadata_path_t>;
+
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "cloud_storage_clients/types.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/sharded.hh>
@@ -80,5 +81,7 @@ std::ostream& operator<<(std::ostream&, inventory_creation_result);
 
 using report_metadata_path
   = named_type<ss::sstring, struct report_metadata_path_t>;
+
+using client_error = cloud_storage_clients::error_outcome;
 
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -1337,7 +1337,7 @@ ss::future<remote::list_result> remote::list_objects(
     // Gathers the items from a series of successful ListObjectsV2 calls
     cloud_storage_clients::client::list_bucket_result list_bucket_result;
 
-    // Keep iterating until the ListObjectsV2 calls has more items to return
+    // Keep iterating while the ListObjectsV2 calls has more items to return
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto res = co_await lease.client->list_objects(
           bucket,

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -909,17 +909,17 @@ remote::download_object(cloud_storage::download_request download_request) {
     co_return *result;
 }
 
-ss::future<download_result> remote::segment_exists(
+ss::future<download_result> remote::object_exists(
   const cloud_storage_clients::bucket_name& bucket,
-  const remote_segment_path& segment_path,
-  retry_chain_node& parent) {
+  const cloud_storage_clients::object_key& path,
+  retry_chain_node& parent,
+  existence_check_type object_type) {
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(cst_log, fib);
-    auto path = cloud_storage_clients::object_key(segment_path());
     auto lease = co_await _pool.local().acquire(fib.root_abort_source());
     auto permit = fib.retry();
-    vlog(ctxlog.debug, "Check segment {}", path);
+    vlog(ctxlog.debug, "Check {} {}", object_type, path);
     std::optional<download_result> result;
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto resp = co_await lease.client->head_object(
@@ -959,20 +959,33 @@ ss::future<download_result> remote::segment_exists(
     if (!result) {
         vlog(
           ctxlog.warn,
-          "HeadObject from {}, backoff quota exceded, segment at {} "
+          "HeadObject from {}, backoff quota exceded, {} at {} "
           "not available",
           bucket,
+          object_type,
           path);
         result = download_result::timedout;
     } else {
         vlog(
           ctxlog.warn,
-          "HeadObject from {}, {}, segment at {} not available",
+          "HeadObject from {}, {}, {} at {} not available",
           bucket,
           *result,
+          object_type,
           path);
     }
     co_return *result;
+}
+
+ss::future<download_result> remote::segment_exists(
+  const cloud_storage_clients::bucket_name& bucket,
+  const remote_segment_path& segment_path,
+  retry_chain_node& parent) {
+    co_return co_await object_exists(
+      bucket,
+      cloud_storage_clients::object_key{segment_path},
+      parent,
+      existence_check_type::segment);
 }
 
 ss::future<upload_result> remote::delete_object(

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -355,6 +355,12 @@ public:
     ss::future<download_result>
     download_object(download_request download_request) override;
 
+    ss::future<download_result> object_exists(
+      const cloud_storage_clients::bucket_name& bucket,
+      const cloud_storage_clients::object_key& path,
+      retry_chain_node& parent,
+      existence_check_type object_type);
+
     /// Checks if the segment exists in the bucket
     ss::future<download_result> segment_exists(
       const cloud_storage_clients::bucket_name& bucket,

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -547,4 +547,14 @@ void transfer_details::on_backoff(remote_probe& probe) {
     run_callback(backoff_cb, probe);
 }
 
+std::ostream& operator<<(std::ostream& os, existence_check_type head) {
+    switch (head) {
+        using enum cloud_storage::existence_check_type;
+    case object:
+        return os << "object";
+    case segment:
+        return os << "segment";
+    }
+}
+
 } // namespace cloud_storage

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -439,6 +439,10 @@ enum class download_type {
 
 std::ostream& operator<<(std::ostream&, download_type);
 
+enum class existence_check_type { object, segment };
+
+std::ostream& operator<<(std::ostream&, existence_check_type);
+
 class remote_probe;
 using probe_callback_t = ss::noncopyable_function<void(remote_probe&)>;
 


### PR DESCRIPTION
Adds a utility to scan through all the dates available for a given inventory config and find the latest report which has been generated and is ready for download.

Returns the path to manifest describing the report found.

The caller can then use the metadata to download the actual report.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
