### PR TITLE
[v23.3.x] Fixed background apply fiber race condition in `raft::state_machine_manager`

### DIFF
--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -114,7 +114,7 @@ private:
     using state_machines_t = absl::flat_hash_map<ss::sstring, entry_ptr>;
 
     void maybe_start_background_apply(const entry_ptr&);
-    ss::future<> background_apply_fiber(entry_ptr);
+    ss::future<> background_apply_fiber(entry_ptr, ssx::semaphore_units);
 
     ss::future<> apply_raft_snapshot();
     ss::future<> do_apply_raft_snapshot(

--- a/src/v/raft/tests/stm_manager_test.cc
+++ b/src/v/raft/tests/stm_manager_test.cc
@@ -128,6 +128,31 @@ TEST_F_CORO(state_machine_fixture, test_apply_throwing_exception) {
         ASSERT_EQ_CORO(stm->state, expected);
     }
 }
+TEST_F_CORO(
+  state_machine_fixture, test_apply_throwing_exception_waiting_for_each_batch) {
+    /**
+     * Create 3 replicas group with simple_kv STM
+     */
+    create_nodes();
+    std::vector<ss::shared_ptr<simple_kv>> stms;
+
+    for (auto& [id, node] : nodes()) {
+        raft::state_machine_manager_builder builder;
+        auto kv_stm = builder.create_stm<simple_kv>(*node);
+        auto throwing_kv_stm = builder.create_stm<throwing_kv>(*node);
+        co_await node->init_and_start(all_vnodes(), std::move(builder));
+        stms.push_back(kv_stm);
+        stms.push_back(ss::dynamic_pointer_cast<simple_kv>(throwing_kv_stm));
+    }
+
+    auto expected = co_await build_random_state(5000, wait_for_each_batch::yes);
+
+    co_await wait_for_apply();
+
+    for (auto& stm : stms) {
+        ASSERT_EQ_CORO(stm->state, expected);
+    }
+}
 
 TEST_F_CORO(state_machine_fixture, test_recovery_without_snapshot) {
     /**


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16850
