### PR TITLE
net: Added EHOSTUNREACH to retry list

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -17,6 +17,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/net/tls.hh>
 
+#include <asm-generic/errno.h>
 #include <gnutls/gnutls.h>
 
 namespace net {
@@ -53,6 +54,10 @@ bool is_reconnect_error(const std::system_error& e) {
         case ECONNABORTED:
         case EAGAIN:
         case EPIPE:
+        case EHOSTUNREACH:
+        case EHOSTDOWN:
+        case ENETRESET:
+        case ENETDOWN:
             return true;
         default:
             return false;


### PR DESCRIPTION
Fixes: #16901

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [X] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Added `EHOSTUNREACH` to retry-able error code list