### PR TITLE
Revert "rm_stm/idempotency: fix the producer lock scope"

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -1166,6 +1166,7 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
         req_ptr->set_value<ret_t>(errc::replication_error);
         co_return errc::replication_error;
     }
+    units.return_all();
     enqueued->set_value();
     auto replicated = co_await ss::coroutine::as_future(
       std::move(stages.replicate_finished));
@@ -1181,7 +1182,6 @@ ss::future<result<kafka_result>> rm_stm::do_idempotent_replicate(
         req_ptr->set_value<ret_t>(result.error());
         co_return result.error();
     }
-    units.return_all();
     // translate to kafka offset.
     auto kafka_offset = from_log_offset(result.value().last_offset);
     auto final_result = kafka_result{.last_offset = kafka_offset};


### PR DESCRIPTION
Reverts redpanda-data/redpanda#16706

We don't have enough evidence that this caused the correctness issue and on the flip side it caused a performance regression. 
## Release Notes
- none