### PR TITLE
Use cryptolib instead of gnutls for HMAC and secure digests

### DIFF
--- a/src/v/hashing/CMakeLists.txt
+++ b/src/v/hashing/CMakeLists.txt
@@ -9,7 +9,7 @@ v_cc_library(
   DEPS
     xxHash::xxhash
     Crc32c::crc32c
-    GnuTLS::GnuTLS
+    v::crypto
     v::bytes
   DEFINES
     -DXXH_PRIVATE_API

--- a/src/v/hashing/include/hashing/secure.h
+++ b/src/v/hashing/include/hashing/secure.h
@@ -10,99 +10,92 @@
  */
 #pragma once
 #include "bytes/bytes.h"
-
-#include <gnutls/crypto.h>
-#include <gnutls/gnutls.h>
-
-class hmac_exception final : public std::exception {
-public:
-    explicit hmac_exception(const char* msg)
-      : _msg(msg) {}
-
-    const char* what() const noexcept final { return _msg; }
-
-private:
-    const char* _msg;
-};
-
-class hash_exception final : public std::exception {
-public:
-    explicit hash_exception(const char* msg)
-      : _msg(msg) {}
-
-    const char* what() const noexcept final { return _msg; }
-
-private:
-    const char* _msg;
-};
+#include "crypto/crypto.h"
 
 namespace internal {
 
-template<gnutls_mac_algorithm_t Algo, size_t DigestSize>
+/**
+ * Creates a context that can be used to perform an HMAC operation
+ *
+ * @tparam Algo The algorithm type
+ * @tparam DigestSize The expected size of the digest
+ * @note To maintainers, do not create a new exception class that inherits from
+ * `crypto::exception`.  There are other exceptions within the crypto library
+ * that inherit from `crypto::exception` that are hidden from users.
+ */
+template<crypto::digest_type Algo, size_t DigestSize>
 class hmac {
     static_assert(DigestSize > 0, "digest cannot be zero length");
 
 public:
-    // silence clang-tidy about _handle being uninitialized
-    // NOLINTNEXTLINE(hicpp-member-init, cppcoreguidelines-pro-type-member-init)
+    /**
+     * Construct a new hmac object
+     *
+     * @param key The key to use in the HMAC operation
+     * @throws crypto::exception If DigestSize is invalid or internal error with
+     * crypto lib
+     */
     explicit hmac(std::string_view key)
-      : hmac(key.data(), key.size()) {}
+      : _ctx(Algo, key) {
+        validate_hmac_len();
+    }
 
-    // silence clang-tidy about _handle being uninitialized
-    // NOLINTNEXTLINE(hicpp-member-init, cppcoreguidelines-pro-type-member-init)
     explicit hmac(bytes_view key)
-      : hmac(key.data(), key.size()) {}
+      : _ctx(Algo, key) {
+        validate_hmac_len();
+    }
 
     hmac(const hmac&) = delete;
     hmac& operator=(const hmac&) = delete;
     hmac(hmac&&) = delete;
     hmac& operator=(hmac&&) = delete;
 
-    ~hmac() noexcept { gnutls_hmac_deinit(_handle, nullptr); }
+    ~hmac() noexcept = default;
 
-    void update(std::string_view data) { update(data.data(), data.size()); }
-    void update(bytes_view data) { update(data.data(), data.size()); }
+    /**
+     * Updates the HMAC operation with the supplied data
+     *
+     * @throws crypto::exception If there is an internal error with crypto lib
+     */
+    void update(std::string_view data) { _ctx.update(data); }
+    void update(bytes_view data) { _ctx.update(data); }
 
     template<std::size_t Size>
     void update(const std::array<char, Size>& data) {
-        update(data.data(), Size);
+        _ctx.update({data.data(), data.size()});
     }
 
     /**
-     * Return the current output and reset.
+     * Return the signature and resets the context so it can be used again
+     * @throws crypto::exception If there is an internal error with crypto lib
      */
     std::array<char, DigestSize> reset() {
         std::array<char, DigestSize> digest;
-        gnutls_hmac_output(_handle, digest.data());
+        _ctx.reset(digest);
         return digest;
     }
 
 private:
-    // silence clang-tidy about _handle being uninitialized
-    // NOLINTNEXTLINE(hicpp-member-init, cppcoreguidelines-pro-type-member-init)
-    hmac(const void* key, size_t size) {
-        int ret = gnutls_hmac_init(&_handle, Algo, key, size);
-        if (unlikely(ret)) {
-            throw hmac_exception(gnutls_strerror(ret));
-        }
-
-        ret = gnutls_hmac_get_len(Algo);
-        if (unlikely(ret != DigestSize)) {
-            throw hmac_exception("invalid digest length");
+    void validate_hmac_len() {
+        auto len = _ctx.size();
+        if (unlikely(len != DigestSize)) {
+            throw crypto::exception("invalid digest length");
         }
     }
 
-    void update(const void* data, size_t size) {
-        int ret = gnutls_hmac(_handle, data, size);
-        if (unlikely(ret)) {
-            throw hmac_exception(gnutls_strerror(ret));
-        }
-    }
-
-    gnutls_hmac_hd_t _handle;
+    crypto::hmac_ctx _ctx;
 };
 
-template<gnutls_digest_algorithm_t Algo, size_t DigestSize>
+/**
+ * Creates a context that can be used to perform digest operations
+ *
+ * @tparam Algo The algorithm to perform
+ * @tparam DigestSize The expected digest size
+ * @note To maintainers, do not create a new exception class that inherits from
+ * `crypto::exception`.  There are other exceptions within the crypto library
+ * that inherit from `crypto::exception` that are hidden from users.
+ */
+template<crypto::digest_type Algo, size_t DigestSize>
 class hash {
     static_assert(DigestSize > 0, "digest cannot be zero length");
 
@@ -110,17 +103,18 @@ public:
     static constexpr auto digest_size = DigestSize;
     using digest_type = std::array<char, DigestSize>;
 
-    // silence clang-tidy about _handle being uninitialized
-    // NOLINTNEXTLINE(hicpp-member-init, cppcoreguidelines-pro-type-member-init)
-    hash() {
-        int ret = gnutls_hash_init(&_handle, Algo);
-        if (unlikely(ret)) {
-            throw hash_exception(gnutls_strerror(ret));
-        }
+    /**
+     * Construct a new hash object
+     *
+     * @throws crypto::exception If DigestSize is not correct or if there is an
+     * internal error with crypto lib
+     */
+    hash()
+      : _ctx(Algo) {
+        auto len = _ctx.size();
 
-        ret = gnutls_hash_get_len(Algo);
-        if (unlikely(ret != DigestSize)) {
-            throw hash_exception("invalid digest length");
+        if (unlikely(len != DigestSize)) {
+            throw crypto::exception("invalid digest length");
         }
     }
 
@@ -129,37 +123,37 @@ public:
     hash(hash&&) = delete;
     hash& operator=(hash&&) = delete;
 
-    ~hash() noexcept { gnutls_hash_deinit(_handle, nullptr); }
-
-    void update(std::string_view data) { update(data.data(), data.size()); }
-    void update(bytes_view data) { update(data.data(), data.size()); }
+    ~hash() noexcept = default;
 
     /**
-     * Return the current output and reset.
+     * Updates the hash operation with the provided message
+     *
+     * @throws crypto::exception IF there is an internal error with crypto lib
+     */
+    void update(std::string_view data) { _ctx.update(data); }
+    void update(bytes_view data) { _ctx.update(data); }
+
+    /**
+     * Return the digest of the data and resets the context so it can be used
+     * again
+     * @throws crypto::exception On internal error with crypto lib
      */
     digest_type reset() {
         std::array<char, DigestSize> digest;
-        gnutls_hash_output(_handle, digest.data());
+        _ctx.reset(digest);
         return digest;
     }
 
 private:
-    void update(const void* data, size_t size) {
-        int ret = gnutls_hash(_handle, data, size);
-        if (unlikely(ret)) {
-            throw hash_exception(gnutls_strerror(ret));
-        }
-    }
-
-    gnutls_hash_hd_t _handle;
+    crypto::digest_ctx _ctx;
 };
 
 } // namespace internal
 
 // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
-using hmac_sha256 = internal::hmac<GNUTLS_MAC_SHA256, 32>;
-using hmac_sha512 = internal::hmac<GNUTLS_MAC_SHA512, 64>;
-using hash_sha256 = internal::hash<GNUTLS_DIG_SHA256, 32>;
-using hash_sha512 = internal::hash<GNUTLS_DIG_SHA512, 64>;
-using hash_md5 = internal::hash<GNUTLS_DIG_MD5, 16>;
+using hmac_sha256 = internal::hmac<crypto::digest_type::SHA256, 32>;
+using hmac_sha512 = internal::hmac<crypto::digest_type::SHA512, 64>;
+using hash_sha256 = internal::hash<crypto::digest_type::SHA256, 32>;
+using hash_sha512 = internal::hash<crypto::digest_type::SHA512, 64>;
+using hash_md5 = internal::hash<crypto::digest_type::MD5, 16>;
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)

--- a/src/v/net/CMakeLists.txt
+++ b/src/v/net/CMakeLists.txt
@@ -16,6 +16,7 @@ v_cc_library(
     v::metrics
     v::hashing
     v::compression
+    GnuTLS::GnuTLS
   )
 
 add_subdirectory(tests)


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes: https://github.com/redpanda-data/core-internal/issues/1121

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
