### PR TITLE
remote partition_manifest validation for topic recovery

### DIFF
--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -988,6 +988,40 @@ ss::future<download_result> remote::segment_exists(
       existence_check_type::segment);
 }
 
+ss::future<remote::partition_manifest_existence>
+remote::partition_manifest_exists(
+  const cloud_storage_clients::bucket_name& bucket,
+  model::ntp ntp,
+  model::initial_revision_id rev_id,
+  retry_chain_node& parent) {
+    // first check serde and exit early if it exists
+    auto serde_res = co_await object_exists(
+      bucket,
+      cloud_storage_clients::object_key{generate_partition_manifest_path(
+        ntp, rev_id, manifest_format::serde)()},
+      parent,
+      existence_check_type::manifest);
+
+    switch (serde_res) {
+    case download_result::success:
+        co_return partition_manifest_existence{
+          download_result::success, manifest_format::serde};
+    case download_result::notfound: {
+        auto json_res = co_await object_exists(
+          bucket,
+          cloud_storage_clients::object_key{generate_partition_manifest_path(
+            ntp, rev_id, manifest_format::json)()},
+          parent,
+          existence_check_type::manifest);
+        co_return partition_manifest_existence{json_res, manifest_format::json};
+    }
+    case download_result::failed:
+    case download_result::timedout:
+        // do not try to check for json in case of failures
+        co_return partition_manifest_existence{serde_res, {}};
+    }
+}
+
 ss::future<upload_result> remote::delete_object(
   const cloud_storage_clients::bucket_name& bucket,
   const cloud_storage_clients::object_key& path,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -385,6 +385,28 @@ public:
       const remote_segment_path& path,
       retry_chain_node& parent);
 
+    struct partition_manifest_existence {
+        download_result download_result;
+        manifest_format manifest_format;
+    };
+
+    /// \brief Specialization of object_exists for partition_manifest.
+    /// Checks the existence of either serde or json format.
+    /// This a chained operation, possible results are
+    /// <success, manifest_format::serde>, <success, manifest_format::json>,
+    /// <notfound/failed/timedout, [don't care]> the serde format is checked
+    /// first, if found the function will not check the existence of the json
+    /// format.
+    /// \param ntp ntp to query.
+    /// \param rev_id initial revision id of the remote partition.
+    /// \return partition_manifest_exists_result that
+    /// contains the result of the download and the format of the manifest.
+    ss::future<partition_manifest_existence> partition_manifest_exists(
+      const cloud_storage_clients::bucket_name& bucket,
+      model::ntp npt,
+      model::initial_revision_id rev_id,
+      retry_chain_node& parent);
+
     /// \brief Delete object from S3
     ///
     /// The method deletes the object. It can retry after some errors.

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -564,6 +564,8 @@ std::ostream& operator<<(std::ostream& os, existence_check_type head) {
         return os << "object";
     case segment:
         return os << "segment";
+    case manifest:
+        return os << "manifest";
     }
 }
 

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -418,7 +418,7 @@ enum class download_type { object, segment_index, inventory_report_manifest };
 
 std::ostream& operator<<(std::ostream&, download_type);
 
-enum class existence_check_type { object, segment };
+enum class existence_check_type { object, segment, manifest };
 
 std::ostream& operator<<(std::ostream&, existence_check_type);
 

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -85,6 +85,8 @@ rpcgen(
 
 v_cc_library(
   NAME cluster
+  HDRS
+    topic_recovery_validator.h
   SRCS
     metadata_cache.cc
     partition_manager.cc
@@ -206,6 +208,7 @@ v_cc_library(
     tx_topic_manager.cc
     shard_placement_table.cc
     shard_balancer.cc
+    topic_recovery_validator.cc
   DEPS
     Seastar::seastar
     bootstrap_rpc

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -88,6 +88,7 @@ enum class errc : int16_t {
     topic_invalid_partitions_fd_limit,
     topic_invalid_partitions_decreased,
     producer_ids_vcluster_limit_exceeded,
+    validation_of_recovery_topic_failed,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -256,6 +257,8 @@ struct errc_category final : public std::error_category {
             return "Can not decrease the number of partitions";
         case errc::producer_ids_vcluster_limit_exceeded:
             return "To many vclusters registered in producer state cache";
+        case errc::validation_of_recovery_topic_failed:
+            return "Validation of recovery topic failed";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/partition_manager.cc
+++ b/src/v/cluster/partition_manager.cc
@@ -275,7 +275,7 @@ partition_manager::maybe_download_log(
     vlog(
       clusterlog.debug,
       "Logs can't be downloaded because cloud storage is not configured. "
-      "Continue creating {} witout downloading the logs.",
+      "Continue creating {} without downloading the logs.",
       ntp_cfg);
     co_return cloud_storage::log_recovery_result{};
 }

--- a/src/v/cluster/topic_recovery_validator.cc
+++ b/src/v/cluster/topic_recovery_validator.cc
@@ -247,6 +247,12 @@ maybe_validate_recovery_topic(
       = config::shard_local_cfg()
           .cloud_storage_recovery_topic_validation_depth.value();
 
+    if (checks_mode == model::recovery_validation_mode::no_check) {
+        // skip validation, return an empty map. this is interpreted as "no
+        // failures"
+        co_return absl::flat_hash_map<model::partition_id, validation_result>{};
+    }
+
     vlog(
       clusterlog.info,
       "Performing validation mode={} max_semgment_depth={} on topic {} with {} "
@@ -271,11 +277,6 @@ maybe_validate_recovery_topic(
         return absl::flat_hash_map<model::partition_id, validation_result>{
           init.begin(), init.end()};
     }();
-
-    if (checks.mode == model::recovery_validation_mode::no_check) {
-        // skip validation
-        co_return std::move(results);
-    }
 
     auto [ns, topic] = assignable_config.cfg.tp_ns;
 

--- a/src/v/cluster/topic_recovery_validator.cc
+++ b/src/v/cluster/topic_recovery_validator.cc
@@ -1,0 +1,305 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "topic_recovery_validator.h"
+
+#include "cloud_storage/anomalies_detector.h"
+#include "cluster/logger.h"
+
+#include <seastar/coroutine/as_future.hh>
+
+namespace cluster {
+
+// Each partition gets a separate retry_chain_node and a logger tied to it.
+// From this a common retry_chain_logger is created
+partition_validator::partition_validator(
+  cloud_storage::remote& remote,
+  cloud_storage_clients::bucket_name const& bucket,
+  ss::abort_source& as,
+  model::ntp ntp,
+  model::initial_revision_id rev_id,
+  recovery_checks checks)
+  : remote_{&remote}
+  , bucket_{&bucket}
+  , as_{&as}
+  , ntp_{std::move(ntp)}
+  , rev_id_{rev_id}
+  , op_rtc_{retry_chain_node{
+      as,
+      300s,
+      config::shard_local_cfg().cloud_storage_initial_backoff_ms.value()}}
+  , op_logger_{retry_chain_logger{
+      clusterlog,
+      op_rtc_,
+      ssx::sformat("recovery validation of {}/{}", ntp_, rev_id_)}}
+  , checks_{checks} {}
+
+ss::future<validation_result> partition_validator::run() {
+    op_logger_.debug(
+      "will perform checks: mode={}, max_segment_depth={}",
+      checks_.mode,
+      checks_.max_segment_depth);
+
+    switch (checks_.mode) {
+        using enum model::recovery_validation_mode;
+    case no_check:
+        // Handle this for switch-completeness, should be already
+        // handled by the caller
+        return ss::make_ready_future<validation_result>(
+          validation_result::passed);
+    case check_manifest_existence:
+        return do_validate_manifest_existence();
+    case check_manifest_and_segment_metadata:
+        return do_validate_manifest_metadata();
+    }
+}
+
+ss::future<validation_result>
+partition_validator::do_validate_manifest_existence() {
+    auto [download_res, manifest_format]
+      = co_await remote_->partition_manifest_exists(
+        *bucket_, ntp_, rev_id_, op_rtc_);
+    // only res==success (manifest found) or res==notfound (manifest NOT
+    // found) make sense. warn for timedout and failed
+    if (download_res == cloud_storage::download_result::success) {
+        op_logger_.info("manifest found, validation ok");
+        co_return validation_result::passed;
+    }
+
+    if (download_res == cloud_storage::download_result::notfound) {
+        op_logger_.info("no manifest, validation ok");
+        co_return validation_result::missing_manifest;
+    }
+
+    // abnormal failure mode: could be a configuration issue or an
+    // external service issue (note that the manifest path will end in
+    // .bin but the value is just a hint of the HEAD request that
+    // generated the abnormal result)
+    op_logger_.error(
+      "manifest {} download error: download_result: {}, validation not ok",
+      get_path(manifest_format),
+      download_res);
+
+    co_return validation_result::download_issue;
+}
+
+ss::future<validation_result>
+partition_validator::do_validate_manifest_metadata() {
+    // allow enough quota just to check existence and self metadata check
+    // and few segments existence
+    // TODO ensure that future evolution of anomalies detector operate on a
+    // "metadata first" behaviour
+    auto detector = cloud_storage::anomalies_detector{
+      *bucket_,
+      ntp_,
+      rev_id_,
+      *remote_,
+      op_logger_,
+      *as_,
+    };
+
+    // spin up detector
+    auto anomalies_fut = co_await ss::coroutine::as_future(detector.run(
+      op_rtc_,
+      cloud_storage::anomalies_detector::segment_depth_t{
+        checks_.max_segment_depth}));
+
+    if (anomalies_fut.failed()) {
+        // propagate shutdown exceptions, but treat other exceptions as hard
+        // failures. likely could be serde exceptions for a corrupt file
+        auto ex = anomalies_fut.get_exception();
+        if (ssx::is_shutdown_exception(ex)) {
+            co_return ss::coroutine::exception(ex);
+        }
+        op_logger_.error(
+          "manifest {} metadata check threw exception: {}, "
+          "validation not ok",
+          get_path(),
+          ex);
+        co_return validation_result::anomaly_detected;
+    }
+
+    // examine anomalies, some are real failures while other can be
+    // tolerated
+    auto anomalies = anomalies_fut.get();
+    if (anomalies.status == cloud_storage::scrub_status::failed) {
+        // download issue. could be a configuration issue or a s3 issue
+        op_logger_.error(
+          "manifest {} metadata check download failure, validation not ok",
+          get_path());
+        co_return validation_result::download_issue;
+    }
+
+    if (!anomalies.detected.has_value()) {
+        // no anomalies detected, everything is ok up to segment depth
+        op_logger_.info("manifest metadata check passed, validation ok");
+        co_return validation_result::passed;
+    }
+
+    // this unpack is to trigger a compilation error if a new field is added
+    // to cloud_storage::anomalies. If a new anomalies is added, it should
+    // be also handled here
+    auto const& [no_partition_manifest, missing_spillovers, missing_segments, segment_anomalies, ignore1, ignore2, ignore3, ignore4]
+      = anomalies.detected;
+
+    if (no_partition_manifest) {
+        // missing manifest anomaly can be ok: this means the partition did
+        // not have time to upload data
+        op_logger_.info("manifest metadata check: no manifest, validation ok");
+        co_return validation_result::missing_manifest;
+    }
+
+    if (!missing_segments.empty()) {
+        // missing segments could be problematic and need an operator fixing
+        // the manifest before proceeding
+        op_logger_.error(
+          "manifest metadata check: missing segment, validation not ok");
+        co_return validation_result::anomaly_detected;
+    }
+
+    if (!missing_spillovers.empty()) {
+        // missing spillover manifest are not as problematic as missing
+        // segments, but still require manual intervention to fix the
+        // manifest for a correct operation
+        op_logger_.error("manifest metadata check: missing spillover "
+                         "manifests, validation not ok");
+        co_return validation_result::anomaly_detected;
+    }
+
+    // see src/v/cluster/partition_probe.cc for categorization of sev-high and
+    // sev-low classify anomaly_meta as failure or ok (not problematic for the
+    // recovery use case) true: failure, false: passed
+    constexpr static auto is_fatal_anomaly =
+      [](cloud_storage::anomaly_meta const& am) {
+          using enum cloud_storage::anomaly_type;
+          switch (am.type) {
+          case offset_gap:
+              return true;
+          case offset_overlap:
+          case missing_delta:
+          case non_monotonical_delta:
+          case end_delta_smaller:
+          case committed_smaller:
+              return false;
+          }
+      };
+
+    if (std::ranges::any_of(segment_anomalies, is_fatal_anomaly)) {
+        op_logger_.error("manifest metadata check: fatal segment "
+                         "anomalies, validation not ok");
+        co_return validation_result::anomaly_detected;
+    } else {
+        op_logger_.warn("manifest metadata check: minor segment anomalies, "
+                        "validation ok");
+        co_return validation_result::passed;
+    }
+}
+
+cloud_storage::remote_manifest_path
+partition_validator::get_path(cloud_storage::manifest_format format) {
+    return cloud_storage::generate_partition_manifest_path(
+      ntp_, rev_id_, format);
+}
+
+// wrap allocation and execution of partition_validation,
+ss::future<validation_result> do_validate_recovery_partition(
+  cloud_storage::remote& remote,
+  cloud_storage_clients::bucket_name const& bucket,
+  ss::abort_source& as,
+  model::ntp ntp,
+  model::initial_revision_id rev_id,
+  model::recovery_validation_mode mode,
+  size_t max_segment_depth) {
+    auto p_validator = partition_validator{
+      remote, bucket, as, std::move(ntp), rev_id, {mode, max_segment_depth}};
+    co_return co_await p_validator.run();
+}
+
+/// for each partition implicitly referenced by assignable_config, validate
+/// its partition manifest. perform checks based on recovery_checks.mode
+ss::future<absl::flat_hash_map<model::partition_id, validation_result>>
+maybe_validate_recovery_topic(
+  custom_assignable_topic_configuration const& assignable_config,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage::remote& remote,
+  ss::abort_source& as) {
+    auto [initial_rev_id, num_partitions]
+      = assignable_config.cfg.properties.remote_topic_properties.value();
+
+    if (num_partitions <= 0) {
+        vlog(
+          clusterlog.error,
+          "invalid num_partition {} for {}",
+          num_partitions,
+          assignable_config.cfg.tp_ns);
+        co_return absl::flat_hash_map<model::partition_id, validation_result>{};
+    }
+
+    auto checks_mode = config::shard_local_cfg()
+                         .cloud_storage_recovery_topic_validation_mode.value();
+    auto checks_depth
+      = config::shard_local_cfg()
+          .cloud_storage_recovery_topic_validation_depth.value();
+
+    vlog(
+      clusterlog.info,
+      "Performing validation mode={} max_semgment_depth={} on topic {} with {} "
+      "partitions",
+      checks_mode,
+      checks_depth,
+      assignable_config.cfg.tp_ns,
+      num_partitions);
+
+    auto enumerate_partitions = std::views::iota(0, num_partitions)
+                                | std::views::transform([](auto p) {
+                                      return model::partition_id{p};
+                                  });
+    // container for the results of each separate validation procedure.
+    // default value: passed
+    auto results = [&] {
+        auto init = enumerate_partitions
+                    | std::views::transform([](model::partition_id id) {
+                          return std::pair{id, validation_result::passed};
+                      })
+                    | std::views::common;
+        return absl::flat_hash_map<model::partition_id, validation_result>{
+          init.begin(), init.end()};
+    }();
+
+    if (checks.mode == model::recovery_validation_mode::no_check) {
+        // skip validation
+        co_return std::move(results);
+    }
+
+    auto [ns, topic] = assignable_config.cfg.tp_ns;
+
+    // cap the concurrency, we could be dealing with 100+ partitions for a
+    // topic
+    constexpr static auto concurrency = 64;
+
+    // start validation for each partition, collect the results and return
+    // them
+
+    co_await ss::max_concurrent_for_each(
+      enumerate_partitions, concurrency, [&](model::partition_id p) {
+          return do_validate_recovery_partition(
+                   remote,
+                   bucket,
+                   as,
+                   model::ntp{ns, topic, p},
+                   initial_rev_id,
+                   checks_mode,
+                   checks_depth)
+            .then([&results, p](validation_result res) { results[p] = res; });
+      });
+
+    co_return results;
+}
+
+} // namespace cluster

--- a/src/v/cluster/topic_recovery_validator.h
+++ b/src/v/cluster/topic_recovery_validator.h
@@ -40,6 +40,7 @@ enum class validation_result {
 /// Returns a map partition->validation_result that can be used to drive further
 /// decisions. In the future, the value of the map can be extended to contain
 /// the partition_manifest and other data.
+/// if the map is empty, it has to be interpreted as "validation ok"
 ss::future<absl::flat_hash_map<model::partition_id, validation_result>>
 maybe_validate_recovery_topic(
   custom_assignable_topic_configuration const& assignable_config,

--- a/src/v/cluster/topic_recovery_validator.h
+++ b/src/v/cluster/topic_recovery_validator.h
@@ -1,0 +1,96 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "cloud_storage/remote.h"
+#include "cluster/types.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/future.hh>
+
+#include <absl/container/flat_hash_map.h>
+
+namespace cluster {
+
+enum class validation_result {
+    // validation was passed (no_check will be converted to passed)
+    passed = 0,
+    // no manifest found in ts. it can be ok, if for example there was not
+    // enough time to upload a manifest before the crash
+    missing_manifest,
+    // reading the manifest generated a failure that cannot be handled by
+    // redpanda. for example a serde_exception indicating a corrupt file, or
+    // missing segments
+    anomaly_detected,
+    // download of a critical object for validation failed due to timeout or
+    // generic failure. might indicate an issue with the external api, or
+    // cluster configuration
+    download_issue,
+};
+
+/// For each partition implicitly referenced by assignable_config, validate its
+/// partition manifest. Perform checks based on recovery_checks.mode .
+/// Returns a map partition->validation_result that can be used to drive further
+/// decisions. In the future, the value of the map can be extended to contain
+/// the partition_manifest and other data.
+ss::future<absl::flat_hash_map<model::partition_id, validation_result>>
+maybe_validate_recovery_topic(
+  custom_assignable_topic_configuration const& assignable_config,
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage::remote& remote,
+  ss::abort_source& as);
+
+/// used by maybe_validate_recovery_topic to validate a single partition
+/// manifest.
+class partition_validator {
+public:
+    struct recovery_checks {
+        model::recovery_validation_mode mode;
+        size_t max_segment_depth;
+    };
+
+    partition_validator(
+      cloud_storage::remote& remote,
+      cloud_storage_clients::bucket_name const& bucket,
+      ss::abort_source& as,
+      model::ntp ntp,
+      model::initial_revision_id rev_id,
+      recovery_checks checks);
+
+    /// Perform validation on the ntp as specified with checks
+    ss::future<validation_result> run();
+
+private:
+    // check manifest existence, handle download_result::success as Found
+    // and the rest as NotFound (but warn for failed and timedout).
+    // This existence check could be flattened in anomalies_detector, but
+    // it's not a perfect overlap with the functionalities, so it's
+    // performed externally
+    ss::future<validation_result> do_validate_manifest_existence();
+
+    // delegate to anomalies_detector to run few checks on the remote partition,
+    // interpret the result to produce a validation_result
+    ss::future<validation_result> do_validate_manifest_metadata();
+
+    // utility method for logging
+    cloud_storage::remote_manifest_path get_path(
+      cloud_storage::manifest_format format
+      = cloud_storage::manifest_format::serde);
+
+    cloud_storage::remote* remote_;
+    cloud_storage_clients::bucket_name const* bucket_;
+    ss::abort_source* as_;
+    model::ntp ntp_;
+    model::initial_revision_id rev_id_;
+    retry_chain_node op_rtc_;
+    retry_chain_logger op_logger_;
+    recovery_checks checks_;
+};
+} // namespace cluster

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1925,6 +1925,25 @@ configuration::configuration()
       "Retention in bytes for topics created during automated recovery",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_GiB)
+  , cloud_storage_recovery_topic_validation_mode(
+      *this,
+      "cloud_storage_recovery_topic_validation_mode",
+      "Validation mode performed before recovering a topic from cloud storage",
+      {.needs_restart = needs_restart::no,
+       .example = "check_manifest_existence",
+       .visibility = visibility::tunable},
+      model::recovery_validation_mode::check_manifest_existence,
+      {model::recovery_validation_mode::check_manifest_existence,
+       model::recovery_validation_mode::check_manifest_and_segment_metadata,
+       model::recovery_validation_mode::no_check})
+  , cloud_storage_recovery_topic_validation_depth(
+      *this,
+      "cloud_storage_recovery_topic_validation_depth",
+      "Number of segment metadata to validate, from newest to oldest, when "
+      "`cloud_storage_recovery_topic_validation_mode` is "
+      "`check_manifest_and_segment_metadata`",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      10)
   , cloud_storage_segment_size_target(
       *this,
       "cloud_storage_segment_size_target",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -358,6 +358,11 @@ struct configuration final : public config_store {
     property<size_t> cloud_storage_max_segments_pending_deletion_per_partition;
     property<bool> cloud_storage_enable_compacted_topic_reupload;
     property<size_t> cloud_storage_recovery_temporary_retention_bytes_default;
+    // validation of topic manifest during recovery
+    enum_property<model::recovery_validation_mode>
+      cloud_storage_recovery_topic_validation_mode;
+    property<uint32_t> cloud_storage_recovery_topic_validation_depth;
+
     property<std::optional<size_t>> cloud_storage_segment_size_target;
     property<std::optional<size_t>> cloud_storage_segment_size_min;
     property<std::optional<size_t>> cloud_storage_max_throughput_per_shard;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -565,4 +565,27 @@ struct convert<model::write_caching_mode> {
     }
 };
 
+template<>
+struct convert<model::recovery_validation_mode> {
+    using type = model::recovery_validation_mode;
+    constexpr static auto acceptable_values = std::to_array(
+      {"check_manifest_existence",
+       "check_manifest_and_segment_metadata",
+       "no_check"});
+    static Node encode(type const& rhs) {
+        Node node;
+        return Node{boost::lexical_cast<std::string>(rhs)};
+    }
+    static bool decode(Node const& node, type& rhs) {
+        auto node_str = node.as<std::string>();
+        if (
+          std::ranges::find(acceptable_values, node_str)
+          == acceptable_values.end()) {
+            return false;
+        }
+        rhs = boost::lexical_cast<type>(node_str);
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -645,6 +645,9 @@ consteval std::string_view property_type_name() {
         return "string";
     } else if constexpr (std::is_same_v<type, model::write_caching_mode>) {
         return "string";
+    } else if constexpr (std::
+                           is_same_v<type, model::recovery_validation_mode>) {
+        return "recovery_validation_mode";
     } else {
         static_assert(
           utils::unsupported_type<T>::value, "Type name not defined");

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -189,6 +189,12 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
+  const model::recovery_validation_mode& v) {
+    stringize(w, v);
+}
+
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::broker_endpoint& ep) {
     w.StartObject();
     w.Key("name");

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -97,4 +97,6 @@ void rjson_serialize(
 void rjson_serialize(
   json::Writer<json::StringBuffer>&, const model::broker_endpoint&);
 
+void rjson_serialize(
+  json::Writer<json::StringBuffer>&, const model::recovery_validation_mode&);
 } // namespace json

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -106,6 +106,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::inconsistent_stm_update:
     case cluster::errc::waiting_for_shard_placement_update:
     case cluster::errc::producer_ids_vcluster_limit_exceeded:
+    case cluster::errc::validation_of_recovery_topic_failed:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -620,6 +620,21 @@ struct broker_v0 {
 };
 
 } // namespace internal
+
+enum class recovery_validation_mode : std::uint16_t {
+    // ensure that either the manifest is in TS or that no manifest is present.
+    // download issues will fail the validation
+    check_manifest_existence = 0,
+    // download the manifest and check the most recent segments up to
+    // max_segment_depth
+    check_manifest_and_segment_metadata = 1,
+    // do not perform any check, validation is considered successful
+    no_check = 0xff,
+};
+
+std::ostream& operator<<(std::ostream&, recovery_validation_mode);
+std::istream& operator>>(std::istream&, recovery_validation_mode&);
+
 } // namespace model
 
 template<>

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -535,4 +535,34 @@ write_caching_mode_from_string(std::string_view s) {
         model::write_caching_mode::disabled)
       .default_match(std::nullopt);
 }
+
+std::ostream& operator<<(std::ostream& os, recovery_validation_mode vm) {
+    using enum recovery_validation_mode;
+    switch (vm) {
+    case check_manifest_existence:
+        return os << "check_manifest_existence";
+    case check_manifest_and_segment_metadata:
+        return os << "check_manifest_and_segment_metadata";
+    case no_check:
+        return os << "no_check";
+    }
+}
+
+std::istream& operator>>(std::istream& is, recovery_validation_mode& vm) {
+    using enum recovery_validation_mode;
+    auto s = ss::sstring{};
+    is >> s;
+    try {
+        vm = string_switch<recovery_validation_mode>(s)
+               .match("check_manifest_existence", check_manifest_existence)
+               .match(
+                 "check_manifest_and_segment_metadata",
+                 check_manifest_and_segment_metadata)
+               .match("no_check", no_check);
+    } catch (std::runtime_error const&) {
+        is.setstate(std::ios::failbit);
+    }
+    return is;
+}
+
 } // namespace model

--- a/src/v/model/tests/lexical_cast_tests.cc
+++ b/src/v/model/tests/lexical_cast_tests.cc
@@ -10,6 +10,7 @@
 #include "model/record.h"
 #define BOOST_TEST_MODULE model
 #include "model/compression.h"
+#include "model/metadata.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -85,3 +86,25 @@ BOOST_AUTO_TEST_CASE(timestamp_type_printing) {
     BOOST_CHECK_EQUAL(
       "LogAppendTime", fmt::format("{}", model::timestamp_type::append_time));
 };
+
+BOOST_AUTO_TEST_CASE(recovery_validation_mode_enum_roundtrip) {
+    // test that all recovery_validation_mode have a unique string
+    // representation
+    using enum model::recovery_validation_mode;
+
+    BOOST_CHECK_EQUAL(
+      boost::lexical_cast<model::recovery_validation_mode>("no_check"),
+      no_check);
+    BOOST_CHECK_EQUAL(
+      boost::lexical_cast<model::recovery_validation_mode>(
+        "check_manifest_existence"),
+      check_manifest_existence);
+    BOOST_CHECK_EQUAL(
+      boost::lexical_cast<model::recovery_validation_mode>(
+        "check_manifest_and_segment_metadata"),
+      check_manifest_and_segment_metadata);
+    BOOST_REQUIRE_THROW(
+      boost::lexical_cast<model::recovery_validation_mode>(
+        "this_mode_does_not_exists"),
+      boost::bad_lexical_cast);
+}

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -675,6 +675,10 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 valid_value = random.choice(
                     [e for e in p['enum_values'] if e != initial_value])
 
+            if name == 'cloud_storage_recovery_topic_validation_mode':
+                valid_value = random.choice(
+                    [e for e in p['enum_values'] if e != initial_value])
+
             updates[name] = valid_value
 
         patch_result = self.admin.patch_cluster_config(upsert=updates,

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -10,6 +10,7 @@ import io
 import json
 import os
 import pprint
+import random
 import re
 import time
 from collections import defaultdict, deque
@@ -1063,6 +1064,116 @@ class ManyPartitionsCase(BaseCase):
         return super().restore_redpanda(baseline, controller_checksums)
 
 
+class PreventRecoveryOfDamagedPartitionsCase(BaseCase):
+    """
+    Damage a partition by removing some of the newest segments,
+    and check that the whole partition is prevented from recovering
+    recovery_check_mode dictates the operation of this test.
+    """
+    def __init__(self, redpanda, s3_client, kafka_tools, rpk_client, s3_bucket,
+                 logger, rpk_producer_maker):
+        super().__init__(redpanda, s3_client, kafka_tools, rpk_client,
+                         s3_bucket, logger, rpk_producer_maker)
+
+        # this topic will not be damaged
+        self.recoverable_topic = TopicSpec(name="panda-topic-recovery-ok",
+                                           partition_count=1,
+                                           replication_factor=3)
+        # this topic will be damaged by removing a segment
+        self.unrecoverable_topic = TopicSpec(
+            name="panda-topic-recovery-NOT-OK",
+            partition_count=1,
+            replication_factor=1)
+
+        # base class will create the topics via this
+        self.topics = [self.unrecoverable_topic, self.recoverable_topic]
+        # and will verify recovery of this list
+        self.expected_recovered_topics = [self.recoverable_topic]
+
+    def generate_baseline(self):
+        """Produce enough data to trigger uploads to S3/minio"""
+        for topic in self.topics:
+            producer = self._rpk_producer_maker(topic=topic.name,
+                                                msg_count=10000,
+                                                msg_size=1024)
+            producer.start()
+            producer.wait()
+            producer.free()
+
+        quiesce_uploads(self._redpanda, [topic.name for topic in self.topics],
+                        300)
+
+    def _delete(self, key):
+        """delete a segment"""
+        self._deleted_segment_size = self._s3.get_object_meta(
+            self._bucket, key).content_length
+        self.logger.info(
+            f"deleting segment file {key} of size {self._deleted_segment_size}"
+        )
+        self._s3.delete_object(self._bucket, key, True)
+
+    def _find_and_remove_newest_segments(self, topic: TopicSpec, skip: int):
+        """Find and remove a segment from a partition of topic. skip is the number of newest segment to skip before selecting the victim"""
+
+        # list all segments in cloud storage
+        all_segs = {
+            key: parse_s3_segment_path(key)
+            for key in self._list_objects() if key.endswith(".log.1")
+        }
+
+        # filter topics for topic.name/partition
+        partition = 0
+        segs_for_topic_partition: dict[int, str] = {
+            comps.base_offset: obj_key
+            for obj_key, comps in all_segs.items()
+            if comps.ntpr.topic == topic.name
+            and comps.ntpr.partition == partition
+        }
+
+        # sort in descending order by base offset, skip the first #skip elements, pick the first as the victim
+        victim = sorted(segs_for_topic_partition.items(),
+                        reverse=True)[skip:skip + 1]
+        assert len(
+            victim
+        ) > 0, f"no segment found for {topic.name}/{partition} at depth {skip}. total size {len(segs_for_topic_partition)}"
+
+        self.logger.info(f"victim={victim[0]} for {topic.name}/{partition}")
+
+        self._delete(victim[0][1])
+
+    def validate_cluster(self, baseline, restored):
+        """Check that self unrecoverable_topic is not present"""
+        assert len(
+            list(self._rpk.describe_topic(self.unrecoverable_topic.name))
+        ) == 0, f"topic {self.unrecoverable_topic.name} is present"
+
+    def restore_redpanda(self, baseline, controller_checksums):
+
+        # skip 4 segments before deleting one. validation_depth=10 should fail the recovery
+        self._find_and_remove_newest_segments(self.unrecoverable_topic, skip=4)
+
+        # set a check-mode that will stops if segments are not found in remote storage
+        self._redpanda.set_cluster_config(
+            values={
+                'cloud_storage_recovery_topic_validation_mode':
+                'check_manifest_and_segment_metadata',
+                'cloud_storage_recovery_topic_validation_depth': '10',
+            })
+
+        # restore recoverable topic. this should not fail
+        super().restore_redpanda(baseline, controller_checksums,
+                                 [self.recoverable_topic])
+
+        # restore unrecoverable topic. this should fail
+        exception = None
+        try:
+            super().restore_redpanda(baseline, controller_checksums,
+                                     [self.unrecoverable_topic])
+        except RpkException as e:
+            exception = e
+        assert exception is not None, f"RpkException expected for unrecoverable {self.unrecoverable_topic.name}"
+
+
 class TopicRecoveryTest(RedpandaTest):
     def __init__(self, test_context: TestContext, *args, **kwargs):
         si_settings = SISettings(test_context,
@@ -1650,4 +1761,18 @@ class TopicRecoveryTest(RedpandaTest):
                                        num_topics=5,
                                        num_partitions_per_topic=20,
                                        check_mode=check_mode)
+        self.do_run(test_case)
+
+    @cluster(num_nodes=4,
+             log_allow_list=TRANSIENT_ERRORS +
+             ["recovery validation", "Stopping recovery of"])
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_prevent_recovery(self, cloud_storage_type):
+        """
+        Check that failing a check prevents recovery of the topic.
+        """
+        self.redpanda.si_settings.set_expected_damage({"missing_segments"})
+        test_case = PreventRecoveryOfDamagedPartitionsCase(
+            self.redpanda, self.cloud_storage_client, self.kafka_tools,
+            self.rpk, self.s3_bucket, self.logger, self.rpk_producer_maker)
         self.do_run(test_case)

--- a/tests/rptest/tests/topic_recovery_test.py
+++ b/tests/rptest/tests/topic_recovery_test.py
@@ -1035,6 +1035,11 @@ class TopicRecoveryTest(RedpandaTest):
             *args,
             si_settings=si_settings,
             environment={'__REDPANDA_TOPIC_REC_DL_CHECK_MILLIS': 5000},
+            # ensure that only the light check of manifest existence is performed
+            extra_rp_conf={
+                'cloud_storage_recovery_topic_validation_mode':
+                'check_manifest_existence',
+            },
             **kwargs)
 
         self.kafka_tools = KafkaCliTools(self.redpanda)


### PR DESCRIPTION
Introduced a new function to perform metadata validation for a remote topic to be used during the process of topic recovery.

For each partition, checks if the manifest exists in the cloud and optionally checks if the file can be decoded and self-consistent up to N most recent segment_meta,

For each partition, the S3 cost is 1 HeadObject request for the partition_manifest OR 1Get + 1HeadObject request for N segment_meta.

in general, we could limit the depth of the check by
- num segments
- offset
- total time

num segments correlates directly with the speed of the operation while being deterministic.
offset could map better with what the user wants, but it's more challenging to implement with the current reverse iteration implementation of segment_meta_cstore.
total time, it's a strong guarantee, but the final result depends on the load of the system.

This PR implements a max_num_segment limit, as it's easier to reason about. A follow-up can implement the other two modes if there is a request for this.

The check is performed in parallel for each partition with a cap.

The result can be 

```
passed   // checks are on
missing_manifest // allowed for topics that did not have time to upload a manifest

failure    // decoding failure or metadata inconsistencies; should stop 
download_issue // cloud storage configuration error or service error; should stop
```

The validation mode is driven by a new (nullopt) topic property and a cluster-level default + force flag.

A new topic_property allows users to define validation manually by editing the topic_manifest.json file.
otherwise, cluster-level defaults will be used.

```cpp
    enum_property<model::recovery_validation_mode>
      cloud_storage_recovery_topic_validation_mode;
    property<uint16_t> cloud_storage_recovery_topic_validation_depth;
    property<bool> cloud_storage_recovery_topic_force_ovveride_cfg;
```

The last one is an escape hatch to override `recovery_checks` with the cluster defaults
 
Fixes https://github.com/redpanda-data/core-internal/issues/1138
Fixes https://github.com/redpanda-data/core-internal/issues/1139

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* before creating a recovery topic, perform metadata validation on the cloud data to ensure that each partition can be recovered successfully  
