### PR TITLE
c/topic_table: replaced partition metadata map with chunked_vector

### DIFF
--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -94,9 +94,9 @@ public:
         auto md = node_application(source_node)
                     ->controller->get_topics_state()
                     .local()
-                    .get_topic_metadata(model::topic_namespace_view(ntp));
+                    .get_topic_metadata_ref(model::topic_namespace_view(ntp));
 
-        return md->get_assignments().begin()->replicas;
+        return md->get().get_assignments().begin()->replicas;
     }
 
     void create_topic(cluster::topic_configuration cfg) {
@@ -180,7 +180,7 @@ public:
     }
 
     void populate_all_topics_with_data() {
-        auto md = get_local_cache(model::node_id(0)).all_topics_metadata();
+        auto& md = get_local_cache(model::node_id(0)).all_topics_metadata();
         for (auto& [tp_ns, topic_metadata] : md) {
             for (auto& p : topic_metadata.get_assignments()) {
                 model::ntp ntp(tp_ns.ns, tp_ns.tp, p.id);

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -22,7 +22,7 @@ using namespace std::chrono_literals;
 
 FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
     create_topics();
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
 
     BOOST_REQUIRE_EQUAL(md.size(), 3);
 
@@ -60,7 +60,7 @@ FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
         model::offset(0))
       .get0();
 
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
     BOOST_REQUIRE(md.contains(make_tp_ns("test_tp_1")));
 

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -80,7 +80,7 @@ constexpr uint64_t max_cluster_capacity() {
 FIXTURE_TEST(
   test_dispatching_happy_path_create, topic_table_updates_dispatcher_fixture) {
     create_topics();
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
 
     BOOST_REQUIRE_EQUAL(md.size(), 3);
 
@@ -123,7 +123,7 @@ FIXTURE_TEST(
         make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3"))))
       .get0();
 
-    auto md = table.local().all_topics_metadata();
+    auto& md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
 
     BOOST_REQUIRE_EQUAL(md.contains(make_tp_ns("test_tp_1")), true);

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -14,6 +14,7 @@
 #include "cluster/commands.h"
 #include "cluster/topic_table_probe.h"
 #include "cluster/types.h"
+#include "container/contiguous_range_map.h"
 #include "model/fundamental.h"
 #include "model/limits.h"
 #include "model/metadata.h"
@@ -216,7 +217,8 @@ public:
 
     struct topic_metadata_item {
         topic_metadata metadata;
-        absl::node_hash_map<model::partition_id, partition_meta> partitions;
+        contiguous_range_map<model::partition_id::type, partition_meta>
+          partitions;
 
         assignments_set& get_assignments() {
             return metadata.get_assignments();
@@ -646,10 +648,6 @@ private:
     };
 
     void notify_waiters();
-
-    template<typename Func>
-    std::vector<std::invoke_result_t<Func, const topic_metadata_item&>>
-    transform_topics(Func&&) const;
 
     void change_partition_replicas(
       model::ntp ntp,

--- a/src/v/container/CMakeLists.txt
+++ b/src/v/container/CMakeLists.txt
@@ -1,5 +1,7 @@
+find_package(Roaring REQUIRED)
 v_cc_library(
   NAME container
+  DEPS Roaring::roaring
 )
 
 add_subdirectory(tests)

--- a/src/v/container/include/container/contiguous_range_map.h
+++ b/src/v/container/include/container/contiguous_range_map.h
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "container/fragmented_vector.h"
+
+/**
+ * Contiguous range map is an associative sorted container backed by
+ * chunked_vector designed to efficiently store objects indexed with contiguous
+ * and limited range of integers starting at 0. The container provides a
+ * wrapper around basic chunked vector that reassembles the API of a standard
+ * map.
+ *
+ * The wrapper allows random inserts of elements to the map although this is
+ * not supported by standard vector.
+ *
+ * Underlying container is resized every time its size is not sufficient to
+ * account for emplaced key.
+ *
+ * The contiguous_range_map tolerates gap in the range of keys however
+ * number and size of gaps is proportional to performance penalty hit when
+ * incrementing or decrementing iterators.
+ *
+ * NOTE:
+ * A map can store elements for key's which range starts from value greater than
+ * 0 but it will cause significant memory loss. If we will need to store such a
+ * ranges we may introduce non type template parameter indicating offset.
+ */
+template<std::integral KeyT, typename ValueT>
+class contiguous_range_map {
+public:
+    using value_type = std::pair<const KeyT, ValueT>;
+    using key_type = KeyT;
+    using mapped_type = ValueT;
+
+private:
+    using underlying_t = chunked_vector<std::optional<value_type>>;
+
+private:
+    template<bool Const>
+    class iter {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type =
+          typename std::conditional_t<Const, const value_type, value_type>;
+
+        using difference_type = std::ptrdiff_t;
+        using pointer = value_type*;
+        using reference = value_type&;
+
+        iter() = default;
+
+        /**
+         * Conversion operator allowing iterator to be converted to
+         * const_iterator, as required by the general iterator contract.
+         */
+        operator iter<true>() const { // NOLINT(hicpp-explicit-conversions)
+            iter<true> ret;
+            ret._container = _container;
+            ret._it = _it;
+            return ret;
+        }
+
+        reference operator*() const { return _it->value(); }
+
+        pointer operator->() const { return &(_it->value()); }
+
+        iter& operator++() {
+            ++_it;
+            skip_to_next_present();
+            return *this;
+        }
+
+        iter operator++(int) {
+            auto tmp = *this;
+            ++*this;
+            return tmp;
+        }
+
+        bool operator==(const iter& o) const {
+            return std::tie(_it, _container) == std::tie(o._it, o._container);
+        };
+
+        auto operator<=>(const iter& o) const {
+            return std::tie(_it, _container) <=> std::tie(o._it, o._container);
+        };
+
+    private:
+        void skip_to_next_present() {
+            while (_it != _container->_values.end() && !_it->has_value()) {
+                ++_it;
+            }
+        }
+
+        friend class contiguous_range_map<KeyT, ValueT>;
+        using parent_t = std::conditional_t<
+          Const,
+          const contiguous_range_map<KeyT, ValueT>,
+          contiguous_range_map<KeyT, ValueT>>;
+
+        iter(
+          parent_t* map,
+          typename parent_t::underlying_t::template iter<Const> it)
+          : _it(it)
+          , _container(map) {
+            skip_to_next_present();
+        }
+
+        typename parent_t::underlying_t::template iter<Const> _it;
+        parent_t* _container;
+    };
+
+public:
+    using iterator = iter<false>;
+    using const_iterator = iter<true>;
+
+    contiguous_range_map() noexcept = default;
+    contiguous_range_map& operator=(contiguous_range_map&& other) noexcept {
+        if (this != &other) {
+            this->_size = other._size;
+            this->_values = std::move(other._values);
+            other._size = 0;
+        }
+        return *this;
+    }
+
+    contiguous_range_map(contiguous_range_map&& other) noexcept {
+        *this = std::move(other);
+    }
+    contiguous_range_map(const contiguous_range_map&) = delete;
+    contiguous_range_map& operator=(const contiguous_range_map& other) = delete;
+    ~contiguous_range_map() noexcept = default;
+
+    /**
+     * Determines if element comparing equal to given key exists in a map.
+     */
+    bool contains(KeyT key) const {
+        check_key(key);
+        return _values.size() > key && _values[key].has_value();
+    }
+
+    /**
+     * Returns an element comparing equal to given key. If an element for the
+     * given key is not present the default element will be constructed.
+     */
+    mapped_type& operator[](KeyT key) { return emplace(key).first->second; }
+    /**
+     * Constructs element for given key in place.
+     *
+     * Returns a pair containing an iterator to the element (either existing or
+     * newly created one) and a boolean indicating if element was inserted.
+     *
+     * Element constructor is not invoked if an element already exists in the
+     * map.
+     */
+    template<typename... Args>
+    std::pair<iterator, bool> emplace(KeyT key, Args&&... args) {
+        check_key(key);
+        /**
+         * Inserting last element directly with emplace_back
+         */
+        if (static_cast<size_t>(key) == _values.size()) {
+            _values.emplace_back(
+              std::make_pair(key, ValueT(std::forward<Args>(args)...)));
+            _size++;
+            return {iter<false>(this, _values.begin() + key), true};
+        }
+        while (static_cast<size_t>(key) >= _values.size()) {
+            _values.emplace_back();
+        }
+        auto it = _values.begin() + key;
+        if (it->has_value()) {
+            return {iter<false>(this, it), false};
+        }
+
+        it->emplace(std::make_pair(key, ValueT(std::forward<Args>(args)...)));
+        _size++;
+        return std::make_pair(iter<false>(this, it), true);
+    }
+
+    /**
+     * Resizes the underlying chunked vector to be ready to up to requested_size
+     * of keys. Effectively the last key that the map would be able to accept
+     * without resizing further is equal to `requested_size - 1`
+     */
+    void reserve(size_t requested_size) {
+        _values.reserve(requested_size);
+        while (_values.size() < requested_size) {
+            _values.emplace_back();
+        }
+    }
+
+    /**
+     * Shrinks the underlying vector removing all empty slots from the back.
+     */
+    void shrink_to_fit() {
+        while (!_values.back().has_value()) {
+            _values.pop_back();
+        }
+    }
+    /**
+     * Returns the actual number of elements allocated in the underlying vector.
+     */
+    size_t capacity() const { return _values.size(); }
+
+    iterator begin() { return iter<false>(this, _values.begin()); }
+    iterator end() { return iter<false>(this, _values.end()); }
+
+    const_iterator begin() const { return iter<true>(this, _values.begin()); }
+    const_iterator end() const { return iter<true>(this, _values.end()); }
+
+    /**
+     * Return number of valid elements in the map
+     */
+    size_t size() const { return _size; }
+
+    /**
+     * Returns iterator to an element with requested key or `end()` if the
+     * element is not present in the map
+     */
+    iterator find(KeyT key) {
+        check_key(key);
+        if (static_cast<size_t>(key) < _values.size()) {
+            auto it = _values.begin() + static_cast<size_t>(key);
+            if (it->has_value()) {
+                return iterator(this, it);
+            }
+        }
+        return end();
+    }
+    /**
+     * Returns iterator to an element with requested key or `end()` if the
+     * element is not present in the map
+     */
+    const_iterator find(KeyT key) const {
+        check_key(key);
+        if (static_cast<size_t>(key) < _values.size()) {
+            auto it = _values.begin() + static_cast<size_t>(key);
+            if (it->has_value()) {
+                return const_iterator(this, it);
+            }
+        }
+        return end();
+    }
+    /**
+     * Removes the element with given key from the map.
+     *
+     * NOTE: it does not shrink the underlying data structure.
+     */
+    void erase(KeyT key) {
+        check_key(key);
+        if (static_cast<size_t>(key) < _values.size()) {
+            if (_values[static_cast<size_t>(key)].has_value()) {
+                _values[static_cast<size_t>(key)].reset();
+                --_size;
+            }
+        }
+    }
+    /**
+     * Removes the element pointed by given iterator from the map.
+     *
+     * NOTE: it does not shrink the underlying data structure.
+     */
+    void erase(const_iterator it) {
+        if (it._it->has_value()) {
+            auto mutable_it = iterator(
+              this, _values.begin() + it._it->value().first);
+            mutable_it._it->reset();
+            --_size;
+        }
+    }
+
+private:
+    static void check_key(KeyT key) {
+        vassert(
+          key >= 0,
+          "contiguous_range_map keys must be positive. current key {}",
+          key);
+    }
+    underlying_t _values;
+    // number of valid entries
+    size_t _size{0};
+};

--- a/src/v/container/tests/CMakeLists.txt
+++ b/src/v/container/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ rp_test(
   BINARY_NAME container_unit
   SOURCES
     fragmented_vector_test.cc
+    contiguous_range_map_test.cc
   LIBRARIES v::gtest_main v::random v::serde
   ARGS "-- -c 1"
 )

--- a/src/v/container/tests/CMakeLists.txt
+++ b/src/v/container/tests/CMakeLists.txt
@@ -21,7 +21,9 @@ rp_test(
 rp_test(
   BENCHMARK_TEST
   BINARY_NAME container
-  SOURCES vector_bench.cc
+  SOURCES 
+    vector_bench.cc
+    map_bench.cc
   LIBRARIES 
     Seastar::seastar_perf_testing
     v::seastar_testing_main

--- a/src/v/container/tests/bench_utils.h
+++ b/src/v/container/tests/bench_utils.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "random/generators.h"
+#include "utils/functional.h"
+#include "utils/type_traits.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <string>
+
+struct large_struct {
+    size_t foo;
+    size_t bar;
+    std::string qux;
+    std::string baz;
+    std::string more;
+    std::string data;
+    size_t okdone;
+
+    bool operator==(const large_struct&) const = default;
+    auto operator<=>(const large_struct&) const = default;
+};
+
+template<typename ValueT>
+static auto make_value() {
+    if constexpr (std::is_same_v<ValueT, int64_t>) {
+        return static_cast<int64_t>(random_generators::get_int<int64_t>());
+
+    } else if constexpr (std::is_same_v<ValueT, ss::sstring>) {
+        constexpr size_t max_str_len = 64;
+        return random_generators::gen_alphanum_string(
+          random_generators::get_int<size_t>(0, max_str_len));
+    } else if constexpr (std::is_same_v<ValueT, large_struct>) {
+        constexpr size_t max_str_len = 64;
+        constexpr size_t max_num_cardinality = 16;
+        return large_struct{
+          .foo = random_generators::get_int<size_t>(0, max_num_cardinality),
+          .bar = random_generators::get_int<size_t>(0, max_num_cardinality),
+          .qux = random_generators::gen_alphanum_string(
+            random_generators::get_int<size_t>(0, max_str_len)),
+          .baz = random_generators::gen_alphanum_string(
+            random_generators::get_int<size_t>(0, max_str_len)),
+          .more = random_generators::gen_alphanum_string(
+            random_generators::get_int<size_t>(0, max_str_len)),
+          .data = random_generators::gen_alphanum_string(
+            random_generators::get_int<size_t>(0, max_str_len)),
+          .okdone = random_generators::get_int<size_t>(),
+        };
+    } else {
+        static_assert(utils::unsupported_type<ValueT>::value, "unsupported");
+    }
+}

--- a/src/v/container/tests/contiguous_range_map_test.cc
+++ b/src/v/container/tests/contiguous_range_map_test.cc
@@ -1,0 +1,191 @@
+#include "container/contiguous_range_map.h"
+#include "container/zip.h"
+#include "gtest/gtest.h"
+#include "random/generators.h"
+#include "test_utils/randoms.h"
+
+#include <absl/container/btree_map.h>
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+using int_range_map = contiguous_range_map<uint, int>;
+
+static_assert(std::forward_iterator<int_range_map::iterator>);
+static_assert(std::forward_iterator<int_range_map::const_iterator>);
+static_assert(std::copy_constructible<int_range_map::iterator>);
+static_assert(std::copy_constructible<int_range_map::const_iterator>);
+
+struct verifier {
+    template<typename Func>
+    auto mutate(Func f) {
+        f(expected);
+        return f(under_test);
+    }
+    testing::AssertionResult is_valid() {
+        if (under_test.size() != expected.size()) {
+            testing::AssertionFailure() << fmt::format(
+              "Expected size {} is different than current size {}",
+              expected.size(),
+              under_test.size());
+        }
+
+        for (auto tuple : container::zip(expected, under_test)) {
+            auto& expected_value = tuple.get<0>();
+            auto& current_value = tuple.get<1>();
+            if (expected_value != current_value) {
+                return testing::AssertionFailure() << fmt::format(
+                         "Expected value {}:{} does not match the current "
+                         "value: "
+                         "{}:{}",
+                         expected_value.first,
+                         expected_value.second,
+                         current_value.first,
+                         current_value.second);
+            }
+        }
+
+        return testing::AssertionSuccess();
+    }
+
+    int_range_map under_test;
+    std::map<uint, int> expected;
+};
+
+TEST(IntegerRangeMap, Emplace) {
+    verifier v;
+
+    EXPECT_EQ(v.under_test.begin(), v.under_test.end());
+
+    auto [it, success] = v.mutate([](auto& m) { return m.emplace(1, 0); });
+    EXPECT_TRUE(success);
+
+    EXPECT_EQ(it, v.under_test.begin());
+    EXPECT_EQ(it->first, 1);
+    EXPECT_EQ(it->second, 0);
+
+    auto [new_it, not_success] = v.mutate(
+      [](auto& m) { return m.emplace(1, 10); });
+    EXPECT_FALSE(not_success);
+    EXPECT_EQ(new_it->first, 1);
+    EXPECT_EQ(new_it->second, 0);
+
+    EXPECT_TRUE(v.is_valid());
+}
+
+TEST(IntegerRangeMap, EmplaceErase) {
+    verifier v;
+    v.mutate([](auto& m) { return m.erase(0); });
+
+    v.mutate([](auto& m) { return m.emplace(1, 0); });
+    v.mutate([](auto& m) { return m.emplace(3, 0); });
+    v.mutate([](auto& m) { return m.emplace(8, 0); });
+    v.mutate([](auto& m) { return m.emplace(10, 0); });
+    v.mutate([](auto& m) { return m.emplace(15, 0); });
+
+    v.mutate([](auto& m) { return m.erase(8); });
+    v.mutate([](auto& m) { return m.erase(6); });
+    v.mutate([](auto& m) { return m.erase(3); });
+
+    v.mutate([](auto& m) {
+        auto it = m.find(10);
+        m.erase(it);
+    });
+
+    EXPECT_TRUE(v.is_valid());
+}
+
+TEST(IntegerRangeMap, ReserveShrink) {
+    verifier v;
+    v.under_test.reserve(16);
+    EXPECT_EQ(v.under_test.capacity(), 16);
+    EXPECT_TRUE(v.is_valid());
+
+    v.mutate([](auto& m) { return m.emplace(1, 0); });
+    v.mutate([](auto& m) { return m.emplace(3, 0); });
+    v.mutate([](auto& m) { return m.emplace(8, 0); });
+    v.mutate([](auto& m) { return m.emplace(10, 0); });
+    v.mutate([](auto& m) { return m.emplace(15, 0); });
+
+    v.mutate([](auto& m) { return m.erase(15); });
+    v.mutate([](auto& m) { return m.erase(10); });
+    v.mutate([](auto& m) { return m.erase(3); });
+    // erase should not change capacity
+    EXPECT_EQ(v.under_test.capacity(), 16);
+    v.under_test.shrink_to_fit();
+    EXPECT_EQ(v.under_test.capacity(), 9);
+    EXPECT_TRUE(v.is_valid());
+}
+
+TEST(IntegerRangeMap, Iterator) {
+    verifier v;
+
+    EXPECT_EQ(v.under_test.begin(), v.under_test.end());
+
+    auto [it_1, success_1] = v.mutate([](auto& m) { return m.emplace(1, 0); });
+    auto [it_2, success_2] = v.mutate([](auto& m) { return m.emplace(3, 0); });
+
+    EXPECT_GT(it_2, it_1);
+
+    auto first = v.under_test.begin();
+    auto second = std::next(v.under_test.begin());
+    EXPECT_GT(second, first);
+    EXPECT_EQ(std::next(v.under_test.begin()), second);
+
+    EXPECT_TRUE(v.is_valid());
+}
+
+TEST(IntegerRangeMap, RandomOperations) {
+    verifier v;
+    static constexpr int key_set_cardinality = 3000000;
+    for (int i = 0; i < 50000; ++i) {
+        int key = random_generators::get_int(key_set_cardinality);
+        if (tests::random_bool()) {
+            auto value = random_generators::get_int(5000);
+            v.mutate([key, value](auto& m) { return m.emplace(key, value); });
+        } else {
+            v.mutate([key](auto& m) { return m.erase(key); });
+        }
+    }
+
+    EXPECT_TRUE(v.is_valid());
+}
+
+TEST(IntegerRangeMap, LookUp) {
+    verifier v;
+
+    for (auto i = 0; i < 10; i += 2) {
+        v.mutate([i](auto& m) { return m.emplace(i, 2 * i); });
+    }
+    EXPECT_EQ(v.under_test.find(0)->first, 0);
+    EXPECT_EQ(v.under_test.find(0)->second, 0);
+    EXPECT_EQ(v.under_test.find(4)->first, 4);
+    EXPECT_EQ(v.under_test.find(4)->second, 8);
+
+    EXPECT_EQ(v.under_test.find(80), v.under_test.end());
+
+    EXPECT_EQ(v.expected[0], 0);
+    EXPECT_EQ(v.expected[2], 4);
+
+    EXPECT_EQ(v.under_test[0], 0);
+
+    v.under_test[5] = 1;
+    v.expected[5] = 1;
+    EXPECT_EQ(v.under_test[5], 1);
+
+    EXPECT_TRUE(v.is_valid());
+}
+
+TEST(IntegerRangeMap, UpdateViaIterator) {
+    verifier v;
+
+    for (auto i = 0; i < 10; i += 2) {
+        v.mutate([i](auto& m) { return m.emplace(i, 2 * i); });
+    }
+
+    v.mutate([](auto& m) {
+        auto it = m.find(4);
+        it->second = 200;
+    });
+
+    EXPECT_TRUE(v.is_valid());
+}

--- a/src/v/container/tests/map_bench.cc
+++ b/src/v/container/tests/map_bench.cc
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "container/contiguous_range_map.h"
+#include "container/tests/bench_utils.h"
+#include "random/generators.h"
+
+#include <seastar/testing/perf_tests.hh>
+
+#include <absl/container/btree_map.h>
+#include <boost/range/irange.hpp>
+
+template<typename MapT, size_t KeySetSize, size_t FillPercent>
+class MapBenchTest {
+    using key_t = typename MapT::key_type;
+    static auto make_value() {
+        return ::make_value<typename MapT::mapped_type>();
+    }
+
+    static std::vector<typename MapT::key_type> make_keys() {
+        std::vector<key_t> keys;
+        keys.reserve(int(KeySetSize * (FillPercent / 100.0)));
+        for (auto i : boost::irange<key_t>(0, KeySetSize)) {
+            if (random_generators::get_int(0, 100) <= FillPercent) {
+                keys.push_back(i);
+            }
+        }
+
+        return keys;
+    }
+    static auto make_filled() {
+        MapT v;
+        auto keys = make_keys();
+        for (auto k : keys) {
+            v[k] = make_value();
+        }
+        return v;
+    }
+
+public:
+    size_t run_sequential_fill_test() {
+        MapT map;
+        auto val = make_value();
+        auto keys = make_keys();
+        perf_tests::start_measuring_time();
+        for (auto& k : keys) {
+            map.emplace(k, val);
+        }
+        perf_tests::stop_measuring_time();
+        return KeySetSize * (FillPercent / 100.0);
+    }
+
+    size_t run_random_fill_test() {
+        MapT map;
+        auto val = make_value();
+        auto keys = make_keys();
+        std::shuffle(
+          keys.begin(), keys.end(), random_generators::internal::gen);
+        perf_tests::start_measuring_time();
+        for (auto& k : keys) {
+            map.emplace(k, val);
+        }
+        perf_tests::stop_measuring_time();
+        return KeySetSize * (FillPercent / 100.0);
+    }
+
+    size_t run_look_up_test() {
+        MapT map = make_filled();
+        std::vector<key_t> to_query;
+        std::generate_n(std::back_inserter(to_query), 1000, [] {
+            return random_generators::get_int<key_t>(KeySetSize);
+        });
+        perf_tests::start_measuring_time();
+        for (const auto& i : to_query) {
+            perf_tests::do_not_optimize(map.find(i));
+        }
+        perf_tests::stop_measuring_time();
+        return 1000;
+    }
+
+    size_t run_iterate_test() {
+        MapT map = make_filled();
+
+        perf_tests::start_measuring_time();
+        for (const auto& p : map) {
+            perf_tests::do_not_optimize(p);
+        }
+        perf_tests::stop_measuring_time();
+        return KeySetSize * (FillPercent / 100.0);
+    }
+};
+
+// NOLINTBEGIN(*-macro-*)
+#define INT_KEY_MAP_PERF_TEST(                                                        \
+  container, key, value, fill_factor, key_set_size)                                   \
+    class                                                                             \
+      IntMapBenchTest_##container##_##key##_##value##_##fill_factor##_##key_set_size  \
+      : public MapBenchTest<                                                          \
+          container<key, value>,                                                      \
+          key_set_size,                                                               \
+          fill_factor> {};                                                            \
+    PERF_TEST_F(                                                                      \
+      IntMapBenchTest_##container##_##key##_##value##_##fill_factor##_##key_set_size, \
+      SequentialFill) {                                                               \
+        return run_sequential_fill_test();                                            \
+    }                                                                                 \
+    PERF_TEST_F(                                                                      \
+      IntMapBenchTest_##container##_##key##_##value##_##fill_factor##_##key_set_size, \
+      RandomFill) {                                                                   \
+        return run_random_fill_test();                                                \
+    }                                                                                 \
+    PERF_TEST_F(                                                                      \
+      IntMapBenchTest_##container##_##key##_##value##_##fill_factor##_##key_set_size, \
+      LookUp) {                                                                       \
+        return run_look_up_test();                                                    \
+    }                                                                                 \
+    PERF_TEST_F(                                                                      \
+      IntMapBenchTest_##container##_##key##_##value##_##fill_factor##_##key_set_size, \
+      Iterate) {                                                                      \
+        return run_iterate_test();                                                    \
+    }
+
+// NOLINTEND(*-macro-*)
+
+static constexpr int full = 100;
+static constexpr int half_full = 50;
+
+template<typename K, typename V>
+using std_map = std::map<K, V>;
+template<typename K, typename V>
+using absl_btree_map = absl::btree_map<K, V>;
+
+INT_KEY_MAP_PERF_TEST(std_map, uint64_t, large_struct, full, 1000);
+INT_KEY_MAP_PERF_TEST(std_map, uint64_t, large_struct, full, 100000);
+INT_KEY_MAP_PERF_TEST(std_map, uint64_t, large_struct, half_full, 1000);
+INT_KEY_MAP_PERF_TEST(std_map, uint64_t, large_struct, half_full, 100000);
+
+INT_KEY_MAP_PERF_TEST(absl_btree_map, uint64_t, large_struct, full, 1000);
+INT_KEY_MAP_PERF_TEST(absl_btree_map, uint64_t, large_struct, full, 100000);
+INT_KEY_MAP_PERF_TEST(absl_btree_map, uint64_t, large_struct, half_full, 1000);
+INT_KEY_MAP_PERF_TEST(
+  absl_btree_map, uint64_t, large_struct, half_full, 100000);
+
+INT_KEY_MAP_PERF_TEST(contiguous_range_map, uint64_t, large_struct, full, 1000);
+INT_KEY_MAP_PERF_TEST(
+  contiguous_range_map, uint64_t, large_struct, full, 100000);
+INT_KEY_MAP_PERF_TEST(
+  contiguous_range_map, uint64_t, large_struct, half_full, 1000);
+INT_KEY_MAP_PERF_TEST(
+  contiguous_range_map, uint64_t, large_struct, half_full, 100000);

--- a/src/v/container/tests/vector_bench.cc
+++ b/src/v/container/tests/vector_bench.cc
@@ -10,6 +10,7 @@
  */
 
 #include "container/fragmented_vector.h"
+#include "container/tests/bench_utils.h"
 #include "random/generators.h"
 #include "utils/functional.h"
 #include "utils/type_traits.h"
@@ -20,54 +21,10 @@
 #include <iterator>
 #include <vector>
 
-struct large_struct {
-    size_t foo;
-    size_t bar;
-    std::string qux;
-    std::string baz;
-    std::string more;
-    std::string data;
-    size_t okdone;
-
-    bool operator==(const large_struct&) const = default;
-    auto operator<=>(const large_struct&) const = default;
-};
-
 template<typename Vector, size_t Size>
 class VectorBenchTest {
     static auto make_value() {
-        if constexpr (std::is_same_v<typename Vector::value_type, int64_t>) {
-            return static_cast<int64_t>(random_generators::get_int<int64_t>());
-
-        } else if constexpr (std::is_same_v<
-                               typename Vector::value_type,
-                               ss::sstring>) {
-            constexpr size_t max_str_len = 64;
-            return random_generators::gen_alphanum_string(
-              random_generators::get_int<size_t>(0, max_str_len));
-        } else if constexpr (std::is_same_v<
-                               typename Vector::value_type,
-                               large_struct>) {
-            constexpr size_t max_str_len = 64;
-            constexpr size_t max_num_cardinality = 16;
-            return large_struct{
-              .foo = random_generators::get_int<size_t>(0, max_num_cardinality),
-              .bar = random_generators::get_int<size_t>(0, max_num_cardinality),
-              .qux = random_generators::gen_alphanum_string(
-                random_generators::get_int<size_t>(0, max_str_len)),
-              .baz = random_generators::gen_alphanum_string(
-                random_generators::get_int<size_t>(0, max_str_len)),
-              .more = random_generators::gen_alphanum_string(
-                random_generators::get_int<size_t>(0, max_str_len)),
-              .data = random_generators::gen_alphanum_string(
-                random_generators::get_int<size_t>(0, max_str_len)),
-              .okdone = random_generators::get_int<size_t>(),
-            };
-        } else {
-            static_assert(
-              utils::unsupported_type<typename Vector::value_type>::value,
-              "unsupported");
-        }
+        return ::make_value<typename Vector::value_type>();
     }
     static auto make_filled() {
         Vector v;


### PR DESCRIPTION
A set of partition ids in each topic is a monotonically increasing sequence of numbers without gaps. This allows us to use a vector instead of an associative container to keep the partition metadata in topics table. Usage of `chunked_vector` prevents large memory allocations.

Fixes: #15610

## Benchmark results 
### `std::map`

```
test                             iterations      median         mad         min         max      allocs       tasks        inst
full_1000.SequentialFill           15959000    36.492ns     0.017ns    36.431ns    36.539ns       3.587       0.000       520.6
full_1000.RandomFill                8883000    70.880ns     0.036ns    70.844ns    70.952ns       3.587       0.000       448.6
full_1000.LookUp                    1622000    27.718ns     0.028ns    27.687ns    27.756ns       0.000       0.000       130.6
full_1000.Iterate                   1693000     3.894ns     0.002ns     3.886ns     3.897ns       0.000       0.000        16.2

full_100000.SequentialFill         13100000    43.760ns     0.140ns    43.620ns    44.167ns       3.629       0.000       634.1
full_100000.RandomFill              4300000   163.417ns     0.524ns   162.450ns   164.026ns       3.600       0.000       507.7
full_100000.LookUp                    17000   116.046ns     0.268ns   115.778ns   120.801ns       0.000       0.000       204.2
full_100000.Iterate                 1700000     7.345ns     0.039ns     7.306ns     7.674ns       0.000       0.000        16.0

half_full_1000.SequentialFill      13015500    39.139ns     0.011ns    39.129ns    39.162ns       3.620       0.000       504.2
half_full_1000.RandomFill           8263000    67.078ns     0.006ns    67.036ns    67.115ns       3.620       0.000       439.3
half_full_1000.LookUp               2993000    29.814ns     0.007ns    29.761ns    29.870ns       0.000       0.000       120.2
half_full_1000.Iterate              1642500     4.765ns     0.010ns     4.744ns     4.780ns       0.000       0.000        16.6

half_full_100000.SequentialFill    12550000    39.913ns     0.191ns    39.316ns    40.239ns       3.602       0.000       616.1
half_full_100000.RandomFill         4850000   137.204ns     0.510ns   135.549ns   139.806ns       3.556       0.000       494.3
half_full_100000.LookUp               33000    78.105ns     0.218ns    77.475ns    78.568ns       0.000       0.000       193.6
half_full_100000.Iterate            1650000     4.519ns     0.024ns     4.490ns     4.543ns       0.000       0.000        16.2
```
### `absl::btree_map`
```
test                             iterations      median         mad         min         max      allocs       tasks        inst
full_1000.SequentialFill           13100000    54.911ns     0.020ns    54.878ns    54.936ns       2.846       0.000       680.1
full_1000.RandomFill                7910000    90.543ns     0.078ns    90.451ns    90.685ns       2.912       0.000       838.0
full_1000.LookUp                    1583000    37.979ns     0.039ns    37.940ns    38.048ns       0.000       0.000       138.5
full_1000.Iterate                   1692000     1.483ns     0.001ns     1.482ns     1.485ns       0.000       0.000        14.3

full_100000.SequentialFill         12000000    58.674ns     0.489ns    57.425ns    59.163ns       2.858       0.000       793.8
full_100000.RandomFill              4100000   191.376ns     0.681ns   190.658ns   193.918ns       2.882       0.000       925.3
full_100000.LookUp                    17000   137.310ns     1.853ns   135.036ns   140.049ns       0.000       0.000       216.5
full_100000.Iterate                 1700000     2.558ns     0.034ns     2.524ns     2.796ns       0.000       0.000        14.0

half_full_1000.SequentialFill      11447000    54.669ns     0.023ns    54.534ns    54.785ns       2.869       0.000       664.1
half_full_1000.RandomFill           7337000    86.871ns     0.025ns    86.816ns    86.928ns       2.940       0.000       827.9
half_full_1000.LookUp               2913000    35.055ns     0.025ns    35.026ns    35.096ns       0.000       0.000       120.8
half_full_1000.Iterate              1636500     1.794ns     0.002ns     1.792ns     1.801ns       0.000       0.000        14.6

half_full_100000.SequentialFill    11150000    55.771ns     0.317ns    54.961ns    56.307ns       2.821       0.000       779.1
half_full_100000.RandomFill         4500000   166.781ns     0.175ns   165.512ns   167.473ns       2.847       0.000       917.1
half_full_100000.LookUp               33000    93.257ns     0.231ns    93.026ns    94.207ns       0.000       0.000       198.6
half_full_100000.Iterate            1650000     1.505ns     0.001ns     1.497ns     1.506ns       0.000       0.000        14.1
```
### `contiguous_range_map`
```
test                             iterations      median         mad         min         max      allocs       tasks        inst
full_1000.SequentialFill           22216000    26.186ns     0.010ns    26.176ns    26.234ns       2.600       0.000       446.1
full_1000.RandomFill               16853000    26.494ns     0.011ns    26.480ns    26.564ns       2.601       0.000       443.6
full_1000.LookUp                    1776000     1.553ns     0.001ns     1.549ns     1.557ns       0.000       0.000        34.2
full_1000.Iterate                   1788000     1.419ns     0.002ns     1.415ns     1.430ns       0.000       0.000        32.3

full_100000.SequentialFill         21600000    25.120ns     0.288ns    24.776ns    25.488ns       2.567       0.000       414.8
full_100000.RandomFill             10200000    55.801ns     0.389ns    53.163ns    56.190ns       2.606       0.000       435.5
full_100000.LookUp                    19000     9.691ns     0.096ns     9.595ns     9.894ns       0.000       0.000        34.3
full_100000.Iterate                 1800000     4.454ns     0.011ns     4.424ns     4.547ns       0.000       0.000        32.0

half_full_1000.SequentialFill      13759500    37.094ns     0.007ns    37.065ns    37.190ns       2.641       0.000       486.3
half_full_1000.RandomFill          12300000    31.107ns     0.012ns    31.047ns    31.121ns       2.632       0.000       473.2
half_full_1000.LookUp               3304000     5.142ns     0.001ns     5.136ns     5.144ns       0.000       0.000        28.3
half_full_1000.Iterate              1671000     9.897ns     0.007ns     9.889ns     9.909ns       0.000       0.000        46.7

half_full_100000.SequentialFill    14250000    31.808ns     0.138ns    31.669ns    32.137ns       2.603       0.000       445.7
half_full_100000.RandomFill         9350000    51.917ns     0.905ns    50.982ns    52.972ns       2.597       0.000       453.1
half_full_100000.LookUp               35000    10.103ns     0.133ns     9.937ns    10.262ns       0.000       0.000        28.3
half_full_100000.Iterate            1700000    11.780ns     0.071ns    11.693ns    11.929ns       0.000       0.000        46.2
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none