### PR TITLE
k/group_manager: used chunked_vector when cleaning groups

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2684,9 +2684,9 @@ ss::future<error_code> group::remove() {
     co_return error_code::none;
 }
 
-ss::future<>
-group::remove_topic_partitions(const std::vector<model::topic_partition>& tps) {
-    std::vector<std::pair<model::topic_partition, offset_metadata>> removed;
+ss::future<> group::remove_topic_partitions(
+  const chunked_vector<model::topic_partition>& tps) {
+    chunked_vector<std::pair<model::topic_partition, offset_metadata>> removed;
     for (const auto& tp : tps) {
         _pending_offset_commits.erase(tp);
         if (auto offset = _offsets.extract(tp); offset) {

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -17,6 +17,7 @@
 #include "cluster/simple_batch_builder.h"
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/tx_utils.h"
+#include "container/fragmented_vector.h"
 #include "kafka/group_probe.h"
 #include "kafka/protocol/fwd.h"
 #include "kafka/protocol/offset_commit.h"
@@ -644,7 +645,7 @@ public:
 
     // remove offsets associated with topic partitions
     ss::future<>
-    remove_topic_partitions(const std::vector<model::topic_partition>& tps);
+    remove_topic_partitions(const chunked_vector<model::topic_partition>& tps);
 
     const ss::lw_shared_ptr<cluster::partition> partition() const {
         return _partition;

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -239,7 +239,7 @@ private:
     void handle_topic_delta(cluster::topic_table::delta_range_t);
 
     ss::future<> cleanup_removed_topic_partitions(
-      const std::vector<model::topic_partition>&);
+      const chunked_vector<model::topic_partition>&);
 
     ss::future<> handle_partition_leader_change(
       model::term_id,


### PR DESCRIPTION
Consumer groups are removed when a topic that they are related with is removed from topics table. Previously the code cleaning up consumer groups was using a plain `std::vector` to store deltas coming from the `cluster::topics_table` notification. That lead to large allocation. Replaced the `std::vector` with chunked vector to make allocation size controlled.

Fixes: #15946

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
