### PR TITLE
write caching - configurations

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -251,6 +251,9 @@ partition_raft_state get_partition_raft_state(consensus_ptr ptr) {
     raft_state.has_pending_flushes = ptr->has_pending_flushes();
     raft_state.is_leader = ptr->is_leader();
     raft_state.is_elected_leader = ptr->is_elected_leader();
+    raft_state.write_caching_enabled = ptr->write_caching_enabled();
+    raft_state.flush_bytes = ptr->flush_bytes();
+    raft_state.flush_ms = ptr->flush_ms();
 
     const auto& fstats = ptr->get_follower_stats();
     if (ptr->is_elected_leader() && fstats.size() > 0) {

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -372,4 +372,19 @@ const topic_disabled_partitions_set* metadata_cache::get_topic_disabled_set(
     return _topics_state.local().get_topic_disabled_set(ns_tp);
 }
 
+std::optional<model::write_caching_mode>
+metadata_cache::get_topic_write_caching_mode(
+  model::topic_namespace_view tp) const {
+    auto topic = get_topic_cfg(tp);
+    if (!topic) {
+        return std::nullopt;
+    }
+    if (
+      config::shard_local_cfg().write_caching()
+      == model::write_caching_mode::disabled) {
+        return model::write_caching_mode::disabled;
+    }
+    return topic->properties.write_caching;
+}
+
 } // namespace cluster

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -204,6 +204,9 @@ public:
     const topic_disabled_partitions_set*
       get_topic_disabled_set(model::topic_namespace_view) const;
 
+    std::optional<model::write_caching_mode>
+      get_topic_write_caching_mode(model::topic_namespace_view) const;
+
 private:
     ss::sharded<topic_table>& _topics_state;
     ss::sharded<members_table>& _members_table;

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -751,6 +751,8 @@ ss::future<> partition::update_configuration(topic_properties properties) {
         _topic_cfg->properties = std::move(properties);
     }
 
+    _raft->notify_config_update();
+
     // If this partition's cloud storage mode changed, rebuild the archiver.
     // This must happen after raft update, because it reads raft's
     // ntp_config to decide whether to construct an archiver.

--- a/src/v/cluster/tests/topic_properties_generator.h
+++ b/src/v/cluster/tests/topic_properties_generator.h
@@ -63,6 +63,12 @@ inline cluster::topic_properties random_topic_properties() {
 
     // Always set remote_delete=false to survive an ADL roundtrip
     properties.remote_delete = false;
+    properties.write_caching = tests::random_optional([] {
+        return random_generators::random_choice(
+          {model::write_caching_mode::on,
+           model::write_caching_mode::off,
+           model::write_caching_mode::disabled});
+    });
 
     return properties;
 }

--- a/src/v/cluster/tests/topic_properties_generator.h
+++ b/src/v/cluster/tests/topic_properties_generator.h
@@ -69,6 +69,10 @@ inline cluster::topic_properties random_topic_properties() {
            model::write_caching_mode::off,
            model::write_caching_mode::disabled});
     });
+    properties.flush_ms = tests::random_optional(
+      [] { return tests::random_duration_ms(); });
+    properties.flush_bytes = tests::random_optional(
+      [] { return random_generators::get_int<size_t>(); });
 
     return properties;
 }

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -901,6 +901,8 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
       properties.initial_retention_local_target_ms,
       overrides.initial_retention_local_target_ms);
     incremental_update(properties.write_caching, overrides.write_caching);
+    incremental_update(properties.flush_ms, overrides.flush_ms);
+    incremental_update(properties.flush_bytes, overrides.flush_bytes);
     // no configuration change, no need to generate delta
     if (properties == properties_snapshot) {
         co_return errc::success;

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -900,6 +900,7 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     incremental_update(
       properties.initial_retention_local_target_ms,
       overrides.initial_retention_local_target_ms);
+    incremental_update(properties.write_caching, overrides.write_caching);
     // no configuration change, no need to generate delta
     if (properties == properties_snapshot) {
         co_return errc::success;

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -198,7 +198,8 @@ bool topic_properties::has_overrides() const {
            || record_value_subject_name_strategy_compat.has_value()
            || initial_retention_local_target_bytes.is_engaged()
            || initial_retention_local_target_ms.is_engaged()
-           || write_caching.has_value();
+           || write_caching.has_value() || flush_ms.has_value()
+           || flush_bytes.has_value();
 }
 
 bool topic_properties::requires_remote_erase() const {
@@ -229,6 +230,8 @@ topic_properties::get_ntp_cfg_overrides() const {
       = initial_retention_local_target_bytes;
     ret.initial_retention_local_target_ms = initial_retention_local_target_ms;
     ret.write_caching = write_caching;
+    ret.flush_ms = flush_ms;
+    ret.flush_bytes = flush_bytes;
     return ret;
 }
 
@@ -357,7 +360,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "initial_retention_local_target_bytes: {}, "
       "initial_retention_local_target_ms: {}, "
       "mpx_virtual_cluster_id: {}, ",
-      "write_caching: {}}}",
+      "write_caching: {}, ",
+      "flush_ms: {}, "
+      "flush_bytes: {}}}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -386,7 +391,9 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.initial_retention_local_target_bytes,
       properties.initial_retention_local_target_ms,
       properties.mpx_virtual_cluster_id,
-      properties.write_caching);
+      properties.write_caching,
+      properties.flush_ms,
+      properties.flush_bytes);
 
     return o;
 }
@@ -2203,6 +2210,8 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       tristate<size_t>{std::nullopt},
       tristate<std::chrono::milliseconds>{std::nullopt},
+      std::nullopt,
+      std::nullopt,
       std::nullopt,
       std::nullopt};
 }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -197,7 +197,8 @@ bool topic_properties::has_overrides() const {
            || record_value_subject_name_strategy.has_value()
            || record_value_subject_name_strategy_compat.has_value()
            || initial_retention_local_target_bytes.is_engaged()
-           || initial_retention_local_target_ms.is_engaged();
+           || initial_retention_local_target_ms.is_engaged()
+           || write_caching.has_value();
 }
 
 bool topic_properties::requires_remote_erase() const {
@@ -227,6 +228,7 @@ topic_properties::get_ntp_cfg_overrides() const {
     ret.initial_retention_local_target_bytes
       = initial_retention_local_target_bytes;
     ret.initial_retention_local_target_ms = initial_retention_local_target_ms;
+    ret.write_caching = write_caching;
     return ret;
 }
 
@@ -354,7 +356,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       "record_value_subject_name_strategy_compat: {}, "
       "initial_retention_local_target_bytes: {}, "
       "initial_retention_local_target_ms: {}, "
-      "mpx_virtual_cluster_id: {}}}",
+      "mpx_virtual_cluster_id: {}, ",
+      "write_caching: {}}}",
       properties.compression,
       properties.cleanup_policy_bitflags,
       properties.compaction_strategy,
@@ -382,7 +385,8 @@ std::ostream& operator<<(std::ostream& o, const topic_properties& properties) {
       properties.record_value_subject_name_strategy_compat,
       properties.initial_retention_local_target_bytes,
       properties.initial_retention_local_target_ms,
-      properties.mpx_virtual_cluster_id);
+      properties.mpx_virtual_cluster_id,
+      properties.write_caching);
 
     return o;
 }
@@ -654,7 +658,7 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       "record_value_subject_name_strategy: {}"
       "record_value_subject_name_strategy_compat: {}, "
       "initial_retention_local_target_bytes: {}, "
-      "initial_retention_local_target_ms: {}",
+      "initial_retention_local_target_ms: {}, write_caching: {}",
       i.compression,
       i.cleanup_policy_bitflags,
       i.compaction_strategy,
@@ -677,7 +681,8 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       i.record_value_subject_name_strategy,
       i.record_value_subject_name_strategy_compat,
       i.initial_retention_local_target_bytes,
-      i.initial_retention_local_target_ms);
+      i.initial_retention_local_target_ms,
+      i.write_caching);
     return o;
 }
 
@@ -2198,6 +2203,7 @@ adl<cluster::topic_properties>::from(iobuf_parser& parser) {
       std::nullopt,
       tristate<size_t>{std::nullopt},
       tristate<std::chrono::milliseconds>{std::nullopt},
+      std::nullopt,
       std::nullopt};
 }
 

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -665,7 +665,8 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       "record_value_subject_name_strategy: {}"
       "record_value_subject_name_strategy_compat: {}, "
       "initial_retention_local_target_bytes: {}, "
-      "initial_retention_local_target_ms: {}, write_caching: {}",
+      "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
+      "flush_bytes: {}",
       i.compression,
       i.cleanup_policy_bitflags,
       i.compaction_strategy,
@@ -689,7 +690,9 @@ std::ostream& operator<<(std::ostream& o, const incremental_topic_updates& i) {
       i.record_value_subject_name_strategy_compat,
       i.initial_retention_local_target_bytes,
       i.initial_retention_local_target_ms,
-      i.write_caching);
+      i.write_caching,
+      i.flush_ms,
+      i.flush_bytes);
     return o;
 }
 
@@ -1823,7 +1826,10 @@ void adl<cluster::incremental_topic_updates>::to(
       t.record_value_subject_name_strategy,
       t.record_value_subject_name_strategy_compat,
       t.initial_retention_local_target_bytes,
-      t.initial_retention_local_target_ms);
+      t.initial_retention_local_target_ms,
+      t.write_caching,
+      t.flush_ms,
+      t.flush_bytes);
 }
 
 cluster::incremental_topic_updates
@@ -1943,6 +1949,19 @@ adl<cluster::incremental_topic_updates>::from(iobuf_parser& in) {
         updates.initial_retention_local_target_ms
           = adl<cluster::property_update<tristate<std::chrono::milliseconds>>>{}
               .from(in);
+    }
+
+    if (
+      version
+      <= cluster::incremental_topic_updates::version_with_write_caching) {
+        updates.write_caching = adl<cluster::property_update<
+          std::optional<model::write_caching_mode>>>{}
+                                  .from(in);
+        updates.flush_ms = adl<cluster::property_update<
+          std::optional<std::chrono::milliseconds>>>{}
+                             .from(in);
+        updates.flush_bytes
+          = adl<cluster::property_update<std::optional<size_t>>>{}.from(in);
     }
 
     return updates;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1508,7 +1508,9 @@ struct topic_properties
       tristate<size_t> initial_retention_local_target_bytes,
       tristate<std::chrono::milliseconds> initial_retention_local_target_ms,
       std::optional<model::vcluster_id> mpx_virtual_cluster_id,
-      std::optional<model::write_caching_mode> write_caching)
+      std::optional<model::write_caching_mode> write_caching,
+      std::optional<std::chrono::milliseconds> flush_ms,
+      std::optional<size_t> flush_bytes)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -1542,7 +1544,9 @@ struct topic_properties
           initial_retention_local_target_bytes)
       , initial_retention_local_target_ms(initial_retention_local_target_ms)
       , mpx_virtual_cluster_id(mpx_virtual_cluster_id)
-      , write_caching(write_caching) {}
+      , write_caching(write_caching)
+      , flush_ms(flush_ms)
+      , flush_bytes(flush_bytes) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -1586,6 +1590,8 @@ struct topic_properties
       std::nullopt};
     std::optional<model::vcluster_id> mpx_virtual_cluster_id;
     std::optional<model::write_caching_mode> write_caching;
+    std::optional<std::chrono::milliseconds> flush_ms;
+    std::optional<size_t> flush_bytes;
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -1624,7 +1630,9 @@ struct topic_properties
           initial_retention_local_target_bytes,
           initial_retention_local_target_ms,
           mpx_virtual_cluster_id,
-          write_caching);
+          write_caching,
+          flush_ms,
+          flush_bytes);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)
@@ -1767,6 +1775,8 @@ struct incremental_topic_updates
     property_update<tristate<std::chrono::milliseconds>>
       initial_retention_local_target_ms;
     property_update<std::optional<model::write_caching_mode>> write_caching;
+    property_update<std::optional<std::chrono::milliseconds>> flush_ms;
+    property_update<std::optional<size_t>> flush_bytes;
 
     auto serde_fields() {
         return std::tie(
@@ -1793,7 +1803,9 @@ struct incremental_topic_updates
           record_value_subject_name_strategy_compat,
           initial_retention_local_target_bytes,
           initial_retention_local_target_ms,
-          write_caching);
+          write_caching,
+          flush_ms,
+          flush_bytes);
     }
 
     friend std::ostream&

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -3896,7 +3896,7 @@ struct partition_stm_state
 struct partition_raft_state
   : serde::envelope<
       partition_raft_state,
-      serde::version<2>,
+      serde::version<3>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
 
@@ -3918,6 +3918,9 @@ struct partition_raft_state
     bool is_leader;
     bool is_elected_leader;
     std::vector<partition_stm_state> stms;
+    bool write_caching_enabled;
+    size_t flush_bytes;
+    std::chrono::milliseconds flush_ms;
 
     struct follower_state
       : serde::envelope<
@@ -4006,7 +4009,10 @@ struct partition_raft_state
           is_elected_leader,
           followers,
           stms,
-          recovery_state);
+          recovery_state,
+          write_caching_enabled,
+          flush_bytes,
+          flush_ms);
     }
 
     friend bool

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1729,6 +1729,7 @@ struct incremental_topic_updates
     static constexpr int8_t version_with_segment_ms = -5;
     static constexpr int8_t version_with_schema_id_validation = -6;
     static constexpr int8_t version_with_initial_retention = -7;
+    static constexpr int8_t version_with_write_caching = -8;
     // negative version indicating different format:
     // -1 - topic_updates with data_policy
     // -2 - topic_updates without data_policy
@@ -1736,7 +1737,8 @@ struct incremental_topic_updates
     // -4 - topic update with batch_max_bytes and retention.local.target
     // -6 - topic updates with schema id validation
     // -7 - topic updates with initial retention
-    static constexpr int8_t version = version_with_initial_retention;
+    // -8 - write caching properties
+    static constexpr int8_t version = version_with_write_caching;
     property_update<std::optional<model::compression>> compression;
     property_update<std::optional<model::cleanup_policy_bitflags>>
       cleanup_policy_bitflags;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1473,7 +1473,7 @@ struct remote_topic_properties
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<7>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<8>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -1507,7 +1507,8 @@ struct topic_properties
         record_value_subject_name_strategy_compat,
       tristate<size_t> initial_retention_local_target_bytes,
       tristate<std::chrono::milliseconds> initial_retention_local_target_ms,
-      std::optional<model::vcluster_id> mpx_virtual_cluster_id)
+      std::optional<model::vcluster_id> mpx_virtual_cluster_id,
+      std::optional<model::write_caching_mode> write_caching)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -1540,7 +1541,8 @@ struct topic_properties
       , initial_retention_local_target_bytes(
           initial_retention_local_target_bytes)
       , initial_retention_local_target_ms(initial_retention_local_target_ms)
-      , mpx_virtual_cluster_id(mpx_virtual_cluster_id) {}
+      , mpx_virtual_cluster_id(mpx_virtual_cluster_id)
+      , write_caching(write_caching) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -1583,6 +1585,7 @@ struct topic_properties
     tristate<std::chrono::milliseconds> initial_retention_local_target_ms{
       std::nullopt};
     std::optional<model::vcluster_id> mpx_virtual_cluster_id;
+    std::optional<model::write_caching_mode> write_caching;
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -1620,7 +1623,8 @@ struct topic_properties
           record_value_subject_name_strategy_compat,
           initial_retention_local_target_bytes,
           initial_retention_local_target_ms,
-          mpx_virtual_cluster_id);
+          mpx_virtual_cluster_id,
+          write_caching);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)
@@ -1708,7 +1712,7 @@ struct property_update<tristate<T>>
 struct incremental_topic_updates
   : serde::envelope<
       incremental_topic_updates,
-      serde::version<5>,
+      serde::version<6>,
       serde::compat_version<0>> {
     static constexpr int8_t version_with_data_policy = -1;
     static constexpr int8_t version_with_shadow_indexing = -3;
@@ -1762,6 +1766,7 @@ struct incremental_topic_updates
     property_update<tristate<size_t>> initial_retention_local_target_bytes;
     property_update<tristate<std::chrono::milliseconds>>
       initial_retention_local_target_ms;
+    property_update<std::optional<model::write_caching_mode>> write_caching;
 
     auto serde_fields() {
         return std::tie(
@@ -1787,7 +1792,8 @@ struct incremental_topic_updates
           record_value_subject_name_strategy,
           record_value_subject_name_strategy_compat,
           initial_retention_local_target_bytes,
-          initial_retention_local_target_ms);
+          initial_retention_local_target_ms,
+          write_caching);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -353,7 +353,8 @@ struct compat_check<cluster::topic_properties> {
         json_write(mpx_virtual_cluster_id);
         json::write_exceptional_member_type(
           wr, "write_caching", obj.write_caching);
-        json_write(write_caching);
+        json_write(flush_ms);
+        json_write(flush_bytes);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -387,6 +388,8 @@ struct compat_check<cluster::topic_properties> {
         json_read(initial_retention_local_target_ms);
         json_read(mpx_virtual_cluster_id);
         json_read(write_caching);
+        json_read(flush_ms);
+        json_read(flush_bytes);
         return obj;
     }
 
@@ -415,6 +418,8 @@ struct compat_check<cluster::topic_properties> {
           = tristate<std::chrono::milliseconds>{std::nullopt};
         obj.mpx_virtual_cluster_id = std::nullopt;
         obj.write_caching = std::nullopt;
+        obj.flush_bytes = std::nullopt;
+        obj.flush_ms = std::nullopt;
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -490,6 +495,8 @@ struct compat_check<cluster::topic_configuration> {
         obj.properties.initial_retention_local_target_ms
           = tristate<std::chrono::milliseconds>{std::nullopt};
         obj.properties.write_caching = std::nullopt;
+        obj.properties.flush_bytes = std::nullopt;
+        obj.properties.flush_ms = std::nullopt;
 
         obj.properties.mpx_virtual_cluster_id = std::nullopt;
 
@@ -557,6 +564,8 @@ struct compat_check<cluster::create_topics_request> {
               = tristate<std::chrono::milliseconds>{std::nullopt};
             topic.properties.mpx_virtual_cluster_id = std::nullopt;
             topic.properties.write_caching = std::nullopt;
+            topic.properties.flush_bytes = std::nullopt;
+            topic.properties.flush_ms = std::nullopt;
         }
         if (req != obj) {
             throw compat_error(fmt::format(
@@ -621,6 +630,8 @@ struct compat_check<cluster::create_topics_reply> {
               = tristate<std::chrono::milliseconds>{std::nullopt};
             topic.properties.mpx_virtual_cluster_id = std::nullopt;
             topic.properties.write_caching = std::nullopt;
+            topic.properties.flush_bytes = std::nullopt;
+            topic.properties.flush_ms = std::nullopt;
         }
         if (reply != obj) {
             throw compat_error(fmt::format(

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -351,6 +351,9 @@ struct compat_check<cluster::topic_properties> {
         json_write(initial_retention_local_target_bytes);
         json_write(initial_retention_local_target_ms);
         json_write(mpx_virtual_cluster_id);
+        json::write_exceptional_member_type(
+          wr, "write_caching", obj.write_caching);
+        json_write(write_caching);
     }
 
     static cluster::topic_properties from_json(json::Value& rd) {
@@ -383,6 +386,7 @@ struct compat_check<cluster::topic_properties> {
         json_read(initial_retention_local_target_bytes);
         json_read(initial_retention_local_target_ms);
         json_read(mpx_virtual_cluster_id);
+        json_read(write_caching);
         return obj;
     }
 
@@ -410,6 +414,7 @@ struct compat_check<cluster::topic_properties> {
         obj.initial_retention_local_target_ms
           = tristate<std::chrono::milliseconds>{std::nullopt};
         obj.mpx_virtual_cluster_id = std::nullopt;
+        obj.write_caching = std::nullopt;
 
         if (reply != obj) {
             throw compat_error(fmt::format(
@@ -484,6 +489,7 @@ struct compat_check<cluster::topic_configuration> {
           std::nullopt};
         obj.properties.initial_retention_local_target_ms
           = tristate<std::chrono::milliseconds>{std::nullopt};
+        obj.properties.write_caching = std::nullopt;
 
         obj.properties.mpx_virtual_cluster_id = std::nullopt;
 
@@ -550,6 +556,7 @@ struct compat_check<cluster::create_topics_request> {
             topic.properties.initial_retention_local_target_ms
               = tristate<std::chrono::milliseconds>{std::nullopt};
             topic.properties.mpx_virtual_cluster_id = std::nullopt;
+            topic.properties.write_caching = std::nullopt;
         }
         if (req != obj) {
             throw compat_error(fmt::format(
@@ -613,6 +620,7 @@ struct compat_check<cluster::create_topics_reply> {
             topic.properties.initial_retention_local_target_ms
               = tristate<std::chrono::milliseconds>{std::nullopt};
             topic.properties.mpx_virtual_cluster_id = std::nullopt;
+            topic.properties.write_caching = std::nullopt;
         }
         if (reply != obj) {
             throw compat_error(fmt::format(

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -635,7 +635,13 @@ struct instance_generator<cluster::topic_properties> {
             [] { return random_generators::get_int<size_t>(); }),
           tests::random_tristate([] { return tests::random_duration_ms(); }),
           tests::random_optional(
-            [] { return model::vcluster_id(random_xid()); })};
+            [] { return model::vcluster_id(random_xid()); }),
+          tests::random_optional([] {
+              return random_generators::random_choice(
+                {model::write_caching_mode::on,
+                 model::write_caching_mode::off,
+                 model::write_caching_mode::disabled});
+          })};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -641,7 +641,10 @@ struct instance_generator<cluster::topic_properties> {
                 {model::write_caching_mode::on,
                  model::write_caching_mode::off,
                  model::write_caching_mode::disabled});
-          })};
+          }),
+          tests::random_optional([] { return tests::random_duration_ms(); }),
+          tests::random_optional(
+            [] { return random_generators::get_int<size_t>(); })};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -605,7 +605,7 @@ inline void rjson_serialize(
       "initial_retention_local_target_ms",
       tps.initial_retention_local_target_ms);
     write_member(w, "mpx_virtual_cluster_id", tps.mpx_virtual_cluster_id);
-
+    write_exceptional_member_type(w, "write_caching", tps.write_caching);
     w.EndObject();
 }
 
@@ -669,6 +669,7 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
       "initial_retention_local_target_ms",
       obj.initial_retention_local_target_ms);
     read_member(rd, "mpx_virtual_cluster_id", obj.mpx_virtual_cluster_id);
+    read_member(rd, "write_caching", obj.write_caching);
 }
 
 inline void rjson_serialize(

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -606,6 +606,8 @@ inline void rjson_serialize(
       tps.initial_retention_local_target_ms);
     write_member(w, "mpx_virtual_cluster_id", tps.mpx_virtual_cluster_id);
     write_exceptional_member_type(w, "write_caching", tps.write_caching);
+    write_member(w, "flush_bytes", tps.flush_bytes);
+    write_member(w, "flush_ms", tps.flush_ms);
     w.EndObject();
 }
 
@@ -670,6 +672,8 @@ inline void read_value(json::Value const& rd, cluster::topic_properties& obj) {
       obj.initial_retention_local_target_ms);
     read_member(rd, "mpx_virtual_cluster_id", obj.mpx_virtual_cluster_id);
     read_member(rd, "write_caching", obj.write_caching);
+    read_member(rd, "flush_bytes", obj.flush_bytes);
+    read_member(rd, "flush_ms", obj.flush_ms);
 }
 
 inline void rjson_serialize(

--- a/src/v/compat/model_json.h
+++ b/src/v/compat/model_json.h
@@ -202,7 +202,7 @@ inline void read_value(json::Value const& rd, model::topic_metadata& tm) {
 template<typename T>
 inline constexpr bool is_exceptional_enum
   = std::is_enum_v<T>
-    && (std::is_same_v<T, model::compression> || std::is_same_v<T, model::timestamp_type> || std::is_same_v<T, model::cleanup_policy_bitflags>);
+    && (std::is_same_v<T, model::compression> || std::is_same_v<T, model::timestamp_type> || std::is_same_v<T, model::cleanup_policy_bitflags> || std::is_same_v<T, model::write_caching_mode>);
 
 template<typename T>
 inline constexpr bool is_exceptional_enum_wrapped_opt
@@ -258,6 +258,12 @@ inline void rjson_serialize_exceptional_type(
   const model::cleanup_policy_bitflags& c) {
     using underlying_t = std::underlying_type_t<model::cleanup_policy_bitflags>;
     rjson_serialize(w, static_cast<underlying_t>(c));
+}
+
+inline void rjson_serialize_exceptional_type(
+  json::Writer<json::StringBuffer>& w, const model::write_caching_mode& m) {
+    using underlying_t = std::underlying_type_t<model::write_caching_mode>;
+    rjson_serialize(w, static_cast<underlying_t>(m));
 }
 
 } // namespace json

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -382,6 +382,8 @@ configuration::configuration()
       "requested",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       256_KiB)
+  // todo (bharathv): deprecate raft_flush_timer_interval_ms in favor of
+  // raft_replica_max_flush_delay_ms
   , raft_flush_timer_interval_ms(
       *this,
       "raft_flush_timer_interval_ms",
@@ -389,6 +391,19 @@ configuration::configuration()
       "`raft_replica_max_pending_flush_bytes`",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100ms)
+  , raft_replica_max_flush_delay_ms(
+      *this,
+      "raft_replica_max_flush_delay_ms",
+      "Maximum delay (in ms) between two subsequent flushes. After this delay, "
+      "the log will be automatically force flushed.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      100ms,
+      [](auto const& v) -> std::optional<ss::sstring> {
+          if (v < 1ms) {
+              return "flush delay should be atleast 1ms";
+          }
+          return std::nullopt;
+      })
   , enable_usage(
       *this,
       "enable_usage",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -963,6 +963,21 @@ configuration::configuration()
       "one follower",
       {.visibility = visibility::tunable},
       16)
+  , write_caching(
+      *this,
+      "write_caching",
+      "Cache batches until the segment appender chunk is full instead of "
+      "flushing for every acks=all write. This is the global default "
+      "for all topics and can be overriden at a topic scope with property "
+      "write.caching. 'disabled' mode takes precedence over topic overrides "
+      "and disables the feature altogether for the entire cluster.",
+      {.needs_restart = needs_restart::no,
+       .example = "on",
+       .visibility = visibility::user},
+      model::write_caching_mode::off,
+      {model::write_caching_mode::on,
+       model::write_caching_mode::off,
+       model::write_caching_mode::disabled})
   , reclaim_min_size(
       *this,
       "reclaim_min_size",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -106,6 +106,7 @@ struct configuration final : public config_store {
     bounded_property<size_t> raft_recovery_concurrency_per_shard;
     property<std::optional<size_t>> raft_replica_max_pending_flush_bytes;
     property<std::chrono::milliseconds> raft_flush_timer_interval_ms;
+    property<std::chrono::milliseconds> raft_replica_max_flush_delay_ms;
     // Kafka
     property<bool> enable_usage;
     bounded_property<size_t> usage_num_windows;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -200,6 +200,7 @@ struct configuration final : public config_store {
     property<bool> raft_recovery_throttle_disable_dynamic_mode;
     property<std::optional<uint32_t>> raft_smp_max_non_local_requests;
     property<uint32_t> raft_max_concurrent_append_requests_per_follower;
+    enum_property<model::write_caching_mode> write_caching;
 
     property<size_t> reclaim_min_size;
     property<size_t> reclaim_max_size;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -531,4 +531,21 @@ struct convert<model::fetch_read_strategy> {
     }
 };
 
+template<>
+struct convert<model::write_caching_mode> {
+    using type = model::write_caching_mode;
+
+    static Node encode(const type& rhs) { return Node(fmt::format("{}", rhs)); }
+
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+        auto mode = model::write_caching_mode_from_string(value);
+        if (!mode) {
+            return false;
+        }
+        rhs = mode.value();
+        return true;
+    }
+};
+
 } // namespace YAML

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -643,6 +643,8 @@ consteval std::string_view property_type_name() {
         return "string";
     } else if constexpr (std::is_same_v<type, model::fetch_read_strategy>) {
         return "string";
+    } else if constexpr (std::is_same_v<type, model::write_caching_mode>) {
+        return "string";
     } else {
         static_assert(
           utils::unsupported_type<T>::value, "Type name not defined");

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -166,6 +166,11 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::write_caching_mode& v) {
+    stringize(w, v);
+}
+
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const model::cloud_storage_chunk_eviction_strategy& v) {
     stringize(w, v);

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -80,6 +80,9 @@ void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::fetch_read_strategy& v);
 
 void rjson_serialize(
+  json::Writer<json::StringBuffer>& w, const model::write_caching_mode& v);
+
+void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
   const model::cloud_storage_chunk_eviction_strategy& v);
 

--- a/src/v/kafka/protocol/CMakeLists.txt
+++ b/src/v/kafka/protocol/CMakeLists.txt
@@ -40,6 +40,7 @@ v_cc_library(
     kafka_batch_adapter.cc
   DEPS
     Seastar::seastar
+    v::model
     v::bytes
     v::rpc
     absl::flat_hash_map

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -270,9 +270,27 @@ create_topic_properties_update(
                 parse_and_set_optional(
                   update.properties.write_caching,
                   cfg.value,
-                  kafka::config_resource_operation::set);
+                  kafka::config_resource_operation::set,
+                  write_caching_config_validator{});
                 continue;
             }
+            if (cfg.name == topic_property_flush_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.flush_ms,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  flush_ms_validator{});
+                continue;
+            }
+            if (cfg.name == topic_property_flush_bytes) {
+                parse_and_set_optional(
+                  update.properties.flush_bytes,
+                  cfg.value,
+                  kafka::config_resource_operation::set,
+                  flush_bytes_validator{});
+                continue;
+            }
+
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<
               alter_configs_resource_response>(

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -266,6 +266,13 @@ create_topic_properties_update(
                 // Skip unsupported Kafka config
                 continue;
             };
+            if (cfg.name == topic_property_write_caching) {
+                parse_and_set_optional(
+                  update.properties.write_caching,
+                  cfg.value,
+                  kafka::config_resource_operation::set);
+                continue;
+            }
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<
               alter_configs_resource_response>(

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -382,6 +382,36 @@ struct write_caching_config_validator {
     }
 };
 
+struct flush_ms_validator {
+    std::optional<ss::sstring> operator()(
+      const ss::sstring&,
+      const std::optional<std::chrono::milliseconds>& maybe_value) {
+        if (!maybe_value) {
+            return std::nullopt;
+        }
+        auto value = maybe_value.value();
+        if (value < 1ms) {
+            return fmt::format(
+              "config value too low, expected to be atleast 1ms");
+        }
+        return std::nullopt;
+    }
+};
+
+struct flush_bytes_validator {
+    std::optional<ss::sstring>
+    operator()(const ss::sstring&, const std::optional<size_t>& maybe_value) {
+        if (!maybe_value) {
+            return std::nullopt;
+        }
+        auto value = maybe_value.value();
+        if (value <= 0) {
+            return fmt::format("config value too low, expected to be > 0");
+        }
+        return std::nullopt;
+    }
+};
+
 template<typename T, typename... ValidatorTypes>
 requires requires(
   model::topic_namespace_view tns,

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -86,7 +86,8 @@ using validators = make_validator_types<
   batch_max_bytes_limits,
   subject_name_strategy_validator,
   replication_factor_must_be_greater_or_equal_to_minimum,
-  vcluster_id_validator>;
+  vcluster_id_validator,
+  write_caching_configs_validator>;
 
 static std::vector<creatable_topic_configs>
 properties_to_result_configs(config_map_t config_map) {

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -610,30 +610,6 @@ static void report_broker_config(
       &describe_as_string<bool>);
 }
 
-int64_t describe_retention_duration(
-  tristate<std::chrono::milliseconds>& overrides,
-  std::optional<std::chrono::milliseconds> def) {
-    if (overrides.is_disabled()) {
-        return -1;
-    }
-    if (overrides.has_optional_value()) {
-        return overrides.value().count();
-    }
-
-    return def ? def->count() : -1;
-}
-int64_t describe_retention_bytes(
-  tristate<size_t>& overrides, std::optional<size_t> def) {
-    if (overrides.is_disabled()) {
-        return -1;
-    }
-    if (overrides.has_optional_value()) {
-        return overrides.value();
-    }
-
-    return def.value_or(-1);
-}
-
 template<>
 ss::future<response_ptr> describe_configs_handler::handle(
   request_context ctx, [[maybe_unused]] ss::smp_service_group ssg) {

--- a/src/v/kafka/server/handlers/describe_configs.cc
+++ b/src/v/kafka/server/handlers/describe_configs.cc
@@ -116,7 +116,8 @@ consteval describe_configs_type property_config_type() {
         std::is_same_v<T, config::data_directory_path> ||
         std::is_same_v<T, v8_engine::data_policy> ||
         std::is_same_v<T, pandaproxy::schema_registry::subject_name_strategy> || 
-        std::is_same_v<T, model::vcluster_id>;
+        std::is_same_v<T, model::vcluster_id> ||
+        std::is_same_v<T, model::write_caching_mode>;
 
     constexpr auto is_long_type = is_long<T> ||
         // Long type since seconds is atleast a 35-bit signed integral
@@ -777,6 +778,51 @@ ss::future<response_ptr> describe_configs_handler::handle(
                 request.data.include_documentation,
                 config::shard_local_cfg().kafka_batch_max_bytes.desc()),
               &describe_as_string<uint32_t>);
+
+            add_topic_config_if_requested(
+              resource,
+              result,
+              config::shard_local_cfg().write_caching.name(),
+              config::shard_local_cfg().write_caching(),
+              topic_property_write_caching,
+              ctx.metadata_cache().get_topic_write_caching_mode(
+                topic_config->tp_ns),
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg().write_caching.desc()),
+              &describe_as_string<model::write_caching_mode>);
+
+            add_topic_config_if_requested(
+              resource,
+              result,
+              config::shard_local_cfg()
+                .raft_replica_max_pending_flush_bytes.name(),
+              config::shard_local_cfg()
+                .raft_replica_max_pending_flush_bytes()
+                .value_or(std::numeric_limits<size_t>::max()),
+              topic_property_flush_bytes,
+              topic_config->properties.flush_bytes,
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg()
+                  .raft_replica_max_pending_flush_bytes.desc()),
+              &describe_as_string<size_t>);
+
+            add_topic_config_if_requested(
+              resource,
+              result,
+              config::shard_local_cfg().raft_replica_max_flush_delay_ms.name(),
+              config::shard_local_cfg().raft_replica_max_flush_delay_ms(),
+              topic_property_flush_ms,
+              topic_config->properties.flush_ms,
+              request.data.include_synonyms,
+              maybe_make_documentation(
+                request.data.include_documentation,
+                config::shard_local_cfg()
+                  .raft_replica_max_flush_delay_ms.desc()),
+              &describe_as_string<std::chrono::milliseconds>);
 
             // Shadow indexing properties
             add_topic_config_if_requested(

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -284,6 +284,22 @@ create_topic_properties_update(
                   write_caching_config_validator{});
                 continue;
             }
+            if (cfg.name == topic_property_flush_ms) {
+                parse_and_set_optional_duration(
+                  update.properties.flush_ms,
+                  cfg.value,
+                  op,
+                  flush_ms_validator{});
+                continue;
+            }
+            if (cfg.name == topic_property_flush_bytes) {
+                parse_and_set_optional(
+                  update.properties.flush_bytes,
+                  cfg.value,
+                  op,
+                  flush_bytes_validator{});
+                continue;
+            }
 
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -302,10 +302,20 @@ create_topic_properties_update(
             }
 
         } catch (const validation_error& e) {
+            vlog(
+              klog.debug,
+              "Validation error during request: {} for config: {}",
+              e.what(),
+              cfg.name);
             return make_error_alter_config_resource_response<
               incremental_alter_configs_resource_response>(
               resource, error_code::invalid_config, e.what());
         } catch (const boost::bad_lexical_cast& e) {
+            vlog(
+              klog.debug,
+              "Parsing error during request: {} for config: {}",
+              e.what(),
+              cfg.name);
             return make_error_alter_config_resource_response<
               incremental_alter_configs_resource_response>(
               resource,
@@ -313,6 +323,7 @@ create_topic_properties_update(
               fmt::format(
                 "unable to parse property {} value {}", cfg.name, cfg.value));
         }
+        vlog(klog.debug, "Unsupported property: {}", cfg.name);
         // Unsupported property, return error
         return make_error_alter_config_resource_response<resp_resource_t>(
           resource,

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -276,6 +276,14 @@ create_topic_properties_update(
                 // Skip unsupported Kafka config
                 continue;
             }
+            if (cfg.name == topic_property_write_caching) {
+                parse_and_set_optional(
+                  update.properties.write_caching,
+                  cfg.value,
+                  op,
+                  write_caching_config_validator{});
+                continue;
+            }
 
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -127,7 +127,6 @@ static constexpr std::array<std::string_view, 20> allowlist_topic_noop_confs = {
   "leader.replication.throttled.replicas",
   "index.interval.bytes",
   "follower.replication.throttled.replicas",
-  "flush.ms",
   "flush.messages",
   "file.delete.delay.ms",
   "delete.retention.ms",

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -69,6 +69,9 @@ static constexpr std::string_view topic_property_segment_ms = "segment.ms";
 static constexpr std::string_view topic_property_write_caching
   = "write.caching";
 
+static constexpr std::string_view topic_property_flush_ms = "flush.ms";
+static constexpr std::string_view topic_property_flush_bytes = "flush.bytes";
+
 // Server side schema id validation
 static constexpr std::string_view topic_property_record_key_schema_id_validation
   = "redpanda.key.schema.id.validation";

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -66,6 +66,8 @@ static constexpr std::string_view topic_property_replication_factor
 static constexpr std::string_view topic_property_remote_delete
   = "redpanda.remote.delete";
 static constexpr std::string_view topic_property_segment_ms = "segment.ms";
+static constexpr std::string_view topic_property_write_caching
+  = "write.caching";
 
 // Server side schema id validation
 static constexpr std::string_view topic_property_record_key_schema_id_validation

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -155,20 +155,6 @@ struct replication_factor_must_be_greater_or_equal_to_minimum {
     }
 };
 
-struct unsupported_configuration_entries {
-    static constexpr error_code ec = error_code::invalid_config;
-    static constexpr const char* error_message
-      = "Not supported configuration entry ";
-
-    static bool is_valid(const creatable_topic& c) {
-        auto config_entries = config_map(c.configs);
-        auto end = config_entries.end();
-        return end == config_entries.find("min.insync.replicas")
-               && end == config_entries.find("flush.messages")
-               && end == config_entries.find("flush.ms");
-    }
-};
-
 struct remote_read_and_write_are_not_supported_for_read_replica {
     static constexpr error_code ec = error_code::invalid_config;
     static constexpr const char* error_message

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -564,6 +564,38 @@ std::istream& operator>>(std::istream&, fetch_read_strategy&);
  */
 using vcluster_id = named_type<xid, struct v_cluster_id_tag>;
 
+/**
+ * Type that represents the cluster wide write caching mode.
+ */
+enum class write_caching_mode : uint8_t {
+    // on by default for all topics
+    on = 0,
+    // off by default for all topics
+    off = 1,
+    // disabled by default clusterwide.
+    // cannot be overriden at topic level.
+    disabled = 2
+};
+
+constexpr const char* write_caching_mode_to_string(write_caching_mode s) {
+    switch (s) {
+    case write_caching_mode::on:
+        return "on";
+    case write_caching_mode::off:
+        return "off";
+    case write_caching_mode::disabled:
+        return "disabled";
+    default:
+        throw std::invalid_argument("unknown write_caching_mode");
+    }
+}
+
+std::optional<write_caching_mode>
+  write_caching_mode_from_string(std::string_view);
+
+std::ostream& operator<<(std::ostream&, write_caching_mode);
+std::istream& operator>>(std::istream&, write_caching_mode&);
+
 namespace internal {
 /*
  * Old version for use in backwards compatibility serialization /

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -497,4 +497,37 @@ std::istream& operator>>(std::istream& i, fetch_read_strategy& strat) {
     return i;
 }
 
+std::ostream& operator<<(std::ostream& o, write_caching_mode mode) {
+    o << write_caching_mode_to_string(mode);
+    return o;
+}
+
+std::istream& operator>>(std::istream& i, write_caching_mode& mode) {
+    ss::sstring s;
+    i >> s;
+    auto value = write_caching_mode_from_string(s);
+    if (!value) {
+        i.setstate(std::ios::failbit);
+        return i;
+    }
+    mode = *value;
+    return i;
+}
+
+std::optional<write_caching_mode>
+write_caching_mode_from_string(std::string_view s) {
+    return string_switch<std::optional<write_caching_mode>>(s)
+      .match(
+        model::write_caching_mode_to_string(model::write_caching_mode::on),
+        model::write_caching_mode::on)
+      .match(
+        model::write_caching_mode_to_string(model::write_caching_mode::off),
+        model::write_caching_mode::off)
+      .match(
+        model::write_caching_mode_to_string(
+          model::write_caching_mode::disabled),
+        model::write_caching_mode::disabled)
+      .default_match(std::nullopt);
+}
+
 } // namespace model

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -529,5 +529,4 @@ write_caching_mode_from_string(std::string_view s) {
         model::write_caching_mode::disabled)
       .default_match(std::nullopt);
 }
-
 } // namespace model

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -146,7 +146,10 @@ consensus::consensus(
   , _configuration_manager(std::move(initial_cfg), _group, _storage, _ctxlog)
   , _node_priority_override(voter_priority_override)
   , _keep_snapshotted_log(should_keep_snapshotted_log)
-  , _append_requests_buffer(*this, 256) {
+  , _append_requests_buffer(*this, 256)
+  , _write_caching_enabled(log_config().write_caching())
+  , _flush_bytes(log_config().flush_bytes())
+  , _flush_ms(log_config().flush_ms()) {
     setup_metrics();
     setup_public_metrics();
     update_follower_stats(_configuration_manager.get_latest());
@@ -3886,6 +3889,12 @@ std::optional<model::offset> consensus::get_learner_start_offset() const {
         return latest_cfg.get_configuration_update()->learner_start_offset;
     }
     return std::nullopt;
+}
+
+void consensus::notify_config_update() {
+    _write_caching_enabled = log_config().write_caching();
+    _flush_bytes = log_config().flush_bytes();
+    _flush_ms = log_config().flush_ms();
 }
 
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -521,6 +521,10 @@ public:
     // hook called on desired cluster/topic configuration updates.
     void notify_config_update();
 
+    bool write_caching_enabled() const { return _write_caching_enabled; }
+    size_t flush_bytes() const { return _flush_bytes; }
+    std::chrono::milliseconds flush_ms() const { return _flush_ms; }
+
 private:
     friend replicate_entries_stm;
     friend vote_stm;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -518,6 +518,9 @@ public:
 
     inline void maybe_update_leader(vnode request_node);
 
+    // hook called on desired cluster/topic configuration updates.
+    void notify_config_update();
+
 private:
     friend replicate_entries_stm;
     friend vote_stm;
@@ -885,6 +888,14 @@ private:
      * queue to regulate how many raft groups can go into recovery concurrently.
      */
     std::optional<follower_recovery_state> _follower_recovery_state;
+
+    // write caching configurations
+    // cached locally so we don't reconcile them for every request. They are
+    // updated lazily via notify_config_update()
+    // todo(bharathv): add jitter
+    bool _write_caching_enabled;
+    size_t _flush_bytes;
+    std::chrono::milliseconds _flush_ms;
 
     friend std::ostream& operator<<(std::ostream&, const consensus&);
 };

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -49,6 +49,8 @@ public:
         config::binding<std::chrono::milliseconds> election_timeout_ms;
         config::binding<std::optional<size_t>> replica_max_not_flushed_bytes;
         config::binding<std::chrono::milliseconds> flush_timer_interval_ms;
+        config::binding<model::write_caching_mode> write_caching;
+        config::binding<std::chrono::milliseconds> write_caching_flush_ms;
     };
     using config_provider_fn = ss::noncopyable_function<configuration()>;
 
@@ -98,6 +100,8 @@ public:
 private:
     void trigger_leadership_notification(raft::leadership_status);
     void setup_metrics();
+
+    void trigger_config_update_notification();
 
     ss::future<> flush_groups();
 

--- a/src/v/raft/tests/simple_raft_fixture.h
+++ b/src/v/raft/tests/simple_raft_fixture.h
@@ -97,8 +97,9 @@ struct simple_raft_fixture {
                   .replica_max_not_flushed_bytes
                   = config::mock_binding<std::optional<size_t>>(std::nullopt),
                   .flush_timer_interval_ms = config::mock_binding(100ms),
-
-                };
+                  .write_caching = config::mock_binding(
+                    model::write_caching_mode::off),
+                  .write_caching_flush_ms = config::mock_binding(100ms)};
             },
             [] {
                 return raft::recovery_memory_quota::configuration{

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -1032,6 +1032,18 @@
                     "type": "boolean",
                     "description": "True of voted a leader"
                 },
+                "write_caching_enabled": {
+                    "type": "boolean",
+                    "description": "Whether write caching is enabled for this replica"
+                },
+                "flush_ms": {
+                    "type": "long",
+                    "description": "flush delay ms, used for cached writes."
+                },
+                "flush_bytes": {
+                    "type": "long",
+                    "description": "unflushed bytes size flush trigger, used for cached writes."
+                },
                 "followers": {
                     "type": "array",
                     "items": {

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -65,6 +65,9 @@ void fill_raft_state(
     raft_state.has_pending_flushes = src.has_pending_flushes;
     raft_state.is_leader = src.is_leader;
     raft_state.is_elected_leader = src.is_elected_leader;
+    raft_state.write_caching_enabled = src.write_caching_enabled;
+    raft_state.flush_bytes = src.flush_bytes;
+    raft_state.flush_ms = src.flush_ms.count();
     if (src.followers) {
         for (const auto& f : *src.followers) {
             ss::httpd::debug_json::raft_follower_state follower_state;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1329,6 +1329,10 @@ void application::wire_up_redpanda_services(
                   .raft_replica_max_pending_flush_bytes.bind(),
               .flush_timer_interval_ms
               = config::shard_local_cfg().raft_flush_timer_interval_ms.bind(),
+              .write_caching = config::shard_local_cfg().write_caching.bind(),
+              .write_caching_flush_ms
+              = config::shard_local_cfg()
+                  .raft_replica_max_flush_delay_ms.bind(),
             };
         },
         [] {

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -71,6 +71,8 @@ public:
         tristate<std::chrono::milliseconds> initial_retention_local_target_ms{
           std::nullopt};
 
+        std::optional<model::write_caching_mode> write_caching;
+
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
     };
@@ -253,6 +255,17 @@ public:
         }
 
         return config::shard_local_cfg().log_segment_ms;
+    }
+
+    bool write_caching() const {
+        auto cluster_default = config::shard_local_cfg().write_caching();
+        if (cluster_default == model::write_caching_mode::disabled) {
+            return false;
+        }
+        auto value = _overrides
+                       ? _overrides->write_caching.value_or(cluster_default)
+                       : cluster_default;
+        return value == model::write_caching_mode::on;
     }
 
 private:

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -13,6 +13,7 @@
 #include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
+#include "model/namespace.h"
 #include "ssx/sformat.h"
 #include "tristate.h"
 
@@ -72,6 +73,9 @@ public:
           std::nullopt};
 
         std::optional<model::write_caching_mode> write_caching;
+
+        std::optional<std::chrono::milliseconds> flush_ms;
+        std::optional<size_t> flush_bytes;
 
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
@@ -258,6 +262,9 @@ public:
     }
 
     bool write_caching() const {
+        if (!model::is_user_topic(_ntp)) {
+            return false;
+        }
         auto cluster_default = config::shard_local_cfg().write_caching();
         if (cluster_default == model::write_caching_mode::disabled) {
             return false;
@@ -266,6 +273,22 @@ public:
                        ? _overrides->write_caching.value_or(cluster_default)
                        : cluster_default;
         return value == model::write_caching_mode::on;
+    }
+
+    std::chrono::milliseconds flush_ms() const {
+        auto cluster_default
+          = config::shard_local_cfg().raft_replica_max_flush_delay_ms();
+        return _overrides ? _overrides->flush_ms.value_or(cluster_default)
+                          : cluster_default;
+    }
+
+    size_t flush_bytes() const {
+        const auto& conf
+          = config::shard_local_cfg().raft_replica_max_pending_flush_bytes();
+        auto cluster_default = conf.value_or(
+          std::numeric_limits<size_t>::max());
+        return _overrides ? _overrides->flush_bytes.value_or(cluster_default)
+                          : cluster_default;
     }
 
 private:

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -107,7 +107,8 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "retention_local_target_bytes: {}, retention_local_target_ms: {}, "
       "remote_delete: {}, segment_ms: {}, "
       "initial_retention_local_target_bytes: {}, "
-      "initial_retention_local_target_ms: {}, write_caching: {}}}",
+      "initial_retention_local_target_ms: {}, write_caching: {}, flush_ms: {}, "
+      "flush_bytes: {}}}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -120,7 +121,9 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.segment_ms,
       v.initial_retention_local_target_bytes,
       v.initial_retention_local_target_ms,
-      v.write_caching);
+      v.write_caching,
+      v.flush_ms,
+      v.flush_bytes);
 
     return o;
 }

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -107,7 +107,7 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       "retention_local_target_bytes: {}, retention_local_target_ms: {}, "
       "remote_delete: {}, segment_ms: {}, "
       "initial_retention_local_target_bytes: {}, "
-      "initial_retention_local_target_ms: {}}}",
+      "initial_retention_local_target_ms: {}, write_caching: {}}}",
       v.compaction_strategy,
       v.cleanup_policy_bitflags,
       v.segment_size,
@@ -119,7 +119,8 @@ operator<<(std::ostream& o, const ntp_config::default_overrides& v) {
       v.remote_delete,
       v.segment_ms,
       v.initial_retention_local_target_bytes,
-      v.initial_retention_local_target_ms);
+      v.initial_retention_local_target_ms,
+      v.write_caching);
 
     return o;
 }

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -231,6 +231,21 @@ class DescribeTopicsTest(RedpandaTest):
                 "for all topics and can be overriden at a topic scope with property "
                 "write.caching. 'disabled' mode takes precedence over topic overrides "
                 "and disables the feature altogether for the entire cluster."),
+            "flush.ms":
+            ConfigProperty(
+                config_type="LONG",
+                value="100",
+                doc_string=
+                "Maximum delay (in ms) between two subsequent flushes. After this delay, "
+                "the log will be automatically force flushed."),
+            "flush.bytes":
+            ConfigProperty(
+                config_type="LONG",
+                value="262144",
+                doc_string=
+                "Max not flushed bytes per partition. If configured threshold is reached "
+                "log will automatically be flushed even though it wasn't explicitly "
+                "requested"),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -221,6 +221,16 @@ class DescribeTopicsTest(RedpandaTest):
                 "storage write enabled. If no initial local target retention is "
                 "configured all locally retained data will be delivered to learner when "
                 "joining partition replica set"),
+            "write.caching":
+            ConfigProperty(
+                config_type="STRING",
+                value="off",
+                doc_string=
+                "Cache batches until the segment appender chunk is full instead of "
+                "flushing for every acks=all write. This is the global default "
+                "for all topics and can be overriden at a topic scope with property "
+                "write.caching. 'disabled' mode takes precedence over topic overrides "
+                "and disables the feature altogether for the entire cluster."),
         }
 
         tp_spec = TopicSpec()

--- a/tests/rptest/tests/write_caching_test.py
+++ b/tests/rptest/tests/write_caching_test.py
@@ -1,0 +1,146 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.clients.rpk import RpkException, RpkTool
+from rptest.clients.types import TopicSpec
+from rptest.services.cluster import cluster
+from rptest.tests.redpanda_test import RedpandaTest
+from enum import Enum
+
+
+# no StrEnum support in test python version
+class WriteCachingMode(str, Enum):
+    ON = "on"
+    OFF = "off"
+    DISABLED = "disabled"
+
+    def __bool__(self):
+        return self.value == self.ON
+
+    def __str__(self):
+        return self.value
+
+
+class WriteCachingPropertiesTest(RedpandaTest):
+    WRITE_CACHING_PROP = "write.caching"
+    FLUSH_MS_PROP = "flush.ms"
+    FLUSH_BYTES_PROP = "flush.bytes"
+
+    WRITE_CACHING_DEBUG_KEY = "write_caching_enabled"
+    FLUSH_MS_DEBUG_KEY = "flush_ms"
+    FLUSH_BYTES_DEBUG_KEY = "flush_bytes"
+
+    def __init__(self, test_context):
+        super(WriteCachingPropertiesTest,
+              self).__init__(test_context=test_context, num_brokers=3)
+        self.topic_name = "test"
+        self.topics = [TopicSpec(name=self.topic_name)]
+
+    def configs_converged(self, write_caching: WriteCachingMode, flush_ms: int,
+                          flush_bytes: int):
+        """Checks that the desired write caching configuration is set in topic & partition (raft) states"""
+        assert self.rpk
+        assert self.admin
+
+        configs = self.rpk.describe_topic_configs(self.topic_name)
+        assert self.WRITE_CACHING_PROP in configs.keys(), configs
+        assert self.FLUSH_MS_PROP in configs.keys(), configs
+        assert self.FLUSH_BYTES_PROP in configs.keys(), configs
+
+        properties_check = configs[self.WRITE_CACHING_PROP][0] == str(
+            write_caching) and configs[self.FLUSH_MS_PROP][0] == str(
+                flush_ms) and configs[self.FLUSH_BYTES_PROP][0] == str(
+                    flush_bytes)
+
+        if not properties_check:
+            return False
+
+        partition_state = self.admin.get_partition_state(
+            "kafka", self.topic_name, 0)
+        replicas = partition_state["replicas"]
+        assert len(replicas) == 3
+
+        for replica in replicas:
+            raft_state = replica["raft_state"]
+            assert self.WRITE_CACHING_DEBUG_KEY in raft_state.keys(
+            ), raft_state
+            assert self.FLUSH_MS_DEBUG_KEY in raft_state.keys(), raft_state
+            assert self.FLUSH_BYTES_DEBUG_KEY in raft_state.keys(), raft_state
+
+            replica_check = raft_state[self.WRITE_CACHING_DEBUG_KEY] == bool(
+                write_caching) and raft_state[
+                    self.FLUSH_MS_DEBUG_KEY] == flush_ms and raft_state[
+                        self.FLUSH_BYTES_DEBUG_KEY] == flush_bytes
+
+            if not replica_check:
+                return False
+
+        return True
+
+    def validate_topic_configs(self, write_caching: WriteCachingMode,
+                               flush_ms: int, flush_bytes: int):
+        self.redpanda.wait_until(
+            lambda: self.configs_converged(write_caching, flush_ms, flush_bytes
+                                           ),
+            timeout_sec=30,
+            backoff_sec=2,
+            err_msg="Write caching configuration failed to converge")
+
+    def set_cluster_config(self, key: str, value):
+        self.rpk.cluster_config_set(key, value)
+
+    def set_topic_properties(self, key: str, value):
+        self.rpk.alter_topic_config(self.topic_name, key, value)
+
+    @cluster(num_nodes=3)
+    def test_properties(self):
+        self.admin = self.redpanda._admin
+        self.rpk = RpkTool(self.redpanda)
+
+        write_caching_conf = "write_caching"
+        flush_ms_conf = "raft_replica_max_flush_delay_ms"
+        flush_bytes_conf = "raft_replica_max_pending_flush_bytes"
+
+        # Validate cluster defaults
+        self.validate_topic_configs(WriteCachingMode.OFF, 100, 262144)
+
+        # Changing cluster level configs
+        self.set_cluster_config(write_caching_conf, "on")
+        self.validate_topic_configs(WriteCachingMode.ON, 100, 262144)
+        self.set_cluster_config(flush_ms_conf, 200)
+        self.validate_topic_configs(WriteCachingMode.ON, 200, 262144)
+        self.set_cluster_config(flush_bytes_conf, 32768)
+        self.validate_topic_configs(WriteCachingMode.ON, 200, 32768)
+
+        # Turn off write caching at topic level
+        self.set_topic_properties(self.WRITE_CACHING_PROP, "off")
+        self.validate_topic_configs(WriteCachingMode.OFF, 200, 32768)
+
+        # Turn off write caching at cluster level but enable at topic level
+        # topic properties take precedence
+        self.set_cluster_config(write_caching_conf, "off")
+        self.set_topic_properties(self.WRITE_CACHING_PROP, "on")
+        self.validate_topic_configs(WriteCachingMode.ON, 200, 32768)
+
+        # Kill switch test, disable write caching feature globally,
+        # should override topic level property
+        self.set_cluster_config(write_caching_conf, "disabled")
+        self.validate_topic_configs(WriteCachingMode.DISABLED, 200, 32768)
+
+        # Try to update the topic property now, should throw an error
+        try:
+            self.set_topic_properties(self.WRITE_CACHING_PROP, "on")
+            assert False, "No exception thrown when updating topic propertes in disabled mode."
+        except RpkException as e:
+            assert "INVALID_CONFIG" in str(e)
+
+        # Enable again
+        self.set_cluster_config(write_caching_conf, "on")
+        self.set_topic_properties(self.WRITE_CACHING_PROP, "on")
+        self.validate_topic_configs(WriteCachingMode.ON, 200, 32768)


### PR DESCRIPTION

This PR adds all the configurations/tunables needed for the write caching project as described in https://docs.google.com/document/d/1gD2vXeQuv9gslagl6rDxx3XQsBI9BkXT2Ktpz9my2V0/edit#heading=h.5zvj0etnl8iy

The code using them will come as a separate PR, so until that lands these are dummy unused configurations, just splitting them out into a separate PR for reviewers' convenience.

Summary of configurations

Cluster level:

* write_caching - cluster level write caching default - [on, off, disabled]
* raft_replica_max_flush_delay_ms - for timer based flush - default 100ms
* (to be deprecated) raft_flush_timer_interval_ms 

Topic level:

* write.caching - topic level override for write_caching - [on, off]
* flush.ms - topic level override for raft_replica_max_flush_delay_ms
* flush.bytes - topic level override for raft_replica_max_pending_flush_bytes

write_caching=disabled is intended to be the  feature kill switch that takes precedence over topic overrides.

## Release Notes
### Features
* Adds new cluster and topic level configurations for write caching feature.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
