### PR TITLE
Add an option to specify topic name for nodes_report_cloud_segments

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -821,9 +821,9 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
             # Wait until theres some traffic
             tgen.wait_for_traffic(acked=self.msg_count,
                                   timeout_sec=self.msg_timeout)
-
+            self.logger.info(f"Topic is: {self.topic}")
             # S3 up -> down -> up
-            self.stage_block_s3()
+            self.stage_block_s3(self.topic)
 
         self.redpanda.assert_cluster_is_reusable()
 
@@ -841,8 +841,11 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         return increase == 0
 
     def stage_block_s3(self):
-        self.logger.info(f"Getting the first 100 segments into the cloud")
-        wait_until(lambda: nodes_report_cloud_segments(self.redpanda, 100),
+        self.logger.info(
+            f"Getting the first 100 segments into the cloud for specific topic"
+        )
+        wait_until(lambda: nodes_report_cloud_segments(self.redpanda, 100, self
+                                                       .topic),
                    timeout_sec=600,
                    backoff_sec=5)
         self.logger.info(f"Blocking S3 traffic for all nodes")


### PR DESCRIPTION
<!--
This PR is related to https://github.com/redpanda-data/core-internal/issues/989

This is an improvement to be able to count segments for a specific topic. We should be able to specify a topic name and count topic-specific segments. Added this as an optional filed, so other tests would not brake.

Also, included official AWS IP ranges.json file that would be used later for blocking traffic using IPs. We may create a separate issue for that.

This task is focusing on the following:

HTT.test_disrupt_cloud_storage calls stage_block_s3 which tries to get 100 segments into the cloud, presumably for the topic under test.

However, this may succeed spuriously for every tier as there are system topics with cloud segments (For example 500+ for T1 cluster) as described in https://github.com/redpanda-data/core-internal/issues/987.

This check should be topic-specific as described in https://github.com/redpanda-data/core-internal/issues/987.

-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

### Improvements
Improvements to internal high thougput tests to be able to specify and count topic-specific segments

###  Release Notes
* none
This is internal testing HTT and release notes not required.

NOTE: This has NOT been tested locally yet. I would need to pull this code to my AWS EC2 instance and test it. Submitting PR for initial discussion and comments
