### PR TITLE
gha: allow manually dispatching the open source build

### DIFF
--- a/.github/workflows/build-redpanda.yml
+++ b/.github/workflows/build-redpanda.yml
@@ -9,6 +9,7 @@
 
 name: build-redpanda
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 1-5'
 


### PR DESCRIPTION
We would like to be able to manually test a PR against the open source build and this allows that.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
