### PR TITLE
[v23.3.x] storage: fix windowed compaction error handling

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -340,6 +340,9 @@ ss::future<ss::stop_iteration> copy_data_segment_reducer::filter_and_append(
 
 ss::future<ss::stop_iteration>
 copy_data_segment_reducer::operator()(model::record_batch b) {
+    if (_inject_failure) {
+        throw std::runtime_error("injected error");
+    }
     const auto comp = b.header().attrs.compression();
     if (!b.compressed()) {
         co_return co_await filter_and_append(comp, std::move(b));

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -125,13 +125,15 @@ public:
       bool internal_topic,
       offset_delta_time apply_offset,
       model::offset segment_last_offset = model::offset{},
-      compacted_index_writer* cidx = nullptr)
+      compacted_index_writer* cidx = nullptr,
+      bool inject_failure = false)
       : _should_keep_fn(std::move(f))
       , _segment_last_offset(segment_last_offset)
       , _appender(a)
       , _compacted_idx(cidx)
       , _idx(index_state::make_empty_index(apply_offset))
-      , _internal_topic(internal_topic) {}
+      , _internal_topic(internal_topic)
+      , _inject_failure(inject_failure) {}
 
     ss::future<ss::stop_iteration> operator()(model::record_batch);
     storage::index_state end_of_stream() { return std::move(_idx); }
@@ -161,6 +163,9 @@ private:
     /// We need to know if this is an internal topic to inform whether to
     /// index on non-raft-data batches
     bool _internal_topic;
+
+    /// If set to true, will throw an exception on operator().
+    bool _inject_failure;
 };
 
 class index_rebuilder_reducer : public compaction_reducer {

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -447,7 +447,7 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
           *_probe,
           *_readers_cache,
           _manager.resources(),
-          storage::internal::should_apply_delta_time_offset(_feature_table));
+          _feature_table);
 
         vlog(
           gclog.debug,
@@ -545,7 +545,7 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
           *_probe,
           *_readers_cache,
           _manager.resources(),
-          storage::internal::should_apply_delta_time_offset(_feature_table));
+          _feature_table);
 
         vlog(
           gclog.debug,
@@ -688,8 +688,8 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
               *appender,
               compacted_idx_writer,
               *_probe,
-              storage::internal::should_apply_delta_time_offset(
-                _feature_table));
+              storage::internal::should_apply_delta_time_offset(_feature_table),
+              _feature_table);
 
         } catch (...) {
             eptr = std::current_exception();
@@ -906,7 +906,7 @@ ss::future<compaction_result> disk_log_impl::compact_adjacent_segments(
       *_probe,
       *_readers_cache,
       _manager.resources(),
-      storage::internal::should_apply_delta_time_offset(_feature_table));
+      _feature_table);
     _probe->delete_segment(*replacement.get());
     vlog(gclog.debug, "Final compacted segment {}", replacement);
 

--- a/src/v/storage/fs_utils.cc
+++ b/src/v/storage/fs_utils.cc
@@ -106,7 +106,7 @@ segment_full_path segment_full_path::to_compacted_index() const {
     if (extension == ".log") {
         return with_extension(".compaction_index");
     } else if (extension == ".log.compaction.staging") {
-        return with_extension("log.compaction.compaction_index");
+        return with_extension(".log.compaction.compaction_index");
     } else {
         vassert(false, "Unexpected extension {}", extension);
     }

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -187,7 +187,8 @@ ss::future<index_state> deduplicate_segment(
   compacted_index_writer& cmp_idx_writer,
   probe& probe,
   offset_delta_time should_offset_delta_times,
-  ss::sharded<features::feature_table>&) {
+  ss::sharded<features::feature_table>& feature_table,
+  bool inject_reader_failure) {
     auto read_holder = co_await seg->read_lock();
     if (seg->is_closed()) {
         throw segment_closed_exception();
@@ -202,7 +203,8 @@ ss::future<index_state> deduplicate_segment(
       seg->path().is_internal_topic(),
       should_offset_delta_times,
       seg->offsets().committed_offset,
-      &cmp_idx_writer);
+      &cmp_idx_writer,
+      inject_reader_failure);
 
     auto new_idx = co_await rdr.consume(
       std::move(copy_reducer), model::no_timeout);

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -206,7 +206,7 @@ ss::future<index_state> deduplicate_segment(
       &cmp_idx_writer,
       inject_reader_failure);
 
-    auto new_idx = co_await rdr.consume(
+    auto new_idx = co_await std::move(rdr).consume(
       std::move(copy_reducer), model::no_timeout);
     new_idx.broker_timestamp = seg->index().broker_timestamp();
     co_return new_idx;

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -186,7 +186,8 @@ ss::future<index_state> deduplicate_segment(
   segment_appender& appender,
   compacted_index_writer& cmp_idx_writer,
   probe& probe,
-  offset_delta_time should_offset_delta_times) {
+  offset_delta_time should_offset_delta_times,
+  ss::sharded<features::feature_table>&) {
     auto read_holder = co_await seg->read_lock();
     if (seg->is_closed()) {
         throw segment_closed_exception();

--- a/src/v/storage/segment_deduplication_utils.h
+++ b/src/v/storage/segment_deduplication_utils.h
@@ -57,6 +57,7 @@ ss::future<index_state> deduplicate_segment(
   compacted_index_writer& cmp_idx_writer,
   storage::probe& probe,
   offset_delta_time should_offset_delta_times,
-  ss::sharded<features::feature_table>&);
+  ss::sharded<features::feature_table>&,
+  bool inject_reader_failure = false);
 
 } // namespace storage

--- a/src/v/storage/segment_deduplication_utils.h
+++ b/src/v/storage/segment_deduplication_utils.h
@@ -56,6 +56,7 @@ ss::future<index_state> deduplicate_segment(
   segment_appender& appender,
   compacted_index_writer& cmp_idx_writer,
   storage::probe& probe,
-  offset_delta_time should_offset_delta_times);
+  offset_delta_time should_offset_delta_times,
+  ss::sharded<features::feature_table>&);
 
 } // namespace storage

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -39,7 +39,7 @@ ss::future<compaction_result> self_compact_segment(
   storage::probe&,
   storage::readers_cache&,
   storage::storage_resources&,
-  offset_delta_time apply_offset);
+  ss::sharded<features::feature_table>& feature_table);
 
 /// \brief, rebuilds a given segment's compacted index. This method acquires
 /// locks on the segment.

--- a/src/v/storage/tests/utils/disk_log_builder.h
+++ b/src/v/storage/tests/utils/disk_log_builder.h
@@ -376,6 +376,10 @@ public:
 
     void set_time(model::timestamp t) { _ts_cursor = t; }
 
+    ss::sharded<features::feature_table>& feature_table() {
+        return _feature_table;
+    }
+
 private:
     template<typename Consumer>
     auto consume_impl(Consumer c, log_reader_config config) {


### PR DESCRIPTION
Backport of [#16928](https://github.com/redpanda-data/redpanda/pull/16928)

Fixes https://github.com/redpanda-data/redpanda/issues/16937
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Also pulls in https://github.com/redpanda-data/redpanda/pull/16295/commits/5ad9e142b1b9c3d6ee76ced767e324193335a2d9

CONFLICT:
- some reducer code in this branch has a default argument, but not on dev

We were previously using the l-value-variant of
model::record_batch_reader::consume(), which doesn't have a built-in
call to finally(). For a log_reader, this meant that in some scenarios
(e.g. if the reducer were to fail) we could end up not calling
finally(), and therefore wouldn't clear the underlying segment reader.

This is exactly what happened, as we hit:

std::runtime_error (lz4f_compressend:ERROR_dstMaxSize_tooSmall)

errors as we compressed/decompressed batches, and then ultimately
crashed because the log_reader was not closed:

Assert failure: (.../redpanda/redpanda/src/v/storage/log_reader.h:141) '!_iterator.reader' log reader destroyed with live reader"

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in windowed compaction that could cause Redpanda to crash when an error occurs while reading batches.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
