### PR TITLE
[v23.3.x] rpk: support advertised addresses in `rpk redpanda config bootstrap`

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/config.go
+++ b/src/go/rpk/pkg/cli/redpanda/config.go
@@ -292,6 +292,9 @@ func parseAdvertisedKafka(adv string, defHost string) (config.NamedSocketAddress
 		}
 		host, port = vnet.SplitHostPortDefault(hostport, config.DefaultKafkaPort)
 	}
+	if host == "0.0.0.0" {
+		return config.NamedSocketAddress{}, errors.New("unexpected kafka advertised address '0.0.0.0' this will cause the broker to fail during startup validation")
+	}
 	return config.NamedSocketAddress{
 		Address: host,
 		Port:    port,
@@ -306,6 +309,9 @@ func parseAdvertisedRPC(adv string, defHost string) (*config.SocketAddress, erro
 			return nil, err
 		}
 		host, port = vnet.SplitHostPortDefault(hostport, config.DefaultRPCPort)
+	}
+	if host == "0.0.0.0" {
+		return nil, errors.New("unexpected rpc advertised address '0.0.0.0' this will cause the broker to fail during startup validation")
 	}
 	return &config.SocketAddress{
 		Address: host,

--- a/src/go/rpk/pkg/config/config.go
+++ b/src/go/rpk/pkg/config/config.go
@@ -23,6 +23,7 @@ const (
 	DefaultAdminPort     = 9644
 	DefaultRPCPort       = 33145
 	DefaultListenAddress = "0.0.0.0"
+	LoopbackIP           = "127.0.0.1"
 
 	DefaultBallastFilePath = "/var/lib/redpanda/data/ballast"
 	DefaultBallastFileSize = "1GiB"

--- a/tests/rptest/tests/rpk_start_test.py
+++ b/tests/rptest/tests/rpk_start_test.py
@@ -128,7 +128,9 @@ class RpkRedpandaStartTest(RedpandaTest):
             node.account.ssh(f"{rpk} redpanda config bootstrap {seeds_arg} && " \
                     f"{rpk} redpanda config set redpanda.empty_seed_starts_cluster false && " \
                     f"{rpk} redpanda config set redpanda.rpc_server " \
-                    f"'{{\"address\":\"{node.account.hostname}\",\"port\":33145}}'")
+                    f"'{{\"address\":\"{node.account.hostname}\",\"port\":33145}}' &&" \
+                    f"{rpk} redpanda config set redpanda.advertised_rpc_api " \
+                    f"'{{\"address\":\"{node.account.hostname}\",\"port\":33145}}'" )
 
         self.redpanda.for_nodes(self.redpanda.nodes, config_bootstrap_with_rpk)
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16652
Fixes: https://github.com/redpanda-data/redpanda/issues/16941,