### PR TITLE
transform: multiple output topics control plane

### DIFF
--- a/src/v/cluster/plugin_frontend.cc
+++ b/src/v/cluster/plugin_frontend.cc
@@ -487,7 +487,7 @@ errc plugin_frontend::validator::validate_mutation(const transform_cmd& cmd) {
                 loggable_string(cmd.value.name()));
               return errc::transform_invalid_create;
           }
-          constexpr static size_t max_output_topics = 1;
+          constexpr static size_t max_output_topics = 8;
           if (cmd.value.output_topics.size() > max_output_topics) {
               vlog(
                 clusterlog.info,

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -372,14 +372,14 @@ public:
             throw std::runtime_error("unable to create transform source");
         }
         auto src = std::make_unique<partition_source>(*std::move(partition));
-        vassert(
-          meta.output_topics.size() == 1,
-          "only a single output topic is supported");
-        const auto& output_topic = meta.output_topics[0];
+
         std::vector<std::unique_ptr<sink>> sinks;
-        auto sink = std::make_unique<rpc_client_sink>(
-          output_topic.tp, ntp.tp.partition, _topic_table, _client);
-        sinks.push_back(std::move(sink));
+        sinks.reserve(meta.output_topics.size());
+        for (const auto& output_topic : meta.output_topics) {
+            auto sink = std::make_unique<rpc_client_sink>(
+              output_topic.tp, ntp.tp.partition, _topic_table, _client);
+            sinks.push_back(std::move(sink));
+        }
 
         auto offset_tracker = std::make_unique<offset_tracker_impl>(
           id, ntp.tp.partition, meta.output_topics.size(), _client, _batcher);

--- a/src/v/wasm/tests/wasi_test.cc
+++ b/src/v/wasm/tests/wasi_test.cc
@@ -46,7 +46,7 @@ TEST_F(WasmTestFixture, Wasi) {
     std::vector<std::string> expected_env{
       ss::format("REDPANDA_INPUT_TOPIC={}", meta().input_topic.tp()),
       ss::format(
-        "REDPANDA_OUTPUT_TOPIC={}", meta().output_topics.begin()->tp()),
+        "REDPANDA_OUTPUT_TOPIC_0={}", meta().output_topics.begin()->tp()),
     };
     ASSERT_EQ(environment_variables, expected_env);
 

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -1598,11 +1598,14 @@ bool is_exported_memory(const parser::module_export& mod_export) {
 }
 
 bool is_transform_abi_check_fn(const parser::module_import& mod_import) {
-    return mod_import
-           == parser::module_import{
-             .module_name = ss::sstring(transform_module::name),
-             .item_name = "check_abi_version_1",
-             .description = parser::declaration::function{}};
+    constexpr std::array version = {1, 2};
+    return absl::c_any_of(version, [&mod_import](int version) {
+        return mod_import
+               == parser::module_import{
+                 .module_name = ss::sstring(transform_module::name),
+                 .item_name = ss::format("check_abi_version_{}", version),
+                 .description = parser::declaration::function{}};
+    });
 }
 
 ss::future<> wasmtime_runtime::validate(iobuf buf) {

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -424,7 +424,11 @@ absl::flat_hash_map<ss::sstring, ss::sstring>
 make_environment_vars(const model::transform_metadata& meta) {
     absl::flat_hash_map<ss::sstring, ss::sstring> env = meta.environment;
     env.emplace("REDPANDA_INPUT_TOPIC", meta.input_topic.tp());
-    env.emplace("REDPANDA_OUTPUT_TOPIC", meta.output_topics.begin()->tp());
+    for (size_t i = 0; i < meta.output_topics.size(); ++i) {
+        env.emplace(
+          ss::format("REDPANDA_OUTPUT_TOPIC_{}", i),
+          meta.output_topics[i].tp());
+    }
     return env;
 }
 


### PR DESCRIPTION
The control plane already mostly supports multiple output topics, this patchset removes the last of the validation needed to deploy transforms with multiple outputs. However there are currently no SDKs with support for multiple outputs, so there isn't a way to write tests yet. Those tests will come in followups once the SDKs are updated.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* Data Transforms now support writing to multiple output topics. The `REDPANDA_OUTPUT_TOPIC` environment variable exposed in transforms is now removed for `REDPANDA_OUTPUT_TOPIC_%d` for each output topic specified.
