### PR TITLE
Ensure `fragment_vector` fragments are always <= 128KiB

### DIFF
--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -48,13 +48,13 @@ public:
                                               == std::dynamic_extent;
 
 private:
+    static constexpr size_t max_allocation_size = 128UL * 1024;
 
     // calculate the maximum number of elements per fragment while
     // keeping the element count a power of two
     static constexpr size_t calc_elems_per_frag(size_t esize) {
         size_t max = fragment_size_bytes / esize;
         if constexpr (is_chunked_vector) {
-            constexpr size_t max_allocation_size = 128UL * 1024;
             max = max_allocation_size / esize;
         }
         assert(max > 0);
@@ -83,6 +83,10 @@ public:
      * to a power of two.
      */
     static constexpr size_t max_frag_bytes = elems_per_frag * sizeof(T);
+
+    static_assert(
+      max_frag_bytes <= max_allocation_size,
+      "max size of a fragment must be <= 128KiB");
 
     fragmented_vector() noexcept = default;
     fragmented_vector& operator=(const fragmented_vector&) noexcept = delete;

--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -16,6 +16,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/util/later.hh>
 
+#include <bit>
 #include <climits>
 #include <compare>
 #include <cstddef>
@@ -47,12 +48,6 @@ public:
                                               == std::dynamic_extent;
 
 private:
-    // Compute the previous (or equal) power of two relative to `size`.
-    static constexpr size_t pow2_floor(size_t size) {
-        unsigned lz = std::countl_zero(size);
-        unsigned shift = (sizeof(size_t) * CHAR_BIT) - lz;
-        return 1UL << shift;
-    }
 
     // calculate the maximum number of elements per fragment while
     // keeping the element count a power of two
@@ -63,7 +58,7 @@ private:
             max = max_allocation_size / esize;
         }
         assert(max > 0);
-        return pow2_floor(max);
+        return std::bit_floor(max);
     }
 
     static constexpr size_t elems_per_frag = calc_elems_per_frag(sizeof(T));


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Previously `fragment_vector<T>::pow2_floor(size_t size)` wouldn't correctly calculate the nearest power of 2 `<= size`. This resulted in cases such as;
```
sizeof(cluster::topic_status) * chunked_vector<cluster::topic_status>::elems_per_frag <= 128UL * 1024
```
not being true. This PR replaces `pow2_floor` with a standard library equivalent and adds a static assertion to ensure the size of fragments is always `<= 128KiB`.

Fixes https://github.com/redpanda-data/redpanda/issues/16957

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
