### PR TITLE
cst/inv: locate latest report

### DIFF
--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -10,10 +10,14 @@
 
 #include "cloud_storage/inventory/aws_ops.h"
 
+#include "bytes/streambuf.h"
 #include "cloud_storage/remote.h"
+#include "json/istreamwrapper.h"
 
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/xml_parser.hpp>
+#include <re2/re2.h>
 
 using boost::property_tree::ptree;
 
@@ -60,6 +64,37 @@ iobuf to_xml(const aws_report_configuration& cfg) {
     iobuf b;
     b.append(sstr.str().data(), sstr.str().size());
     return b;
+}
+
+// YYYY-MM-DDTHH-MMZ/
+const re2::RE2 trailing_date_expression{R"(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}Z/)"};
+
+struct path_with_datetime {
+    cloud_storage::inventory::report_datetime datetime;
+    cloud_storage_clients::object_key path;
+};
+
+bool is_datetime(std::string_view path) {
+    return RE2::FullMatch(path, trailing_date_expression);
+}
+
+path_with_datetime
+checksum_path(std::string_view prefix, std::string_view date_string) {
+    date_string.remove_suffix(1);
+    return {
+      .datetime = cloud_storage::inventory::
+        report_datetime{date_string.data(), date_string.size()},
+      .path = cloud_storage_clients::object_key{
+        fmt::format("{}{}/manifest.checksum", prefix, date_string)}};
+}
+
+json::Document parse_json_response(iobuf resp) {
+    iobuf_istreambuf ibuf{resp};
+    std::istream stream{&ibuf};
+    json::Document doc;
+    json::IStreamWrapper wrapper(stream);
+    doc.ParseStream(wrapper);
+    return doc;
 }
 
 } // namespace
@@ -109,6 +144,158 @@ ss::future<bool> aws_ops::inventory_configuration_exists(
        = {.bucket = _bucket, .key = _inventory_key, .parent_rtc = parent_rtc},
        .payload = buf});
     co_return dl_res == download_result::success;
+}
+
+ss::future<result<report_metadata, error_outcome>>
+aws_ops::fetch_latest_report_metadata(
+  cloud_storage::cloud_storage_api& remote,
+  retry_chain_node& parent_rtc) const noexcept {
+    try {
+        co_return co_await do_fetch_latest_report_metadata(remote, parent_rtc);
+    } catch (...) {
+        co_return error_outcome::failed;
+    }
+}
+
+ss::future<result<report_metadata, error_outcome>>
+aws_ops::do_fetch_latest_report_metadata(
+  cloud_storage::cloud_storage_api& remote,
+  retry_chain_node& parent_rtc) const {
+    // The prefix is generated according to
+    // https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-inventory-location.html
+    const auto full_prefix = cloud_storage_clients::object_key{
+      fmt::format("{}/{}/{}/", _prefix, _bucket, _inventory_config_id)};
+    const auto list_result = co_await remote.list_objects(
+      _bucket, parent_rtc, full_prefix, '/');
+
+    if (list_result.has_error()) {
+        co_return error_outcome::failed;
+    }
+
+    auto transform_to_checksum = [&full_prefix](auto datetime) {
+        return checksum_path(full_prefix().native(), datetime);
+    };
+
+    // The prefix may contain non-datetime folders such as hive data, which we
+    // ignore. The datetime folders are normalized with the prefix, and then the
+    // checksum file path is appended to them. The final result is a series of
+    // paths to checksums which we need to probe.
+    auto filtered = list_result.value().common_prefixes
+                    | std::views::filter(is_datetime)
+                    | std::views::transform(transform_to_checksum);
+
+    std::vector<path_with_datetime> checksum_paths{
+      filtered.begin(), filtered.end()};
+
+    // The datetime strings (YYYY-MM-DDTHH-MMZ) can be sorted by lexical
+    // comparison
+    std::ranges::sort(
+      checksum_paths, [](const auto& first, const auto& second) {
+          return first.datetime > second.datetime;
+      });
+
+    // A checksum appears in the bucket at the designated location only once the
+    // inventory is ready, so we probe the checksum files from latest to
+    // earliest. We stop at the first checksum we find.
+    for (const auto& path_with_datetime : checksum_paths) {
+        const auto result = co_await remote.object_exists(
+          _bucket,
+          path_with_datetime.path,
+          parent_rtc,
+          existence_check_type::object);
+
+        // The latest checksum file does not exist. The report is not ready yet.
+        if (result == download_result::notfound) {
+            // Try the next latest report.
+            continue;
+        }
+
+        // If we failed to check for the checksum existence, instead of probing
+        // older reports we bail out and try again later.
+        if (result != download_result::success) {
+            co_return error_outcome::failed;
+        }
+
+        auto path = path_with_datetime.path();
+
+        // Once a checksum is found, we download the corresponding
+        // manifest.json file
+        path.replace_extension("json");
+
+        const auto manifest_path = cloud_storage_clients::object_key{path};
+
+        // The manifest is downloaded, parsed and report paths are extracted
+        // from it.
+        auto report_paths = co_await fetch_and_parse_metadata(
+          remote, parent_rtc, manifest_path);
+
+        if (report_paths.has_error()) {
+            co_return report_paths.error();
+        }
+
+        co_return report_metadata{
+          .metadata_path = manifest_path,
+          .report_paths = report_paths.value(),
+          .datetime = path_with_datetime.datetime};
+    }
+
+    co_return error_outcome::failed;
+}
+
+ss::future<result<report_paths, error_outcome>>
+aws_ops::fetch_and_parse_metadata(
+  cloud_storage::cloud_storage_api& remote,
+  retry_chain_node& parent_rtc,
+  cloud_storage_clients::object_key metadata_path) const noexcept {
+    try {
+        co_return co_await do_fetch_and_parse_metadata(
+          remote, parent_rtc, metadata_path);
+    } catch (...) {
+        co_return error_outcome::failed;
+    }
+}
+
+ss::future<result<report_paths, error_outcome>>
+aws_ops::do_fetch_and_parse_metadata(
+  cloud_storage::cloud_storage_api& remote,
+  retry_chain_node& parent_rtc,
+  cloud_storage_clients::object_key metadata_path) const {
+    iobuf json_recv;
+    const auto dl_res = co_await remote.download_object({
+      .transfer_details
+      = {.bucket = _bucket, .key = metadata_path, .parent_rtc = parent_rtc},
+      .type = download_type::inventory_report_manifest,
+      .payload = json_recv,
+    });
+
+    if (dl_res != download_result::success) {
+        co_return error_outcome::manifest_download_failed;
+    }
+
+    co_return parse_report_paths(std::move(json_recv));
+}
+
+result<report_paths, error_outcome>
+aws_ops::parse_report_paths(iobuf json_response) const {
+    const auto doc = parse_json_response(std::move(json_response));
+    if (doc.HasParseError()) {
+        return error_outcome::manifest_deserialization_failed;
+    }
+
+    if (!doc.IsObject() || !doc.HasMember("files") || !doc["files"].IsArray()) {
+        return error_outcome::manifest_files_parse_failed;
+    }
+
+    auto has_embedded_key_path = [](const auto& f) {
+        return f.IsObject() && f.HasMember("key") && f["key"].IsString();
+    };
+
+    auto paths = doc["files"].GetArray()
+                 | std::views::filter(has_embedded_key_path)
+                 | std::views::transform(
+                   [](const auto& f) { return f["key"].GetString(); });
+
+    return {paths.begin(), paths.end()};
 }
 
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/aws_ops.cc
+++ b/src/v/cloud_storage/inventory/aws_ops.cc
@@ -111,8 +111,7 @@ aws_ops::aws_ops(
       fmt::format("?inventory&id={}", _inventory_config_id())})
   , _prefix(std::move(inventory_prefix)) {}
 
-ss::future<cloud_storage::upload_result>
-aws_ops::create_inventory_configuration(
+ss::future<op_result<void>> aws_ops::create_inventory_configuration(
   cloud_storage::cloud_storage_api& remote,
   retry_chain_node& parent_rtc,
   report_generation_frequency frequency,
@@ -124,14 +123,20 @@ aws_ops::create_inventory_configuration(
       .prefix = _prefix,
       .frequency = frequency};
 
-    co_return co_await remote.upload_object(
+    const auto create_res = co_await remote.upload_object(
       {.transfer_details
        = {.bucket = _bucket, .key = _inventory_key, .parent_rtc = parent_rtc},
        .type = upload_type::inventory_configuration,
        .payload = to_xml(cfg)});
+
+    if (create_res != upload_result::success) {
+        co_return error_outcome::create_inv_cfg_failed;
+    }
+
+    co_return outcome::success();
 }
 
-ss::future<bool> aws_ops::inventory_configuration_exists(
+ss::future<op_result<bool>> aws_ops::inventory_configuration_exists(
   cloud_storage::cloud_storage_api& remote, retry_chain_node& parent_rtc) {
     // This buffer is thrown away after the GET call returns, we might introduce
     // some sort of struct (or reuse the aws_report_configuration used for
@@ -143,11 +148,19 @@ ss::future<bool> aws_ops::inventory_configuration_exists(
       {.transfer_details
        = {.bucket = _bucket, .key = _inventory_key, .parent_rtc = parent_rtc},
        .payload = buf});
-    co_return dl_res == download_result::success;
+
+    if (dl_res == download_result::success) {
+        co_return true;
+    }
+
+    if (dl_res == download_result::notfound) {
+        co_return false;
+    }
+
+    co_return error_outcome::failed_to_check_inv_status;
 }
 
-ss::future<result<report_metadata, error_outcome>>
-aws_ops::fetch_latest_report_metadata(
+ss::future<op_result<report_metadata>> aws_ops::fetch_latest_report_metadata(
   cloud_storage::cloud_storage_api& remote,
   retry_chain_node& parent_rtc) const noexcept {
     try {
@@ -157,8 +170,7 @@ aws_ops::fetch_latest_report_metadata(
     }
 }
 
-ss::future<result<report_metadata, error_outcome>>
-aws_ops::do_fetch_latest_report_metadata(
+ss::future<op_result<report_metadata>> aws_ops::do_fetch_latest_report_metadata(
   cloud_storage::cloud_storage_api& remote,
   retry_chain_node& parent_rtc) const {
     // The prefix is generated according to
@@ -242,8 +254,7 @@ aws_ops::do_fetch_latest_report_metadata(
     co_return error_outcome::failed;
 }
 
-ss::future<result<report_paths, error_outcome>>
-aws_ops::fetch_and_parse_metadata(
+ss::future<op_result<report_paths>> aws_ops::fetch_and_parse_metadata(
   cloud_storage::cloud_storage_api& remote,
   retry_chain_node& parent_rtc,
   cloud_storage_clients::object_key metadata_path) const noexcept {
@@ -255,8 +266,7 @@ aws_ops::fetch_and_parse_metadata(
     }
 }
 
-ss::future<result<report_paths, error_outcome>>
-aws_ops::do_fetch_and_parse_metadata(
+ss::future<op_result<report_paths>> aws_ops::do_fetch_and_parse_metadata(
   cloud_storage::cloud_storage_api& remote,
   retry_chain_node& parent_rtc,
   cloud_storage_clients::object_key metadata_path) const {
@@ -275,8 +285,7 @@ aws_ops::do_fetch_and_parse_metadata(
     co_return parse_report_paths(std::move(json_recv));
 }
 
-result<report_paths, error_outcome>
-aws_ops::parse_report_paths(iobuf json_response) const {
+op_result<report_paths> aws_ops::parse_report_paths(iobuf json_response) const {
     const auto doc = parse_json_response(std::move(json_response));
     if (doc.HasParseError()) {
         return error_outcome::manifest_deserialization_failed;

--- a/src/v/cloud_storage/inventory/aws_ops.h
+++ b/src/v/cloud_storage/inventory/aws_ops.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "base/outcome.h"
 #include "cloud_storage/inventory/types.h"
 #include "cloud_storage_clients/types.h"
 #include "model/fundamental.h"
@@ -33,7 +34,33 @@ public:
     ss::future<bool> inventory_configuration_exists(
       cloud_storage::cloud_storage_api&, retry_chain_node&) override;
 
+    /// Returns metadata for the latest available report for
+    /// inventory configuration assigned to this object
+    ss::future<result<report_metadata, error_outcome>>
+    fetch_latest_report_metadata(
+      cloud_storage::cloud_storage_api&,
+      retry_chain_node&) const noexcept override;
+
 private:
+    ss::future<result<report_metadata, error_outcome>>
+    do_fetch_latest_report_metadata(
+      cloud_storage::cloud_storage_api&, retry_chain_node&) const;
+
+    /// Fetches the report manifest and parses out report paths from the JSON
+    /// document
+    ss::future<result<report_paths, error_outcome>> fetch_and_parse_metadata(
+      cloud_storage::cloud_storage_api& remote,
+      retry_chain_node& parent_rtc,
+      cloud_storage_clients::object_key metadata_path) const noexcept;
+
+    ss::future<result<report_paths, error_outcome>> do_fetch_and_parse_metadata(
+      cloud_storage::cloud_storage_api& remote,
+      retry_chain_node& parent_rtc,
+      cloud_storage_clients::object_key metadata_path) const;
+
+    result<report_paths, error_outcome>
+    parse_report_paths(iobuf json_response) const;
+
     cloud_storage_clients::bucket_name _bucket;
     inventory_config_id _inventory_config_id;
     cloud_storage_clients::object_key _inventory_key;

--- a/src/v/cloud_storage/inventory/aws_ops.h
+++ b/src/v/cloud_storage/inventory/aws_ops.h
@@ -25,41 +25,38 @@ public:
       inventory_config_id inventory_config_id,
       ss::sstring inventory_prefix);
 
-    ss::future<cloud_storage::upload_result> create_inventory_configuration(
+    ss::future<op_result<void>> create_inventory_configuration(
       cloud_storage::cloud_storage_api&,
       retry_chain_node&,
       report_generation_frequency,
       report_format) override;
 
-    ss::future<bool> inventory_configuration_exists(
+    ss::future<op_result<bool>> inventory_configuration_exists(
       cloud_storage::cloud_storage_api&, retry_chain_node&) override;
 
     /// Returns metadata for the latest available report for
     /// inventory configuration assigned to this object
-    ss::future<result<report_metadata, error_outcome>>
-    fetch_latest_report_metadata(
+    ss::future<op_result<report_metadata>> fetch_latest_report_metadata(
       cloud_storage::cloud_storage_api&,
       retry_chain_node&) const noexcept override;
 
 private:
-    ss::future<result<report_metadata, error_outcome>>
-    do_fetch_latest_report_metadata(
+    ss::future<op_result<report_metadata>> do_fetch_latest_report_metadata(
       cloud_storage::cloud_storage_api&, retry_chain_node&) const;
 
     /// Fetches the report manifest and parses out report paths from the JSON
     /// document
-    ss::future<result<report_paths, error_outcome>> fetch_and_parse_metadata(
+    ss::future<op_result<report_paths>> fetch_and_parse_metadata(
       cloud_storage::cloud_storage_api& remote,
       retry_chain_node& parent_rtc,
       cloud_storage_clients::object_key metadata_path) const noexcept;
 
-    ss::future<result<report_paths, error_outcome>> do_fetch_and_parse_metadata(
+    ss::future<op_result<report_paths>> do_fetch_and_parse_metadata(
       cloud_storage::cloud_storage_api& remote,
       retry_chain_node& parent_rtc,
       cloud_storage_clients::object_key metadata_path) const;
 
-    result<report_paths, error_outcome>
-    parse_report_paths(iobuf json_response) const;
+    op_result<report_paths> parse_report_paths(iobuf json_response) const;
 
     cloud_storage_clients::bucket_name _bucket;
     inventory_config_id _inventory_config_id;

--- a/src/v/cloud_storage/inventory/inv_ops.h
+++ b/src/v/cloud_storage/inventory/inv_ops.h
@@ -21,14 +21,17 @@ class inv_ops {
 public:
     explicit inv_ops(ops_t ops);
 
-    ss::future<cloud_storage::upload_result>
+    ss::future<op_result<void>>
     create_inventory_configuration(cloud_storage_api&, retry_chain_node&);
 
-    ss::future<bool>
+    ss::future<op_result<bool>>
     inventory_configuration_exists(cloud_storage_api&, retry_chain_node&);
 
-    ss::future<inventory_creation_result>
+    ss::future<op_result<inventory_creation_result>>
     maybe_create_inventory_configuration(cloud_storage_api&, retry_chain_node&);
+
+    ss::future<op_result<report_metadata>>
+    fetch_latest_report_metadata(cloud_storage_api&, retry_chain_node&);
 
 private:
     ops_t _inv_ops;

--- a/src/v/cloud_storage/inventory/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/inventory/tests/CMakeLists.txt
@@ -1,9 +1,10 @@
 rp_test(
   UNIT_TEST
   GTEST
-  BINARY_NAME create_inv_cfg
+  BINARY_NAME inv_api
   SOURCES
     create_inventory_config_test.cc
+    fetch_report_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     Boost::unit_test_framework

--- a/src/v/cloud_storage/inventory/tests/common.h
+++ b/src/v/cloud_storage/inventory/tests/common.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_storage/remote.h"
+
+#include <gmock/gmock.h>
+
+namespace cloud_storage::inventory {
+
+class MockRemote : public cloud_storage::cloud_storage_api {
+public:
+    MOCK_METHOD(
+      ss::future<cloud_storage::upload_result>,
+      upload_object,
+      (cloud_storage::upload_request),
+      (override));
+    MOCK_METHOD(
+      ss::future<cloud_storage::download_result>,
+      download_object,
+      (cloud_storage::download_request),
+      (override));
+    MOCK_METHOD(
+      ss::future<cloud_storage::cloud_storage_api::list_result>,
+      list_objects,
+      (const cloud_storage_clients::bucket_name&,
+       retry_chain_node&,
+       std::optional<cloud_storage_clients::object_key>,
+       std::optional<char>,
+       std::optional<cloud_storage_clients::client::item_filter>),
+      (override));
+    MOCK_METHOD(
+      ss::future<cloud_storage::download_result>,
+      object_exists,
+      (const cloud_storage_clients::bucket_name&,
+       const cloud_storage_clients::object_key&,
+       retry_chain_node&,
+       existence_check_type),
+      (override));
+};
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
+++ b/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
@@ -10,9 +10,7 @@
 
 #include "cloud_storage/inventory/aws_ops.h"
 #include "cloud_storage/inventory/inv_ops.h"
-#include "cloud_storage/remote.h"
-
-#include <gmock/gmock.h>
+#include "cloud_storage/inventory/tests/common.h"
 
 namespace cst = cloud_storage;
 namespace t = ::testing;
@@ -34,37 +32,6 @@ const auto expected_xml_payload = fmt::format(
   fmt::arg("schedule", frequency),
   fmt::arg("id", id));
 
-class MockRemote : public cst::cloud_storage_api {
-public:
-    MOCK_METHOD(
-      ss::future<cst::upload_result>,
-      upload_object,
-      (cst::upload_request),
-      (override));
-    MOCK_METHOD(
-      ss::future<cst::download_result>,
-      download_object,
-      (cst::download_request),
-      (override));
-    MOCK_METHOD(
-      ss::future<cloud_storage::cloud_storage_api::list_result>,
-      list_objects,
-      (const cloud_storage_clients::bucket_name&,
-       retry_chain_node&,
-       std::optional<cloud_storage_clients::object_key>,
-       std::optional<char>,
-       std::optional<cloud_storage_clients::client::item_filter>),
-      (override));
-    MOCK_METHOD(
-      ss::future<cloud_storage::download_result>,
-      object_exists,
-      (const cloud_storage_clients::bucket_name&,
-       const cloud_storage_clients::object_key&,
-       retry_chain_node&,
-       cloud_storage::existence_check_type),
-      (override));
-};
-
 std::string iobuf_to_xml(iobuf buf) {
     iobuf_parser p{std::move(buf)};
     return p.read_string(p.bytes_left());
@@ -82,7 +49,7 @@ validate_create_request(cst::upload_request request) {
 
 template<typename T, typename... Ts>
 void test_create(T t, Ts... args) {
-    MockRemote remote;
+    cst::inventory::MockRemote remote;
     EXPECT_CALL(remote, upload_object(t::_))
       .Times(1)
       .WillOnce(t::Invoke(validate_create_request));
@@ -121,7 +88,7 @@ validate_inventory_exists_request(cst::download_request request) {
 }
 
 TEST(InvCfgExists, HighLevelApi) {
-    MockRemote remote;
+    cst::inventory::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(1)
       .WillOnce(t::Invoke(validate_inventory_exists_request));
@@ -138,7 +105,7 @@ TEST(InvCfgExists, HighLevelApi) {
 }
 
 TEST(CreateInvCfg, IfExistsDoesNotCreate) {
-    MockRemote remote;
+    cst::inventory::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(1)
       .WillOnce(t::Invoke(validate_inventory_exists_request));
@@ -157,7 +124,7 @@ TEST(CreateInvCfg, IfExistsDoesNotCreate) {
 }
 
 TEST(CreateInvCfg, IfDoesNotExistCreates) {
-    MockRemote remote;
+    cst::inventory::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(1)
       .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
@@ -186,7 +153,7 @@ TEST(CreateInvCfg, CreationRace) {
     // Then, we try to create and it fails
     // Finally, the config exists
     // The outcome should be `already_exists` and not `failed`
-    MockRemote remote;
+    cst::inventory::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(2)
       .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
@@ -213,7 +180,7 @@ TEST(CreateInvCfg, CreationRace) {
 }
 
 TEST(CreateInvCfg, FailedToCreate) {
-    MockRemote remote;
+    cst::inventory::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(2)
       .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(

--- a/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
+++ b/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
@@ -13,13 +13,14 @@
 #include "cloud_storage/inventory/tests/common.h"
 
 namespace cst = cloud_storage;
+namespace csi = cst::inventory;
 namespace t = ::testing;
 
 constexpr auto id = "redpanda-inv-weekly";
 constexpr auto bucket = "test-bucket";
 constexpr auto prefix = "inv-prefix";
-constexpr auto format = cst::inventory::report_format::csv;
-constexpr auto frequency = cst::inventory::report_generation_frequency::daily;
+constexpr auto format = csi::report_format::csv;
+constexpr auto frequency = csi::report_generation_frequency::daily;
 const auto expected_key = fmt::format("?inventory&id={}", id);
 const auto expected_xml_payload = fmt::format(
   R"({header}
@@ -49,7 +50,7 @@ validate_create_request(cst::upload_request request) {
 
 template<typename T, typename... Ts>
 void test_create(T t, Ts... args) {
-    cst::inventory::MockRemote remote;
+    csi::MockRemote remote;
     EXPECT_CALL(remote, upload_object(t::_))
       .Times(1)
       .WillOnce(t::Invoke(validate_create_request));
@@ -60,23 +61,23 @@ void test_create(T t, Ts... args) {
     const auto result
       = t.create_inventory_configuration(remote, parent, args...).get();
 
-    ASSERT_EQ(result, cst::upload_result::success);
+    EXPECT_TRUE(result.has_value());
 }
 
 TEST(CreateInvCfg, LowLevelApi) {
     test_create(
-      cst::inventory::aws_ops{
+      csi::aws_ops{
         cloud_storage_clients::bucket_name{bucket},
-        cst::inventory::inventory_config_id{id},
+        csi::inventory_config_id{id},
         prefix},
       frequency,
       format);
 }
 
 TEST(CreateInvCfg, HighLevelApi) {
-    test_create(cst::inventory::inv_ops{cst::inventory::aws_ops{
+    test_create(csi::inv_ops{csi::aws_ops{
       cloud_storage_clients::bucket_name{bucket},
-      cst::inventory::inventory_config_id{id},
+      csi::inventory_config_id{id},
       prefix}});
 }
 
@@ -88,7 +89,7 @@ validate_inventory_exists_request(cst::download_request request) {
 }
 
 TEST(InvCfgExists, HighLevelApi) {
-    cst::inventory::MockRemote remote;
+    csi::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(1)
       .WillOnce(t::Invoke(validate_inventory_exists_request));
@@ -96,16 +97,19 @@ TEST(InvCfgExists, HighLevelApi) {
     ss::abort_source as;
     retry_chain_node parent{as};
 
-    cst::inventory::inv_ops ops{cst::inventory::aws_ops{
+    csi::inv_ops ops{csi::aws_ops{
       cloud_storage_clients::bucket_name{bucket},
-      cst::inventory::inventory_config_id{id},
+      csi::inventory_config_id{id},
       prefix}};
 
-    ASSERT_TRUE(ops.inventory_configuration_exists(remote, parent).get());
+    const auto exists
+      = ops.inventory_configuration_exists(remote, parent).get();
+    EXPECT_TRUE(exists.has_value());
+    EXPECT_TRUE(exists.value());
 }
 
 TEST(CreateInvCfg, IfExistsDoesNotCreate) {
-    cst::inventory::MockRemote remote;
+    csi::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(1)
       .WillOnce(t::Invoke(validate_inventory_exists_request));
@@ -113,18 +117,20 @@ TEST(CreateInvCfg, IfExistsDoesNotCreate) {
     ss::abort_source as;
     retry_chain_node parent{as};
 
-    cst::inventory::inv_ops ops{cst::inventory::aws_ops{
+    csi::inv_ops ops{csi::aws_ops{
       cloud_storage_clients::bucket_name{bucket},
-      cst::inventory::inventory_config_id{id},
+      csi::inventory_config_id{id},
       prefix}};
 
-    ASSERT_EQ(
-      ops.maybe_create_inventory_configuration(remote, parent).get(),
-      cst::inventory::inventory_creation_result::already_exists);
+    const auto maybe_create_res
+      = ops.maybe_create_inventory_configuration(remote, parent).get();
+    EXPECT_TRUE(maybe_create_res.has_value());
+    EXPECT_EQ(
+      maybe_create_res.value(), csi::inventory_creation_result::already_exists);
 }
 
 TEST(CreateInvCfg, IfDoesNotExistCreates) {
-    cst::inventory::MockRemote remote;
+    csi::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(1)
       .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
@@ -137,14 +143,15 @@ TEST(CreateInvCfg, IfDoesNotExistCreates) {
     ss::abort_source as;
     retry_chain_node parent{as};
 
-    cst::inventory::inv_ops ops{cst::inventory::aws_ops{
+    csi::inv_ops ops{csi::aws_ops{
       cloud_storage_clients::bucket_name{bucket},
-      cst::inventory::inventory_config_id{id},
+      csi::inventory_config_id{id},
       prefix}};
 
-    ASSERT_EQ(
-      ops.maybe_create_inventory_configuration(remote, parent).get(),
-      cst::inventory::inventory_creation_result::success);
+    const auto create_res
+      = ops.maybe_create_inventory_configuration(remote, parent).get();
+    EXPECT_TRUE(create_res.has_value());
+    EXPECT_EQ(create_res.value(), csi::inventory_creation_result::success);
 }
 
 TEST(CreateInvCfg, CreationRace) {
@@ -153,7 +160,7 @@ TEST(CreateInvCfg, CreationRace) {
     // Then, we try to create and it fails
     // Finally, the config exists
     // The outcome should be `already_exists` and not `failed`
-    cst::inventory::MockRemote remote;
+    csi::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(2)
       .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
@@ -169,18 +176,20 @@ TEST(CreateInvCfg, CreationRace) {
     ss::abort_source as;
     retry_chain_node parent{as};
 
-    cst::inventory::inv_ops ops{cst::inventory::aws_ops{
+    csi::inv_ops ops{csi::aws_ops{
       cloud_storage_clients::bucket_name{bucket},
-      cst::inventory::inventory_config_id{id},
+      csi::inventory_config_id{id},
       prefix}};
 
-    ASSERT_EQ(
-      ops.maybe_create_inventory_configuration(remote, parent).get(),
-      cst::inventory::inventory_creation_result::already_exists);
+    const auto create_res
+      = ops.maybe_create_inventory_configuration(remote, parent).get();
+    EXPECT_TRUE(create_res.has_value());
+    EXPECT_EQ(
+      create_res.value(), csi::inventory_creation_result::already_exists);
 }
 
 TEST(CreateInvCfg, FailedToCreate) {
-    cst::inventory::MockRemote remote;
+    csi::MockRemote remote;
     EXPECT_CALL(remote, download_object(t::_))
       .Times(2)
       .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
@@ -196,12 +205,13 @@ TEST(CreateInvCfg, FailedToCreate) {
     ss::abort_source as;
     retry_chain_node parent{as};
 
-    cst::inventory::inv_ops ops{cst::inventory::aws_ops{
+    csi::inv_ops ops{csi::aws_ops{
       cloud_storage_clients::bucket_name{bucket},
-      cst::inventory::inventory_config_id{id},
+      csi::inventory_config_id{id},
       prefix}};
 
-    ASSERT_EQ(
-      ops.maybe_create_inventory_configuration(remote, parent).get(),
-      cst::inventory::inventory_creation_result::failed);
+    const auto create_res
+      = ops.maybe_create_inventory_configuration(remote, parent).get();
+    EXPECT_TRUE(create_res.has_error());
+    EXPECT_EQ(create_res.error(), csi::error_outcome::create_inv_cfg_failed);
 }

--- a/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
+++ b/src/v/cloud_storage/inventory/tests/create_inventory_config_test.cc
@@ -46,6 +46,23 @@ public:
       download_object,
       (cst::download_request),
       (override));
+    MOCK_METHOD(
+      ss::future<cloud_storage::cloud_storage_api::list_result>,
+      list_objects,
+      (const cloud_storage_clients::bucket_name&,
+       retry_chain_node&,
+       std::optional<cloud_storage_clients::object_key>,
+       std::optional<char>,
+       std::optional<cloud_storage_clients::client::item_filter>),
+      (override));
+    MOCK_METHOD(
+      ss::future<cloud_storage::download_result>,
+      object_exists,
+      (const cloud_storage_clients::bucket_name&,
+       const cloud_storage_clients::object_key&,
+       retry_chain_node&,
+       cloud_storage::existence_check_type),
+      (override));
 };
 
 std::string iobuf_to_xml(iobuf buf) {

--- a/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage/inventory/aws_ops.h"
+#include "cloud_storage/inventory/inv_ops.h"
+#include "cloud_storage/inventory/tests/common.h"
+
+namespace cst = cloud_storage;
+namespace csi = cst::inventory;
+namespace cl = cloud_storage_clients;
+namespace t = ::testing;
+
+const auto id = csi::inventory_config_id{"redpanda-inv-weekly"};
+const auto bucket = cl::bucket_name{"test-bucket"};
+constexpr auto prefix = "inv-prefix";
+const auto list_prefix = fmt::format("{}/{}/{}/", prefix, bucket, id);
+constexpr auto latest_date = "1945-05-07T23-23Z/";
+constexpr auto latest_date_which_has_report = "1757-06-23T00-02Z/";
+
+constexpr std::string_view manifest_json_valid = R"(
+{
+    "sourceBucket": "example-source-bucket",
+    "destinationBucket": "arn:aws:s3:::example-inventory-destination-bucket",
+    "version": "2016-11-30",
+    "creationTimestamp" : "1514944800000",
+    "fileFormat": "CSV",
+    "fileSchema": "Bucket, Key...",
+    "files": [
+        {
+            "key": "first-key",
+            "size": 2147483647,
+            "MD5checksum": "f11166069f1990abeb9c97ace9cdfabc"
+        }
+    ]
+}
+)";
+
+void setup_and_validate_list_call(
+  csi::MockRemote& remote,
+  retry_chain_node& parent,
+  cl::client::list_bucket_result result) {
+    EXPECT_CALL(
+      remote,
+      list_objects(
+        t::Eq(bucket),
+        t::Ref(parent),
+        t::Eq(list_prefix),
+        t::Optional('/'),
+        t::Eq(std::nullopt)))
+      .Times(1)
+      .WillOnce(
+        t::Return(ss::make_ready_future<cst::cloud_storage_api::list_result>(
+          std::move(result))));
+}
+
+TEST(FindLatestReport, NoReportsExist) {
+    ss::abort_source as;
+    retry_chain_node parent{as};
+
+    csi::MockRemote remote;
+    setup_and_validate_list_call(remote, parent, {});
+
+    csi::aws_ops ops{bucket, id, prefix};
+    const auto result = ops.fetch_latest_report_metadata(remote, parent).get();
+
+    EXPECT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), csi::error_outcome::failed);
+}
+
+TEST(FindLatestReport, NonDatePathsIgnored) {
+    ss::abort_source as;
+    retry_chain_node parent{as};
+
+    const auto dates = cl::client::list_bucket_result{
+      .common_prefixes = {"1215-06/", "133701Z/"}};
+
+    csi::MockRemote remote;
+    setup_and_validate_list_call(remote, parent, dates);
+
+    csi::aws_ops ops{bucket, id, prefix};
+    const auto result = ops.fetch_latest_report_metadata(remote, parent).get();
+
+    EXPECT_TRUE(result.has_error());
+    EXPECT_EQ(result.error(), csi::error_outcome::failed);
+}
+
+ss::future<cst::download_result>
+validate_req_and_return_manifest(cst::download_request r) {
+    EXPECT_TRUE(r.payload.empty());
+    EXPECT_EQ(r.type, cloud_storage::download_type::inventory_report_manifest);
+    EXPECT_EQ(r.transfer_details.bucket, bucket);
+    EXPECT_EQ(
+      r.transfer_details.key(),
+      fmt::format(
+        "{}{}/manifest.json", list_prefix, latest_date_which_has_report));
+
+    r.payload.append(manifest_json_valid.data(), manifest_json_valid.size());
+    return ss::make_ready_future<cst::download_result>(
+      cloud_storage::download_result::success);
+}
+
+template<typename Ops, typename... T>
+void run_test(csi::MockRemote& remote, retry_chain_node& parent, T... ts) {
+    // We expect the following prefixes to be checked, in order from latest to
+    // earliest.
+    // The scanning will stop once the first manifest checksum is found
+    const auto dates = cl::client::list_bucket_result{
+      .common_prefixes = {
+        "1215-06-15T01-02Z/",
+        latest_date_which_has_report,
+        latest_date,
+        "1337-05-24T02-01Z/"}};
+
+    setup_and_validate_list_call(remote, parent, dates);
+
+    // The latest date does not have a manifest checksum, so it will be checked
+    // and then discarded
+    EXPECT_CALL(
+      remote,
+      object_exists(
+        t::Eq(bucket),
+        t::Eq(fmt::format("{}{}manifest.checksum", list_prefix, latest_date)),
+        t::Ref(parent),
+        t::Eq(cst::existence_check_type::object)))
+      .Times(1)
+      .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
+        cst::download_result::notfound)));
+
+    // The next latest date does have a checksum file, so it becomes the result
+    EXPECT_CALL(
+      remote,
+      object_exists(
+        t::Eq(bucket),
+        t::Eq(fmt::format(
+          "{}{}manifest.checksum", list_prefix, latest_date_which_has_report)),
+        t::Ref(parent),
+        t::Eq(cst::existence_check_type::object)))
+      .Times(1)
+      .WillOnce(t::Return(ss::make_ready_future<cst::download_result>(
+        cst::download_result::success)));
+
+    // Return a valid manifest on being called
+    EXPECT_CALL(remote, download_object(t::_))
+      .Times(1)
+      .WillOnce(t::Invoke(validate_req_and_return_manifest));
+
+    auto ops = Ops{ts...};
+    const auto result = ops.fetch_latest_report_metadata(remote, parent).get();
+
+    EXPECT_TRUE(result.has_value());
+    const auto report_metadata = result.value();
+
+    EXPECT_EQ(
+      report_metadata.metadata_path,
+      fmt::format(
+        "{}{}manifest.json", list_prefix, latest_date_which_has_report));
+
+    EXPECT_EQ(report_metadata.report_paths.size(), 1);
+    EXPECT_EQ(report_metadata.report_paths[0], "first-key");
+
+    // Test data has a trailing slash
+    EXPECT_EQ(report_metadata.datetime() + "/", latest_date_which_has_report);
+}
+
+TEST(FindLatestReport, LatestReportPathReturned) {
+    ss::abort_source as;
+    retry_chain_node parent{as};
+    csi::MockRemote remote;
+    run_test<csi::aws_ops>(remote, parent, bucket, id, prefix);
+}

--- a/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
@@ -175,3 +175,10 @@ TEST(FindLatestReport, LatestReportPathReturned) {
     csi::MockRemote remote;
     run_test<csi::aws_ops>(remote, parent, bucket, id, prefix);
 }
+
+TEST(FindLatestReport, InvOps) {
+    ss::abort_source as;
+    retry_chain_node parent{as};
+    csi::MockRemote remote;
+    run_test<csi::inv_ops>(remote, parent, csi::aws_ops{bucket, id, prefix});
+}

--- a/src/v/cloud_storage/inventory/types.cc
+++ b/src/v/cloud_storage/inventory/types.cc
@@ -30,8 +30,6 @@ std::ostream& operator<<(std::ostream& os, inventory_creation_result icr) {
         using enum cloud_storage::inventory::inventory_creation_result;
     case success:
         return os << "success";
-    case failed:
-        return os << "failed";
     case already_exists:
         return os << "already-exists";
     }

--- a/src/v/cloud_storage/inventory/types.h
+++ b/src/v/cloud_storage/inventory/types.h
@@ -10,7 +10,8 @@
 
 #pragma once
 
-#include "base/seastarx.h"
+#include "base/outcome.h"
+#include "cloud_storage_clients/types.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/sharded.hh>
@@ -27,6 +28,51 @@ enum class upload_result;
 
 namespace cloud_storage::inventory {
 
+enum class error_outcome {
+    success = 0,
+    failed,
+    manifest_download_failed,
+    manifest_files_parse_failed,
+    manifest_deserialization_failed,
+};
+
+struct error_outcome_category final : public std::error_category {
+    const char* name() const noexcept final {
+        return "cloud_storage::inventory::errc";
+    }
+
+    std::string message(int c) const final {
+        switch (static_cast<error_outcome>(c)) {
+        case error_outcome::success:
+            return "Success";
+        case error_outcome::failed:
+            return "Failed";
+        case error_outcome::manifest_download_failed:
+            return "Failed to download manifest";
+        case error_outcome::manifest_files_parse_failed:
+            return "Failed to extract files object from manifest";
+        case error_outcome::manifest_deserialization_failed:
+            return "Failed to parse manifest to JSON";
+        default:
+            return fmt::format("Unknown outcome ({})", c);
+        }
+    }
+};
+
+inline const std::error_category& error_category() noexcept {
+    static error_outcome_category e;
+    return e;
+}
+
+inline std::error_code make_error_code(error_outcome e) noexcept {
+    return {static_cast<int>(e), error_category()};
+}
+
+inline std::ostream& operator<<(std::ostream& o, error_outcome e) {
+    o << error_category().message(static_cast<int>(e));
+    return o;
+}
+
 // The identifier for a specific report configuration scheduled to run at a
 // fixed frequency and producing files of a fixed format.
 using inventory_config_id = named_type<ss::sstring, struct inventory_config>;
@@ -36,6 +82,25 @@ std::ostream& operator<<(std::ostream&, report_generation_frequency);
 
 enum class report_format { csv };
 std::ostream& operator<<(std::ostream&, report_format);
+
+// A string is used instead of a chrono type because the strings returned by the
+// vendor APIs are already roughly ISO-8601 formatted. This format is well
+// suited for lexical sorting as well as creating directories on disk to store
+// data for a given date, these are the only operations we need this type for.
+using report_datetime = named_type<ss::sstring, struct report_datetime_t>;
+
+// Stores a path to one or more reports. While in most cases one report run will
+// generate just one CSV file, in some cases (e.g. Google with more than 1
+// million objects) there may be more than one file per run. The result stores
+// paths in a vector and the caller is made to handle multiple files per run to
+// accomodate for these cases.
+using report_paths = std::vector<cloud_storage_clients::object_key>;
+
+struct report_metadata {
+    cloud_storage_clients::object_key metadata_path;
+    report_paths report_paths;
+    report_datetime datetime;
+};
 
 /// \brief This class is not directly used for runtime polymorphism, it exists
 /// as a convenience to define constraints for inv_ops_variant, to make sure
@@ -54,6 +119,11 @@ public:
     virtual ss::future<bool> inventory_configuration_exists(
       cloud_storage::cloud_storage_api& remote, retry_chain_node& parent_rtc)
       = 0;
+
+    virtual ss::future<result<report_metadata, error_outcome>>
+    fetch_latest_report_metadata(
+      cloud_storage::cloud_storage_api&, retry_chain_node&) const noexcept
+      = 0;
 };
 
 template<typename T>
@@ -71,3 +141,9 @@ enum class inventory_creation_result {
 std::ostream& operator<<(std::ostream&, inventory_creation_result);
 
 } // namespace cloud_storage::inventory
+
+namespace std {
+template<>
+struct is_error_code_enum<cloud_storage::inventory::error_outcome>
+  : true_type {};
+} // namespace std

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -1337,7 +1337,7 @@ ss::future<remote::list_result> remote::list_objects(
     // Gathers the items from a series of successful ListObjectsV2 calls
     cloud_storage_clients::client::list_bucket_result list_bucket_result;
 
-    // Keep iterating until the ListObjectsV2 calls has more items to return
+    // Keep iterating while the ListObjectsV2 calls has more items to return
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto res = co_await lease.client->list_objects(
           bucket,

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -909,17 +909,17 @@ remote::download_object(cloud_storage::download_request download_request) {
     co_return *result;
 }
 
-ss::future<download_result> remote::segment_exists(
+ss::future<download_result> remote::object_exists(
   const cloud_storage_clients::bucket_name& bucket,
-  const remote_segment_path& segment_path,
-  retry_chain_node& parent) {
+  const cloud_storage_clients::object_key& path,
+  retry_chain_node& parent,
+  existence_check_type object_type) {
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(cst_log, fib);
-    auto path = cloud_storage_clients::object_key(segment_path());
     auto lease = co_await _pool.local().acquire(fib.root_abort_source());
     auto permit = fib.retry();
-    vlog(ctxlog.debug, "Check segment {}", path);
+    vlog(ctxlog.debug, "Check {} {}", object_type, path);
     std::optional<download_result> result;
     while (!_gate.is_closed() && permit.is_allowed && !result) {
         auto resp = co_await lease.client->head_object(
@@ -959,20 +959,33 @@ ss::future<download_result> remote::segment_exists(
     if (!result) {
         vlog(
           ctxlog.warn,
-          "HeadObject from {}, backoff quota exceded, segment at {} "
+          "HeadObject from {}, backoff quota exceded, {} at {} "
           "not available",
           bucket,
+          object_type,
           path);
         result = download_result::timedout;
     } else {
         vlog(
           ctxlog.warn,
-          "HeadObject from {}, {}, segment at {} not available",
+          "HeadObject from {}, {}, {} at {} not available",
           bucket,
           *result,
+          object_type,
           path);
     }
     co_return *result;
+}
+
+ss::future<download_result> remote::segment_exists(
+  const cloud_storage_clients::bucket_name& bucket,
+  const remote_segment_path& segment_path,
+  retry_chain_node& parent) {
+    co_return co_await object_exists(
+      bucket,
+      cloud_storage_clients::object_key{segment_path},
+      parent,
+      existence_check_type::segment);
 }
 
 ss::future<upload_result> remote::delete_object(

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -355,6 +355,12 @@ public:
     ss::future<download_result>
     download_object(download_request download_request) override;
 
+    ss::future<download_result> object_exists(
+      const cloud_storage_clients::bucket_name& bucket,
+      const cloud_storage_clients::object_key& path,
+      retry_chain_node& parent,
+      existence_check_type object_type);
+
     /// Checks if the segment exists in the bucket
     ss::future<download_result> segment_exists(
       const cloud_storage_clients::bucket_name& bucket,

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -534,6 +534,8 @@ std::ostream& operator<<(std::ostream& os, download_type download) {
         return os << "object";
     case segment_index:
         return os << "segment-index";
+    case inventory_report_manifest:
+        return os << "inventory-report-manifest";
     }
 }
 

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -547,4 +547,14 @@ void transfer_details::on_backoff(remote_probe& probe) {
     run_callback(backoff_cb, probe);
 }
 
+std::ostream& operator<<(std::ostream& os, existence_check_type head) {
+    switch (head) {
+        using enum cloud_storage::existence_check_type;
+    case object:
+        return os << "object";
+    case segment:
+        return os << "segment";
+    }
+}
+
 } // namespace cloud_storage

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -439,6 +439,10 @@ enum class download_type {
 
 std::ostream& operator<<(std::ostream&, download_type);
 
+enum class existence_check_type { object, segment };
+
+std::ostream& operator<<(std::ostream&, existence_check_type);
+
 class remote_probe;
 using probe_callback_t = ss::noncopyable_function<void(remote_probe&)>;
 

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -432,10 +432,7 @@ enum class upload_type {
 
 std::ostream& operator<<(std::ostream&, upload_type);
 
-enum class download_type {
-    object,
-    segment_index,
-};
+enum class download_type { object, segment_index, inventory_report_manifest };
 
 std::ostream& operator<<(std::ostream&, download_type);
 


### PR DESCRIPTION
Adds a utility to scan through all the dates available for a given inventory config and find the latest report which has been generated and is ready for download.

Returns the path to manifest describing the report found as well as report paths and the datetime.

The caller can then use the metadata to download the actual report.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
