### PR TITLE
[v23.3.x] Ensure `fragment_vector` fragments are always <= 128KiB

### DIFF
--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -48,13 +48,13 @@ public:
                                               == std::dynamic_extent;
 
 private:
+    static constexpr size_t max_allocation_size = 128UL * 1024;
 
     // calculate the maximum number of elements per fragment while
     // keeping the element count a power of two
     static constexpr size_t calc_elems_per_frag(size_t esize) {
         size_t max = fragment_size_bytes / esize;
         if constexpr (is_chunked_vector) {
-            constexpr size_t max_allocation_size = 128UL * 1024;
             max = max_allocation_size / esize;
         }
         assert(max > 0);
@@ -83,6 +83,10 @@ public:
      * to a power of two.
      */
     static constexpr size_t max_frag_bytes = elems_per_frag * sizeof(T);
+
+    static_assert(
+      max_frag_bytes <= max_allocation_size,
+      "max size of a fragment must be <= 128KiB");
 
     fragmented_vector() noexcept = default;
     fragmented_vector& operator=(const fragmented_vector&) noexcept = delete;

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -16,6 +16,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/util/later.hh>
 
+#include <bit>
 #include <climits>
 #include <compare>
 #include <cstddef>
@@ -47,12 +48,6 @@ public:
                                               == std::dynamic_extent;
 
 private:
-    // Compute the previous (or equal) power of two relative to `size`.
-    static constexpr size_t pow2_floor(size_t size) {
-        unsigned lz = std::countl_zero(size);
-        unsigned shift = (sizeof(size_t) * CHAR_BIT) - lz;
-        return 1UL << shift;
-    }
 
     // calculate the maximum number of elements per fragment while
     // keeping the element count a power of two
@@ -63,7 +58,7 @@ private:
             max = max_allocation_size / esize;
         }
         assert(max > 0);
-        return pow2_floor(max);
+        return std::bit_floor(max);
     }
 
     static constexpr size_t elems_per_frag = calc_elems_per_frag(sizeof(T));


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16958
Fixes: https://github.com/redpanda-data/redpanda/issues/16964,