### PR TITLE
tests: Tweak OMBValidationTest.test_max_connections

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -140,8 +140,8 @@ class OMBValidationTest(RedpandaCloudTest):
         #
 
         PRODUCER_TIMEOUT_MS = 5000
-        OMB_WORKERS = 4
-        SWARM_WORKERS = 5
+        OMB_WORKERS = 2
+        SWARM_WORKERS = 7
 
         # OMB parameters
         #
@@ -209,7 +209,7 @@ class OMBValidationTest(RedpandaCloudTest):
 
         # single producer runtime
         # Roughly every 500 connection needs 60 seconds to ramp up
-        time_per_500_s = 120
+        time_per_500_s = 60
         warm_up_time_s = max(
             time_per_500_s * math.ceil(_target_per_node / 500), time_per_500_s)
         target_runtime_s = 60 * (test_duration +
@@ -268,10 +268,10 @@ class OMBValidationTest(RedpandaCloudTest):
         try:
             benchmark.wait(timeout_sec=benchmark_time_min * 60)
 
-            for s in swarm:
-                s.wait(timeout_sec=5 * 60)
-
             benchmark.check_succeed()
+
+            for s in swarm:
+                s.wait(timeout_sec=30 * 60)
 
         finally:
             self.rpk.delete_topic(swarm_topic_name)


### PR DESCRIPTION
Minor tweaks to make this more stable:

 - Assign more nodes to client-swarm than OMB: The OMB workload is
   actually very gentle. The "hard" part is on the client-swarm side so
   more cores help there.
 - Reduce the wait time: This seems quite high and slows down the test a
   lot at higher connetion counts
 - Adjust client-wait ordering: The test is fundamentally broken in how
   it works as it doesn't properly calculate the amount of clients that
   can connect. We need to fix client-swarm such that we can wait for all
   clients connect and then just explicitly stop them at the end of the
   test. For now rearrange the waiting of the clients to finish such that
   it's more likely to pass (wait for OMB first and then for client
   swarms).

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none

