### PR TITLE
Prepare leader_balancer for node-local core assignment

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -569,6 +569,7 @@ ss::future<> controller::start(
             _partition_leaders.local(),
             _members_table.local(),
             _hm_backend.local(),
+            _feature_table.local(),
             std::ref(_connections),
             std::ref(_shard_table),
             std::ref(_partition_manager),

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -534,24 +534,6 @@ ss::future<> controller::start(
             _raft0->group());
       })
       .then([this] {
-          _leader_balancer = std::make_unique<leader_balancer>(
-            _tp_state.local(),
-            _partition_leaders.local(),
-            _members_table.local(),
-            std::ref(_connections),
-            std::ref(_shard_table),
-            std::ref(_partition_manager),
-            std::ref(_as),
-            config::shard_local_cfg().enable_leader_balancer.bind(),
-            config::shard_local_cfg().leader_balancer_idle_timeout.bind(),
-            config::shard_local_cfg().leader_balancer_mute_timeout.bind(),
-            config::shard_local_cfg().leader_balancer_node_mute_timeout.bind(),
-            config::shard_local_cfg()
-              .leader_balancer_transfer_limit_per_shard.bind(),
-            _raft0);
-          return _leader_balancer->start();
-      })
-      .then([this] {
           return _health_manager.start_single(
             _raft0->self().id(),
             config::shard_local_cfg().internal_topic_replication_factor(),
@@ -580,6 +562,25 @@ ss::future<> controller::start(
             std::ref(_feature_table),
             std::ref(_partition_leaders),
             std::ref(_tp_state));
+      })
+      .then([this] {
+          _leader_balancer = std::make_unique<leader_balancer>(
+            _tp_state.local(),
+            _partition_leaders.local(),
+            _members_table.local(),
+            _hm_backend.local(),
+            std::ref(_connections),
+            std::ref(_shard_table),
+            std::ref(_partition_manager),
+            std::ref(_as),
+            config::shard_local_cfg().enable_leader_balancer.bind(),
+            config::shard_local_cfg().leader_balancer_idle_timeout.bind(),
+            config::shard_local_cfg().leader_balancer_mute_timeout.bind(),
+            config::shard_local_cfg().leader_balancer_node_mute_timeout.bind(),
+            config::shard_local_cfg()
+              .leader_balancer_transfer_limit_per_shard.bind(),
+            _raft0);
+          return _leader_balancer->start();
       })
       .then([this] { return _hm_frontend.start(std::ref(_hm_backend)); })
       .then([this] {

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -677,6 +677,7 @@ struct ntp_report {
     size_t size_bytes;
     std::optional<uint8_t> under_replicated_replicas;
     size_t reclaimable_size_bytes;
+    ss::shard_id shard;
 };
 
 partition_status to_partition_status(const ntp_report& ntpr) {
@@ -687,7 +688,8 @@ partition_status to_partition_status(const ntp_report& ntpr) {
       .revision_id = ntpr.leader.revision_id,
       .size_bytes = ntpr.size_bytes,
       .under_replicated_replicas = ntpr.under_replicated_replicas,
-      .reclaimable_size_bytes = ntpr.reclaimable_size_bytes};
+      .reclaimable_size_bytes = ntpr.reclaimable_size_bytes,
+      .shard = ntpr.shard};
 }
 
 ss::chunked_fifo<ntp_report> collect_shard_local_reports(
@@ -711,6 +713,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 .size_bytes = p.second->size_bytes() + p.second->non_log_disk_size_bytes(),
                 .under_replicated_replicas = p.second->get_under_replicated(),
                 .reclaimable_size_bytes = p.second->reclaimable_size_bytes(),
+                .shard = ss::this_shard_id(),
               };
           });
     } else {
@@ -726,6 +729,7 @@ ss::chunked_fifo<ntp_report> collect_shard_local_reports(
                 .size_bytes = partition->size_bytes() + partition->non_log_disk_size_bytes(),
                 .under_replicated_replicas = partition->get_under_replicated(),
                 .reclaimable_size_bytes = partition->reclaimable_size_bytes(),
+                .shard = ss::this_shard_id(),
                 });
             }
         }

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -141,14 +141,15 @@ std::ostream& operator<<(std::ostream& o, const partition_status& ps) {
     fmt::print(
       o,
       "{{id: {}, term: {}, leader_id: {}, revision_id: {}, size_bytes: {}, "
-      "reclaimable_size_bytes: {}, under_replicated: {}}}",
+      "reclaimable_size_bytes: {}, under_replicated: {}, shard: {}}}",
       ps.id,
       ps.term,
       ps.leader_id,
       ps.revision_id,
       ps.size_bytes,
       ps.reclaimable_size_bytes,
-      ps.under_replicated_replicas);
+      ps.under_replicated_replicas,
+      ps.shard);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -57,8 +57,9 @@ struct node_state
 
 struct partition_status
   : serde::
-      envelope<partition_status, serde::version<2>, serde::compat_version<0>> {
+      envelope<partition_status, serde::version<3>, serde::compat_version<0>> {
     static constexpr size_t invalid_size_bytes = size_t(-1);
+    static constexpr uint32_t invalid_shard_id = uint32_t(-1);
 
     model::partition_id id;
     model::term_id term;
@@ -82,6 +83,8 @@ struct partition_status
      */
     std::optional<size_t> reclaimable_size_bytes;
 
+    uint32_t shard = invalid_shard_id;
+
     auto serde_fields() {
         return std::tie(
           id,
@@ -90,7 +93,8 @@ struct partition_status
           revision_id,
           size_bytes,
           under_replicated_replicas,
-          reclaimable_size_bytes);
+          reclaimable_size_bytes,
+          shard);
     }
 
     friend std::ostream& operator<<(std::ostream&, const partition_status&);

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -676,16 +676,7 @@ leader_balancer::index_type leader_balancer::build_index() {
             if (auto it = _in_flight_changes.find(partition.group);
                 it != _in_flight_changes.end()) {
                 const auto& assignment = it->second.value;
-
-                std::vector<model::broker_shard> replicas = partition.replicas;
-                // Swap to and from in the replicas
-                if (auto r_it = std::find(
-                      replicas.begin(), replicas.end(), assignment.to);
-                    r_it != replicas.end()) {
-                    *r_it = assignment.from;
-                }
-
-                index[assignment.to][partition.group] = std::move(replicas);
+                index[assignment.to][partition.group] = partition.replicas;
                 continue;
             }
 

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -52,6 +52,7 @@ leader_balancer::leader_balancer(
   partition_leaders_table& leaders,
   members_table& members,
   health_monitor_backend& health_monitor,
+  features::feature_table& feature_table,
   ss::sharded<rpc::connection_cache>& connections,
   ss::sharded<shard_table>& shard_table,
   ss::sharded<partition_manager>& partition_manager,
@@ -71,6 +72,7 @@ leader_balancer::leader_balancer(
   , _leaders(leaders)
   , _members(members)
   , _health_monitor(health_monitor)
+  , _feature_table(feature_table)
   , _connections(connections)
   , _shard_table(shard_table)
   , _partition_manager(partition_manager)

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -13,6 +13,7 @@
 #include "base/seastarx.h"
 #include "base/vlog.h"
 #include "cluster/controller_service.h"
+#include "cluster/health_monitor_backend.h"
 #include "cluster/logger.h"
 #include "cluster/members_table.h"
 #include "cluster/partition_leaders_table.h"
@@ -50,6 +51,7 @@ leader_balancer::leader_balancer(
   topic_table& topics,
   partition_leaders_table& leaders,
   members_table& members,
+  health_monitor_backend& health_monitor,
   ss::sharded<rpc::connection_cache>& connections,
   ss::sharded<shard_table>& shard_table,
   ss::sharded<partition_manager>& partition_manager,
@@ -68,6 +70,7 @@ leader_balancer::leader_balancer(
   , _topics(topics)
   , _leaders(leaders)
   , _members(members)
+  , _health_monitor(health_monitor)
   , _connections(connections)
   , _shard_table(shard_table)
   , _partition_manager(partition_manager)

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -105,9 +105,12 @@ private:
     using index_type = leader_balancer_strategy::index_type;
     using reassignment = leader_balancer_strategy::reassignment;
 
+    using group_replicas_t = absl::btree_map<raft::group_id, replicas_t>;
+    ss::future<std::optional<group_replicas_t>>
+    collect_group_replicas_from_health_report();
     leader_balancer_types::group_id_to_topic_revision_t
     build_group_id_to_topic_rev() const;
-    index_type build_index();
+    index_type build_index(std::optional<group_replicas_t>);
     leader_balancer_types::muted_groups_t muted_groups() const;
     absl::flat_hash_set<model::node_id> muted_nodes() const;
 

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -86,6 +86,7 @@ public:
       partition_leaders_table&,
       members_table&,
       health_monitor_backend&,
+      features::feature_table&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<shard_table>&,
       ss::sharded<partition_manager>&,
@@ -195,6 +196,7 @@ private:
     partition_leaders_table& _leaders;
     members_table& _members;
     health_monitor_backend& _health_monitor;
+    features::feature_table& _feature_table;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;

--- a/src/v/cluster/scheduling/leader_balancer.h
+++ b/src/v/cluster/scheduling/leader_balancer.h
@@ -85,6 +85,7 @@ public:
       topic_table&,
       partition_leaders_table&,
       members_table&,
+      health_monitor_backend&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<shard_table>&,
       ss::sharded<partition_manager>&,
@@ -193,6 +194,7 @@ private:
     topic_table& _topics;
     partition_leaders_table& _leaders;
     members_table& _members;
+    health_monitor_backend& _health_monitor;
     ss::sharded<rpc::connection_cache>& _connections;
     ss::sharded<shard_table>& _shard_table;
     ss::sharded<partition_manager>& _partition_manager;

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -99,6 +99,8 @@ std::string_view to_string_view(feature f) {
         return "audit_logging";
     case feature::compaction_placeholder_batch:
         return "compaction_placeholder_batch";
+    case feature::node_local_core_assignment:
+        return "node_local_core_assignment";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -74,6 +74,7 @@ enum class feature : std::uint64_t {
     cloud_metadata_cluster_recovery = 1ULL << 40U,
     audit_logging = 1ULL << 41U,
     compaction_placeholder_batch = 1ULL << 42U,
+    node_local_core_assignment = 1ULL << 43U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -370,7 +371,14 @@ constexpr static std::array feature_schema{
     "compaction_placeholder_batch",
     feature::compaction_placeholder_batch,
     feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always}};
+    feature_spec::prepare_policy::always},
+  feature_spec{
+    cluster::cluster_version{12},
+    "node_local_core_assignment",
+    feature::node_local_core_assignment,
+    feature_spec::available_policy::always,
+    feature_spec::prepare_policy::always},
+};
 
 std::string_view to_string_view(feature);
 std::string_view to_string_view(feature_state::state);


### PR DESCRIPTION
After node-local partition-core assignment becomes enabled, we can no longer rely on global replica shard info from the topic table. Use shard info from the health report instead.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none