### PR TITLE
Name all util/mutexes

### DIFF
--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -321,7 +321,7 @@ private:
 private:
     prefix_logger _logger;
 
-    mutex _lock;
+    mutex _lock{"archival_metadata_stm"};
 
     ss::shared_ptr<util::mem_tracker> _mem_tracker;
     ss::shared_ptr<cloud_storage::partition_manifest> _manifest;

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -60,7 +60,7 @@ private:
       config_version_unset}; // Only maintained on `version_shard`
 
     // Serialize writes to generate version numbers.
-    mutex _write_lock;
+    mutex _write_lock{"config_frontend::write"};
 
     // Set once at construction to enable unit testing
     model::node_id _self;

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -441,7 +441,7 @@ private:
     // there is a consistent state. All readers/updaters grab this
     // in read mode and wait until the snapshot operations finish.
     ss::rwlock _snapshot_lock;
-    mutex _repartitioning_lock;
+    mutex _repartitioning_lock{"distributed_kv_stm::repartitioning_lock"};
 };
 
 } // namespace cluster

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -197,7 +197,7 @@ private:
     std::optional<size_t> _bytes_in_cloud_storage;
 
     ss::gate _gate;
-    mutex _refresh_mutex;
+    mutex _refresh_mutex{"health_monitor_backend::refresh"};
     ss::sharded<node::local_monitor>& _local_monitor;
 
     std::vector<std::pair<cluster::notification_id_type, health_node_cb_t>>

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -118,7 +118,7 @@ private:
     ss::future<> apply_raft_snapshot(const iobuf&) final;
     ss::future<bool> sync(model::timeout_clock::duration);
 
-    mutex _lock;
+    mutex _lock{"id_allocator"};
 
     // id_allocator_stm is a state machine generating unique increasing IDs.
     // When a node becomes a leader it allocates a range of IDs of size

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -153,7 +153,7 @@ private:
     consensus_ptr _raft0;
     ss::sharded<ss::abort_source>& _as;
     ss::gate _bg;
-    mutex _lock;
+    mutex _lock{"members_backend::lock"};
     model::term_id _last_term;
 
     // replicas reallocations in progress

--- a/src/v/cluster/metadata_dissemination_service.h
+++ b/src/v/cluster/metadata_dissemination_service.h
@@ -156,7 +156,7 @@ private:
     ss::chunked_fifo<ntp_leader_revision> _requests;
     std::vector<net::unresolved_address> _seed_servers;
     broker_updates_t _pending_updates;
-    mutex _lock;
+    mutex _lock{"metadata_dissemination_service"};
     ss::timer<> _dispatch_timer;
     ss::abort_source _as;
     ss::gate _bg;

--- a/src/v/cluster/migrations/tx_manager_migrator.h
+++ b/src/v/cluster/migrations/tx_manager_migrator.h
@@ -221,7 +221,7 @@ private:
     int16_t _internal_topic_replication_factor;
     config::binding<int> _manager_partition_count;
     int32_t _requested_partition_count;
-    mutex _migration_mutex;
+    mutex _migration_mutex{"tx_manager_migrator"};
 
     ss::abort_source _as;
 };

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -108,7 +108,7 @@ private:
     config::binding<std::chrono::milliseconds> _node_status_interval;
     config::binding<size_t> _raft_learner_recovery_rate;
 
-    mutex _lock{};
+    mutex _lock{"partition_balancer_backend::lock"};
     ss::gate _gate;
     ss::timer<clock_t> _timer;
     notification_id_type _topic_table_updates;

--- a/src/v/cluster/plugin_frontend.h
+++ b/src/v/cluster/plugin_frontend.h
@@ -164,6 +164,6 @@ private:
 
     // is null if not on shard0
     controller_stm* _controller;
-    mutex _mu;
+    mutex _mu{"plugin_frontend::mu"};
 };
 } // namespace cluster

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -243,7 +243,7 @@ private:
     model::producer_identity _id;
     raft::group_id _group;
     // serializes all the operations on this producer
-    mutex _op_lock;
+    mutex _op_lock{"producer_state::_op_lock"};
     std::reference_wrapper<producer_state_manager> _parent;
 
     requests _requests;

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -527,7 +527,7 @@ private:
         auto lock_it = _tx_locks.find(pid);
         if (lock_it == _tx_locks.end()) {
             auto [new_it, _] = _tx_locks.try_emplace(
-              pid, ss::make_lw_shared<mutex>());
+              pid, ss::make_lw_shared<mutex>("get_tx_lock"));
             lock_it = new_it;
         }
         return lock_it->second;

--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -92,7 +92,7 @@ private:
     ss::gate _gate;
     ss::scheduling_group _st_sg;
     bool _cancelling{false};
-    mutex _lock;
+    mutex _lock{"self_test"};
     self_test::diskcheck _disk_test;
     self_test::netcheck _network_test;
 };

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -170,7 +170,7 @@ private:
     absl::node_hash_map<model::ntp, placement_state> _states;
 
     // only on shard 0, _ntp2target will hold targets for all ntps on this node.
-    mutex _mtx;
+    mutex _mtx{"shard_placement_table"};
     absl::node_hash_map<model::ntp, shard_placement_target> _ntp2target;
 };
 

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -938,7 +938,7 @@ bool tm_stm::is_expired(const tm_transaction& tx) {
 ss::lw_shared_ptr<mutex> tm_stm::get_tx_lock(kafka::transactional_id tid) {
     auto [lock_it, inserted] = _tx_locks.try_emplace(tid, nullptr);
     if (inserted) {
-        lock_it->second = ss::make_lw_shared<mutex>();
+        lock_it->second = ss::make_lw_shared<mutex>("tm_stm::tx_lock");
     }
     return lock_it->second;
 }
@@ -947,7 +947,7 @@ ss::future<txlock_unit>
 tm_stm::lock_tx(kafka::transactional_id tx_id, std::string_view lock_name) {
     auto [lock_it, inserted] = _tx_locks.try_emplace(tx_id, nullptr);
     if (inserted) {
-        lock_it->second = ss::make_lw_shared<mutex>();
+        lock_it->second = ss::make_lw_shared<mutex>("lock_tx");
     }
     auto units = co_await lock_it->second->get_units();
     co_return txlock_unit(this, std::move(units), tx_id, lock_name);
@@ -957,7 +957,7 @@ std::optional<txlock_unit>
 tm_stm::try_lock_tx(kafka::transactional_id tx_id, std::string_view lock_name) {
     auto [lock_it, inserted] = _tx_locks.try_emplace(tx_id, nullptr);
     if (inserted) {
-        lock_it->second = ss::make_lw_shared<mutex>();
+        lock_it->second = ss::make_lw_shared<mutex>("tm_stm::tx_lock");
     }
     auto units = lock_it->second->try_get_units();
     if (units) {

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -382,7 +382,7 @@ private:
     ss::sharded<features::feature_table>& _feature_table;
     ss::lw_shared_ptr<cluster::tm_stm_cache> _cache;
 
-    mutex _tx_thrashing_lock;
+    mutex _tx_thrashing_lock{"tm_stm::tx_thrashing_lock"};
     prefix_logger _ctx_log;
 
     ss::future<> apply(const model::record_batch& b) final;

--- a/src/v/cluster/tx_topic_manager.h
+++ b/src/v/cluster/tx_topic_manager.h
@@ -58,6 +58,6 @@ private:
     config::binding<uint64_t> _segment_size;
     config::binding<std::chrono::milliseconds> _retention_duration;
     ss::gate _gate;
-    mutex _reconciliation_mutex;
+    mutex _reconciliation_mutex{"tx_topic_manager::reconciliation_mutex"};
 };
 } // namespace cluster

--- a/src/v/kafka/client/broker.h
+++ b/src/v/kafka/client/broker.h
@@ -27,7 +27,7 @@ namespace kafka::client {
 
 struct gated_mutex {
     gated_mutex()
-      : _mutex{}
+      : _mutex{"gated_mutex"}
       , _gate{} {}
 
     template<typename Func>
@@ -44,7 +44,7 @@ struct gated_mutex {
 
     ss::future<> close() { return _gate.close(); }
 
-    mutex _mutex;
+    mutex _mutex{"gated_mutex"};
     ss::gate _gate;
 };
 

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -395,7 +395,7 @@ private:
         /**
          * Mutex is used to control concurrency per virtual connection.
          */
-        mutex _lock;
+        mutex _lock{"virtual_connection_state::lock"};
         ss::lowres_clock::time_point _last_request_timestamp;
     };
 

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -749,7 +749,7 @@ private:
         auto lock_it = _tx_locks.find(pid);
         if (lock_it == _tx_locks.end()) {
             auto [new_it, _] = _tx_locks.try_emplace(
-              pid, ss::make_lw_shared<mutex>());
+              pid, ss::make_lw_shared<mutex>("tx_lock_group"));
             lock_it = new_it;
         }
         return lock_it->second;

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -240,7 +240,7 @@ private:
     ss::timer<ss::lowres_clock> _balancer_timer;
     ss::lowres_clock::time_point _balancer_timer_last_ran;
     ss::gate _balancer_gate;
-    mutex _balancer_mx;
+    mutex _balancer_mx{"snc_quota_manager::balancer"};
     ingress_egress_state<quota_t> _node_deficit{0, 0};
 
     // operational, used on each shard

--- a/src/v/kafka/server/usage_aggregator.h
+++ b/src/v/kafka/server/usage_aggregator.h
@@ -149,7 +149,7 @@ private:
     ss::timer<clock_type> _close_window_timer;
     ss::timer<clock_type> _persist_disk_timer;
 
-    mutex _m;
+    mutex _m{"usage_aggregator"};
     ss::gate _bg_write_gate;
     ss::gate _gate;
     size_t _current_window{0};

--- a/src/v/kafka/server/usage_manager.h
+++ b/src/v/kafka/server/usage_manager.h
@@ -119,7 +119,7 @@ private:
 
     /// Per-core metric, shard-0 aggregates these values across shards
     usage _current_bucket;
-    mutex _background_mutex;
+    mutex _background_mutex{"usage_monitor::_background_mutex"};
     ss::gate _background_gate;
 
     /// Valid on core-0 when usage_enabled() == true

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -126,7 +126,7 @@ private:
         // Lock to prevent multiple fibers trying to concurrently
         // do reclaims (would happen if multiple incoming connections
         // on the same shard when available==0)
-        mutex reclaim_lock;
+        mutex reclaim_lock{"conn_quota::reclaim_lock"};
     };
 
     friend std::ostream& operator<<(std::ostream& o, const home_allowance& ha) {

--- a/src/v/net/dns.cc
+++ b/src/v/net/dns.cc
@@ -20,7 +20,7 @@ namespace net {
 
 ss::future<ss::socket_address> resolve_dns(unresolved_address address) {
     static thread_local ss::net::dns_resolver resolver;
-    static thread_local mutex m;
+    static thread_local mutex m{"resolve_dns"};
     // lock
     auto units = co_await m.get_units();
     // resolve

--- a/src/v/pandaproxy/kafka_client_cache.cc
+++ b/src/v/pandaproxy/kafka_client_cache.cc
@@ -91,7 +91,7 @@ std::pair<client_ptr, client_mu_ptr> kafka_client_cache::fetch_or_insert(
         vlog(plog.debug, "Make client for user {}", k);
 
         client = make_client(user, authn_method);
-        client_mu = ss::make_lw_shared<mutex>();
+        client_mu = ss::make_lw_shared<mutex>("client_mu");
         inner_list.emplace_front(k, client, client_mu);
     } else {
         // If the passwords don't match, update the password on the client, so

--- a/src/v/pandaproxy/kafka_client_cache.h
+++ b/src/v/pandaproxy/kafka_client_cache.h
@@ -101,6 +101,6 @@ private:
     std::list<timestamped_user> _evicted_items;
     ss::timer<ss::lowres_clock> _gc_timer;
     ss::gate _gc_gate;
-    mutex _gc_lock;
+    mutex _gc_lock{"kafka_client_cache::gc_lock"};
 };
 } // namespace pandaproxy

--- a/src/v/raft/configuration_manager.h
+++ b/src/v/raft/configuration_manager.h
@@ -202,7 +202,7 @@ private:
     model::offset _highest_known_offset;
     storage::api& _storage;
     ss::condition_variable _config_changed;
-    mutex _lock;
+    mutex _lock{"configuration_manager"};
     /**
      * We will persist highest known offset every 64MB, given this during
      * bootstrap redpanda will have to read up to 64MB per raft group.

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -830,13 +830,13 @@ private:
 
     /// all raft operations must happen exclusively since the common case
     /// is for the operation to touch the disk
-    mutex _op_lock;
+    mutex _op_lock{"consensus::op_lock"};
     /// since snapshot state is orthogonal to raft state when writing snapshot
     /// it is enough to grab the snapshot mutex, there is no need to keep
     /// oplock, if the two locks are expected to be acquired at the same time
     /// the snapshot lock should always be an internal (taken after the
     /// _op_lock)
-    mutex _snapshot_lock;
+    mutex _snapshot_lock{"consensus::snapshot_lock"};
     /// used for notifying when commits happened to log
     event_manager _event_manager;
     std::unique_ptr<probe> _probe;

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -107,7 +107,7 @@ private:
 
     raft::group_configuration create_initial_configuration(
       std::vector<model::broker>, model::revision_id) const;
-    mutex _groups_mutex;
+    mutex _groups_mutex{"group_manager"};
     model::node_id _self;
     ss::scheduling_group _raft_sg;
     raft::consensus_client_protocol _client;

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -219,7 +219,7 @@ private:
     heartbeat_requests_v2 requests_for_range_v2();
     // private members
 
-    mutex _lock;
+    mutex _lock{"heartbeat_manager"};
     clock_type::time_point _hbeat = clock_type::now();
     config::binding<std::chrono::milliseconds> _heartbeat_interval;
     config::binding<std::chrono::milliseconds> _heartbeat_timeout;

--- a/src/v/raft/mux_state_machine.h
+++ b/src/v/raft/mux_state_machine.h
@@ -221,10 +221,10 @@ protected:
 
     // Locked for the whole duration of writing a snapshot to ensure that there
     // are no concurrent attempts.
-    mutex _write_snapshot_mtx;
+    mutex _write_snapshot_mtx{"mex_state_machine::write_snapshot"};
     // Locked when a command is applied to the stm or when creating a snapshot
     // to ensure that the state machine state does not change.
-    mutex _apply_mtx;
+    mutex _apply_mtx{"mex_state_machine::apply"};
 
     // we keep states in a tuple to automatically dispatch updates to correct
     // state

--- a/src/v/raft/offset_translator.h
+++ b/src/v/raft/offset_translator.h
@@ -140,7 +140,7 @@ private:
 
     size_t _map_version = 0;
 
-    mutex _checkpoint_lock;
+    mutex _checkpoint_lock{"offset_translator::checkpoint_lock"};
 
     size_t _bytes_processed_at_checkpoint = 0;
     size_t _map_version_at_checkpoint = 0;

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -257,7 +257,7 @@ private:
 
     ss::future<> do_write_local_snapshot();
 
-    mutex _op_lock;
+    mutex _op_lock{"persisted_stm::op_lock"};
     std::vector<ss::lw_shared_ptr<expiring_promise<bool>>> _sync_waiters;
     ss::condition_variable _on_snapshot_hydrated;
     bool _snapshot_hydrated{false};

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -162,7 +162,7 @@ private:
     ssx::semaphore _max_batch_size_sem;
     size_t _max_batch_size;
     std::vector<item_ptr> _item_cache;
-    mutex _lock;
+    mutex _lock{"replicate_batcher"};
     ss::gate _bg;
     // If true, a background flush must be pending. Used to coalesce
     // background flush requests, since one flush dequeues all items

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -136,7 +136,7 @@ private:
     std::optional<model::record_batch_reader> _batches;
     absl::flat_hash_map<vnode, follower_req_seq> _followers_seq;
     absl::flat_hash_map<vnode, consensus::suppress_heartbeats_guard> _hb_guards;
-    mutex _share_mutex;
+    mutex _share_mutex{"replicate_entries_stm::share"};
     ssx::semaphore _dispatch_sem{0, "raft/repl-dispatch"};
     ss::gate _req_bg;
     ctx_log _ctxlog;

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -142,7 +142,8 @@ private:
 
         ss::sstring name;
         ss::shared_ptr<state_machine_base> stm;
-        mutex background_apply_mutex;
+        mutex background_apply_mutex{
+          "state_machine_manager::background_apply_mutex"};
     };
     using entry_ptr = ss::lw_shared_ptr<state_machine_entry>;
     using state_machines_t
@@ -177,7 +178,7 @@ private:
 
     consensus* _raft;
     ctx_log _log;
-    mutex _apply_mutex;
+    mutex _apply_mutex{"stm_manager::apply"};
     state_machines_t _machines;
     model::offset _next{0};
     ss::gate _gate;

--- a/src/v/raft/tests/mutex_buffer_test.cc
+++ b/src/v/raft/tests/mutex_buffer_test.cc
@@ -23,7 +23,7 @@ struct fixture {
           response{r.content + "-response"});
     }
 
-    mutex lock;
+    mutex lock{"mutex_buffer_test"};
     raft::details::mutex_buffer<request, response> buf;
 };
 

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -141,7 +141,7 @@ connection_cache::connection_cache(
       [this]() mutable noexcept { shutdown(); });
     if (ss::this_shard_id() == _coordinator_shard) {
         _coordinator_state = std::make_unique<coordinator_state>(
-          mutex(),
+          mutex{"connection_cache"},
           connection_allocation_strategy(connections_per_node, ss::smp::count));
     }
 }

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -501,7 +501,7 @@ FIXTURE_TEST(timeout_test_cleanup_resources, rpc_integration_fixture) {
     auto client = rpc::make_client<echo::echo_client_protocol>(client_config());
     client.connect(model::no_timeout).get();
     using units_t = std::vector<ssx::semaphore_units>;
-    ::mutex lock;
+    ::mutex lock{"rpc_integration_fixture"};
     units_t units;
     units.push_back(std::move(lock.get_units().get()));
 
@@ -536,7 +536,7 @@ FIXTURE_TEST(test_cleanup_on_timeout_before_sending, rpc_integration_fixture) {
     // case resource units must be returned before the request finishes.
     std::vector<ss::future<>> requests;
     for (size_t i = 0; i < num_reqs; ++i) {
-        auto lock = ss::make_lw_shared<::mutex>();
+        auto lock = ss::make_lw_shared<::mutex>("rpc_integration_fixture");
 
         auto units = lock->try_get_units();
         BOOST_REQUIRE(units);

--- a/src/v/security/audit/audit_log_manager.cc
+++ b/src/v/security/audit/audit_log_manager.cc
@@ -160,7 +160,7 @@ private:
     /// Primitives for ensuring background work and toggling of switch w/ async
     /// work occur in lock step
     ss::gate _gate;
-    mutex _mutex;
+    mutex _mutex{"audit_log_manager::mutex"};
 
     /// In the case the client did not finish intialization this optional may be
     /// fufilled by a fiber attempting to shutdown the client. The future will

--- a/src/v/ssx/sharded_ptr.h
+++ b/src/v/ssx/sharded_ptr.h
@@ -120,7 +120,7 @@ private:
     }
     ss::shard_id _shard;
     std::vector<std::shared_ptr<T>> _state;
-    mutex _mutex;
+    mutex _mutex{"sharded_ptr"};
 };
 
 } // namespace ssx

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -315,7 +315,7 @@ private:
     model::offset _start_offset;
     // Used to serialize updates to _start_offset. See the update_start_offset
     // method.
-    mutex _start_offset_lock;
+    mutex _start_offset_lock{"disk_log_impl::start_offset_lock"};
     lock_manager _lock_mngr;
     std::unique_ptr<storage::probe> _probe;
     failure_probes _failure_probes;
@@ -330,7 +330,7 @@ private:
     // repeatedly takes+releases segment read locks, and without this extra
     // coarse grained lock, the compaction can happen in between steps.
     // See https://github.com/redpanda-data/redpanda/issues/7118
-    mutex _segment_rewrite_lock;
+    mutex _segment_rewrite_lock{"segment_rewrite_lock"};
 
     // Bytes written since last time we requested stm snapshot
     ssx::semaphore_units _stm_dirty_bytes_units;
@@ -344,7 +344,7 @@ private:
     // We need to take this irrespective of whether we're actually rolling or
     // not, in order to ensure that writers wait for a background roll to
     // complete if one is ongoing.
-    mutex _segments_rolling_lock;
+    mutex _segments_rolling_lock{"segments_rolling_lock"};
     // This counter is incremented when the log is truncated. It doesn't
     // count logical truncations and can be incremented multiple times.
     size_t _suffix_truncation_indicator{0};

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -162,7 +162,7 @@ private:
     ssx::semaphore _sem{0, "s/kvstore"};
     ss::lw_shared_ptr<segment> _segment;
     // Protect _db and _next_offset across asynchronous mutations.
-    mutex _db_mut;
+    mutex _db_mut{"kvstore::db_mut"};
     model::offset _next_offset;
     absl::btree_map<bytes, iobuf, bytes_type_cmp> _db;
     std::optional<ntp_sanitizer_config> _ntp_sanitizer_config;

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -712,7 +712,8 @@ ss::future<> log_manager::dispatch_topic_dir_deletion(ss::sstring dir) {
     return ss::smp::submit_to(
              0,
              [dir = std::move(dir)]() mutable {
-                 static thread_local mutex fs_lock;
+                 static thread_local mutex fs_lock{
+                   "dispatch_topic_dir_deletion"};
                  return fs_lock.with([dir = std::move(dir)] {
                      return ss::file_exists(dir).then([dir](bool exists) {
                          if (!exists) {

--- a/src/v/storage/segment_reader.h
+++ b/src/v/storage/segment_reader.h
@@ -155,7 +155,7 @@ private:
 
     // Protects open/close of _data_file, to avoid double-opening on
     // concurrent calls to get()
-    mutex _open_lock;
+    mutex _open_lock{"segment_reader::open_lock"};
 
     // This is only initialized if _data_file_refcount is greater than zero
     ss::file _data_file;

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2081,7 +2081,7 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
           std::move(appender), model::no_timeout);
     };
 
-    mutex write_mutex;
+    mutex write_mutex{"e2e_test::write_mutex"};
     /**
      * Sequence of events is as follow:
      *
@@ -2461,7 +2461,7 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
 
     int cnt = 0;
     int max = 500;
-    mutex log_mutex;
+    mutex log_mutex{"e2e_test::log_mutex"};
     auto produce = ss::do_until(
       [&] { return cnt > max; },
       [&log, &cnt, &log_mutex] {
@@ -2583,7 +2583,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
     int cnt = 0;
     int max = 50;
     bool done = false;
-    mutex log_mutex;
+    mutex log_mutex{"e2e_test::log_mutex"};
     auto produce
       = ss::do_until(
           [&] { return cnt > max || done; },
@@ -3379,7 +3379,7 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
 
     int cnt = 0;
     int max = 500;
-    mutex log_mutex;
+    mutex log_mutex{"e2e_test::log_mutex"};
     model::offset last_truncate;
 
     auto produce = ss::do_until(

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -397,7 +397,7 @@ public:
     }
 
 private:
-    mutex _mu;
+    mutex _mu{"proc_factory"};
     wasm_engine_factory _wasm_engine_factory;
     cluster::partition_manager* _partition_manager;
     rpc::client* _client;

--- a/src/v/transform/rpc/client.h
+++ b/src/v/transform/rpc/client.h
@@ -204,7 +204,8 @@ private:
     ss::sharded<local_service>* _local_service;
     ss::abort_source _as;
     ss::gate _gate;
-    mutex _wasm_binary_max_size_updater_mu;
+    mutex _wasm_binary_max_size_updater_mu{
+      "client::wasm_binary_max_size_updater"};
     config::binding<size_t> _max_wasm_binary_size;
 };
 

--- a/src/v/utils/mutex.h
+++ b/src/v/utils/mutex.h
@@ -34,10 +34,6 @@ public:
     using time_point = typename ss::semaphore::time_point;
     using units = typename ssx::semaphore_units;
 
-    // TODO: stop using this constructor and force usage of explicit names.
-    mutex()
-      : _sem(1, "mutex") {}
-
     explicit mutex(ss::sstring name)
       : _sem(1, std::move(name)) {}
 

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -118,7 +118,7 @@ public:
     }
 
 private:
-    mutex _mu;
+    mutex _mu{"wasm_shared_engine"};
     size_t _ref_count = 0;
     ss::shared_ptr<engine> _underlying;
     // This factory reference is here to keep the cache entry alive.
@@ -146,7 +146,8 @@ public:
         auto it = mu_map->find(offset);
         mutex* mu = nullptr;
         if (it == mu_map->end()) {
-            auto inserted = mu_map->emplace(offset, std::make_unique<mutex>());
+            auto inserted = mu_map->emplace(
+              offset, std::make_unique<mutex>("factory_creation_lock_guard"));
             vassert(inserted.second, "expected mutex to be inserted");
             mu = inserted.first->second.get();
         } else {
@@ -205,7 +206,7 @@ public:
     ss::future<int64_t> gc() { return gc_btree_map(&_cache); }
 
 private:
-    mutex _mu;
+    mutex _mu{"wasm_engine_cache"};
     absl::btree_map<model::offset, ss::weak_ptr<shared_engine>> _cache;
 };
 


### PR DESCRIPTION
Certain structures like semaphore and mutex can be "named" which is
useful to identify a particular structure in log messages, exceptions
or just about anything you can imagine.

When we added support for named mutexes, we did not give names to all
existing mutexes, perhaps because there are a lot of them: the
unnamed version of the constructor was left and removing it was
left as a TODO.

This series crosses that TODO off the list and names all existing
mutexes that weren't already named and removes the unnamed
constructor. 

See also #5489.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
