### PR TITLE
increased a timeout for cluster replicas

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -1159,7 +1159,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         return self.redpanda.kubectl.cmd([
             'wait', 'cluster', cluster_name, '-n=redpanda',
             "--for=jsonpath='{.status.readyReplicas}'=" + str(ready_replicas),
-            '--timeout=600s'
+            '--timeout=900s'
         ]).decode()
 
     def _patch_cluster_replicas(self, cluster_name, replicas):

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -1159,7 +1159,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         return self.redpanda.kubectl.cmd([
             'wait', 'cluster', cluster_name, '-n=redpanda',
             "--for=jsonpath='{.status.readyReplicas}'=" + str(ready_replicas),
-            '--timeout=900s'
+            '--timeout=1200s'
         ]).decode()
 
     def _patch_cluster_replicas(self, cluster_name, replicas):


### PR DESCRIPTION
Buildkite HTT failure: 12163

## Backports Required
- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

### Bug Fixes
This change should make sure that HTT tests pass when checking for cluster replicas status. Based on logs, 10 minutes seems to be not enough.

### Improvements
This change should make sure that HTT tests pass when checking for cluster replicas status. Based on logs, 10 minutes seems to be not enough.


[INFO - 2024-03-07 06:11:53,073 - high_throughput_test - _stage_add_and_decommission - lineno:1259]: scaling out cluster rp-cnkk9q2vmreg2bvgr9jg from 3 to 4 [INFO - 2024-03-07 06:11:53,645 - high_throughput_test - _stage_add_and_decommission - lineno:1264]: waiting for cluster rp-cnkk9q2vmreg2bvgr9jg to have ready replicas 4 ... ... [INFO - 2024-03-07 06:21:58,549 - kubectl - _cmd - lineno:161]: Command failed (rc=1). --------- stdout ----------- --------- stderr ----------- error: timed out waiting for the condition on clusters/rp-cnkk9q2vmreg2bvgr9jg ERROR: Process exited with status 1

Update:
Message from Simon,

It timed out waiting for 4th pod to appear. i see the timeout is 600 seconds (10 minutes) i think to add a node will take approx (7mins to reconcile, and 3mins to launch, reboot, then configure xfs raid before pod starts) - so 10 minutes is too tight. Best to increase that to 20mins IMO.

So increasing it to 20 minutes based on discussion 