### PR TITLE
cluster: Avoid oversize allocs for topic creation and configuration

### DIFF
--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -283,7 +283,8 @@ FIXTURE_TEST(recovery_with_existing_topic, fixture) {
         {model::ns{"kafka"}, model::topic{"test"}, 1, 1}}}};
     auto topic_create_result = app.controller->get_topics_frontend()
                                  .local()
-                                 .create_topics(topic_cfg, model::no_timeout)
+                                 .create_topics(
+                                   std::move(topic_cfg), model::no_timeout)
                                  .get();
     wait_for_topics(std::move(topic_create_result)).get();
     set_expectations_and_listen(

--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -278,10 +278,9 @@ FIXTURE_TEST(recovery_with_missing_topic_manifest, fixture) {
 }
 
 FIXTURE_TEST(recovery_with_existing_topic, fixture) {
-    cluster::topic_configuration cfg{
-      model::ns{"kafka"}, model::topic{"test"}, 1, 1};
-    std::vector<cluster::custom_assignable_topic_configuration> topic_cfg = {
-      cluster::custom_assignable_topic_configuration{std::move(cfg)}};
+    cluster::custom_assignable_topic_configuration_vector topic_cfg{
+      {cluster::custom_assignable_topic_configuration{
+        {model::ns{"kafka"}, model::topic{"test"}, 1, 1}}}};
     auto topic_create_result = app.controller->get_topics_frontend()
                                  .local()
                                  .create_topics(topic_cfg, model::no_timeout)

--- a/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
+++ b/src/v/cluster/cloud_metadata/cluster_recovery_backend.cc
@@ -230,7 +230,7 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
     case recovery_stage::recovered_remote_topic_data: {
         retry_chain_node topics_retry(&parent_retry);
         // TODO: batch this up.
-        std::vector<topic_configuration> topics;
+        topic_configuration_vector topics;
         for (size_t i = 0; i < actions.remote_topics.size(); i++) {
             auto& topic_cfg = actions.remote_topics[i];
             if (topic_cfg.is_internal()) {
@@ -259,7 +259,7 @@ ss::future<cluster::errc> cluster_recovery_backend::do_action(
     case recovery_stage::recovered_topic_data: {
         retry_chain_node topics_retry(&parent_retry);
         // TODO: batch this up.
-        std::vector<topic_configuration> topics;
+        topic_configuration_vector topics;
         for (size_t i = 0; i < actions.local_topics.size(); i++) {
             topics.emplace_back(std::move(actions.local_topics[i]));
             vlog(clusterlog.debug, "Creating topic {}", topics.back().tp_ns);

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -111,9 +111,9 @@ bool are_replica_sets_equal(
     return l_sorted == r_sorted;
 }
 
-std::vector<custom_assignable_topic_configuration>
-without_custom_assignments(std::vector<topic_configuration> topics) {
-    std::vector<custom_assignable_topic_configuration> assignable_topics;
+custom_assignable_topic_configuration_vector
+without_custom_assignments(topic_configuration_vector topics) {
+    custom_assignable_topic_configuration_vector assignable_topics;
     assignable_topics.reserve(topics.size());
     std::transform(
       std::make_move_iterator(topics.begin()),

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -25,6 +25,7 @@
 #include <seastar/core/future.hh>
 
 #include <chrono>
+#include <iterator>
 
 namespace cluster {
 
@@ -115,8 +116,8 @@ without_custom_assignments(std::vector<topic_configuration> topics) {
     std::vector<custom_assignable_topic_configuration> assignable_topics;
     assignable_topics.reserve(topics.size());
     std::transform(
-      topics.begin(),
-      topics.end(),
+      std::make_move_iterator(topics.begin()),
+      std::make_move_iterator(topics.end()),
       std::back_inserter(assignable_topics),
       [](topic_configuration cfg) {
           return custom_assignable_topic_configuration(std::move(cfg));

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -193,8 +193,8 @@ ss::future<std::error_code> replicate_and_wait(
       });
 }
 
-std::vector<custom_assignable_topic_configuration>
-  without_custom_assignments(std::vector<topic_configuration>);
+custom_assignable_topic_configuration_vector
+  without_custom_assignments(topic_configuration_vector);
 
 template<class T>
 inline std::vector<T>

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -158,10 +158,10 @@ service::purged_topic(purged_topic_request r, rpc::streaming_context&) {
         [](topic_result res) { return purged_topic_reply(std::move(res)); });
 }
 
-std::pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
+std::pair<std::vector<model::topic_metadata>, topic_configuration_vector>
 service::fetch_metadata_and_cfg(const std::vector<topic_result>& res) {
     std::vector<model::topic_metadata> md;
-    std::vector<topic_configuration> cfg;
+    topic_configuration_vector cfg;
     md.reserve(res.size());
     for (const auto& r : res) {
         if (r.ec == errc::success) {

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -237,7 +237,7 @@ service::do_update_topic_properties(update_topic_properties_request req) {
     // local topic frontend instance will eventually dispatch request to _raft0
     // core
     auto res = co_await _topics_frontend.local().update_topic_properties(
-      req.updates,
+      std::move(req).updates,
       config::shard_local_cfg().replicate_append_timeout_ms()
         + model::timeout_clock::now());
 

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -137,9 +137,8 @@ public:
 
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
-    std::
-      pair<std::vector<model::topic_metadata>, std::vector<topic_configuration>>
-      fetch_metadata_and_cfg(const std::vector<topic_result>&);
+    std::pair<std::vector<model::topic_metadata>, topic_configuration_vector>
+    fetch_metadata_and_cfg(const std::vector<topic_result>&);
 
     ss::future<finish_partition_update_reply>
       do_finish_partition_update(finish_partition_update_request);

--- a/src/v/cluster/tests/autocreate_test.cc
+++ b/src/v/cluster/tests/autocreate_test.cc
@@ -25,9 +25,9 @@
 #include <chrono>
 #include <vector>
 
-std::vector<cluster::topic_configuration> test_topics_configuration(
+cluster::topic_configuration_vector test_topics_configuration(
   cluster::replication_factor rf = cluster::replication_factor{1}) {
-    return std::vector<cluster::topic_configuration>{
+    return cluster::topic_configuration_vector{
       cluster::topic_configuration(test_ns, model::topic("tp-1"), 10, rf),
       cluster::topic_configuration(test_ns, model::topic("tp-2"), 10, rf),
       cluster::topic_configuration(test_ns, model::topic("tp-3"), 10, rf),

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -221,7 +221,7 @@ public:
               return it.second->app.controller->is_raft0_leader();
           });
         auto& app_0 = leader_it->second->app;
-        std::vector<cluster::topic_configuration> cfgs = {
+        cluster::topic_configuration_vector cfgs = {
           cluster::topic_configuration{
             tp_ns.ns, tp_ns.tp, partitions, replication_factor}};
         auto results = app_0.controller->get_topics_frontend()

--- a/src/v/cluster/tests/controller_api_tests.cc
+++ b/src/v/cluster/tests/controller_api_tests.cc
@@ -45,7 +45,7 @@ FIXTURE_TEST(test_querying_ntp_status, cluster_test_fixture) {
     auto leader = get_node_application(*leader_id);
 
     // create topic
-    std::vector<cluster::topic_configuration> topics;
+    cluster::topic_configuration_vector topics;
     topics.emplace_back(test_ntp.ns, test_ntp.tp.topic, 3, 1);
 
     leader->controller->get_topics_frontend()

--- a/src/v/cluster/tests/controller_api_tests.cc
+++ b/src/v/cluster/tests/controller_api_tests.cc
@@ -51,7 +51,7 @@ FIXTURE_TEST(test_querying_ntp_status, cluster_test_fixture) {
     leader->controller->get_topics_frontend()
       .local()
       .create_topics(
-        cluster::without_custom_assignments(topics),
+        cluster::without_custom_assignments(std::move(topics)),
         1s + model::timeout_clock::now())
       .get();
 

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -221,12 +221,11 @@ FIXTURE_TEST(test_ntp_filter, cluster_test_fixture) {
     }).get();
 
     // create topics
-    std::vector<cluster::topic_configuration> topics;
-    topics.push_back(topic_cfg(model::kafka_namespace, "tp-1", 3, 3));
-    topics.push_back(topic_cfg(model::kafka_namespace, "tp-2", 3, 2));
-    topics.push_back(topic_cfg(model::kafka_namespace, "tp-3", 3, 1));
-    topics.push_back(
-      topic_cfg(model::kafka_internal_namespace, "internal-1", 3, 2));
+    cluster::topic_configuration_vector topics{
+      topic_cfg(model::kafka_namespace, "tp-1", 3, 3),
+      topic_cfg(model::kafka_namespace, "tp-2", 3, 2),
+      topic_cfg(model::kafka_namespace, "tp-3", 3, 1),
+      topic_cfg(model::kafka_internal_namespace, "internal-1", 3, 2)};
 
     n1->controller->get_topics_frontend()
       .local()

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -88,7 +88,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE_EQUAL(cache_2.node_count(), 3);
 
     // Create topic with replication factor 1
-    std::vector<cluster::topic_configuration> topics;
+    cluster::topic_configuration_vector topics;
     topics.emplace_back(model::ns("default"), model::topic("test_1"), 3, 1);
     cntrl_0->controller->get_topics_frontend()
       .local()
@@ -122,7 +122,7 @@ FIXTURE_TEST(test_metadata_dissemination_joining_node, cluster_test_fixture) {
     BOOST_REQUIRE_EQUAL(cache_1.node_count(), 2);
 
     // Create topic with replication factor 1
-    std::vector<cluster::topic_configuration> topics;
+    cluster::topic_configuration_vector topics;
     topics.emplace_back(model::ns("default"), model::topic("test_1"), 3, 1);
     cntrl_0->controller->get_topics_frontend()
       .local()

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1698,7 +1698,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(data);
     }
     {
-        std::vector<cluster::topic_configuration> topics;
+        cluster::topic_configuration_vector topics;
         for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
             topics.push_back(random_topic_configuration());
         }

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1337,7 +1337,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         roundtrip_test(data);
     }
     {
-        std::vector<cluster::topic_properties_update> updates;
+        cluster::topic_properties_update_vector updates;
         for (int i = 0, mi = random_generators::get_int(10); i < mi; i++) {
             cluster::property_update<std::optional<v8_engine::data_policy>>
               data_policy;
@@ -1350,16 +1350,15 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
             cluster::incremental_topic_custom_updates custom_properties{
               .data_policy = data_policy,
             };
-            updates.push_back(cluster::topic_properties_update{
+            updates.emplace_back(
               model::random_topic_namespace(),
               random_incremental_topic_updates(),
-              custom_properties,
-            });
+              custom_properties);
         }
         cluster::update_topic_properties_request data{
-          .updates = updates,
+          .updates = std::move(updates),
         };
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
     }
     {
         cluster::topic_result data{

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1703,13 +1703,13 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
             topics.push_back(random_topic_configuration());
         }
         cluster::create_topics_request data{
-          .topics = topics,
+          .topics = std::move(topics),
           .timeout = random_timeout_clock_duration(),
         };
         // adl encoding for topic_configuration doesn't encode/decode to exact
         // equality, but also already existed prior to serde support being added
         // so only testing the serde case.
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
     }
     {
         auto data = random_partition_metadata();
@@ -1743,7 +1743,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         // adl serialization doesn't preserve equality for topic_configuration.
         // serde serialization does and was added after support for adl so adl
         // semantics are preserved.
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
     }
     {
         raft::transfer_leadership_request data{

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -420,7 +420,8 @@ topic_recovery_service::create_topics(const recovery_request& request) {
       [&request](const auto& m) { return make_topic_config(m, request); });
 
     co_return co_await _topics_frontend.local().autocreate_topics(
-      topic_configs, config::shard_local_cfg().create_topic_timeout_ms());
+      std::move(topic_configs),
+      config::shard_local_cfg().create_topic_timeout_ms());
 }
 
 ss::future<std::vector<cloud_storage::topic_manifest>>

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -16,6 +16,7 @@
 #include "cloud_storage/topic_manifest.h"
 #include "cluster/topic_recovery_status_frontend.h"
 #include "cluster/topics_frontend.h"
+#include "cluster/types.h"
 
 #include <seastar/http/request.hh>
 #include <seastar/util/defer.hh>
@@ -533,7 +534,7 @@ ss::future<> topic_recovery_service::reset_topic_configurations() {
         co_return;
     }
 
-    std::vector<cluster::topic_properties_update> updates;
+    cluster::topic_properties_update_vector updates;
     updates.reserve(_downloaded_manifests->size());
     std::transform(
       std::make_move_iterator(_downloaded_manifests->begin()),

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -410,7 +410,7 @@ static cluster::topic_configuration make_topic_config(
 
 ss::future<std::vector<cluster::topic_result>>
 topic_recovery_service::create_topics(const recovery_request& request) {
-    std::vector<cluster::topic_configuration> topic_configs;
+    cluster::topic_configuration_vector topic_configs;
     topic_configs.reserve(_downloaded_manifests->size());
 
     std::transform(

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -108,7 +108,7 @@ needs_linearizable_barrier(const std::vector<topic_result>& results) {
 }
 
 ss::future<std::vector<topic_result>> topics_frontend::create_topics(
-  std::vector<custom_assignable_topic_configuration> topics,
+  custom_assignable_topic_configuration_vector topics,
   model::timeout_clock::time_point timeout) {
     for (auto& tp : topics) {
         /**
@@ -770,8 +770,7 @@ ss::future<topic_result> topics_frontend::do_purged_topic(
 }
 
 ss::future<std::vector<topic_result>> topics_frontend::autocreate_topics(
-  std::vector<topic_configuration> topics,
-  model::timeout_clock::duration timeout) {
+  topic_configuration_vector topics, model::timeout_clock::duration timeout) {
     vlog(clusterlog.trace, "Auto create topics {}", topics);
 
     auto leader = _leaders.local().get_leader(model::controller_ntp);
@@ -795,7 +794,7 @@ ss::future<std::vector<topic_result>> topics_frontend::autocreate_topics(
 ss::future<std::vector<topic_result>>
 topics_frontend::dispatch_create_to_leader(
   model::node_id leader,
-  std::vector<topic_configuration> topics,
+  topic_configuration_vector topics,
   model::timeout_clock::duration timeout) {
     vlog(clusterlog.trace, "Dispatching create topics to {}", leader);
     auto r = co_await _connections.local()

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -803,7 +803,8 @@ topics_frontend::dispatch_create_to_leader(
                  ss::this_shard_id(),
                  leader,
                  timeout,
-                 [topics, timeout](controller_client_protocol cp) mutable {
+                 [topics{topics.copy()},
+                  timeout](controller_client_protocol cp) mutable {
                      return cp.create_topics(
                        create_topics_request{
                          .topics = std::move(topics), .timeout = timeout},

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -62,7 +62,7 @@ public:
       config::binding<int16_t>);
 
     ss::future<std::vector<topic_result>> create_topics(
-      std::vector<custom_assignable_topic_configuration>,
+      custom_assignable_topic_configuration_vector,
       model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> delete_topics(
@@ -83,7 +83,7 @@ public:
       do_purged_topic(nt_revision, model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> autocreate_topics(
-      std::vector<topic_configuration>, model::timeout_clock::duration);
+      topic_configuration_vector, model::timeout_clock::duration);
 
     ss::future<std::error_code> move_partition_replicas(
       model::ntp,
@@ -210,7 +210,7 @@ private:
 
     ss::future<std::vector<topic_result>> dispatch_create_to_leader(
       model::node_id,
-      std::vector<topic_configuration>,
+      topic_configuration_vector,
       model::timeout_clock::duration);
 
     ss::future<topic_result> dispatch_purged_topic_to_leader(

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -152,7 +152,7 @@ public:
       std::optional<model::term_id> = std::nullopt);
 
     ss::future<std::vector<topic_result>> update_topic_properties(
-      std::vector<topic_properties_update>, model::timeout_clock::time_point);
+      topic_properties_update_vector, model::timeout_clock::time_point);
 
     ss::future<std::vector<topic_result>> create_partitions(
       std::vector<create_partitions_configuration>,

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -1380,7 +1380,7 @@ adl<cluster::create_topics_request>::from(iobuf io) {
 
 cluster::create_topics_request
 adl<cluster::create_topics_request>::from(iobuf_parser& in) {
-    using underlying_t = std::vector<cluster::topic_configuration>;
+    using underlying_t = cluster::topic_configuration_vector;
     auto configs = adl<underlying_t>().from(in);
     auto timeout = adl<model::timeout_clock::duration>().from(in);
     return cluster::create_topics_request{
@@ -1401,7 +1401,7 @@ cluster::create_topics_reply
 adl<cluster::create_topics_reply>::from(iobuf_parser& in) {
     auto results = adl<std::vector<cluster::topic_result>>().from(in);
     auto md = adl<std::vector<model::topic_metadata>>().from(in);
-    auto cfg = adl<std::vector<cluster::topic_configuration>>().from(in);
+    auto cfg = adl<cluster::topic_configuration_vector>().from(in);
     return cluster::create_topics_reply{
       std::move(results), std::move(md), std::move(cfg)};
 }

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1943,7 +1943,7 @@ struct topic_configuration
       = default;
 };
 
-using topic_configuration_vector = std::vector<topic_configuration>;
+using topic_configuration_vector = chunked_vector<topic_configuration>;
 
 struct custom_partition_assignment {
     model::partition_id id;
@@ -1972,7 +1972,7 @@ struct custom_assignable_topic_configuration {
 };
 
 using custom_assignable_topic_configuration_vector
-  = std::vector<custom_assignable_topic_configuration>;
+  = chunked_vector<custom_assignable_topic_configuration>;
 
 struct create_partitions_configuration
   : serde::envelope<
@@ -2188,6 +2188,10 @@ struct create_topics_request
     operator<<(std::ostream&, const create_topics_request&);
 
     auto serde_fields() { return std::tie(topics, timeout); }
+
+    create_topics_request copy() const {
+        return {.topics = topics.copy(), .timeout = timeout};
+    }
 };
 
 struct create_topics_reply
@@ -2215,6 +2219,10 @@ struct create_topics_reply
     friend std::ostream& operator<<(std::ostream&, const create_topics_reply&);
 
     auto serde_fields() { return std::tie(results, metadata, configs); }
+
+    create_topics_reply copy() const {
+        return {results, metadata, configs.copy()};
+    }
 };
 
 struct purged_topic_request

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1943,6 +1943,8 @@ struct topic_configuration
       = default;
 };
 
+using topic_configuration_vector = std::vector<topic_configuration>;
+
 struct custom_partition_assignment {
     model::partition_id id;
     std::vector<model::node_id> replicas;
@@ -1968,6 +1970,9 @@ struct custom_assignable_topic_configuration {
     friend std::ostream&
     operator<<(std::ostream&, const custom_assignable_topic_configuration&);
 };
+
+using custom_assignable_topic_configuration_vector
+  = std::vector<custom_assignable_topic_configuration>;
 
 struct create_partitions_configuration
   : serde::envelope<
@@ -2172,7 +2177,7 @@ struct create_topics_request
       create_topics_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    std::vector<topic_configuration> topics;
+    topic_configuration_vector topics;
     model::timeout_clock::duration timeout;
 
     friend bool
@@ -2192,13 +2197,13 @@ struct create_topics_reply
       serde::compat_version<0>> {
     std::vector<topic_result> results;
     std::vector<model::topic_metadata> metadata;
-    std::vector<topic_configuration> configs;
+    topic_configuration_vector configs;
 
     create_topics_reply() noexcept = default;
     create_topics_reply(
       std::vector<topic_result> results,
       std::vector<model::topic_metadata> metadata,
-      std::vector<topic_configuration> configs)
+      topic_configuration_vector configs)
       : results(std::move(results))
       , metadata(std::move(metadata))
       , configs(std::move(configs)) {}

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1873,6 +1873,8 @@ struct topic_properties_update
     }
 };
 
+using topic_properties_update_vector = chunked_vector<topic_properties_update>;
+
 // Structure holding topic configuration, optionals will be replaced by broker
 // defaults
 struct topic_configuration
@@ -2307,7 +2309,7 @@ struct update_topic_properties_request
       update_topic_properties_request,
       serde::version<0>,
       serde::compat_version<0>> {
-    std::vector<topic_properties_update> updates;
+    topic_properties_update_vector updates;
 
     friend std::ostream&
     operator<<(std::ostream&, const update_topic_properties_request&);
@@ -2318,6 +2320,10 @@ struct update_topic_properties_request
       = default;
 
     auto serde_fields() { return std::tie(updates); }
+
+    update_topic_properties_request copy() const {
+        return {.updates = updates.copy()};
+    }
 };
 
 struct update_topic_properties_reply
@@ -5088,8 +5094,7 @@ struct adl<cluster::update_topic_properties_request> {
         serialize(out, std::move(r.updates));
     }
     cluster::update_topic_properties_request from(iobuf_parser& in) {
-        auto updates
-          = adl<std::vector<cluster::topic_properties_update>>{}.from(in);
+        auto updates = adl<cluster::topic_properties_update_vector>{}.from(in);
         return {.updates = std::move(updates)};
     }
 };

--- a/src/v/compat/check.h
+++ b/src/v/compat/check.h
@@ -270,11 +270,11 @@ void verify_serde_round_trip(T, compat_binary test) {
         }                                                                      \
                                                                                \
         static std::vector<compat_binary> to_binary(Type obj) {                \
-            return compat_binary::serde_and_adl(obj);                          \
+            return compat_binary::serde_and_adl(std::move(obj));               \
         }                                                                      \
                                                                                \
         static void check(Type obj, compat_binary test) {                      \
-            verify_adl_or_serde(obj, std::move(test));                         \
+            verify_adl_or_serde(std::move(obj), std::move(test));              \
         }                                                                      \
     };
 

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -431,7 +431,7 @@ template<>
 struct compat_check<cluster::topic_configuration> {
     static constexpr std::string_view name = "cluster::topic_configuration";
 
-    static std::vector<cluster::topic_configuration> create_test_cases() {
+    static cluster::topic_configuration_vector create_test_cases() {
         return generate_instances<cluster::topic_configuration>();
     }
 

--- a/src/v/compat/cluster_compat.h
+++ b/src/v/compat/cluster_compat.h
@@ -432,7 +432,9 @@ struct compat_check<cluster::topic_configuration> {
     static constexpr std::string_view name = "cluster::topic_configuration";
 
     static cluster::topic_configuration_vector create_test_cases() {
-        return generate_instances<cluster::topic_configuration>();
+        auto i = generate_instances<cluster::topic_configuration>();
+        return {
+          std::make_move_iterator(i.begin()), std::make_move_iterator(i.end())};
     }
 
     static void to_json(
@@ -521,12 +523,12 @@ struct compat_check<cluster::create_topics_request> {
 
     static std::vector<compat_binary>
     to_binary(cluster::create_topics_request obj) {
-        return compat_binary::serde_and_adl(obj);
+        return compat_binary::serde_and_adl(std::move(obj));
     }
 
     static void check(cluster::create_topics_request obj, compat_binary test) {
         if (test.name == "serde") {
-            verify_serde_only(obj, test);
+            verify_serde_only(obj.copy(), test);
             return;
         }
         vassert(test.name == "adl", "Unknown compat_binary format encounterd");
@@ -586,12 +588,12 @@ struct compat_check<cluster::create_topics_reply> {
 
     static std::vector<compat_binary>
     to_binary(cluster::create_topics_reply obj) {
-        return compat_binary::serde_and_adl(obj);
+        return compat_binary::serde_and_adl(std::move(obj));
     }
 
     static void check(cluster::create_topics_reply obj, compat_binary test) {
         if (test.name == "serde") {
-            verify_serde_only(obj, test);
+            verify_serde_only(obj.copy(), test);
             return;
         }
         vassert(test.name == "adl", "Unknown compat_binary format encounterd");

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -669,7 +669,7 @@ template<>
 struct instance_generator<cluster::create_topics_request> {
     static cluster::create_topics_request random() {
         return {
-          .topics = tests::random_vector(
+          .topics = tests::random_chunked_vector(
             [] {
                 return instance_generator<
                   cluster::topic_configuration>::random();
@@ -689,7 +689,7 @@ struct instance_generator<cluster::create_topics_reply> {
             [] { return instance_generator<cluster::topic_result>::random(); }),
           tests::random_vector(
             [] { return instance_generator<model::topic_metadata>::random(); }),
-          tests::random_vector([] {
+          tests::random_chunked_vector([] {
               return instance_generator<cluster::topic_configuration>::random();
           })};
     }

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -809,7 +809,7 @@ struct instance_generator<cluster::topic_properties_update> {
 template<>
 struct instance_generator<cluster::update_topic_properties_request> {
     static cluster::update_topic_properties_request random() {
-        return {.updates = tests::random_vector([] {
+        return {.updates = tests::random_chunked_vector([] {
                     return instance_generator<
                       cluster::topic_properties_update>::random();
                 })};

--- a/src/v/kafka/server/handlers/configs/config_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_utils.h
@@ -217,7 +217,7 @@ ss::future<std::vector<R>> do_alter_topics_configuration(
           error_code::invalid_config,
           "duplicated topic {} alter config request"));
     }
-    std::vector<cluster::topic_properties_update> updates;
+    cluster::topic_properties_update_vector updates;
     for (auto& r : boost::make_iterator_range(resources.begin(), valid_end)) {
         auto res = f(r);
         if (res.has_error()) {

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -122,8 +122,8 @@ requires(KafkaApiTypeIter it) {
 }
 // clang-format on
 auto to_cluster_type(KafkaApiTypeIter begin, KafkaApiTypeIter end)
-  -> std::vector<decltype(to_cluster_type(*begin))> {
-    std::vector<decltype(to_cluster_type(*begin))> cluster_types;
+  -> chunked_vector<decltype(to_cluster_type(*begin))> {
+    chunked_vector<decltype(to_cluster_type(*begin))> cluster_types;
     cluster_types.reserve(std::distance(begin, end));
     std::transform(
       begin,

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -558,7 +558,7 @@ public:
       std::optional<cluster::topic_properties> props = std::nullopt,
       int16_t replication_factor = 1,
       bool wait = true) {
-        std::vector<cluster::topic_configuration> cfgs = {
+        cluster::topic_configuration_vector cfgs = {
           cluster::topic_configuration{
             tp_ns.ns, tp_ns.tp, partitions, replication_factor}};
         if (props.has_value()) {

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -77,10 +77,18 @@ auto random_tristate(Func f) {
 }
 
 template<typename Fn, typename T = std::invoke_result_t<Fn>>
-inline auto random_vector(Fn&& gen, size_t size = 20) -> std::vector<T> {
+auto random_vector(Fn&& gen, size_t size = 20) -> std::vector<T> {
     std::vector<T> v;
     v.resize(size);
     std::generate_n(v.begin(), size, gen);
+    return v;
+}
+
+template<typename Fn, typename T = std::invoke_result_t<Fn>>
+auto random_chunked_vector(Fn&& gen, size_t size = 20) -> chunked_vector<T> {
+    chunked_vector<T> v;
+    v.reserve(size);
+    std::generate_n(std::back_inserter(v), size, gen);
     return v;
 }
 


### PR DESCRIPTION
Convert some types from `std::vector` to `chunked_vector` to avoid oversize allocations
* `topic_configuration` (392 bytes)
* `custom_assignable_topic_configuration` (416 bytes)
* `topic_properties_update` (456 bytes)

Fixes #16758 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* cluster: Avoid oversize allocs for topic creation and configuration
