### PR TITLE
storage: space management o11y

### DIFF
--- a/src/v/resource_mgmt/storage.cc
+++ b/src/v/resource_mgmt/storage.cc
@@ -15,9 +15,11 @@
 #include "cloud_storage/cache_service.h"
 #include "cluster/node/local_monitor.h"
 #include "cluster/partition_manager.h"
+#include "prometheus/prometheus_sanitize.h"
 #include "storage/disk_log_impl.h"
 #include "utils/human.h"
 
+#include <seastar/core/metrics_registration.hh>
 #include <seastar/util/log.hh>
 
 static ss::logger rlog("resource_mgmt");
@@ -47,7 +49,8 @@ disk_space_manager::disk_space_manager(
   , _disk_reservation_percent(std::move(disk_reservation_percent))
   , _data_disk_size(_local_monitor->local().get_state_cached().data_disk.total)
   , _target_size(0)
-  , _policy(_pm, _storage) {
+  , _policy(_pm, _storage)
+  , _probe(this) {
     update_target_size(); // initialize
     _enabled.watch([this] {
         vlog(
@@ -76,6 +79,7 @@ ss::future<> disk_space_manager::start() {
         _data_disk_nid = _storage_node->local().register_disk_notification(
           node::disk_type::data,
           [this](node::disk_space_info info) { _data_disk_info = info; });
+        _probe.setup_metrics();
     }
     co_return;
 }
@@ -507,6 +511,11 @@ ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
         co_return;
     }
 
+    _probe.set_total_usage(usage.usage.total());
+    _probe.set_retention_reclaimable(usage.reclaim.retention);
+    _probe.set_available_reclaimable(usage.reclaim.available);
+    _probe.set_local_retention_reclaimable(usage.reclaim.local_retention);
+
     /*
      * inform local monitor of latest usage/reclaim info for health report
      */
@@ -541,6 +550,8 @@ ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
           human::bytes(config::shard_local_cfg().log_segment_size()),
           human::bytes(target_size));
         _previous_reclaim = false;
+        _probe.set_target_excess(0);
+        _probe.set_reclaim_estimate(0);
         co_return;
     }
     _previous_reclaim = true;
@@ -558,6 +569,7 @@ ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
     const auto target_excess = static_cast<uint64_t>(
       real_target_excess
       * config::shard_local_cfg().retention_local_trim_overage_coeff());
+    _probe.set_target_excess(target_excess);
 
     /*
      * when log storage has exceeded the target usage, then there are some knobs
@@ -595,21 +607,30 @@ ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
         if (schedule.sched_size > 0) {
             auto estimate = _policy.evict_until_local_retention(
               schedule, target_excess);
+            _probe.set_reclaim_local(estimate);
 
             if (estimate < target_excess) {
-                estimate += _policy.evict_until_low_space_non_hinted(
+                const auto amount = _policy.evict_until_low_space_non_hinted(
                   schedule, target_excess - estimate);
+                _probe.set_reclaim_low_non_hinted(amount);
+                estimate += amount;
             }
 
             if (estimate < target_excess) {
-                estimate += _policy.evict_until_low_space_hinted(
+                const auto amount = _policy.evict_until_low_space_hinted(
                   schedule, target_excess - estimate);
+                _probe.set_reclaim_low_hinted(amount);
+                estimate += amount;
             }
 
             if (estimate < target_excess) {
-                estimate += _policy.evict_until_active_segment(
+                const auto amount = _policy.evict_until_active_segment(
                   schedule, target_excess - estimate);
+                _probe.set_reclaim_active_segment(amount);
+                estimate += amount;
             }
+
+            _probe.set_reclaim_estimate(estimate);
 
             /*
              * at this point if we haven't been able to meet the target then
@@ -641,6 +662,71 @@ ss::future<> disk_space_manager::manage_data_disk(uint64_t target_size) {
      * ask storage across all nodes to apply retention rules asap.
      */
     co_await _storage->invoke_on_all([](api& api) { api.trigger_gc(); });
+}
+
+disk_space_manager::probe::probe(disk_space_manager* sm)
+  : _sm(sm) {}
+
+void disk_space_manager::probe::setup_metrics() {
+    if (config::shard_local_cfg().disable_metrics()) {
+        return;
+    }
+
+    namespace sm = ss::metrics;
+
+    const auto group_name = prometheus_sanitize::metrics_name(
+      "space_management");
+
+    std::vector<sm::impl::metric_definition_impl> defs;
+
+    /*
+     * The currently configured target size for the data disk. When disk
+     * usage exceeds this amount then the expectation is that space
+     * management will reclaim data.
+     *
+     * If space management is disabled the metric value is 0.
+     */
+    defs.emplace_back(sm::make_gauge(
+      "target_disk_size",
+      [this]() { return _sm->enabled() ? _sm->_target_size : 0; },
+      sm::description("Target maximum number of stored bytes.")));
+
+    defs.emplace_back(sm::make_gauge(
+      "total_disk_usage",
+      [this]() { return _total_usage; },
+      sm::description(
+        "Total amount of disk usage under control of space management.")));
+
+    defs.emplace_back(sm::make_gauge(
+      "total_retention_reclaimable",
+      [this]() { return _retention_reclaimable; },
+      sm::description("Total amount of reclaimable data through standard "
+                      "retention policy.")));
+
+    defs.emplace_back(sm::make_gauge(
+      "total_available_reclaimable",
+      [this]() { return _available_reclaimable; },
+      sm::description("Total amount of available reclaimable data by space "
+                      "management.")));
+
+    defs.emplace_back(sm::make_gauge(
+      "total_local_retention_reclaimable",
+      [this]() { return _local_retention_reclaimable; },
+      sm::description("Total amount of reclaimable data above the local "
+                      "retention target.")));
+
+    defs.emplace_back(sm::make_gauge(
+      "target_excess",
+      [this]() { return _target_excess; },
+      sm::description("Amount of data usage that exceeds target threshold.")));
+
+    defs.emplace_back(sm::make_gauge(
+      "reclaim_estimate",
+      [this]() { return _reclaim_estimate; },
+      sm::description("Estimated amount of data reclaimed by space "
+                      "management in last schedule.")));
+
+    _metrics.add_group(group_name, std::move(defs), {}, {sm::shard_label});
 }
 
 } // namespace storage

--- a/src/v/resource_mgmt/storage.h
+++ b/src/v/resource_mgmt/storage.h
@@ -243,6 +243,116 @@ public:
     ss::future<> stop();
 
 private:
+    class probe {
+    public:
+        explicit probe(disk_space_manager*);
+
+        void setup_metrics();
+
+        /*
+         * The total amount of data usage from the perspective of space
+         * management. This is generally a bit different from the total amount
+         * of space that redpanda is using because space management only
+         * considers data that it may eventually be able to reclaim. This value
+         * should reflect the total disk usage for both cloud and non-cloud
+         * enabled topics.
+         */
+        void set_total_usage(size_t usage) noexcept { _total_usage = usage; }
+
+        /*
+         * This is the amount of data that is currently reclaimable by the
+         * normal retention policy. Space management only kicks in when it needs
+         * to reclaim more data than is available through the normal retention
+         * mechanism.
+         */
+        void set_retention_reclaimable(size_t size) noexcept {
+            _retention_reclaimable = size;
+        }
+
+        /*
+         * The total available amount for reclaim by space management is the
+         * amount of data reclaimable by normal retention policy plus the amount
+         * of data has been uploaded into the cloud, and thus safe to remove if
+         * necessary to meet the configured usage target.
+         */
+        void set_available_reclaimable(size_t size) noexcept {
+            _available_reclaimable = size;
+        }
+
+        /*
+         * The total amount of data that can be safely reclaimed and which if
+         * reclaimed would not violate the local retention policy.
+         */
+        void set_local_retention_reclaimable(size_t size) noexcept {
+            _local_retention_reclaimable = size;
+        }
+
+        /*
+         * The amount of data usage above the target threshold. when space
+         * management runs if this value is positive then space management will
+         * try to ensure this much data is reclaimed, if that is by applying
+         * normal retention policy or applying space management over policy.
+         */
+        void set_target_excess(size_t size) noexcept { _target_excess = size; }
+
+        /*
+         * The amount of data estimated to be reclaimed by the currently
+         * installed space management schedule that is above the local retention
+         * policy setting.
+         */
+        void set_reclaim_local(size_t size) noexcept { _reclaim_local = size; }
+
+        /*
+         * The amount of data estimated to be reclaimed by the currently
+         * installed space management schedule that is above the non-hinted
+         * low-space threshold setting.
+         */
+        void set_reclaim_low_non_hinted(size_t size) noexcept {
+            _reclaim_low_non_hinted = size;
+        }
+
+        /*
+         * The amount of data estimated to be reclaimed by the currently
+         * installed space management schedule that is above the hinted
+         * low-space threshold setting.
+         */
+        void set_reclaim_low_hinted(size_t size) noexcept {
+            _reclaim_low_hinted = size;
+        }
+
+        /*
+         * The amount of data estimated to be reclaimed by the currently
+         * installed space management schedule that is above the active segment.
+         */
+        void set_reclaim_active_segment(size_t size) noexcept {
+            _reclaim_active_segment = size;
+        }
+
+        /*
+         * The amount of data that the latest reclaim schedule has estimated
+         * will be reclaimed. A positive value means that space management is
+         * trying to reclaim data that would othewise not be reclaimed by the
+         * normal retention policy.
+         */
+        void set_reclaim_estimate(size_t size) noexcept {
+            _reclaim_estimate = size;
+        }
+
+    private:
+        disk_space_manager* _sm;
+        metrics::internal_metric_groups _metrics;
+        size_t _total_usage{0};
+        size_t _retention_reclaimable{0};
+        size_t _available_reclaimable{0};
+        size_t _local_retention_reclaimable{0};
+        size_t _target_excess{0};
+        size_t _reclaim_local{0};
+        size_t _reclaim_low_non_hinted{0};
+        size_t _reclaim_low_hinted{0};
+        size_t _reclaim_active_segment{0};
+        size_t _reclaim_estimate{0};
+    };
+
     config::binding<bool> _enabled;
     config::binding<bool> _enabled_override;
     ss::sharded<cluster::node::local_monitor>* _local_monitor;
@@ -271,6 +381,7 @@ private:
     ss::future<> run_loop();
     ssx::semaphore _control_sem{0, "resource_mgmt::space_manager"};
     bool _previous_reclaim{false};
+    probe _probe;
 };
 
 } // namespace storage

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2445,6 +2445,7 @@ disk_log_impl::remove_prefix_full_segments(truncate_prefix_config cfg) {
       [this] {
           auto ptr = _segs.front();
           _segs.pop_front();
+          _probe->add_bytes_prefix_truncated(ptr->file_size());
           return remove_segment_permanently(ptr, "remove_prefix_full_segments");
       });
 }

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -152,6 +152,11 @@ void probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _partition_bytes; },
           sm::description("Current size of partition in bytes"),
           labels),
+        sm::make_counter(
+          "bytes_prefix_truncated",
+          [this] { return _bytes_prefix_truncated; },
+          sm::description("Number of bytes removed by prefix truncation."),
+          labels),
       },
       {},
       {sm::shard_label, partition_label});

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -113,11 +113,16 @@ public:
      */
     void clear_metrics() { _metrics.clear(); }
 
+    void add_bytes_prefix_truncated(size_t bytes) {
+        _bytes_prefix_truncated += bytes;
+    }
+
 private:
     uint64_t _partition_bytes = 0;
     uint64_t _bytes_written = 0;
     uint64_t _bytes_read = 0;
     uint64_t _cached_bytes_read = 0;
+    uint64_t _bytes_prefix_truncated = 0;
 
     uint64_t _batches_written = 0;
     uint64_t _batches_read = 0;


### PR DESCRIPTION
Adds many space management related metrics that are useful for understanding what is happening on the system when disk space utilization is high.

All metrics are per-node. The only exception is the shard/partition aggregated metric related to prefix truncation bytes (same aggregation level as all other per-partition data).

No new public metrics were added.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
