### PR TITLE
crypto: Move special members after impl definition

### DIFF
--- a/src/v/crypto/digest.cc
+++ b/src/v/crypto/digest.cc
@@ -18,17 +18,6 @@
 #include <type_traits>
 
 namespace crypto {
-digest_ctx::~digest_ctx() noexcept = default;
-digest_ctx::digest_ctx(digest_ctx&&) noexcept = default;
-digest_ctx& digest_ctx::operator=(digest_ctx&&) noexcept = default;
-
-static_assert(
-  std::is_nothrow_move_constructible_v<digest_ctx>,
-  "digest_ctx should be nothrow move constructible");
-static_assert(
-  std::is_nothrow_move_assignable_v<digest_ctx>,
-  "digest_ctx should be nothrow move assignable");
-
 class digest_ctx::impl {
 public:
     explicit impl(digest_type type)
@@ -111,6 +100,17 @@ private:
 
 digest_ctx::digest_ctx(digest_type type)
   : _impl(std::make_unique<impl>(type)) {}
+
+digest_ctx::~digest_ctx() noexcept = default;
+digest_ctx::digest_ctx(digest_ctx&&) noexcept = default;
+digest_ctx& digest_ctx::operator=(digest_ctx&&) noexcept = default;
+
+static_assert(
+  std::is_nothrow_move_constructible_v<digest_ctx>,
+  "digest_ctx should be nothrow move constructible");
+static_assert(
+  std::is_nothrow_move_assignable_v<digest_ctx>,
+  "digest_ctx should be nothrow move assignable");
 
 size_t digest_ctx::size() const { return _impl->size(); }
 size_t digest_ctx::size(digest_type type) {

--- a/src/v/crypto/hmac.cc
+++ b/src/v/crypto/hmac.cc
@@ -17,17 +17,6 @@
 #include <openssl/params.h>
 
 namespace crypto {
-hmac_ctx::~hmac_ctx() noexcept = default;
-hmac_ctx::hmac_ctx(hmac_ctx&&) noexcept = default;
-hmac_ctx& hmac_ctx::operator=(hmac_ctx&&) noexcept = default;
-
-static_assert(
-  std::is_nothrow_move_constructible_v<hmac_ctx>,
-  "hmac_ctx should be nothrow move constructible");
-static_assert(
-  std::is_nothrow_move_assignable_v<hmac_ctx>,
-  "hmac_ctx should be nothrow move assignable");
-
 class hmac_ctx::impl {
 public:
     impl(digest_type type, bytes_view key) {
@@ -128,6 +117,17 @@ hmac_ctx::hmac_ctx(digest_type type, bytes_view key)
 hmac_ctx::hmac_ctx(digest_type type, std::string_view key)
   : _impl(
     std::make_unique<impl>(type, internal::string_view_to_bytes_view(key))) {}
+
+hmac_ctx::~hmac_ctx() noexcept = default;
+hmac_ctx::hmac_ctx(hmac_ctx&&) noexcept = default;
+hmac_ctx& hmac_ctx::operator=(hmac_ctx&&) noexcept = default;
+
+static_assert(
+  std::is_nothrow_move_constructible_v<hmac_ctx>,
+  "hmac_ctx should be nothrow move constructible");
+static_assert(
+  std::is_nothrow_move_assignable_v<hmac_ctx>,
+  "hmac_ctx should be nothrow move assignable");
 
 size_t hmac_ctx::size() const { return _impl->size(); }
 size_t hmac_ctx::size(digest_type type) { return impl::size(type); }

--- a/src/v/crypto/signature.cc
+++ b/src/v/crypto/signature.cc
@@ -17,17 +17,6 @@
 #include <openssl/evp.h>
 
 namespace crypto {
-verify_ctx::~verify_ctx() noexcept = default;
-verify_ctx::verify_ctx(verify_ctx&&) noexcept = default;
-verify_ctx& verify_ctx::operator=(verify_ctx&&) noexcept = default;
-
-static_assert(
-  std::is_nothrow_move_constructible_v<verify_ctx>,
-  "verify_ctx should be nothrow move constructible");
-static_assert(
-  std::is_nothrow_move_assignable_v<verify_ctx>,
-  "verify_ctx should be nothrow move assignable");
-
 class verify_ctx::impl {
 public:
     impl(digest_type type, const key& key)
@@ -87,6 +76,17 @@ private:
 
 verify_ctx::verify_ctx(digest_type type, const key& key)
   : _impl(std::make_unique<impl>(type, key)) {}
+
+verify_ctx::~verify_ctx() noexcept = default;
+verify_ctx::verify_ctx(verify_ctx&&) noexcept = default;
+verify_ctx& verify_ctx::operator=(verify_ctx&&) noexcept = default;
+
+static_assert(
+  std::is_nothrow_move_constructible_v<verify_ctx>,
+  "verify_ctx should be nothrow move constructible");
+static_assert(
+  std::is_nothrow_move_assignable_v<verify_ctx>,
+  "verify_ctx should be nothrow move assignable");
 
 verify_ctx& verify_ctx::update(bytes_view msg) {
     _impl->update(msg);


### PR DESCRIPTION
Otherwise they still see an incomplete type.

Spotted with Clang 18

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
