### PR TITLE
raft|cluster: Address some warnings

### DIFF
--- a/src/v/cluster/cloud_metadata/offsets_recovery_manager.cc
+++ b/src/v/cluster/cloud_metadata/offsets_recovery_manager.cc
@@ -56,7 +56,7 @@ ss::future<error_outcome> offsets_recovery_manager::recover(
           model::kafka_consumer_offsets_nt, parent_retry.get_deadline());
     }
     for (size_t i = 0; i < snapshot_paths_per_pid.size(); i++) {
-        auto pid = model::partition_id{i};
+        auto pid = model::partition_id(i);
         auto ntp = model::ntp{
           model::kafka_consumer_offsets_nt.ns,
           model::kafka_consumer_offsets_nt.tp,

--- a/src/v/cluster/cloud_metadata/offsets_recovery_service.h
+++ b/src/v/cluster/cloud_metadata/offsets_recovery_service.h
@@ -41,7 +41,7 @@ public:
     }
 
     ss::future<offsets_upload_reply> offsets_upload(
-      offsets_upload_request req, rpc::streaming_context& ctx) override {
+      offsets_upload_request req, rpc::streaming_context&) override {
         if (!_offsets_upload_router.local_is_initialized()) {
             co_return offsets_upload_reply{.ec = errc::feature_disabled};
         }
@@ -52,7 +52,7 @@ public:
     }
 
     ss::future<offsets_recovery_reply> offsets_recovery(
-      offsets_recovery_request req, rpc::streaming_context& ctx) override {
+      offsets_recovery_request req, rpc::streaming_context&) override {
         if (!_offsets_recovery_router.local_is_initialized()) {
             co_return offsets_recovery_reply{.ec = errc::feature_disabled};
         }

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1446,8 +1446,8 @@ template<typename Func>
 ss::future<result<ss::stop_iteration>>
 controller_backend::apply_configuration_change_on_leader(
   ss::lw_shared_ptr<partition> partition,
-  const replicas_t& expected_replicas,
-  model::revision_id cmd_rev,
+  const replicas_t&,
+  model::revision_id,
   Func&& func) {
     if (partition->is_leader()) {
         // we are the leader, update configuration

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -126,8 +126,8 @@ public:
           });
     }
 
-    ss::future<> apply_local_snapshot(
-      raft::stm_snapshot_header header, iobuf&& bytes) override {
+    ss::future<>
+    apply_local_snapshot(raft::stm_snapshot_header, iobuf&& bytes) override {
         auto holder = _gate.hold();
         auto units = _snapshot_lock.hold_write_lock();
 

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -206,8 +206,8 @@ public:
         iobuf buf;
         serde::write(buf, key);
         auto bytes = iobuf_to_bytes(buf);
-        auto result = model::partition_id{
-          murmur2(bytes.c_str(), bytes.length()) % num_partitions.value()};
+        auto result = model::partition_id(
+          murmur2(bytes.c_str(), bytes.length()) % num_partitions.value());
 
         auto res = co_await replicate_and_wait(
           make_coordinator_assignment_batch(

--- a/src/v/cluster/leader_router.h
+++ b/src/v/cluster/leader_router.h
@@ -260,7 +260,7 @@ template<typename req_t, typename resp_t, typename handler_t>
 requires IsHandler<req_t, resp_t, handler_t>
 ss::future<resp_t>
 leader_router<req_t, resp_t, handler_t>::find_shard_and_process(
-  req_t req, model::ntp ntp, model::timeout_clock::duration timeout) {
+  req_t req, model::ntp ntp, model::timeout_clock::duration) {
     auto holder = ss::gate::holder(_gate);
     auto shard = _shard_table.local().shard_for(ntp);
     if (unlikely(!shard)) {

--- a/src/v/cluster/partition_recovery_manager.cc
+++ b/src/v/cluster/partition_recovery_manager.cc
@@ -420,7 +420,7 @@ void partition_downloader::update_downloaded_offsets(
 ss::future<partition_downloader::download_part>
 partition_downloader::download_log_with_capped_size(
   offset_map_t offset_map,
-  const partition_manifest& manifest,
+  const partition_manifest&,
   const std::filesystem::path& prefix,
   size_t max_size) {
     vlog(_ctxlog.info, "Starting log download with size limit at {}", max_size);
@@ -499,7 +499,7 @@ partition_downloader::download_log_with_capped_size(
 ss::future<partition_downloader::download_part>
 partition_downloader::download_log_with_capped_time(
   offset_map_t offset_map,
-  const partition_manifest& manifest,
+  const partition_manifest&,
   const std::filesystem::path& prefix,
   model::timestamp_clock::duration retention_time) {
     vlog(

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -949,7 +949,7 @@ ss::future<result<kafka_result>> rm_stm::do_sync_and_transactional_replicate(
   producer_ptr producer,
   model::batch_identity bid,
   model::record_batch_reader rdr,
-  ssx::semaphore_units units) {
+  ssx::semaphore_units) {
     if (!co_await sync(_sync_timeout)) {
         vlog(
           _ctx_log.trace,

--- a/src/v/cluster/self_test/netcheck.cc
+++ b/src/v/cluster/self_test/netcheck.cc
@@ -177,7 +177,7 @@ ss::future<size_t> netcheck::process_netcheck_reply(
   result<rpc::client_context<netcheck_response>> reply,
   run_fiber_opts& fiber_state,
   model::node_id peer,
-  metrics& m) {
+  metrics&) {
     if (!reply) {
         if (
           reply.error() == rpc::errc::client_request_timeout

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -622,7 +622,7 @@ service::cancel_node_partition_movements(
 
 ss::future<cancel_partition_movements_reply>
 service::do_cancel_all_partition_movements(
-  cancel_all_partition_movements_request req) {
+  cancel_all_partition_movements_request) {
     auto ret
       = co_await _topics_frontend.local().cancel_moving_all_partition_replicas(
         default_move_interruption_timeout + model::timeout_clock::now());

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -214,7 +214,7 @@ struct partition_balancer_planner_fixture {
           replication_factor);
 
         ss::chunked_fifo<cluster::partition_assignment> assignments;
-        for (size_t i = 0; i < partition_nodes.size(); ++i) {
+        for (model::partition_id::type i = 0; i < partition_nodes.size(); ++i) {
             const auto& nodes = partition_nodes[i];
             BOOST_REQUIRE_EQUAL(nodes.size(), replication_factor);
             std::vector<model::broker_shard> replicas;

--- a/src/v/cluster/tests/partition_balancer_planner_test.cc
+++ b/src/v/cluster/tests/partition_balancer_planner_test.cc
@@ -15,7 +15,7 @@
 static ss::logger logger("partition_balancer_planner");
 
 // a shorthand to avoid spelling out model::node_id
-static model::node_id n(int64_t id) { return model::node_id{id}; };
+static model::node_id n(model::node_id::type id) { return model::node_id{id}; };
 
 using namespace std::chrono_literals;
 

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -635,7 +635,7 @@ private:
 };
 
 FIXTURE_TEST(test_decommission, partition_balancer_sim_fixture) {
-    for (size_t i = 0; i < 4; ++i) {
+    for (model::node_id::type i = 0; i < 4; ++i) {
         add_node(model::node_id{i}, 100_GiB);
     }
     add_topic("mytopic", 100, 3, 100_MiB);
@@ -647,7 +647,7 @@ FIXTURE_TEST(test_decommission, partition_balancer_sim_fixture) {
 }
 
 FIXTURE_TEST(test_two_decommissions, partition_balancer_sim_fixture) {
-    for (size_t i = 0; i < 5; ++i) {
+    for (model::node_id::type i = 0; i < 5; ++i) {
         add_node(model::node_id{i}, 100_GiB);
     }
     add_topic("mytopic", 200, 3, 100_MiB);
@@ -675,7 +675,7 @@ FIXTURE_TEST(test_two_decommissions, partition_balancer_sim_fixture) {
 }
 
 FIXTURE_TEST(test_counts_rebalancing, partition_balancer_sim_fixture) {
-    for (size_t i = 0; i < 3; ++i) {
+    for (model::node_id::type i = 0; i < 3; ++i) {
         add_node(model::node_id{i}, 1000_GiB, 4);
     }
 
@@ -699,7 +699,7 @@ FIXTURE_TEST(test_counts_rebalancing, partition_balancer_sim_fixture) {
 
 FIXTURE_TEST(
   test_heterogeneous_racks_full_disk, partition_balancer_sim_fixture) {
-    for (size_t i = 0; i < 3; ++i) {
+    for (model::node_id::type i = 0; i < 3; ++i) {
         add_node(
           model::node_id{i},
           1000_GiB,

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -197,7 +197,7 @@ FIXTURE_TEST(
     check_final_counts({4, 4, 4, 0});
 
     // get data needed to move a partition
-    auto get_partition = [&](size_t id) {
+    auto get_partition = [&](model::partition_id::type id) {
         model::ntp ntp{
           create_topic_cmd.key.ns,
           create_topic_cmd.key.tp,

--- a/src/v/cluster/topic_recovery_service.cc
+++ b/src/v/cluster/topic_recovery_service.cc
@@ -429,7 +429,7 @@ ss::future<std::vector<cloud_storage::topic_manifest>>
 topic_recovery_service::filter_existing_topics(
   std::vector<remote_segment_path> items,
   const recovery_request& request,
-  std::optional<model::ns> filter_ns) {
+  std::optional<model::ns>) {
     absl::flat_hash_map<ss::sstring, absl::flat_hash_set<ss::sstring>>
       topic_index;
 

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -727,7 +727,7 @@ ss::future<try_abort_reply> tx_gateway_frontend::do_try_abort(
   kafka::transactional_id tx_id,
   model::producer_identity pid,
   model::tx_seq tx_seq,
-  model::timeout_clock::duration timeout) {
+  model::timeout_clock::duration) {
     auto term_opt = co_await stm->sync();
 
     if (!term_opt.has_value()) {

--- a/src/v/raft/tests/offset_translator_tests.cc
+++ b/src/v/raft/tests/offset_translator_tests.cc
@@ -361,7 +361,7 @@ struct fuzz_checker {
                 for (auto o = batch.base_offset(); o <= batch.last_offset();
                      ++o) {
                     _self._kafka_offsets.push_back(
-                      model::offset{_self._log_offsets.size()});
+                      model::offset(_self._log_offsets.size()));
                     if (
                       batch.header().type
                       == model::record_batch_type::raft_data) {
@@ -486,8 +486,8 @@ struct fuzz_checker {
         }
 
         // check translation for high watermark (first unoccupied offset)
-        model::offset hwm_lo{_kafka_offsets.size()};
-        model::offset hwm_ko{_log_offsets.size()};
+        model::offset hwm_lo(_kafka_offsets.size());
+        model::offset hwm_ko(_log_offsets.size());
         BOOST_TEST_CONTEXT("With log offset: " << hwm_lo) {
             BOOST_REQUIRE_EQUAL(hwm_ko, _tr->state()->from_log_offset(hwm_lo));
         }


### PR DESCRIPTION
Spotted with Clang 18

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
