### PR TITLE
treewide: Address some warnings

### DIFF
--- a/src/v/io/tests/common.cc
+++ b/src/v/io/tests/common.cc
@@ -129,7 +129,7 @@ seastar::future<> io_queue_workload_generator::generate_writes() {
 }
 
 seastar::future<> io_queue_workload_generator::generate_reads() {
-    return seastar::async([=] {
+    return seastar::async([this] {
         while (completed_reads.size() < num_io_ops) {
             if (auto* write = select_random_write(); write != nullptr) {
                 submitted_reads.push_back(make_page(write->offset()));

--- a/src/v/kafka/client/test/partitioners.cc
+++ b/src/v/kafka/client/test/partitioners.cc
@@ -31,7 +31,7 @@ model::partition_id murmur2(const iobuf& buf, size_t p_cnt) {
     iobuf_const_parser parser{buf};
     auto b = parser.read_bytes(parser.bytes_left());
     auto hash = murmur2(b.data(), b.size());
-    return model::partition_id{hash % p_cnt};
+    return model::partition_id(hash % p_cnt);
 }
 
 static const auto no_partition{std::nullopt};

--- a/src/v/kafka/server/handlers/handler_probe.cc
+++ b/src/v/kafka/server/handlers/handler_probe.cc
@@ -32,7 +32,7 @@ handler_probe_manager::handler_probe_manager()
   , _probes(max_api_key() + 2) {
     const auto unknown_handler_key = max_api_key() + 1;
     for (size_t i = 0; i < _probes.size(); i++) {
-        auto key = api_key{i};
+        auto key = api_key(i);
 
         if (handler_for_key(key) || i == unknown_handler_key) {
             _probes[i].setup_metrics(_metrics, key);

--- a/src/v/kafka/server/tests/offset_for_leader_epoch_utils.cc
+++ b/src/v/kafka/server/tests/offset_for_leader_epoch_utils.cc
@@ -30,7 +30,7 @@ kafka_offset_for_epoch_transport::offsets_for_leaders(
         t.partitions.emplace_back(kafka::offset_for_leader_partition{
           .partition = pid,
           .current_leader_epoch = kafka::leader_epoch{-1},
-          .leader_epoch = kafka::leader_epoch{term()},
+          .leader_epoch = kafka::leader_epoch(term()),
         });
     }
     req.data.topics.emplace_back(std::move(t));

--- a/src/v/kafka/server/tests/produce_consume_test.cc
+++ b/src/v/kafka/server/tests/produce_consume_test.cc
@@ -505,7 +505,7 @@ struct throughput_limits_fixure : prod_consume_fixture {
     }
 
     auto do_produce(
-      unsigned i,
+      int i,
       size_t batches_cnt,
       size_t batch_size,
       honour_throttle honour_throttle) {
@@ -528,8 +528,7 @@ struct throughput_limits_fixure : prod_consume_fixture {
         return std::make_tuple(data_len, total_len, total_throttle_time);
     }
 
-    auto do_consume(
-      unsigned int i, size_t data_cap, honour_throttle honour_throttle) {
+    auto do_consume(int i, size_t data_cap, honour_throttle honour_throttle) {
         const model::partition_id p_id{i};
         size_t data_len{0};
         size_t total_len{0};
@@ -657,7 +656,7 @@ struct throughput_limits_fixure : prod_consume_fixture {
           = transform_reduce_thread_per_core(
             policy,
             [&](auto i) {
-                const model::partition_id p_id{i};
+                const model::partition_id p_id(i);
                 const auto data_cap = (kafka_in_data_len / ss::smp::count)
                                       - batch_size * 2;
                 return do_consume(i, data_cap, honour_throttle);

--- a/src/v/pandaproxy/schema_registry/validation.cc
+++ b/src/v/pandaproxy/schema_registry/validation.cc
@@ -107,8 +107,6 @@ std::vector<int32_t> get_proto_offsets(iobuf_parser& p) {
 
 ss::future<std::optional<ss::sstring>> get_record_name(
   pandaproxy::schema_registry::sharded_store& store,
-  field field,
-  const model::topic& topic,
   subject_name_strategy sns,
   const canonical_schema_definition& schema,
   std::optional<std::vector<int32_t>>& offsets) {
@@ -275,7 +273,7 @@ public:
         }
 
         auto record_name = co_await get_record_name(
-          *_api->_store, field, topic, sns, *schema, proto_offsets);
+          *_api->_store, sns, *schema, proto_offsets);
         if (!record_name) {
             vlog(
               plog.debug,

--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -393,7 +393,7 @@ void configuration_manager::maybe_store_highest_known_offset_in_background(
 }
 
 ss::future<>
-configuration_manager::do_maybe_store_highest_known_offset(size_t bytes) {
+configuration_manager::do_maybe_store_highest_known_offset(size_t) {
     if (_hko_checkpoint_in_progress) {
         // This could be a mutex, but it doesn't make much sense to wait on it.
         // In an unlikely event checkpointing fails, immediate retry by another

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -435,7 +435,7 @@ ss::future<> create_offset_translator_state_for_pre_existing_partition(
   storage::api& api,
   const storage::ntp_config& ntp_cfg,
   raft::group_id group,
-  model::offset min_rp_offset,
+  model::offset,
   model::offset max_rp_offset,
   ss::lw_shared_ptr<storage::offset_translator_state> ot_state) {
     // Prepare offset_translator state in kvstore

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -449,7 +449,7 @@ admin_server::oidc_whoami_handler(std::unique_ptr<ss::http::request> req) {
 
 ss::future<ss::json::json_return_type>
 admin_server::oidc_keys_cache_invalidate_handler(
-  std::unique_ptr<ss::http::request> req) {
+  std::unique_ptr<ss::http::request>) {
     auto f = co_await ss::coroutine::as_future(
       _controller->get_oidc_service().invoke_on_all(
         [](auto& s) { return s.refresh_keys(); }));

--- a/src/v/redpanda/admin/security.cc
+++ b/src/v/redpanda/admin/security.cc
@@ -462,7 +462,7 @@ admin_server::oidc_keys_cache_invalidate_handler(
 }
 
 ss::future<ss::json::json_return_type>
-admin_server::oidc_revoke_handler(std::unique_ptr<ss::http::request> req) {
+admin_server::oidc_revoke_handler(std::unique_ptr<ss::http::request>) {
     auto f = co_await ss::coroutine::as_future(
       _controller->get_oidc_service().invoke_on_all(
         [](auto& s) { return s.refresh_keys(); }));

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3993,8 +3993,7 @@ admin_server::get_partition_cloud_storage_status(
 }
 
 ss::future<ss::json::json_return_type>
-admin_server::get_cloud_storage_lifecycle(
-  std::unique_ptr<ss::http::request> req) {
+admin_server::get_cloud_storage_lifecycle(std::unique_ptr<ss::http::request>) {
     ss::httpd::shadow_indexing_json::get_lifecycle_response response;
 
     auto& topic_table = _controller->get_topics_state().local();

--- a/src/v/rpc/connection_cache.cc
+++ b/src/v/rpc/connection_cache.cc
@@ -240,7 +240,7 @@ ss::future<> connection_cache::apply_changes(
 }
 
 ss::future<> connection_cache::remove_broker_client_coordinator(
-  model::node_id self, model::node_id dest) {
+  model::node_id, model::node_id dest) {
     vassert(ss::this_shard_id() == _coordinator_shard, "not the coordinator");
 
     if (is_shutting_down()) {

--- a/src/v/utils/tests/retry_test.cc
+++ b/src/v/utils/tests/retry_test.cc
@@ -66,8 +66,6 @@ SEASTAR_THREAD_TEST_CASE(retry_then_fail_when_cancelled) {
                                std::rethrow_exception(eptr);
                            } catch (const ss::abort_requested_exception&) {
                                return true;
-                           } catch (const ss::sleep_aborted&) {
-                               return true;
                            } catch (...) {
                                return false;
                            }


### PR DESCRIPTION
Spotted with Clang 18

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none