### PR TITLE
Shard producer state manager with `v_cluster_id`

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -87,6 +87,7 @@ enum class errc : int16_t {
     topic_invalid_partitions_memory_limit,
     topic_invalid_partitions_fd_limit,
     topic_invalid_partitions_decreased,
+    producer_ids_vcluster_limit_exceeded,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -253,6 +254,8 @@ struct errc_category final : public std::error_category {
             return "Can not increase partition count due to FD limit";
         case errc::topic_invalid_partitions_decreased:
             return "Can not decrease the number of partitions";
+        case errc::producer_ids_vcluster_limit_exceeded:
+            return "To many vclusters registered in producer state cache";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/producer_state_manager.cc
+++ b/src/v/cluster/producer_state_manager.cc
@@ -12,8 +12,11 @@
 #include "producer_state_manager.h"
 
 #include "cluster/logger.h"
+#include "cluster/producer_state.h"
+#include "cluster/types.h"
 #include "prometheus/prometheus_sanitize.h"
 
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/metrics.hh>
 #include <seastar/util/defer.hh>
 
@@ -23,7 +26,8 @@ producer_state_manager::producer_state_manager(
   config::binding<uint64_t> max_producer_ids,
   std::chrono::milliseconds producer_expiration_ms)
   : _producer_expiration_ms(producer_expiration_ms)
-  , _max_ids(std::move(max_producer_ids)) {
+  , _max_ids(std::move(max_producer_ids))
+  , _cache(_max_ids, _max_ids) {
     setup_metrics();
 }
 
@@ -48,7 +52,7 @@ void producer_state_manager::setup_metrics() {
       prometheus_sanitize::metrics_name("cluster:producer_state_manager"),
       {sm::make_gauge(
          "producer_manager_total_active_producers",
-         [this] { return _num_producers; },
+         [this] { return _cache.get_stats().total_size; },
          sm::description(
            "Total number of active idempotent and transactional producers.")),
        sm::make_counter(
@@ -57,64 +61,50 @@ void producer_state_manager::setup_metrics() {
          sm::description("Number of evicted producers so far."))});
 }
 
-void producer_state_manager::register_producer(producer_state& state) {
-    link(state);
-    ++_num_producers;
-    vlog(clusterlog.debug, "Registered producer: {}", state);
+void producer_state_manager::register_producer(
+  producer_state& state, std::optional<model::vcluster_id> vcluster) {
+    vlog(
+      clusterlog.debug,
+      "Registering producer: {}, current producer count: {}",
+      state,
+      _cache.get_stats().total_size);
+    _cache.insert(vcluster.value_or(no_vcluster), state);
 }
 
-void producer_state_manager::deregister_producer(producer_state& state) {
-    if (state._hook.is_linked()) {
-        state._hook.unlink();
-        --_num_producers;
-        vlog(clusterlog.debug, "Removing producer: {}", state);
-    }
+void producer_state_manager::deregister_producer(
+  producer_state& state, std::optional<model::vcluster_id> vcluster) {
+    vlog(
+      clusterlog.debug,
+      "Removing producer: {}, current producer count: {}",
+      state,
+      _cache.get_stats().total_size);
+    _cache.remove(vcluster.value_or(no_vcluster), state);
 }
-
-void producer_state_manager::link(producer_state& state) {
-    vassert(
-      !state._hook.is_linked(),
-      "double linking of producer state {}",
-      state._id);
-    _lru_producers.push_back(state);
+void producer_state_manager::touch(
+  producer_state& state, std::optional<model::vcluster_id> vcluster) {
+    vlog(clusterlog.trace, "Touched producer: {}", state);
+    _cache.touch(vcluster.value_or(no_vcluster), state);
 }
-
-bool producer_state_manager::can_evict_producer(
-  const producer_state& state) const {
-    return _num_producers > _max_ids()
-           || state.ms_since_last_update() > _producer_expiration_ms;
-}
-
 void producer_state_manager::evict_excess_producers() {
-    ssx::background = ssx::spawn_with_gate_then(_gate, [this]() {
-                          do_evict_excess_producers();
-                      }).finally([this] {
-        if (!_gate.is_closed()) {
-            _reaper.arm(period);
-        }
-    });
-}
-
-void producer_state_manager::do_evict_excess_producers() {
-    if (_gate.is_closed()) {
-        return;
-    }
-    vlog(clusterlog.debug, "producer eviction tick");
-    auto it = _lru_producers.begin();
-    while (it != _lru_producers.end() && can_evict_producer(*it)) {
-        auto it_copy = it;
-        ++it;
-        auto& state = *it_copy;
-        // Here eviction does not need to check if an operation is
-        // currently in progress on the producer at this point. That
-        // is because the producer unlinks itself from this list
-        // temporarily and relinks back after the operation is finished
-        // essentially resulting in the fact that only currently inactive
-        // producers are in the list. This makes the whole logic lock free.
-        ssx::spawn_with_gate(_gate, [&state] { return state.evict(); });
-        --_num_producers;
-        ++_eviction_counter;
+    _cache.evict_older_than<ss::lowres_system_clock>(
+      ss::lowres_system_clock::now() - _producer_expiration_ms);
+    if (!_gate.is_closed()) {
+        _reaper.arm(period);
     }
 }
 
+bool producer_state_manager::pre_eviction_hook::operator()(
+  producer_state& state) const noexcept {
+    return state.can_evict();
+}
+
+producer_state_manager::post_eviction_hook::post_eviction_hook(
+  producer_state_manager& mgr)
+  : _state_manger(mgr) {}
+
+void producer_state_manager::post_eviction_hook::operator()(
+  producer_state& state) const noexcept {
+    _state_manger._eviction_counter++;
+    return state._post_eviction_hook();
+}
 }; // namespace cluster

--- a/src/v/cluster/producer_state_manager.h
+++ b/src/v/cluster/producer_state_manager.h
@@ -23,8 +23,10 @@ namespace cluster {
 class producer_state_manager {
 public:
     explicit producer_state_manager(
+
       config::binding<uint64_t> max_producer_ids,
-      std::chrono::milliseconds producer_expiration_ms);
+      std::chrono::milliseconds producer_expiration_ms,
+      config::binding<size_t> virtual_cluster_min_producer_ids);
 
     ss::future<> start();
     ss::future<> stop();
@@ -78,6 +80,7 @@ private:
     // all partitions. When exceeded, producers are evicted on an
     // LRU basis.
     config::binding<uint64_t> _max_ids;
+    config::binding<size_t> _virtual_cluster_min_producer_ids;
     // cache of all producers on this shard
     cache_t _cache;
     ss::timer<ss::steady_clock_type> _reaper;

--- a/src/v/cluster/producer_state_manager.h
+++ b/src/v/cluster/producer_state_manager.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "cluster/namespaced_cache.h"
 #include "cluster/producer_state.h"
 #include "config/property.h"
 #include "metrics/metrics.h"
@@ -19,9 +20,7 @@
 #include <seastar/core/sharded.hh>
 
 namespace cluster {
-
-class producer_state_manager
-  : public ss::peering_sharded_service<producer_state_manager> {
+class producer_state_manager {
 public:
     explicit producer_state_manager(
       config::binding<uint64_t> max_producer_ids,
@@ -29,35 +28,58 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
-
-    // register = link + producer_count++
-    // note: register is a reserved word in c++
-    void register_producer(producer_state&);
-    void deregister_producer(producer_state&);
-    // temporary relink already accounted producer
-    void link(producer_state&);
+    /**
+     * Adds producer state to the producer state manager cache
+     */
+    void register_producer(producer_state&, std::optional<model::vcluster_id>);
+    /**
+     * Removes producer from the producer state manager. (This method does not
+     * call eviction hook)
+     */
+    void
+    deregister_producer(producer_state&, std::optional<model::vcluster_id>);
+    /**
+     * Touch a producer in underlying queue
+     */
+    void touch(producer_state&, std::optional<model::vcluster_id>);
 
 private:
     static constexpr std::chrono::seconds period{5};
+    /**
+     *  Constant to be used when a partition has no vcluster_id assigned.
+     */
+    static constexpr model::vcluster_id no_vcluster{xid::data_t{0x00}};
+
+    struct pre_eviction_hook {
+        bool operator()(producer_state&) const noexcept;
+    };
+
+    struct post_eviction_hook {
+        explicit post_eviction_hook(producer_state_manager&);
+
+        void operator()(producer_state&) const noexcept;
+
+        producer_state_manager& _state_manger;
+    };
+    friend post_eviction_hook;
+    using cache_t = namespaced_cache<
+      producer_state,
+      model::vcluster_id,
+      &producer_state::_hook,
+      pre_eviction_hook,
+      post_eviction_hook>;
+
     void setup_metrics();
     void evict_excess_producers();
-    void do_evict_excess_producers();
-
-    bool can_evict_producer(const producer_state&) const;
-
-    size_t _num_producers = 0;
     size_t _eviction_counter = 0;
     // if a producer is inactive for this long, it will be gc-ed
     std::chrono::milliseconds _producer_expiration_ms;
-    // maximum # of active producers allowed on this shard across
-    // all partitions. When exceeded, producers are evctied on an
+    // maximum number of active producers allowed on this shard across
+    // all partitions. When exceeded, producers are evicted on an
     // LRU basis.
     config::binding<uint64_t> _max_ids;
-    // list of all producers on this shard. producer lifetime is tied to
-    // raft group which owns it. linking/unlinking and LRU-ness maintenance
-    // is the responsibility of the producers themselves.
-    // Check producer_state::run_func()
-    intrusive_list<producer_state, &producer_state::_hook> _lru_producers;
+    // cache of all producers on this shard
+    cache_t _cache;
     ss::timer<ss::steady_clock_type> _reaper;
     ss::gate _gate;
     metrics::internal_metric_groups _metrics;

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -11,6 +11,7 @@
 
 #include "bytes/iostream.h"
 #include "cluster/logger.h"
+#include "cluster/producer_state_manager.h"
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/tx_snapshot_utils.h"
 #include "kafka/protocol/wire.h"
@@ -305,14 +306,12 @@ producer_ptr rm_stm::maybe_create_producer(model::producer_identity pid) {
     if (it != _producers.end()) {
         return it->second;
     }
-    auto result = _producers.emplace(
-      pid,
-      ss::make_lw_shared<producer_state>(
-        _producer_state_manager.local(), pid, _raft->group(), [pid, this] {
-            cleanup_producer_state(pid);
-        }));
-    ;
-    return result.first->second;
+    auto producer = ss::make_lw_shared<producer_state>(
+      pid, _raft->group(), [pid, this] { cleanup_producer_state(pid); });
+    _producer_state_manager.local().register_producer(*producer, std::nullopt);
+    _producers.emplace(pid, producer);
+
+    return producer;
 }
 
 void rm_stm::cleanup_producer_state(model::producer_identity pid) {
@@ -336,9 +335,12 @@ void rm_stm::cleanup_producer_state(model::producer_identity pid) {
 
 ss::future<> rm_stm::reset_producers() {
     co_await ss::max_concurrent_for_each(
-      _producers.begin(), _producers.end(), 32, [](auto& it) {
+      _producers.begin(), _producers.end(), 32, [this](auto& it) {
           auto& producer = it.second;
-          return producer->shutdown_input().discard_result();
+          producer->shutdown_input();
+          _producer_state_manager.local().deregister_producer(
+            *producer, std::nullopt);
+          return ss::now();
       });
     _producers.clear();
 }
@@ -1077,10 +1079,14 @@ ss::future<result<kafka_result>> rm_stm::transactional_replicate(
         co_return errc::generic_tx_error;
     }
     auto producer = maybe_create_producer(bid.pid);
-    co_return co_await producer->run_with_lock([&](ssx::semaphore_units units) {
-        return do_sync_and_transactional_replicate(
-          producer, bid, std::move(rdr), std::move(units));
-    });
+    co_return co_await producer
+      ->run_with_lock([&](ssx::semaphore_units units) {
+          return do_sync_and_transactional_replicate(
+            producer, bid, std::move(rdr), std::move(units));
+      })
+      .finally([this, producer] {
+          _producer_state_manager.local().touch(*producer, std::nullopt);
+      });
 }
 
 ss::future<result<kafka_result>> rm_stm::do_sync_and_idempotent_replicate(
@@ -1195,15 +1201,19 @@ ss::future<result<kafka_result>> rm_stm::idempotent_replicate(
   raft::replicate_options opts,
   ss::lw_shared_ptr<available_promise<>> enqueued) {
     auto producer = maybe_create_producer(bid.pid);
-    co_return co_await producer->run_with_lock([&](ssx::semaphore_units units) {
-        return do_sync_and_idempotent_replicate(
-          producer,
-          bid,
-          std::move(br),
-          opts,
-          std::move(enqueued),
-          std::move(units));
-    });
+    co_return co_await producer
+      ->run_with_lock([&](ssx::semaphore_units units) {
+          return do_sync_and_idempotent_replicate(
+            producer,
+            bid,
+            std::move(br),
+            opts,
+            std::move(enqueued),
+            std::move(units));
+      })
+      .finally([this, producer] {
+          _producer_state_manager.local().touch(*producer, std::nullopt);
+      });
 }
 
 ss::future<result<kafka_result>> rm_stm::replicate_msg(
@@ -1763,7 +1773,10 @@ void rm_stm::apply_data(
         const auto last_offset = header.last_offset();
         const auto last_kafka_offset = from_log_offset(header.last_offset());
         auto producer = maybe_create_producer(bid.pid);
-        producer->update(bid, last_kafka_offset);
+        auto needs_touch = producer->update(bid, last_kafka_offset);
+        if (needs_touch) {
+            _producer_state_manager.local().touch(*producer, std::nullopt);
+        }
 
         if (bid.is_transactional) {
             vlog(
@@ -1891,12 +1904,11 @@ rm_stm::apply_local_snapshot(raft::stm_snapshot_header hdr, iobuf&& tx_ss_buf) {
             continue;
         }
         auto pid = entry._id;
-        _producers.emplace(
-          pid,
-          ss::make_lw_shared<producer_state>(
-            _producer_state_manager.local(),
-            [this, pid] { cleanup_producer_state(pid); },
-            std::move(entry)));
+        auto producer = ss::make_lw_shared<producer_state>(
+          [pid, this] { cleanup_producer_state(pid); }, std::move(entry));
+        _producer_state_manager.local().register_producer(
+          *producer, std::nullopt);
+        _producers.emplace(pid, producer);
     }
 
     abort_index last{.last = model::offset(-1)};

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -15,6 +15,7 @@
 #include "cluster/fwd.h"
 #include "cluster/producer_state.h"
 #include "cluster/state_machine_registry.h"
+#include "cluster/topic_table.h"
 #include "cluster/tx_utils.h"
 #include "cluster/types.h"
 #include "config/property.h"
@@ -114,7 +115,8 @@ public:
       raft::consensus*,
       ss::sharded<cluster::tx_gateway_frontend>&,
       ss::sharded<features::feature_table>&,
-      ss::sharded<producer_state_manager>&);
+      ss::sharded<producer_state_manager>&,
+      std::optional<model::vcluster_id>);
 
     ss::future<checked<model::term_id, tx_errc>> begin_tx(
       model::producer_identity,
@@ -581,6 +583,7 @@ private:
     ss::timer<clock_type> _log_stats_timer;
     prefix_logger _ctx_log;
     ss::sharded<producer_state_manager>& _producer_state_manager;
+    std::optional<model::vcluster_id> _vcluster_id;
 
     producers_t _producers;
     metrics::internal_metric_groups _metrics;
@@ -606,7 +609,8 @@ public:
       bool enable_idempotence,
       ss::sharded<tx_gateway_frontend>&,
       ss::sharded<cluster::producer_state_manager>&,
-      ss::sharded<features::feature_table>&);
+      ss::sharded<features::feature_table>&,
+      ss::sharded<cluster::topic_table>&);
     bool is_applicable_for(const storage::ntp_config&) const final;
     void create(raft::state_machine_manager_builder&, raft::consensus*) final;
 
@@ -616,6 +620,7 @@ private:
     ss::sharded<tx_gateway_frontend>& _tx_gateway_frontend;
     ss::sharded<cluster::producer_state_manager>& _producer_state_manager;
     ss::sharded<features::feature_table>& _feature_table;
+    ss::sharded<topic_table>& _topics;
 };
 
 model::record_batch make_fence_batch_v1(

--- a/src/v/cluster/tests/producer_state_tests.cc
+++ b/src/v/cluster/tests/producer_state_tests.cc
@@ -11,13 +11,21 @@
 
 #include "cluster/producer_state.h"
 #include "cluster/producer_state_manager.h"
+#include "cluster/types.h"
 #include "config/mock_property.h"
+#include "config/property.h"
 #include "model/tests/randoms.h"
 #include "test_utils/async.h"
 #include "test_utils/fixture.h"
 
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/testing/thread_test_case.hh>
 
+#include <absl/container/flat_hash_map.h>
+#include <boost/test/tools/old/interface.hpp>
+
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -26,41 +34,47 @@ using namespace std::chrono_literals;
 ss::logger logger{"producer_state_test"};
 
 struct test_fixture {
+    using psm_ptr = std::unique_ptr<cluster::producer_state_manager>;
+
     static constexpr uint64_t default_max_producers = 10;
 
-    cluster::producer_state_manager& manager() { return _psm.local(); }
-
-    void check_producers(size_t registered) {
+    void validate_producer_count(size_t registered) {
         BOOST_REQUIRE_EQUAL(
           manager()._cache.get_stats().total_size, registered);
     }
 
-    test_fixture() {
-        ss::smp::invoke_on_all([]() {
-            config::shard_local_cfg().disable_metrics.set_value(true);
-        }).get();
-        config::shard_local_cfg().disable_metrics.set_value(true);
-        _max_producers.start(default_max_producers).get();
-        _psm
-          .start(ss::sharded_parameter(
-            [this] { return _max_producers.local().bind(); }))
-          .get();
-        _psm.invoke_on_all(&cluster::producer_state_manager::start).get();
-        check_producers(0);
+    void validate_namespace_count(size_t registered) {
+        BOOST_REQUIRE_EQUAL(
+          manager()._cache.get_stats().namespaces.size(), registered);
+    }
+
+    void create_producer_state_manager(
+      size_t max_producers, size_t min_producers_per_vcluster) {
+        _psm = std::make_unique<cluster::producer_state_manager>(
+          config::mock_binding<size_t>(max_producers),
+          std::chrono::milliseconds::max(),
+          config::mock_binding<size_t>(min_producers_per_vcluster));
+        _psm->start().get();
+        validate_producer_count(0);
+        validate_namespace_count(0);
     }
 
     ~test_fixture() {
-        _max_producers.stop().get();
-        _psm.stop().get();
+        if (_psm) {
+            _psm->stop().get();
+        }
     }
 
-    cluster::producer_ptr new_producer(ss::noncopyable_function<void()> f = [] {
-    }) {
+    cluster::producer_state_manager& manager() { return *_psm; }
+
+    cluster::producer_ptr new_producer(
+      ss::noncopyable_function<void()> f = [] {},
+      std::optional<model::vcluster_id> vcluster = std::nullopt) {
         auto p = ss::make_lw_shared<cluster::producer_state>(
           model::random_producer_identity(),
           raft::group_id{_counter++},
           std::move(f));
-        manager().register_producer(*p, std::nullopt);
+        manager().register_producer(*p, vcluster);
         return p;
     }
 
@@ -72,12 +86,12 @@ struct test_fixture {
         producers.clear();
     }
 
-    long _counter = 0;
-    ss::sharded<config::mock_property<uint64_t>> _max_producers;
-    ss::sharded<cluster::producer_state_manager> _psm;
+    int64_t _counter{0};
+    psm_ptr _psm;
 };
 
 FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
+    create_producer_state_manager(10, 10);
     const size_t num_producers = 10;
     std::vector<cluster::producer_ptr> producers;
     producers.reserve(num_producers);
@@ -85,7 +99,7 @@ FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
         producers.push_back(new_producer());
     }
     // Ensure all producers are registered and linked up
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
 
     // run an active operation on producer, should temporarily
     // unlink itself.
@@ -97,10 +111,10 @@ FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
     });
 
     wait_for_func_begin.wait().get();
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
     // create one producer more and to trigger eviction
     auto new_p = new_producer();
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
     // validate that first producer is not evicted
     BOOST_REQUIRE(producers[0]->is_evicted() == false);
     BOOST_REQUIRE(producers[0]->can_evict() == false);
@@ -109,13 +123,14 @@ FIXTURE_TEST(test_locked_producer_is_not_evicted, test_fixture) {
 
     f.get();
     producers.push_back(new_p);
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
 
     clean(producers);
-    check_producers(0);
+    validate_producer_count(0);
 }
 
 FIXTURE_TEST(test_lru_maintenance, test_fixture) {
+    create_producer_state_manager(10, 10);
     const size_t num_producers = 5;
     std::vector<cluster::producer_ptr> producers;
     producers.reserve(num_producers);
@@ -123,7 +138,7 @@ FIXTURE_TEST(test_lru_maintenance, test_fixture) {
         auto prod = new_producer();
         producers.push_back(prod);
     }
-    check_producers(num_producers);
+    validate_producer_count(num_producers);
 
     // run a function on each producer and ensure that is the
     // moved to the end of LRU list
@@ -132,10 +147,11 @@ FIXTURE_TEST(test_lru_maintenance, test_fixture) {
     }
 
     clean(producers);
-    check_producers(0);
+    validate_producer_count(0);
 }
 
 FIXTURE_TEST(test_eviction_max_pids, test_fixture) {
+    create_producer_state_manager(10, 10);
     int evicted_so_far = 0;
     std::vector<cluster::producer_ptr> producers;
     producers.reserve(default_max_producers);
@@ -150,12 +166,12 @@ FIXTURE_TEST(test_eviction_max_pids, test_fixture) {
         producers.push_back(new_producer([&] { evicted_so_far++; }));
     }
 
-    check_producers(default_max_producers);
+    validate_producer_count(default_max_producers);
 
     RPTEST_REQUIRE_EVENTUALLY(
       10s, [&] { return evicted_so_far == extra_producers; });
 
-    check_producers(default_max_producers);
+    validate_producer_count(default_max_producers);
 
     // producers are evicted on an lru basis, so the prefix
     // set of producers should be evicted first.
@@ -164,4 +180,91 @@ FIXTURE_TEST(test_eviction_max_pids, test_fixture) {
     }
 
     clean(producers);
+}
+
+FIXTURE_TEST(test_state_management_with_multiple_namespaces, test_fixture) {
+    size_t total_producers = 20;
+    model::vcluster_id vcluster_1 = model::vcluster_id(
+      xid::from_string("00000000000000000100"));
+    model::vcluster_id vcluster_2 = model::vcluster_id(
+      xid::from_string("00000000000000000200"));
+    model::vcluster_id vcluster_3 = model::vcluster_id(
+      xid::from_string("00000000000000000300"));
+    model::vcluster_id vcluster_4 = model::vcluster_id(
+      xid::from_string("00000000000000000400"));
+    model::vcluster_id vcluster_5 = model::vcluster_id(
+      xid::from_string("00000000000000000500"));
+
+    absl::flat_hash_map<model::vcluster_id, size_t> evicted_producers;
+    create_producer_state_manager(total_producers, 5);
+    struct vcluster_producer {
+        model::vcluster_id vcluster;
+        cluster::producer_ptr producer;
+    };
+    std::vector<vcluster_producer> producers;
+    producers.reserve(default_max_producers);
+
+    auto new_vcluster_producer = [&](model::vcluster_id& vcluster) {
+        auto p = new_producer([&] { evicted_producers[vcluster]++; }, vcluster);
+        producers.push_back(
+          vcluster_producer{.vcluster = vcluster, .producer = p});
+    };
+    /**
+     * Fill producer state manager with producers from one vcluster
+     */
+    for (int i = 0; i < total_producers; ++i) {
+        new_vcluster_producer(vcluster_1);
+    }
+    validate_producer_count(20);
+    validate_namespace_count(1);
+    /**
+     * Add 3 producers in another vcluster
+     */
+    for (int i = 0; i < 3; ++i) {
+        new_vcluster_producer(vcluster_2);
+    }
+    validate_producer_count(20);
+    // namespace count should increase
+    validate_namespace_count(2);
+    // 3 producers should be evicted from vcluster_1
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_1], 3);
+
+    for (int i = 0; i < 10; ++i) {
+        new_vcluster_producer(vcluster_2);
+    }
+
+    validate_producer_count(20);
+    // namespace count should increase
+    validate_namespace_count(2);
+    // 10 producers should be evicted from vcluster_1
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_1], 10);
+    // 3 producers should be evicted from vcluster_2
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_2], 3);
+
+    for (int i = 0; i < 5; ++i) {
+        new_vcluster_producer(vcluster_3);
+        new_vcluster_producer(vcluster_4);
+    }
+    /**
+     * Another five elements should be evicted from each existing vcluster
+     */
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_1], 15);
+    BOOST_REQUIRE_EQUAL(evicted_producers[vcluster_2], 8);
+
+    validate_producer_count(20);
+    // namespace count should increase
+    validate_namespace_count(4);
+
+    /**
+     * No more space in the manager for another vcluster.
+     */
+    BOOST_REQUIRE_EXCEPTION(
+      new_vcluster_producer(vcluster_5),
+      cluster::cache_full_error,
+      [](const auto& ex) { return true; });
+
+    for (auto vp : producers) {
+        manager().deregister_producer(*vp.producer, vp.vcluster);
+        vp.producer->shutdown_input();
+    }
 }

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -198,14 +198,12 @@ inline tx_snapshot_v3::tx_seqs_snapshot random_tx_seqs_snapshot() {
 
 namespace tests {
 
-inline cluster::producer_ptr
-random_producer_state(cluster::producer_state_manager& psm) {
+inline cluster::producer_ptr random_producer_state() {
     return ss::make_lw_shared<cluster::producer_state>(
-      psm,
       model::producer_identity{
         random_generators::get_int<int64_t>(),
         random_generators::get_int<int16_t>()},
-      tests::random_named_int<raft::group_id>(),
+      random_named_int<raft::group_id>(),
       ss::noncopyable_function<void()>{});
 }
 

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -23,7 +23,8 @@ struct rm_stm_test_fixture : simple_raft_fixture {
         producer_state_manager
           .start(
             config::mock_binding(std::numeric_limits<uint64_t>::max()),
-            std::chrono::milliseconds::max())
+            std::chrono::milliseconds::max(),
+            config::mock_binding(std::numeric_limits<uint64_t>::max()))
           .get();
         producer_state_manager
           .invoke_on_all(

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -8,15 +8,27 @@
 // by the Apache License, Version 2.0
 
 #pragma once
+#include "cluster/producer_state_manager.h"
 #include "cluster/rm_stm.h"
 #include "config/property.h"
 #include "raft/tests/simple_raft_fixture.h"
+
+#include <seastar/core/sharded.hh>
 
 static ss::logger logger{"rm_stm-test"};
 
 struct rm_stm_test_fixture : simple_raft_fixture {
     void create_stm_and_start_raft(
       storage::ntp_config::default_overrides overrides = {}) {
+        producer_state_manager
+          .start(
+            config::mock_binding(std::numeric_limits<uint64_t>::max()),
+            std::chrono::milliseconds::max())
+          .get();
+        producer_state_manager
+          .invoke_on_all(
+            [](cluster::producer_state_manager& mgr) { return mgr.start(); })
+          .get();
         create_raft(overrides);
         raft::state_machine_manager_builder stm_m_builder;
 
@@ -25,10 +37,17 @@ struct rm_stm_test_fixture : simple_raft_fixture {
           _raft.get(),
           tx_gateway_frontend,
           _feature_table,
-          _producer_state_manager);
+          producer_state_manager);
 
         _raft->start(std::move(stm_m_builder)).get();
         _started = true;
+    }
+
+    ~rm_stm_test_fixture() {
+        if (_started) {
+            stop_all();
+            producer_state_manager.stop().get();
+        }
     }
 
     const cluster::rm_stm::producers_t& producers() const {
@@ -49,5 +68,6 @@ struct rm_stm_test_fixture : simple_raft_fixture {
     }
 
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
+    ss::sharded<cluster::producer_state_manager> producer_state_manager;
     ss::shared_ptr<cluster::rm_stm> _stm;
 };

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -37,7 +37,8 @@ struct rm_stm_test_fixture : simple_raft_fixture {
           _raft.get(),
           tx_gateway_frontend,
           _feature_table,
-          producer_state_manager);
+          producer_state_manager,
+          std::nullopt);
 
         _raft->start(std::move(stm_m_builder)).get();
         _started = true;

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -778,9 +778,9 @@ cluster::tx_snapshot_v4 make_tx_snapshot_v4() {
         cluster::random_expiration_snapshot)};
 }
 
-cluster::tx_snapshot make_tx_snapshot_v5(cluster::producer_state_manager& mgr) {
+cluster::tx_snapshot make_tx_snapshot_v5() {
     auto producers = tests::random_frag_vector(
-      tests::random_producer_state, 50, mgr);
+      tests::random_producer_state, 50);
     fragmented_vector<cluster::producer_state_snapshot> snapshots;
     for (auto producer : producers) {
         snapshots.push_back(producer->snapshot(kafka::offset{0}));
@@ -906,7 +906,7 @@ FIXTURE_TEST(test_snapshot_v3_v4_v5_equivalence, rm_stm_test_fixture) {
     }
 
     {
-        snap_v5 = make_tx_snapshot_v5(_producer_state_manager.local());
+        snap_v5 = make_tx_snapshot_v5();
         snap_v5.offset = stm.last_applied_offset();
         auto num_producers_from_snapshot = snap_v5.producers.size();
         auto highest_pid_from_snapshot = snap_v5.highest_producer_id;

--- a/src/v/cluster/tests/tx_compaction_tests.cc
+++ b/src/v/cluster/tests/tx_compaction_tests.cc
@@ -24,6 +24,7 @@ using cluster::tx_executor;
     auto stop = ss::defer([&] {                                                \
         _data_dir = "test_dir_" + random_generators::gen_alphanum_string(6);   \
         stop_all();                                                            \
+        producer_state_manager.stop().get();                                   \
         _stm = nullptr;                                                        \
     });                                                                        \
     wait_for_confirmed_leader();                                               \

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3047,7 +3047,14 @@ configuration::configuration()
       "enable_mpx_extensions",
       "Enable Redpanda extensions for MPX.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      false) {}
+      false)
+  , virtual_cluster_min_producer_ids(
+      *this,
+      "virtual_cluster_min_producer_ids",
+      "Minimum number of active producers per virtual cluster",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::numeric_limits<uint64_t>::max(),
+      {.min = 1}) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {
     if (!root_node["redpanda"]) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -567,6 +567,7 @@ struct configuration final : public config_store {
 
     // MPX
     property<bool> enable_mpx_extensions;
+    bounded_property<uint64_t> virtual_cluster_min_producer_ids;
 
     configuration();
 

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -105,6 +105,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::role_does_not_exist:
     case cluster::errc::inconsistent_stm_update:
     case cluster::errc::waiting_for_shard_placement_update:
+    case cluster::errc::producer_ids_vcluster_limit_exceeded:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/handlers/produce.cc
+++ b/src/v/kafka/server/handlers/produce.cc
@@ -146,6 +146,8 @@ static error_code map_produce_error_code(std::error_code ec) {
             return error_code::out_of_order_sequence_number;
         case cluster::errc::invalid_request:
             return error_code::invalid_request;
+        case cluster::errc::producer_ids_vcluster_limit_exceeded:
+            return error_code::policy_violation;
         case cluster::errc::generic_tx_error:
             return error_code::unknown_server_error;
         default:

--- a/src/v/raft/tests/mux_state_machine_test.cc
+++ b/src/v/raft/tests/mux_state_machine_test.cc
@@ -7,19 +7,15 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
-#include "base/outcome.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
 #include "model/timeout_clock.h"
+#include "raft/mux_state_machine.h"
 #include "raft/tests/simple_raft_fixture.h"
-#include "raft/types.h"
-#include "random/generators.h"
 #include "reflection/adl.h"
-#include "serde/serde.h"
 #include "storage/record_batch_builder.h"
 #include "storage/tests/utils/disk_log_builder.h"
-#include "test_utils/async.h"
 #include "test_utils/fixture.h"
 
 #include <seastar/core/abort_source.hh>
@@ -30,8 +26,6 @@
 
 #include <boost/range/irange.hpp>
 #include <boost/test/tools/old/interface.hpp>
-
-#include <thread>
 
 using namespace std::chrono_literals;
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1431,7 +1431,11 @@ void application::wire_up_redpanda_services(
       ss::sharded_parameter([]() {
           return config::shard_local_cfg().max_concurrent_producer_ids.bind();
       }),
-      config::shard_local_cfg().transactional_id_expiration_ms.value())
+      config::shard_local_cfg().transactional_id_expiration_ms.value(),
+      ss::sharded_parameter([]() {
+          return config::shard_local_cfg()
+            .virtual_cluster_min_producer_ids.bind();
+      }))
       .get();
 
     producer_manager.invoke_on_all(&cluster::producer_state_manager::start)

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2558,7 +2558,8 @@ void application::start_runtime_services(
             config::shard_local_cfg().enable_idempotence.value(),
             tx_gateway_frontend,
             producer_manager,
-            feature_table);
+            feature_table,
+            controller->get_topics_state());
           pm.register_factory<cluster::log_eviction_stm_factory>(
             storage.local().kvs());
           pm.register_factory<cluster::archival_metadata_stm_factory>(

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "bytes/random.h"
+#include "cluster/producer_state.h"
 #include "container/fragmented_vector.h"
 #include "random/generators.h"
 #include "tristate.h"

--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -724,34 +724,25 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         ans = rpk.cluster_config_set("max_concurrent_producer_ids",
                                      str(max_concurrent_producer_ids))
 
-        test_producer = ck.Producer({
-            'bootstrap.servers':
-            self.redpanda.brokers(),
-            'enable.idempotence':
-            True,
-        })
-
         topic = self.topics[0].name
-        test_producer.produce(topic,
-                              '0',
-                              '0',
-                              partition=0,
-                              on_delivery=self.on_delivery)
-        test_producer.flush()
 
-        max_producers = 51
+        def _produce_one(producer, idx):
+            self.logger.debug(f"producing using {idx} producer")
+            producer.produce(topic,
+                             f"record-key-producer-{idx}",
+                             f"record-value-producer-{idx}",
+                             partition=0,
+                             on_delivery=self.on_delivery)
+            producer.flush()
+
+        max_producers = 50
         producers = []
-        for i in range(max_producers - 1):
+        for i in range(max_producers):
             p = ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'enable.idempotence': True,
             })
-            p.produce(topic,
-                      str(i + 1),
-                      str(i + 1),
-                      partition=0,
-                      on_delivery=self.on_delivery)
-            p.flush()
+            _produce_one(p, i)
             producers.append(p)
 
         evicted_count = max_producers - max_concurrent_producer_ids
@@ -796,31 +787,23 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
                    err_msg="Producers not evicted in time")
 
         try:
-            test_producer.produce(topic,
-                                  'test',
-                                  'test',
-                                  partition=0,
-                                  on_delivery=self.on_delivery)
-            test_producer.flush()
+            _produce_one(producers[0], 0)
             assert False, "We can not produce after cleaning in rm_stm"
         except ck.cimpl.KafkaException as e:
             kafka_error = e.args[0]
             kafka_error.code(
             ) == ck.cimpl.KafkaError.OUT_OF_ORDER_SEQUENCE_NUMBER
 
-        last_worked_producers = max_producers - max_concurrent_producer_ids - 1
-        for i in range(max_concurrent_producer_ids):
-            producers[last_worked_producers + i].produce(
-                topic,
-                str(max_producers + i),
-                str(max_producers + i),
-                partition=0,
-                on_delivery=self.on_delivery)
-            producers[last_worked_producers + i].flush()
+        # validate that the producers are evicted with LRU policy,
+        # starting from this producer there should be no sequence
+        # number errors as those producer state should not be evicted
+        last_not_evicted_producer_idx = max_producers - max_concurrent_producer_ids + 1
+        for i in range(last_not_evicted_producer_idx, len(producers)):
+            _produce_one(producers[i], i)
 
-        should_be_consumed = max_producers + max_concurrent_producer_ids - 1
+        expected_records = len(
+            producers) - last_not_evicted_producer_idx + max_producers
         num_consumed = 0
-        prev_rec = bytes("0", 'UTF-8')
 
         consumer = ck.Consumer({
             'bootstrap.servers': self.redpanda.brokers(),
@@ -830,20 +813,13 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
 
         consumer.subscribe([topic])
 
-        while num_consumed < should_be_consumed:
+        while num_consumed < expected_records:
             self.redpanda.logger.debug(
-                f"Consumed {num_consumed}. Should consume at the end {should_be_consumed}"
-            )
+                f"Consumed {num_consumed} of of {expected_records}")
             records = self.consume(consumer)
-
-            for record in records:
-                assert prev_rec == record.key(
-                ), f"Expected {prev_rec}. Got {record.key()}"
-                prev_rec = bytes(str(int(prev_rec) + 1), 'UTF-8')
-
             num_consumed += len(records)
 
-        assert num_consumed == should_be_consumed
+        assert num_consumed == expected_records
 
 
 @contextmanager


### PR DESCRIPTION
Change implementation of `producer_state_manager` to keep separate producer state LRU cache for each `v_cluster_id.` This approach isolates each virtual cluster queue and guarantees fair distribution of producer state slots among them. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements
- none
* Short description of how this PR improves existing behavior.

-->
- none