### PR TITLE
ducktape: temp fix for erlang 26.2.3 arm

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -25,6 +25,13 @@ apt-get install -qq elixir erlang-dev erlang-xmerl
 mix local.hex --force && mix local.rebar --force
 
 pushd /opt/ocsf-server
+
+# temporary workaround for erlang 26.2.3 arm core dump
+# https://github.com/erlang/otp/issues/8238#issuecomment-1987173291
+if [ $(uname -m) = "aarch64" ]; then
+	MIX_ENV=prod mix archive.install --force github hexpm/hex branch latest
+fi
+
 ./build_server.sh
 # The following is required because the server attempts to write logs
 # to the `dist/tmp` directory.  This is fine in docker ducktape as the user


### PR DESCRIPTION
Fixes [error](https://buildkite.com/redpanda/redpanda/builds/45869#018e20ad-5d8b-4717-b1ae-a5867d5cf343/6-11976):
```
Cannot allocate 976733209832459912 bytes of memory (of type "heap_frag").

Crash dump is being written to: erl_crash.dump...beam/erl_term.h:1492:tag_val_def() Assertion failed: tag_val_def error
./build_server.sh: line 4: 34609 Aborted                 (core dumped) MIX_ENV=prod mix do deps.get, deps.compile
```

Using temp workaround: https://github.com/erlang/otp/issues/8238#issuecomment-1987173291

related issue: https://redpandadata.atlassian.net/browse/PESDLC-948

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none