### PR TITLE
[v23.3.x] ducktape: temp fix for erlang 26.2.3 arm

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -25,6 +25,13 @@ apt-get install -qq elixir erlang-dev erlang-xmerl
 mix local.hex --force && mix local.rebar --force
 
 pushd /opt/ocsf-server
+
+# temporary workaround for erlang 26.2.3 arm core dump
+# https://github.com/erlang/otp/issues/8238#issuecomment-1987173291
+if [ $(uname -m) = "aarch64" ]; then
+	MIX_ENV=prod mix archive.install --force github hexpm/hex branch latest
+fi
+
 ./build_server.sh
 # The following is required because the server attempts to write logs
 # to the `dist/tmp` directory.  This is fine in docker ducktape as the user


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17000
