### PR TITLE
CORE-6: Pre-fetching algorithms

### DIFF
--- a/src/v/crypto/crypto.cc
+++ b/src/v/crypto/crypto.cc
@@ -66,5 +66,16 @@ EVP_MD* get_md(digest_type type) {
 
     return it->second.get();
 }
+
+EVP_MAC* get_mac() {
+    static thread_local EVP_MAC_ptr mac;
+    if (!mac) {
+        mac = EVP_MAC_ptr(EVP_MAC_fetch(nullptr, "HMAC", "?provider=fips"));
+        if (!mac) {
+            throw ossl_error("Failed to fetch HMAC algorithm");
+        }
+    }
+    return mac.get();
+}
 } // namespace internal
 } // namespace crypto

--- a/src/v/crypto/crypto.cc
+++ b/src/v/crypto/crypto.cc
@@ -11,6 +11,10 @@
 
 #include "crypto/crypto.h"
 
+#include "crypto/types.h"
+#include "internal.h"
+
+#include <absl/container/node_hash_map.h>
 namespace crypto {
 std::ostream& operator<<(std::ostream& os, digest_type type) {
     switch (type) {
@@ -40,4 +44,27 @@ std::ostream& operator<<(std::ostream& os, format_type type) {
         return os << "DER";
     }
 }
+
+namespace internal {
+EVP_MD* get_md(digest_type type) {
+    // Map of pre-fetched MD pointers.  This replaces the older way of getting
+    // a digest pointer via something like `EVP_sha256()`.  The old way is
+    // slower compared to pre-fetching the algorithm.
+    static thread_local absl::node_hash_map<digest_type, EVP_MD_ptr> md_map;
+    auto it = md_map.find(type);
+    if (it == md_map.end()) {
+        auto alg = fmt::to_string(type);
+        auto md_ptr = EVP_MD_fetch(nullptr, alg.c_str(), "?provider=fips");
+        if (!md_ptr) {
+            throw ossl_error(fmt::format("Failed to fetch algorithm {}", alg));
+        }
+        auto res = md_map.insert_or_assign(type, EVP_MD_ptr(md_ptr));
+        vassert(
+          res.second, "Failed to insert/create the fetched algorithm {}", alg);
+        return md_ptr;
+    }
+
+    return it->second.get();
+}
+} // namespace internal
 } // namespace crypto

--- a/src/v/crypto/hmac.cc
+++ b/src/v/crypto/hmac.cc
@@ -13,6 +13,7 @@
 #include "internal.h"
 #include "ssl_utils.h"
 
+#include <openssl/core_names.h>
 #include <openssl/evp.h>
 #include <openssl/params.h>
 
@@ -22,7 +23,7 @@ public:
     impl(digest_type type, bytes_view key) {
         std::array<OSSL_PARAM, 2> params{
           OSSL_PARAM_construct_utf8_string(
-            "digest",
+            OSSL_MAC_PARAM_DIGEST,
             // NOLINTNEXTLINE
             const_cast<char*>(get_digest_str(type)),
             0),

--- a/src/v/crypto/hmac.cc
+++ b/src/v/crypto/hmac.cc
@@ -27,13 +27,8 @@ public:
             const_cast<char*>(get_digest_str(type)),
             0),
           OSSL_PARAM_construct_end()};
-        _mac = internal::EVP_MAC_ptr(EVP_MAC_fetch(nullptr, "HMAC", nullptr));
-        if (!_mac) {
-            throw internal::ossl_error(
-              "Failed to fetch HMAC for MAC operation");
-        }
-
-        _mac_ctx = internal::EVP_MAC_CTX_ptr(EVP_MAC_CTX_new(_mac.get()));
+        _mac_ctx = internal::EVP_MAC_CTX_ptr(
+          EVP_MAC_CTX_new(internal::get_mac()));
         if (
           1
           != EVP_MAC_init(
@@ -88,7 +83,6 @@ public:
     static size_t size(digest_type type) { return digest_ctx::size(type); }
 
 private:
-    internal::EVP_MAC_ptr _mac;
     internal::EVP_MAC_CTX_ptr _mac_ctx;
 
     static const char* get_digest_str(digest_type type) {

--- a/src/v/crypto/hmac.cc
+++ b/src/v/crypto/hmac.cc
@@ -18,22 +18,43 @@
 #include <openssl/params.h>
 
 namespace crypto {
+namespace {
+static const auto sha256_params = []() {
+    std::array<OSSL_PARAM, 2> params{
+      OSSL_PARAM_construct_utf8_string(
+        OSSL_MAC_PARAM_DIGEST, const_cast<char*>("SHA256"), 0),
+      OSSL_PARAM_construct_end()};
+    return params;
+}();
+
+static const auto sha512_params = []() {
+    std::array<OSSL_PARAM, 2> params{
+      OSSL_PARAM_construct_utf8_string(
+        OSSL_MAC_PARAM_DIGEST, const_cast<char*>("SHA512"), 0),
+      OSSL_PARAM_construct_end()};
+    return params;
+}();
+
+static const std::array<OSSL_PARAM, 2>& get_param(digest_type type) {
+    switch (type) {
+    case digest_type::SHA256:
+        return sha256_params;
+    case digest_type::SHA512:
+        return sha512_params;
+    default:
+        vassert(false, "Cannot create an HMAC for digest type {}", type);
+    };
+}
+} // namespace
 class hmac_ctx::impl {
 public:
     impl(digest_type type, bytes_view key) {
-        std::array<OSSL_PARAM, 2> params{
-          OSSL_PARAM_construct_utf8_string(
-            OSSL_MAC_PARAM_DIGEST,
-            // NOLINTNEXTLINE
-            const_cast<char*>(get_digest_str(type)),
-            0),
-          OSSL_PARAM_construct_end()};
         _mac_ctx = internal::EVP_MAC_CTX_ptr(
           EVP_MAC_CTX_new(internal::get_mac()));
         if (
           1
           != EVP_MAC_init(
-            _mac_ctx.get(), key.data(), key.size(), params.data())) {
+            _mac_ctx.get(), key.data(), key.size(), get_param(type).data())) {
             throw internal::ossl_error(
               fmt::format("Failed to initialize HMAC-{}", type));
         }

--- a/src/v/crypto/internal.h
+++ b/src/v/crypto/internal.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "bytes/bytes.h"
+#include "ssl_utils.h"
 
 namespace crypto::internal {
 inline bytes_view string_view_to_bytes_view(std::string_view v) {
@@ -24,4 +25,6 @@ inline bytes_span<> char_span_to_bytes_span(std::span<char> v) {
     // NOLINTNEXTLINE: allow reinterpret_cast
     return {reinterpret_cast<bytes_span<>::value_type*>(v.data()), v.size()};
 }
+
+EVP_MD* get_md(digest_type type);
 } // namespace crypto::internal

--- a/src/v/crypto/internal.h
+++ b/src/v/crypto/internal.h
@@ -27,4 +27,5 @@ inline bytes_span<> char_span_to_bytes_span(std::span<char> v) {
 }
 
 EVP_MD* get_md(digest_type type);
+EVP_MAC* get_mac();
 } // namespace crypto::internal

--- a/src/v/crypto/ssl_utils.h
+++ b/src/v/crypto/ssl_utils.h
@@ -39,17 +39,6 @@ public:
     static std::string build_error();
 };
 
-inline const EVP_MD* get_md(digest_type type) {
-    switch (type) {
-    case digest_type::MD5:
-        return EVP_md5();
-    case digest_type::SHA256:
-        return EVP_sha256();
-    case digest_type::SHA512:
-        return EVP_sha512();
-    }
-}
-
 template<typename T, void (*fn)(T*)>
 struct deleter {
     void operator()(T* ptr) { fn(ptr); }
@@ -60,6 +49,7 @@ using handle = std::unique_ptr<T, deleter<T, fn>>;
 
 using BIO_ptr = handle<BIO, BIO_free_all>;
 using BN_ptr = handle<BIGNUM, BN_free>;
+using EVP_MD_ptr = handle<EVP_MD, EVP_MD_free>;
 using EVP_MAC_ptr = handle<EVP_MAC, EVP_MAC_free>;
 using EVP_MAC_CTX_ptr = handle<EVP_MAC_CTX, EVP_MAC_CTX_free>;
 using EVP_MD_CTX_ptr = handle<EVP_MD_CTX, EVP_MD_CTX_free>;

--- a/src/v/crypto/test/CMakeLists.txt
+++ b/src/v/crypto/test/CMakeLists.txt
@@ -12,7 +12,7 @@ rp_test(
       v::crypto
       v::gtest_main
     LABELS crypto
-    ARGS "-- -c 1"      
+    ARGS "-- -c 1"
 )
 
 if(Redpanda_BUILD_COMPLIANCE)
@@ -53,3 +53,27 @@ rp_test(
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/test_openssl_conf.cnf.in
                ${CMAKE_CURRENT_BINARY_DIR}/test/openssl_conf.cnf)
+
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME crypto_bench
+  SOURCES crypto_bench.cc
+  LIBRARIES
+    Seastar::seastar_perf_testing v::crypto v::random GnuTLS::GnuTLS
+  LABELS crypto
+  ENV "OPENSSL_CONF=${CMAKE_CURRENT_BINARY_DIR}/test/openssl_conf.cnf;MODULE_DIR=${REDPANDA_DEPS_INSTALL_DIR}/lib64/ossl-modules"
+)
+
+if(Redpanda_BUILD_COMPLIANCE)
+rp_test(
+  BENCHMARK_TEST
+  BINARY_NAME crypto_bench_fips
+  SOURCES crypto_bench.cc
+  DEFINITIONS
+    PERF_FIPS_MODE
+  LIBRARIES
+    Seastar::seastar_perf_testing v::crypto v::random GnuTLS::GnuTLS
+  LABELS crypto
+  ENV "OPENSSL_CONF=${CMAKE_CURRENT_BINARY_DIR}/test/openssl_conf.cnf;MODULE_DIR=${REDPANDA_DEPS_INSTALL_DIR}/lib64/ossl-modules"
+)
+endif()

--- a/src/v/crypto/test/crypto_bench.cc
+++ b/src/v/crypto/test/crypto_bench.cc
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "crypto/crypto.h"
+#include "crypto/ossl_context_service.h"
+#include "random/generators.h"
+#include "ssx/thread_worker.h"
+
+#include <seastar/core/sleep.hh>
+#include <seastar/testing/perf_tests.hh>
+
+#include <gnutls/crypto.h>
+#include <gnutls/gnutls.h>
+
+static constexpr size_t inner_iters = 1000;
+
+template<gnutls_mac_algorithm_t Algo, size_t DigestSize>
+class hmac {
+    static_assert(DigestSize > 0, "digest cannot be zero length");
+
+public:
+    // silence clang-tidy about _handle being uninitialized
+    // NOLINTNEXTLINE(hicpp-member-init, cppcoreguidelines-pro-type-member-init)
+    explicit hmac(std::string_view key)
+      : hmac(key.data(), key.size()) {}
+
+    // silence clang-tidy about _handle being uninitialized
+    // NOLINTNEXTLINE(hicpp-member-init, cppcoreguidelines-pro-type-member-init)
+    explicit hmac(bytes_view key)
+      : hmac(key.data(), key.size()) {}
+
+    hmac(const hmac&) = delete;
+    hmac& operator=(const hmac&) = delete;
+    hmac(hmac&&) = delete;
+    hmac& operator=(hmac&&) = delete;
+
+    ~hmac() noexcept { gnutls_hmac_deinit(_handle, nullptr); }
+
+    void update(std::string_view data) { update(data.data(), data.size()); }
+    void update(bytes_view data) { update(data.data(), data.size()); }
+
+    template<std::size_t Size>
+    void update(const std::array<char, Size>& data) {
+        update(data.data(), Size);
+    }
+
+    /**
+     * Return the current output and reset.
+     */
+    std::array<char, DigestSize> reset() {
+        std::array<char, DigestSize> digest;
+        gnutls_hmac_output(_handle, digest.data());
+        return digest;
+    }
+
+private:
+    // silence clang-tidy about _handle being uninitialized
+    // NOLINTNEXTLINE(hicpp-member-init, cppcoreguidelines-pro-type-member-init)
+    hmac(const void* key, size_t size) {
+        int ret = gnutls_hmac_init(&_handle, Algo, key, size);
+        if (unlikely(ret)) {
+            throw std::runtime_error(gnutls_strerror(ret));
+        }
+
+        ret = gnutls_hmac_get_len(Algo);
+        if (unlikely(ret != DigestSize)) {
+            throw std::runtime_error("invalid digest length");
+        }
+    }
+
+    void update(const void* data, size_t size) {
+        int ret = gnutls_hmac(_handle, data, size);
+        if (unlikely(ret)) {
+            throw std::runtime_error(gnutls_strerror(ret));
+        }
+    }
+
+    gnutls_hmac_hd_t _handle;
+};
+
+template<gnutls_digest_algorithm_t Algo, size_t DigestSize>
+class hash {
+public:
+    static constexpr auto digest_size = DigestSize;
+    using digest_type = std::array<char, DigestSize>;
+
+    hash() {
+        int ret = gnutls_hash_init(&_handle, Algo);
+        if (unlikely(ret)) {
+            throw std::runtime_error("hash init failed");
+        }
+
+        ret = gnutls_hash_get_len(Algo);
+        if (unlikely(ret != DigestSize)) {
+            throw std::runtime_error("BOO");
+        }
+    }
+
+    hash(const hash&) = delete;
+    hash& operator=(const hash&) = delete;
+    hash(hash&&) = delete;
+    hash& operator=(hash&&) = delete;
+
+    ~hash() noexcept { gnutls_hash_deinit(_handle, nullptr); }
+
+    void update(std::string_view data) { update(data.data(), data.size()); }
+    void update(bytes_view data) { update(data.data(), data.size()); }
+
+    /**
+     * Return the current output and reset.
+     */
+    digest_type reset() {
+        std::array<char, DigestSize> digest;
+        gnutls_hash_output(_handle, digest.data());
+        return digest;
+    }
+
+private:
+    void update(const void* data, size_t size) {
+        int ret = gnutls_hash(_handle, data, size);
+        if (unlikely(ret)) {
+            throw std::runtime_error("blah update");
+        }
+    }
+
+    gnutls_hash_hd_t _handle;
+};
+
+using hmac_sha256 = hmac<GNUTLS_MAC_SHA256, 32>;
+using hmac_sha512 = hmac<GNUTLS_MAC_SHA512, 64>;
+using hash_sha256 = hash<GNUTLS_DIG_SHA256, 32>;
+using hash_sha512 = hash<GNUTLS_DIG_SHA512, 64>;
+using hash_md5 = hash<GNUTLS_DIG_MD5, 16>;
+
+template<typename F>
+static size_t test_body(size_t msg_len, F n) {
+    auto buffer = random_generators::gen_alphanum_string(msg_len);
+    for (auto i = inner_iters; i--;) {
+        auto s = n(buffer);
+        perf_tests::do_not_optimize(s);
+    }
+    perf_tests::stop_measuring_time();
+    return inner_iters * msg_len;
+}
+
+struct openssl_perf {
+public:
+    openssl_perf()
+      : _thread_worker{std::make_unique<ssx::singleton_thread_worker>()} {
+#ifdef PERF_FIPS_MODE
+        auto fips_mode = crypto::is_fips_mode::yes;
+#else
+        auto fips_mode = crypto::is_fips_mode::no;
+#endif
+        _thread_worker->start({.name = "worker"}).get();
+        _svc
+          .start(
+            std::ref(*_thread_worker),
+            get_config_file_path(),
+            ::getenv("MODULE_DIR"),
+            fips_mode)
+          .get();
+        _svc.invoke_on_all(&crypto::ossl_context_service::start).get();
+    }
+
+    ~openssl_perf() {
+        _svc.stop().get();
+        _thread_worker->stop().get();
+        _thread_worker.reset();
+    }
+
+private:
+    std::unique_ptr<ssx::singleton_thread_worker> _thread_worker{nullptr};
+    ss::sharded<crypto::ossl_context_service> _svc;
+
+    static std::string get_config_file_path() {
+        auto conf_file = ::getenv("OPENSSL_CONF");
+        if (conf_file) {
+            return conf_file;
+        } else {
+            return "";
+        }
+    }
+};
+
+#ifndef PERF_FIPS_MODE
+PERF_TEST_F(openssl_perf, md5_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        return crypto::digest(crypto::digest_type::MD5, buffer);
+    });
+}
+#endif
+
+PERF_TEST_F(openssl_perf, sha256_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        return crypto::digest(crypto::digest_type::SHA256, buffer);
+    });
+}
+
+PERF_TEST_F(openssl_perf, sha512_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        return crypto::digest(crypto::digest_type::SHA512, buffer);
+    });
+}
+
+PERF_TEST(gnutls, md5_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        hash_md5 md5{};
+        md5.update(buffer);
+        return md5.reset();
+    });
+}
+
+PERF_TEST(gnutls, sha256_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        hash_sha256 sha256{};
+        sha256.update(buffer);
+        return sha256.reset();
+    });
+}
+
+PERF_TEST(gnutls, sha512_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        hash_sha512 sha512{};
+        sha512.update(buffer);
+        return sha512.reset();
+    });
+}
+
+PERF_TEST_F(openssl_perf, hmac_sha256_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        auto key = random_generators::gen_alphanum_string(32);
+        return crypto::hmac(crypto::digest_type::SHA256, key, buffer);
+    });
+}
+
+PERF_TEST_F(openssl_perf, hmac_sha512_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        auto key = random_generators::gen_alphanum_string(32);
+        return crypto::hmac(crypto::digest_type::SHA512, key, buffer);
+    });
+}
+
+PERF_TEST(gnutls, hmac_sha256_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        auto key = random_generators::gen_alphanum_string(32);
+        hmac_sha256 hmac{key};
+        hmac.update(buffer);
+        return hmac.reset();
+    });
+}
+
+PERF_TEST(gnutls, hmac_sha512_1k) {
+    return test_body(1024, [](const ss::sstring& buffer) {
+        auto key = random_generators::gen_alphanum_string(32);
+        hmac_sha512 hmac{key};
+        hmac.update(buffer);
+        return hmac.reset();
+    });
+}


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This change improves the performance of the crypto library by pre-fetching the MD and HMAC operations.

See the performance section in [OpenSSL's docs](https://www.openssl.org/docs/man3.1/man7/crypto.html#performance)

Fixes: https://github.com/redpanda-data/core-internal/issues/1152
Fixes: https://github.com/redpanda-data/core-internal/issues/1154

[CORE-8]
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none


[CORE-8]: https://redpandadata.atlassian.net/browse/CORE-8?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ