### PR TITLE
transform-sdk/rust: multiple output topics

### DIFF
--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -99,6 +99,7 @@ jobs:
         env:
           IDENTITY: identity.wasm
           LOGGING: identity_logging.wasm
+          TEE: "@UNIMPLEMENTED@"
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v
@@ -139,7 +140,8 @@ jobs:
         run: |
           cargo build --target=wasm32-wasi --release \
             --example=identity \
-            --example=identity_logging
+            --example=identity_logging \
+            --example=tee
       - name: Download integration test suite
         uses: actions/download-artifact@v4
         with:
@@ -150,6 +152,7 @@ jobs:
         env:
           IDENTITY: target/wasm32-wasi/release/examples/identity.wasm
           LOGGING: target/wasm32-wasi/release/examples/identity_logging.wasm
+          TEE: target/wasm32-wasi/release/examples/tee.wasm
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v
@@ -202,6 +205,7 @@ jobs:
         env:
           IDENTITY: build/identity_transform
           LOGGING: build/identity_logging_transform
+          TEE: "@UNIMPLEMENTED@"
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           tinygo build -scheduler=none -target=wasi -o identity.wasm ./identity
           tinygo build -scheduler=none -target=wasi -o identity_logging.wasm ./identity_logging
+          tinygo build -scheduler=none -target=wasi -o tee.wasm ./tee
       - name: Download integration test suite
         uses: actions/download-artifact@v4
         with:
@@ -99,7 +100,7 @@ jobs:
         env:
           IDENTITY: identity.wasm
           LOGGING: identity_logging.wasm
-          TEE: "@UNIMPLEMENTED@"
+          TEE: tee.wasm
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v

--- a/src/transform-sdk/cpp/src/transform_sdk.cc
+++ b/src/transform-sdk/cpp/src/transform_sdk.cc
@@ -490,6 +490,10 @@ void assert(bool cond, std::format_string<Args...> fmt, Args&&... args) {
     }
 }
 
+// Ignore this lint check, as it can't tell our custom `assert` method
+// is a check.
+// NOLINTBEGIN(*-unchecked-optional-access)
+
 void test_zigzag_roundtrip() {
     constexpr auto testcases = std::to_array<int64_t>(
       {0,
@@ -608,6 +612,8 @@ void test_record_roundtrip(random_bytes_engine* rng) {
         assert(result.value() == rec, "record mismatch");
     }
 }
+
+// NOLINTEND(*-unchecked-optional-access)
 
 void run_test_suite() {
     unsigned seed = std::random_device()();

--- a/src/transform-sdk/go/transform/internal/testdata/tee/transform.go
+++ b/src/transform-sdk/go/transform/internal/testdata/tee/transform.go
@@ -1,0 +1,39 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redpanda-data/redpanda/src/transform-sdk/go/transform"
+)
+
+func main() {
+	transform.OnRecordWritten(teeTransfrom)
+}
+
+func teeTransfrom(e transform.WriteEvent, w transform.RecordWriter) error {
+	for i := 0; i < 8; i += 1 {
+		topic, ok := os.LookupEnv(fmt.Sprintf("REDPANDA_OUTPUT_TOPIC_%d", i))
+		if !ok {
+			break
+		}
+		if err := w.Write(e.Record(), transform.ToTopic(topic)); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/src/transform-sdk/rust/core-sys/src/abi.rs
+++ b/src/transform-sdk/rust/core-sys/src/abi.rs
@@ -14,7 +14,7 @@
 
 #[link(wasm_import_module = "redpanda_transform")]
 extern "C" {
-    #[link_name = "check_abi_version_1"]
+    #[link_name = "check_abi_version_2"]
     pub(crate) fn check_abi();
 
     #[link_name = "read_batch_header"]
@@ -42,4 +42,12 @@ extern "C" {
 
     #[link_name = "write_record"]
     pub(crate) fn write_record(buf: *const u8, len: u32) -> i32;
+
+    #[link_name = "write_record_with_options"]
+    pub(crate) fn write_record_with_options(
+        buf: *const u8,
+        buf_len: u32,
+        opts: *const u8,
+        opts_len: u32,
+    ) -> i32;
 }

--- a/src/transform-sdk/rust/core-sys/src/stub_abi.rs
+++ b/src/transform-sdk/rust/core-sys/src/stub_abi.rs
@@ -47,3 +47,12 @@ pub(crate) unsafe fn read_next_record(
 pub(crate) unsafe fn write_record(_buf: *const u8, _len: u32) -> i32 {
     panic!("stub");
 }
+
+pub(crate) unsafe fn write_record_with_options(
+    _buf: *const u8,
+    _buf_len: u32,
+    _opts: *const u8,
+    _opts_len: u32,
+) -> i32 {
+    panic!("stub");
+}

--- a/src/transform-sdk/rust/examples/tee.rs
+++ b/src/transform-sdk/rust/examples/tee.rs
@@ -1,0 +1,38 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use anyhow::Result;
+use redpanda_transform_sdk::*;
+
+// This example shows the basic usage of the crate:
+// This transform does nothing but copy the same data from an
+// input topic to all output topics.
+fn main() {
+    // Make sure to register your callback and perform other setup in main
+    on_record_written(my_transform);
+}
+
+// This will be called for each record in the source topic.
+//
+// The output records returned will be written to all destination topics.
+fn my_transform(event: WriteEvent, writer: &mut RecordWriter) -> Result<()> {
+    // Redpanda automatically populates environment variables with the output topic configuration.
+    // We can dynamically lookup our output topic using these environment variables.
+    let output_topics =
+        (0..8).filter_map(|i| std::env::var(std::format!("REDPANDA_OUTPUT_TOPIC_{}", i)).ok());
+    for topic in output_topics {
+        writer.write_with_options(event.record.as_ref(), WriteOptions::to_topic(&topic))?;
+    }
+    Ok(())
+}

--- a/src/transform-sdk/rust/sr-types/src/lib.rs
+++ b/src/transform-sdk/rust/sr-types/src/lib.rs
@@ -38,12 +38,13 @@ pub struct SchemaId(pub i32);
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SchemaVersion(pub i32);
 
-/// Reference is a way for one schema to reference another. The details
-/// for how referencing is done are type-specific; for example, JSON objects
+/// Reference is a way for one schema to reference another.
+///
+/// The details for how referencing is done are type-specific; for example, JSON objects
 /// that use the key "$ref" can refer to another schema via URL. For more details
 /// on references, see the following link:
 ///
-///  https://docs.redpanda.com/current/manage/schema-reg/schema-reg-api/#reference-a-schema
+///  <https://docs.redpanda.com/current/manage/schema-reg/schema-reg-api/#reference-a-schema>
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Reference {
     name: String,

--- a/src/transform-sdk/tests/admin_client.go
+++ b/src/transform-sdk/tests/admin_client.go
@@ -101,6 +101,7 @@ func (cl *AdminAPIClient) DeployTransform(ctx context.Context, metadata Transfor
 }
 
 func isTransformsRunning(transforms []TransformMetadata, name string) bool {
+	fmt.Println("is running:", name, transforms)
 	for _, t := range transforms {
 		if t.Name != name {
 			continue
@@ -180,6 +181,27 @@ func (cl *AdminAPIClient) DeleteTransform(ctx context.Context, name string) erro
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("failed to build http request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := cl.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	return checkResponse(resp)
+}
+
+// SetLog level for a broker logger
+func (cl *AdminAPIClient) SetLogLevel(ctx context.Context, logger string, level string) error {
+	endpoint, err := url.JoinPath(cl.baseUrl, "/v1/config/log_level", url.PathEscape(logger))
+	if err != nil {
+		return fmt.Errorf("failed to join url path: %w", err)
+	}
+	endpoint += fmt.Sprintf("?level=%s", level)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, endpoint, nil)
 	if err != nil {
 		return fmt.Errorf("failed to build http request: %w", err)
 	}

--- a/src/transform-sdk/tests/integration_test.go
+++ b/src/transform-sdk/tests/integration_test.go
@@ -46,6 +46,11 @@ func TestMain(m *testing.M) {
 		log.Fatalf("unable to access Admin API Address: %v", err)
 	}
 	adminClient = NewAdminAPIClient(adminURL)
+	for _, logger := range []string{"transform", "wasm"} {
+		if err := adminClient.SetLogLevel(ctx, logger, "trace"); err != nil {
+			log.Fatalf("unable to set log level: %v", err)
+		}
+	}
 
 	// Setup broker
 	broker, err := container.KafkaSeedBroker(ctx)

--- a/src/transform-sdk/tests/integration_test.go
+++ b/src/transform-sdk/tests/integration_test.go
@@ -88,7 +88,6 @@ func deployTransform(t *testing.T, metadata TransformDeployMetadata, binary []by
 }
 
 func TestIdentity(t *testing.T) {
-	t.Parallel()
 	binary := loadWasmFile(t, "IDENTITY")
 	metadata := TransformDeployMetadata{
 		Name:         "identity-xform",
@@ -139,7 +138,6 @@ type openTelemetryLogEvent struct {
 }
 
 func TestLogging(t *testing.T) {
-	t.Parallel()
 	binary := loadWasmFile(t, "LOGGING")
 	metadata := TransformDeployMetadata{
 		Name:         "logging-xform",
@@ -171,7 +169,6 @@ func TestLogging(t *testing.T) {
 }
 
 func TestMultipleOutputs(t *testing.T) {
-	t.Parallel()
 	binary := loadWasmFile(t, "TEE")
 	metadata := TransformDeployMetadata{
 		Name:         "tee-xform",

--- a/src/transform-sdk/tests/test_util.go
+++ b/src/transform-sdk/tests/test_util.go
@@ -57,7 +57,7 @@ func startRedpanda(ctx context.Context) (*redpanda.Container, context.CancelFunc
 				req.LogConsumerCfg = &testcontainers.LogConsumerConfig{}
 			}
 			// Comment this out to get broker logs
-			// req.LogConsumerCfg.Consumers = append(req.LogConsumerCfg.Consumers, &StdoutLogConsumer{})
+			// req.LogConsumerCfg.Consumers = append(req.LogConsumerCfg.Consumers, &stdoutLogConsumer{})
 		}),
 		redpanda.WithEnableWasmTransform(),
 	)
@@ -77,8 +77,12 @@ func requireRecordsEquals(t *testing.T, fetches kgo.Fetches, records ...*kgo.Rec
 	require.Equal(t, fetches.NumRecords(), len(records))
 	for i, got := range fetches.Records() {
 		want := records[i]
-		require.Equal(t, want.Key, got.Key, "record %d key mismatch", i)
-		require.Equal(t, want.Value, got.Value, "record %d value mismatch", i)
-		require.Equal(t, want.Headers, got.Headers, "record %d headers mismatch", i)
+		requireRecordEquals(t, got, want, "record %d mismatch", i)
 	}
+}
+
+func requireRecordEquals(t *testing.T, got *kgo.Record, want *kgo.Record, msg string, args ...interface{}) {
+	require.Equal(t, want.Key, got.Key, "record key mismatch: %v", fmt.Sprintf(msg, args...))
+	require.Equal(t, want.Value, got.Value, "record value mismatch: %v", fmt.Sprintf(msg, args...))
+	require.Equal(t, want.Headers, got.Headers, "record headers mismatch: %v", fmt.Sprintf(msg, args...))
 }

--- a/src/transform-sdk/tests/test_util.go
+++ b/src/transform-sdk/tests/test_util.go
@@ -56,7 +56,7 @@ func startRedpanda(ctx context.Context) (*redpanda.Container, context.CancelFunc
 			if req.LogConsumerCfg == nil {
 				req.LogConsumerCfg = &testcontainers.LogConsumerConfig{}
 			}
-			// Comment this out to get broker logs
+			// Uncomment this to get broker logs
 			// req.LogConsumerCfg.Consumers = append(req.LogConsumerCfg.Consumers, &stdoutLogConsumer{})
 		}),
 		redpanda.WithEnableWasmTransform(),


### PR DESCRIPTION
Add support for the new method to write options in v2 of the broker's
ABI. This includes specifying write options in the RecordWriter
interface that can then be used to call the new `write_with_options`
method with the specified topic name.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* The rust transform-sdk gains the ability to write to multiple output topics.
  This feature can only be used in Redpanda v24.1.x or newer.


