### PR TITLE
write caching - raft implementation

### DIFF
--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -294,10 +294,12 @@ ss::future<log_eviction_stm::offset_result> log_eviction_stm::replicate_command(
   model::record_batch batch,
   ss::lowres_clock::time_point deadline,
   std::optional<std::reference_wrapper<ss::abort_source>> as) {
+    auto opts = raft::replicate_options(raft::consistency_level::quorum_ack);
+    opts.set_force_flush();
     auto fut = _raft->replicate(
       _raft->term(),
       model::make_memory_record_batch_reader(std::move(batch)),
-      raft::replicate_options{raft::consistency_level::quorum_ack});
+      opts);
 
     /// Execute the replicate command bound by timeout and cancellable via
     /// abort_source mechanism

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -93,7 +93,9 @@ model::control_record_type parse_control_batch(const model::record_batch& b) {
 }
 
 raft::replicate_options make_replicate_options() {
-    return raft::replicate_options(raft::consistency_level::quorum_ack);
+    auto opts = raft::replicate_options(raft::consistency_level::quorum_ack);
+    opts.set_force_flush();
+    return opts;
 }
 
 } // namespace

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -42,8 +42,106 @@
 namespace cluster {
 using namespace std::chrono_literals;
 
-static ss::sstring abort_idx_name(model::offset first, model::offset last) {
+namespace {
+ss::sstring abort_idx_name(model::offset first, model::offset last) {
     return fmt::format("abort.idx.{}.{}", first, last);
+}
+
+model::record_batch make_tx_control_batch(
+  model::producer_identity pid, model::control_record_type crt) {
+    iobuf key;
+    kafka::protocol::encoder kw(key);
+    kw.write(model::current_control_record_version());
+    kw.write(static_cast<int16_t>(crt));
+
+    iobuf value;
+    kafka::protocol::encoder vw(value);
+    vw.write(static_cast<int16_t>(0));
+    vw.write(static_cast<int32_t>(0));
+
+    storage::record_batch_builder builder(
+      model::record_batch_type::raft_data, model::offset(0));
+    builder.set_producer_identity(pid.id, pid.epoch);
+    builder.set_control_type();
+    builder.set_transactional_type();
+    builder.add_raw_kw(
+      std::move(key), std::move(value), std::vector<model::record_header>());
+
+    return std::move(builder).build();
+}
+
+model::control_record_type parse_control_batch(const model::record_batch& b) {
+    const auto& hdr = b.header();
+
+    vassert(
+      hdr.type == model::record_batch_type::raft_data,
+      "expect data batch type got {}",
+      hdr.type);
+    vassert(hdr.attrs.is_control(), "expect control attrs got {}", hdr.attrs);
+    vassert(
+      b.record_count() == 1, "control batch must contain a single record");
+
+    auto r = b.copy_records();
+    auto& record = *r.begin();
+    auto key = record.release_key();
+    kafka::protocol::decoder key_reader(std::move(key));
+    auto version = model::control_record_version(key_reader.read_int16());
+    vassert(
+      version == model::current_control_record_version,
+      "unknown control record version");
+    return model::control_record_type(key_reader.read_int16());
+}
+} // namespace
+
+fence_batch_data read_fence_batch(model::record_batch&& b) {
+    const auto& hdr = b.header();
+    auto bid = model::batch_identity::from(hdr);
+
+    vassert(
+      b.record_count() == 1,
+      "model::record_batch_type::tx_fence batch must contain a single record");
+    auto r = b.copy_records();
+    auto& record = *r.begin();
+    auto val_buf = record.release_value();
+
+    iobuf_parser val_reader(std::move(val_buf));
+    auto version = reflection::adl<int8_t>{}.from(val_reader);
+    vassert(
+      version <= rm_stm::fence_control_record_version,
+      "unknown fence record version: {} expected: {}",
+      version,
+      rm_stm::fence_control_record_version);
+
+    std::optional<model::tx_seq> tx_seq{};
+    std::optional<std::chrono::milliseconds> transaction_timeout_ms;
+    if (version >= rm_stm::fence_control_record_v1_version) {
+        tx_seq = reflection::adl<model::tx_seq>{}.from(val_reader);
+        transaction_timeout_ms
+          = reflection::adl<std::chrono::milliseconds>{}.from(val_reader);
+    }
+    model::partition_id tm{model::legacy_tm_ntp.tp.partition};
+    if (version >= rm_stm::fence_control_record_version) {
+        tm = reflection::adl<model::partition_id>{}.from(val_reader);
+    }
+
+    auto key_buf = record.release_key();
+    iobuf_parser key_reader(std::move(key_buf));
+    auto batch_type = reflection::adl<model::record_batch_type>{}.from(
+      key_reader);
+    vassert(
+      hdr.type == batch_type,
+      "broken model::record_batch_type::tx_fence batch. expected batch type {} "
+      "got: {}",
+      hdr.type,
+      batch_type);
+    auto p_id = model::producer_id(reflection::adl<int64_t>{}.from(key_reader));
+    vassert(
+      p_id == bid.pid.id,
+      "broken model::record_batch_type::tx_fence batch. expected pid {} got: "
+      "{}",
+      bid.pid.id,
+      p_id);
+    return fence_batch_data{bid, tx_seq, transaction_timeout_ms, tm};
 }
 
 model::record_batch make_fence_batch_v1(
@@ -98,101 +196,15 @@ model::record_batch make_fence_batch_v2(
     return std::move(builder).build();
 }
 
-fence_batch_data read_fence_batch(model::record_batch&& b) {
-    const auto& hdr = b.header();
-    auto bid = model::batch_identity::from(hdr);
-
-    vassert(
-      b.record_count() == 1,
-      "model::record_batch_type::tx_fence batch must contain a single record");
-    auto r = b.copy_records();
-    auto& record = *r.begin();
-    auto val_buf = record.release_value();
-
-    iobuf_parser val_reader(std::move(val_buf));
-    auto version = reflection::adl<int8_t>{}.from(val_reader);
-    vassert(
-      version <= rm_stm::fence_control_record_version,
-      "unknown fence record version: {} expected: {}",
-      version,
-      rm_stm::fence_control_record_version);
-
-    std::optional<model::tx_seq> tx_seq{};
-    std::optional<std::chrono::milliseconds> transaction_timeout_ms;
-    if (version >= rm_stm::fence_control_record_v1_version) {
-        tx_seq = reflection::adl<model::tx_seq>{}.from(val_reader);
-        transaction_timeout_ms
-          = reflection::adl<std::chrono::milliseconds>{}.from(val_reader);
+model::record_batch rm_stm::make_fence_batch(
+  model::producer_identity pid,
+  model::tx_seq tx_seq,
+  std::chrono::milliseconds transaction_timeout_ms,
+  model::partition_id tm) {
+    if (is_transaction_partitioning()) {
+        return make_fence_batch_v2(pid, tx_seq, transaction_timeout_ms, tm);
     }
-    model::partition_id tm{model::legacy_tm_ntp.tp.partition};
-    if (version >= rm_stm::fence_control_record_version) {
-        tm = reflection::adl<model::partition_id>{}.from(val_reader);
-    }
-
-    auto key_buf = record.release_key();
-    iobuf_parser key_reader(std::move(key_buf));
-    auto batch_type = reflection::adl<model::record_batch_type>{}.from(
-      key_reader);
-    vassert(
-      hdr.type == batch_type,
-      "broken model::record_batch_type::tx_fence batch. expected batch type {} "
-      "got: {}",
-      hdr.type,
-      batch_type);
-    auto p_id = model::producer_id(reflection::adl<int64_t>{}.from(key_reader));
-    vassert(
-      p_id == bid.pid.id,
-      "broken model::record_batch_type::tx_fence batch. expected pid {} got: "
-      "{}",
-      bid.pid.id,
-      p_id);
-    return fence_batch_data{bid, tx_seq, transaction_timeout_ms, tm};
-}
-
-static model::record_batch make_tx_control_batch(
-  model::producer_identity pid, model::control_record_type crt) {
-    iobuf key;
-    kafka::protocol::encoder kw(key);
-    kw.write(model::current_control_record_version());
-    kw.write(static_cast<int16_t>(crt));
-
-    iobuf value;
-    kafka::protocol::encoder vw(value);
-    vw.write(static_cast<int16_t>(0));
-    vw.write(static_cast<int32_t>(0));
-
-    storage::record_batch_builder builder(
-      model::record_batch_type::raft_data, model::offset(0));
-    builder.set_producer_identity(pid.id, pid.epoch);
-    builder.set_control_type();
-    builder.set_transactional_type();
-    builder.add_raw_kw(
-      std::move(key), std::move(value), std::vector<model::record_header>());
-
-    return std::move(builder).build();
-}
-
-static model::control_record_type
-parse_control_batch(const model::record_batch& b) {
-    const auto& hdr = b.header();
-
-    vassert(
-      hdr.type == model::record_batch_type::raft_data,
-      "expect data batch type got {}",
-      hdr.type);
-    vassert(hdr.attrs.is_control(), "expect control attrs got {}", hdr.attrs);
-    vassert(
-      b.record_count() == 1, "control batch must contain a single record");
-
-    auto r = b.copy_records();
-    auto& record = *r.begin();
-    auto key = record.release_key();
-    kafka::protocol::decoder key_reader(std::move(key));
-    auto version = model::control_record_version(key_reader.read_int16());
-    vassert(
-      version == model::current_control_record_version,
-      "unknown control record version");
-    return model::control_record_type(key_reader.read_int16());
+    return make_fence_batch_v1(pid, tx_seq, transaction_timeout_ms);
 }
 
 model::control_record_type
@@ -338,17 +350,6 @@ ss::future<checked<model::term_id, tx_errc>> rm_stm::begin_tx(
             })
             .finally([u = std::move(unit)] {});
       });
-}
-
-model::record_batch rm_stm::make_fence_batch(
-  model::producer_identity pid,
-  model::tx_seq tx_seq,
-  std::chrono::milliseconds transaction_timeout_ms,
-  model::partition_id tm) {
-    if (is_transaction_partitioning()) {
-        return make_fence_batch_v2(pid, tx_seq, transaction_timeout_ms, tm);
-    }
-    return make_fence_batch_v1(pid, tx_seq, transaction_timeout_ms);
 }
 
 ss::future<checked<model::term_id, tx_errc>> rm_stm::do_begin_tx(

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -90,6 +90,14 @@ model::record_batch do_serialize_tx(T tx) {
 
 } // namespace
 
+ss::future<result<raft::replicate_result>>
+tm_stm::replicate_quorum_ack(model::term_id term, model::record_batch&& batch) {
+    return _raft->replicate(
+      term,
+      model::make_memory_record_batch_reader(std::move(batch)),
+      raft::replicate_options{raft::consistency_level::quorum_ack});
+}
+
 model::record_batch tm_stm::serialize_tx(tm_transaction tx) {
     if (use_new_tx_version()) {
         return do_serialize_tx(tx);

--- a/src/v/cluster/tm_stm.cc
+++ b/src/v/cluster/tm_stm.cc
@@ -92,10 +92,10 @@ model::record_batch do_serialize_tx(T tx) {
 
 ss::future<result<raft::replicate_result>>
 tm_stm::replicate_quorum_ack(model::term_id term, model::record_batch&& batch) {
+    auto opts = raft::replicate_options{raft::consistency_level::quorum_ack};
+    opts.set_force_flush();
     return _raft->replicate(
-      term,
-      model::make_memory_record_batch_reader(std::move(batch)),
-      raft::replicate_options{raft::consistency_level::quorum_ack});
+      term, model::make_memory_record_batch_reader(std::move(batch)), opts);
 }
 
 model::record_batch tm_stm::serialize_tx(tm_transaction tx) {

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -395,12 +395,7 @@ private:
       quorum_write_empty_batch(model::timeout_clock::time_point);
 
     ss::future<result<raft::replicate_result>>
-    replicate_quorum_ack(model::term_id term, model::record_batch&& batch) {
-        return _raft->replicate(
-          term,
-          model::make_memory_record_batch_reader(std::move(batch)),
-          raft::replicate_options{raft::consistency_level::quorum_ack});
-    }
+    replicate_quorum_ack(model::term_id term, model::record_batch&& batch);
 
     bool is_transaction_ga() {
         return _feature_table.local().is_active(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -382,14 +382,13 @@ configuration::configuration()
       "requested",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       256_KiB)
-  // todo (bharathv): deprecate raft_flush_timer_interval_ms in favor of
-  // raft_replica_max_flush_delay_ms
   , raft_flush_timer_interval_ms(
       *this,
       "raft_flush_timer_interval_ms",
       "Interval of checking partition against the "
-      "`raft_replica_max_pending_flush_bytes`",
-      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      "`raft_replica_max_pending_flush_bytes`, deprecated started 24.1, use "
+      "raft_replica_max_flush_delay_ms instead ",
+      {.visibility = visibility::deprecated},
       100ms)
   , raft_replica_max_flush_delay_ms(
       *this,

--- a/src/v/kafka/protocol/schemata/produce_request.json
+++ b/src/v/kafka/protocol/schemata/produce_request.json
@@ -35,10 +35,19 @@
   "fields": [
     { "name": "TransactionalId", "type": "string", "versions": "3+", "nullableVersions": "0+", "entityType": "transactionalId",
       "about": "The transactional ID, or null if the producer is not transactional." },
-    { "name": "Acks", "type": "int16", "versions": "0+",
-      "about": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments, 1 for only the leader and -1 for the full ISR." },
-    { "name": "TimeoutMs", "type": "int32", "versions": "0+",
-      "about": "The timeout to await a response in miliseconds." },
+    {
+      "name": "Acks",
+      "type": "int16",
+      "versions": "0+",
+      "about": "The number of acknowledgments the producer requires the leader to have received before considering a request complete. Allowed values: 0 for no acknowledgments, 1 for only the leader and -1 for the full ISR."
+    },
+    {
+      "name": "TimeoutMs",
+      "type": "int32",
+      "versions": "0+",
+      "default": "-1",
+      "about": "The timeout to await a response in milliseconds. Default of -1 translates to a no timeout."
+    },
     { "name": "Topics", "type": "[]TopicProduceData", "versions": "0+", 
       "about": "Each topic to produce to.", "fields": [
       { "name": "Name", "type": "string", "versions": "0+", "entityType": "topicName",

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2615,6 +2615,7 @@ append_entries_reply consensus::make_append_entries_reply(
 
 ss::future<consensus::flushed> consensus::flush_log() {
     if (!has_pending_flushes()) {
+        _last_flush_time = clock_type::now();
         co_return flushed::no;
     }
     auto flushed_up_to = _log->offsets().dirty_offset;
@@ -2622,6 +2623,7 @@ ss::future<consensus::flushed> consensus::flush_log() {
     _probe->log_flushed();
     _pending_flush_bytes = 0;
     co_await _log->flush();
+    _last_flush_time = clock_type::now();
     const auto lstats = _log->offsets();
     /**
      * log flush may be interleaved with trucation, hence we need to check

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -846,7 +846,7 @@ replicate_stages consensus::do_replicate(
     }
 
     return wrap_stages_with_gate(
-      _bg, _batcher.replicate(expected_term, std::move(rdr), opts.consistency));
+      _bg, _batcher.replicate(expected_term, std::move(rdr), opts));
 }
 
 ss::future<model::record_batch_reader>

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -148,8 +148,8 @@ consensus::consensus(
   , _keep_snapshotted_log(should_keep_snapshotted_log)
   , _append_requests_buffer(*this, 256)
   , _write_caching_enabled(log_config().write_caching())
-  , _flush_bytes(log_config().flush_bytes())
-  , _flush_ms(log_config().flush_ms()) {
+  , _max_pending_flush_bytes(log_config().flush_bytes())
+  , _max_flush_delay_ms(log_config().flush_ms()) {
     setup_metrics();
     setup_public_metrics();
     update_follower_stats(_configuration_manager.get_latest());
@@ -3907,8 +3907,8 @@ std::optional<model::offset> consensus::get_learner_start_offset() const {
 
 void consensus::notify_config_update() {
     _write_caching_enabled = log_config().write_caching();
-    _flush_bytes = log_config().flush_bytes();
-    _flush_ms = log_config().flush_ms();
+    _max_pending_flush_bytes = log_config().flush_bytes();
+    _max_flush_delay_ms = log_config().flush_ms();
 }
 
 } // namespace raft

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -149,7 +149,8 @@ consensus::consensus(
   , _append_requests_buffer(*this, 256)
   , _write_caching_enabled(log_config().write_caching())
   , _max_pending_flush_bytes(log_config().flush_bytes())
-  , _max_flush_delay_ms(log_config().flush_ms()) {
+  , _max_flush_delay_ms(flush_jitter_t{log_config().flush_ms(), flush_ms_jitter}
+                          .next_duration()) {
     setup_metrics();
     setup_public_metrics();
     update_follower_stats(_configuration_manager.get_latest());
@@ -3908,7 +3909,9 @@ std::optional<model::offset> consensus::get_learner_start_offset() const {
 void consensus::notify_config_update() {
     _write_caching_enabled = log_config().write_caching();
     _max_pending_flush_bytes = log_config().flush_bytes();
-    _max_flush_delay_ms = log_config().flush_ms();
+    _max_flush_delay_ms
+      = flush_jitter_t{log_config().flush_ms(), flush_ms_jitter}
+          .next_duration();
 }
 
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -360,6 +360,10 @@ public:
     }
     size_t received_snapshot_bytes() const { return _received_snapshot_bytes; }
     bool has_pending_flushes() const { return _pending_flush_bytes > 0; }
+    std::chrono::milliseconds time_since_last_flush() const {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+          clock_type::now() - _last_flush_time);
+    }
 
     model::offset start_offset() const {
         return model::next_offset(_last_snapshot_index);
@@ -824,6 +828,7 @@ private:
 
     replicate_batcher _batcher;
     size_t _pending_flush_bytes{0};
+    clock_type::time_point _last_flush_time;
 
     /// used to wait for background ops before shutting down
     ss::gate _bg;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -653,6 +653,7 @@ private:
 
     void maybe_update_last_visible_index(model::offset);
     void maybe_update_majority_replicated_index();
+    void do_update_majority_replicated_index(model::offset new_value);
 
     voter_priority next_target_priority();
     voter_priority get_node_priority(vnode) const;
@@ -841,6 +842,7 @@ private:
     std::unique_ptr<probe> _probe;
     ctx_log _ctxlog;
     ss::condition_variable _commit_index_updated;
+    ss::condition_variable _majority_replicated_index_updated;
 
     std::chrono::milliseconds _replicate_append_timeout;
     std::chrono::milliseconds _recovery_append_timeout;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -900,7 +900,9 @@ private:
     // write caching configurations
     // cached locally so we don't reconcile them for every request. They are
     // updated lazily via notify_config_update()
-    // todo(bharathv): add jitter
+    using flush_jitter_t
+      = simple_time_jitter<clock_type, std::chrono::milliseconds>;
+    static constexpr std::chrono::milliseconds flush_ms_jitter{5};
     bool _write_caching_enabled;
     size_t _max_pending_flush_bytes;
     std::chrono::milliseconds _max_flush_delay_ms;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -284,7 +284,7 @@ public:
     model::offset committed_offset() const { return _commit_index; }
     model::offset flushed_offset() const { return _flushed_offset; }
     model::offset last_quorum_replicated_index() const {
-        return _last_quorum_replicated_index;
+        return _last_quorum_replicated_index_with_flush;
     }
     model::offset majority_replicated_index() const {
         return _majority_replicated_index;
@@ -872,12 +872,13 @@ private:
     size_t _received_snapshot_bytes = 0;
 
     /**
-     * We keep an idex of the most recent entry replicated with quorum
-     * consistency level to make sure that all requests replicated with quorum
-     * consistency level will not be visible before they are committed by
-     * majority.
+     * We keep an index of the most recent entry replicated with quorum
+     * consistency level and flush to ensure they are not visible until
+     * they are raft committed (flushed on a majority). This ensures that
+     * writes with lower ack levels following the above writes do not
+     * mistakenly make them visible before they are raft committed.
      */
-    model::offset _last_quorum_replicated_index;
+    model::offset _last_quorum_replicated_index_with_flush;
     model::offset _last_leader_visible_offset;
     flush_after_append _last_write_flushed;
     offset_monitor _consumable_offset_monitor;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -879,7 +879,7 @@ private:
      */
     model::offset _last_quorum_replicated_index;
     model::offset _last_leader_visible_offset;
-    consistency_level _last_write_consistency_level;
+    flush_after_append _last_write_flushed;
     offset_monitor _consumable_offset_monitor;
     ss::condition_variable _follower_reply;
     append_entries_buffer _append_requests_buffer;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -511,11 +511,6 @@ public:
     get_follower_recovery_state() const {
         return _follower_recovery_state;
     }
-    /**
-     * Flushes underlying log only if there are more not flushed bytes than the
-     * requested threshold.
-     */
-    ss::future<> maybe_flush_log(size_t threshold_bytes);
 
     inline void maybe_update_leader(vnode request_node);
 
@@ -776,6 +771,9 @@ private:
         return _features.is_active(features::feature::raft_config_serde);
     }
 
+    ss::future<> maybe_flush_log();
+    ss::future<> background_flusher();
+
     // args
     vnode _self;
     raft::group_id _group;
@@ -906,6 +904,8 @@ private:
     bool _write_caching_enabled;
     size_t _max_pending_flush_bytes;
     std::chrono::milliseconds _max_flush_delay_ms;
+
+    ss::condition_variable _background_flusher;
 
     friend std::ostream& operator<<(std::ostream&, const consensus&);
 };

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -359,7 +359,7 @@ public:
         return _received_snapshot_index;
     }
     size_t received_snapshot_bytes() const { return _received_snapshot_bytes; }
-    bool has_pending_flushes() const { return _not_flushed_bytes > 0; }
+    bool has_pending_flushes() const { return _pending_flush_bytes > 0; }
 
     model::offset start_offset() const {
         return model::next_offset(_last_snapshot_index);
@@ -823,7 +823,7 @@ private:
     follower_stats _fstats;
 
     replicate_batcher _batcher;
-    size_t _not_flushed_bytes{0};
+    size_t _pending_flush_bytes{0};
 
     /// used to wait for background ops before shutting down
     ss::gate _bg;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -523,8 +523,8 @@ public:
     void notify_config_update();
 
     bool write_caching_enabled() const { return _write_caching_enabled; }
-    size_t flush_bytes() const { return _flush_bytes; }
-    std::chrono::milliseconds flush_ms() const { return _flush_ms; }
+    size_t flush_bytes() const { return _max_pending_flush_bytes; }
+    std::chrono::milliseconds flush_ms() const { return _max_flush_delay_ms; }
 
 private:
     friend replicate_entries_stm;
@@ -902,8 +902,8 @@ private:
     // updated lazily via notify_config_update()
     // todo(bharathv): add jitter
     bool _write_caching_enabled;
-    size_t _flush_bytes;
-    std::chrono::milliseconds _flush_ms;
+    size_t _max_pending_flush_bytes;
+    std::chrono::milliseconds _max_flush_delay_ms;
 
     friend std::ostream& operator<<(std::ostream&, const consensus&);
 };

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -51,23 +51,12 @@ group_manager::group_manager(
       _configuration.recovery_concurrency_per_shard,
       _configuration.heartbeat_interval)
   , _feature_table(feature_table.local())
-  , _flush_timer_jitter(_configuration.flush_timer_interval_ms)
   , _is_ready(false) {
-    _flush_timer.set_callback([this] {
-        ssx::spawn_with_gate(_gate, [this] {
-            return flush_groups().finally([this] {
-                if (_gate.is_closed()) {
-                    return;
-                }
-                _flush_timer.arm(_flush_timer_jitter());
-            });
-        });
-    });
     _configuration.write_caching.watch(
       [this]() { trigger_config_update_notification(); });
     _configuration.write_caching_flush_ms.watch(
       [this]() { trigger_config_update_notification(); });
-    _configuration.replica_max_not_flushed_bytes.watch(
+    _configuration.write_caching_flush_bytes.watch(
       [this]() { trigger_config_update_notification(); });
     setup_metrics();
 }
@@ -75,12 +64,10 @@ group_manager::group_manager(
 ss::future<> group_manager::start() {
     co_await _heartbeats.start();
     co_await _recovery_scheduler.start();
-    _flush_timer.arm(_flush_timer_jitter());
 }
 
 ss::future<> group_manager::stop() {
     auto f = _gate.close();
-    _flush_timer.cancel();
 
     f = f.then([this] { return _recovery_scheduler.stop(); });
 
@@ -234,25 +221,6 @@ void group_manager::setup_metrics() {
         "group_count",
         [this] { return _groups.size(); },
         sm::description("Number of raft groups"))});
-}
-
-ss::future<> group_manager::flush_groups() {
-    /**
-     * Assumes that gate is already held
-     */
-    auto u = co_await _groups_mutex.get_units();
-
-    co_await ss::max_concurrent_for_each(
-      _groups.begin(),
-      _groups.end(),
-      32,
-      [this](const ss::lw_shared_ptr<consensus>& raft) {
-          if (_configuration.replica_max_not_flushed_bytes()) {
-              return raft->maybe_flush_log(
-                _configuration.replica_max_not_flushed_bytes().value());
-          }
-          return ss::now();
-      });
 }
 
 void group_manager::trigger_config_update_notification() {

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -44,10 +44,9 @@ public:
         config::binding<bool> enable_lw_heartbeat;
         config::binding<size_t> recovery_concurrency_per_shard;
         config::binding<std::chrono::milliseconds> election_timeout_ms;
-        config::binding<std::optional<size_t>> replica_max_not_flushed_bytes;
-        config::binding<std::chrono::milliseconds> flush_timer_interval_ms;
         config::binding<model::write_caching_mode> write_caching;
         config::binding<std::chrono::milliseconds> write_caching_flush_ms;
+        config::binding<std::optional<size_t>> write_caching_flush_bytes;
     };
     using config_provider_fn = ss::noncopyable_function<configuration()>;
 
@@ -100,8 +99,6 @@ private:
 
     void trigger_config_update_notification();
 
-    ss::future<> flush_groups();
-
     raft::group_configuration create_initial_configuration(
       std::vector<model::broker>, model::revision_id) const;
     mutex _groups_mutex{"group_manager"};
@@ -120,8 +117,6 @@ private:
     recovery_memory_quota _recovery_mem_quota;
     recovery_scheduler _recovery_scheduler;
     features::feature_table& _feature_table;
-    ss::timer<clock_type> _flush_timer;
-    timeout_jitter _flush_timer_jitter;
 
     bool _is_ready;
 };

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -194,12 +194,10 @@ recovery_stm::should_flush(model::offset follower_committed_match_index) const {
     const bool is_last_batch = _last_batch_offset == lstats.dirty_offset;
     const bool follower_has_batches_to_commit
       = follower_committed_match_index < _ptr->_last_quorum_replicated_index;
-    const bool last_replicate_with_quorum = _ptr->_last_write_consistency_level
-                                            == consistency_level::quorum_ack;
 
     const bool is_last
       = is_last_batch
-        && (follower_has_batches_to_commit || last_replicate_with_quorum);
+        && (follower_has_batches_to_commit || _ptr->_last_write_flushed);
 
     // Flush every `checkpoint_flush_size` bytes recovered to ensure that the
     // follower's stms can apply batches from the cache rather than disk.

--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -193,7 +193,8 @@ recovery_stm::should_flush(model::offset follower_committed_match_index) const {
 
     const bool is_last_batch = _last_batch_offset == lstats.dirty_offset;
     const bool follower_has_batches_to_commit
-      = follower_committed_match_index < _ptr->_last_quorum_replicated_index;
+      = follower_committed_match_index
+        < _ptr->_last_quorum_replicated_index_with_flush;
 
     const bool is_last
       = is_last_batch

--- a/src/v/raft/replicate.h
+++ b/src/v/raft/replicate.h
@@ -25,14 +25,26 @@ enum class consistency_level { quorum_ack, leader_ack, no_ack };
 struct replicate_options {
     explicit replicate_options(consistency_level l)
       : consistency(l)
-      , timeout(std::nullopt) {}
+      , timeout(std::nullopt)
+      , _force_flush(false) {}
 
     replicate_options(consistency_level l, std::chrono::milliseconds timeout)
       : consistency(l)
-      , timeout(timeout) {}
+      , timeout(timeout)
+      , _force_flush(false) {}
+
+    // Callers may choose to force flush on an individual replicate request
+    // basis. This is useful if certain callers intend to override any
+    // default behavior at global/topic scope.
+    // For example: when write caching is enabled on the topic and a caller
+    // can still force a flush with this override. This override takes
+    // precendence over any other setting.
+    void set_force_flush() { _force_flush = true; }
+    bool force_flush() const { return _force_flush; }
 
     consistency_level consistency;
     std::optional<std::chrono::milliseconds> timeout;
+    bool _force_flush;
 };
 
 struct replicate_result {

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -321,7 +321,6 @@ ss::future<> replicate_batcher::do_flush(
   append_entries_request req,
   std::vector<ssx::semaphore_units> u,
   absl::flat_hash_map<vnode, follower_req_seq> seqs) {
-    auto needs_flush = req.is_flush_required();
     _ptr->_probe->replicate_batch_flushed();
     auto stm = ss::make_lw_shared<replicate_entries_stm>(
       _ptr, std::move(req), std::move(seqs));
@@ -348,7 +347,7 @@ ss::future<> replicate_batcher::do_flush(
          * NOTE: this happens in background since we do not want to block
          * replicate batcher
          */
-        if (leader_result && needs_flush) {
+        if (leader_result) {
             (void)stm->wait_for_majority()
               .then([holder = std::move(holder),
                      notifications = std::move(notifications)](

--- a/src/v/raft/replicate_batcher.cc
+++ b/src/v/raft/replicate_batcher.cc
@@ -217,6 +217,9 @@ ss::future<> replicate_batcher::flush(
         auto needs_flush = flush_after_append::no;
 
         for (auto& n : item_cache) {
+            if (unlikely(n->ready())) {
+                continue;
+            }
             if (
               !n->get_expected_term().has_value()
               || n->get_expected_term().value() == term) {

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -60,6 +60,9 @@ public:
         consistency_level get_consistency_level() const {
             return _replicate_opts.consistency;
         }
+        bool force_flush_requested() const {
+            return _replicate_opts.force_flush();
+        }
 
         auto release_data() {
             return std::make_tuple(std::move(_data), std::move(_units));

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -85,6 +85,8 @@ public:
             return _promise.get_future();
         }
 
+        bool ready() const { return _ready; }
+
     private:
         void expire_with_timeout() {
             if (!_ready) {

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -32,16 +32,15 @@ public:
           std::vector<model::record_batch> batches,
           ssx::semaphore_units u,
           std::optional<model::term_id> expected_term,
-          consistency_level c_lvl,
-          std::optional<std::chrono::milliseconds> timeout)
+          replicate_options opts)
           : _record_count(record_count)
           , _data(std::move(batches))
           , _units(std::move(u))
           , _expected_term(expected_term)
-          , _consistency_lvl(c_lvl) {
+          , _replicate_opts(opts) {
             _timeout_timer.set_callback([this] { expire_with_timeout(); });
-            if (timeout) {
-                _timeout_timer.arm(timeout.value());
+            if (_replicate_opts.timeout) {
+                _timeout_timer.arm(_replicate_opts.timeout.value());
             }
         };
 
@@ -59,7 +58,7 @@ public:
 
         size_t get_record_count() const { return _record_count; }
         consistency_level get_consistency_level() const {
-            return _consistency_lvl;
+            return _replicate_opts.consistency;
         }
 
         auto release_data() {
@@ -99,9 +98,7 @@ public:
         std::vector<model::record_batch> _data;
         ssx::semaphore_units _units;
         std::optional<model::term_id> _expected_term;
-        // consistency level is stored to distinguish when an item promise
-        // should be signaled with replication result
-        consistency_level _consistency_lvl;
+        replicate_options _replicate_opts;
         /**
          * Item keeps semaphore units until replicate batcher is done with
          * processing the request.
@@ -123,8 +120,7 @@ public:
     replicate_stages replicate(
       std::optional<model::term_id>,
       model::record_batch_reader,
-      consistency_level,
-      std::optional<std::chrono::milliseconds> = std::nullopt);
+      replicate_options);
 
     ss::future<> flush(ssx::semaphore_units u, bool const transfer_flush);
 
@@ -140,22 +136,19 @@ private:
     ss::future<item_ptr> do_cache(
       std::optional<model::term_id>,
       model::record_batch_reader,
-      consistency_level,
-      std::optional<std::chrono::milliseconds>);
+      replicate_options);
 
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(
       std::optional<model::term_id>,
       ss::circular_buffer<model::record_batch>,
       size_t,
-      consistency_level,
-      std::optional<std::chrono::milliseconds>);
+      replicate_options);
 
     ss::future<result<replicate_result>> cache_and_wait_for_result(
       ss::promise<> enqueued,
       std::optional<model::term_id> expected_term,
       model::record_batch_reader r,
-      consistency_level consistency_lvl,
-      std::optional<std::chrono::milliseconds> timeout);
+      replicate_options);
 
     consensus* _ptr;
     ssx::semaphore _max_batch_size_sem;

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -199,7 +199,9 @@ replicate_entries_stm::append_to_self() {
           vlog(_ctxlog.trace, "Leader append result: {}", res);
           // only update visibility upper bound if all quorum
           // replicated entries are committed already
-          if (_ptr->_commit_index >= _ptr->_last_quorum_replicated_index) {
+          if (
+            _ptr->_commit_index
+            >= _ptr->_last_quorum_replicated_index_with_flush) {
               // for relaxed consistency mode update visibility
               // upper bound with last offset appended to the log
               _ptr->_visibility_upper_bound_index = std::max(

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -341,7 +341,7 @@ result<replicate_result> replicate_entries_stm::build_replicate_result() const {
 }
 
 ss::future<result<replicate_result>>
-replicate_entries_stm::wait_for_majority() {
+replicate_entries_stm::wait_for_majority_flush() {
     if (!_append_result) {
         co_return build_replicate_result();
     }
@@ -379,6 +379,11 @@ replicate_entries_stm::wait_for_majority() {
         co_return result<replicate_result>(
           make_error_code(errc::shutting_down));
     }
+}
+
+ss::future<result<replicate_result>>
+replicate_entries_stm::wait_for_majority() {
+    co_return co_await wait_for_majority_flush();
 }
 
 result<replicate_result> replicate_entries_stm::process_result(

--- a/src/v/raft/replicate_entries_stm.cc
+++ b/src/v/raft/replicate_entries_stm.cc
@@ -189,9 +189,7 @@ replicate_entries_stm::append_to_self() {
       .then([this](model::record_batch_reader batches) mutable {
           vlog(_ctxlog.trace, "Self append entries - {}", _meta);
 
-          _ptr->_last_write_consistency_level
-            = _is_flush_required ? consistency_level::quorum_ack
-                                 : consistency_level::leader_ack;
+          _ptr->_last_write_flushed = _is_flush_required;
           return _ptr->disk_append(
             std::move(batches),
             _is_flush_required ? consensus::update_last_quorum_index::yes

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -125,6 +125,8 @@ private:
 
     result<replicate_result> build_replicate_result() const;
 
+    ss::future<result<replicate_result>> wait_for_majority_flush();
+
     consensus* _ptr;
     /// we keep a copy around until we finish the retries
     protocol_metadata _meta;

--- a/src/v/raft/replicate_entries_stm.h
+++ b/src/v/raft/replicate_entries_stm.h
@@ -127,6 +127,8 @@ private:
 
     ss::future<result<replicate_result>> wait_for_majority_flush();
 
+    ss::future<result<replicate_result>> wait_for_majority_no_flush();
+
     consensus* _ptr;
     /// we keep a copy around until we finish the retries
     protocol_metadata _meta;

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -58,7 +58,7 @@ set(gsrcs
 rp_test(
   UNIT_TEST
   GTEST
-  TIMEOUT 500
+  TIMEOUT 1000
   BINARY_NAME gtest_raft
   SOURCES ${gsrcs}
   LIBRARIES  v::raft v::storage_test_utils v::model_test_utils v::features v::gtest_main

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -178,33 +178,30 @@ TEST_F_CORO(
     co_await wait_for_committed_offset(result.value().last_offset, 10s);
 }
 
-FIXTURE_TEST(
-  test_last_visible_offset_monitor_relaxed_consistency, raft_test_fixture) {
+TEST_F_CORO(
+  raft_fixture, test_last_visible_offset_monitor_relaxed_consistency) {
     // This tests a property of the visible offset monitor that the fetch path
     // relies on to work correctly. Even with relaxed consistency.
-    raft_group gr = raft_group(raft::group_id(0), 3);
-    gr.enable_all();
-    gr.wait_for_leader().get0();
 
-    model::node_id leader_id;
-    for (auto& m : gr.get_members()) {
-        if (m.second.consensus->is_elected_leader()) {
-            leader_id = m.first;
-            break;
-        }
-    }
+    co_await create_simple_group(3);
+    // wait for leader
+    auto leader = co_await wait_for_leader(10s);
+    auto& leader_node = node(leader);
+    auto leader_raft = leader_node.raft();
 
-    auto leader_raft = gr.get_member(leader_id).consensus;
-    auto last_visible = leader_raft->last_visible_index();
-
-    auto offset_change_fut = leader_raft->visible_offset_monitor().wait(
-      model::next_offset(last_visible), model::timeout_clock::now() + 1min, {});
+    auto waiter = leader_raft->visible_offset_monitor().wait(
+      model::offset{50}, model::timeout_clock::now() + 10s, {});
 
     // replicate some batches with relaxed consistency
-    replicate_random_batches(gr, 20, raft::consistency_level::leader_ack)
-      .get0();
+    auto result = co_await leader_node.raft()->replicate(
+      make_batches(10, 10, 128),
+      replicate_options(raft::consistency_level::leader_ack));
 
-    offset_change_fut.get();
+    ASSERT_TRUE_CORO(result.has_value());
+
+    vlog(logger().info, "waiting for offset: {}", result.value().last_offset);
+
+    co_await std::move(waiter);
 };
 
 /**

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -710,6 +710,14 @@ ss::future<> raft_fixture::reset_background_flushing() const {
     notify_replicas_on_config_change();
 }
 
+ss::future<> raft_fixture::set_write_caching(bool value) const {
+    auto mode = value ? model::write_caching_mode::on
+                      : model::write_caching_mode::off;
+    co_await ss::smp::invoke_on_all(
+      [mode]() { config::shard_local_cfg().write_caching.set_value(mode); });
+    notify_replicas_on_config_change();
+}
+
 std::ostream& operator<<(std::ostream& o, msg_type type) {
     switch (type) {
     case msg_type::append_entries:

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -458,6 +458,7 @@ public:
     void notify_replicas_on_config_change() const;
     ss::future<> disable_background_flushing() const;
     ss::future<> reset_background_flushing() const;
+    ss::future<> set_write_caching(bool) const;
 
 private:
     void validate_leaders();

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -455,6 +455,10 @@ public:
 
     ss::logger& logger() { return _logger; }
 
+    void notify_replicas_on_config_change() const;
+    ss::future<> disable_background_flushing() const;
+    ss::future<> reset_background_flushing() const;
+
 private:
     void validate_leaders();
 

--- a/src/v/raft/tests/simple_raft_fixture.h
+++ b/src/v/raft/tests/simple_raft_fixture.h
@@ -94,12 +94,11 @@ struct simple_raft_fixture {
                   .recovery_concurrency_per_shard
                   = config::mock_binding<size_t>(64),
                   .election_timeout_ms = config::mock_binding(10ms),
-                  .replica_max_not_flushed_bytes
-                  = config::mock_binding<std::optional<size_t>>(std::nullopt),
-                  .flush_timer_interval_ms = config::mock_binding(100ms),
                   .write_caching = config::mock_binding(
                     model::write_caching_mode::off),
-                  .write_caching_flush_ms = config::mock_binding(100ms)};
+                  .write_caching_flush_ms = config::mock_binding(100ms),
+                  .write_caching_flush_bytes
+                  = config::mock_binding<std::optional<size_t>>(std::nullopt)};
             },
             [] {
                 return raft::recovery_memory_quota::configuration{

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -324,7 +324,7 @@ ss::future<> vote_stm::update_vote_state(ssx::semaphore_units u) {
     // Set last heartbeat timestamp to max as we are the leader
     _ptr->_hbeat = clock_type::time_point::max();
     vlog(_ctxlog.info, "becoming the leader term:{}", term);
-    _ptr->_last_quorum_replicated_index = _ptr->_flushed_offset;
+    _ptr->_last_quorum_replicated_index_with_flush = _ptr->_flushed_offset;
 
     auto ec = co_await replicate_config_as_new_leader(std::move(u));
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1325,16 +1325,13 @@ void application::wire_up_redpanda_services(
                   .raft_recovery_concurrency_per_shard.bind(),
               .election_timeout_ms
               = config::shard_local_cfg().raft_election_timeout_ms.bind(),
-              .replica_max_not_flushed_bytes
-              = config::shard_local_cfg()
-                  .raft_replica_max_pending_flush_bytes.bind(),
-              .flush_timer_interval_ms
-              = config::shard_local_cfg().raft_flush_timer_interval_ms.bind(),
               .write_caching = config::shard_local_cfg().write_caching.bind(),
               .write_caching_flush_ms
               = config::shard_local_cfg()
                   .raft_replica_max_flush_delay_ms.bind(),
-            };
+              .write_caching_flush_bytes
+              = config::shard_local_cfg()
+                  .raft_replica_max_pending_flush_bytes.bind()};
         },
         [] {
             return raft::recovery_memory_quota::configuration{

--- a/tests/rptest/tests/write_caching_test.py
+++ b/tests/rptest/tests/write_caching_test.py
@@ -66,6 +66,10 @@ class WriteCachingPropertiesTest(RedpandaTest):
         replicas = partition_state["replicas"]
         assert len(replicas) == 3
 
+        def validate_flush_ms(val: int) -> bool:
+            # account for jitter
+            return flush_ms - 5 <= val <= flush_ms + 5
+
         for replica in replicas:
             raft_state = replica["raft_state"]
             assert self.WRITE_CACHING_DEBUG_KEY in raft_state.keys(
@@ -74,8 +78,8 @@ class WriteCachingPropertiesTest(RedpandaTest):
             assert self.FLUSH_BYTES_DEBUG_KEY in raft_state.keys(), raft_state
 
             replica_check = raft_state[self.WRITE_CACHING_DEBUG_KEY] == bool(
-                write_caching) and raft_state[
-                    self.FLUSH_MS_DEBUG_KEY] == flush_ms and raft_state[
+                write_caching) and validate_flush_ms(
+                    raft_state[self.FLUSH_MS_DEBUG_KEY]) and raft_state[
                         self.FLUSH_BYTES_DEBUG_KEY] == flush_bytes
 
             if not replica_check:


### PR DESCRIPTION
Implements raft side of things for write caching. Summary of changes

* Decouples flush decision from acks level. Currently quorum_ack requests are automatically flushed. 
* Implement background flushing based on flush.ms/bytes
* Preliminary test coverage in unit tests / ducktape.

Next set of patches:

* More tests (failure injection, node_operations)
* Metrics/instrumentation.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* raft_flush_timer_interval_ms is deprecated, use raft_replica_max_flush_delay_ms instead. The latter supports periodic flushing for any un flushed bytes and carries the same default as raft_flush_timer_interval_ms. 


<!-- release notes already added in the configurations PR -- >


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
