### PR TITLE
Check cloud type and do not run if FMC

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -35,6 +35,7 @@ from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark, Vali
 from rptest.services.openmessaging_benchmark_configs import \
     OMBSampleConfigurations
 from rptest.services.producer_swarm import ProducerSwarm
+from rptest.services.redpanda_cloud import CLOUD_TYPE_FMC
 from rptest.services.redpanda_cloud import CloudTierName, get_config_profile_name, PROVIDER_AWS
 from rptest.services.redpanda import (RESTART_LOG_ALLOW_LIST, MetricsEndpoint,
                                       RedpandaService, SISettings,
@@ -807,6 +808,11 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         cloudv2 API to create/update buckets and its
         properties/policies
         """
+        if self.redpanda.cloud_type == CLOUD_TYPE_FMC:
+            self.logger.warn(
+                'This test is designed for BYOC only, this is FMC')
+            return
+
         # create default topics
         self._create_default_topics()
 


### PR DESCRIPTION
This is a HTT cloud type check for:
https://github.com/redpanda-data/core-internal/issues/990

This test was designed for BYOC only, and code already has a message:

Using it against FMC clouds will cause it to fail as
        there is no access to S3 account that is used inside
        cloudv2 API to create/update buckets and its
        properties/policies

This improvement would check if test is being executed on FMC and show a warning in logs as well is would not be executed

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

### Improvements
* See above
