### PR TITLE
admin/transform: 400 for missing topics

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1050,6 +1050,7 @@ ss::future<> admin_server::throw_on_error(
             throw ss::httpd::base_exception(
               fmt::format("Too many requests: {}", ec.message()),
               ss::http::reply::status_type::too_many_requests);
+        case cluster::errc::topic_not_exists:
         case cluster::errc::transform_does_not_exist:
         case cluster::errc::transform_invalid_update:
         case cluster::errc::transform_invalid_create:


### PR DESCRIPTION
When deploying a data transform, the input and output topics must
already exist. Currently the validation catches this error, but the
result is a 500, when it should be a 400.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Return a HTTP 400 error code when deploying a transform to a topic that doesn't exist instead of a 500
