### PR TITLE
Fix a segfault when recovery mode is partially enabled

### DIFF
--- a/src/v/cluster/cloud_metadata/offsets_recovery_service.h
+++ b/src/v/cluster/cloud_metadata/offsets_recovery_service.h
@@ -42,6 +42,10 @@ public:
 
     ss::future<offsets_upload_reply> offsets_upload(
       offsets_upload_request req, rpc::streaming_context& ctx) override {
+        if (!_offsets_upload_router.local_is_initialized()) {
+            co_return offsets_upload_reply{.ec = errc::feature_disabled};
+        }
+
         auto ntp = req.offsets_ntp;
         co_return co_await _offsets_upload_router.local().process_or_dispatch(
           std::move(req), std::move(ntp), _metadata_timeout_ms());
@@ -49,6 +53,10 @@ public:
 
     ss::future<offsets_recovery_reply> offsets_recovery(
       offsets_recovery_request req, rpc::streaming_context& ctx) override {
+        if (!_offsets_recovery_router.local_is_initialized()) {
+            co_return offsets_recovery_reply{.ec = errc::feature_disabled};
+        }
+
         auto ntp = req.offsets_ntp;
         co_return co_await _offsets_recovery_router.local().process_or_dispatch(
           std::move(req), std::move(ntp), 30s);


### PR DESCRIPTION
In a mixed-mode clusters RPC requests for uploading consumer offsets to cloud storage could be issued from a node in normal mode to a node in recovery mode. Previously this resulted in a segfault.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
### Bug Fixes
* Fix a crash that happened when a cluster that was partially in recovery mode tried to upload consumer offsets to cloud storage.
