### PR TITLE
storage: mutex compaction and prefix truncation

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2479,6 +2479,8 @@ ss::future<> disk_log_impl::do_truncate_prefix(truncate_prefix_config cfg) {
      * whose max offset falls below the new starting offset.
      */
     {
+        ssx::semaphore_units seg_rewrite_units
+          = co_await _segment_rewrite_lock.get_units();
         auto cache_lock = co_await _readers_cache->evict_prefix_truncate(
           cfg.start_offset);
         co_await remove_prefix_full_segments(cfg);


### PR DESCRIPTION
A crash was observed in CI caused by storage layer metadata inconsistency and accompanied by data loss.

```
Assert failure: (src/v/raft/consensus.cc:2434) 'last_included_term.has_value()' Unable to get term for snapshot last included offset: 9499, log: {
    offsets: {start_offset:9457, committed_offset:11164, committed_offset_term:2, dirty_offset:11164, dirty_offset_term:2},
    is_closed: false, segments: [
        {size: 12, [
            {offset_tracker:{term:2, base_offset:9500, committed_offset:9669, dirty_offset:9669},
```

Notice that `start_offset` as reported by the storage layer is lower than the `base_offset` of the first segment. `start_offset` must be great-or-equal.

In the logs the following lines were observed:

```
Compacting 2 adjacent segments: [
   Segment 1: {offset_tracker:{term:1, base_offset:9190, committed_offset:9456, dirty_offset:9456} ...
   Segment 2: {offset_tracker:{term:1, base_offset:9457, committed_offset:9499, dirty_offset:9499} ...
```

Followed shortly after by:

```
log_eviction_stm.cc:164 - requested to write raft snapshot (prefix_truncate) at 9456

disk_log_impl.cc:917 - Final compacted segment {offset_tracker:{term:1, base_offset:9190, committed_offset:9499, dirty_offset:9499}
segment_utils.cc:483 - swapping compacted segment temp file /var/lib/redpanda/data/kafka/test-topic/0_28/9190-1-v1.log.compaction.staging with the segment /var/lib/redpanda/data/kafka/test-topic/0_28/9190-1-v1.log

disk_log_impl.cc:2403 - Removing "/var/lib/redpanda/data/kafka/test-topic/0_28/9190-1-v1.log" (remove_prefix_full_segments, {offset_tracker:{term:1, base_offset:9190, committed_offset:9456, dirty_offset:9456} ...
```

This points to a race condition between adjacent segment compaction and prefix truncation. Segment 2 was "folded" into Segment 1. When prefix truncation tried to remove the pre-compaction Segment 1 it ended up removing data for Segment 2 as well. The result is data loss and metadata inconsistency.

We fix this by introducing mutual exclusion of truncation and compaction routine similar to what we do in suffix truncation.

---

I believe this can also be fixed by just taking a read/write lock on the segment but the change is more intrusive as it requires additional refactoring.

---

Reproduced with these changes https://gist.github.com/nvartolomei/d25ee2b9b2c25e6a2726f96ad89ab723

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

### Bug Fixes

* Fix a race condition between suffix truncation / delete records and adjacent segment compaction that can lead to crashes and data-loss.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
