### PR TITLE
Fix/rapid json assert

### DIFF
--- a/src/v/cloud_storage/tests/tx_range_manifest_test.cc
+++ b/src/v/cloud_storage/tests/tx_range_manifest_test.cc
@@ -102,3 +102,15 @@ SEASTAR_THREAD_TEST_CASE(serialization_roundtrip_test) {
     restored.update(std::move(rstr)).get();
     BOOST_REQUIRE(m == restored);
 }
+
+SEASTAR_THREAD_TEST_CASE(update_with_invalid_tx_manifest) {
+    auto m = tx_range_manifest{segment_path};
+
+    constexpr static auto invalid_manifest = std::string_view{"{}"};
+    auto in = iobuf{};
+    in.append(invalid_manifest.data(), invalid_manifest.size());
+    auto res = m.update(make_iobuf_input_stream(std::move(in)));
+    res.wait();
+    BOOST_REQUIRE(res.failed());
+    std::ignore = res.get_exception();
+}

--- a/src/v/json/_include_first.h
+++ b/src/v/json/_include_first.h
@@ -11,7 +11,12 @@
 
 #pragma once
 
-#include "base/vassert.h"
+#include <seastar/util/backtrace.hh>
 
 #define RAPIDJSON_HAS_STDSTRING 1
-#define RAPIDJSON_ASSERT(x) vassert(x, "Rapidjson ")
+#define RAPIDJSON_ASSERT(x)                                                    \
+    do {                                                                       \
+        if (!(x)) [[unlikely]] {                                               \
+            seastar::throw_with_backtrace<std::runtime_error>("Rapidjson");    \
+        }                                                                      \
+    } while (0)


### PR DESCRIPTION
When using json::Document, the document should be validated before accessing members or member call should be protected by if(HasMember()), otherwise RAPIDJSON_ASSERT(false) will be invoked.

this pr changes the implementation to ss::throw_with_backtrace<std::runtime_exception>("RapidJson"), to not cause the process to stop before handling the (potential) issue

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none 