### PR TITLE
Role based authorization

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -147,7 +147,9 @@ ss::future<> controller::wire_up() {
       .then([this] { return _roles.start(); })
       .then([this] {
           return _authorizer.start(
-            []() { return config::shard_local_cfg().superusers.bind(); });
+            ss::sharded_parameter(
+              []() { return config::shard_local_cfg().superusers.bind(); }),
+            ss::sharded_parameter([this] { return &_roles.local(); }));
       })
       .then([this] {
           return _oidc_service.start(

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -25,7 +25,7 @@ seastar::logger seclog("security");
 
 std::optional<std::reference_wrapper<const acl_entry>> acl_entry_set::find(
   acl_operation operation,
-  const acl_principal& principal,
+  const acl_principal_base& principal,
   const acl_host& host,
   acl_permission perm) const {
     for (const auto& entry : _entries) {
@@ -63,7 +63,7 @@ bool acl_matches::empty() const {
 
 std::optional<acl_matches::acl_match> acl_matches::find(
   acl_operation operation,
-  const acl_principal& principal,
+  const acl_principal_base& principal,
   const acl_host& host,
   acl_permission perm) const {
     for (const auto& entries : prefixes) {
@@ -323,8 +323,10 @@ std::ostream& operator<<(std::ostream& os, principal_type type) {
     __builtin_unreachable();
 }
 
-std::ostream& operator<<(std::ostream& os, const acl_principal& principal) {
-    fmt::print(os, "type {{{}}} name {{{}}}", principal._type, principal._name);
+std::ostream&
+operator<<(std::ostream& os, const acl_principal_base& principal) {
+    fmt::print(
+      os, "type {{{}}} name {{{}}}", principal.type(), principal.name_view());
     return os;
 }
 

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -182,7 +182,21 @@ public:
      * Get the principal type
      */
     principal_type type() const override { return _type; }
-    bool wildcard() const { return _name == "*"; }
+    /**
+     * Check whether this is a 'wildcard' principal.
+     *
+     * Note that this is type()-dependent. A principal of type 'role' is
+     * always exempt from wildcard matching.
+     */
+    bool wildcard() const {
+        switch (_type) {
+        case principal_type::user:
+        case principal_type::ephemeral_user:
+            return _name == "*";
+        case principal_type::role:
+            return false;
+        }
+    }
 
     // Needed for ADL serialization
     const ss::sstring& name() const { return _name; }

--- a/src/v/security/acl.h
+++ b/src/v/security/acl.h
@@ -123,37 +123,107 @@ std::ostream& operator<<(std::ostream&, resource_type);
 std::ostream& operator<<(std::ostream&, pattern_type);
 std::ostream& operator<<(std::ostream&, principal_type);
 
-/*
- * Kafka principal is (principal-type, principal)
+/**
+ * Abstract interface for Kafka principals.
+ *
+ * A Kafka principal is (principal-type, principal).
+ *
+ * Note that no virtual destructor is provided here. This is intentional.
+ * acl_principal_base is meant to support polymorphic references at various
+ * auth APIs, **not** to support polymorphic construction/destruction of
+ * principal instances.
+ *
  */
-class acl_principal
+class acl_principal_base {
+public:
+    /**
+     * Get a view to the principal name.
+     */
+    virtual std::string_view name_view() const = 0;
+    /**
+     * Get the principal type
+     */
+    virtual principal_type type() const = 0;
+
+private:
+    template<typename H>
+    friend H AbslHashValue(H h, const acl_principal_base& e) {
+        return H::combine(std::move(h), e.type(), e.name_view());
+    }
+
+    friend bool
+    operator==(const acl_principal_base& l, const acl_principal_base& r) {
+        return l.type() == r.type() && l.name_view() == r.name_view();
+    }
+
+    friend std::ostream& operator<<(std::ostream&, const acl_principal_base&);
+};
+
+/**
+ * Concrete instance of a Kafka principal.
+ *
+ * This implementation owns the memory for its name.
+ */
+class acl_principal final
   : public serde::
-      envelope<acl_principal, serde::version<0>, serde::compat_version<0>> {
+      envelope<acl_principal, serde::version<0>, serde::compat_version<0>>
+  , public acl_principal_base {
 public:
     acl_principal() = default;
     acl_principal(principal_type type, ss::sstring name)
       : _type(type)
       , _name(std::move(name)) {}
 
-    friend bool operator==(const acl_principal&, const acl_principal&)
-      = default;
-
-    template<typename H>
-    friend H AbslHashValue(H h, const acl_principal& e) {
-        return H::combine(std::move(h), e._type, e._name);
-    }
-
-    friend std::ostream& operator<<(std::ostream&, const acl_principal&);
-
-    const ss::sstring& name() const { return _name; }
-    principal_type type() const { return _type; }
+    /**
+     * Get a view to the principal name.
+     */
+    std::string_view name_view() const override { return _name; }
+    /**
+     * Get the principal type
+     */
+    principal_type type() const override { return _type; }
     bool wildcard() const { return _name == "*"; }
+
+    // Needed for ADL serialization
+    const ss::sstring& name() const { return _name; }
 
     auto serde_fields() { return std::tie(_type, _name); }
 
 private:
     principal_type _type;
     ss::sstring _name;
+};
+
+/**
+ * Concrete instance of a Kafka principal.
+ *
+ * This implementation does _not_ own the memory for its name. Use
+ * with care, similarly to a string_view, only when the lifetime of
+ * the view is known not to exceed the referenced principal.
+ *
+ */
+class acl_principal_view final : public acl_principal_base {
+public:
+    acl_principal_view() = delete;
+    acl_principal_view(principal_type type, std::string_view name)
+      : _type(type)
+      , _name(name) {}
+    explicit acl_principal_view(const acl_principal& p)
+      : _type(p.type())
+      , _name(p.name_view()) {}
+
+    /**
+     * Get a view to the principal name.
+     */
+    std::string_view name_view() const override { return _name; }
+    /**
+     * Get the principal type
+     */
+    principal_type type() const override { return _type; }
+
+private:
+    principal_type _type;
+    std::string_view _name;
 };
 
 inline const acl_principal acl_wildcard_user(principal_type::user, "*");

--- a/src/v/security/acl_store.h
+++ b/src/v/security/acl_store.h
@@ -46,13 +46,13 @@ public:
 
     std::optional<const_reference> find(
       acl_operation operation,
-      const acl_principal& principal,
+      const acl_principal_base& principal,
       const acl_host& host,
       acl_permission perm) const;
 
     bool contains(
       acl_operation operation,
-      const acl_principal& principal,
+      const acl_principal_base& principal,
       const acl_host& host,
       acl_permission perm) const {
         return find(operation, principal, host, perm).has_value();
@@ -103,13 +103,13 @@ public:
 
     std::optional<acl_match> find(
       acl_operation operation,
-      const acl_principal& principal,
+      const acl_principal_base& principal,
       const acl_host& host,
       acl_permission perm) const;
 
     bool contains(
       acl_operation operation,
-      const acl_principal& principal,
+      const acl_principal_base& principal,
       const acl_host& host,
       acl_permission perm) const {
         return find(operation, principal, host, perm).has_value();

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -293,7 +293,7 @@ private:
      */
     std::optional<acl_matches::acl_match> acl_any_implied_ops_allowed(
       const acl_matches& acls,
-      const acl_principal& principal,
+      const acl_principal_base& principal,
       const acl_host& host,
       const acl_operation operation) const {
         auto check_op = [&acls, &principal, &host](

--- a/src/v/security/role.cc
+++ b/src/v/security/role.cc
@@ -33,16 +33,28 @@ std::ostream& operator<<(std::ostream& os, role_member_type t) {
     __builtin_unreachable();
 }
 
-std::ostream& operator<<(std::ostream& os, const role_member& m) {
+std::ostream& operator<<(std::ostream& os, const role_member_view& m) {
     fmt::print(os, "{{{}}}:{{{}}}", m.type(), m.name());
     return os;
 }
 
-role_member role_member::from_principal(const security::acl_principal& p) {
-    return {member_type_for_principal_type(p.type()), ss::sstring{p.name()}};
+std::ostream& operator<<(std::ostream& os, const role_member& m) {
+    return os << role_member_view{m.type(), m.name()};
 }
 
-// TODO(oren): maybe we should have the role name on the role?
+role_member_view::role_member_view(const role_member& m)
+  : _type(m.type())
+  , _name(m.name()) {}
+
+role_member_view
+role_member_view::from_principal(const security::acl_principal& p) {
+    return {member_type_for_principal_type(p.type()), p.name_view()};
+}
+
+role_member role_member::from_principal(const security::acl_principal& p) {
+    return role_member{role_member_view::from_principal(p)};
+}
+
 std::ostream& operator<<(std::ostream& os, const role& r) {
     fmt::print(os, "role members: {{{}}}", fmt::join(r.members(), ","));
     return os;

--- a/src/v/security/role.cc
+++ b/src/v/security/role.cc
@@ -11,6 +11,20 @@
 #include "security/role.h"
 
 namespace security {
+
+namespace {
+role_member_type member_type_for_principal_type(security::principal_type p) {
+    switch (p) {
+    case security::principal_type::user:
+        return role_member_type::user;
+    case security::principal_type::ephemeral_user:
+    case security::principal_type::role:
+        vassert(false, "Invalid principal_type {{{}}} for role membership", p);
+    }
+    __builtin_unreachable();
+}
+} // namespace
+
 std::ostream& operator<<(std::ostream& os, role_member_type t) {
     switch (t) {
     case role_member_type::user:
@@ -24,9 +38,19 @@ std::ostream& operator<<(std::ostream& os, const role_member& m) {
     return os;
 }
 
+role_member role_member::from_principal(const security::acl_principal& p) {
+    return {member_type_for_principal_type(p.type()), p.name()};
+}
+
 // TODO(oren): maybe we should have the role name on the role?
 std::ostream& operator<<(std::ostream& os, const role& r) {
     fmt::print(os, "role members: {{{}}}", fmt::join(r.members(), ","));
     return os;
 }
+
+security::acl_principal role::to_principal(std::string_view role_name) {
+    return {
+      security::principal_type::role, {role_name.data(), role_name.size()}};
+}
+
 } // namespace security

--- a/src/v/security/role.cc
+++ b/src/v/security/role.cc
@@ -39,7 +39,7 @@ std::ostream& operator<<(std::ostream& os, const role_member& m) {
 }
 
 role_member role_member::from_principal(const security::acl_principal& p) {
-    return {member_type_for_principal_type(p.type()), p.name()};
+    return {member_type_for_principal_type(p.type()), ss::sstring{p.name()}};
 }
 
 // TODO(oren): maybe we should have the role name on the role?
@@ -51,6 +51,11 @@ std::ostream& operator<<(std::ostream& os, const role& r) {
 security::acl_principal role::to_principal(std::string_view role_name) {
     return {
       security::principal_type::role, {role_name.data(), role_name.size()}};
+}
+
+security::acl_principal_view
+role::to_principal_view(std::string_view role_name) {
+    return {security::principal_type::role, role_name};
 }
 
 } // namespace security

--- a/src/v/security/role.h
+++ b/src/v/security/role.h
@@ -83,6 +83,11 @@ public:
      * Construct a concrete acl_principal of principal_type::role
      */
     static security::acl_principal to_principal(std::string_view role_name);
+    /**
+     * Construct a concrete acl_principal_view of principal_type::role
+     */
+    static security::acl_principal_view
+    to_principal_view(std::string_view role_name);
 
 private:
     friend bool operator==(const role&, const role&) = default;

--- a/src/v/security/role.h
+++ b/src/v/security/role.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "absl/container/flat_hash_set.h"
+#include "security/acl.h"
 #include "security/types.h"
 #include "serde/envelope.h"
 
@@ -42,6 +43,8 @@ public:
     role_member_type type() const { return _type; }
 
     auto serde_fields() { return std::tie(_type, _name); }
+
+    static role_member from_principal(const security::acl_principal& p);
 
 private:
     friend bool operator==(const role_member&, const role_member&) = default;
@@ -75,6 +78,11 @@ public:
     auto end() const { return _members.end(); }
     auto cbegin() const { return _members.cbegin(); }
     auto cend() const { return _members.cend(); }
+
+    /**
+     * Construct a concrete acl_principal of principal_type::role
+     */
+    static security::acl_principal to_principal(std::string_view role_name);
 
 private:
     friend bool operator==(const role&, const role&) = default;

--- a/src/v/security/role_store.h
+++ b/src/v/security/role_store.h
@@ -75,6 +75,9 @@ class role_store {
       detail::role_member_eq>;
 
 public:
+    using roles_range
+      = boost::iterator_range<name_view_set_type::const_iterator>;
+
     role_store() noexcept = default;
     role_store(const role_store&) = delete;
     role_store& operator=(const role_store&) = delete;
@@ -110,8 +113,7 @@ public:
     }
 
     template<RoleMember T>
-    boost::iterator_range<name_view_set_type::const_iterator>
-    roles_for_member(const T& user) const {
+    roles_range roles_for_member(const T& user) const {
         if (auto it = _members_store.find(user); it != _members_store.end()) {
             return it->second;
         }

--- a/src/v/security/role_store.h
+++ b/src/v/security/role_store.h
@@ -25,6 +25,27 @@
 
 namespace security {
 
+namespace detail {
+
+// Hash and Equal structs for transparent lookups in node_hash_map
+struct role_member_hash {
+    using is_transparent = std::true_type;
+
+    size_t operator()(role_member_view v) const {
+        return absl::Hash<role_member_view>{}(v);
+    }
+};
+
+struct role_member_eq {
+    using is_transparent = std::true_type;
+
+    bool operator()(role_member_view lhs, role_member_view rhs) const {
+        return lhs == rhs;
+    }
+};
+
+} // namespace detail
+
 /*
  * Store for roles and role members.
  *
@@ -47,8 +68,11 @@ class role_store {
     };
     using role_set_type = absl::node_hash_set<role_name>;
     using name_view_set_type = absl::flat_hash_set<role_name_view>;
-    using members_store_type
-      = absl::node_hash_map<role_member, name_view_set_type>;
+    using members_store_type = absl::node_hash_map<
+      role_member,
+      name_view_set_type,
+      detail::role_member_hash,
+      detail::role_member_eq>;
 
 public:
     role_store() noexcept = default;
@@ -85,8 +109,9 @@ public:
         return role{{member_rng.begin(), member_rng.end()}};
     }
 
+    template<RoleMember T>
     boost::iterator_range<name_view_set_type::const_iterator>
-    roles_for_member(const role_member& user) const {
+    roles_for_member(const T& user) const {
         if (auto it = _members_store.find(user); it != _members_store.end()) {
             return it->second;
         }

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -88,7 +88,7 @@ static authorizer make_test_instance(
     return authorizer(allow, std::move(b), *roles.value_or(&_roles));
 }
 
-BOOST_AUTO_TEST_CASE(resource_type_auto) {
+BOOST_AUTO_TEST_CASE(authz_resource_type_auto) {
     BOOST_REQUIRE(
       get_resource_type<model::topic>() == security::resource_type::topic);
     BOOST_REQUIRE(
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(resource_type_auto) {
       != get_resource_type<kafka::group_id>());
 }
 
-BOOST_AUTO_TEST_CASE(empty_resource_name) {
+BOOST_AUTO_TEST_CASE(authz_empty_resource_name) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.0.1");
 
@@ -143,7 +143,7 @@ BOOST_AUTO_TEST_CASE(empty_resource_name) {
 
 static const model::topic default_topic("topic1");
 
-BOOST_AUTO_TEST_CASE(deny_applies_first) {
+BOOST_AUTO_TEST_CASE(authz_deny_applies_first) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.2.1");
 
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(deny_applies_first) {
     BOOST_REQUIRE(!result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(allow_all) {
+BOOST_AUTO_TEST_CASE(authz_allow_all) {
     acl_principal user(principal_type::user, "random");
     acl_host host("192.0.4.4");
 
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(allow_all) {
     BOOST_REQUIRE(!result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(super_user_allow) {
+BOOST_AUTO_TEST_CASE(authz_super_user_allow) {
     acl_principal user1(principal_type::user, "superuser1");
     acl_principal user2(principal_type::user, "superuser2");
     acl_host host("192.0.4.4");
@@ -311,7 +311,7 @@ BOOST_AUTO_TEST_CASE(super_user_allow) {
     BOOST_REQUIRE(!result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(wildcards) {
+BOOST_AUTO_TEST_CASE(authz_wildcards) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.0.1");
 
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(wildcards) {
     BOOST_REQUIRE(!result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(no_acls_deny) {
+BOOST_AUTO_TEST_CASE(authz_no_acls_deny) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.0.1");
 
@@ -402,7 +402,7 @@ BOOST_AUTO_TEST_CASE(no_acls_deny) {
     BOOST_REQUIRE(result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(no_acls_allow) {
+BOOST_AUTO_TEST_CASE(authz_no_acls_allow) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.0.1");
 
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(no_acls_allow) {
     BOOST_REQUIRE(result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(implied_acls) {
+BOOST_AUTO_TEST_CASE(authz_implied_acls) {
     auto test_allow = [](acl_operation op, std::set<acl_operation> allowed) {
         acl_principal user(principal_type::user, "alice");
         acl_host host("192.168.3.1");
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(implied_acls) {
     test_deny(acl_operation::describe_configs, {});
 }
 
-BOOST_AUTO_TEST_CASE(allow_for_all_wildcard_resource) {
+BOOST_AUTO_TEST_CASE(authz_allow_for_all_wildcard_resource) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.3.1");
 
@@ -599,7 +599,7 @@ BOOST_AUTO_TEST_CASE(allow_for_all_wildcard_resource) {
     BOOST_REQUIRE(!result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(remove_acl_wildcard_resource) {
+BOOST_AUTO_TEST_CASE(authz_remove_acl_wildcard_resource) {
     auto auth = make_test_instance();
 
     std::vector<acl_binding> bindings;
@@ -617,7 +617,7 @@ BOOST_AUTO_TEST_CASE(remove_acl_wildcard_resource) {
     BOOST_REQUIRE(get_acls(auth, wildcard_resource) == expected);
 }
 
-BOOST_AUTO_TEST_CASE(remove_all_acl_wildcard_resource) {
+BOOST_AUTO_TEST_CASE(authz_remove_all_acl_wildcard_resource) {
     auto auth = make_test_instance();
 
     std::vector<acl_binding> bindings;
@@ -633,7 +633,7 @@ BOOST_AUTO_TEST_CASE(remove_all_acl_wildcard_resource) {
     BOOST_REQUIRE(get_acls(auth, acl_binding_filter::any()).empty());
 }
 
-BOOST_AUTO_TEST_CASE(allow_for_all_prefixed_resource) {
+BOOST_AUTO_TEST_CASE(authz_allow_for_all_prefixed_resource) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.3.1");
 
@@ -666,7 +666,7 @@ BOOST_AUTO_TEST_CASE(allow_for_all_prefixed_resource) {
     BOOST_REQUIRE(!result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(remove_acl_prefixed_resource) {
+BOOST_AUTO_TEST_CASE(authz_remove_acl_prefixed_resource) {
     auto auth = make_test_instance();
 
     std::vector<acl_binding> bindings;
@@ -684,7 +684,7 @@ BOOST_AUTO_TEST_CASE(remove_acl_prefixed_resource) {
     BOOST_REQUIRE(get_acls(auth, prefixed_resource) == expected);
 }
 
-BOOST_AUTO_TEST_CASE(remove_all_acl_prefixed_resource) {
+BOOST_AUTO_TEST_CASE(authz_remove_all_acl_prefixed_resource) {
     auto auth = make_test_instance();
 
     std::vector<acl_binding> bindings;
@@ -700,7 +700,7 @@ BOOST_AUTO_TEST_CASE(remove_all_acl_prefixed_resource) {
     BOOST_REQUIRE(get_acls(auth, acl_binding_filter::any()).empty());
 }
 
-BOOST_AUTO_TEST_CASE(acls_on_literal_resource) {
+BOOST_AUTO_TEST_CASE(authz_acls_on_literal_resource) {
     auto auth = make_test_instance();
 
     std::vector<acl_binding> bindings;
@@ -734,7 +734,7 @@ BOOST_AUTO_TEST_CASE(acls_on_literal_resource) {
     BOOST_REQUIRE(get_acls(auth, prefixed_resource).empty());
 }
 
-BOOST_AUTO_TEST_CASE(acls_on_wildcard_resource) {
+BOOST_AUTO_TEST_CASE(authz_acls_on_wildcard_resource) {
     auto auth = make_test_instance();
 
     std::vector<acl_binding> bindings;
@@ -758,7 +758,7 @@ BOOST_AUTO_TEST_CASE(acls_on_wildcard_resource) {
     BOOST_REQUIRE(get_acls(auth, prefixed_resource).empty());
 }
 
-BOOST_AUTO_TEST_CASE(acls_on_prefixed_resource) {
+BOOST_AUTO_TEST_CASE(authz_acls_on_prefixed_resource) {
     auto auth = make_test_instance();
 
     std::vector<acl_binding> bindings;
@@ -782,7 +782,7 @@ BOOST_AUTO_TEST_CASE(acls_on_prefixed_resource) {
     BOOST_REQUIRE(get_acls(auth, default_resource).empty());
 }
 
-BOOST_AUTO_TEST_CASE(auth_prefix_resource) {
+BOOST_AUTO_TEST_CASE(authz_auth_prefix_resource) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.3.1");
 
@@ -846,7 +846,7 @@ BOOST_AUTO_TEST_CASE(auth_prefix_resource) {
     BOOST_REQUIRE_EQUAL(result.resource_name, default_resource.name());
 }
 
-BOOST_AUTO_TEST_CASE(single_char) {
+BOOST_AUTO_TEST_CASE(authz_single_char) {
     acl_principal user(principal_type::user, "alice");
     acl_host host("192.168.3.1");
 
@@ -895,7 +895,7 @@ BOOST_AUTO_TEST_CASE(single_char) {
     BOOST_REQUIRE(result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(get_acls_principal) {
+BOOST_AUTO_TEST_CASE(authz_get_acls_principal) {
     acl_principal user(principal_type::user, "alice");
 
     auto auth = make_test_instance();
@@ -932,7 +932,7 @@ BOOST_AUTO_TEST_CASE(get_acls_principal) {
     BOOST_REQUIRE(get_acls(auth, user).empty());
 }
 
-BOOST_AUTO_TEST_CASE(acl_filter) {
+BOOST_AUTO_TEST_CASE(authz_acl_filter) {
     acl_principal user(principal_type::user, "alice");
 
     resource_pattern resource1(
@@ -1003,7 +1003,7 @@ BOOST_AUTO_TEST_CASE(acl_filter) {
         acl_entry_filter::any()))));
 }
 
-BOOST_AUTO_TEST_CASE(topic_acl) {
+BOOST_AUTO_TEST_CASE(authz_topic_acl) {
     acl_principal user1(principal_type::user, "alice");
     acl_principal user2(principal_type::user, "rob");
     acl_principal user3(principal_type::user, "batman");
@@ -1115,7 +1115,7 @@ BOOST_AUTO_TEST_CASE(topic_acl) {
 
 // a bug had allowed a topic with read permissions (prefix) to authorize a group
 // for read permissions when the topic name was a prefix of the group name
-BOOST_AUTO_TEST_CASE(topic_group_same_name) {
+BOOST_AUTO_TEST_CASE(authz_topic_group_same_name) {
     auto auth = make_test_instance();
 
     std::vector<acl_binding> bindings;

--- a/src/v/security/tests/authorizer_test.cc
+++ b/src/v/security/tests/authorizer_test.cc
@@ -9,6 +9,7 @@
 #include "config/mock_property.h"
 #include "random/generators.h"
 #include "security/authorizer.h"
+#include "security/role.h"
 #include "security/role_store.h"
 #include "utils/base64.h"
 
@@ -85,7 +86,7 @@ static authorizer make_test_instance(
     auto b = config::mock_binding<std::vector<ss::sstring>>(
       std::vector<ss::sstring>{});
 
-    return authorizer(allow, std::move(b), *roles.value_or(&_roles));
+    return {allow, std::move(b), roles.value_or(&_roles)};
 }
 
 BOOST_AUTO_TEST_CASE(authz_resource_type_auto) {
@@ -217,7 +218,7 @@ BOOST_AUTO_TEST_CASE(authz_super_user_allow) {
     config::mock_property<std::vector<ss::sstring>> superuser_config_prop(
       std::vector<ss::sstring>{});
     role_store roles;
-    authorizer auth(superuser_config_prop.bind(), roles);
+    authorizer auth(superuser_config_prop.bind(), &roles);
 
     acl_entry acl(
       acl_wildcard_user,
@@ -422,14 +423,23 @@ BOOST_AUTO_TEST_CASE(authz_no_acls_allow) {
     BOOST_REQUIRE(result.empty_matches);
 }
 
-BOOST_AUTO_TEST_CASE(authz_implied_acls) {
-    auto test_allow = [](acl_operation op, std::set<acl_operation> allowed) {
+static void do_implied_acls(
+  const acl_principal& bind_principal,
+  std::optional<role_store*> roles = std::nullopt) {
+    auto test_allow = [&bind_principal, &roles](
+                        acl_operation op, std::set<acl_operation> allowed) {
         acl_principal user(principal_type::user, "alice");
+        BOOST_REQUIRE(
+          user == bind_principal
+          || bind_principal.type() == principal_type::role);
+
         acl_host host("192.168.3.1");
 
-        acl_entry acl(user, acl_wildcard_host, op, acl_permission::allow);
+        acl_entry acl(
+          bind_principal, acl_wildcard_host, op, acl_permission::allow);
 
-        auto auth = make_test_instance();
+        auto auth = make_test_instance(
+          authorizer::allow_empty_matches::no, roles);
 
         std::vector<acl_binding> bindings;
         resource_pattern resource(
@@ -474,16 +484,26 @@ BOOST_AUTO_TEST_CASE(authz_implied_acls) {
         }
     };
 
-    auto test_deny = [](acl_operation op, std::set<acl_operation> denied) {
+    auto test_deny = [&bind_principal, &roles](
+                       acl_operation op, std::set<acl_operation> denied) {
         acl_principal user(principal_type::user, "alice");
+        BOOST_REQUIRE(
+          user == bind_principal
+          || bind_principal.type() == principal_type::role);
+
         acl_host host("192.168.3.1");
 
-        acl_entry deny(user, acl_wildcard_host, op, acl_permission::deny);
+        acl_entry deny(
+          bind_principal, acl_wildcard_host, op, acl_permission::deny);
 
         acl_entry allow(
-          user, acl_wildcard_host, acl_operation::all, acl_permission::allow);
+          bind_principal,
+          acl_wildcard_host,
+          acl_operation::all,
+          acl_permission::allow);
 
-        auto auth = make_test_instance();
+        auto auth = make_test_instance(
+          authorizer::allow_empty_matches::no, roles);
 
         std::vector<acl_binding> bindings;
         resource_pattern resource(
@@ -564,6 +584,10 @@ BOOST_AUTO_TEST_CASE(authz_implied_acls) {
     test_deny(acl_operation::describe, {});
     test_allow(acl_operation::alter_configs, {acl_operation::describe_configs});
     test_deny(acl_operation::describe_configs, {});
+}
+
+BOOST_AUTO_TEST_CASE(authz_implied_acls) {
+    do_implied_acls(acl_principal{principal_type::user, "alice"});
 }
 
 BOOST_AUTO_TEST_CASE(authz_allow_for_all_wildcard_resource) {
@@ -1133,6 +1157,409 @@ BOOST_AUTO_TEST_CASE(authz_topic_group_same_name) {
       kafka::group_id("topic-foo"), acl_operation::read, user, host));
     BOOST_REQUIRE(!auth.authorized(
       kafka::group_id("topic-foo-xxx"), acl_operation::read, user, host));
+}
+
+BOOST_AUTO_TEST_CASE(role_authz_principal_view) {
+    ss::sstring s1{"foor"};
+    ss::sstring s2{"bar"};
+
+    BOOST_REQUIRE_NE(s1, s2);
+    acl_principal p1{principal_type::user, s1};
+    acl_principal p2{principal_type::user, s2};
+    acl_principal_view pv1{p1};
+
+    BOOST_CHECK_NE(p1, p2);
+    BOOST_CHECK_EQUAL(p1, pv1);
+    BOOST_CHECK_NE(p2, pv1);
+
+    acl_principal p3{principal_type::role, s1};
+    acl_principal p4{principal_type::role, s2};
+    acl_principal_view pv3{p3};
+
+    BOOST_CHECK_NE(p3, p4);
+    BOOST_CHECK_EQUAL(p3, pv3);
+    BOOST_CHECK_NE(p4, pv3);
+
+    // respects principal type
+    BOOST_CHECK_NE(p1, p3);
+    BOOST_CHECK_NE(p2, p4);
+    BOOST_CHECK_NE(p1, pv3);
+    BOOST_CHECK_NE(pv1, pv3);
+}
+
+BOOST_AUTO_TEST_CASE(role_authz_simple_allow) {
+    acl_principal user1(principal_type::user, "phyllis");
+    acl_principal user2(principal_type::user, "lola");
+    acl_principal user3(principal_type::user, "dietrichson");
+    acl_principal user4(principal_type::user, "walter");
+    role_name role_name1{"dietrichsons"};
+    acl_principal role1 = role::to_principal(role_name1());
+
+    acl_host host1("192.168.1.2");
+    auto host_any = acl_host::wildcard_host();
+    const model::topic topic1("topic1");
+
+    role the_dietrichsons{{
+      /* members */
+      role_member::from_principal(user1),
+      role_member::from_principal(user2),
+    }};
+
+    // role1 -> allow read
+    acl_entry acl1(role1, host_any, acl_operation::read, acl_permission::allow);
+
+    // user3 -> allow describe
+    acl_entry acl2(
+      user3, host_any, acl_operation::describe, acl_permission::allow);
+
+    // user4 -> allow write
+    acl_entry acl3(
+      user4, host_any, acl_operation::write, acl_permission::allow);
+
+    std::vector<acl_binding> bindings;
+
+    resource_pattern resource(
+      resource_type::topic, topic1(), pattern_type::literal);
+    bindings.emplace_back(resource, acl1);
+    bindings.emplace_back(resource, acl3);
+
+    role_store roles;
+    auto auth = make_test_instance(authorizer::allow_empty_matches::no, &roles);
+    auth.add_bindings(bindings);
+
+    // We haven't populated the role store yet
+    auto result = auth.authorized(topic1, acl_operation::read, user1, host1);
+    BOOST_CHECK(!bool(result));
+    BOOST_CHECK(!result.acl.has_value());
+    BOOST_CHECK(!result.resource_pattern.has_value());
+    BOOST_CHECK(!result.role.has_value());
+
+    // Add the role to the store
+    BOOST_CHECK(roles.put(role_name1, the_dietrichsons));
+
+    // check authZ for both role members
+    for (const auto& user : {user1, user2}) {
+        auto result = auth.authorized(topic1, acl_operation::read, user, host1);
+        BOOST_CHECK(bool(result));
+        BOOST_CHECK_EQUAL(result.acl, acl1);
+        BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+        BOOST_CHECK_EQUAL(result.role, role_name1);
+    }
+
+    // confirm that the non-member user3 was not granted read access
+    result = auth.authorized(topic1, acl_operation::read, user3, host1);
+    BOOST_CHECK(!bool(result));
+    BOOST_CHECK(!result.acl.has_value());
+    BOOST_CHECK(!result.resource_pattern.has_value());
+    BOOST_CHECK(!result.role.has_value());
+
+    // check that the non-member user4 does have write access
+    result = auth.authorized(topic1, acl_operation::write, user4, host1);
+    BOOST_CHECK(bool(result));
+    BOOST_CHECK_EQUAL(result.acl, acl3);
+    BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+    BOOST_CHECK(!result.role.has_value());
+
+    // And confirm that role members do NOT have write access
+    for (const auto& user : {user1, user2}) {
+        auto result = auth.authorized(
+          topic1, acl_operation::write, user, host1);
+        BOOST_CHECK(!bool(result));
+        BOOST_CHECK(!result.acl.has_value());
+        BOOST_CHECK(!result.resource_pattern.has_value());
+        // No role here, becuase there was no match
+        BOOST_CHECK(!result.role.has_value());
+    }
+
+    // Add user3 to the role
+    auto r = roles.get(role_name1);
+    BOOST_CHECK(roles.remove(role_name1));
+    BOOST_REQUIRE(r.has_value());
+    BOOST_CHECK_EQUAL(r.value(), the_dietrichsons);
+    auto r1_members = std::move(r.value()).members();
+    r1_members.insert(role_member::from_principal(user3));
+    roles.put(role_name1, std::move(r1_members));
+
+    // user3 should now have read permissions
+    result = auth.authorized(topic1, acl_operation::read, user3, host1);
+    BOOST_CHECK(bool(result));
+    BOOST_CHECK_EQUAL(result.acl, acl1);
+    BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+    BOOST_CHECK_EQUAL(result.role, role_name1);
+}
+
+BOOST_AUTO_TEST_CASE(role_authz_user_deny_applies_first) {
+    acl_principal user1(principal_type::user, "user1");
+    role_name role_name1("role1");
+    acl_principal role_principal1 = role::to_principal(role_name1());
+    acl_host host1("192.168.1.2");
+
+    acl_entry deny_user(
+      user1,
+      acl_host::wildcard_host(),
+      acl_operation::write,
+      acl_permission::deny);
+
+    acl_entry allow_role(
+      role_principal1,
+      acl_host::wildcard_host(),
+      acl_operation::all,
+      acl_permission::allow);
+
+    std::vector<acl_binding> bindings;
+    resource_pattern resource(
+      resource_type::topic, default_topic(), pattern_type::literal);
+    bindings.emplace_back(resource, deny_user);
+    bindings.emplace_back(resource, allow_role);
+
+    role_store roles;
+    roles.put(role_name1, role{});
+    auto auth = make_test_instance(authorizer::allow_empty_matches::no, &roles);
+    auth.add_bindings(bindings);
+
+    // user1 should be denied write access to the topic
+
+    for (auto op :
+         {acl_operation::read, acl_operation::write, acl_operation::describe}) {
+        auto result = auth.authorized(default_topic, op, user1, host1);
+        BOOST_CHECK(!bool(result));
+        if (op == acl_operation::write) {
+            BOOST_CHECK_EQUAL(result.acl, deny_user);
+            BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+        } else {
+            BOOST_CHECK(!result.acl.has_value());
+            BOOST_CHECK(!result.resource_pattern.has_value());
+        }
+        BOOST_CHECK(!result.role.has_value());
+    }
+
+    // now add user1 to the role, which is already bound to the allow all acl
+
+    BOOST_CHECK(roles.remove(role_name1));
+    BOOST_CHECK(roles.put(
+      role_name1,
+      std::vector<role_member>{role_member::from_principal(user1)}));
+
+    // user1 should now have read and describe access, but the deny acl should
+    // still take precedence for writes
+    for (auto op :
+         {acl_operation::read, acl_operation::write, acl_operation::describe}) {
+        auto result = auth.authorized(default_topic, op, user1, host1);
+        if (op == acl_operation::write) {
+            BOOST_CHECK(!bool(result));
+            BOOST_CHECK_EQUAL(result.acl, deny_user);
+            BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+            BOOST_CHECK(!result.role.has_value());
+        } else {
+            BOOST_CHECK(bool(result));
+            BOOST_CHECK_EQUAL(result.acl, allow_role);
+            BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+            BOOST_CHECK_EQUAL(result.role, role_name1);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(role_authz_role_deny_applies_first) {
+    acl_principal user1(principal_type::user, "user1");
+    role_name role_name1("role1");
+    acl_principal role_principal1 = role::to_principal(role_name1());
+    acl_host host1("192.168.1.2");
+
+    acl_entry allow_user(
+      user1,
+      acl_host::wildcard_host(),
+      acl_operation::all,
+      acl_permission::allow);
+
+    acl_entry deny_role(
+      role_principal1,
+      acl_host::wildcard_host(),
+      acl_operation::write,
+      acl_permission::deny);
+
+    std::vector<acl_binding> bindings;
+    resource_pattern resource(
+      resource_type::topic, default_topic(), pattern_type::literal);
+    bindings.emplace_back(resource, allow_user);
+    bindings.emplace_back(resource, deny_role);
+
+    role_store roles;
+    roles.put(role_name1, role{});
+    auto auth = make_test_instance(authorizer::allow_empty_matches::no, &roles);
+    auth.add_bindings(bindings);
+
+    // user1 should be have full access to the topic
+
+    for (auto op :
+         {acl_operation::read, acl_operation::write, acl_operation::describe}) {
+        auto result = auth.authorized(default_topic, op, user1, host1);
+        BOOST_CHECK(bool(result));
+        BOOST_CHECK_EQUAL(result.acl, allow_user);
+        BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+        BOOST_CHECK(!result.role.has_value());
+    }
+
+    // now add user1 to the role, which is already bound to the deny write acl
+
+    BOOST_CHECK(roles.remove(role_name1));
+    BOOST_CHECK(roles.put(
+      role_name1,
+      std::vector<role_member>{role_member::from_principal(user1)}));
+
+    // user1 should still have read and describe access, but the deny acl from
+    // the role should take precedence
+
+    for (auto op :
+         {acl_operation::read, acl_operation::write, acl_operation::describe}) {
+        auto result = auth.authorized(default_topic, op, user1, host1);
+        if (op == acl_operation::write) {
+            BOOST_CHECK(!bool(result));
+            BOOST_CHECK_EQUAL(result.acl, deny_role);
+            BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+            BOOST_CHECK_EQUAL(result.role, role_name1);
+        } else {
+            BOOST_CHECK(bool(result));
+            BOOST_CHECK_EQUAL(result.acl, allow_user);
+            BOOST_CHECK_EQUAL(result.resource_pattern, resource);
+            BOOST_CHECK(!result.role.has_value());
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(role_authz_get_acls_principal) {
+    acl_principal role(principal_type::role, "admins");
+
+    // NOTE(oren): Wildcard roles are rejected at the Kafka layer, but we
+    // can verify acl_store behavior nevertheless.
+    acl_principal wildcard_role(principal_type::role, "*");
+
+    auto auth = make_test_instance();
+
+    std::vector<acl_binding> bindings;
+    bindings.emplace_back(
+      default_resource,
+      acl_entry(
+        role, acl_wildcard_host, acl_operation::write, acl_permission::allow));
+    auth.add_bindings(bindings);
+
+    BOOST_REQUIRE(get_acls(auth, wildcard_role).empty());
+    BOOST_REQUIRE_EQUAL(get_acls(auth, role).size(), 1);
+
+    {
+        std::vector<acl_binding_filter> filters;
+        filters.emplace_back(default_resource, acl_entry_filter::any());
+        auth.remove_bindings(filters);
+    }
+
+    bindings.clear();
+    bindings.emplace_back(
+      default_resource,
+      acl_entry(
+        wildcard_role,
+        acl_wildcard_host,
+        acl_operation::write,
+        acl_permission::allow));
+    auth.add_bindings(bindings);
+
+    BOOST_REQUIRE_EQUAL(get_acls(auth, wildcard_role).size(), 1);
+    BOOST_REQUIRE(get_acls(auth, role).empty());
+}
+
+BOOST_AUTO_TEST_CASE(role_authz_wildcard_no_auth) {
+    acl_principal user1(principal_type::user, "alice");
+    acl_principal role1(principal_type::role, "admins");
+    acl_principal wildcard_role(principal_type::role, "*");
+    acl_host host1("192.168.3.1");
+
+    role_store roles;
+    roles.put(
+      role_name{role1.name()}, role{{role_member::from_principal(user1)}});
+    roles.put(
+      role_name{wildcard_role.name()},
+      role{{role_member::from_principal(user1)}});
+
+    auto auth = make_test_instance();
+
+    // NOTE(oren): again, note that this usage would be rejected at Kafka layer,
+    // but it's probably a good idea to codify expected behavior somewhere.
+    std::vector<acl_binding> bindings;
+    bindings.emplace_back(
+      resource_pattern{
+        resource_type::topic, default_topic(), pattern_type::literal},
+      acl_entry(
+        wildcard_role,
+        acl_wildcard_host,
+        acl_operation::write,
+        acl_permission::allow));
+    auth.add_bindings(bindings);
+
+    auto result = auth.authorized(
+      default_topic, acl_operation::write, user1, host1);
+
+    BOOST_CHECK(!result.authorized);
+}
+
+BOOST_AUTO_TEST_CASE(role_authz_implied_acls) {
+    role_store roles;
+    role_name role_name1{"admin"};
+    role_member mem1{role_member_type::user, "alice"};
+    roles.put(role_name1, role{{mem1}});
+    do_implied_acls(role::to_principal(role_name1()), &roles);
+}
+
+BOOST_AUTO_TEST_CASE(role_authz_user_same_name) {
+    role_store roles;
+    role_name role_name1{"admin"};
+    acl_principal user1{principal_type::user, "admin"};
+    acl_principal user2{principal_type::user, "alice"};
+    roles.put(role_name1, role{{role_member::from_principal(user2)}});
+    auto auth = make_test_instance(authorizer::allow_empty_matches::no, &roles);
+    acl_host host1("192.168.1.1");
+
+    acl_entry allow_user(
+      user1,
+      acl_host::wildcard_host(),
+      acl_operation::read,
+      acl_permission::allow);
+
+    acl_entry deny_role(
+      role::to_principal(role_name1()),
+      acl_host::wildcard_host(),
+      acl_operation::read,
+      acl_permission::deny);
+
+    std::vector<acl_binding> bindings;
+    resource_pattern resource(
+      resource_type::topic, default_topic(), pattern_type::literal);
+    bindings.emplace_back(resource, allow_user);
+    auth.add_bindings(bindings);
+
+    auto result = auth.authorized(
+      default_topic, acl_operation::read, user1, host1);
+    BOOST_CHECK(result.authorized);
+    BOOST_CHECK_EQUAL(result.acl, allow_user);
+    BOOST_CHECK_EQUAL(result.principal, user1);
+
+    result = auth.authorized(default_topic, acl_operation::read, user2, host1);
+    BOOST_CHECK(!result.authorized);
+    BOOST_CHECK(!result.acl.has_value());
+    BOOST_CHECK_EQUAL(result.principal, user2);
+    BOOST_CHECK(!result.role.has_value());
+
+    bindings.clear();
+    bindings.emplace_back(resource, deny_role);
+    auth.add_bindings(bindings);
+
+    result = auth.authorized(default_topic, acl_operation::read, user1, host1);
+    BOOST_CHECK(result.authorized);
+    BOOST_CHECK_EQUAL(result.acl, allow_user);
+    BOOST_CHECK_EQUAL(result.principal, user1);
+
+    result = auth.authorized(default_topic, acl_operation::read, user2, host1);
+    BOOST_CHECK(!result.authorized);
+    BOOST_CHECK_EQUAL(result.acl, deny_role);
+    BOOST_CHECK_EQUAL(result.principal, user2);
+    BOOST_CHECK_EQUAL(result.role, role_name1);
 }
 
 } // namespace security

--- a/src/v/security/tests/role_store_bench.cc
+++ b/src/v/security/tests/role_store_bench.cc
@@ -8,7 +8,9 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "config/mock_property.h"
 #include "random/generators.h"
+#include "security/authorizer.h"
 #include "security/role.h"
 #include "security/role_store.h"
 
@@ -21,19 +23,18 @@
 
 namespace {
 
-using role_name = security::role_name;
-using role_member = security::role_member;
-using role_member_type = security::role_member_type;
-using role = security::role;
-using role_store = security::role_store;
+using namespace security;
 
-namespace {
+// choose something that will generally circumvent small string optimization
+constexpr size_t NAME_LEN = 32;
+
 std::vector<role_member> generate_members(size_t N) {
     std::vector<role_member> mems;
     mems.reserve(N);
     absl::c_for_each(boost::irange(0ul, N), [&mems](auto) {
         mems.emplace_back(
-          role_member_type::user, random_generators::gen_alphanum_string(32));
+          role_member_type::user,
+          random_generators::gen_alphanum_string(NAME_LEN));
     });
     return mems;
 }
@@ -42,7 +43,7 @@ std::vector<role_name> generate_role_names(size_t N) {
     std::vector<role_name> roles;
     roles.reserve(N);
     absl::c_for_each(boost::irange(0ul, N), [&roles](auto) {
-        roles.emplace_back(random_generators::gen_alphanum_string(32));
+        roles.emplace_back(random_generators::gen_alphanum_string(NAME_LEN));
     });
     return roles;
 }
@@ -50,6 +51,8 @@ constexpr size_t N_MEMBERS = 1024ul;
 constexpr size_t N_ROLES = 512ul;
 
 const std::vector<role_member> members_data = generate_members(N_MEMBERS);
+const std::vector<role_member> members_512_data = generate_members(512ul);
+const std::vector<role_name> role_names_data = generate_role_names(N_ROLES);
 
 role_store make_store(
   const decltype(role_names_data)& roles = role_names_data,
@@ -68,7 +71,16 @@ role_store make_store(
 }
 
 const role_store store_512_r_1Ki_m_data = make_store();
-} // namespace
+const role_store store_256_r_1Ki_m_data = make_store(
+  generate_role_names(256ul), members_data);
+const role_store store_128_r_1Ki_m_data = make_store(
+  generate_role_names(128ul), members_data);
+const role_store store_64_r_1Ki_m_data = make_store(
+  generate_role_names(64ul), members_data);
+const role_store store_64_r_512_m_data = make_store(
+  generate_role_names(64ul), members_512_data);
+const role_store store_8_r_1Ki_m_data = make_store(
+  generate_role_names(8ul), members_data);
 
 template<bool materialize>
 void run_get_member_roles() {
@@ -144,11 +156,163 @@ PERF_TEST(role_store_bench, update_role) {
 
 PERF_TEST(role_store_bench, put_role) {
     role_store store = make_store();
-    role_name name{random_generators::gen_alphanum_string(32)};
+    role_name name{random_generators::gen_alphanum_string(NAME_LEN)};
     std::vector<role_member> all_members;
     all_members.reserve(N_MEMBERS);
     absl::c_copy(members_data, std::back_inserter(all_members));
     perf_tests::start_measuring_time();
     store.put(std::move(name), std::move(all_members));
+    perf_tests::stop_measuring_time();
+}
+
+namespace {
+
+authorizer
+make_test_authorizer(std::optional<const role_store*> roles = std::nullopt) {
+    static role_store _roles;
+    auto b = config::mock_binding<std::vector<ss::sstring>>(
+      std::vector<ss::sstring>{});
+
+    return {
+      authorizer::allow_empty_matches::no,
+      std::move(b),
+      roles.value_or(&_roles)};
+}
+
+void run_authz(
+  const role_store& store,
+  const std::vector<role_member>& members,
+  acl_permission perm = acl_permission::allow,
+  size_t n_extra_bindings = 0) {
+    auto mem1 = members[random_generators::get_int(members.size() - 1)];
+    std::optional<role> role1;
+    std::optional<role_name> role1_name;
+    while (!role1_name.has_value()) {
+        auto rng = store.range(
+          [&mem1](const auto& e) { return role_store::has_member(e, mem1); });
+        if (rng.empty()) {
+            mem1 = members[random_generators::get_int(members.size() - 1)];
+            continue;
+        }
+        role1_name.emplace(rng.front());
+        role1.emplace(std::move(store.get(role1_name.value()).value()));
+    }
+
+    auto role1_principal = role::to_principal(role1_name.value()());
+    acl_principal mem1_principal{
+      principal_type::user, ss::sstring(mem1.name())};
+
+    const model::topic topic1("topic1");
+    acl_host host1("192.168.1.1");
+
+    auto any_host = acl_host::wildcard_host();
+
+    std::vector<acl_entry> acls = {
+      {role1_principal, any_host, acl_operation::read, perm},
+      {role1_principal, any_host, acl_operation::write, perm},
+      {role1_principal, any_host, acl_operation::describe, perm},
+      {role1_principal, any_host, acl_operation::alter, perm}};
+
+    for (auto i : boost::irange(n_extra_bindings)) {
+        acls.emplace_back(
+          acl_principal{
+            principal_type::user,
+            fmt::format(
+              "{}----{}", i, random_generators::gen_alphanum_string(27))},
+          any_host,
+          acl_operation::all,
+          perm);
+    }
+
+    std::vector<acl_binding> bindings;
+    for (const auto& acl : acls) {
+        resource_pattern resource(
+          resource_type::topic, topic1(), pattern_type::prefixed);
+        bindings.emplace_back(resource, acl);
+    }
+
+    auto auth = make_test_authorizer(&store);
+    auth.add_bindings(bindings);
+
+    const auto& m = members[random_generators::get_int(members.size() - 1)];
+    acl_principal p{principal_type::user, ss::sstring{m.name()}};
+
+    perf_tests::start_measuring_time();
+    auto result = auth.authorized(topic1, acl_operation::read, p, host1);
+    perf_tests::do_not_optimize(result);
+    perf_tests::stop_measuring_time();
+}
+
+} // namespace
+
+PERF_TEST(role_store_bench, role_authz_512_roles_1Ki_members) {
+    run_authz(store_512_r_1Ki_m_data, members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_256_roles_1Ki_members) {
+    run_authz(store_256_r_1Ki_m_data, members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_128_roles_1Ki_members) {
+    run_authz(store_128_r_1Ki_m_data, members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members) {
+    run_authz(store_64_r_1Ki_m_data, members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members_4_extra_bindings) {
+    run_authz(store_64_r_1Ki_m_data, members_data, acl_permission::allow, 4);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members_8_extra_bindings) {
+    run_authz(store_64_r_1Ki_m_data, members_data, acl_permission::allow, 8);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_1Ki_members_16_extra_bindings) {
+    run_authz(store_64_r_1Ki_m_data, members_data, acl_permission::allow, 16);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_512_members) {
+    run_authz(store_64_r_512_m_data, members_512_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_64_roles_512_members_deny) {
+    run_authz(store_64_r_512_m_data, members_512_data, acl_permission::deny);
+}
+
+PERF_TEST(role_store_bench, role_authz_8_roles_1Ki_members) {
+    run_authz(store_8_r_1Ki_m_data, members_data);
+}
+
+PERF_TEST(role_store_bench, role_authz_empty_store) {
+    acl_principal user1{
+      principal_type::user, random_generators::gen_alphanum_string(NAME_LEN)};
+    const model::topic topic1("tioopic1");
+    acl_host host1("192.168.1.1");
+
+    acl_permission perm = acl_permission::allow;
+
+    acl_entry acl1(user1, acl_host::wildcard_host(), acl_operation::read, perm);
+
+    acl_entry acl2(
+      user1, acl_host::wildcard_host(), acl_operation::write, perm);
+
+    acl_entry acl3(
+      user1, acl_host::wildcard_host(), acl_operation::describe, perm);
+
+    std::vector<acl_binding> bindings;
+    for (const auto& acl : {acl1, acl2, acl3}) {
+        resource_pattern resource(
+          resource_type::topic, topic1(), pattern_type::prefixed);
+        bindings.emplace_back(resource, acl);
+    }
+
+    auto auth = make_test_authorizer();
+    auth.add_bindings(bindings);
+
+    perf_tests::start_measuring_time();
+    auto result = auth.authorized(topic1, acl_operation::read, user1, host1);
+    perf_tests::do_not_optimize(result);
     perf_tests::stop_measuring_time();
 }


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR wires roles into the authorization flow in redpanda.

closes https://github.com/redpanda-data/core-internal/issues/1101

Preliminary benchmarks:

| test                                                               |  iterations |      median |         mad |         min |         max |      allocs |       tasks |        inst |
| -                                                                  |           - |           - |           - |           - |           - |           - |           - |           - |
| role_store_bench.get_member_roles                                  |    12917749 |    49.132ns |     0.044ns |    48.993ns |    49.264ns |       0.000 |       0.000 |         0.0 |
| role_store_bench.get_member_roles_bare_query                       |    13760304 |    49.146ns |     0.118ns |    48.996ns |    49.708ns |       0.000 |       0.000 |         0.0 |
| role_store_bench.user_range_query                                  |     9672507 |    78.019ns |     0.068ns |    77.803ns |    78.220ns |       0.000 |       0.000 |         0.0 |
| role_store_bench.user_range_query_bare_query                       |    20385250 |    25.463ns |     0.026ns |    25.398ns |    25.521ns |       0.000 |       0.000 |         0.0 |
| role_store_bench.remove_role                                       |          47 |    18.703us |   658.064ns |    18.023us |    29.874us |       0.000 |       0.000 |         0.0 |
| role_store_bench.update_role                                       |          47 |    60.956us |   255.915ns |    60.310us |    61.285us |     525.704 |       0.000 |         0.0 |
| role_store_bench.put_role                                          |          47 |    24.174us |   211.787ns |    23.914us |    24.997us |       1.696 |       0.000 |         0.0 |
| role_store_bench.role_authz_512_roles_1Ki_members                  |       28388 |     5.719us |    13.480ns |     5.630us |     5.734us |       4.032 |       0.000 |         0.0 |
| role_store_bench.role_authz_256_roles_1Ki_members                  |       31263 |     2.995us |     2.483ns |     2.990us |     3.002us |       4.036 |       0.000 |         0.0 |
| role_store_bench.role_authz_128_roles_1Ki_members                  |       34120 |     1.619us |     0.803ns |     1.617us |     1.621us |       3.918 |       0.000 |         0.0 |
| role_store_bench.role_authz_64_roles_1Ki_members                   |       34654 |   921.467ns |     2.078ns |   912.048ns |   924.389ns |       3.993 |       0.000 |         0.0 |
| role_store_bench.role_authz_64_roles_1Ki_members_4_extra_bindings  |       32975 |     1.034us |     1.012ns |     1.031us |     1.035us |       3.988 |       0.000 |         0.0 |
| role_store_bench.role_authz_64_roles_1Ki_members_8_extra_bindings  |       31677 |     1.040us |     0.607ns |     1.038us |     1.044us |       3.991 |       0.000 |         0.0 |
| role_store_bench.role_authz_64_roles_1Ki_members_16_extra_bindings |       28099 |     1.165us |     1.988ns |     1.156us |     1.167us |       3.993 |       0.000 |         0.0 |
| role_store_bench.role_authz_64_roles_512_members                   |       70935 |   924.544ns |     4.125ns |   915.173ns |   928.669ns |       3.976 |       0.000 |         0.0 |
| role_store_bench.role_authz_64_roles_512_members_deny              |       72286 |   691.401ns |     0.590ns |   690.265ns |   693.075ns |       3.972 |       0.000 |         0.0 |
| role_store_bench.role_authz_8_roles_1Ki_members                    |       36066 |   299.003ns |     0.320ns |   298.146ns |   299.322ns |       4.028 |       0.000 |         0.0 |
| role_store_bench.role_authz_empty_store                            |     1774757 |    95.098ns |     0.028ns |    94.953ns |    95.189ns |       2.000 |       0.000 |         0.0 |

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
