### PR TITLE
tools/cmake_test: remove accidental env override

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -368,7 +368,7 @@ client_pool::acquire(ss::abort_source& as) {
                   if (!pool->_pool.empty()) {
                       vlog(
                         pool_log.debug,
-                        "disposing the the oldest client connection and "
+                        "disposing the oldest client connection and "
                         "replacing it with the borrowed one");
                       pool->_pool.push_back(std::move(client));
                       client = std::move(pool->_pool.front());

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -323,7 +323,6 @@ class TestRunner():
 
         # setup llvm symbolizer. first look for location in ci, then in redpanda
         # vbuild directory. if none, then asan will look in PATH
-        env = os.environ.copy()
         llvm_symbolizer = shutil.which("llvm-symbolizer",
                                        path="/vectorized/llvm/bin")
         if llvm_symbolizer is None:


### PR DESCRIPTION
This nuked the above set environment variables. Noticed this because unit tests were succeeded with UBSAN warnings which meant that `halt_on_error=1:abort_on_error=1` didn't take effect.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
