### PR TITLE
Commented out this log info since it is AWS specific and affects GCP

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -98,8 +98,8 @@ class CloudCleanup():
         self.provider = make_provider_client(self.config.provider, self.log,
                                              self.config.region, _keyId,
                                              _secret)
-        self.log.info(f"# Provider {self.config.provider} initialized. Running"
-                      f" as '{self.provider.get_caller_identity()['Arn']}'")
+        #self.log.info(f"# Provider {self.config.provider} initialized. Running"
+        #              f" as '{self.provider.get_caller_identity()['Arn']}'")
         self.utils = CloudClusterUtils(_fake_context, self.log, _keyId,
                                        _secret, self.config.provider,
                                        self.config.api_url, oauth_url_origin,


### PR DESCRIPTION
CDT tests are failing for GCP, since cleanup stage uses AWS specific implementation. It is used only for log message, so commenting it out to get tests running again

## Backports Required
* none - not a bug fix

## Release Notes
* none

### Improvements
CDT tests are failing for GCP, since cleanup stage uses AWS specific implementation. It is used only for log message, so commenting it out to get tests running again