### PR TITLE
storage: ensure monotonic stable offset updates

### DIFF
--- a/src/v/storage/segment.cc
+++ b/src/v/storage/segment.cc
@@ -340,7 +340,7 @@ ss::future<> segment::do_flush() {
         // outstanding flushes once the one executed later in terms of offset
         // finishes we guarantee that all previous flushes finished.
         _tracker.committed_offset = std::max(o, _tracker.committed_offset);
-        _tracker.stable_offset = _tracker.committed_offset;
+        _tracker.stable_offset = std::max(o, _tracker.stable_offset);
         _reader->set_file_size(std::max(fsize, _reader->file_size()));
         clear_cached_disk_usage();
     });

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -38,6 +38,7 @@
 #include "utils/to_string.h"
 
 #include <seastar/core/io_priority_class.hh>
+#include <seastar/core/loop.hh>
 #include <seastar/core/seastar.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/when_all.hh>
@@ -2113,7 +2114,33 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
         futures.push_back(append_with_lock());
     }
 
+    bool run_monitor = true;
+    auto prev_stable_offset = model::offset{};
+    auto prev_committed_offset = model::offset{};
+
+    auto monitor = ss::now().then([&] {
+        return ss::do_until(
+          [&] { return !run_monitor; },
+          [&]() mutable -> auto {
+              if (log->segment_count() == 0) {
+                  return ss::now();
+              }
+              auto stable = log->segments().back()->offsets().stable_offset;
+              BOOST_REQUIRE_LE(prev_stable_offset, stable);
+              prev_stable_offset = stable;
+
+              auto committed
+                = log->segments().back()->offsets().committed_offset;
+              BOOST_REQUIRE_LE(prev_committed_offset, committed);
+              prev_committed_offset = committed;
+
+              return ss::now();
+          });
+    });
+
     ss::when_all_succeed(futures.begin(), futures.end()).get();
+    run_monitor = false;
+    monitor.get();
 }
 
 FIXTURE_TEST(changing_cleanup_policy_back_and_forth, storage_test_fixture) {


### PR DESCRIPTION
This change is similar to
https://github.com/redpanda-data/redpanda/pull/1826 but for stable offsets this time.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
