### PR TITLE
io: add pager for append-only file abstraction

### DIFF
--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -11,6 +11,7 @@ v_cc_library(
     io_queue.cc
     scheduler.cc
     page_cache.cc
+    pager.cc
   DEPS
     Seastar::seastar
     absl::btree

--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -10,6 +10,7 @@ v_cc_library(
     logger.cc
     io_queue.cc
     scheduler.cc
+    page_cache.cc
   DEPS
     Seastar::seastar
     absl::btree

--- a/src/v/io/CMakeLists.txt
+++ b/src/v/io/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
     scheduler.cc
     page_cache.cc
     pager.cc
+    paging_data_source.cc
   DEPS
     Seastar::seastar
     absl::btree

--- a/src/v/io/README.md
+++ b/src/v/io/README.md
@@ -15,3 +15,7 @@ High-level scheduling across I/O queues.
 ### `persistence`
 
 Abstract storage interface with disk and memory backends.
+
+### `pager`
+
+Abstraction of an append-only file.

--- a/src/v/io/io_queue.h
+++ b/src/v/io/io_queue.h
@@ -44,6 +44,9 @@ class io_queue {
 public:
     /**
      * Callback invoked when the scheduler completes an operation.
+     *
+     * Write completions are delivered only if after the write has completed the
+     * operation will not be requeued.
      */
     using completion_callback_type
       = seastar::noncopyable_function<void(page&) noexcept>;

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -54,18 +54,11 @@ auto underlying(T type) {
     return static_cast<std::underlying_type_t<T>>(type);
 }
 
-void page::set_flag(flags flag) noexcept {
-    assert(flag != flags::num_flags);
-    flags_.set(underlying(flag));
-}
+void page::set_flag(flags flag) noexcept { flags_.set(underlying(flag)); }
 
-void page::clear_flag(flags flag) noexcept {
-    assert(flag != flags::num_flags);
-    flags_.reset(underlying(flag));
-}
+void page::clear_flag(flags flag) noexcept { flags_.reset(underlying(flag)); }
 
 bool page::test_flag(flags flag) const noexcept {
-    assert(flag != flags::num_flags);
     return flags_.test(underlying(flag));
 }
 

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -10,12 +10,26 @@
  */
 #include "io/page.h"
 
+#include "base/vassert.h"
+
 namespace experimental::io {
 
 page::page(uint64_t offset, seastar::temporary_buffer<char> data)
   : offset_(offset)
   , size_(data.size())
   , data_(std::move(data)) {}
+
+page::page(
+  uint64_t offset,
+  seastar::temporary_buffer<char> data,
+  const class cache_hook& hook)
+  : cache_hook(hook)
+  , offset_(offset)
+  , size_(data.size())
+  , data_(std::move(data)) {
+    vassert(
+      hook.evicted(), "Non-evicted cache hook for page offset {}", offset_);
+}
 
 uint64_t page::offset() const noexcept { return offset_; }
 

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -54,7 +54,12 @@ auto underlying(T type) {
     return static_cast<std::underlying_type_t<T>>(type);
 }
 
-void page::set_flag(flags flag) noexcept { flags_.set(underlying(flag)); }
+void page::set_flag(flags flag) noexcept {
+    flags_.set(underlying(flag));
+    vassert(
+      !(test_flag(flags::dirty) && test_flag(flags::faulting)),
+      "Dirty and faulting states are mutually exclusive");
+}
 
 void page::clear_flag(flags flag) noexcept { flags_.reset(underlying(flag)); }
 

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -42,6 +42,11 @@ const seastar::temporary_buffer<char>& page::data() const noexcept {
     return data_;
 }
 
+char* page::get_write() noexcept {
+    vassert(!test_flag(flags::faulting), "Cannot access faulting page data");
+    return data_.get_write();
+}
+
 void page::clear() { data_ = {}; }
 
 template<typename T>

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -24,6 +24,7 @@ uint64_t page::size() const noexcept { return size_; }
 seastar::temporary_buffer<char>& page::data() noexcept { return data_; }
 
 const seastar::temporary_buffer<char>& page::data() const noexcept {
+    vassert(!test_flag(flags::faulting), "Cannot access faulting page data");
     return data_;
 }
 

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -64,4 +64,11 @@ bool page::test_flag(flags flag) const noexcept {
     return flags_.test(underlying(flag));
 }
 
+void page::add_waiter(page::waiter& waiter) { waiters_.push_back(waiter); }
+
+void page::signal_waiters() {
+    waiters_.clear_and_dispose(
+      [](page::waiter* waiter) { waiter->ready.set_value(); });
+}
+
 } // namespace experimental::io

--- a/src/v/io/page.cc
+++ b/src/v/io/page.cc
@@ -28,6 +28,8 @@ const seastar::temporary_buffer<char>& page::data() const noexcept {
     return data_;
 }
 
+void page::clear() { data_ = {}; }
+
 template<typename T>
 auto underlying(T type) {
     return static_cast<std::underlying_type_t<T>>(type);

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "container/intrusive_list_helpers.h"
+#include "io/cache.h"
 
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/core/temporary_buffer.hh>
@@ -29,6 +30,16 @@ public:
      * Construct a page with the given \p offset and \p data.
      */
     page(uint64_t offset, seastar::temporary_buffer<char> data);
+
+    /**
+     * Construct a page with the given \p offset, \p data, and cache entry state
+     * \p hook. The hook is used to transfer cache entry statistics, and
+     * must not currently represent a page stored in the cache.
+     */
+    page(
+      uint64_t offset,
+      seastar::temporary_buffer<char> data,
+      const cache_hook& hook);
 
     page(const page&) = delete;
     page& operator=(const page&) = delete;
@@ -105,6 +116,12 @@ public:
         return !test_flag(flags::faulting) && !test_flag(flags::dirty)
                && use_count() == 1;
     }
+
+    /**
+     * Page cache entry intrusive list hook.
+     */
+    // NOLINTNEXTLINE(*-non-private-member-variables-in-classes)
+    cache_hook cache_hook;
 
 private:
     static constexpr auto num_page_flags

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -142,6 +142,13 @@ public:
      */
     void signal_waiters();
 
+    /*
+     * Return a write pointer to the page memory.
+     *
+     * The page must not be faulting.
+     */
+    [[nodiscard]] char* get_write() noexcept;
+
 private:
     static constexpr auto num_page_flags
       = static_cast<std::underlying_type_t<flags>>(flags::num_flags);

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -70,7 +70,8 @@ public:
 
     /*
      * read,write: page is queued for read or write
-     * faulting: page is faulting when a read is occuring in response to a cache miss.
+     * faulting: page is faulting when a read is occuring in response to a cache
+     * miss.
      * dirty: page contains data not persisted to disk
      */
     enum class flags { faulting, dirty, read, write, queued, num_flags };

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -57,8 +57,10 @@ public:
 
     /*
      * read,write: page is queued for read or write
+     * faulting: page is faulting when a read is occuring in response to a cache miss.
+     * dirty: page contains data not persisted to disk
      */
-    enum class flags { read, write, queued, num_flags };
+    enum class flags { faulting, dirty, read, write, queued, num_flags };
 
     /**
      * set a page flag.

--- a/src/v/io/page.h
+++ b/src/v/io/page.h
@@ -83,6 +83,11 @@ public:
     // NOLINTNEXTLINE(*-non-private-member-variables-in-classes)
     intrusive_list_hook io_queue_hook;
 
+    /**
+     * Release the page data.
+     */
+    void clear();
+
 private:
     static constexpr auto num_page_flags
       = static_cast<std::underlying_type_t<flags>>(flags::num_flags);

--- a/src/v/io/page_cache.cc
+++ b/src/v/io/page_cache.cc
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/page_cache.h"
+
+namespace experimental::io {
+
+void page_cache::insert(page& page) noexcept { cache_.insert(page); }
+
+void page_cache::remove(const page& page) noexcept { cache_.remove(page); }
+
+bool page_cache::evict::operator()(page& page) noexcept {
+    if (page.may_evict()) {
+        page.clear();
+        return true;
+    }
+    return false;
+}
+
+size_t page_cache::cost::operator()(const page& /*page*/) noexcept { return 1; }
+
+} // namespace experimental::io

--- a/src/v/io/page_cache.h
+++ b/src/v/io/page_cache.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+#include "io/cache.h"
+#include "io/page.h"
+
+namespace experimental::io {
+
+/**
+ * The page cache tracks pages and controls cache eviction.
+ */
+class page_cache {
+    struct evict {
+        bool operator()(page&) noexcept;
+    };
+
+    struct cost {
+        size_t operator()(const page&) noexcept;
+    };
+
+    using cache_type = cache<page, &page::cache_hook, evict, cost>;
+
+public:
+    using config = cache_type::config;
+
+    /**
+     * Initialize with the given configuration.
+     */
+    explicit page_cache(config cfg)
+      : cache_(cfg) {}
+
+    /**
+     * Insert @page into the cache.
+     *
+     * The page must not already be stored in the cache.
+     */
+    void insert(page& page) noexcept;
+
+    /**
+     * Remove @page from the cache.
+     *
+     * The page must currently be stored in the cache.
+     */
+    void remove(const page&) noexcept;
+
+private:
+    cache_type cache_;
+};
+
+} // namespace experimental::io

--- a/src/v/io/pager.cc
+++ b/src/v/io/pager.cc
@@ -222,9 +222,7 @@ void pager::handle_completion(page& page) noexcept {
         page.signal_waiters();
     } else if (page.test_flag(page::flags::dirty)) {
         vassert(page.test_flag(page::flags::write), "Expected write page");
-        if (!page.test_flag(page::flags::queued)) {
-            page.clear_flag(page::flags::dirty);
-        }
+        page.clear_flag(page::flags::dirty);
     }
 }
 

--- a/src/v/io/pager.cc
+++ b/src/v/io/pager.cc
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/pager.h"
+
+#include "base/vassert.h"
+#include "io/page.h"
+#include "io/page_cache.h"
+#include "io/scheduler.h"
+
+#include <seastar/core/align.hh>
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/sleep.hh>
+
+#include <span>
+
+namespace experimental::io {
+
+pager::pager(
+  std::filesystem::path file,
+  size_t size,
+  persistence* storage,
+  page_cache* cache,
+  scheduler* sched)
+  : file_(std::move(file))
+  , size_(size)
+  , cache_(cache)
+  , sched_(sched)
+  , queue_(
+      storage, file_, [](page& page) noexcept { handle_completion(page); }) {
+    sched_->add_queue(&queue_);
+}
+
+seastar::future<> pager::close() noexcept {
+    co_await scheduler::remove_queue(&queue_);
+    for (const auto& page : pages_) {
+        cache_->remove(*page);
+    }
+}
+
+seastar::lw_shared_ptr<page>
+pager::alloc_page(uint64_t offset, std::optional<cache_hook> hook) noexcept {
+    auto buf = seastar::temporary_buffer<char>::aligned(page_size, page_size);
+    if (hook.has_value()) {
+        return seastar::make_lw_shared<page>(
+          offset, std::move(buf), hook.value());
+    }
+    return seastar::make_lw_shared<page>(offset, std::move(buf));
+}
+
+seastar::future<std::vector<seastar::lw_shared_ptr<page>>>
+pager::read(const read_config cfg) noexcept {
+    // the logical size that is visible to the reader
+    const auto file_size = size_;
+
+    std::vector<seastar::lw_shared_ptr<page>> pages;
+
+    if (cfg.length == 0 || cfg.offset >= file_size) {
+        co_return pages;
+    }
+
+    size_t total = 0;
+    uint64_t offset = cfg.offset;
+    while (true) {
+        /*
+         * this will either be a cache hit, or the miss will be handled
+         * synchronously. this is roughly the location to implement read-ahead
+         * where by a cache miss will continue reading, but return the pages
+         * that were available in the cache.
+         */
+        auto page = co_await get_page(offset);
+
+        pages.emplace_back(page);
+        total += page->size();
+
+        if (total >= cfg.length) {
+            break;
+        }
+
+        offset = page->offset() + page->size();
+        if (offset >= file_size) {
+            break;
+        }
+    }
+
+    co_return pages;
+}
+
+seastar::future<> pager::append(seastar::temporary_buffer<char> data) noexcept {
+    /*
+     * helper to copy up to size bytes from the input data into a page at a
+     * specific offset. the number of bytes copied is returned.
+     */
+    const auto copy = [this, &data](size_t size, page* page, size_t off) {
+        const std::span src(data.get(), std::min(data.size(), size));
+        auto dst = std::span(page->get_write(), page->size()).subspan(off);
+        std::copy_n(src.begin(), src.size(), dst.begin());
+        data.trim_front(src.size());
+        /*
+         * the scheduler does the right thing if pages are marked more than once
+         * as dirty and resubmitted for write-back.
+         */
+        page->set_flag(page::flags::dirty);
+        sched_->submit_write(&queue_, page);
+        return src.size();
+    };
+
+    /*
+     * handle the page mapped by the append position (ie the file size). if the
+     * file size is aligned, then no page is mapped. otherwise, the page may
+     * need to be paged in for read-modify-write.
+     */
+    auto offset = size_; // offset of the first byte being appended
+    if ((offset % page_size) != 0) {
+        auto page = co_await get_page(offset);
+        const auto written = offset - page->offset();
+        const auto capacity = page->size() - written;
+        offset += copy(capacity, page.get(), written);
+    }
+
+    /*
+     * the remaining pages are new and will be filled, except for the last page
+     * created by this loop which may be partially filled.
+     */
+    while (!data.empty()) {
+        auto page = alloc_page(offset);
+        offset += copy(page->size(), page.get(), 0);
+        const auto res = pages_.insert(page);
+        vassert(
+          res.second,
+          "Page already cached offset {} size {}",
+          page->offset(),
+          page->size());
+        cache_->insert(*page);
+    }
+
+    size_ = offset;
+}
+
+seastar::future<seastar::lw_shared_ptr<page>>
+pager::get_page(uint64_t offset) noexcept {
+    /*
+     * find the page mapped by the target offset and return (page, true) if the
+     * page exists and has not yet been evicted. in all other cases, allocate a
+     * new page and return (page, false).
+     */
+    auto find_or_alloc_page = [this, offset] {
+        if (auto it = pages_.find(offset); it != pages_.end()) {
+            auto page = *it;
+            if (!page->data().empty()) {
+                return std::make_pair(std::move(page), true);
+            }
+            /*
+             * reusing the page is technically possible, but isn't yet done,
+             * in favor of the simplicity of re-creating the page with a
+             * specific known states. the cache hook is transferred so that we
+             * do not lose the cache statistics.
+             */
+            pages_.erase(it);
+            return std::make_pair(
+              alloc_page(page->offset(), page->cache_hook), false);
+        }
+        return std::make_pair(
+          alloc_page(seastar::align_down(offset, page_size)), false);
+    };
+
+    while (true) {
+        auto [page, found] = find_or_alloc_page();
+        if (found) {
+            /*
+             * the page may be in the cache index, but faulting. in this case we
+             * can wait until the fault is finished and try again.
+             */
+            if (page->test_flag(page::flags::faulting)) {
+                page::waiter waiter;
+                page->add_waiter(waiter);
+                co_await waiter.ready.get_future();
+                continue;
+            }
+            vassert(
+              page->size() > 0, "Empty page at offset {}", page->offset());
+            co_return page;
+        }
+
+        /*
+         * the page was not found in the index, so we need to fault it in.
+         *
+         * NOTE: due to a not yet known issue, when waiter is allocated on the
+         * stack, co_await on the waiter triggers clang-tidy check
+         * StackAddressEscape. this seems like a false positive, so allocate on
+         * the heap for now to trick it.
+         */
+        auto waiter = std::make_unique<page::waiter>();
+        page->set_flag(page::flags::faulting);
+        page->add_waiter(*waiter);
+
+        cache_->insert(*page);
+
+        auto res = pages_.insert(page);
+        vassert(
+          res.second,
+          "Page already in index offset {} size {}",
+          page->offset(),
+          page->size());
+
+        sched_->submit_read(&queue_, page.get());
+        co_await waiter->ready.get_future();
+    }
+}
+
+void pager::handle_completion(page& page) noexcept {
+    if (page.test_flag(page::flags::faulting)) {
+        vassert(page.test_flag(page::flags::read), "Expected read page");
+        page.clear_flag(page::flags::faulting);
+        page.signal_waiters();
+    } else if (page.test_flag(page::flags::dirty)) {
+        vassert(page.test_flag(page::flags::write), "Expected write page");
+        if (!page.test_flag(page::flags::queued)) {
+            page.clear_flag(page::flags::dirty);
+        }
+    }
+}
+
+} // namespace experimental::io

--- a/src/v/io/pager.h
+++ b/src/v/io/pager.h
@@ -100,12 +100,21 @@ private:
 
     static void handle_completion(page&) noexcept;
 
+    /// The underlying file managed by this pager.
     std::filesystem::path file_;
+
+    /// The readable size of the file.
     size_t size_;
+
+    /// Global page cache eviction. Doesn't own the pages.
     page_cache* cache_;
+
+    /// Pages that contain data for this file.
+    page_set pages_;
+
+    /// The IO scheduler and queue for IO operations on this file.
     scheduler* sched_;
     scheduler::queue queue_;
-    page_set pages_;
 };
 
 } // namespace experimental::io

--- a/src/v/io/pager.h
+++ b/src/v/io/pager.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "io/cache.h"
+#include "io/page_set.h"
+#include "io/scheduler.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/temporary_buffer.hh>
+
+namespace experimental::io {
+
+class page_cache;
+
+/**
+ * The pager wraps a normal file and presents an abstraction of an append-only
+ * file. All standard life cycle events of a file must be handled out-of-band,
+ * such as file creation, deletion, and renaming.
+ *
+ * The pager is responsible for managing the index of in-memory pages and
+ * offering write-back caching capabilities in conjunction with the page cache
+ * and the I/O scheduler.
+ */
+class pager {
+    static constexpr uint64_t page_size = 4096;
+
+public:
+    /**
+     * Construct a new pager for the file identified by \p file with initial
+     * size \size. Any data contained in the underlying file at offsets greather
+     * than or equal to \p size will not be visible and will be overwritten when
+     * new data is appended.
+     */
+    pager(
+      std::filesystem::path file,
+      size_t size,
+      persistence*,
+      page_cache*,
+      scheduler*);
+
+    pager(const pager&) = delete;
+    pager& operator=(const pager&) = delete;
+    pager(pager&&) noexcept = delete;
+    pager& operator=(pager&&) noexcept = delete;
+    ~pager() noexcept = default;
+
+    /**
+     * Shutdown the pager. After calling this do no submit reads or writes.
+     * Inflight I/O operations will be completed.
+     */
+    seastar::future<> close() noexcept;
+
+    /**
+     * Writes data to the end of the file. The file size will be extended by the
+     * number of bytes being appended. When the returned future completes the
+     * file size will have been updated and the newly appended data will be
+     * visible to readers. The data may not yet have been written to the
+     * underlying file or persistent storage.
+     */
+    seastar::future<> append(seastar::temporary_buffer<char> data) noexcept;
+
+    /**
+     * Configuration object for read interface.
+     */
+    struct read_config {
+        uint64_t offset;
+        uint64_t length;
+    };
+
+    /**
+     * Return pages that overlap the region defined by \p cfg. A subset of the
+     * pages for the entire range may be returned, in which case the caller
+     * should advance the starting offset to retrieve additional pages. Reads
+     * past the end-of-file will return an empty result.
+     *
+     * Caller should ensure that the length of the read does not result in a
+     * vector that would exceed recommended contiguous allocation limits.
+     */
+    seastar::future<std::vector<seastar::lw_shared_ptr<page>>>
+    read(read_config cfg) noexcept;
+
+private:
+    static seastar::lw_shared_ptr<page> alloc_page(
+      uint64_t offset, std::optional<cache_hook> hook = std::nullopt) noexcept;
+
+    /*
+     * Read a page from the underlying file.
+     */
+    seastar::future<seastar::lw_shared_ptr<page>>
+    get_page(uint64_t offset) noexcept;
+
+    static void handle_completion(page&) noexcept;
+
+    std::filesystem::path file_;
+    size_t size_;
+    page_cache* cache_;
+    scheduler* sched_;
+    scheduler::queue queue_;
+    page_set pages_;
+};
+
+} // namespace experimental::io

--- a/src/v/io/paging_data_source.cc
+++ b/src/v/io/paging_data_source.cc
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "io/paging_data_source.h"
+
+#include "base/vassert.h"
+#include "io/pager.h"
+
+#include <seastar/core/coroutine.hh>
+
+namespace experimental::io {
+
+paging_data_source::paging_data_source(pager* pager, config config)
+  : pager_(pager)
+  , offset_(config.offset)
+  , remaining_(config.length) {}
+
+paging_data_source::paging_data_source(
+  std::vector<seastar::lw_shared_ptr<page>> pages, config config)
+  : pager_(nullptr)
+  , offset_(config.offset)
+  , remaining_(config.length)
+  , pages_(std::move(pages)) {
+    std::reverse(pages_.begin(), pages_.end());
+}
+
+seastar::future<seastar::temporary_buffer<char>>
+paging_data_source::get() noexcept {
+    if (remaining_ == 0) {
+        co_return seastar::temporary_buffer<char>();
+    }
+
+    /*
+     * Hydrate the set of pages from the pager.
+     */
+    if (pages_.empty()) {
+        if (pager_ != nullptr) {
+            pages_ = co_await pager_->read({offset_, remaining_});
+            std::reverse(pages_.begin(), pages_.end());
+        }
+        if (pages_.empty()) {
+            co_return seastar::temporary_buffer<char>();
+        }
+    }
+
+    /*
+     * pages are reversed since erasing the front of a vector is expensive. we
+     * could also track the index or change pager iterface to provide something
+     * like a std::deque which is more efficient.
+     */
+    pages_.back()->cache_hook.touch();
+    const auto page = pages_.back();
+    pages_.pop_back();
+
+    auto buf = page->data().clone();
+    vassert(
+      !buf.empty(),
+      "Attempted to access evicted page at offset {}",
+      page->offset());
+
+    buf.trim_front(offset_ - page->offset());
+    if (buf.size() > remaining_) {
+        buf.trim(remaining_);
+    }
+
+    offset_ += buf.size();
+    remaining_ -= buf.size();
+
+    co_return buf;
+}
+
+} // namespace experimental::io

--- a/src/v/io/paging_data_source.h
+++ b/src/v/io/paging_data_source.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+#include <seastar/core/temporary_buffer.hh>
+
+namespace experimental::io {
+
+class page;
+class pager;
+
+/**
+ * An implementation of seastar::data_source backed by io::pager. Use this to
+ * construct a Seastar input stream over file, providing write-back caching.
+ */
+class paging_data_source final : public seastar::data_source_impl {
+public:
+    struct config {
+        uint64_t offset;
+        uint64_t length;
+    };
+
+    /**
+     * Construct a paging data source over the data managed by \p pager, limited
+     * to the range defined by \p config.
+     */
+    paging_data_source(pager* pager, config config);
+
+    /**
+     * Construct a paging data source backed by a fixed set of pages.
+     */
+    paging_data_source(
+      std::vector<seastar::lw_shared_ptr<page>>, config config);
+
+    /**
+     * Read some data.
+     */
+    seastar::future<seastar::temporary_buffer<char>> get() noexcept override;
+
+private:
+    seastar::temporary_buffer<char>
+    finalize(seastar::temporary_buffer<char> page);
+
+    pager* pager_;
+
+    /// The next offset from which to read.
+    uint64_t offset_;
+
+    /// The amount of data left to read.
+    uint64_t remaining_;
+
+    /// Queue of retreived pages. Will be stored in reverse order of page
+    /// offset for more efficient removal when consuming pages.
+    std::vector<seastar::lw_shared_ptr<page>> pages_;
+};
+
+} // namespace experimental::io

--- a/src/v/io/tests/CMakeLists.txt
+++ b/src/v/io/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ rp_test(
     page_set_test.cc
     io_queue_test.cc
     scheduler_test.cc
+    pager_test.cc
   LIBRARIES
     v::gtest_main
     v::io

--- a/src/v/io/tests/common.cc
+++ b/src/v/io/tests/common.cc
@@ -18,6 +18,8 @@
 #include <seastar/core/thread.hh>
 #include <seastar/util/later.hh>
 
+#include <absl/strings/escaping.h>
+
 #include <random>
 #include <span>
 
@@ -198,8 +200,10 @@ testing::AssertionResult EqualInputStreams(
                      "Input 1/2 chunk sizes {} vs {}. data {} vs {}",
                      data1.size(),
                      data2.size(),
-                     std::string_view(data1.get(), len),
-                     std::string_view(data2.get(), len));
+                     absl::CHexEscape(
+                       std::string_view(data1.get(), len).substr(0, 20)),
+                     absl::CHexEscape(
+                       std::string_view(data2.get(), len).substr(0, 20)));
         }
         data1.trim_front(len);
         data2.trim_front(len);

--- a/src/v/io/tests/page_test.cc
+++ b/src/v/io/tests/page_test.cc
@@ -104,3 +104,25 @@ TEST(Page, EvictionCheck) {
     [[maybe_unused]] auto p2 = p;
     EXPECT_FALSE(p->may_evict());
 }
+
+TEST(Page, Waiters) {
+    io::page::waiter w0;
+    io::page::waiter w1;
+
+    io::page p(1, {});
+    p.add_waiter(w0);
+    p.add_waiter(w1);
+
+    auto f0 = w0.ready.get_future();
+    auto f1 = w1.ready.get_future();
+
+    EXPECT_FALSE(f0.available());
+    EXPECT_FALSE(f1.available());
+
+    p.signal_waiters();
+
+    EXPECT_TRUE(f0.available());
+    EXPECT_TRUE(f1.available());
+    EXPECT_FALSE(f0.failed());
+    EXPECT_FALSE(f1.failed());
+}

--- a/src/v/io/tests/page_test.cc
+++ b/src/v/io/tests/page_test.cc
@@ -49,6 +49,23 @@ TEST(Page, SetData) {
     EXPECT_EQ(p.data(), d1);
 }
 
+TEST(Page, Clear) {
+    constexpr auto size = 10;
+
+    auto d0 = make_random_data(size).get();
+    io::page p(1, d0.share());
+
+    EXPECT_EQ(p.size(), size);
+    EXPECT_EQ(p.data().size(), size);
+    EXPECT_EQ(p.data(), d0);
+
+    p.clear();
+
+    EXPECT_EQ(p.size(), 10); // page remembers its size
+    EXPECT_EQ(p.data().size(), 0);
+    EXPECT_EQ(p.data(), make_random_data(0).get());
+}
+
 TEST(Page, Flags) {
     io::page p(1, {});
 

--- a/src/v/io/tests/pager_test.cc
+++ b/src/v/io/tests/pager_test.cc
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "base/units.h"
+#include "io/page_cache.h"
+#include "io/pager.h"
+#include "io/paging_data_source.h"
+#include "io/persistence.h"
+#include "io/scheduler.h"
+#include "io/tests/common.h"
+#include "test_utils/test.h"
+#include "utils/memory_data_source.h"
+
+#include <seastar/core/iostream.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/util/later.hh>
+
+#include <boost/range/irange.hpp>
+
+namespace io = experimental::io;
+
+namespace {
+/*
+ * Variety of sizes useful in test configurations for hitting edge cases.
+ */
+std::vector<uint64_t> test_case_sizes() {
+    // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+    return std::vector<uint64_t>{
+      0,         1,          2,          3,         512 - 2,    512 - 1,
+      512,       512 + 1,    512 + 2,    4_KiB - 2, 4_KiB - 1,  4_KiB,
+      4_KiB + 1, 4_KiB + 2,  8_KiB - 2,  8_KiB - 1, 8_KiB,      8_KiB + 1,
+      8_KiB + 2, 16_KiB - 2, 16_KiB - 1, 16_KiB,    16_KiB + 1, 16_KiB + 2,
+    };
+    // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+}
+} // namespace
+
+/*
+ * Base pager test with a configured pager and its dependencies.
+ */
+class PagerTestBase : public StorageTest {
+public:
+    [[nodiscard]] virtual size_t open_files() { return 100; }
+
+    void SetUp() override {
+        StorageTest::SetUp();
+
+        /*
+         * the scheduler and pager do not create files.
+         */
+        add_cleanup_file(file_);
+        storage()->create(file_.string()).get()->close().get();
+
+        io::page_cache::config cache_config{
+          .cache_size = 2_MiB, .small_size = 1_MiB};
+        cache_ = std::make_unique<io::page_cache>(cache_config);
+
+        scheduler_ = std::make_unique<io::scheduler>(open_files());
+        pager_ = std::make_unique<io::pager>(
+          file_, 0, storage(), cache_.get(), scheduler_.get());
+    }
+
+    void TearDown() override {
+        pager_->close().get();
+
+        for (auto& file : cleanup_files_) {
+            try {
+                seastar::remove_file(file.string()).get();
+            } catch (...) {
+            }
+        }
+    }
+
+    void add_cleanup_file(std::filesystem::path file) {
+        cleanup_files_.push_back(std::move(file));
+    }
+
+    io::pager& pager() { return *pager_; }
+
+private:
+    std::filesystem::path file_{"foo"};
+    std::unique_ptr<io::page_cache> cache_;
+    std::unique_ptr<io::scheduler> scheduler_;
+    std::unique_ptr<io::pager> pager_;
+    std::vector<std::filesystem::path> cleanup_files_;
+};
+
+/*
+ * Base pager test fixture that preallocates file with random data.
+ */
+class PreallocPagerTest : public PagerTestBase {
+public:
+    [[nodiscard]] virtual uint64_t file_size() const = 0;
+
+    void SetUp() override {
+        PagerTestBase::SetUp();
+        fill_data = make_random_data(file_size()).get();
+        pager().append(data()).get();
+    }
+
+    seastar::temporary_buffer<char> data() { return fill_data.share(); }
+
+private:
+    seastar::temporary_buffer<char> fill_data;
+};
+
+/*
+ * Simple PagerTest is a PreallocPagerTest with required parameters.
+ */
+class PagerTest
+  : public PreallocPagerTest
+  , public ::testing::WithParamInterface<std::tuple<bool, uint64_t>> {
+public:
+    [[nodiscard]] bool disk_persistence() const override {
+        return std::get<0>(GetParam());
+    }
+
+    [[nodiscard]] uint64_t file_size() const override {
+        return std::get<1>(GetParam());
+    }
+};
+
+/*
+ * Pager test fixture with a test parameter for controlling append size.
+ */
+class AppendPagerTest
+  : public PreallocPagerTest
+  , public ::testing::WithParamInterface<std::tuple<bool, uint64_t, uint64_t>> {
+public:
+    [[nodiscard]] bool disk_persistence() const override {
+        return std::get<0>(GetParam());
+    }
+
+    [[nodiscard]] uint64_t file_size() const override {
+        return std::get<1>(GetParam());
+    }
+
+    static uint64_t append_size() { return std::get<2>(GetParam()); }
+};
+
+TEST_P(PagerTest, ZeroLengthReadReturnsNoPages) {
+    /*
+     * No matter the offset, zero length reads return no data
+     */
+    for (auto offset : boost::irange(file_size())) {
+        const io::pager::read_config cfg{.offset = offset, .length = 0};
+        EXPECT_TRUE(pager().read(cfg).get().empty());
+    }
+}
+
+TEST_P(PagerTest, ReadFromPastEOFReturnsNoPages) {
+    /*
+     * Reads [0, ...) bytes at offset file_size + [0, ...)
+     */
+    for (auto delta : boost::irange(0, 3)) {
+        for (auto length : boost::irange<size_t>(0, 3)) {
+            const io::pager::read_config cfg{
+              .offset = file_size() + delta, .length = length};
+            EXPECT_TRUE(pager().read(cfg).get().empty());
+        }
+    }
+}
+
+TEST_P(PagerTest, Read) {
+    /*
+     * read from every offset
+     */
+    for (auto offset : boost::irange(file_size())) {
+        /*
+         * with a variety of lengths
+         */
+        std::vector<uint64_t> lengths{1, 2, 4096};
+        lengths.push_back(file_size() - offset); // up to eof
+        lengths.push_back(file_size() + 1);      // past eof
+        std::sort(lengths.begin(), lengths.end());
+        lengths.erase(
+          std::unique(lengths.begin(), lengths.end()), lengths.end());
+
+        for (const auto len : lengths) {
+            auto pages = pager().read({offset, len}).get();
+
+            // returns at least one page
+            ASSERT_FALSE(pages.empty());
+
+            // pages are non-empty
+            EXPECT_TRUE(std::all_of(pages.begin(), pages.end(), [](auto page) {
+                return !page->data().empty();
+            }));
+
+            // pages are adjacent, and offsets are in ascending order
+            for (auto pit = pages.begin(), it = std::next(pit);
+                 it != pages.end();
+                 ++it, ++pit) {
+                auto& prev = *pit;
+                auto& curr = *it;
+                EXPECT_EQ(prev->offset() + prev->data().size(), curr->offset());
+            }
+
+            /*
+             * page range must start at or before the target offset. the result
+             * should be minimal, meaning the first page should also contain the
+             * target offset, not merely be ordered before the target. same for
+             * the end of the range.
+             */
+            EXPECT_LE(pages.front()->offset(), offset);
+            EXPECT_LT(
+              offset, pages.front()->offset() + pages.front()->data().size());
+            EXPECT_LT(pages.back()->offset(), offset + len);
+
+            // no page should ever start after the end of the file
+            EXPECT_LT(pages.back()->offset(), file_size());
+
+            /*
+             * the total bytes returned may exceed the read length in order to
+             * cover the range (e.g. len=1 will still need to return a full
+             * page). in this case it should only be the final page that
+             * accounts for the excess.
+             */
+            const auto total = std::accumulate(
+              pages.begin(), pages.end(), size_t{0}, [](size_t acc, auto page) {
+                  return acc + page->data().size();
+              });
+            if (total > len) {
+                EXPECT_LT(total - pages.back()->data().size(), len);
+            }
+
+            /*
+             * the ending offset of the range formed by the intersection of the
+             * eof, the requested range, and the pages returned from read().
+             */
+            const auto end_offset = std::min(
+              std::min(file_size(), offset + len),
+              pages.back()->offset() + pages.back()->data().size());
+
+            // total requested data read (size of the intersection)
+            const auto read_size = end_offset - offset;
+
+            /*
+             * an input stream over the intersection of the returned pages from
+             * filemap::read and the requested [offset, len) range.
+             */
+            seastar::input_stream<char> input1(
+              seastar::data_source(std::make_unique<io::paging_data_source>(
+                pages, io::paging_data_source::config{offset, read_size})));
+
+            /*
+             * an input stream over a view of the input seed data constrained to
+             * what was returned by pager::read.
+             */
+            seastar::input_stream<char> input2(
+              seastar::data_source(std::make_unique<memory_data_source>(
+                data().share(offset, read_size))));
+
+            EXPECT_TRUE(EqualInputStreams(input1, input2));
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  Pager,
+  PagerTest,
+  ::testing::Combine(
+    ::testing::Bool(), ::testing::ValuesIn(test_case_sizes())));
+
+TEST_P(AppendPagerTest, Append) {
+    auto data_to_append = make_random_data(append_size()).get();
+
+    // input stream over [0, file_size() + append_size() * count)
+    auto pager_istream = [&](int count) {
+        return seastar::input_stream<char>(
+          seastar::data_source(std::make_unique<io::paging_data_source>(
+            &pager(),
+            io::paging_data_source::config{
+              0, file_size() + (count * append_size())})));
+    };
+
+    // input stream over sequence of temporary buffers
+    auto mem_istream = [](auto... tb) {
+        std::vector<seastar::temporary_buffer<char>> bufs;
+        (bufs.push_back(std::move(tb)), ...);
+        return seastar::input_stream<char>(seastar::data_source(
+          std::make_unique<memory_data_source>(std::move(bufs))));
+    };
+
+    // no appends
+    {
+        auto input1 = pager_istream(0);
+        auto input2 = mem_istream(data().share());
+        EXPECT_TRUE(EqualInputStreams(input1, input2));
+    }
+
+    // first append
+    pager().append(data_to_append.share()).get();
+    {
+        auto input1 = pager_istream(1);
+        auto input2 = mem_istream(data().share(), data_to_append.share());
+        EXPECT_TRUE(EqualInputStreams(input1, input2));
+    }
+
+    // second append
+    pager().append(data_to_append.share()).get();
+    {
+        auto input1 = pager_istream(2);
+        auto input2 = mem_istream(
+          data().share(), data_to_append.share(), data_to_append.share());
+        EXPECT_TRUE(EqualInputStreams(input1, input2));
+    }
+
+    // third append
+    pager().append(data_to_append.share()).get();
+    {
+        auto input1 = pager_istream(3);
+        auto input2 = mem_istream(
+          data().share(),
+          data_to_append.share(),
+          data_to_append.share(),
+          data_to_append.share());
+        EXPECT_TRUE(EqualInputStreams(input1, input2));
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  Pager,
+  AppendPagerTest,
+  ::testing::Combine(
+    ::testing::Bool(),
+    ::testing::ValuesIn(test_case_sizes()),
+    ::testing::ValuesIn(test_case_sizes())));


### PR DESCRIPTION
Add io::pager which provides an append-only abstraction on top of the files using io::scheduler for the write-back process.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

