### PR TITLE
rptest: fix _lifecycle_test naming

### DIFF
--- a/tests/rptest/scale_tests/many_topics_test.py
+++ b/tests/rptest/scale_tests/many_topics_test.py
@@ -463,7 +463,7 @@ class ManyTopicsTest(RedpandaTest):
 
     def _decommission_node_unsafely(self):
         """
-        Simulates a common failure of a node dying and a new 
+        Simulates a common failure of a node dying and a new
         node being created to replace it.
         """
         # select a node at random from the current broker set to decom.
@@ -1085,7 +1085,7 @@ class ManyTopicsTest(RedpandaTest):
 
         return topic_prefixes, produce_node_topic_count, consume_node_topic_count
 
-    def _lifecycle_test(self, test):
+    def _lifecycle_test_impl(self, test):
         self._start_initial_broker_set()
 
         tsm = TopicScaleProfileManager()
@@ -1156,38 +1156,38 @@ class ManyTopicsTest(RedpandaTest):
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_restart_safely(self):
-        self._lifecycle_test(self._restart_safely)
+        self._lifecycle_test_impl(self._restart_safely)
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_restart_unsafely(self):
-        self._lifecycle_test(self._restart_unsafely)
+        self._lifecycle_test_impl(self._restart_unsafely)
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_rolling_restarts(self):
-        self._lifecycle_test(self._rolling_restarts)
+        self._lifecycle_test_impl(self._rolling_restarts)
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_node_safely(self):
-        self._lifecycle_test(self._decommission_node_safely)
+        self._lifecycle_test_impl(self._decommission_node_safely)
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_node_unsafely(self):
-        self._lifecycle_test(self._decommission_node_unsafely)
+        self._lifecycle_test_impl(self._decommission_node_unsafely)
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_block_s3_on_random_node(self):
         self._target_port = 9000
-        self._lifecycle_test(self._isolate_all_nodes)
+        self._lifecycle_test_impl(self._isolate_all_nodes)
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_isolate_random_node_from_cluster(self):
         self._target_port = 33145
-        self._lifecycle_test(self._isolate_random_node)
+        self._lifecycle_test_impl(self._isolate_random_node)
 
     @cluster(num_nodes=16, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_isolate_random_node_from_clients(self):
         self._target_port = 9092
-        self._lifecycle_test(self._isolate_random_node)
+        self._lifecycle_test_impl(self._isolate_random_node)
 
     @cluster(num_nodes=12, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_many_topics_throughput(self):


### PR DESCRIPTION
Ducktape uses method naming to decide what is a test and our ManyTopicsTest had a _lifecycle_test method which is a helper called by tests and not a standalone test itself, but DT will call it as a standalone test causing a CI failure.

Rename it to _lifecycle_test_impl to avoid this.

Fixes #17040.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
