### PR TITLE
cluster: invoke config_frontend methods on controller shard

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -323,7 +323,7 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
     auto result = app.controller->get_config_frontend()
                     .local()
-                    .do_patch(
+                    .patch(
                       cluster::config_update_request{
                         .upsert = {{"cluster_id", "foo"}}},
                       model::timeout_clock::now() + 5s)
@@ -361,7 +361,7 @@ FIXTURE_TEST(
     // Now do something to trigger another controller snapshot.
     auto result = app.controller->get_config_frontend()
                     .local()
-                    .do_patch(
+                    .patch(
                       cluster::config_update_request{
                         .upsert = {{"cluster_id", "foo"}}},
                       model::timeout_clock::now() + 5s)

--- a/src/v/cluster/config_frontend.cc
+++ b/src/v/cluster/config_frontend.cc
@@ -134,11 +134,16 @@ ss::future<std::error_code> config_frontend::set_status(
 /**
  * For config_manager to notify the frontend of what the next version
  * number should be.
- *
- * Must be called on version_shard (the shard where writes are
- * serialized to generate version numbers).
  */
-void config_frontend::set_next_version(config_version v) {
+ss::future<> config_frontend::set_next_version(config_version v) {
+    co_return co_await container().invoke_on(
+      cluster::config_frontend::version_shard,
+      [v](cluster::config_frontend& cfg_frontend) mutable {
+          return cfg_frontend.do_set_next_version(v);
+      });
+}
+
+void config_frontend::do_set_next_version(config_version v) {
     vassert(
       ss::this_shard_id() == version_shard, "Must be called on version_shard");
     vlog(clusterlog.trace, "set_next_version: {}", v);

--- a/src/v/cluster/config_frontend.h
+++ b/src/v/cluster/config_frontend.h
@@ -45,11 +45,13 @@ public:
     ss::future<std::error_code>
     set_status(config_status&, model::timeout_clock::time_point);
 
-    void set_next_version(config_version v);
+    ss::future<> set_next_version(config_version v);
 
 private:
     ss::future<patch_result>
     do_patch(config_update_request&&, model::timeout_clock::time_point);
+
+    void do_set_next_version(config_version v);
 
     ss::sharded<controller_stm>& _stm;
     ss::sharded<rpc::connection_cache>& _connections;

--- a/src/v/cluster/config_manager.cc
+++ b/src/v/cluster/config_manager.cc
@@ -167,7 +167,7 @@ ss::future<> config_manager::do_bootstrap() {
       });
 
     // Version of the first write
-    _frontend.local().set_next_version(config_version{1});
+    co_await _frontend.local().set_next_version(config_version{1});
 
     try {
         auto patch_result = co_await _frontend.local().patch(
@@ -206,7 +206,8 @@ ss::future<> config_manager::start() {
           clusterlog.trace,
           "Starting config_manager... (seen version {})",
           _seen_version);
-        _frontend.local().set_next_version(_seen_version + config_version{1});
+        co_await _frontend.local().set_next_version(
+          _seen_version + config_version{1});
     }
 
     vlog(clusterlog.trace, "Starting reconcile_status...");
@@ -227,7 +228,7 @@ ss::future<> config_manager::start() {
             _reconcile_wait.signal();
         });
 
-    return ss::now();
+    co_return co_await ss::now();
 }
 void config_manager::handle_cluster_members_update(
   model::node_id id, model::membership_state new_state) {
@@ -913,7 +914,8 @@ config_manager::apply_delta(cluster_config_delta_cmd&& cmd_in) {
     vassert(
       ss::this_shard_id() == config_frontend::version_shard,
       "Must be called on frontend version_shard");
-    _frontend.local().set_next_version(_seen_version + config_version{1});
+    co_await _frontend.local().set_next_version(
+      _seen_version + config_version{1});
 
     const cluster_config_delta_cmd_data& data = cmd.value;
     vlog(

--- a/src/v/cluster/metrics_reporter.cc
+++ b/src/v/cluster/metrics_reporter.cc
@@ -342,7 +342,7 @@ ss::future<> metrics_reporter::propagate_cluster_id() {
         co_return;
     }
 
-    auto result = co_await _config_frontend.local().do_patch(
+    auto result = co_await _config_frontend.local().patch(
       config_update_request{.upsert = {{"cluster_id", _cluster_info.uuid}}},
       model::timeout_clock::now() + 5s);
     if (result.errc) {

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -417,14 +417,10 @@ service::config_status(config_status_request req, rpc::streaming_context&) {
 
 ss::future<config_update_reply>
 service::config_update(config_update_request req, rpc::streaming_context&) {
-    auto patch_result = co_await _config_frontend.invoke_on(
-      config_frontend::version_shard,
-      [req = std::move(req)](config_frontend& fe) mutable {
-          return fe.patch(
-            std::move(req),
-            config::shard_local_cfg().replicate_append_timeout_ms()
-              + model::timeout_clock::now());
-      });
+    auto patch_result = co_await _config_frontend.local().patch(
+      std::move(req),
+      config::shard_local_cfg().replicate_append_timeout_ms()
+        + model::timeout_clock::now());
 
     if (patch_result.errc.category() == error_category()) {
         co_return config_update_reply{

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -463,15 +463,11 @@ static ss::future<std::vector<resp_resource_t>> alter_broker_configuartion(
 
         auto resp
           = co_await ctx.config_frontend()
-              .invoke_on(
-                cluster::config_frontend::version_shard,
-                [req = std::move(req)](cluster::config_frontend& fe) mutable {
-                    return fe.patch(
-                      std::move(req),
-                      model::timeout_clock::now()
-                        + config::shard_local_cfg()
-                            .alter_topic_cfg_timeout_ms());
-                })
+              .local()
+              .patch(
+                std::move(req),
+                model::timeout_clock::now()
+                  + config::shard_local_cfg().alter_topic_cfg_timeout_ms())
               .then([resource](cluster::config_frontend::patch_result pr) {
                   std::error_code& ec = pr.errc;
                   error_code kec = error_code::none;

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -331,13 +331,13 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   test_topic_describe_configs_requested_properties, alter_config_test_fixture) {
     wait_for_controller_leadership().get();
+
+    cluster::config_update_request r{
+      .upsert = {{"enable_schema_id_validation", "compat"}}};
     app.controller->get_config_frontend()
-      .invoke_on_all([](cluster::config_frontend& cfg_frontend) {
-          cluster::config_update_request r{
-            .upsert = {{"enable_schema_id_validation", "compat"}}};
-          return cfg_frontend.patch(r, model::timeout_clock::now() + 1s)
-            .discard_result();
-      })
+      .local()
+      .patch(r, model::timeout_clock::now() + 1s)
+      .discard_result()
       .get();
 
     model::topic test_tp{"topic-1"};

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1863,11 +1863,9 @@ admin_server::patch_cluster_config_handler(
       update.upsert.size(),
       update.remove.size());
 
-    auto patch_result = co_await _controller->get_config_frontend().invoke_on(
-      cluster::config_frontend::version_shard,
-      [update = std::move(update)](cluster::config_frontend& fe) mutable {
-          return fe.patch(std::move(update), model::timeout_clock::now() + 5s);
-      });
+    auto patch_result
+      = co_await _controller->get_config_frontend().local().patch(
+        std::move(update), model::timeout_clock::now() + 5s);
 
     co_await throw_on_error(*req, patch_result.errc, model::controller_ntp);
 


### PR DESCRIPTION
Various places in the code were calling do_patch directly without regard
to the requirement that do_patch has to be called on the controller
shard.

This caused a fixture test to fail because it tried to invoke do_patch
on all shards and this violates the assertion in do_patch of
config_frontend.cc, causing it to fail with the error message "Must be
called on version_shard".

This fixes it by changing config_fronter::patch() to invoke do_patch on
the controller shard, and moving all calls of do_patch to call patch
instead.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

### Bug Fixes

* Fixes a bug of config_frontend methods getting called on shards other than the controller shard.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->