### PR TITLE
admin: implement create role API

### DIFF
--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -453,6 +453,9 @@ private:
     ss::future<ss::json::json_return_type>
     oidc_revoke_handler(std::unique_ptr<ss::http::request> req);
 
+    ss::future<ss::json::json_return_type>
+    create_role_handler(std::unique_ptr<ss::http::request> req);
+
     /// Kafka routes
     ss::future<ss::json::json_return_type>
       kafka_transfer_leadership_handler(std::unique_ptr<ss::http::request>);


### PR DESCRIPTION
This implements the `create_role_handler` which will allow the creation of
an empty role to which users can later be assigned to.

Closes https://github.com/redpanda-data/core-internal/issues/1104

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
