### PR TITLE
[backport][v23.3.x] tx/compaction: don't deduplicate control batches

### DIFF
--- a/src/v/cluster/tests/tx_compaction_utils.h
+++ b/src/v/cluster/tests/tx_compaction_utils.h
@@ -171,10 +171,11 @@ public:
             auto type = batch.header().type;
             BOOST_REQUIRE_NE(type, model::record_batch_type::tx_prepare);
             if (batch.header().attrs.is_transactional()) {
+                if (batch.header().attrs.is_control()) {
+                    continue;
+                }
                 model::producer_identity pid{
                   batch.header().producer_id, batch.header().producer_epoch};
-                // no control (commit/abort) batches.
-                BOOST_REQUIRE(!batch.header().attrs.is_control());
                 BOOST_REQUIRE_EQUAL(type, model::record_batch_type::raft_data);
                 BOOST_REQUIRE(_committed_pids.contains(pid));
                 BOOST_REQUIRE(!_aborted_pids.contains(pid));

--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -462,19 +462,6 @@ ss::future<ss::stop_iteration> tx_reducer::operator()(model::record_batch&& b) {
         if (is_control) {
             // tx_commit / tx_abort / unknown
 
-            // Control batches are not discarded but are compacted in the same
-            // manner as other data batches. This approach prevents the
-            // elimination of the last batch within a segment when it happens to
-            // be a control batch. If the final batch in a segment is discarded,
-            // and there are no subsequent data batches, it could lead to
-            // clients being unable to advance their consumable offset until the
-            // Last Stable Offset (LSO) is reached, creating the perception of a
-            // stuck consumer unable to make progress.
-
-            // However, this situation is not problematic when the last batch is
-            // an aborted data batch. This is because we can guarantee the
-            // presence of user consumable batches following it, specifically
-            // the abort control batch, ensuring continuous consumer progress.
             handle_tx_control_batch(b);
         } else if (is_data) {
             // User produced data batches in tx scope..

--- a/src/v/storage/segment_utils.h
+++ b/src/v/storage/segment_utils.h
@@ -212,6 +212,11 @@ struct clean_segment_value
 };
 
 inline bool is_compactible(const model::record_batch_header& h) {
+    if (h.attrs.is_control()) {
+        // Keep control batches to ensure we maintain transaction boundaries.
+        // They should be rare.
+        return false;
+    }
     static const auto filtered_types = model::offset_translator_batch_types();
     auto n = std::count(filtered_types.begin(), filtered_types.end(), h.type);
     return n == 0;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This is a select backport of commit from https://github.com/redpanda-data/redpanda/pull/16295

Fixes: https://github.com/redpanda-data/redpanda/issues/16679

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Bug Fixes
* Retains control batches from transactions to preserve transaction boundaries. This prevents some (very unlikely) scenarios where aborted data is read.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
