### PR TITLE
cloud_storage_clients: classify request_timeout as retriable

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -446,7 +446,8 @@ ss::future<result<T, error_outcome>> s3_client::send_request(
             outcome = error_outcome::fail;
         } else if (
           err.code() == s3_error_code::slow_down
-          || err.code() == s3_error_code::internal_error) {
+          || err.code() == s3_error_code::internal_error
+          || err.code() == s3_error_code::request_timeout) {
             // This can happen when we're dealing with high request rate to
             // the manifest's prefix. Backoff algorithm should be applied.
             // In principle only slow_down should occur, but in practice


### PR DESCRIPTION
Seen random_node_operations_test

```
<BadLogLines nodes=ip-172-31-1-9(1) example="ERROR 2024-03-14 11:55:32,224 [shard 0:au  ] s3 - s3_client.cc:469 - Accessing panda-bucket-b3a2fc8c-e1f8-11ee-8182-c3cdd68eb941, unexpected REST API error "" detected, code: RequestTimeout, request_id: E6840FAB839FF7F5, resource:">
```

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
