### PR TITLE
added topic parameter

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -1305,7 +1305,8 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                                self.msg_size) as tgen:
             tgen.wait_for_traffic(acked=self.msg_count,
                                   timeout_sec=self.msg_timeout)
-            wait_until(lambda: nodes_report_cloud_segments(self.redpanda, 100),
+            wait_until(lambda: nodes_report_cloud_segments(
+                self.redpanda, 100, self.topic),
                        timeout_sec=600,
                        backoff_sec=5)
             tgen._producer.wait_for_offset_map()


### PR DESCRIPTION
HTT.test_disrupt_cloud_storage stage_block_s3 may not create cloud segments #989
This check should be topic-specific

## Backports Required

- [X ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

### Improvements
We recently added an option to specify topic name when we get segments. Some tests were already updated as part of that work GH ticket:
https://github.com/redpanda-data/redpanda/pull/16925

This is another place where we use `nodes_report_cloud_segments` in HTT, so this should close our 
https://github.com/redpanda-data/core-internal/issues/989

