### PR TITLE
[v23.3.x] cloud_storage_clients: classify request_timeout as retriable

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -446,7 +446,8 @@ ss::future<result<T, error_outcome>> s3_client::send_request(
             outcome = error_outcome::fail;
         } else if (
           err.code() == s3_error_code::slow_down
-          || err.code() == s3_error_code::internal_error) {
+          || err.code() == s3_error_code::internal_error
+          || err.code() == s3_error_code::request_timeout) {
             // This can happen when we're dealing with high request rate to
             // the manifest's prefix. Backoff algorithm should be applied.
             // In principle only slow_down should occur, but in practice


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17101
