### PR TITLE
rpk profile: a few more fixes

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -131,8 +131,10 @@ rpk will talk to a localhost:9092 cluster until you swap to a different profile.
 			// The current profile was auth'd to the current organization.
 			// We tell the status of what org the user is talking to.
 			if p.FromCloud {
-				fmt.Printf("You are talking to a cloud cluster %q (rpk profile name: %q) ", p.CloudCluster.FullName(), p.Name)
-				fmt.Println("To switch which cluster you are talking to, use 'rpk cloud cluster select'.")
+				fmt.Printf("You are talking to a cloud cluster %q (rpk profile name: %q)\n", p.CloudCluster.FullName(), p.Name)
+				fmt.Println("Select a different cluster to talk to (or ctrl+c to keep the current cluster)?")
+				err = profile.CreateFlow(cmd.Context(), fs, cfg, yAct, authVir, "", "", "prompt", false, nil, "", "")
+				profile.MaybeDieExistingName(err)
 				return
 			}
 

--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -121,7 +121,7 @@ To create a new rpk profile for a cluster in this organization, try either:
 rpk will talk to a localhost:9092 cluster until you swap to a different profile.
 `)
 				} else {
-					fmt.Println("rpk will switch to a cloud cluster profile automatically, if you want to interrupt this process, feel free to ctrl+c now.")
+					fmt.Println("rpk will switch to a cloud cluster profile automatically, if you want to interrupt this process, you can ctrl+c now.")
 					err = profile.CreateFlow(cmd.Context(), fs, cfg, yAct, authVir, "", "", "prompt", false, nil, "", "")
 					profile.MaybeDieExistingName(err)
 				}

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -59,7 +59,8 @@ using --from-cloud or --from-rpk-container.
 * You can use --from-profile to generate a profile from an existing profile or
   from from a profile in a yaml file. First, the filename is checked, then an
   existing profile name is checked. The special value "current" creates a new
-  profile from the existing profile.
+  profile from the existing profile with any active environment variables or
+  flags applied.
 
 * You can use --from-cloud to generate a profile from an existing cloud cluster
   id. Note that you must be logged in with 'rpk cloud login' first. The special

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -591,27 +591,14 @@ func PromptCloudClusterProfile(ctx context.Context, yAuth *config.RpkCloudAuth, 
 		return CloudClusterOutputs{}, ErrNoCloudClusters
 	}
 
-	// If there is just 1 cluster/virtual-cluster we go ahead and select that.
-	var selected nameAndCluster
-	if len(cs) == 1 && len(vcs) == 0 {
-		selected = nameAndCluster{
-			name: fmt.Sprintf("%s/%s", cloudapi.FindNamespace(cs[0].NamespaceUUID, nss), cs[0].Name),
-			c:    &cs[0],
-		}
-	} else if len(vcs) == 1 && len(cs) == 0 {
-		selected = nameAndCluster{
-			name: fmt.Sprintf("%s/%s", cloudapi.FindNamespace(vcs[0].NamespaceUUID, nss), vcs[0].Name),
-			vc:   &vcs[0],
-		}
-	} else {
-		ncs := combineClusterNames(nss, vcs, cs)
-		names := ncs.names()
-		idx, err := out.PickIndex(names, "Which cloud namespace/cluster would you like to talk to?")
-		if err != nil {
-			return CloudClusterOutputs{}, err
-		}
-		selected = ncs[idx]
+	// Always prompt, even if there is only one option.
+	ncs := combineClusterNames(nss, vcs, cs)
+	names := ncs.names()
+	idx, err := out.PickIndex(names, "Which cloud namespace/cluster would you like to talk to?")
+	if err != nil {
+		return CloudClusterOutputs{}, err
 	}
+	selected := ncs[idx]
 
 	var o CloudClusterOutputs
 	// We have a cluster selected, but the list response does not return

--- a/src/go/rpk/pkg/cli/profile/profile.go
+++ b/src/go/rpk/pkg/cli/profile/profile.go
@@ -82,6 +82,10 @@ func ValidProfiles(fs afero.Fs, p *config.Params) func(*cobra.Command, []string,
 // Cloud profile helpers
 /////////////////////
 
+// ErrNoCloudClusters is returned from from CreateFlow or
+// PromptCloudClusterProfile if there are no cloud clusters available.
+var ErrNoCloudClusters = errors.New("no cloud clusters available")
+
 // RpkCloudProfileName is the default profile name used when a user creates a
 // cloud cluster profile with no name, or
 const RpkCloudProfileName = "rpk-cloud"

--- a/src/go/rpk/pkg/config/params.go
+++ b/src/go/rpk/pkg/config/params.go
@@ -1162,6 +1162,14 @@ func (c *Config) promptDeleteOldRpkYaml(fs afero.Fs) error {
 	}
 	var deleteAuthNames []string
 	var deleteProfileNames []string
+	containsAuth := func(name string) bool {
+		for _, delName := range deleteAuthNames {
+			if delName == name {
+				return true
+			}
+		}
+		return false
+	}
 	for _, a := range c.rpkYamlActual.CloudAuths {
 		if a.Organization == "" || a.OrgID == "" {
 			deleteAuthNames = append(deleteAuthNames, a.Name)
@@ -1170,7 +1178,11 @@ func (c *Config) promptDeleteOldRpkYaml(fs afero.Fs) error {
 	}
 	for _, p := range c.rpkYamlActual.Profiles {
 		cc := &p.CloudCluster
-		if p.FromCloud && c.rpkYamlActual.LookupAuth(cc.AuthOrgID, cc.AuthKind) == nil {
+		if !p.FromCloud {
+			continue
+		}
+		a := c.rpkYamlActual.LookupAuth(cc.AuthOrgID, cc.AuthKind)
+		if a == nil || containsAuth(a.Name) {
 			deleteProfileNames = append(deleteProfileNames, p.Name)
 			continue
 		}

--- a/src/go/rpk/pkg/oauth/load.go
+++ b/src/go/rpk/pkg/oauth/load.go
@@ -13,6 +13,8 @@ import (
 	"go.uber.org/zap"
 )
 
+var inTests bool
+
 // LoadFlow loads or creates a config at default path, and validates and
 // refreshes or creates an auth token using the given authentication provider.
 //
@@ -78,7 +80,7 @@ func LoadFlow(ctx context.Context, fs afero.Fs, cfg *config.Config, cl Client, n
 			}
 			orgOnce = true
 
-			if cloudAPIURL == "" {
+			if inTests {
 				zap.L().Sugar().Debug("returning fake organization because cloudAPIURL is empty")
 				return cloudapi.Organization{cloudapi.NameID{
 					ID:   "no-url-org-id",

--- a/src/go/rpk/pkg/oauth/load_test.go
+++ b/src/go/rpk/pkg/oauth/load_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func init() {
+	inTests = true
+}
+
 func TestLoadFlow(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
* Deletes some old logic that avoided prompting if only one cluster existed
* Made some testing branch _much_ more foolproof. Turns out we use an empty cloud URL always, which then defaults to prod inside the cloud API package.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none