### PR TITLE
ducktape: deflake test_topic_aware_rebalance in debug mode 

### DIFF
--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -132,10 +132,25 @@ class MultiTopicAutomaticLeadershipBalancingTest(RedpandaTest):
                 total_leaders = sum(1 if t.leader else 0 for t in tps)
                 total_nodes = set(t.leader for t in tps if t.leader)
 
+                self.logger.debug(
+                    f"Topic: {t.name}, total_leaders: {total_leaders}, total_nodes: {len(total_nodes)}"
+                )
+
                 if len(total_nodes) < nodes:
+                    self.logger.debug(
+                        f"Fewer nodes: {len(total_nodes)} than expected: {nodes}"
+                    )
                     return False
 
                 if total_leaders != t.partition_count:
+                    self.logger.debug(
+                        f"Fewer leaders: {total_leaders} than expected: {t.partition_count}"
+                    )
+                    missing_leaders = [
+                        f"{t.topic}/{t.index}" for t in tps if not t.leader
+                    ]
+                    self.logger.debug(
+                        f"partitions without leaders: {missing_leaders}")
                     return False
 
             return True

--- a/tests/rptest/tests/leadership_transfer_test.py
+++ b/tests/rptest/tests/leadership_transfer_test.py
@@ -110,12 +110,6 @@ class LeadershipTransferTest(RedpandaTest):
 
 
 class MultiTopicAutomaticLeadershipBalancingTest(RedpandaTest):
-    topics = (
-        TopicSpec(partition_count=61, replication_factor=3),
-        TopicSpec(partition_count=151, replication_factor=3),
-        TopicSpec(partition_count=263, replication_factor=3),
-    )
-
     def __init__(self, test_context):
         extra_rp_conf = dict(leader_balancer_idle_timeout=20000,
                              leader_balancer_mode="random_hill_climbing")
@@ -123,6 +117,13 @@ class MultiTopicAutomaticLeadershipBalancingTest(RedpandaTest):
         super(MultiTopicAutomaticLeadershipBalancingTest,
               self).__init__(test_context=test_context,
                              extra_rp_conf=extra_rp_conf)
+        self.topics = [
+            TopicSpec(partition_count=61, replication_factor=3),
+            TopicSpec(partition_count=151, replication_factor=3),
+        ]
+        if not self.debug_mode:
+            self.topics.append(
+                TopicSpec(partition_count=263, replication_factor=3))
 
     @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_topic_aware_rebalance(self):


### PR DESCRIPTION
The test is failing in debug mode as raft RPCs are timing out,
presumably due to slow debug build and large partition count. Reduced
the # of topics when running in debug mode.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
