### PR TITLE
RBAC: /v1/security/users/roles 

### DIFF
--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -452,6 +452,8 @@ private:
     oidc_keys_cache_invalidate_handler(std::unique_ptr<ss::http::request> req);
     ss::future<ss::json::json_return_type>
     oidc_revoke_handler(std::unique_ptr<ss::http::request> req);
+    ss::future<ss::json::json_return_type> list_user_roles_handler(
+      std::unique_ptr<ss::http::request>, request_auth_result);
 
     ss::future<ss::json::json_return_type>
     create_role_handler(std::unique_ptr<ss::http::request> req);

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -132,8 +132,14 @@ class RolesList:
     def __init__(self, roles: list[RoleDescription]):
         self.roles = roles
 
+    def __getitem__(self, i) -> RoleDescription:
+        return self.roles[i]
+
     def __len__(self):
         return len(self.roles)
+
+    def __str__(self):
+        return json.dumps(self.roles)
 
     @classmethod
     def from_json(cls, body: bytes):
@@ -983,8 +989,11 @@ class Admin:
         return self._request("get", "security/users", node=node,
                              params=params).json()
 
-    def list_user_roles(self):
-        return self._request("get", f"security/users/roles")
+    def list_user_roles(self, filter: Optional[str] = None):
+        params = {}
+        if filter is not None:
+            params['filter'] = filter
+        return self._request("get", f"security/users/roles", params=params)
 
     def create_role(self, role: str):
         return self._request("post", "security/roles", json=dict(role=role))


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

- GET /v1/security/users/roles
   - operationID: list_user_roles

Closes https://github.com/redpanda-data/core-internal/issues/1172

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* Introduces GET /v1/security/users/roles (Admin API)

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
