### PR TITLE
compression: Allocate memory for LZ4_compressEnd

### DIFF
--- a/src/v/compression/internal/lz4_frame_compressor.cc
+++ b/src/v/compression/internal/lz4_frame_compressor.cc
@@ -145,6 +145,16 @@ iobuf lz4_frame_compressor::compress(const iobuf& b) {
         output_cursor += code;
     }
 
+    if (const auto sz_for_compress_end = LZ4F_compressBound(0, &prefs);
+        output_sz - output_cursor < sz_for_compress_end) {
+        obuf.trim(output_cursor);
+        ret.append(std::move(obuf));
+        obuf = ss::temporary_buffer<char>(sz_for_compress_end);
+        output = obuf.get_write();
+        output_sz = obuf.size();
+        output_cursor = 0;
+    }
+
     code = LZ4F_compressEnd(
       ctx, output + output_cursor, output_sz - output_cursor, nullptr);
     check_lz4_error("lz4f_compressend:{}", code);


### PR DESCRIPTION
Before this change the code assumed that the destination temp. buffer always had enough free space for `LZ4F_compressEnd` operation. This change checks the free size before calling `LZ4F_compressEnd` and allocates a new buffer if necessary.

Note that the free space required is computed using `LZ4F_compressBound` with a `srcSize` of 0. By looking at `LZ4F_compressEnd` code, it may seem as if we can just check if 12 bytes are free in the destination buffer, whereas `LZ4F_compressBound` always assumes at least 65443 ie 65535 + block header size (4) + frame footer (4) possibly resulting in much larger allocation.

However, lz4frame docstring for `LZ4F_compressBound` states that:

> When srcSize==0, LZ4F_compressBound() provides an upper bound for LZ4F_flush() and LZ4F_compressEnd() instead.

Additionally `LZ4F_compressEnd` may also perform a flush which may need more than 12 bytes.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
