### PR TITLE
Azure AKS OIDC federation / Azure VM user-assigned managed identity  support

### DIFF
--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -1,7 +1,10 @@
 v_cc_library(
     NAME cloud_roles
+    HDRS
+    apply_abs_oauth_credentials.h
     SRCS
     apply_abs_credentials.cc
+    apply_abs_oauth_credentials.cc
     apply_aws_credentials.cc
     apply_credentials.cc
     apply_gcp_credentials.cc

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -1,6 +1,7 @@
 v_cc_library(
     NAME cloud_roles
     HDRS
+    azure_aks_refresh_impl.h
     apply_abs_oauth_credentials.h
     SRCS
     apply_abs_credentials.cc
@@ -11,6 +12,7 @@ v_cc_library(
     aws_refresh_impl.cc
     aws_sts_refresh_impl.cc
     gcp_refresh_impl.cc
+    azure_aks_refresh_impl.cc
     probe.cc
     refresh_credentials.cc
     request_response_helpers.cc

--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -2,6 +2,7 @@ v_cc_library(
     NAME cloud_roles
     HDRS
     azure_aks_refresh_impl.h
+    azure_vm_refresh_impl.h
     apply_abs_oauth_credentials.h
     SRCS
     apply_abs_credentials.cc
@@ -13,6 +14,7 @@ v_cc_library(
     aws_sts_refresh_impl.cc
     gcp_refresh_impl.cc
     azure_aks_refresh_impl.cc
+    azure_vm_refresh_impl.cc
     probe.cc
     refresh_credentials.cc
     request_response_helpers.cc

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.cc
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.cc
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "apply_abs_oauth_credentials.h"
+
+namespace cloud_roles {
+apply_abs_oauth_credentials::apply_abs_oauth_credentials(
+  abs_oauth_credentials const& credentials)
+  : _oauth_token{fmt::format("Bearer {}", credentials.oauth_token())} {}
+
+std::error_code apply_abs_oauth_credentials::add_auth(
+  http::client::request_header& header) const {
+    auto token = _oauth_token();
+    // x-ms-version requests a specific version for the abs api, the hardcoded
+    // value is the one we test
+    header.set("x-ms-version", azure_storage_api_version);
+    header.insert(
+      boost::beast::http::field::authorization, {token.data(), token.size()});
+    return {};
+}
+
+void apply_abs_oauth_credentials::reset_creds(credentials creds) {
+    if (!std::holds_alternative<abs_oauth_credentials>(creds)) {
+        throw std::runtime_error(fmt_with_ctx(
+          fmt::format,
+          "credential applier reset with incorrect credential type {}",
+          creds));
+    }
+    *this = apply_abs_oauth_credentials{std::get<abs_oauth_credentials>(creds)};
+}
+
+std::ostream& apply_abs_oauth_credentials::print(std::ostream& os) const {
+    fmt::print(os, "apply_abs_oauth_credentials");
+    return os;
+}
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.h
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/apply_credentials.h"
+
+namespace cloud_roles {
+
+/// Azure Managed Identities uses Bearer tokens to authorize a request
+class apply_abs_oauth_credentials final : public apply_credentials::impl {
+public:
+    explicit apply_abs_oauth_credentials(
+      abs_oauth_credentials const& credentials);
+
+    std::error_code
+    add_auth(http::client::request_header& header) const override;
+
+    void reset_creds(credentials creds) override;
+    std::ostream& print(std::ostream& os) const override;
+
+private:
+    oauth_token_str _oauth_token;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/apply_credentials.cc
+++ b/src/v/cloud_roles/apply_credentials.cc
@@ -11,6 +11,7 @@
 #include "cloud_roles/apply_credentials.h"
 
 #include "cloud_roles/apply_abs_credentials.h"
+#include "cloud_roles/apply_abs_oauth_credentials.h"
 #include "cloud_roles/apply_aws_credentials.h"
 #include "cloud_roles/apply_gcp_credentials.h"
 
@@ -26,6 +27,10 @@ apply_credentials make_credentials_applier(credentials creds) {
       },
       [](abs_credentials abs) -> std::unique_ptr<apply_credentials::impl> {
           return std::make_unique<apply_abs_credentials>(std::move(abs));
+      },
+      [](abs_oauth_credentials const& abs_oauth)
+        -> std::unique_ptr<apply_credentials::impl> {
+          return std::make_unique<apply_abs_oauth_credentials>(abs_oauth);
       })};
 }
 

--- a/src/v/cloud_roles/azure_aks_refresh_impl.cc
+++ b/src/v/cloud_roles/azure_aks_refresh_impl.cc
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "azure_aks_refresh_impl.h"
+
+#include "json/schema.h"
+#include "request_response_helpers.h"
+#include "utils/file_io.h"
+
+#include <seastar/coroutine/as_future.hh>
+#include <seastar/coroutine/exception.hh>
+
+#include <boost/algorithm/string/trim.hpp>
+#include <rapidjson/error/en.h>
+
+namespace {
+
+// utility to wrap std::getenv for required environment variables
+ss::sstring load_from_env(const char* env_var) {
+    auto env_value = std::getenv(env_var);
+    if (!env_value) {
+        throw std::runtime_error(fmt::format(
+          "environment variable {} is not set, the Azure AKS client cannot "
+          "function "
+          "without this.",
+          env_var));
+    }
+    return env_value;
+}
+
+constexpr static auto env_var_azure_client_id = "AZURE_CLIENT_ID";
+constexpr static auto env_var_azure_tenant_id = "AZURE_TENANT_ID";
+constexpr static auto env_var_azure_federated_token_file
+  = "AZURE_FEDERATED_TOKEN_FILE";
+constexpr static auto env_var_azure_authority_host = "AZURE_AUTHORITY_HOST";
+
+} // namespace
+
+namespace cloud_roles {
+
+azure_aks_refresh_impl::azure_aks_refresh_impl(
+  net::unresolved_address address,
+  aws_region_name region,
+  ss::abort_source& as,
+  retry_params retry_params)
+  : refresh_credentials::impl(
+    [&] {
+        if (!address.host().empty()) {
+            // non-empty host: it's an override that we should use
+            return std::move(address);
+        }
+        // empty host: use env_var
+        return net::unresolved_address{
+          load_from_env(env_var_azure_authority_host), default_port};
+    }(),
+    std::move(region),
+    as,
+    retry_params)
+  , client_id_{load_from_env(env_var_azure_client_id)}
+  , tenant_id_{load_from_env(env_var_azure_tenant_id)}
+  , federated_token_file_{load_from_env(env_var_azure_federated_token_file)} {}
+
+std::ostream& azure_aks_refresh_impl::print(std::ostream& os) const {
+    fmt::print(os, "azure_aks_refresh_impl{{address:{}}}", address());
+    return os;
+}
+
+ss::future<api_response> azure_aks_refresh_impl::fetch_credentials() {
+    // https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#third-case-access-token-request-with-a-federated-credential
+    // load the encoded jwt from the token file (its content is rotated by k8s),
+    //
+    // compose:
+    // POST /{tenant_id_}/oauth2/v2.0/token HTTP/1.1
+    // Host: {authority_host_}:443
+    // Content-Type: application/x-www-form-urlencoded
+    //
+    // scope=https%3A%2F%2Fgraph.microsoft.com%2F.default
+    // &client_id={client_id_}
+    // &client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-type%3Ajwt-bearer
+    // &client_assertion={content(federated_token_file_)}
+    // &grant_type=client_credentials
+
+    auto jwt_token_fut = co_await ss::coroutine::as_future(
+      read_fully_to_string({federated_token_file_}));
+    if (jwt_token_fut.failed()) {
+        vlog(
+          clrl_log.error,
+          "failed to read OIDC pod token from file {}",
+          federated_token_file_);
+        co_return ss::coroutine::exception(jwt_token_fut.get_exception());
+    }
+
+    auto jwt_token = std::string{jwt_token_fut.get()};
+    boost::trim(jwt_token);
+
+    // setup header for www-form-urlencoded body
+    auto access_token_req
+      = boost::beast::http::request<boost::beast::http::string_body>{};
+    access_token_req.method(boost::beast::http::verb::post);
+    access_token_req.target(fmt::format("/{}/oauth2/v2.0/token", tenant_id_));
+    access_token_req.set(
+      boost::beast::http::field::host,
+      fmt::format("{}:{}", address().host(), address().port())),
+      access_token_req.set(
+        boost::beast::http::field::user_agent, "redpanda.vectorized.io");
+    access_token_req.set(
+      boost::beast::http::field::content_type,
+      "application/x-www-form-urlencoded");
+
+    // compose the body of the request with the informations retrieved from the
+    // env variables
+    auto body = ssx::sformat(
+      "scope={}"
+      "&client_id={}"
+      "&client_assertion_type=urn%3Aietf%3Aparams%3Aoauth%3Aclient-assertion-"
+      "type%3Ajwt-bearer"
+      "&client_assertion={}"
+      "&grant_type=client_credentials",
+      uri_encode("https://storage.azure.com/.default", true),
+      client_id_,
+      jwt_token);
+
+    // AKS requires a TLS enabled client by default, but in test mode where we
+    // use the http imposter, we need to use a simple client.
+    auto tls_enabled = refresh_credentials::client_tls_enabled::yes;
+    if (address().port() != default_port) {
+        tls_enabled = refresh_credentials::client_tls_enabled::no;
+    }
+
+    co_return co_await request_with_payload(
+      co_await make_api_client("azure_aks_oidc", tls_enabled),
+      std::move(access_token_req),
+      std::move(body));
+}
+
+api_response_parse_result azure_aks_refresh_impl::parse_response(iobuf resp) {
+    // schema for (an example)
+    //  {
+    //    "token_type": "Bearer",
+    //    "expires_in": 3599,
+    //    "access_token":
+    //    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBP..."
+    //  }
+    constexpr static auto success_schema_str = R"json(
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "token_type": {
+      "type": "string",
+      "pattern": "Bearer"
+    },
+    "expires_in": {
+      "type": "integer"
+    },
+    "access_token": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "token_type", 
+    "expires_in",
+    "access_token"
+  ]
+}
+)json";
+
+    auto maybe_jresp = parse_json_response_and_validate(
+      success_schema_str, std::move(resp));
+
+    return ss::visit(
+      maybe_jresp,
+      [](auto err_resp) -> api_response_parse_result {
+          return std::move(err_resp);
+      },
+      [&](json::Document const& jresp) -> api_response_parse_result {
+          next_sleep_duration(
+            std::chrono::seconds{jresp["expires_in"].GetInt()});
+          auto& access_token = jresp["access_token"];
+          return abs_oauth_credentials{oauth_token_str{ss::sstring{
+            access_token.GetString(), access_token.GetStringLength()}}};
+      });
+}
+} // namespace cloud_roles

--- a/src/v/cloud_roles/azure_aks_refresh_impl.h
+++ b/src/v/cloud_roles/azure_aks_refresh_impl.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/refresh_credentials.h"
+
+namespace cloud_roles {
+
+class azure_aks_refresh_impl final : public refresh_credentials::impl {
+public:
+    // for AKS, the login host is set via an env variable. to conform to the
+    // refresh_credentials::impl interface, expose an empty string as
+    // default_host. this is used to build the address constructor parameter and
+    // to pass overrides for testings
+    constexpr static std::string_view default_host = {};
+    constexpr static uint16_t default_port = 443;
+
+    azure_aks_refresh_impl(
+      net::unresolved_address address,
+      aws_region_name region,
+      ss::abort_source& as,
+      retry_params retry_params);
+
+    /// Fetches credentials from api, the result can be iobuf or an error
+    /// encountered during the fetch operation
+    ss::future<api_response> fetch_credentials() override;
+
+    std::ostream& print(std::ostream& os) const override;
+
+protected:
+    /// Helper to parse the iobuf returned from API into a credentials
+    /// object, customized to API response structure
+    api_response_parse_result parse_response(iobuf resp) override;
+
+private:
+    ss::sstring client_id_;
+    ss::sstring tenant_id_;
+    ss::sstring federated_token_file_;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/azure_vm_refresh_impl.cc
+++ b/src/v/cloud_roles/azure_vm_refresh_impl.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_roles/azure_vm_refresh_impl.h"
+
+#include "cloud_roles/request_response_helpers.h"
+#include "json/ostreamwrapper.h"
+#include "json/schema.h"
+
+#include <rapidjson/error/en.h>
+
+namespace cloud_roles {
+
+azure_vm_refresh_impl::azure_vm_refresh_impl(
+  net::unresolved_address address,
+  aws_region_name region,
+  ss::abort_source& as,
+  retry_params retry_params)
+  : refresh_credentials::impl(
+    std::move(address), std::move(region), as, retry_params) {}
+
+std::ostream& azure_vm_refresh_impl::print(std::ostream& os) const {
+    fmt::print(os, "azure_vm_refresh_impl{{address:{}}}", address());
+    return os;
+}
+
+ss::future<api_response> azure_vm_refresh_impl::fetch_credentials() {
+    auto client_id_opt = config::shard_local_cfg()
+                           .cloud_storage_azure_managed_identity_id.value();
+    if (unlikely(!client_id_opt.has_value())) {
+        // This implementation requires client_id from config to be set.
+        // Strictly speaking, IMDS service does not require it if there is only
+        // a system-assigned managed identity or only one user-assigned managed
+        // identity but it would be brittle to not specify it, it could break if
+        // the user added a new one. This verification is also performed in
+        // admin/server.cc::patch_cluster_config
+        vlog(
+          clrl_log.error,
+          "missing cloud_storage_azure_managed_identity_id in config");
+        // return value is not a perfect match but it works
+        co_return api_request_error{
+          .status = boost::beast::http::status::bad_request,
+          .reason = "missing cloud_storage_azure_managed_identity_id",
+          .error_kind = api_request_error_kind::failed_abort};
+    }
+
+    // performs this GET
+    // 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://storage.azure.com/&client_id={$client_id}'
+    // to the vm-local IMDS
+    auto req = http::client::request_header{};
+    req.method(boost::beast::http::verb::get);
+    // TODO fix deps and use boost::url
+    req.target(fmt::format(
+      "/metadata/identity/oauth2/token?"
+      "api-version=2018-02-01"
+      "&resource=https%3A%2F%2Fstorage.azure.com%2F"
+      "&client_id={}",
+      client_id_opt.value()));
+    req.set("Metadata", "true");
+
+    co_return co_await make_request(
+      co_await make_api_client("azure_vm_instance_metadata"), std::move(req));
+}
+
+api_response_parse_result
+azure_vm_refresh_impl::parse_response(iobuf response) {
+    // Simplified schema for (an example)
+    //  {
+    //    "token_type": "Bearer",
+    //    "expires_in": "3599",
+    //    "access_token":
+    //    "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ik1uQ19WWmNBVGZNNXBP..."
+    //  }
+    // Note that the expires_in field is a string, not an integer,
+    // so a simple regex is used to validate a positive number of up of 18
+    // digits. The complete response has more fields but we just care for
+    // these 3.
+
+    constexpr static auto success_schema_str = R"json(
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "token_type": {
+      "type": "string",
+      "pattern": "Bearer"
+    },
+    "expires_in": {
+      "type": "string",
+      "pattern":  "^ *\\+?[0-9]{1,18} *$"
+    },
+    "access_token": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "token_type", 
+    "expires_in",
+    "access_token"
+  ]
+}
+)json";
+
+    auto maybe_jresp = parse_json_response_and_validate(
+      success_schema_str, std::move(response));
+    return std::visit(
+      ss::make_visitor(
+        [](auto err_resp) -> api_response_parse_result {
+            return std::move(err_resp);
+        },
+        [&](json::Document jresp) -> api_response_parse_result {
+            auto& expires_in_str = jresp["expires_in"];
+            next_sleep_duration(
+              std::chrono::seconds{boost::lexical_cast<int64_t>(
+                expires_in_str.GetString(), expires_in_str.GetStringLength())});
+            auto& access_token = jresp["access_token"];
+            return abs_oauth_credentials{oauth_token_str{
+              access_token.GetString(), access_token.GetStringLength()}};
+        }),
+      std::move(maybe_jresp));
+}
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/azure_vm_refresh_impl.h
+++ b/src/v/cloud_roles/azure_vm_refresh_impl.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cloud_roles/refresh_credentials.h"
+
+namespace cloud_roles {
+
+class azure_vm_refresh_impl final : public refresh_credentials::impl {
+public:
+    // this is the local-only address of the instance metadata service, that
+    // will be used to get an authorization token
+    // https://learn.microsoft.com/en-us/azure/virtual-machines/instance-metadata-service
+    static constexpr std::string_view default_host = "169.254.169.254";
+    static constexpr uint16_t default_port = 80;
+
+    azure_vm_refresh_impl(
+      net::unresolved_address address,
+      aws_region_name region,
+      ss::abort_source& as,
+      retry_params retry_params = default_retry_params);
+    ss::future<api_response> fetch_credentials() override;
+
+    std::ostream& print(std::ostream& os) const override;
+
+protected:
+    api_response_parse_result parse_response(iobuf response) override;
+};
+
+} // namespace cloud_roles

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -14,6 +14,7 @@
 #include "cloud_roles/aws_refresh_impl.h"
 #include "cloud_roles/aws_sts_refresh_impl.h"
 #include "cloud_roles/azure_aks_refresh_impl.h"
+#include "cloud_roles/azure_vm_refresh_impl.h"
 #include "cloud_roles/gcp_refresh_impl.h"
 #include "cloud_roles/logger.h"
 #include "config/configuration.h"
@@ -407,6 +408,13 @@ refresh_credentials make_refresh_credentials(
           retry_params);
     case model::cloud_credentials_source::azure_aks_oidc_federation:
         return make_refresh_credentials<azure_aks_refresh_impl>(
+          as,
+          std::move(creds_update_cb),
+          std::move(region),
+          std::move(endpoint),
+          retry_params);
+    case model::cloud_credentials_source::azure_vm_instance_metadata:
+        return make_refresh_credentials<azure_vm_refresh_impl>(
           as,
           std::move(creds_update_cb),
           std::move(region),

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "cloud_roles/aws_refresh_impl.h"
 #include "cloud_roles/aws_sts_refresh_impl.h"
+#include "cloud_roles/azure_aks_refresh_impl.h"
 #include "cloud_roles/gcp_refresh_impl.h"
 #include "cloud_roles/logger.h"
 #include "config/configuration.h"
@@ -399,6 +400,13 @@ refresh_credentials make_refresh_credentials(
           retry_params);
     case model::cloud_credentials_source::gcp_instance_metadata:
         return make_refresh_credentials<gcp_refresh_impl>(
+          as,
+          std::move(creds_update_cb),
+          std::move(region),
+          std::move(endpoint),
+          retry_params);
+    case model::cloud_credentials_source::azure_aks_oidc_federation:
+        return make_refresh_credentials<azure_aks_refresh_impl>(
           as,
           std::move(creds_update_cb),
           std::move(region),

--- a/src/v/cloud_roles/request_response_helpers.cc
+++ b/src/v/cloud_roles/request_response_helpers.cc
@@ -207,4 +207,33 @@ std::chrono::system_clock::time_point parse_timestamp(std::string_view sv) {
     return std::chrono::system_clock::from_time_t(timegm(&tm));
 }
 
+inline void append_hex_utf8(ss::sstring& result, char ch) {
+    bytes b = {static_cast<uint8_t>(ch)};
+    result.append("%", 1);
+    auto h = to_hex(b);
+    result.append(h.data(), h.size());
+}
+
+ss::sstring uri_encode(const ss::sstring& input, bool encode_slash) {
+    // The function defined here:
+    //     https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
+    ss::sstring result;
+    for (auto ch : input) {
+        if (
+          (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+          || (ch >= '0' && ch <= '9') || (ch == '_') || (ch == '-')
+          || (ch == '~') || (ch == '.')) {
+            result.append(&ch, 1);
+        } else if (ch == '/') {
+            if (encode_slash) {
+                result.append("%2F", 3);
+            } else {
+                result.append(&ch, 1);
+            }
+        } else {
+            append_hex_utf8(result, ch);
+        }
+    }
+    return result;
+}
 } // namespace cloud_roles

--- a/src/v/cloud_roles/request_response_helpers.h
+++ b/src/v/cloud_roles/request_response_helpers.h
@@ -40,4 +40,6 @@ json::Document parse_json_response(iobuf resp);
 
 std::chrono::system_clock::time_point parse_timestamp(std::string_view sv);
 
+ss::sstring uri_encode(const ss::sstring& input, bool encode_slash);
+
 } // namespace cloud_roles

--- a/src/v/cloud_roles/request_response_helpers.h
+++ b/src/v/cloud_roles/request_response_helpers.h
@@ -38,6 +38,14 @@ get_status(http::client::response_stream_ref& resp);
 
 json::Document parse_json_response(iobuf resp);
 
+using validate_and_parse_res = std::variant<
+  json::Document,
+  malformed_api_response_error,
+  api_response_parse_error>;
+/// performs parsing and validation of the response with a json schema v4
+validate_and_parse_res
+parse_json_response_and_validate(std::string_view schema, iobuf resp);
+
 std::chrono::system_clock::time_point parse_timestamp(std::string_view sv);
 
 ss::sstring uri_encode(const ss::sstring& input, bool encode_slash);

--- a/src/v/cloud_roles/signature.cc
+++ b/src/v/cloud_roles/signature.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "bytes/bytes.h"
 #include "cloud_roles/logger.h"
+#include "cloud_roles/request_response_helpers.h"
 #include "config/base_property.h"
 #include "hashing/secure.h"
 #include "ssx/sformat.h"
@@ -135,42 +136,12 @@ inline void tolower(ss::sstring& str) {
     }
 }
 
-inline void append_hex_utf8(ss::sstring& result, char ch) {
-    bytes b = {static_cast<uint8_t>(ch)};
-    result.append("%", 1);
-    auto h = to_hex(b);
-    result.append(h.data(), h.size());
-}
-
 ss::sstring time_source::format(auto fmt) const {
     const auto point = _gettime_fn();
     const std::time_t time = std::chrono::system_clock::to_time_t(point);
     const std::tm gm = fmt::gmtime(time);
 
     return fmt::format(fmt, gm);
-}
-
-ss::sstring uri_encode(const ss::sstring& input, bool encode_slash) {
-    // The function defined here:
-    //     https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html
-    ss::sstring result;
-    for (auto ch : input) {
-        if (
-          (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
-          || (ch >= '0' && ch <= '9') || (ch == '_') || (ch == '-')
-          || (ch == '~') || (ch == '.')) {
-            result.append(&ch, 1);
-        } else if (ch == '/') {
-            if (encode_slash) {
-                result.append("%2F", 3);
-            } else {
-                result.append(&ch, 1);
-            }
-        } else {
-            append_hex_utf8(result, ch);
-        }
-    }
-    return result;
 }
 
 struct target_parts {

--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -178,8 +178,6 @@ template<class Fn>
 time_source::time_source(Fn&& fn, int)
   : _gettime_fn(std::forward<Fn>(fn)) {}
 
-ss::sstring uri_encode(const ss::sstring& input, bool encode_slash);
-
 ss::sstring redact_headers_from_string(const std::string_view original);
 
 } // namespace cloud_roles

--- a/src/v/cloud_roles/signature.h
+++ b/src/v/cloud_roles/signature.h
@@ -149,14 +149,6 @@ public:
     std::error_code sign_header(http::client::request_header& header) const;
 
 private:
-    // Azure expects every request to Blob Storage to contain an
-    // 'x-ms-version' header that specifies the API version to use.
-    // This version is hardcoded in Redpanda to ensure that an API
-    // version that we've tested with is used in field.
-    //
-    // Update this version to use a different storage API version.
-    static constexpr auto azure_storage_api_version = "2023-01-03";
-
     result<ss::sstring>
     get_string_to_sign(http::client::request_header& header) const;
 

--- a/src/v/cloud_roles/tests/CMakeLists.txt
+++ b/src/v/cloud_roles/tests/CMakeLists.txt
@@ -17,6 +17,21 @@ rp_test(
 rp_test(
     UNIT_TEST
     BINARY_NAME
+        schema_parsing_test
+    SOURCES
+        schema_parsing_tests.cc
+    DEFINITIONS BOOST_TEST_DYN_LINK
+    LIBRARIES
+    v::seastar_testing_main
+    Boost::unit_test_framework
+    v::cloud_roles
+    ARGS "-- -c 1"
+    LABELS cloud_roles
+)
+
+rp_test(
+    UNIT_TEST
+    BINARY_NAME
     test_cloud_roles
     SOURCES
     role_client_tests.cc

--- a/src/v/cloud_roles/tests/categorization_tests.cc
+++ b/src/v/cloud_roles/tests/categorization_tests.cc
@@ -56,6 +56,23 @@ SEASTAR_THREAD_TEST_CASE(test_refresh_client_built_according_to_source) {
           ssx::sformat("{}", rc));
     }
 
+    {
+        setenv("AZURE_CLIENT_ID", "client_id", 1);
+        setenv("AZURE_TENANT_ID", "tenant_id", 1);
+        setenv("AZURE_FEDERATED_TOKEN_FILE", "file_path", 1);
+        setenv("AZURE_AUTHORITY_HOST", "host.test.contoso.com", 1);
+
+        auto rc = cloud_roles::make_refresh_credentials(
+          model::cloud_credentials_source::azure_aks_oidc_federation,
+          as,
+          [](auto) { return ss::now(); },
+          region);
+        BOOST_REQUIRE_EQUAL(
+          "azure_aks_refresh_impl{address:{host: host.test.contoso.com, port: "
+          "443}}",
+          ssx::sformat("{}", rc));
+    }
+
     BOOST_REQUIRE_THROW(
       cloud_roles::make_refresh_credentials(
         model::cloud_credentials_source::config_file,

--- a/src/v/cloud_roles/tests/categorization_tests.cc
+++ b/src/v/cloud_roles/tests/categorization_tests.cc
@@ -80,4 +80,11 @@ SEASTAR_THREAD_TEST_CASE(
         BOOST_REQUIRE_EQUAL(
           "apply_aws_credentials", ssx::sformat("{}", applier));
     }
+
+    {
+        cloud_roles::abs_oauth_credentials akc{};
+        auto applier = cloud_roles::make_credentials_applier(std::move(akc));
+        BOOST_REQUIRE_EQUAL(
+          "apply_abs_oauth_credentials", ssx::sformat("{}", applier));
+    }
 }

--- a/src/v/cloud_roles/tests/schema_parsing_tests.cc
+++ b/src/v/cloud_roles/tests/schema_parsing_tests.cc
@@ -1,0 +1,136 @@
+#include "bytes/streambuf.h"
+#include "cloud_roles/request_response_helpers.h"
+
+#include <boost/test/unit_test.hpp>
+
+static auto parse(std::string_view schema, std::string_view data) {
+    auto buf = iobuf{};
+    auto os_buf = iobuf_ostreambuf{buf};
+    std::ostream{&os_buf} << data;
+    return cloud_roles::parse_json_response_and_validate(
+      schema, std::move(buf));
+}
+
+BOOST_AUTO_TEST_CASE(schema_parsing_error) {
+    constexpr static auto schema_string = R"(
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "age": {
+            "type": "string",
+        }
+    },
+    "required": ["name", "age"],
+}
+  )";
+
+    // schema is not a valid json (stray , at the end of the schema)
+    auto parse_schema_fail = parse(
+      schema_string, R"({"name": "John", "age":"42"})");
+    BOOST_CHECK(std::holds_alternative<cloud_roles::api_response_parse_error>(
+      parse_schema_fail));
+}
+
+auto to_str(cloud_roles::validate_and_parse_res const& val) {
+    return ss::visit(
+      val,
+      [](json::Document const&) -> ss::sstring { return "json::Document"; },
+      [](cloud_roles::malformed_api_response_error const& mal) {
+          return ssx::sformat(
+            "malformed_api_response_error: {}", mal.missing_fields);
+      },
+      [](cloud_roles::api_response_parse_error const& pe) {
+          return ssx::sformat("api_response_parse_error: {}", pe.reason);
+      });
+}
+
+BOOST_AUTO_TEST_CASE(schema_parsing_test) {
+    // rapidjson support for regex is just a subset of ecmascript, basically no
+    // character classes like \d or \w. when writing a pattern, fall back to a
+    // simple regex syntax
+    constexpr static auto schema_string = R"(
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "age": {
+            "type": "string",
+            "pattern": "^ *\\+?[0-9]{1,18} *$"
+        }
+    },
+    "required": ["name", "age"]
+}
+  )";
+
+    BOOST_TEST_CONTEXT("good data in") {
+        auto parse_ok = parse(
+          schema_string, R"({"name": "John", "age": "42"})");
+        BOOST_REQUIRE_MESSAGE(
+          std::holds_alternative<json::Document>(parse_ok), to_str(parse_ok));
+        auto& doc = std::get<json::Document>(parse_ok);
+        BOOST_CHECK(doc["name"].GetString() == std::string_view{"John"});
+        BOOST_CHECK(doc["age"].GetString() == std::string_view{"42"});
+    }
+
+    BOOST_TEST_CONTEXT("missing fields are reported") {
+        auto parse_missing = parse(schema_string, R"({"name": "John"})");
+        BOOST_CHECK_MESSAGE(
+          std::holds_alternative<cloud_roles::malformed_api_response_error>(
+            parse_missing),
+          to_str(parse_missing));
+        auto& doc = std::get<cloud_roles::malformed_api_response_error>(
+          parse_missing);
+        BOOST_CHECK(doc.missing_fields == std::vector<ss::sstring>{"age"});
+    }
+
+    BOOST_TEST_CONTEXT(
+      "missing fields takes precedence over malformed response (except for "
+      "`patter: regex` feature of rapidjson)") {
+        auto parse_missing_and_invalid = parse(
+          schema_string, R"({"age": "-42"})");
+        BOOST_CHECK_MESSAGE(
+          std::holds_alternative<cloud_roles::api_response_parse_error>(
+            parse_missing_and_invalid),
+          to_str(parse_missing_and_invalid));
+    }
+
+    BOOST_TEST_CONTEXT("malformed response is reported") {
+        auto parse_invalid = parse(
+          schema_string, R"({"name": "John", "age": "-42"})");
+        BOOST_CHECK_MESSAGE(
+          std::holds_alternative<cloud_roles::api_response_parse_error>(
+            parse_invalid),
+          to_str(parse_invalid));
+
+        auto parse_invalid_type = parse(
+          schema_string, R"({"name": "John", "age": 42})");
+        BOOST_CHECK_MESSAGE(
+          std::holds_alternative<cloud_roles::api_response_parse_error>(
+            parse_invalid_type),
+          to_str(parse_invalid_type));
+    }
+
+    BOOST_TEST_CONTEXT("empty is handled") {
+        auto parse_empty = parse(schema_string, R"({})");
+        BOOST_CHECK_MESSAGE(
+          std::holds_alternative<cloud_roles::malformed_api_response_error>(
+            parse_empty),
+          to_str(parse_empty));
+    }
+
+    BOOST_TEST_CONTEXT("malformed is handled") {
+        auto parse_malformed = parse(
+          schema_string, R"({"name": "John", "age":})");
+        BOOST_CHECK_MESSAGE(
+          std::holds_alternative<cloud_roles::api_response_parse_error>(
+            parse_malformed),
+          to_str(parse_malformed));
+    }
+}

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -59,8 +59,12 @@ std::ostream& operator<<(std::ostream& os, const aws_credentials& ac) {
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const credentials& c) {
-    ss::visit(c, [&os](auto creds) { os << creds; });
+std::ostream& operator<<(std::ostream& os, const abs_credentials& ac) {
+    fmt::print(
+      os,
+      "abs_credentials{{storage_account: **{}**, shared_key: **{}**}}",
+      ac.storage_account().size(),
+      ac.shared_key().size());
     return os;
 }
 
@@ -69,6 +73,16 @@ operator<<(std::ostream& os, const api_response_parse_error& err) {
     fmt::print(os, "api_response_parse_error{{reason:{}}}", err.reason);
     return os;
 }
+
+// tmp trick to ensure that we are not calling into infinite recursion if
+// there is a new credential but no operator<<
+template<std::same_as<credentials> Cred>
+std::ostream& operator<<(std::ostream& os, Cred const& c) {
+    ss::visit(c, [&os](auto const& creds) { os << creds; });
+    return os;
+}
+
+template std::ostream& operator<<(std::ostream& os, credentials const& c);
 
 bool is_retryable(const std::system_error& ec) {
     auto code = ec.code();

--- a/src/v/cloud_roles/types.cc
+++ b/src/v/cloud_roles/types.cc
@@ -68,6 +68,14 @@ std::ostream& operator<<(std::ostream& os, const abs_credentials& ac) {
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const abs_oauth_credentials& ac) {
+    fmt::print(
+      os,
+      "abs_oauth_credentials{{oauth_token:**{}**}}",
+      ac.oauth_token().size());
+    return os;
+}
+
 std::ostream&
 operator<<(std::ostream& os, const api_response_parse_error& err) {
     fmt::print(os, "api_response_parse_error{{reason:{}}}", err.reason);

--- a/src/v/cloud_roles/types.h
+++ b/src/v/cloud_roles/types.h
@@ -102,12 +102,17 @@ struct abs_credentials {
     private_key_str shared_key;
 };
 
+std::ostream& operator<<(std::ostream& os, const abs_credentials& ac);
+
 std::ostream& operator<<(std::ostream& os, const aws_credentials& ac);
 
 using credentials
   = std::variant<aws_credentials, gcp_credentials, abs_credentials>;
 
-std::ostream& operator<<(std::ostream& os, const credentials& c);
+// tmp trick to ensure that we are not calling into infinite recursion if
+// there is a new credential but no operator<<
+template<std::same_as<credentials> Cred>
+std::ostream& operator<<(std::ostream& os, Cred const& c);
 
 using api_response_parse_result = std::variant<
   malformed_api_response_error,

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -1582,7 +1582,9 @@ void auth_refresh_bg_op::do_start_auth_refresh_op(
                   return cloud_roles::aws_region_name{cfg.region};
               },
               [](cloud_storage_clients::abs_configuration const&) {
-                  vassert(false, "Attempt to create refresh creds for ABS");
+                  // Azure Blob Storage does not need a region name to compose
+                  // the requests, so this value is defaulted since it's ignored
+                  // downstream
                   return cloud_roles::aws_region_name{};
               });
             _refresh_credentials.emplace(cloud_roles::make_refresh_credentials(

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -302,6 +302,7 @@ model::cloud_storage_backend infer_backend_from_configuration(
           cloud_storage_credentials_source);
         return model::cloud_storage_backend::google_s3_compat;
     case model::cloud_credentials_source::azure_aks_oidc_federation:
+    case model::cloud_credentials_source::azure_vm_instance_metadata:
         vlog(
           client_config_log.info,
           "cloud_storage_backend derived from cloud_credentials_source {} "

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -301,6 +301,13 @@ model::cloud_storage_backend infer_backend_from_configuration(
           "as google_s3_compat",
           cloud_storage_credentials_source);
         return model::cloud_storage_backend::google_s3_compat;
+    case model::cloud_credentials_source::azure_aks_oidc_federation:
+        vlog(
+          client_config_log.info,
+          "cloud_storage_backend derived from cloud_credentials_source {} "
+          "as azure",
+          cloud_storage_credentials_source);
+        return model::cloud_storage_backend::azure;
     case model::cloud_credentials_source::config_file:
         break;
     }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1647,10 +1647,13 @@ configuration::configuration()
        .example = "config_file",
        .visibility = visibility::user},
       model::cloud_credentials_source::config_file,
-      {model::cloud_credentials_source::config_file,
-       model::cloud_credentials_source::aws_instance_metadata,
-       model::cloud_credentials_source::sts,
-       model::cloud_credentials_source::gcp_instance_metadata})
+      {
+        model::cloud_credentials_source::config_file,
+        model::cloud_credentials_source::aws_instance_metadata,
+        model::cloud_credentials_source::sts,
+        model::cloud_credentials_source::gcp_instance_metadata,
+        model::cloud_credentials_source::azure_aks_oidc_federation,
+      })
   , cloud_storage_roles_operation_timeout_ms(
       *this,
       "cloud_storage_roles_operation_timeout_ms",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1653,7 +1653,17 @@ configuration::configuration()
         model::cloud_credentials_source::sts,
         model::cloud_credentials_source::gcp_instance_metadata,
         model::cloud_credentials_source::azure_aks_oidc_federation,
+        model::cloud_credentials_source::azure_vm_instance_metadata,
       })
+  , cloud_storage_azure_managed_identity_id(
+      *this,
+      "cloud_storage_azure_managed_identity_id",
+      "The managed identity ID to use with Azure Managed Identities. This "
+      "takes affect when the cloud_storage_credential_source configuration "
+      "option is set to azure_vm_instance_metadata.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      std::nullopt,
+      &validate_non_empty_string_opt)
   , cloud_storage_roles_operation_timeout_ms(
       *this,
       "cloud_storage_roles_operation_timeout_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -305,6 +305,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_api_endpoint;
     enum_property<model::cloud_credentials_source>
       cloud_storage_credentials_source;
+    property<std::optional<ss::sstring>>
+      cloud_storage_azure_managed_identity_id;
     property<std::chrono::milliseconds>
       cloud_storage_roles_operation_timeout_ms;
     deprecated_property cloud_storage_reconciliation_ms;

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -233,7 +233,8 @@ struct convert<model::cloud_credentials_source> {
        "aws_instance_metadata",
        "gcp_instance_metadata",
        "sts",
-       "azure_aks_oidc_federation"});
+       "azure_aks_oidc_federation",
+       "azure_vm_instance_metadata"});
 
     static Node encode(const type& rhs) {
         Node node;
@@ -252,6 +253,9 @@ struct convert<model::cloud_credentials_source> {
             break;
         case model::cloud_credentials_source::azure_aks_oidc_federation:
             node = "azure_aks_oidc_federation";
+            break;
+        case model::cloud_credentials_source::azure_vm_instance_metadata:
+            node = "azure_vm_instance_metadata";
             break;
         }
         return node;
@@ -278,7 +282,10 @@ struct convert<model::cloud_credentials_source> {
                 .match("sts", model::cloud_credentials_source::sts)
                 .match(
                   "azure_aks_oidc_federation",
-                  model::cloud_credentials_source::azure_aks_oidc_federation);
+                  model::cloud_credentials_source::azure_aks_oidc_federation)
+                .match(
+                  "azure_vm_instance_metadata",
+                  model::cloud_credentials_source::azure_vm_instance_metadata);
 
         return true;
     }

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -228,8 +228,12 @@ template<>
 struct convert<model::cloud_credentials_source> {
     using type = model::cloud_credentials_source;
 
-    static constexpr std::array<const char*, 4> acceptable_values{
-      "config_file", "aws_instance_metadata", "gcp_instance_metadata", "sts"};
+    static constexpr auto acceptable_values = std::to_array(
+      {"config_file",
+       "aws_instance_metadata",
+       "gcp_instance_metadata",
+       "sts",
+       "azure_aks_oidc_federation"});
 
     static Node encode(const type& rhs) {
         Node node;
@@ -245,6 +249,9 @@ struct convert<model::cloud_credentials_source> {
             break;
         case model::cloud_credentials_source::gcp_instance_metadata:
             node = "gcp_instance_metadata";
+            break;
+        case model::cloud_credentials_source::azure_aks_oidc_federation:
+            node = "azure_aks_oidc_federation";
             break;
         }
         return node;
@@ -268,7 +275,10 @@ struct convert<model::cloud_credentials_source> {
                 .match(
                   "gcp_instance_metadata",
                   model::cloud_credentials_source::gcp_instance_metadata)
-                .match("sts", model::cloud_credentials_source::sts);
+                .match("sts", model::cloud_credentials_source::sts)
+                .match(
+                  "azure_aks_oidc_federation",
+                  model::cloud_credentials_source::azure_aks_oidc_federation);
 
         return true;
     }

--- a/src/v/http/include/http/tests/http_imposter.h
+++ b/src/v/http/include/http/tests/http_imposter.h
@@ -57,7 +57,8 @@ public:
 
     /// Get the latest request to a particular URL
     std::optional<std::reference_wrapper<const http_test_utils::request_info>>
-    get_latest_request(const ss::sstring& url) const;
+    get_latest_request(
+      const ss::sstring& url, bool ignore_url_params = false) const;
 
     /// Get the number of requests to a particular URL
     size_t get_request_count(const ss::sstring& url) const;
@@ -73,7 +74,7 @@ public:
     ///     .then_return("bar");
     http_test_utils::registered_urls& when() { return _urls; }
 
-    bool has_call(std::string_view url) const;
+    bool has_call(std::string_view url, bool ignore_url_params = false) const;
 
     /// Enables requests with a specific condition to fail. The failing
     /// request is also added to the set of calls stored by fixture.

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -462,6 +462,7 @@ enum class cloud_credentials_source {
     sts = 2,
     gcp_instance_metadata = 3,
     azure_aks_oidc_federation = 4,
+    azure_vm_instance_metadata = 5,
 };
 
 std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs);

--- a/src/v/model/metadata.h
+++ b/src/v/model/metadata.h
@@ -461,6 +461,7 @@ enum class cloud_credentials_source {
     aws_instance_metadata = 1,
     sts = 2,
     gcp_instance_metadata = 3,
+    azure_aks_oidc_federation = 4,
 };
 
 std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs);

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -409,6 +409,8 @@ std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs) {
         return os << "gcp_instance_metadata";
     case cloud_credentials_source::azure_aks_oidc_federation:
         return os << "azure_aks_oidc_federation";
+    case cloud_credentials_source::azure_vm_instance_metadata:
+        return os << "azure_vm_instance_metadata";
     }
 }
 

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -407,6 +407,8 @@ std::ostream& operator<<(std::ostream& os, const cloud_credentials_source& cs) {
         return os << "sts";
     case cloud_credentials_source::gcp_instance_metadata:
         return os << "gcp_instance_metadata";
+    case cloud_credentials_source::azure_aks_oidc_federation:
+        return os << "azure_aks_oidc_federation";
     }
 }
 

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1519,11 +1519,8 @@ void config_multi_property_validation(
         using config_properties_seq = std::vector<std::reference_wrapper<
           const config::property<std::optional<ss::sstring>>>>;
 
-        config_properties_seq properties{};
-
-        if (
-          updated_config.cloud_storage_credentials_source
-          == model::cloud_credentials_source::config_file) {
+        switch (updated_config.cloud_storage_credentials_source.value()) {
+        case model::cloud_credentials_source::config_file: {
             config_properties_seq s3_properties = {
               std::ref(updated_config.cloud_storage_region),
               std::ref(updated_config.cloud_storage_bucket),
@@ -1558,7 +1555,10 @@ void config_multi_property_validation(
                   join_properties(s3_properties),
                   join_properties(abs_properties));
             }
-        } else {
+        } break;
+        case model::cloud_credentials_source::aws_instance_metadata:
+        case model::cloud_credentials_source::gcp_instance_metadata:
+        case model::cloud_credentials_source::sts: {
             // TODO(vlad): When we add support for non-config file auth
             // methods for ABS, handling here should be updated too.
             config_properties_seq properties = {
@@ -1572,6 +1572,7 @@ void config_multi_property_validation(
                       = "Must be set when cloud storage enabled";
                 }
             }
+        } break;
         }
     }
     if (


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

# AKS

ASK managed identities are implemented with cloud_role/refresh_credentials implementations
`azure_aks_refresh_impl.cc`
+ new credentials implementation `apply_abs_oauth_credentials.cc`

`azure_aks_refresh_impl.cc` reads these environment variables

```
AZURE_CLIENT_ID
AZURE_TENANT_ID
AZURE_FEDERATED_TOKEN_FILE
AZURE_AUTHORITY_HOST
```

to compose a POST request to retrieve an authorization token that `azure_aks_refresh_impl.cc` will use to authorize calls to ABS.

The env variables are set up directly by AKS.

# Azure VM

User-assigned managed identity via IMDS on a azure VM is implemented in `azure_vm_refresh_impl`
it requires setting `cloud_storage_azure_managed_identity_id` in configs to the user-assigned managed identity client_id.
The implementation will perform a GET request to the instance metadata service to retrieve an authorization token

Fixes https://github.com/redpanda-data/core-internal/issues/1125
Fixes https://github.com/redpanda-data/core-internal/issues/1126

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* AKS OIDC Federation support
* Azure VM user-assigned managed identity support
