### PR TITLE
tests: Update OMB version on CDT

### DIFF
--- a/tests/docker/ducktape-deps/omb
+++ b/tests/docker/ducktape-deps/omb
@@ -2,5 +2,5 @@
 set -e
 git -C /opt clone https://github.com/redpanda-data/openmessaging-benchmark.git
 cd /opt/openmessaging-benchmark
-git reset --hard 8411e4a17f9fe190591389bf9b17c515f144a393
+git reset --hard 50aba841760313fdd86586f0e74484d1721513e4
 mvn clean package -DskipTests


### PR DESCRIPTION
Current version is quite outdated and missing some of recent improvements (e.g.: client stats)


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none

