### PR TITLE
Fixed typo in comment in ntp_archiver

### DIFF
--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -151,7 +151,7 @@ public:
     /// Returns nullopt if not in read replica mode
     std::optional<ss::lowres_clock::time_point> get_last_sync_time() const;
 
-    /// Download manifest from pre-defined S3 locatnewion
+    /// Download manifest from pre-defined S3 location
     ///
     /// \return future that returns true if the manifest was found in S3
     ss::future<std::pair<


### PR DESCRIPTION
Fixed a typo in `ntp_archiver_service.h` as a first task! 

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

- None