### PR TITLE
write caching - raft - metrics

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -843,7 +843,12 @@ replicate_stages consensus::do_replicate(
         _probe->replicate_requests_ack_leader();
         break;
     case consistency_level::quorum_ack:
-        _probe->replicate_requests_ack_all_with_flush();
+        auto flush = opts.force_flush() || !_write_caching_enabled;
+        if (flush) {
+            _probe->replicate_requests_ack_all_with_flush();
+        } else {
+            _probe->replicate_requests_ack_all_without_flush();
+        }
         break;
     }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -843,7 +843,7 @@ replicate_stages consensus::do_replicate(
         _probe->replicate_requests_ack_leader();
         break;
     case consistency_level::quorum_ack:
-        _probe->replicate_requests_ack_all();
+        _probe->replicate_requests_ack_all_with_flush();
         break;
     }
 

--- a/src/v/raft/probe.cc
+++ b/src/v/raft/probe.cc
@@ -79,9 +79,9 @@ void probe::setup_metrics(const model::ntp& ntp) {
           labels),
         sm::make_counter(
           "replicate_ack_all_requests",
-          [this] { return _replicate_requests_ack_all; },
-          sm::description(
-            "Number of replicate requests with quorum ack consistency"),
+          [this] { return _replicate_requests_ack_all_with_flush; },
+          sm::description("Number of replicate requests with quorum ack "
+                          "consistency and explicit flush."),
           labels),
         sm::make_counter(
           "replicate_ack_leader_requests",

--- a/src/v/raft/probe.cc
+++ b/src/v/raft/probe.cc
@@ -84,6 +84,12 @@ void probe::setup_metrics(const model::ntp& ntp) {
                           "consistency and explicit flush."),
           labels),
         sm::make_counter(
+          "replicate_ack_all_requests_no_flush",
+          [this] { return _replicate_requests_ack_all_without_flush; },
+          sm::description("Number of replicate requests with quorum ack "
+                          "consistency but without an explicit flush."),
+          labels),
+        sm::make_counter(
           "replicate_ack_leader_requests",
           [this] { return _replicate_requests_ack_leader; },
           sm::description(

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -35,6 +35,9 @@ public:
     void replicate_requests_ack_all_with_flush() {
         ++_replicate_requests_ack_all_with_flush;
     }
+    void replicate_requests_ack_all_without_flush() {
+        ++_replicate_requests_ack_all_without_flush;
+    }
     void replicate_requests_ack_leader() { ++_replicate_requests_ack_leader; }
     void replicate_requests_ack_none() { ++_replicate_requests_ack_none; }
     void replicate_done() { ++_replicate_requests_done; }
@@ -71,6 +74,7 @@ private:
     uint64_t _append_requests = 0;
     uint64_t _vote_requests_sent = 0;
     uint64_t _replicate_requests_ack_all_with_flush = 0;
+    uint64_t _replicate_requests_ack_all_without_flush = 0;
     uint64_t _replicate_requests_ack_leader = 0;
     uint64_t _replicate_requests_ack_none = 0;
     uint64_t _replicate_requests_done = 0;

--- a/src/v/raft/probe.h
+++ b/src/v/raft/probe.h
@@ -32,7 +32,9 @@ public:
 
     void vote_request_sent() { ++_vote_requests_sent; }
 
-    void replicate_requests_ack_all() { ++_replicate_requests_ack_all; }
+    void replicate_requests_ack_all_with_flush() {
+        ++_replicate_requests_ack_all_with_flush;
+    }
     void replicate_requests_ack_leader() { ++_replicate_requests_ack_leader; }
     void replicate_requests_ack_none() { ++_replicate_requests_ack_none; }
     void replicate_done() { ++_replicate_requests_done; }
@@ -68,7 +70,7 @@ private:
     uint64_t _vote_requests = 0;
     uint64_t _append_requests = 0;
     uint64_t _vote_requests_sent = 0;
-    uint64_t _replicate_requests_ack_all = 0;
+    uint64_t _replicate_requests_ack_all_with_flush = 0;
     uint64_t _replicate_requests_ack_leader = 0;
     uint64_t _replicate_requests_ack_none = 0;
     uint64_t _replicate_requests_done = 0;


### PR DESCRIPTION
Adds a couple of simple metrics for visibility into write caching and raft in general

vectorized_raft_replicate_ack_all_requests_no_flush - # of quorum ack requests without flush (aka with write caching)
vectorized_raft_batch_size_bytes - a histogram of batch sizes as flushed by the replicate batcher, gives visibility into batching at raft layer.

Both are internal metrics at partition scope.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Improvements

* Adds metric for number of quorum ack requests with write caching.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
