### PR TITLE
container: Introduce chunked_hash_map

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -53,6 +53,11 @@ fetch_dep(rapidjson
   TAG 14a5dd756e9bef26f9b53d3b4eb1b73c6a1794d5
   SOURCE_SUBDIR redpanda_build)
 
+fetch_dep(unordered_dense
+  REPO https://github.com/redpanda-data/unordered_dense
+  TAG 9338f301522a965309ecec58ce61f54a52fb5c22
+)
+
 set(CRC32C_BUILD_TESTS OFF)
 set(CRC32C_BUILD_BENCHMARKS OFF)
 set(CRC32C_USE_GLOG OFF)
@@ -130,7 +135,8 @@ FetchContent_MakeAvailable(
     tinygo
     wasmtime
     hdrhistogram
-    ada)
+    ada
+    unordered_dense)
 
 add_library(Crc32c::crc32c ALIAS crc32c)
 add_library(aklomp::base64 ALIAS base64)

--- a/src/v/cluster/scheduling/leader_balancer_random.h
+++ b/src/v/cluster/scheduling/leader_balancer_random.h
@@ -14,14 +14,11 @@
 #include "cluster/scheduling/leader_balancer_constraints.h"
 #include "cluster/scheduling/leader_balancer_strategy.h"
 #include "cluster/scheduling/leader_balancer_types.h"
+#include "container/chunked_hash_map.h"
 #include "container/fragmented_vector.h"
 #include "model/metadata.h"
 #include "raft/fundamental.h"
 #include "random/generators.h"
-
-#include <absl/container/btree_map.h>
-#include <absl/container/flat_hash_map.h>
-#include <absl/container/node_hash_map.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -95,7 +92,7 @@ private:
         raft::group_id group_id;
         model::broker_shard broker_shard;
     };
-    absl::node_hash_map<raft::group_id, model::broker_shard> _current_leaders;
+    chunked_hash_map<raft::group_id, model::broker_shard> _current_leaders;
 
     using replicas_t = fragmented_vector<replica>;
     replicas_t _replicas;

--- a/src/v/container/CMakeLists.txt
+++ b/src/v/container/CMakeLists.txt
@@ -1,7 +1,11 @@
 find_package(Roaring REQUIRED)
+find_package(unordered_dense REQUIRED)
+
 v_cc_library(
   NAME container
-  DEPS Roaring::roaring
+  DEPS
+    Roaring::roaring
+    unordered_dense::unordered_dense
 )
 
 add_subdirectory(tests)

--- a/src/v/container/include/container/chunked_hash_map.h
+++ b/src/v/container/include/container/chunked_hash_map.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <ankerl/unordered_dense.h>
+#include <container/fragmented_vector.h>
+
+/**
+ * @brief A hash map that uses a chunked vector as the underlying storage.
+ *
+ * Use when the hash map is expected to have a large number of elements (e.g.:
+ * scales with partitions or topics). Performance wise it's equal to the abseil
+ * hashmaps.
+ *
+ * NB: References and iterators are not stable across insertions and deletions.
+ *
+ * For more info please see
+ * https://github.com/martinus/unordered_dense/?tab=readme-ov-file#1-overview
+ */
+template<
+  typename Key,
+  typename Value,
+  typename Hash = ankerl::unordered_dense::hash<Key>,
+  typename EqualTo = std::equal_to<Key>>
+using chunked_hash_map = ankerl::unordered_dense::segmented_map<
+  Key,
+  Value,
+  Hash,
+  EqualTo,
+  chunked_vector<std::pair<Key, Value>>,
+  ankerl::unordered_dense::bucket_type::standard,
+  chunked_vector<ankerl::unordered_dense::bucket_type::standard>>;

--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -70,10 +70,15 @@ private:
 
 public:
     using this_type = fragmented_vector<T, fragment_size_bytes>;
+    using backing_type = std::vector<std::vector<T>>;
     using value_type = T;
     using reference = T&;
     using const_reference = const T&;
     using size_type = size_t;
+    using allocator_type = backing_type::allocator_type;
+    using difference_type = backing_type::difference_type;
+    using pointer = T*;
+    using const_pointer = const T*;
 
     /**
      * The maximum number of bytes per fragment as specified in
@@ -89,6 +94,8 @@ public:
       "max size of a fragment must be <= 128KiB");
 
     fragmented_vector() noexcept = default;
+    explicit fragmented_vector(allocator_type alloc)
+      : _frags(alloc) {}
     fragmented_vector& operator=(const fragmented_vector&) noexcept = delete;
     fragmented_vector(fragmented_vector&& other) noexcept {
         *this = std::move(other);
@@ -522,7 +529,7 @@ private:
 
     size_t _size{0};
     size_t _capacity{0};
-    std::vector<std::vector<T>> _frags;
+    backing_type _frags;
 #ifndef NDEBUG
     // Add a generation number that is incremented on every mutation to catch
     // invalidated iterator accesses.

--- a/src/v/container/tests/CMakeLists.txt
+++ b/src/v/container/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ rp_test(
   BINARY_NAME container_unit
   SOURCES
     contiguous_range_map_test.cc
+    chunked_hash_map_test.cc
     interval_set_test.cc
     fragmented_vector_test.cc
   LIBRARIES v::gtest_main v::random v::serde

--- a/src/v/container/tests/chunked_hash_map_test.cc
+++ b/src/v/container/tests/chunked_hash_map_test.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "container/chunked_hash_map.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+struct foo_with_std_hash {
+    int a;
+    int b;
+    auto operator<=>(const foo_with_std_hash&) const = default;
+};
+
+namespace std {
+
+template<>
+struct hash<foo_with_std_hash> {
+    constexpr size_t operator()(const foo_with_std_hash& x) const {
+        return std::hash<int>()(x.a + x.b);
+    }
+};
+
+} // namespace std
+
+struct foo_with_absl_hash {
+    int a;
+    int b;
+
+    auto operator<=>(const foo_with_absl_hash&) const = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const foo_with_absl_hash& x) {
+        return H::combine(std::move(h), x.a, x.b);
+    }
+};
+
+TEST(chunked_hash_map, basic_compile_std_hash) {
+    chunked_hash_map<foo_with_std_hash, int> map;
+    map[{1, 2}] = 2;
+    EXPECT_EQ(map.size(), 1);
+}
+
+TEST(chunked_hash_map, basic_compile_absl_hash) {
+    static_assert(detail::has_absl_hash<foo_with_absl_hash>);
+    chunked_hash_map<foo_with_absl_hash, int> map;
+    map[{1, 2}] = 2;
+    EXPECT_EQ(map.size(), 1);
+}


### PR DESCRIPTION
Introduces `chunked_hash_map` which is a type alias for the segmented
version of https://github.com/martinus/unordered_dense/ using our
`chunked_vector` as a backing array.

This allows us to use a hashmap in scenarios where the map may grow
large (i.e.: scale with partition/topic counts) similar to `chunked_vector`
and avoids us having to fall back to the suboptimal `absl::btree_map`.

Below are some numbers from our leader balanacer benchmark comparing the
different map types:

| test                                                                  |  iterations |      median |         mad |         min |         max |      allocs |       tasks |        inst |
| -                                                                     |           - |           - |           - |           - |           - |           - |           - |           - |
| lb.random_generator_movement_absl_node                                |         149 |     3.120ms |    97.624ns |     3.120ms |     3.122ms |       0.000 |       0.000 |  44663355.3 |
| lb.random_generator_movement_absl_flat                                |         152 |     3.090ms |   342.546ns |     3.089ms |     3.090ms |       0.000 |       0.000 |  44846754.1 |
| lb.random_generator_movement_absl_btree                               |          84 |     8.103ms |   884.595ns |     8.102ms |     8.105ms |       0.000 |       0.000 |  57163339.9 |
| lb.random_generator_movement_std_map                                  |         117 |     5.028ms |   676.256ns |     5.027ms |     5.030ms |       0.000 |       0.000 |  53678485.9 |
| lb.random_generator_movement_unordered_dense                          |         156 |     2.850ms |   576.237ns |     2.849ms |     2.851ms |       0.000 |       0.000 |  43115077.3 |
| lb.random_generator_movement_unordered_dense_segmented                |         149 |     3.111ms |   360.074ns |     3.111ms |     3.115ms |       0.000 |       0.000 |  46250454.0 |
| lb.random_generator_movement_unordered_dense_segmented_frag           |         151 |     3.063ms |   388.795ns |     3.063ms |     3.065ms |       0.000 |       0.000 |  45697581.1 |
| lb.random_generator_movement_unordered_dense_segmented_frag_absl_hash |         139 |     3.643ms |   444.705ns |     3.642ms |     3.643ms |       0.000 |       0.000 |  46476708.7 |


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

