### PR TITLE
git: ignore top level data/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,8 @@ venv.bak/
 
 # default data dir for dev-cluster.py script
 /tools/data
+# If you run dev-cluster.py from the repo root
+/data
 
 # mypy
 .mypy_cache/


### PR DESCRIPTION
This is where ./tools/dev-cluster.py writes data by default if you run it from the root

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
