### PR TITLE
Avoid disconnecting on storage errors in fetch handler

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -147,7 +147,12 @@ static ss::future<read_result> read_from_partition(
     co_await std::move(rdr.reader).release()->finally();
 
     if (e) {
-        std::rethrow_exception(e);
+        vlog(
+          klog.info,
+          "exception while reading topic_partition: {} exception: {}",
+          part.ntp().tp,
+          e);
+        co_return read_result(error_code::kafka_storage_error, start_o, hw);
     }
 
     if (foreign_read) {


### PR DESCRIPTION
The storage layer can thow a few uncaught exceptions that are caught in the fetch handler. I.e,
 - cloud_storage::download_exception
 - seastar::gate_closed_exception

When the fetch handler catches these it will simply close the client connection and log the exception it caught. This isn't the most optimal behavior as the errors caught from the storage layer are retriable. And any data read from other partitions in the fetch request is lost when the connection is closed.

This PR changes the behavior to instead return a retriable error for the partition the storage exception occurs in.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
