### PR TITLE
`shard_placement_table`: stress test and fixes

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -184,6 +184,22 @@ get_allocation_domain(const model::topic_namespace_view tp_ns) {
     return partition_allocation_domains::common;
 }
 
+std::optional<model::revision_id> log_revision_on_node(
+  const topic_table::partition_replicas_view& replicas_view,
+  model::node_id node) {
+    if (contains_node(replicas_view.orig_replicas(), node)) {
+        return replicas_view.revisions().at(node);
+    }
+
+    if (
+      replicas_view.update
+      && contains_node(replicas_view.update->get_target_replicas(), node)) {
+        return replicas_view.update->get_update_revision();
+    }
+
+    return std::nullopt;
+}
+
 std::optional<shard_placement_target> placement_target_on_node(
   const topic_table::partition_replicas_view& replicas_view,
   model::node_id node) {

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -288,6 +288,12 @@ find_shard_on_node(const replicas_t& replicas, model::node_id node) {
     return std::nullopt;
 }
 
+/// Calculates expected log revision of a partition with replicas assignment
+/// determined by partition_replicas_view on a particular node (if the partition
+/// is expected to be there)
+std::optional<model::revision_id> log_revision_on_node(
+  const topic_table::partition_replicas_view&, model::node_id);
+
 /// Calculates the partition placement target (i.e. log revision and shard id)
 /// on a particular node of a partition with replicas assignment determined by
 /// partition_replicas_view (including effects of an in-progress or cancelled

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1059,10 +1059,7 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
           partition_operation_type::reset,
           replicas_view.assignment);
         auto ec = co_await transfer_partition(
-          ntp,
-          group_id,
-          expected_log_revision.value(),
-          placement.shard_revision);
+          ntp, group_id, expected_log_revision.value());
         if (ec) {
             co_return ec;
         }
@@ -1083,8 +1080,7 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
               replicas_view.last_cmd_revision(),
               partition_operation_type::reset,
               replicas_view.assignment);
-            co_await shutdown_partition(
-              std::move(partition), placement.shard_revision);
+            co_await shutdown_partition(std::move(partition));
         }
         co_return ss::stop_iteration::yes;
     }
@@ -1125,7 +1121,6 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
           ntp,
           group_id,
           expected_log_revision.value(),
-          placement.shard_revision,
           std::move(initial_replicas));
         if (ec) {
             co_return ec;
@@ -1321,15 +1316,12 @@ ss::future<std::error_code> controller_backend::create_partition(
   model::ntp ntp,
   raft::group_id group_id,
   model::revision_id log_revision,
-  model::shard_revision_id shard_revision,
   replicas_t initial_replicas) {
     vlog(
       clusterlog.debug,
-      "[{}] creating partition, log revision: {}, shard_revision: {}"
-      ", initial_replicas: {}",
+      "[{}] creating partition, log revision: {}, initial_replicas: {}",
       ntp,
       log_revision,
-      shard_revision,
       initial_replicas);
 
     auto cfg = _topics.local().get_topic_cfg(model::topic_namespace_view(ntp));
@@ -1379,7 +1371,7 @@ ss::future<std::error_code> controller_backend::create_partition(
               read_replica_bucket);
 
             co_await add_to_shard_table(
-              ntp, group_id, ss::this_shard_id(), shard_revision);
+              ntp, group_id, ss::this_shard_id(), log_revision);
         } catch (...) {
             vlog(
               clusterlog.warn,
@@ -1666,48 +1658,42 @@ ss::future<> controller_backend::add_to_shard_table(
   model::ntp ntp,
   raft::group_id raft_group,
   uint32_t shard,
-  model::shard_revision_id revision) {
+  model::revision_id log_revision) {
     // update shard_table: broadcast
     vlog(
       clusterlog.trace,
-      "[{}] adding to shard table at shard {} with revision {}",
+      "[{}] adding to shard table at shard {} with log revision {}",
       ntp,
       shard,
-      revision);
+      log_revision);
     return _shard_table.invoke_on_all(
-      [ntp = std::move(ntp), raft_group, shard, revision](
+      [ntp = std::move(ntp), raft_group, shard, log_revision](
         shard_table& s) mutable {
-          s.update(ntp, raft_group, shard, revision);
+          s.update(ntp, raft_group, shard, log_revision);
       });
 }
 
 ss::future<> controller_backend::remove_from_shard_table(
-  model::ntp ntp,
-  raft::group_id raft_group,
-  model::shard_revision_id expected_rev) {
+  model::ntp ntp, raft::group_id raft_group, model::revision_id log_revision) {
     // update shard_table: broadcast
     vlog(
       clusterlog.trace,
-      "[{}] removing from shard table, expected revision {}",
+      "[{}] removing from shard table, log revision {}",
       ntp,
-      expected_rev);
+      log_revision);
     return _shard_table.invoke_on_all(
-      [ntp = std::move(ntp), raft_group, expected_rev](shard_table& s) mutable {
-          s.erase(ntp, raft_group, expected_rev);
+      [ntp = std::move(ntp), raft_group, log_revision](shard_table& s) mutable {
+          s.erase(ntp, raft_group, log_revision);
       });
 }
 
 ss::future<std::error_code> controller_backend::transfer_partition(
-  model::ntp ntp,
-  raft::group_id group,
-  model::revision_id log_revision,
-  model::shard_revision_id shard_revision) {
+  model::ntp ntp, raft::group_id group, model::revision_id log_revision) {
     vlog(
       clusterlog.debug,
-      "[{}] transferring partition, log_revision: {}, shard_revision: {}",
+      "[{}] transferring partition, log_revision: {}",
       ntp,
-      log_revision,
-      shard_revision);
+      log_revision);
 
     auto maybe_dest = co_await _shard_placement.prepare_transfer(
       ntp, log_revision);
@@ -1718,7 +1704,7 @@ ss::future<std::error_code> controller_backend::transfer_partition(
 
     auto partition = _partition_manager.local().get(ntp);
     if (partition) {
-        co_await shutdown_partition(std::move(partition), shard_revision);
+        co_await shutdown_partition(std::move(partition));
     }
 
     // TODO: copy, not move
@@ -1730,31 +1716,36 @@ ss::future<std::error_code> controller_backend::transfer_partition(
       ntp, ss::this_shard_id(), destination, _storage);
 
     co_await container().invoke_on(
-      destination,
-      [&ntp, log_revision, shard_revision](controller_backend& dest) {
+      destination, [&ntp, log_revision](controller_backend& dest) {
           return dest._shard_placement
             .finish_transfer_on_destination(ntp, log_revision)
-            .then([&] { dest.notify_reconciliation(ntp, shard_revision); });
+            .then([&] {
+                auto it = dest._states.find(ntp);
+                if (it != dest._states.end()) {
+                    it->second->wakeup_event.set();
+                }
+            });
       });
 
     co_await _shard_placement.finish_transfer_on_source(ntp, log_revision);
     co_return errc::success;
 }
 
-ss::future<> controller_backend::shutdown_partition(
-  ss::lw_shared_ptr<partition> partition, model::shard_revision_id shard_rev) {
+ss::future<>
+controller_backend::shutdown_partition(ss::lw_shared_ptr<partition> partition) {
     vlog(
       clusterlog.debug,
-      "[{}] shutting down, shard_rev: {}",
+      "[{}] shutting down, log revision: {}",
       partition->ntp(),
-      shard_rev);
+      partition->get_log_revision_id());
 
     auto ntp = partition->ntp();
     auto gr = partition->group();
 
     try {
         // remove from shard table
-        co_await remove_from_shard_table(ntp, gr, shard_rev);
+        co_await remove_from_shard_table(
+          ntp, gr, partition->get_log_revision_id());
         // shutdown partition
         co_await _partition_manager.local().shutdown(ntp);
     } catch (...) {
@@ -1764,10 +1755,8 @@ ss::future<> controller_backend::shutdown_partition(
          */
         vassert(
           false,
-          "error shutting down {} partition at shard revision {}, error: {}, "
-          "terminating",
+          "error shutting down {} partition, error: {}, terminating",
           ntp,
-          shard_rev,
           std::current_exception());
     }
 }
@@ -1812,8 +1801,7 @@ ss::future<std::error_code> controller_backend::delete_partition(
 
     auto part = _partition_manager.local().get(ntp);
     if (part) {
-        co_await remove_from_shard_table(
-          ntp, part->group(), placement->shard_revision);
+        co_await remove_from_shard_table(ntp, part->group(), log_revision);
         co_await _partition_manager.local().remove(ntp, mode);
     }
 

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -983,14 +983,14 @@ ss::future<result<ss::stop_iteration>> controller_backend::reconcile_ntp_step(
           "[{}] placement must be present if partition is",
           ntp);
         vassert(
-          maybe_placement->local
+          maybe_placement->current
             && partition->get_log_revision_id()
-                 == maybe_placement->local->log_revision
-            && maybe_placement->local->status
+                 == maybe_placement->current->log_revision
+            && maybe_placement->current->status
                  == shard_placement_table::hosted_status::hosted,
           "[{}] unexpected local state: {} (partition log revision: {})",
           ntp,
-          maybe_placement->local,
+          maybe_placement->current,
           partition->get_log_revision_id());
     }
 
@@ -1786,12 +1786,12 @@ ss::future<std::error_code> controller_backend::delete_partition(
           });
     }
 
-    if (!placement || !placement->local) {
+    if (!placement || !placement->current) {
         // nothing to delete
         co_return errc::success;
     }
 
-    auto log_revision = placement->local->log_revision;
+    auto log_revision = placement->current->log_revision;
     if (log_revision > cmd_revision) {
         // Perform an extra revision check to be on the safe side, if the
         // partition has already been re-created with greater revision, do

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -279,23 +279,21 @@ private:
     ss::future<std::error_code> create_partition(
       model::ntp,
       raft::group_id,
-      model::revision_id,
-      model::shard_revision_id,
+      model::revision_id log_revision,
       replicas_t initial_replicas);
 
     ss::future<> add_to_shard_table(
-      model::ntp, raft::group_id, ss::shard_id, model::shard_revision_id);
+      model::ntp,
+      raft::group_id,
+      ss::shard_id,
+      model::revision_id log_revision);
     ss::future<> remove_from_shard_table(
-      model::ntp, raft::group_id, model::shard_revision_id);
+      model::ntp, raft::group_id, model::revision_id log_revision);
 
-    ss::future<> shutdown_partition(
-      ss::lw_shared_ptr<partition>, model::shard_revision_id);
+    ss::future<> shutdown_partition(ss::lw_shared_ptr<partition>);
 
     ss::future<std::error_code> transfer_partition(
-      model::ntp ntp,
-      raft::group_id,
-      model::revision_id,
-      model::shard_revision_id);
+      model::ntp, raft::group_id, model::revision_id log_revision);
 
     ss::future<std::error_code> delete_partition(
       model::ntp,

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -82,6 +82,7 @@ enum class errc : int16_t {
     role_exists,
     role_does_not_exist,
     inconsistent_stm_update,
+    waiting_for_shard_placement_update,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -238,6 +239,8 @@ struct errc_category final : public std::error_category {
             return "Role does not exist";
         case errc::inconsistent_stm_update:
             return "STM command can't be applied";
+        case errc::waiting_for_shard_placement_update:
+            return "Waiting for shard placement table update to finish";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -47,7 +47,7 @@ static ss::future<consensus_ptr> create_raft0(
                   model::controller_ntp,
                   gr,
                   controller_stm_shard,
-                  model::shard_revision_id(0));
+                  model::revision_id(0));
             })
             .then([p] { return p; });
       });

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -104,9 +104,10 @@ public:
           : target(target)
           , shard_revision(rev) {}
 
-        /// If this shard is the initial shard for this partition on this node,
-        /// this field will contain the corresponding shard revision.
-        model::shard_revision_id _is_initial_at_revision;
+        /// If this shard is the initial shard for some incarnation of this
+        /// partition on this node, this field will contain the corresponding
+        /// log revision.
+        std::optional<model::revision_id> _is_initial_for;
         /// If x-shard transfer is in progress, will hold the destination. Note
         /// that it is initialized from target but in contrast to target, it
         /// can't change mid-transfer.

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -193,6 +193,8 @@ private:
     ss::future<> do_delete(const model::ntp&, placement_state&);
 
 private:
+    friend class shard_placement_test_fixture;
+
     // per-shard state
     //
     // node_hash_map for pointer stability

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -192,3 +192,17 @@ rp_test(
   LIBRARIES Seastar::seastar_perf_testing v::cluster
   LABELS cluster
 )
+
+# Needs multiple cores
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME shard_placement_table_test
+  SOURCES
+    shard_placement_table_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::cluster
+  ARGS "-- -c 4"
+  LABELS cluster
+)

--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -1,0 +1,478 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/logger.h"
+#include "cluster/shard_placement_table.h"
+#include "features/feature_table.h"
+#include "ssx/event.h"
+#include "storage/kvstore.h"
+#include "storage/storage_resources.h"
+#include "test_utils/randoms.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/reactor.hh>
+#include <seastar/util/file.hh>
+
+namespace cluster {
+
+namespace {
+
+/// Simplified version of topic_table representing partitions that are expected
+/// to exist on this node.
+struct ntp_table {
+    struct ntp_meta {
+        raft::group_id group;
+        model::revision_id log_revision;
+    };
+
+    absl::flat_hash_map<model::ntp, ntp_meta> ntp2meta;
+    model::revision_id revision;
+};
+
+/// simplified version of controller_backend driving shard_placement_table
+/// reconciliation
+class reconciliation_backend
+  : public ss::peering_sharded_service<reconciliation_backend> {
+public:
+    explicit reconciliation_backend(
+      ss::sharded<ntp_table>& ntpt, ss::sharded<shard_placement_table>& spt)
+      : _ntpt(ntpt.local())
+      , _shard_placement(spt.local()) {}
+
+    ss::future<> stop() {
+        for (auto& [_, rs] : _states) {
+            rs->wakeup_event.set();
+        }
+        co_await _gate.close();
+    }
+
+    ss::future<> start() {
+        for (const auto& [ntp, _] : _ntpt.ntp2meta) {
+            notify_reconciliation(ntp, model::shard_revision_id{0});
+        }
+        co_return;
+    }
+
+    void
+    notify_reconciliation(const model::ntp& ntp, model::shard_revision_id rev) {
+        auto [rs_it, inserted] = _states.try_emplace(ntp);
+        if (inserted) {
+            rs_it->second = ss::make_lw_shared<ntp_reconciliation_state>();
+        }
+        auto& rs = *rs_it->second;
+        if (rs.changed_at) {
+            rs.changed_at = std::max(*rs.changed_at, rev);
+        } else {
+            rs.changed_at = rev;
+        }
+        rs.wakeup_event.set();
+        if (inserted) {
+            ssx::background = reconcile_ntp_fiber(ntp, rs_it->second);
+        }
+    }
+
+    ss::future<bool> is_reconciled() {
+        auto shards_reconciled = co_await container().map(
+          [](reconciliation_backend& rb) { return rb._states.empty(); });
+        co_return std::all_of(
+          shards_reconciled.begin(), shards_reconciled.end(), [](bool x) {
+              return x;
+          });
+    }
+
+private:
+    struct ntp_reconciliation_state {
+        std::optional<model::shard_revision_id> changed_at;
+
+        ssx::event wakeup_event{"c/rb/rfwe"};
+
+        bool is_reconciled() const { return !changed_at.has_value(); }
+
+        void mark_reconciled(model::shard_revision_id rev) {
+            if (changed_at && *changed_at <= rev) {
+                changed_at = std::nullopt;
+            }
+        }
+    };
+
+    ss::future<> reconcile_ntp_fiber(
+      model::ntp ntp, ss::lw_shared_ptr<ntp_reconciliation_state> rs) {
+        if (_gate.is_closed()) {
+            co_return;
+        }
+        auto gate_holder = _gate.hold();
+
+        while (true) {
+            co_await rs->wakeup_event.wait(
+              1ms * random_generators::get_int(200, 300));
+            if (_gate.is_closed()) {
+                break;
+            }
+
+            try {
+                co_await ss::sleep(1ms * random_generators::get_int(30));
+                co_await try_reconcile_ntp(ntp, *rs);
+                if (rs->is_reconciled()) {
+                    _states.erase(ntp);
+                    break;
+                }
+            } catch (...) {
+                auto ex = std::current_exception();
+                if (!ssx::is_shutdown_exception(ex)) {
+                    vlog(
+                      clusterlog.error,
+                      "[{}] unexpected exception during reconciliation: {}",
+                      ntp,
+                      ex);
+                }
+            }
+        }
+    }
+
+    ss::future<>
+    try_reconcile_ntp(const model::ntp& ntp, ntp_reconciliation_state& rs) {
+        while (!rs.is_reconciled() && !_gate.is_closed()) {
+            model::shard_revision_id changed_at = rs.changed_at.value_or(
+              model::shard_revision_id{});
+            try {
+                auto res = co_await reconcile_ntp_step(ntp, rs);
+                if (res.has_value()) {
+                    if (res.value() == ss::stop_iteration::no) {
+                        continue;
+                    } else {
+                        vlog(
+                          clusterlog.trace,
+                          "[{}] reconciled at {}",
+                          ntp,
+                          changed_at);
+                        rs.mark_reconciled(changed_at);
+                    }
+                } else {
+                    vlog(
+                      clusterlog.trace,
+                      "[{}] reconciliation attempt error: {}",
+                      ntp,
+                      res.error());
+                }
+            } catch (ss::gate_closed_exception const&) {
+            } catch (ss::abort_requested_exception const&) {
+            } catch (...) {
+                vlog(
+                  clusterlog.warn,
+                  "[{}] exception occured during reconciliation: {}",
+                  ntp,
+                  std::current_exception());
+            }
+            break;
+        }
+    }
+
+    ss::future<result<ss::stop_iteration>>
+    reconcile_ntp_step(const model::ntp& ntp, ntp_reconciliation_state& rs) {
+        std::optional<shard_placement_table::placement_state> maybe_placement
+          = _shard_placement.state_on_this_shard(ntp);
+        if (!maybe_placement) {
+            co_return ss::stop_iteration::yes;
+        }
+        auto placement = *maybe_placement;
+
+        std::optional<model::revision_id> expected_log_revision;
+        if (auto it = _ntpt.ntp2meta.find(ntp); it != _ntpt.ntp2meta.end()) {
+            expected_log_revision = it->second.log_revision;
+        }
+
+        vlog(
+          clusterlog.trace,
+          "[{}] placement state on this shard: {}, expected_log_revision: {}",
+          ntp,
+          placement,
+          expected_log_revision);
+
+        switch (placement.get_reconciliation_action(expected_log_revision)) {
+        case shard_placement_table::reconciliation_action::remove: {
+            auto cmd_revision = expected_log_revision.value_or(_ntpt.revision);
+            auto ec = co_await delete_partition(ntp, placement, cmd_revision);
+            if (ec) {
+                co_return ec;
+            }
+            co_return ss::stop_iteration::no;
+        }
+        case shard_placement_table::reconciliation_action::
+          wait_for_target_update:
+            co_return errc::waiting_for_shard_placement_update;
+        case shard_placement_table::reconciliation_action::transfer: {
+            auto ec = co_await transfer_partition(
+              ntp, expected_log_revision.value());
+            if (ec) {
+                co_return ec;
+            }
+            co_return ss::stop_iteration::no;
+        }
+        case shard_placement_table::reconciliation_action::create: {
+            if (!_launched.contains(ntp)) {
+                auto ec = co_await create_partition(
+                  ntp, expected_log_revision.value());
+                if (ec) {
+                    co_return ec;
+                }
+            }
+            co_return ss::stop_iteration::yes;
+        }
+        }
+    }
+
+    ss::future<std::error_code>
+    create_partition(const model::ntp& ntp, model::revision_id log_revision) {
+        auto ec = co_await _shard_placement.prepare_create(ntp, log_revision);
+        vlog(clusterlog.trace, "[{}] creating partition: {}", ntp, ec);
+        if (ec) {
+            co_return ec;
+        }
+
+        _launched.insert(ntp);
+
+        co_return errc::success;
+    }
+
+    ss::future<std::error_code> delete_partition(
+      const model::ntp& ntp,
+      shard_placement_table::placement_state placement,
+      model::revision_id cmd_revision) {
+        auto ec = co_await _shard_placement.prepare_delete(ntp, cmd_revision);
+        vlog(
+          clusterlog.trace,
+          "[{}] deleting partition at cmd_revision: {}, ec: {}",
+          ntp,
+          cmd_revision,
+          ec);
+        if (ec) {
+            co_return ec;
+        }
+
+        if (!placement.current) {
+            // nothing to delete
+            co_return errc::success;
+        }
+
+        _launched.erase(ntp);
+
+        co_await _shard_placement.finish_delete(
+          ntp, placement.current->log_revision);
+        co_return ec;
+    }
+
+    ss::future<std::error_code>
+    transfer_partition(const model::ntp& ntp, model::revision_id log_revision) {
+        auto maybe_dest = co_await _shard_placement.prepare_transfer(
+          ntp, log_revision);
+        if (maybe_dest.has_error()) {
+            vlog(
+              clusterlog.trace,
+              "[{}] preparing transfer error: {}",
+              ntp,
+              maybe_dest.error());
+            co_return maybe_dest.error();
+        }
+
+        vlog(
+          clusterlog.trace,
+          "[{}] preparing transfer dest: {}",
+          ntp,
+          maybe_dest.value());
+        ss::shard_id destination = maybe_dest.value();
+
+        _launched.erase(ntp);
+
+        co_await container().invoke_on(
+          destination, [&ntp, log_revision](reconciliation_backend& dest) {
+              return dest._shard_placement
+                .finish_transfer_on_destination(ntp, log_revision)
+                .then([&] {
+                    auto it = dest._states.find(ntp);
+                    if (it != dest._states.end()) {
+                        it->second->wakeup_event.set();
+                    }
+                });
+          });
+
+        co_await _shard_placement.finish_transfer_on_source(ntp, log_revision);
+        vlog(clusterlog.trace, "[{}] transferred", ntp);
+        co_return errc::success;
+    }
+
+private:
+    ntp_table& _ntpt;
+    shard_placement_table& _shard_placement;
+
+    absl::btree_map<model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>>
+      _states;
+    absl::flat_hash_set<model::ntp> _launched;
+    ss::gate _gate;
+};
+
+// Limit concurrency to 4 so that there are more interesting repeats in randomly
+// generated shard ids.
+ss::shard_id get_max_shard_id() {
+    return std::min(ss::smp::count - 1, ss::shard_id(3));
+}
+
+} // namespace
+
+class shard_placement_test_fixture : public seastar_test {
+public:
+    shard_placement_test_fixture()
+      : test_dir("test.data." + random_generators::gen_alphanum_string(10)) {}
+
+    ss::future<> start() {
+        co_await ft.start();
+        co_await ft.invoke_on_all(
+          [](features::feature_table& ft) { ft.testing_activate_all(); });
+
+        co_await ntpt.start();
+
+        co_await sr.start();
+
+        co_await kvs.start(
+          storage::kvstore_config(
+            1_MiB,
+            config::mock_binding(10ms),
+            test_dir,
+            storage::make_sanitized_file_config()),
+          ss::sharded_parameter([this] { return std::ref(sr.local()); }),
+          std::ref(ft));
+        co_await kvs.invoke_on_all(
+          [](storage::kvstore& kvs) { return kvs.start(); });
+
+        co_await spt.start();
+
+        co_await rb.start(std::ref(ntpt), std::ref(spt));
+        co_await rb.invoke_on_all(
+          [](reconciliation_backend& rb) { return rb.start(); });
+    }
+
+    ss::future<> stop() {
+        co_await rb.stop();
+        co_await spt.stop();
+        co_await kvs.stop();
+        co_await sr.stop();
+        co_await ntpt.stop();
+        co_await ft.stop();
+    }
+
+    ss::future<> TearDownAsync() override {
+        co_await stop();
+        co_await ss::recursive_remove_directory(
+          std::filesystem::path(test_dir));
+    }
+
+    ss::sstring test_dir;
+    ss::sharded<features::feature_table> ft;
+    ss::sharded<ntp_table> ntpt;
+    ss::sharded<storage::storage_resources> sr;
+    ss::sharded<storage::kvstore> kvs;
+    ss::sharded<shard_placement_table> spt;
+    ss::sharded<reconciliation_backend> rb;
+};
+
+TEST_F_CORO(shard_placement_test_fixture, StressTest) {
+    model::revision_id cur_revision{1};
+    model::shard_revision_id cur_shard_revision{1};
+    raft::group_id cur_group{1};
+
+    co_await start();
+
+    for (size_t i = 0; i < 10'000; ++i) {
+        if (random_generators::get_int(15) == 0) {
+            vlog(clusterlog.info, "waiting for reconciliation");
+            for (size_t i = 0;; ++i) {
+                ASSERT_TRUE_CORO(i < 50) << "taking too long to reconcile";
+                if (!co_await rb.local().is_reconciled()) {
+                    co_await ss::sleep(100ms);
+                } else {
+                    break;
+                }
+            }
+            vlog(clusterlog.info, "reconciled");
+        }
+
+        // small set of ntps to ensure frequent overlaps
+        model::ntp ntp(
+          model::kafka_namespace, "test_topic", random_generators::get_int(10));
+
+        std::optional<shard_placement_target> target;
+
+        auto pt_it = ntpt.local().ntp2meta.find(ntp);
+        if (pt_it == ntpt.local().ntp2meta.end()) {
+            // add
+            auto group = cur_group++;
+            auto revision = cur_revision++;
+            co_await ntpt.invoke_on_all([&](ntp_table& ntpt) {
+                ntpt.ntp2meta[ntp] = ntp_table::ntp_meta{
+                  .group = group,
+                  .log_revision = revision,
+                };
+                ntpt.revision = revision;
+            });
+
+            target = shard_placement_target(
+              revision, random_generators::get_int(get_max_shard_id()));
+        } else {
+            auto ntp_meta = pt_it->second;
+
+            enum class op_t {
+                transfer,
+                remove,
+                increase_log_rev,
+            };
+
+            op_t op = random_generators::random_choice(
+              {op_t::transfer, op_t::remove, op_t::increase_log_rev});
+            switch (op) {
+            case op_t::transfer:
+                target = shard_placement_target(
+                  ntp_meta.log_revision,
+                  random_generators::get_int(get_max_shard_id()));
+                break;
+            case op_t::remove: {
+                auto revision = cur_revision++;
+                target = std::nullopt;
+                co_await ntpt.invoke_on_all([&](ntp_table& ntpt) {
+                    ntpt.ntp2meta.erase(ntp);
+                    ntpt.revision = revision;
+                });
+                break;
+            }
+            case op_t::increase_log_rev:
+                ntp_meta.log_revision = cur_revision++;
+                target = shard_placement_target(
+                  ntp_meta.log_revision,
+                  random_generators::get_int(get_max_shard_id()));
+                co_await ntpt.invoke_on_all([&](ntp_table& ntpt) {
+                    ntpt.ntp2meta[ntp] = ntp_meta;
+                    ntpt.revision = ntp_meta.log_revision;
+                });
+                break;
+            }
+        }
+
+        co_await spt.local().set_target(
+          ntp,
+          target,
+          cur_shard_revision++,
+          [this](const model::ntp& ntp, model::shard_revision_id rev) {
+              rb.local().notify_reconciliation(ntp, rev);
+          });
+    }
+
+    vlog(clusterlog.info, "finished");
+}
+
+} // namespace cluster

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -100,6 +100,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::role_exists:
     case cluster::errc::role_does_not_exist:
     case cluster::errc::inconsistent_stm_update:
+    case cluster::errc::waiting_for_shard_placement_update:
         break;
     }
     return error_code::unknown_server_error;


### PR DESCRIPTION
Add stress test testing the logic in `shard_placement_table` and fix a few bugs that it found.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none