### PR TITLE
io/tests: fix bugprone-empty-catch

### DIFF
--- a/src/v/io/tests/io_queue_test.cc
+++ b/src/v/io/tests/io_queue_test.cc
@@ -81,7 +81,8 @@ struct queue_tester {
             while (!stop_) {
                 try {
                     queue.open().get();
-                } catch (...) {
+                } catch (const std::exception& ex) {
+                    std::ignore = ex;
                 }
                 sleep_ms(10, 50);
                 if (queue.opened()) {
@@ -116,7 +117,8 @@ TEST_P(IOQueueTest, WriteRead) {
 
     try {
         seastar::remove_file(qt.queue.path().string()).get();
-    } catch (...) {
+    } catch (const std::exception& ex) {
+        std::ignore = ex;
     }
 }
 

--- a/src/v/io/tests/scheduler_test.cc
+++ b/src/v/io/tests/scheduler_test.cc
@@ -61,7 +61,8 @@ public:
         for (auto& file : cleanup_files_) {
             try {
                 seastar::remove_file(file.string()).get();
-            } catch (...) {
+            } catch (const std::exception& ex) {
+                std::ignore = ex;
             }
         }
     }


### PR DESCRIPTION
New in clang-tidy-17

https://clang.llvm.org/extra/clang-tidy/checks/bugprone/empty-catch.html

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
