### PR TITLE
Partition status cstore

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -32,6 +32,7 @@
 #include "cluster/feature_manager.h"
 #include "cluster/fwd.h"
 #include "cluster/health_manager.h"
+#include "cluster/health_monitor_backend.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/logger.h"
 #include "cluster/members_backend.h"

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -92,8 +92,9 @@ feature_manager::start(std::vector<model::node_id>&& cluster_founder_nodes) {
     // Register for node health change notifications
     _health_notify_handle = _hm_backend.local().register_node_callback(
       [this](
-        node_health_report const& report,
-        std::optional<std::reference_wrapper<const node_health_report>>) {
+        columnar_node_health_report const& report,
+        std::optional<
+          std::reference_wrapper<const columnar_node_health_report>>) {
           // If we did not know the node's version or if the report is
           // higher, submit an update.
           auto i = _node_versions.find(report.id);

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -14,6 +14,7 @@
 #include "cluster/cluster_utils.h"
 #include "cluster/commands.h"
 #include "cluster/controller_service.h"
+#include "cluster/health_monitor_backend.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/logger.h"

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -626,6 +626,17 @@ health_monitor_backend::collect_current_node_health() {
     co_return ret;
 }
 
+ss::future<columnar_node_health_report>
+health_monitor_backend::get_current_node_health() {
+    vlog(clusterlog.debug, "getting current node health");
+    auto it = _reports.find(_self);
+    if (it != _reports.end()) {
+        co_return it->second.copy();
+    }
+
+    co_return co_await collect_current_node_health();
+}
+
 namespace {
 
 struct ntp_report {

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -31,8 +31,8 @@
 namespace cluster {
 
 using health_node_cb_t = ss::noncopyable_function<void(
-  node_health_report const&,
-  std::optional<std::reference_wrapper<const node_health_report>>)>;
+  columnar_node_health_report const&,
+  std::optional<std::reference_wrapper<const columnar_node_health_report>>)>;
 
 /**
  * Health monitor backend is responsible for collecting cluster health status
@@ -120,7 +120,7 @@ private:
 
     using status_cache_t = absl::node_hash_map<model::node_id, reply_status>;
     using report_cache_t
-      = absl::node_hash_map<model::node_id, node_health_report>;
+      = absl::node_hash_map<model::node_id, columnar_node_health_report>;
 
     void tick();
     ss::future<std::error_code> collect_cluster_health();

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -115,13 +115,16 @@ private:
         alive is_alive = alive::no;
     };
 
+    using report_variant_t
+      = std::variant<node_health_report, columnar_node_health_report>;
+
     using status_cache_t = absl::node_hash_map<model::node_id, reply_status>;
     using report_cache_t
       = absl::node_hash_map<model::node_id, node_health_report>;
 
     void tick();
     ss::future<std::error_code> collect_cluster_health();
-    ss::future<result<node_health_report>>
+    ss::future<result<report_variant_t>>
       collect_remote_node_health(model::node_id);
     ss::future<std::error_code> maybe_refresh_cluster_health(
       force_refresh, model::timeout_clock::time_point);
@@ -136,8 +139,11 @@ private:
       collect_topic_status(partitions_filter);
     ss::future<topics_store> collect_topic_status();
 
-    result<node_health_report>
+    result<report_variant_t>
       process_node_reply(model::node_id, result<get_node_health_reply>);
+
+    ss::future<std::error_code>
+      process_health_reports(std::vector<result<report_variant_t>>);
 
     std::chrono::milliseconds max_metadata_age();
     void abort_current_refresh();

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -76,6 +76,11 @@ public:
      * format.
      */
     ss::future<columnar_node_health_report> collect_current_node_health();
+    /**
+     * Return cached version of current node health of collects it if it is not
+     * available in cache.
+     */
+    ss::future<columnar_node_health_report> get_current_node_health();
 
     cluster::notification_id_type register_node_callback(health_node_cb_t cb);
     void unregister_node_callback(cluster::notification_id_type id);

--- a/src/v/cluster/health_monitor_backend.h
+++ b/src/v/cluster/health_monitor_backend.h
@@ -71,6 +71,12 @@ public:
     ss::future<result<node_health_report>>
       collect_current_node_health(node_report_filter);
 
+    /**
+     * Collects current node health and returns the report using columnar
+     * format.
+     */
+    ss::future<columnar_node_health_report> collect_current_node_health();
+
     cluster::notification_id_type register_node_callback(health_node_cb_t cb);
     void unregister_node_callback(cluster::notification_id_type id);
 
@@ -128,6 +134,7 @@ private:
 
     ss::future<chunked_vector<topic_status>>
       collect_topic_status(partitions_filter);
+    ss::future<topics_store> collect_topic_status();
 
     result<node_health_report>
       process_node_reply(model::node_id, result<get_node_health_reply>);

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -88,7 +88,7 @@ health_monitor_frontend::is_alive(model::node_id id) const {
 ss::future<columnar_node_health_report>
 health_monitor_frontend::collect_node_health() {
     return dispatch_to_backend([](health_monitor_backend& be) mutable {
-        return be.collect_current_node_health();
+        return be.get_current_node_health();
     });
 }
 

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -10,6 +10,7 @@
  */
 #include "cluster/health_monitor_frontend.h"
 
+#include "cluster/health_monitor_backend.h"
 #include "cluster/logger.h"
 #include "config/property.h"
 #include "model/timeout_clock.h"

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -65,6 +65,12 @@ public:
       collect_node_health(node_report_filter);
 
     /**
+     * Collects node local state into node health report. The report contains
+     * status of all partition replicas that are present on requested node.
+     */
+    ss::future<columnar_node_health_report> collect_node_health();
+
+    /**
      * Return drain status for a given node.
      */
     ss::future<result<std::optional<cluster::drain_manager::drain_status>>>

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -10,7 +10,6 @@
  */
 #pragma once
 #include "cluster/fwd.h"
-#include "cluster/health_monitor_backend.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/node_status_table.h"
 #include "config/property.h"
@@ -20,9 +19,6 @@
 #include "storage/types.h"
 
 #include <seastar/core/sharded.hh>
-
-#include <chrono>
-#include <utility>
 
 namespace cluster {
 
@@ -99,7 +95,7 @@ private:
     template<typename Func>
     auto dispatch_to_backend(Func&& f) {
         return _backend.invoke_on(
-          health_monitor_backend::shard, std::forward<Func>(f));
+          health_monitor_backend_shard, std::forward<Func>(f));
     }
 
     ss::sharded<health_monitor_backend>& _backend;

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -408,7 +408,7 @@ get_node_health_reply get_node_health_reply::copy() const {
 }
 
 std::ostream& operator<<(std::ostream& o, const topic_status& tl) {
-    fmt::print(o, "{{topic: {}, leaders: {}}}", tl.tp_ns, tl.partitions);
+    fmt::print(o, "{{topic: {}, partitions: {}}}", tl.tp_ns, tl.partitions);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -513,11 +513,29 @@ operator<<(std::ostream& o, const columnar_node_health_report& report) {
     return o;
 }
 std::ostream& operator<<(std::ostream& o, const topic_status_view& store) {
+    fmt::print(o, "{{tp_ns: {}, partitions: [", store.tp_ns);
+    print_range(o, store.partitions);
+    fmt::print(o, "]}}");
+    return o;
+}
+
+std::ostream& operator<<(std::ostream& o, const cluster_health_overview& ho) {
     fmt::print(
       o,
-      "{{tp_ns: {}, partitions: [{}]}}",
-      store.tp_ns,
-      fmt::join(store.partitions.begin(), store.partitions.end(), ","));
+      "{{controller_id: {}, nodes: {}, unhealthy_reasons: {}, nodes_down: {}, "
+      "nodes_in_recovery_mode: {}, bytes_in_cloud_storage: {}, "
+      "leaderless_count: {}, under_replicated_count: {}, "
+      "leaderless_partitions: {}, under_replicated_partitions: {}}}",
+      ho.controller_id,
+      ho.all_nodes,
+      ho.unhealthy_reasons,
+      ho.nodes_down,
+      ho.nodes_in_recovery_mode,
+      ho.bytes_in_cloud_storage,
+      ho.leaderless_count,
+      ho.under_replicated_count,
+      ho.leaderless_partitions,
+      ho.under_replicated_partitions);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -397,6 +397,15 @@ partition_statuses_cstore partition_statuses_cstore::copy() const {
     return ret;
 }
 
+get_node_health_reply get_node_health_reply::copy() const {
+    return get_node_health_reply{
+      .error = error,
+      .report = report,
+      .columnar_report = columnar_report
+                           ? std::make_optional(columnar_report->copy())
+                           : std::nullopt,
+    };
+}
 
 std::ostream& operator<<(std::ostream& o, const topic_status& tl) {
     fmt::print(o, "{{topic: {}, leaders: {}}}", tl.tp_ns, tl.partitions);
@@ -442,12 +451,21 @@ std::ostream& operator<<(std::ostream& o, const partitions_filter& filter) {
 }
 
 std::ostream& operator<<(std::ostream& o, const get_node_health_request& r) {
-    fmt::print(o, "{{filter: {}}}", r.filter);
+    fmt::print(
+      o,
+      "{{filter: {}, use_columnar_format: {}}}",
+      r.filter,
+      r.use_columnar_format);
     return o;
 }
 
 std::ostream& operator<<(std::ostream& o, const get_node_health_reply& r) {
-    fmt::print(o, "{{error: {}, report: {}}}", r.error, r.report);
+    fmt::print(
+      o,
+      "{{error: {}, report: {}, columnar_report: {}}}",
+      r.error,
+      r.report,
+      r.columnar_report);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -442,8 +442,7 @@ std::ostream& operator<<(std::ostream& o, const partitions_filter& filter) {
 }
 
 std::ostream& operator<<(std::ostream& o, const get_node_health_request& r) {
-    fmt::print(
-      o, "{{filter: {}, current_version: {}}}", r.filter, r.current_version);
+    fmt::print(o, "{{filter: {}}}", r.filter);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -24,6 +24,7 @@
 
 namespace cluster {
 
+static constexpr ss::shard_id health_monitor_backend_shard = 0;
 /**
  * Health reports
  */

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -767,17 +767,8 @@ struct get_node_health_request
       serde::version<0>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
-    static constexpr int8_t initial_version = 0;
-    // version -1: included revision id in partition status
-    static constexpr int8_t revision_id_version = -1;
-    // version -2: included size_bytes in partition status
-    static constexpr int8_t size_bytes_version = -2;
-
-    static constexpr int8_t current_version = size_bytes_version;
 
     node_report_filter filter;
-    // this field is not serialized
-    int8_t decoded_version = current_version;
 
     friend bool
     operator==(const get_node_health_request&, const get_node_health_request&)
@@ -795,7 +786,6 @@ struct get_node_health_reply
       serde::version<0>,
       serde::compat_version<0>> {
     using rpc_adl_exempt = std::true_type;
-    static constexpr int8_t current_version = 0;
 
     errc error = cluster::errc::success;
     std::optional<node_health_report> report;

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -689,6 +689,9 @@ struct cluster_health_overview {
     std::vector<model::ntp> under_replicated_partitions;
     size_t under_replicated_count{};
     std::optional<size_t> bytes_in_cloud_storage;
+
+    friend std::ostream&
+    operator<<(std::ostream&, const cluster_health_overview&);
 };
 
 using include_partitions_info = ss::bool_class<struct include_partitions_tag>;

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -237,8 +237,9 @@ void partition_balancer_backend::on_topic_table_update() {
 }
 
 void partition_balancer_backend::on_health_monitor_update(
-  node_health_report const& report,
-  std::optional<std::reference_wrapper<const node_health_report>> old_report) {
+  columnar_node_health_report const& report,
+  std::optional<std::reference_wrapper<const columnar_node_health_report>>
+    old_report) {
     if (!old_report) {
         vlog(
           clusterlog.debug,

--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -10,6 +10,7 @@
 
 #include "cluster/partition_balancer_backend.h"
 
+#include "cluster/health_monitor_backend.h"
 #include "cluster/health_monitor_frontend.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/logger.h"

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -26,7 +26,7 @@
 
 namespace cluster {
 
-struct node_health_report;
+struct columnar_node_health_report;
 
 class partition_balancer_backend {
 public:
@@ -82,8 +82,8 @@ private:
     void on_members_update(model::node_id, model::membership_state);
     void on_topic_table_update();
     void on_health_monitor_update(
-      node_health_report const&,
-      std::optional<std::reference_wrapper<const node_health_report>>);
+      columnar_node_health_report const&,
+      std::optional<std::reference_wrapper<const columnar_node_health_report>>);
     size_t get_min_partition_size_threshold() const;
 
 private:

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -535,20 +535,9 @@ service::do_collect_node_health_report(get_node_health_request req) {
         co_return get_node_health_reply{
           .error = map_health_monitor_error_code(res.error())};
     }
-    auto report = std::move(res.value());
-    // clear all revision ids to prevent sending them to old versioned redpanda
-    // nodes
-    if (req.decoded_version > get_node_health_request::revision_id_version) {
-        clear_partition_revisions(report);
-    }
-    // clear all partition sizes to prevent sending them to old versioned
-    // redpanda nodes
-    if (req.decoded_version > get_node_health_request::size_bytes_version) {
-        clear_partition_sizes(report);
-    }
     co_return get_node_health_reply{
       .error = errc::success,
-      .report = std::move(report),
+      .report = std::move(res.value()),
     };
 }
 

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -197,6 +197,19 @@ rp_test(
 )
 
 rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME health_monitor_types_test
+  SOURCES
+    health_monitor_types_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::cluster
+  ARGS "-- -c 1"
+  LABELS cluster
+)
+
+rp_test(
   BENCHMARK_TEST
   BINARY_NAME health_monitor
   SOURCES health_monitor_bench.cc

--- a/src/v/cluster/tests/health_bench.cc
+++ b/src/v/cluster/tests/health_bench.cc
@@ -66,8 +66,9 @@ struct health_bench : health_report_accessor {
         constexpr int nodes = 32;
 
         // genreate a random health report
-        absl::node_hash_map<model::node_id, cluster::node_health_report>
-          reports;
+        absl::
+          node_hash_map<model::node_id, cluster::columnar_node_health_report>
+            reports;
 
         for (int topic = 0; topic < topic_count; topic++) {
             std::vector<topic_status> statuses;
@@ -92,7 +93,8 @@ struct health_bench : health_report_accessor {
             }
 
             for (model::node_id node{0}; node < nodes; node++) {
-                reports[node].topics.emplace_back(statuses.at(node));
+                reports[node].topics.append(
+                  statuses.at(node).tp_ns, statuses.at(node).partitions);
             }
         }
 

--- a/src/v/cluster/tests/health_monitor_test_utils.h
+++ b/src/v/cluster/tests/health_monitor_test_utils.h
@@ -10,6 +10,9 @@
 #pragma once
 
 #include "cluster/health_monitor_backend.h"
+#include "model/fundamental.h"
+#include "random/generators.h"
+#include "test_utils/randoms.h"
 
 namespace cluster {
 // needed only for access to private members
@@ -24,4 +27,79 @@ struct health_report_accessor {
         return health_monitor_backend::aggregate_reports(reports);
     }
 };
+
+chunked_vector<cluster::partition_status>
+make_partition_statues(size_t num_partitions) {
+    chunked_vector<cluster::partition_status> ret;
+    if (num_partitions == 0) {
+        return ret;
+    }
+    ret.reserve(num_partitions);
+
+    for (size_t i = 0; i < num_partitions; ++i) {
+        cluster::partition_status part_status;
+
+        part_status.id = model::partition_id(i);
+        part_status.leader_id = tests::random_optional(
+          []() { return model::node_id(random_generators::get_int(20)); });
+        part_status.reclaimable_size_bytes = random_generators::get_int<size_t>(
+          20000000);
+        part_status.revision_id = model::revision_id(
+          random_generators::get_int<size_t>(100));
+        part_status.term = model::term_id(
+          random_generators::get_int<size_t>(200));
+        part_status.size_bytes = random_generators::get_int<size_t>(20000000);
+        part_status.under_replicated_replicas = tests::random_optional(
+          [] { return random_generators::get_int<uint8_t>(5); });
+        if (tests::random_bool()) {
+            part_status.shard = random_generators::get_int<uint32_t>(128);
+        } else {
+            part_status.shard = uint32_t(-1);
+        }
+
+        ret.push_back(part_status);
+    }
+
+    return ret;
+}
+
+static const std::vector<model::ns> namespaces{
+  model::kafka_namespace, model::kafka_internal_namespace, model::redpanda_ns};
+
+model::topic_namespace make_tp_ns() {
+    return {
+      random_generators::random_choice(namespaces),
+      model::topic("topic-" + random_generators::gen_alphanum_string(10))};
+}
+
+cluster::topic_status make_topic_status(size_t num_partitions) {
+    cluster::topic_status ts;
+    ts.tp_ns = make_tp_ns();
+    ts.partitions = make_partition_statues(num_partitions);
+    return ts;
+}
+
+columnar_node_health_report make_columnar_node_health_report(
+  size_t num_topics, size_t partitions_per_topic) {
+    columnar_node_health_report report;
+    report.id = model::node_id(1);
+
+    report.local_state.redpanda_version = cluster::node::application_version(
+      "v23.3.1");
+    report.local_state.logical_version = cluster::cluster_version(10);
+    report.local_state.uptime = std::chrono::milliseconds(100);
+
+    report.local_state.data_disk.path
+      = "/bar/baz/foo/foo/foo/foo/foo/foo/foo/bar";
+    report.local_state.data_disk.total = 1000;
+    report.local_state.data_disk.free = 500;
+
+    for (size_t i = 0; i < num_topics; ++i) {
+        report.topics.append(
+          make_tp_ns(), make_partition_statues(partitions_per_topic));
+    }
+
+    return report;
+}
+
 } // namespace cluster

--- a/src/v/cluster/tests/health_monitor_types_test.cc
+++ b/src/v/cluster/tests/health_monitor_types_test.cc
@@ -1,0 +1,187 @@
+
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iobuf_parser.h"
+#include "cluster/health_monitor_types.h"
+#include "cluster/tests/health_monitor_test_utils.h"
+#include "container/fragmented_vector.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "random/generators.h"
+#include "serde/async.h"
+#include "serde/envelope.h"
+#include "serde/rw/rw.h"
+#include "test_utils/test.h"
+#include "utils/human.h"
+
+#include <fmt/ostream.h>
+#include <gtest/gtest.h>
+
+#include <tuple>
+#include <utility>
+#include <vector>
+
+using namespace cluster;
+chunked_vector<topic_status> collect_statuses(const topics_store& store) {
+    chunked_vector<topic_status> ret;
+    for (const auto& tp : store) {
+        chunked_vector<partition_status> partitions;
+        for (auto& p : tp.partitions) {
+            partitions.push_back(p);
+        }
+
+        ret.emplace_back(
+          model::topic_namespace(tp.tp_ns), std::move(partitions));
+    }
+    return ret;
+}
+
+TEST(health_monitor_types, test_columnar_format) {
+    chunked_vector<topic_status> original;
+    original.reserve(10);
+    for (int i = 0; i < 10; ++i) {
+        original.emplace_back(make_tp_ns(), make_partition_statues(10));
+    }
+
+    columnar_node_health_report report;
+    for (const auto& topic : original) {
+        report.topics.append(topic.tp_ns, topic.partitions);
+    }
+
+    auto collected = collect_statuses(report.topics);
+    for (auto i = 0; i < original.size(); ++i) {
+        for (auto p = 0; p < collected[i].partitions.size(); ++p) {
+            ASSERT_EQ(
+              collected[i].partitions[p].id, original[i].partitions[p].id);
+            ASSERT_EQ(
+              collected[i].partitions[p].leader_id,
+              original[i].partitions[p].leader_id);
+            ASSERT_EQ(
+              collected[i].partitions[p].revision_id,
+              original[i].partitions[p].revision_id);
+            ASSERT_EQ(
+              collected[i].partitions[p].term, original[i].partitions[p].term);
+            ASSERT_EQ(
+              collected[i].partitions[p].under_replicated_replicas,
+              original[i].partitions[p].under_replicated_replicas.value_or(0));
+            ASSERT_EQ(
+              collected[i].partitions[p].size_bytes,
+              original[i].partitions[p].size_bytes);
+            ASSERT_EQ(
+              collected[i].partitions[p].shard,
+              original[i].partitions[p].shard);
+            ASSERT_EQ(
+              collected[i].partitions[p].reclaimable_size_bytes,
+              original[i].partitions[p].reclaimable_size_bytes);
+        }
+    }
+}
+
+TEST(health_monitor_types, basic_iteration) {
+    auto report = make_columnar_node_health_report(10, 10);
+    size_t topics = 0;
+    size_t partitions = 0;
+    for (auto& tp : report.topics) {
+        for (auto& p : tp.partitions) {
+            ++partitions;
+            (void)(p);
+        }
+        ++topics;
+    }
+
+    EXPECT_EQ(topics, 10);
+    EXPECT_EQ(partitions, 100);
+}
+
+TEST(health_monitor_types, test_conversion_to_legacy_node_report) {
+    auto report = make_columnar_node_health_report(50, 50);
+    auto legacy_report = report.materialize_legacy_report();
+    auto collected = collect_statuses(report.topics);
+
+    EXPECT_EQ(collected, legacy_report.topics);
+}
+
+TEST_CORO(health_monitor_types, serde_roundtrip) {
+    std::vector<std::pair<int, int>> params{
+      std::make_pair(50000, 3),
+      std::make_pair(100, 1500),
+      std::make_pair(100, 200)};
+    for (auto& [topics, partitions] : params) {
+        auto report = make_columnar_node_health_report(topics, partitions);
+        auto expected_view = collect_statuses(report.topics);
+        iobuf columnar_buffer;
+        iobuf legacy_buffer;
+
+        co_await serde::write_async(
+          legacy_buffer, report.materialize_legacy_report());
+        co_await serde::write_async(columnar_buffer, std::move(report));
+
+        fmt::print(
+          "topics: {}, partitions per topic: {}, columnar serialized size: {} "
+          "legacy serialized size: {}\n",
+          topics,
+          partitions,
+          human::bytes(columnar_buffer.size_bytes()),
+          human::bytes(legacy_buffer.size_bytes()));
+        iobuf_parser parser(std::move(columnar_buffer));
+        auto deserialized
+          = co_await serde::read_async<columnar_node_health_report>(parser);
+
+        ASSERT_EQ_CORO(expected_view, collect_statuses(deserialized.topics));
+    }
+}
+
+template<typename ColT>
+void check_size(ColT& c) {
+    iobuf buffer;
+    serde::write(buffer, std::move(c));
+    fmt::print("column size: {}\n", human::bytes(buffer.size_bytes()));
+}
+
+TEST(health_monitor_types, serde_sizes) {
+    std::vector<std::pair<size_t, size_t>> params{
+      std::make_pair(50000, 3),
+      std::make_pair(100, 1500),
+      std::make_pair(100, 200)};
+    for (auto& [topics, partitions] : params) {
+        auto report = make_columnar_node_health_report(topics, partitions);
+        auto expected_view = collect_statuses(report.topics);
+
+        iobuf columnar_buffer;
+        iobuf legacy_buffer;
+        fmt::print(
+          "topics: {}, partitions per topic: {}\n", topics, partitions);
+        auto fields = report.topics.serde_fields();
+        auto buf = serde::to_iobuf(std::get<0>(fields));
+        fmt::print("namespaces: {}\n", human::bytes(buf.size_bytes()));
+        auto buf_2 = serde::to_iobuf(std::move(std::get<1>(fields)));
+        fmt::print("topics: {}\n", human::bytes(buf_2.size_bytes()));
+        auto& p_cstore = std::get<2>(fields);
+        std::apply(
+          [](auto&&... col) { (check_size(col), ...); },
+          p_cstore.serde_fields());
+    }
+}
+
+TEST(health_monitor_types, iteration_types) {
+    auto report = make_columnar_node_health_report(5, 5);
+
+    for (auto& tp : report.topics) {
+        for (auto& p : tp.partitions) {
+            (void)(p);
+        }
+    }
+}
+
+TEST(health_monitor_types, print) {
+    auto report = make_columnar_node_health_report(5, 5);
+
+    fmt::print("{}", report);
+}

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -96,6 +96,18 @@ inline node_health_report random_node_health_report() {
       random_ds};
 }
 
+inline columnar_node_health_report random_columnar_node_health_report() {
+    columnar_node_health_report report;
+    report.id = tests::random_named_int<model::node_id>();
+    report.local_state = node::random_local_state();
+    report.drain_status = random_drain_status();
+    auto topics = tests::random_chunked_vector(random_topic_status);
+    for (auto& t : topics) {
+        report.topics.append(t.tp_ns, t.partitions);
+    }
+    return report;
+}
+
 inline cluster_health_report random_cluster_health_report() {
     return cluster_health_report{
       {},

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -1634,11 +1634,14 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         cluster::get_node_health_reply data{
           .report = report,
         };
-        roundtrip_test(data);
+        roundtrip_test(std::move(data));
         // try serde with non-default error code. adl doesn't encode error so
         // this is a serde only test.
-        data.error = cluster::errc::error_collecting_health_report;
-        roundtrip_test(data);
+        cluster::get_node_health_reply other_data{
+          .report = report,
+        };
+        other_data.error = cluster::errc::error_collecting_health_report;
+        roundtrip_test(std::move(other_data));
     }
     {
         std::vector<model::node_id> nodes;

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -282,6 +282,12 @@ inline void rjson_serialize(
     rjson_serialize(w, f.revision_id);
     w.Key("size_bytes");
     rjson_serialize(w, f.size_bytes);
+    w.Key("under_replicated_replicas");
+    rjson_serialize(w, f.under_replicated_replicas);
+    w.Key("reclaimable_size_bytes");
+    rjson_serialize(w, f.reclaimable_size_bytes);
+    w.Key("shard");
+    rjson_serialize(w, f.shard);
     w.EndObject();
 }
 
@@ -389,14 +395,29 @@ inline void read_value(json::Value const& rd, cluster::partition_status& obj) {
     std::optional<model::node_id> leader_id;
     model::revision_id revision_id;
     size_t size_bytes;
+    std::optional<uint8_t> under_replicated_replicas;
+    std::optional<size_t> reclaimable_size_bytes;
+    uint32_t shard;
 
     read_member(rd, "id", id);
     read_member(rd, "term", term);
     read_member(rd, "leader_id", leader_id);
     read_member(rd, "revision_id", revision_id);
     read_member(rd, "size_bytes", size_bytes);
+    read_member(rd, "under_replicated_replicas", under_replicated_replicas);
+    read_member(rd, "reclaimable_size_bytes", reclaimable_size_bytes);
+    read_member(rd, "shard", shard);
+
     obj = cluster::partition_status{
-      {}, id, term, leader_id, revision_id, size_bytes};
+      .id = id,
+      .term = term,
+      .leader_id = leader_id,
+      .revision_id = revision_id,
+      .size_bytes = size_bytes,
+      .under_replicated_replicas = under_replicated_replicas,
+      .reclaimable_size_bytes = reclaimable_size_bytes,
+      .shard = shard,
+    };
 }
 
 inline void read_value(json::Value const& rd, cluster::topic_status& obj) {

--- a/src/v/compat/get_node_health_compat.h
+++ b/src/v/compat/get_node_health_compat.h
@@ -20,8 +20,14 @@ namespace compat {
 
 GEN_COMPAT_CHECK_SERDE_ONLY(
   cluster::get_node_health_request,
-  { json_write(filter); },
-  { json_read(filter); });
+  {
+      json_write(filter);
+      json_write(use_columnar_format);
+  },
+  {
+      json_read(filter);
+      json_read(use_columnar_format);
+  });
 
 template<>
 struct compat_check<cluster::get_node_health_reply> {
@@ -36,18 +42,20 @@ struct compat_check<cluster::get_node_health_reply> {
       json::Writer<json::StringBuffer>& wr) {
         json_write(error);
         json_write(report);
+        json_write(columnar_report);
     }
 
     static cluster::get_node_health_reply from_json(json::Value& rd) {
         cluster::get_node_health_reply obj;
         json_read(error);
         json_read(report);
+        json_read(columnar_report);
         return obj;
     }
 
     static std::vector<compat_binary>
     to_binary(cluster::get_node_health_reply obj) {
-        return {compat_binary::serde(obj)};
+        return {compat_binary::serde(std::move(obj))};
     }
 
     static void

--- a/src/v/compat/get_node_health_generator.h
+++ b/src/v/compat/get_node_health_generator.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 
+#include "cluster/health_monitor_types.h"
 #include "cluster/tests/randoms.h"
 #include "cluster/types.h"
 #include "compat/generator.h"
@@ -22,9 +23,9 @@ template<>
 struct instance_generator<cluster::get_node_health_request> {
     static cluster::get_node_health_request random() {
         return cluster::get_node_health_request{
-          {},
-          cluster::random_node_report_filter(),
-          random_generators::get_int<int8_t>()};
+          .filter = cluster::random_node_report_filter(),
+          .use_columnar_format = cluster::columnar_version(
+            tests::random_bool())};
     }
     static std::vector<cluster::get_node_health_request> limits() { return {}; }
 };
@@ -36,6 +37,8 @@ struct instance_generator<cluster::get_node_health_reply> {
           .error = instance_generator<cluster::errc>::random(),
           .report = tests::random_optional(
             [] { return cluster::random_node_health_report(); }),
+          .columnar_report = tests::random_optional(
+            [] { return cluster::random_columnar_node_health_report(); }),
         };
     }
     static std::vector<cluster::get_node_health_reply> limits() { return {}; }

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -511,7 +511,7 @@ private:
                         = decom[Is].second;
                       for (auto& e : input) {
                           end_iter = serialize_little_endian<bytes_to_save>(
-                            std::make_unsigned_t<TVal>(e)
+                            static_cast<uint64_t>(e)
                               >> shift_of_to_save_section,
                             end_iter);
                       }
@@ -629,7 +629,7 @@ private:
                           auto tmp = std::make_unsigned_t<TVal>{};
                           end_it = deserialize_little_endian<bytes_to_restore>(
                             end_it, tmp);
-                          e |= tmp << shift_of_restored;
+                          e |= static_cast<uint64_t>(tmp) << shift_of_restored;
                       }
                   }(),
                   ...);

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -258,6 +258,10 @@ struct deltafor_stream_pos_t
     /// Number of rows before the next row
     uint32_t num_rows;
 
+    friend bool
+    operator==(const deltafor_stream_pos_t&, const deltafor_stream_pos_t&)
+      = default;
+
     auto serde_fields() { return std::tie(initial, offset, num_rows); }
 };
 
@@ -992,6 +996,9 @@ public:
         return tmp;
     }
 
+    friend bool operator==(const deltafor_frame&, const deltafor_frame&)
+      = default;
+
 private:
     template<class PredT>
     const_iterator pred_search(value_t value) const {
@@ -1454,6 +1461,10 @@ public:
         }
         return tmp;
     }
+
+    friend bool
+    operator==(const deltafor_column_impl&, const deltafor_column_impl&)
+      = default;
 
 protected:
     auto get_frame_iterator_by_element_index(size_t ix) const {

--- a/src/v/utils/delta_for.h
+++ b/src/v/utils/delta_for.h
@@ -1042,6 +1042,23 @@ public:
         return tmp;
     }
 
+    deltafor_frame copy() const {
+        deltafor_frame f;
+        f._head = _head;
+        f._last_row = _last_row;
+        f._size = _size;
+        if (_tail) {
+            encoder_t enc(
+              _tail->get_initial_value(),
+              _tail->get_row_count(),
+              _tail->get_last_value(),
+              _tail->copy());
+            f._tail = std::move(enc);
+        }
+
+        return f;
+    }
+
     friend bool operator==(const deltafor_frame&, const deltafor_frame&)
       = default;
 
@@ -1680,6 +1697,14 @@ public:
     using typename base_t::const_iterator;
     using typename base_t::lw_const_iterator;
 
+    deltafor_column copy() const {
+        deltafor_column column;
+        for (const auto& f : this->_frames) {
+            column._frames.push_back(f.copy());
+        }
+        return column;
+    }
+
     /// Find first value that matches the predicate
     const_iterator pred_search(
       value_t value, std::regular_invocable<value_t, value_t> auto pred) const {
@@ -1717,6 +1742,14 @@ public:
     using base_t::base_t;
     using typename base_t::const_iterator;
     using typename base_t::lw_const_iterator;
+
+    deltafor_column copy() const {
+        deltafor_column column;
+        for (const auto& f : this->_frames) {
+            column._frames.push_back(f.copy());
+        }
+        return column;
+    }
 
     const_iterator pred_search(
       value_t value, std::regular_invocable<value_t, value_t> auto pred) const {

--- a/src/v/utils/tests/delta_for_test.cc
+++ b/src/v/utils/tests/delta_for_test.cc
@@ -20,6 +20,7 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <iterator>
 #include <ranges>
 #include <stdexcept>
 
@@ -1082,4 +1083,17 @@ BOOST_AUTO_TEST_CASE(test_delta_for_cstore_col_at_with_hint_xor) {
 BOOST_AUTO_TEST_CASE(test_delta_for_cstore_col_at_with_hint_delta) {
     delta_delta_column column{};
     at_with_hint_test_case(short_test_size, column);
+}
+
+static_assert(std::forward_iterator<delta_delta_column::lw_const_iterator>);
+
+BOOST_AUTO_TEST_CASE(test_lw_iterator) {
+    delta_delta_column column;
+    for (auto i = 0; i < 20000; ++i) {
+        column.append(i);
+    }
+    size_t i = 0;
+    for (auto it = column.lw_begin(); it != column.lw_end(); ++it) {
+        BOOST_REQUIRE_EQUAL(i++, *it);
+    }
 }

--- a/src/v/utils/tests/delta_for_test.cc
+++ b/src/v/utils/tests/delta_for_test.cc
@@ -1097,3 +1097,23 @@ BOOST_AUTO_TEST_CASE(test_lw_iterator) {
         BOOST_REQUIRE_EQUAL(i++, *it);
     }
 }
+
+BOOST_AUTO_TEST_CASE(test_copying_delta_spec) {
+    delta_delta_column column;
+    for (auto i = 0; i < 20000; ++i) {
+        column.append(i);
+    }
+    auto another = column.copy();
+
+    BOOST_REQUIRE(another == column);
+}
+
+BOOST_AUTO_TEST_CASE(test_copying_xor_spec) {
+    delta_xor_column column;
+    for (auto i = 0; i < 20000; ++i) {
+        column.append(i);
+    }
+    auto another = column.copy();
+
+    BOOST_REQUIRE(another == column);
+}

--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -98,18 +98,6 @@ class NodeDecommissionWaiter():
             node_id
         ] if decommissioned_node_ids == None else decommissioned_node_ids
 
-    def _nodes_with_decommission_progress_api(self):
-        def has_decommission_progress_api(node):
-            v = int_tuple(
-                VERSION_RE.findall(self.redpanda.get_version(node))[0])
-            # decommission progress api is available since v22.3.12
-            return v[0] >= 23 or (v[0] == 22 and v[1] == 3 and v[2] >= 12)
-
-        return [
-            n for n in self.redpanda.started_nodes()
-            if has_decommission_progress_api(n)
-        ]
-
     def _dump_partition_move_available_bandwidth(self):
         def get_metric(self, node):
             try:
@@ -134,7 +122,7 @@ class NodeDecommissionWaiter():
 
     def _not_decommissioned_node(self):
         return random.choice([
-            n for n in self._nodes_with_decommission_progress_api()
+            n for n in self.redpanda.started_nodes()
             if self.redpanda.node_id(n) not in self.decommissioned_node_ids
         ])
 


### PR DESCRIPTION
Introduced a new way of storing partition statuses in health monitor.
Health monitor gathers information about every partition that exists in
the cluster to provide other components with the information on
partition health, their sizes and other runtime specific metadata. With
large number of topics and partition in the system serde operations are
computationally expensive and the data structures used cause significant
memory pressure.

In order to address that and increase Redpadna capabilities in terms of
supported partition and topic numbers replaced the old way of storing
partition statuses with new optimized columnar format. In columnar
representation values of each field of the `partition_status` data
structure are stored in one `delta_for_column`. All the topic partition
statuses are flattened into one columnar store. This way there is only
few columns to deal with when serializing and deserializing the data
structure. An additional optimisation is to keep an index of all
namespaces instead of having it materialized for each topic in the
report.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- better handling large partition counts