### PR TITLE
clang-tidy: disable misc-include-cleaner

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter,-misc-include-cleaner'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 AnalyzeTemporaryDtors: false

--- a/.clang-tidy-strict
+++ b/.clang-tidy-strict
@@ -1,8 +1,9 @@
 # altera-*, fuschia-*, llvmlibc-*: project specific checks
 # llvm-header-guard: in redpanda we normally to use `#pragma once`
 # modernize-use-trailing-return-type: arbitrary style choice
+# misc-include-cleaner: the check has many false positives and is noisy
 ---
-Checks: '*,-altera-*,-fuchsia-*,-llvmlibc-*,-llvm-header-guard,-modernize-use-trailing-return-type'
+Checks: '*,-altera-*,-fuchsia-*,-llvmlibc-*,-llvm-header-guard,-modernize-use-trailing-return-type,-misc-include-cleaner'
 WarningsAsErrors: false
 CheckOptions:
   - key:             readability-identifier-length.IgnoredVariableNames

--- a/.clang-tidy-strict-tests
+++ b/.clang-tidy-strict-tests
@@ -4,8 +4,9 @@
 # readability-magic-numbers: duplicate
 # cppcoreguidelines-pointer-arithmetic: quality of life improvement
 # misc-non-private-member-variables-in-classes: quality of life improvement
+# misc-include-cleaner: the check has many false positives and is noisy
 ---
 Checks:
-'-readability-function-cognitive-complexity,-readability-identifier-length,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-misc-non-private-member-variables-in-classes'
+'-readability-function-cognitive-complexity,-readability-identifier-length,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-misc-non-private-member-variables-in-classes,-misc-include-cleaner'
 InheritParentConfig: true
 ...


### PR DESCRIPTION
This clang tidy very buggy, and has false positives.
See: https://github.com/search?q=repo%3Allvm%2Fllvm-project+misc-include-cleaner&type=issues

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
