### PR TITLE
tests: allow node ready timeout to be adjusted

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1103,6 +1103,7 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
     COVERAGE_PROFRAW_CAPTURE = os.path.join(PERSISTENT_ROOT,
                                             "redpanda.profraw")
     DEFAULT_NODE_READY_TIMEOUT_SEC = 20
+    NODE_READY_TIMEOUT_MIN_SEC_KEY = "node_ready_timeout_min_sec"
     DEFAULT_CLOUD_STORAGE_SCRUB_TIMEOUT_SEC = 60
     DEDICATED_NODE_KEY = "dedicated_nodes"
     RAISE_ON_ERRORS_KEY = "raise_on_error"
@@ -2259,6 +2260,12 @@ class RedpandaService(RedpandaServiceBase):
 
         if node_ready_timeout_s is None:
             node_ready_timeout_s = RedpandaService.DEFAULT_NODE_READY_TIMEOUT_SEC
+        # apply min timeout rule. some tests may override this with larger
+        # timeouts, so take the maximum.
+        node_ready_timeout_min_s = self._context.globals.get(
+            self.NODE_READY_TIMEOUT_MIN_SEC_KEY, node_ready_timeout_s)
+        node_ready_timeout_s = max(node_ready_timeout_s,
+                                   node_ready_timeout_min_s)
         self.node_ready_timeout_s = node_ready_timeout_s
 
         if cloud_storage_scrub_timeout_s is None:


### PR DESCRIPTION
Sometimes things are slow on bootup (like hella page faults), so provide a mechanism to allow tests to proceed without having to first solve the slow bootup process.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

