### PR TITLE
goreleaser: adjust goreleaser to dynamically link rpk on linux 

### DIFF
--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -85,7 +85,7 @@ builds:
           env:
             - QUILL_LOG_FILE=dist/quill-{{ .Target }}.log
 archives:
-  - id: rpk
+  - id: rpk-zip
     builds:
       - rpk-linux
       - rpk-windows
@@ -96,6 +96,8 @@ release:
   github:
     owner: redpanda-data
     name: redpanda
+  ids:
+    - rpk-zip
   draft: true
   discussion_category_name: Releases
 brews:
@@ -108,7 +110,7 @@ brews:
     folder: Formula
     skip_upload: auto
     ids:
-      - rpk
+      - rpk-zip
     extra_install: |
       generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
     caveats: |

--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -55,12 +55,6 @@ archives:
       - rpk-darwin
     format: zip
     name_template: "rpk-{{ .Os }}-{{ .Arch }}"
-  - id: migration-tool
-    builds:
-      - migration-tool-windows-and-linux
-      - migration-tool-darwin
-    format: zip
-    name_template: "cluster-to-redpanda-migration-{{ .Os }}-{{ .Arch }}"
 release:
   github:
     owner: redpanda-data

--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -1,5 +1,25 @@
 project_name: rpk
 builds:
+  # rpk-windows-and-linux is deprecated; will be replaced by rpk-windows, rpk-linux, rpk-linux-microsoft-go
+  - id: rpk-windows-and-linux
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+      - linux
+    goarch:
+      - amd64
+      - arm64
   - id: rpk-linux-microsoft-go
     dir: ./rpk/
     main: ./cmd/rpk
@@ -87,8 +107,7 @@ builds:
 archives:
   - id: rpk-zip
     builds:
-      - rpk-linux
-      - rpk-windows
+      - rpk-windows-and-linux
       - rpk-darwin
     format: zip
     name_template: "rpk-{{ .Os }}-{{ .Arch }}"

--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -1,5 +1,24 @@
 project_name: rpk
 builds:
+  - id: rpk-linux-microsoft-go
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=1
+      - GOEXPERIMENT=systemcrypto
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
   - id: rpk-linux
     dir: ./rpk/
     main: ./cmd/rpk

--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -1,6 +1,24 @@
 project_name: rpk
 builds:
-  - id: rpk-windows-and-linux
+  - id: rpk-linux
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-windows
     dir: ./rpk/
     main: ./cmd/rpk
     binary: rpk
@@ -15,7 +33,6 @@ builds:
       - CGO_ENABLED=0
     goos:
       - windows
-      - linux
     goarch:
       - amd64
       - arm64
@@ -51,7 +68,8 @@ builds:
 archives:
   - id: rpk
     builds:
-      - rpk-windows-and-linux
+      - rpk-linux
+      - rpk-windows
       - rpk-darwin
     format: zip
     name_template: "rpk-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
fixes https://redpandadata.atlassian.net/browse/PESDLC-1005

add goreleaser build id `rpk-linux-microsoft-go` for use with microsoft's golang compiler. this configures the compiler to dynamically link `rpk` for deb/rpm packages.

the `zip` files of `rpk` generated by goreleaser that are attached as assets to redpanda github releases are left as statically compiled.

~this PR needs to be merged in sync with PR https://github.com/redpanda-data/vtools/pull/2588~
EDIT: i added git commit e6e39e7 so existing vtools can work without changes

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
