### PR TITLE
TLS Metrics: Ensure that recorded expiries advance on credentials reload

### DIFF
--- a/tests/rptest/tests/tls_metrics_test.py
+++ b/tests/rptest/tests/tls_metrics_test.py
@@ -40,7 +40,10 @@ ADMIN_TLS_CONFIG = dict(name='iplistener',
 
 
 class FaketimeTLSProvider(TLSProvider):
-    def __init__(self, tls, broker_faketime='-0d', client_faketime='-0d'):
+    def __init__(self,
+                 tls: tls.TLSCertManager,
+                 broker_faketime='-0d',
+                 client_faketime='-0d'):
         self.tls = tls
         self.broker_faketime = broker_faketime
         self.client_faketime = client_faketime
@@ -251,6 +254,51 @@ class TLSMetricsTest(TLSMetricsTestBase):
         assert 'rpc' in areas
         assert 'rest_proxy' in areas
         assert 'admin' in areas
+
+    @cluster(num_nodes=3)
+    def test_expiry_reload(self):
+        """
+        Verify that when replacing certificat X by certificate Y s.t.
+        expiry(Y) > expiry(X), the new expiry is reflected in the metrics.
+        """
+        node = self.redpanda.nodes[0]
+
+        metrics_samples = self._get_metrics_from_node(node, self.CERT_METRICS)
+        assert metrics_samples is not None, "Failed to get metrics"
+        vals = self._unpack_samples(metrics_samples)
+
+        status_before = dict(
+            expiry=vals['certificate_expires_at_timestamp_seconds'][0]
+            ['value'],
+            loaded=vals['loaded_at_timestamp_seconds'][0]['value'])
+        self.logger.debug(
+            f"Before reload: {json.dumps(status_before, indent=1)}")
+
+        time.sleep(5)
+
+        self.security.tls_provider = FaketimeTLSProvider(
+            tls=tls.TLSCertManager(self.logger, cert_expiry_days=10))
+
+        self.redpanda.set_security_settings(self.security)
+        self.redpanda.write_tls_certs()
+
+        metrics_samples = self._get_metrics_from_node(node, self.CERT_METRICS)
+        assert metrics_samples is not None, "Failed to get metrics"
+        vals = self._unpack_samples(metrics_samples)
+
+        status_after = dict(
+            expiry=vals['certificate_expires_at_timestamp_seconds'][0]
+            ['value'],
+            loaded=vals['loaded_at_timestamp_seconds'][0]['value'])
+        self.logger.debug(
+            f"After reload: {json.dumps(status_after, indent=1)}")
+
+        five_days = 5 * 24 * 60 * 60
+
+        assert status_before['loaded'] < status_after[
+            'loaded'], f"Unexpected status after reload: {json.dumps(status_after)}"
+        assert status_before['expiry'] + five_days < status_after[
+            'expiry'], f"Unexpected status after reload: {json.dumps(status_after)}"
 
 
 class TLSMetricsTestChain(TLSMetricsTestBase):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

What it says on the box.

Fixes https://github.com/redpanda-data/redpanda/issues/16840

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fixes a bug with TLS metrics where expiration timestamps would not advance on certificate reload

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
