### PR TITLE
feature_table: remove dependency on cluster/types.h

### DIFF
--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -18,6 +18,7 @@
 #include "cluster/errc.h"
 #include "cluster/logger.h"
 #include "cluster/prefix_truncate_record.h"
+#include "cluster/types.h"
 #include "config/configuration.h"
 #include "container/fragmented_vector.h"
 #include "features/feature_table.h"

--- a/src/v/archival/scrubber.cc
+++ b/src/v/archival/scrubber.cc
@@ -12,6 +12,7 @@
 
 #include "archival/logger.h"
 #include "archival/ntp_archiver_service.h"
+#include "cluster/errc.h"
 
 namespace archival {
 

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -16,6 +16,7 @@
 #include "cluster/errc.h"
 #include "cluster/logger.h"
 #include "distributed_kv_stm_types.h"
+#include "hashing/murmur.h"
 #include "raft/consensus.h"
 #include "raft/persisted_stm.h"
 #include "utils/fixed_string.h"

--- a/src/v/cluster/log_eviction_stm.cc
+++ b/src/v/cluster/log_eviction_stm.cc
@@ -10,6 +10,7 @@
 #include "cluster/log_eviction_stm.h"
 
 #include "bytes/iostream.h"
+#include "cluster/errc.h"
 #include "cluster/logger.h"
 #include "cluster/prefix_truncate_record.h"
 #include "model/fundamental.h"

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -15,6 +15,7 @@
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
 #include "cluster/tx_hash_ranges.h"
+#include "cluster/version.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -52,13 +53,6 @@
 
 namespace cluster {
 using consensus_ptr = ss::lw_shared_ptr<raft::consensus>;
-
-// A cluster version is a logical protocol version describing the content
-// of the raft0 on disk structures, and available features.  These are
-// passed over the network via the health_manager, and persisted in
-// the feature_manager
-using cluster_version = named_type<int64_t, struct cluster_version_tag>;
-constexpr cluster_version invalid_version = cluster_version{-1};
 
 using replicas_t = std::vector<model::broker_shard>;
 struct allocate_id_request

--- a/src/v/cluster/version.h
+++ b/src/v/cluster/version.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "utils/named_type.h"
+
+namespace cluster {
+
+// A cluster version is a logical protocol version describing the content
+// of the raft0 on disk structures, and available features.  These are
+// passed over the network via the health_manager, and persisted in
+// the feature_manager
+using cluster_version = named_type<int64_t, struct cluster_version_tag>;
+constexpr cluster_version invalid_version = cluster_version{-1};
+
+} // namespace cluster

--- a/src/v/features/feature_state.h
+++ b/src/v/features/feature_state.h
@@ -11,7 +11,9 @@
 
 #pragma once
 
-#include "cluster/types.h"
+#include "cluster/version.h"
+
+#include <cstdint>
 
 namespace features {
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "cluster/types.h"
 #include "features/feature_state.h"
 #include "security/license.h"
 #include "storage/record_batch_builder.h"
@@ -26,6 +25,7 @@ namespace cluster {
 class feature_backend;
 class feature_manager;
 class bootstrap_backend;
+struct feature_update_action;
 } // namespace cluster
 
 namespace features {

--- a/src/v/raft/heartbeat_manager.h
+++ b/src/v/raft/heartbeat_manager.h
@@ -24,6 +24,7 @@
 #include <seastar/util/log.hh>
 
 #include <absl/container/btree_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <absl/container/node_hash_map.h>
 #include <boost/container/flat_set.hpp>
 

--- a/src/v/raft/offset_translator.h
+++ b/src/v/raft/offset_translator.h
@@ -13,6 +13,7 @@
 
 #include "base/units.h"
 #include "model/fundamental.h"
+#include "raft/fundamental.h"
 #include "ssx/semaphore.h"
 #include "storage/fwd.h"
 #include "storage/log.h"

--- a/src/v/raft/recovery_scheduler.cc
+++ b/src/v/raft/recovery_scheduler.cc
@@ -10,11 +10,12 @@
 #include "raft/recovery_scheduler.h"
 
 #include "base/vassert.h"
+#include "cluster/types.h"
 #include "prometheus/prometheus_sanitize.h"
 #include "raft/consensus.h"
 #include "raft/types.h"
-#include "seastar/core/coroutine.hh"
 
+#include <seastar/core/coroutine.hh>
 #include <seastar/core/metrics.hh>
 
 namespace raft {

--- a/src/v/raft/types.cc
+++ b/src/v/raft/types.cc
@@ -11,6 +11,7 @@
 
 #include "base/vassert.h"
 #include "base/vlog.h"
+#include "model/async_adl_serde.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"

--- a/src/v/storage/compaction_reducers.h
+++ b/src/v/storage/compaction_reducers.h
@@ -30,6 +30,8 @@
 #include <fmt/core.h>
 #include <roaring/roaring.hh>
 
+#include <queue>
+
 namespace storage::internal {
 
 struct compaction_reducer {};

--- a/src/v/storage/index_state.cc
+++ b/src/v/storage/index_state.cc
@@ -20,6 +20,7 @@
 #include "serde/serde_exception.h"
 #include "storage/index_state_serde_compat.h"
 #include "storage/logger.h"
+#include "utils/to_string.h"
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>


### PR DESCRIPTION
Feature table is included all over the tree, yet it included
cluster/types.h which has a large number of other dependencies. Feature
table only needs the cluster_version definition. In affect feature table
was being used around the tree as an implicit alias for cluster/types.h.

```
  In file included from src/v/storage/segment_reader.cc:16:
  In file included from src/v/storage/segment_utils.h:20:
  In file included from src/v/storage/readers_cache.h:20:
  In file included from src/v/storage/log_reader.h:20:
  In file included from src/v/storage/segment.h:20:
  In file included from src/v/storage/segment_index.h:13:
  In file included from src/v/features/feature_table.h:14:
  In file included from src/v/cluster/types.h:14:
  In file included from src/v/cluster/cloud_metadata/cluster_manifest.h:13:
  In file included from src/v/cloud_storage/base_manifest.h:14:
  In file included from src/v/cloud_storage/types.h:14:
  In file included from src/v/cloud_storage_clients/configuration.h:14:
  src/redpanda-storage-v2/src/v/cloud_storage_clients/client_probe.h:17:10: fatal error: 'http/probe.h' file not found
  #include "http/probe.h"
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
