### PR TITLE
kafka: chunked_vector for config responses

### DIFF
--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -472,6 +472,7 @@ override_member_container = {
     'creatable_topic_configs': 'chunked_vector',
     'creatable_topic_result': 'chunked_vector',
     'describe_configs_resource_result': 'chunked_vector',
+    'describe_configs_result': 'chunked_vector',
 }
 
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -470,6 +470,7 @@ override_member_container = {
     'offset_fetch_response_partition': 'small_fragment_vector',
     'creatable_topic': 'chunked_vector',
     'creatable_topic_configs': 'chunked_vector',
+    'describe_configs_resource_result': 'chunked_vector',
 }
 
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -470,6 +470,7 @@ override_member_container = {
     'offset_fetch_response_partition': 'small_fragment_vector',
     'creatable_topic': 'chunked_vector',
     'creatable_topic_configs': 'chunked_vector',
+    'creatable_topic_result': 'chunked_vector',
     'describe_configs_resource_result': 'chunked_vector',
 }
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -468,7 +468,8 @@ override_member_container = {
     'metadata_response_topic': 'small_fragment_vector',
     'fetchable_partition_response': 'small_fragment_vector',
     'offset_fetch_response_partition': 'small_fragment_vector',
-    'creatable_topic': 'chunked_vector'
+    'creatable_topic': 'chunked_vector',
+    'creatable_topic_configs': 'chunked_vector',
 }
 
 

--- a/src/v/kafka/protocol/tests/protocol_test.cc
+++ b/src/v/kafka/protocol/tests/protocol_test.cc
@@ -216,21 +216,24 @@ template<>
 long create_default_and_non_default_data(
   decltype(create_topics_response::data)& non_default_data,
   decltype(create_topics_response::data)& default_data) {
+    auto make_topic_result = [](kafka::error_code ec) {
+        return creatable_topic_result{
+          model::topic{"topic1"},
+          {},
+          kafka::error_code{1},
+          "test_error_message",
+          3,
+          16,
+          std::nullopt,
+          ec};
+    };
+
     non_default_data.throttle_time_ms = std::chrono::milliseconds(1000);
+    non_default_data.topics.emplace_back(
+      make_topic_result(kafka::error_code{2}));
 
-    non_default_data.topics.emplace_back(creatable_topic_result{
-      model::topic{"topic1"},
-      {},
-      kafka::error_code{1},
-      "test_error_message",
-      3,
-      16,
-      std::nullopt,
-      kafka::error_code{2}});
-
-    default_data = non_default_data;
-
-    default_data.topics.at(0).topic_config_error_code = kafka::error_code{0};
+    default_data.throttle_time_ms = std::chrono::milliseconds(1000);
+    default_data.topics.emplace_back(make_topic_result(kafka::error_code{0}));
 
     // int16 (2 bytes) + tag (2 bytes)
     return 4;

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -562,12 +562,12 @@ public:
         return _out->size_bytes() - start_size;
     }
 
-    template<typename T, typename ElementWriter>
-    requires requires(ElementWriter writer, encoder& rw, T& elem) {
+    template<typename C, typename ElementWriter>
+    requires requires(
+      ElementWriter writer, encoder& rw, typename C::value_type& elem) {
         { writer(elem, rw) } -> std::same_as<void>;
     }
-    uint32_t write_nullable_array(
-      std::optional<std::vector<T>>& v, ElementWriter&& writer) {
+    uint32_t write_nullable_array(std::optional<C>& v, ElementWriter&& writer) {
         if (!v) {
             return write(int32_t(-1));
         }
@@ -589,12 +589,13 @@ public:
         return _out->size_bytes() - start_size;
     }
 
-    template<typename T, typename ElementWriter>
-    requires requires(ElementWriter writer, encoder& rw, T& elem) {
+    template<typename C, typename ElementWriter>
+    requires requires(
+      ElementWriter writer, encoder& rw, typename C::value_type& elem) {
         { writer(elem, rw) } -> std::same_as<void>;
     }
-    uint32_t write_nullable_flex_array(
-      std::optional<std::vector<T>>& v, ElementWriter&& writer) {
+    uint32_t
+    write_nullable_flex_array(std::optional<C>& v, ElementWriter&& writer) {
         if (!v) {
             return write_unsigned_varint(0);
         }

--- a/src/v/kafka/server/handlers/configs/config_response_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/types.h"
+#include "container/fragmented_vector.h"
 #include "kafka/protocol/describe_configs.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
 
@@ -35,7 +36,7 @@ struct config_response {
     creatable_topic_configs to_create_config();
 };
 
-using config_response_container_t = std::vector<config_response>;
+using config_response_container_t = chunked_vector<config_response>;
 using config_key_t = std::optional<std::vector<ss::sstring>>;
 
 config_response_container_t make_topic_configs(

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -197,7 +197,7 @@ ss::future<response_ptr> create_topics_handler::handle(
             append_topic_configs(ctx, err_resp);
         }
 
-        co_return co_await ctx.respond(err_resp);
+        co_return co_await ctx.respond(std::move(err_resp));
     }
 
     // fill in defaults if necessary
@@ -327,7 +327,7 @@ ss::future<response_ptr> create_topics_handler::handle(
         append_topic_configs(ctx, response);
     }
 
-    co_return co_await ctx.respond(response);
+    co_return co_await ctx.respond(std::move(response));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -24,7 +24,7 @@ namespace kafka {
 
 void append_cluster_results(
   const std::vector<cluster::topic_result>& cluster_results,
-  std::vector<creatable_topic_result>& kafka_results) {
+  chunked_vector<creatable_topic_result>& kafka_results) {
     std::transform(
       cluster_results.begin(),
       cluster_results.end(),

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -13,6 +13,7 @@
 #include "base/seastarx.h"
 #include "cluster/fwd.h"
 #include "cluster/types.h"
+#include "container/fragmented_vector.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/handlers/topics/validators.h"
 #include "model/timeout_clock.h"
@@ -110,7 +111,7 @@ Iter validate_requests_range(
 // Kafka protocol error message
 void append_cluster_results(
   const std::vector<cluster::topic_result>&,
-  std::vector<creatable_topic_result>&);
+  chunked_vector<creatable_topic_result>&);
 
 // Converts objects representing KafkaAPI message to objects consumed
 // by cluster::controller API

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -230,7 +230,7 @@ to_cluster_type(const creatable_topic& t) {
 }
 
 static std::vector<kafka::creatable_topic_configs>
-convert_topic_configs(std::vector<kafka::config_response>&& topic_cfgs) {
+convert_topic_configs(config_response_container_t&& topic_cfgs) {
     auto configs = std::vector<kafka::creatable_topic_configs>();
     configs.reserve(topic_cfgs.size());
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "cluster/types.h"
+#include "container/fragmented_vector.h"
 #include "kafka/protocol/schemata/create_topics_request.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
 #include "kafka/server/errors.h"
@@ -149,12 +150,12 @@ from_cluster_topic_result(const cluster::topic_result& err) {
 }
 
 config_map_t config_map(const std::vector<createable_topic_config>& config);
-config_map_t config_map(const std::vector<creatable_topic_configs>& config);
+config_map_t config_map(const chunked_vector<creatable_topic_configs>& config);
 
 cluster::custom_assignable_topic_configuration
 to_cluster_type(const creatable_topic& t);
 
-std::vector<kafka::creatable_topic_configs> report_topic_configs(
+chunked_vector<kafka::creatable_topic_configs> report_topic_configs(
   const cluster::metadata_cache& metadata_cache,
   const cluster::topic_properties& topic_properties);
 

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -162,7 +162,7 @@ public:
     void assert_property_presented(
       const ss::sstring& resource_name,
       const ss::sstring& key,
-      const kafka::describe_configs_response resp,
+      const kafka::describe_configs_response& resp,
       const bool presented) {
         auto it = std::find_if(
           resp.data.results.begin(),
@@ -187,7 +187,7 @@ public:
 
     void assert_properties_amount(
       const ss::sstring& resource_name,
-      const kafka::describe_configs_response resp,
+      const kafka::describe_configs_response& resp,
       const size_t amount) {
         auto it = std::find_if(
           resp.data.results.begin(),
@@ -206,7 +206,7 @@ public:
       const model::topic& topic,
       const ss::sstring& key,
       const ss::sstring& value,
-      const kafka::describe_configs_response resp) {
+      const kafka::describe_configs_response& resp) {
         auto it = std::find_if(
           resp.data.results.begin(),
           resp.data.results.end(),


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This updates the `CreateTopics` and `DescribeConfigs` kafka api handlers to use `chunked_vector` instead of `std::vector` for the creation of their responses. This is to avoid fragmentation-related issues when the number of topics or partitions is large and so large allocations are necessary to generate the response.

Closes https://github.com/redpanda-data/core-internal/issues/1174

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
