### PR TITLE
transform-sdk/cpp: add string_view conversion from bytes_view

### DIFF
--- a/src/transform-sdk/cpp/examples/identity_logging.cc
+++ b/src/transform-sdk/cpp/examples/identity_logging.cc
@@ -17,19 +17,16 @@
 #include <print>
 
 int main() {
-    // This is an example of copying records from one location to another.
+    // This is an example of copying records from one location to another, with
+    // some printing.
     redpanda::on_record_written(
       [](redpanda::write_event event, redpanda::record_writer* writer) {
           redpanda::bytes_view raw_key = event.record.key.value_or(
             redpanda::bytes_view{});
           redpanda::bytes_view raw_value = event.record.value.value_or(
             redpanda::bytes_view{});
-          // NOLINTBEGIN(*-reinterpret-cast)
-          std::string_view key = {
-            reinterpret_cast<const char*>(raw_key.data()), raw_key.size()};
-          std::string_view value = {
-            reinterpret_cast<const char*>(raw_value.data()), raw_value.size()};
-          // NOLINTEND(*-reinterpret-cast)
+          auto key = std::string_view{raw_key};
+          auto value = std::string_view{raw_value};
           std::println(stderr, "{}:{}", key, value);
           return writer->write(event.record);
       });

--- a/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
+++ b/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
@@ -71,6 +71,9 @@ public:
     /** Returns true if the views have the same contents. */
     bool operator==(const bytes_view& other) const;
 
+    /** Convert this bytes view into a string view. */
+    explicit operator std::string_view() const;
+
 private:
     bytes::const_pointer _start{}, _end{};
 };

--- a/src/transform-sdk/cpp/src/transform_sdk.cc
+++ b/src/transform-sdk/cpp/src/transform_sdk.cc
@@ -59,7 +59,6 @@ void println(std::string_view str) {
     std::fwrite(msg.c_str(), sizeof(char), msg.size(), stderr);
     // NOLINTNEXTLINE
     std::fflush(stderr);
-    std::abort();
 }
 
 /**

--- a/src/transform-sdk/cpp/src/transform_sdk.cc
+++ b/src/transform-sdk/cpp/src/transform_sdk.cc
@@ -271,15 +271,11 @@ read_record_view(bytes_view payload) {
         ASSIGN_OR_RETURN(auto kv_result, read_kv(payload));
         payload = payload.subview(kv_result.read);
         auto [key_opt, value] = kv_result.value;
-        const std::string_view key
-          = key_opt
-              .transform([](bytes_view buf) {
-                  return std::string_view{
-                    // NOLINTNEXTLINE(*reinterpret-cast)
-                    reinterpret_cast<const char*>(buf.data()),
-                    buf.size()};
-              })
-              .value_or(std::string_view{});
+        const std::string_view key = key_opt
+                                       .transform([](bytes_view buf) {
+                                           return std::string_view{buf};
+                                       })
+                                       .value_or(std::string_view{});
         headers.emplace_back(key, value);
     }
     auto [key, value] = kv_result.value;
@@ -423,6 +419,10 @@ bytes::value_type bytes_view::operator[](size_t n) const { return _start[n]; }
 
 bool bytes_view::operator==(const bytes_view& other) const {
     return std::ranges::equal(*this, other);
+}
+bytes_view::operator std::string_view() const {
+    // NOLINTNEXTLINE(*-reinterpret-cast)
+    return {reinterpret_cast<const char*>(data()), size()};
 }
 
 header::operator header_view() const {


### PR DESCRIPTION
A small QoL improvement for the C++ SDK.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
