### PR TITLE
features: rename node_local_core_assignment

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -634,7 +634,7 @@ leader_balancer::build_group_id_to_topic_rev() const {
 ss::future<std::optional<leader_balancer::group_replicas_t>>
 leader_balancer::collect_group_replicas_from_health_report() {
     if (!_feature_table.is_active(
-          features::feature::node_local_core_assignment)) {
+          features::feature::partition_shard_in_health_report)) {
         co_return std::nullopt;
     }
 

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -99,8 +99,8 @@ std::string_view to_string_view(feature f) {
         return "audit_logging";
     case feature::compaction_placeholder_batch:
         return "compaction_placeholder_batch";
-    case feature::node_local_core_assignment:
-        return "node_local_core_assignment";
+    case feature::partition_shard_in_health_report:
+        return "partition_shard_in_health_report";
     case feature::role_based_access_control:
         return "role_base_access_control";
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -74,7 +74,7 @@ enum class feature : std::uint64_t {
     cloud_metadata_cluster_recovery = 1ULL << 40U,
     audit_logging = 1ULL << 41U,
     compaction_placeholder_batch = 1ULL << 42U,
-    node_local_core_assignment = 1ULL << 43U,
+    partition_shard_in_health_report = 1ULL << 43U,
     role_based_access_control = 1ULL << 44U,
 
     // Dummy features for testing only
@@ -375,8 +375,8 @@ constexpr static std::array feature_schema{
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{12},
-    "node_local_core_assignment",
-    feature::node_local_core_assignment,
+    "partition_shard_in_health_report",
+    feature::partition_shard_in_health_report,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{


### PR DESCRIPTION
Rename node_local_core_assignment to partition_shard_in_health_report as it will govern only the leader balancer behavior and actual node-local core assignment will be controlled by a separate feature flag.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none