### PR TITLE
Topic-aware topic/partition creation and partition balancing

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -374,6 +374,10 @@ ss::future<> controller::start(
             ss::sharded_parameter([] {
                 return config::shard_local_cfg()
                   .minimum_topic_replication.bind();
+            }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .partition_autobalancing_topic_aware.bind();
             }));
       })
       .then([this] {

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -659,7 +659,9 @@ ss::future<> controller::start(
             config::shard_local_cfg()
               .partition_autobalancing_min_size_threshold.bind(),
             config::shard_local_cfg().node_status_interval.bind(),
-            config::shard_local_cfg().raft_learner_recovery_rate.bind());
+            config::shard_local_cfg().raft_learner_recovery_rate.bind(),
+            config::shard_local_cfg()
+              .partition_autobalancing_topic_aware.bind());
       })
       .then([this] {
           return _partition_balancer.invoke_on(

--- a/src/v/cluster/members_backend.h
+++ b/src/v/cluster/members_backend.h
@@ -18,34 +18,26 @@ namespace cluster {
 
 class members_backend {
 public:
-    enum class reallocation_state {
-        initial,
-        reassigned,
-        requested,
-        finished,
+    enum class cancellation_state {
         request_cancel,
-        cancelled
+        cancelled,
+        finished,
     };
 
     struct partition_reallocation {
-        explicit partition_reallocation(
-          model::partition_id p_id, uint16_t replication_factor)
-          : constraints(partition_constraints(p_id, replication_factor)) {}
+        partition_reallocation(
+          replicas_t current_rs, replicas_t new_rs, cancellation_state state)
+          : current_replica_set(std::move(current_rs))
+          , new_replica_set(std::move(new_rs))
+          , state(state) {}
 
-        partition_reallocation() = default;
-        void set_new_replicas(allocated_partition units) {
-            allocated = std::move(units);
-            new_replica_set = allocated->replicas();
-        }
+        replicas_t current_replica_set;
+        replicas_t new_replica_set;
+        // Currently members_backend only dispatches cancellations after node
+        // recommission, other required partition movements are dispatched by
+        // partition_balancer.
+        cancellation_state state;
 
-        void release_allocated() { allocated.reset(); }
-
-        std::optional<partition_constraints> constraints;
-        absl::node_hash_set<model::node_id> replicas_to_remove;
-        std::optional<allocated_partition> allocated;
-        std::vector<model::broker_shard> new_replica_set;
-        std::vector<model::broker_shard> current_replica_set;
-        reallocation_state state = reallocation_state::initial;
         friend std::ostream&
         operator<<(std::ostream&, const partition_reallocation&);
     };
@@ -56,35 +48,12 @@ public:
         explicit update_meta(members_manager::node_update update)
           : update(update) {}
 
-        // on demand rebalance request
-        explicit update_meta() noexcept = default;
-
         members_manager::node_update update;
         // it is ok to use a flat hash map here as it it will be limited in
         // size by the max concurrent reallocations batch size
         absl::flat_hash_map<model::ntp, partition_reallocation>
           partition_reallocations;
         bool finished = false;
-        // unevenness error is normalized to be at most 1.0, set to max
-        absl::flat_hash_map<partition_allocation_domain, double>
-          last_unevenness_error;
-    };
-
-    struct reallocation_strategy {
-        reallocation_strategy() = default;
-        reallocation_strategy(const reallocation_strategy&) = default;
-        reallocation_strategy(reallocation_strategy&&) = default;
-        reallocation_strategy& operator=(const reallocation_strategy&)
-          = default;
-        reallocation_strategy& operator=(reallocation_strategy&&) = default;
-        virtual ~reallocation_strategy() = default;
-        virtual void reallocations_for_even_partition_count(
-          size_t batch_size,
-          partition_allocator&,
-          topic_table&,
-          update_meta&,
-          partition_allocation_domain)
-          = 0;
     };
 
     members_backend(
@@ -147,7 +116,6 @@ private:
     ss::sharded<members_manager>& _members_manager;
     ss::sharded<members_frontend>& _members_frontend;
     ss::sharded<features::feature_table>& _features;
-    std::unique_ptr<reallocation_strategy> _reallocation_strategy;
     consensus_ptr _raft0;
     ss::sharded<ss::abort_source>& _as;
     ss::gate _bg;
@@ -163,6 +131,6 @@ private:
     config::binding<size_t> _max_concurrent_reallocations;
 };
 std::ostream&
-operator<<(std::ostream&, const members_backend::reallocation_state&);
+operator<<(std::ostream&, const members_backend::cancellation_state&);
 
 } // namespace cluster

--- a/src/v/cluster/partition_balancer_backend.h
+++ b/src/v/cluster/partition_balancer_backend.h
@@ -50,7 +50,8 @@ public:
       config::binding<size_t>&& segment_fallocation_step,
       config::binding<std::optional<size_t>> min_partition_size_threshold,
       config::binding<std::chrono::milliseconds> node_status_interval,
-      config::binding<size_t> raft_learner_recovery_rate);
+      config::binding<size_t> raft_learner_recovery_rate,
+      config::binding<bool> topic_aware);
 
     void start();
     ss::future<> stop();
@@ -107,6 +108,7 @@ private:
     config::binding<std::optional<size_t>> _min_partition_size_threshold;
     config::binding<std::chrono::milliseconds> _node_status_interval;
     config::binding<size_t> _raft_learner_recovery_rate;
+    config::binding<bool> _topic_aware;
 
     mutex _lock{"partition_balancer_backend::lock"};
     ss::gate _gate;

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -1050,10 +1050,6 @@ partition_balancer_planner::reassignable_partition::get_allocation_constraints(
   double max_disk_usage_ratio) const {
     allocation_constraints constraints;
 
-    // Add constraint on least disk usage
-    constraints.add(
-      least_disk_filled(max_disk_usage_ratio, _ctx.node_disk_reports));
-
     // Add constraint on partition max_disk_usage_ratio overfill
     size_t upper_bound_for_partition_size
       = _sizes.non_reclaimable + _ctx.config().segment_fallocation_step;
@@ -1069,6 +1065,12 @@ partition_balancer_planner::reassignable_partition::get_allocation_constraints(
     if (!_ctx.decommissioning_nodes.empty()) {
         constraints.add(distinct_from(_ctx.decommissioning_nodes));
     }
+
+    // Add constraint on least disk usage
+    constraints.add(least_disk_filled(
+      max_disk_usage_ratio,
+      upper_bound_for_partition_size,
+      _ctx.node_disk_reports));
 
     return constraints;
 }
@@ -1217,16 +1219,18 @@ partition_balancer_planner::force_reassignable_partition::
   get_allocation_constraints(double max_disk_usage_ratio) const {
     allocation_constraints constraints;
 
-    // Add constraint on least disk usage
-    constraints.add(
-      least_disk_filled(max_disk_usage_ratio, _ctx.node_disk_reports));
-
     if (_sizes) {
         // Add constraint on partition max_disk_usage_ratio overfill
         size_t upper_bound_for_partition_size
           = _sizes.value().non_reclaimable
             + _ctx.config().segment_fallocation_step;
         constraints.add(disk_not_overflowed_by_partition(
+          max_disk_usage_ratio,
+          upper_bound_for_partition_size,
+          _ctx.node_disk_reports));
+
+        // Add constraint on least disk usage
+        constraints.add(least_disk_filled(
           max_disk_usage_ratio,
           upper_bound_for_partition_size,
           _ctx.node_disk_reports));

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -22,6 +22,7 @@
 #include "cluster/scheduling/partition_allocator.h"
 #include "cluster/scheduling/types.h"
 #include "cluster/types.h"
+#include "container/chunked_hash_map.h"
 #include "model/namespace.h"
 #include "random/generators.h"
 #include "ssx/sformat.h"
@@ -216,7 +217,7 @@ private:
     };
 
     partition_balancer_planner& _parent;
-    absl::btree_map<model::ntp, partition_sizes> _ntp2sizes;
+    chunked_hash_map<model::ntp, partition_sizes> _ntp2sizes;
     absl::node_hash_map<model::ntp, reassignment_info> _reassignments;
     absl::node_hash_map<model::ntp, allocated_partition> _force_reassignments;
     size_t _failed_actions_count = 0;

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -1072,7 +1072,11 @@ partition_balancer_planner::reassignable_partition::get_allocation_constraints(
 
     // soft constraints
 
+    // Add constraint for balanced replica counts
+    constraints.add(max_final_capacity(get_allocation_domain(ntp())));
+
     // Add constraint on least disk usage
+    constraints.ensure_new_level();
     constraints.add(least_disk_filled(
       max_disk_usage_ratio,
       upper_bound_for_partition_size,

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -45,8 +45,9 @@ distinct_from(const absl::flat_hash_set<model::node_id>& nodes) {
         explicit impl(const absl::flat_hash_set<model::node_id>& nodes)
           : _nodes(nodes) {}
 
-        hard_constraint_evaluator
-        make_evaluator(const model::ntp&, const replicas_t&) const final {
+        hard_constraint_evaluator make_evaluator(
+          const allocated_partition&,
+          std::optional<model::node_id>) const final {
             return [this](const allocation_node& node) {
                 return !_nodes.contains(node.id());
             };

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -113,6 +113,7 @@ private:
 
     ss::future<> init_ntp_sizes_from_health_report(
       const cluster_health_report& health_report, request_context&);
+    ss::future<> init_topic_node_counts(request_context&);
 
     /// Returns a pair of (total, free) bytes on a given node.
     std::pair<uint64_t, uint64_t> get_node_bytes_info(const node::local_state&);

--- a/src/v/cluster/partition_balancer_planner.h
+++ b/src/v/cluster/partition_balancer_planner.h
@@ -56,6 +56,10 @@ struct planner_config {
     // the request but it is not yet considered as a violation of partition
     // balancing rules
     std::chrono::milliseconds node_responsiveness_timeout;
+    // If true, prioritize balancing topic-wise number of
+    // partitions on each node, as opposed to balancing the total number of
+    // partitions.
+    bool topic_aware = false;
 };
 
 class partition_balancer_planner {

--- a/src/v/cluster/scheduling/allocation_node.cc
+++ b/src/v/cluster/scheduling/allocation_node.cc
@@ -50,7 +50,8 @@ allocation_node::allocation_node(
     });
 }
 
-bool allocation_node::is_full(const model::ntp& ntp) const {
+bool allocation_node::is_full(
+  const model::ntp& ntp, bool will_add_allocation) const {
     // Internal topics are excluded from checks to prevent allocation failures
     // when creating them. This is okay because they are fairly small in number
     // compared to kafka user topic partitions.
@@ -67,7 +68,12 @@ bool allocation_node::is_full(const model::ntp& ntp) const {
                                [&ntp](const ss::sstring& topic) {
                                    return topic == ntp.tp.topic();
                                });
-    return !is_internal_topic && _allocated_partitions >= _max_capacity;
+
+    auto count = _allocated_partitions;
+    if (will_add_allocation) {
+        count += 1;
+    }
+    return !is_internal_topic && count > _max_capacity;
 }
 
 ss::shard_id

--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -124,7 +124,7 @@ public:
     bool empty() const {
         return _allocated_partitions == allocation_capacity{0};
     }
-    bool is_full(const model::ntp&) const;
+    bool is_full(const model::ntp&, bool will_add_allocation) const;
     ss::shard_id allocate(partition_allocation_domain);
 
 private:

--- a/src/v/cluster/scheduling/allocation_strategy.cc
+++ b/src/v/cluster/scheduling/allocation_strategy.cc
@@ -46,6 +46,8 @@ std::vector<model::node_id> solve_hard_constraints(
   const std::vector<model::broker_shard>& current_replicas,
   const std::vector<hard_constraint_ptr>& constraints,
   const allocation_state::underlying_t& nodes) {
+    vlog(clusterlog.trace, "applying hard constraints: {}", constraints);
+
     std::vector<hard_constraint_evaluator> evaluators;
     evaluators.reserve(constraints.size());
     for (auto& c : constraints) {
@@ -88,6 +90,9 @@ std::vector<model::node_id> optimize_constraints(
   const soft_constraints_level& constraints,
   const std::vector<model::broker_shard>& current_replicas,
   const allocation_state::underlying_t& allocation_nodes) {
+    vlog(
+      clusterlog.trace, "optimizing soft constraints level: {}", constraints);
+
     std::vector<soft_constraint_evaluator> evaluators;
     evaluators.reserve(constraints.size());
     for (auto& c : constraints) {
@@ -152,6 +157,10 @@ model::node_id find_best_fit(
     for (const auto& lvl : constraints) {
         to_optimize = optimize_constraints(
           to_optimize, lvl, current_replicas, allocation_nodes);
+        vlog(
+          clusterlog.trace,
+          "after optimizing soft constraints level, eligible nodes: {}",
+          to_optimize);
     }
 
     return random_generators::random_choice(to_optimize);
@@ -175,6 +184,11 @@ allocation_strategy simple_allocation_strategy() {
               current_replicas,
               request.hard_constraints,
               state.allocation_nodes());
+
+            vlog(
+              clusterlog.trace,
+              "after applying hard constraints, eligible nodes: {}",
+              possible_nodes);
 
             if (possible_nodes.empty()) {
                 return errc::no_eligible_allocation_nodes;

--- a/src/v/cluster/scheduling/allocation_strategy.cc
+++ b/src/v/cluster/scheduling/allocation_strategy.cc
@@ -28,19 +28,6 @@
 
 namespace cluster {
 
-inline bool contains_node_already(
-  const std::vector<model::broker_shard>& current_allocations,
-  model::node_id id) {
-    auto it = std::find_if(
-      current_allocations.cbegin(),
-      current_allocations.cend(),
-      [id](const model::broker_shard& replica) {
-          return replica.node_id == id;
-      });
-
-    return it != current_allocations.end();
-}
-
 std::vector<model::node_id> solve_hard_constraints(
   const model::ntp& ntp,
   const std::vector<model::broker_shard>& current_replicas,

--- a/src/v/cluster/scheduling/allocation_strategy.h
+++ b/src/v/cluster/scheduling/allocation_strategy.h
@@ -20,43 +20,12 @@ class allocation_state;
 
 class allocation_strategy {
 public:
-    struct impl {
-        /**
-         * Allocates single replica according to set of given allocation
-         * constraints in the specified domain
-         */
-        virtual result<model::node_id> choose_node(
-          const model::ntp&,
-          const replicas_t&,
-          const allocation_constraints&,
-          allocation_state&,
-          partition_allocation_domain)
-          = 0;
-
-        virtual ~impl() noexcept = default;
-    };
-
-    explicit allocation_strategy(std::unique_ptr<impl> impl)
-      : _impl(std::move(impl)) {}
-
     result<model::node_id> choose_node(
       const model::ntp& ntp,
       const replicas_t& current_replicas,
       const allocation_constraints& ac,
       allocation_state& state,
-      const partition_allocation_domain domain) {
-        return _impl->choose_node(ntp, current_replicas, ac, state, domain);
-    }
-
-private:
-    std::unique_ptr<impl> _impl;
+      const partition_allocation_domain domain);
 };
 
-template<typename Impl, typename... Args>
-allocation_strategy make_allocation_strategy(Args&&... args) {
-    return allocation_strategy(
-      std::make_unique<Impl>(std::forward<Args>(args)...));
-}
-
-allocation_strategy simple_allocation_strategy();
 } // namespace cluster

--- a/src/v/cluster/scheduling/allocation_strategy.h
+++ b/src/v/cluster/scheduling/allocation_strategy.h
@@ -21,11 +21,10 @@ class allocation_state;
 class allocation_strategy {
 public:
     result<model::node_id> choose_node(
-      const model::ntp& ntp,
-      const replicas_t& current_replicas,
-      const allocation_constraints& ac,
-      allocation_state& state,
-      const partition_allocation_domain domain);
+      const allocation_state&,
+      const allocation_constraints&,
+      const allocated_partition&,
+      std::optional<model::node_id> prev);
 };
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/constraints.cc
+++ b/src/v/cluster/scheduling/constraints.cc
@@ -201,20 +201,20 @@ hard_constraint disk_not_overflowed_by_partition(
           , _node_disk_reports(node_disk_reports) {}
 
         hard_constraint_evaluator make_evaluator(
-          const allocated_partition&,
-          std::optional<model::node_id>) const final {
-            return [this](const allocation_node& node) {
+          const allocated_partition& partition,
+          std::optional<model::node_id> prev) const final {
+            return [this, &partition, prev](const allocation_node& node) {
                 auto disk_it = _node_disk_reports.find(node.id());
                 if (disk_it == _node_disk_reports.end()) {
                     return false;
-                } else {
-                    const auto& node_disk = disk_it->second;
-                    auto peak_disk_usage = node_disk.used + node_disk.assigned
-                                           + _partition_size;
-                    return peak_disk_usage
-                           < _max_disk_usage_ratio * node_disk.total;
                 }
-                return false;
+                const auto& node_disk = disk_it->second;
+                auto peak_disk_usage = node_disk.used + node_disk.assigned;
+                if (node.id() != prev && !partition.is_original(node.id())) {
+                    peak_disk_usage += _partition_size;
+                }
+                return peak_disk_usage
+                       < _max_disk_usage_ratio * node_disk.total;
             };
         }
 
@@ -269,54 +269,62 @@ soft_constraint max_final_capacity(partition_allocation_domain domain) {
 
 soft_constraint least_disk_filled(
   const double max_disk_usage_ratio,
+  const size_t partition_size,
   const absl::flat_hash_map<model::node_id, node_disk_space>&
     node_disk_reports) {
     class impl : public soft_constraint::impl {
     public:
         impl(
           const double max_disk_usage_ratio,
+          const size_t partition_size,
           const absl::flat_hash_map<model::node_id, node_disk_space>&
             node_disk_reports)
           : _max_disk_usage_ratio(max_disk_usage_ratio)
+          , _partition_size(partition_size)
           , _node_disk_reports(node_disk_reports) {}
 
         soft_constraint_evaluator make_evaluator(
           const allocated_partition&,
-          std::optional<model::node_id>) const final {
-            return [this](const allocation_node& node) -> uint64_t {
+          std::optional<model::node_id> prev) const final {
+            return [this, prev](const allocation_node& node) -> uint64_t {
                 // we return 0 for node filled more or equal to
                 // max_disk_usage_ratio
                 // and 10'000'000 for nodes empty disks
                 auto disk_it = _node_disk_reports.find(node.id());
                 if (disk_it == _node_disk_reports.end()) {
                     return 0;
-                } else {
-                    const auto& node_disk = disk_it->second;
-                    if (node_disk.total == 0) {
-                        return 0;
-                    }
-                    auto peak_disk_usage_ratio = node_disk.peak_used_ratio();
-                    if (peak_disk_usage_ratio > _max_disk_usage_ratio) {
-                        return 0;
-                    } else {
-                        return uint64_t(
-                          soft_constraint::max_score
-                          * ((_max_disk_usage_ratio - peak_disk_usage_ratio) / _max_disk_usage_ratio));
-                    }
                 }
-                return 0;
+                const auto& node_disk = disk_it->second;
+                if (node_disk.total == 0) {
+                    return 0;
+                }
+
+                auto final_used = node_disk.used + node_disk.assigned
+                                  - node_disk.released;
+                if (node.id() != prev) {
+                    final_used += _partition_size;
+                }
+                auto final_ratio = double(final_used) / node_disk.total;
+
+                if (final_ratio > _max_disk_usage_ratio) {
+                    return 0;
+                }
+                return uint64_t(
+                  soft_constraint::max_score
+                  * ((_max_disk_usage_ratio - final_ratio) / _max_disk_usage_ratio));
             };
         }
 
         ss::sstring name() const final { return "least filled disk"; }
 
         const double _max_disk_usage_ratio;
+        const size_t _partition_size;
         const absl::flat_hash_map<model::node_id, node_disk_space>&
           _node_disk_reports;
     };
 
-    return soft_constraint(
-      std::make_unique<impl>(max_disk_usage_ratio, node_disk_reports));
+    return soft_constraint(std::make_unique<impl>(
+      max_disk_usage_ratio, partition_size, node_disk_reports));
 }
 
 soft_constraint distinct_rack_preferred(const members_table& members) {

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -48,18 +48,12 @@ hard_constraint disk_not_overflowed_by_partition(
     node_disk_reports);
 
 /*
- * scores nodes based on partition count after all moves have been finished
- * returning `0` for fully allocated nodes and `max_capacity` for empty nodes
+ * Scores nodes based on partition count after all moves have been finished
+ * returning `0` for fully allocated nodes and `max_capacity` for empty nodes.
+ * If partition_allocation_domain != common, takes into account only counts
+ * in this domain.
  */
-soft_constraint max_final_capacity();
-
-/*
- * scores nodes based on partition counts of priority partitions after all moves
- * have been finished, returning `0` for nodes fully allocated for priority
- * partitions and `max_capacity` for nodes without any priority partitions.
- * non-priority partition allocations are ignored.
- */
-soft_constraint max_final_capacity_in_domain(partition_allocation_domain);
+soft_constraint max_final_capacity(partition_allocation_domain);
 
 /*
  * constraint scores nodes on free disk space

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -140,4 +140,11 @@ distinct_labels_preferred(const char* label_name, Mapper&& mapper) {
 
 soft_constraint distinct_rack_preferred(const members_table&);
 
+/// Scores nodes based on replica count queried from the supplied map (as
+/// opposed to total node count). E.g. if the map represents topic partition
+/// counts, this constraint will implement topic-aware replica placement.
+///
+/// NOTE: counts will be scaled by max node capacity.
+soft_constraint min_count_in_map(std::string_view name, const node2count_t&);
+
 } // namespace cluster

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -86,11 +86,12 @@ distinct_labels_preferred(const char* label_name, Mapper&& mapper) {
           : _label_name(label_name)
           , _mapper(std::forward<Mapper>(mapper)) {}
 
-        soft_constraint_evaluator
-        make_evaluator(const replicas_t& current_replicas) const final {
+        soft_constraint_evaluator make_evaluator(
+          const allocated_partition& partition,
+          std::optional<model::node_id>) const final {
             absl::flat_hash_map<T, size_t> frequency_map;
 
-            for (auto& r : current_replicas) {
+            for (auto& r : partition.replicas()) {
                 auto const l = _mapper(r.node_id);
                 if (!l) {
                     continue;

--- a/src/v/cluster/scheduling/constraints.h
+++ b/src/v/cluster/scheduling/constraints.h
@@ -62,6 +62,7 @@ soft_constraint max_final_capacity(partition_allocation_domain);
  */
 soft_constraint least_disk_filled(
   const double max_disk_usage_ratio,
+  const size_t partition_size,
   const absl::flat_hash_map<model::node_id, node_disk_space>&
     node_disk_reports);
 

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -50,7 +50,6 @@ partition_allocator::partition_allocator(
   config::binding<bool> enable_rack_awareness)
   : _state(std::make_unique<allocation_state>(
     partitions_per_shard, partitions_reserve_shard0, internal_kafka_topics))
-  , _allocation_strategy(simple_allocation_strategy())
   , _members(members)
   , _memory_per_partition(std::move(memory_per_partition))
   , _fds_per_partition(std::move(fds_per_partition))

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -393,11 +393,7 @@ result<reallocation_step> partition_allocator::do_allocate_replica(
     });
 
     auto node = _allocation_strategy.choose_node(
-      partition._ntp,
-      partition._replicas,
-      effective_constraints,
-      *_state,
-      partition._domain);
+      *_state, effective_constraints, partition, prev_node);
     if (!node) {
         return node.error();
     }

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -62,14 +62,18 @@ allocation_constraints partition_allocator::default_constraints(
   const partition_allocation_domain domain) {
     allocation_constraints req;
 
+    // hard constraints
     req.add(distinct_nodes());
     req.add(not_fully_allocated());
     req.add(is_active());
 
-    req.add(max_final_capacity(domain));
+    // soft constraints
     if (_enable_rack_awareness()) {
         req.add(distinct_rack_preferred(_members.local()));
+        req.add_level({});
     }
+    req.add(max_final_capacity(domain));
+
     return req;
 }
 

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -67,11 +67,7 @@ allocation_constraints partition_allocator::default_constraints(
     req.add(not_fully_allocated());
     req.add(is_active());
 
-    if (domain == partition_allocation_domains::common) {
-        req.add(max_final_capacity());
-    } else {
-        req.add(max_final_capacity_in_domain(domain));
-    }
+    req.add(max_final_capacity(domain));
     if (_enable_rack_awareness()) {
         req.add(distinct_rack_preferred(_members.local()));
     }

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -386,11 +386,6 @@ result<reallocation_step> partition_allocator::do_allocate_replica(
             return errc::node_does_not_exists;
         }
     }
-    auto revert = ss::defer([&] {
-        if (prev) {
-            partition.cancel_move(*prev);
-        }
-    });
 
     auto node = _allocation_strategy.choose_node(
       *_state, effective_constraints, partition, prev_node);
@@ -398,7 +393,6 @@ result<reallocation_step> partition_allocator::do_allocate_replica(
         return node.error();
     }
 
-    revert.cancel();
     auto new_replica = partition.add_replica(node.value(), prev);
     std::optional<model::broker_shard> prev_replica;
     if (prev) {

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -189,8 +189,7 @@ private:
       std::optional<model::node_id> previous,
       const allocation_constraints&);
 
-    allocation_constraints
-    default_constraints(const partition_allocation_domain);
+    allocation_constraints default_constraints();
 
     std::unique_ptr<allocation_state> _state;
     allocation_strategy _allocation_strategy;

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -182,7 +182,8 @@ private:
     result<allocated_partition> allocate_new_partition(
       model::topic_namespace nt,
       partition_constraints,
-      partition_allocation_domain);
+      partition_allocation_domain,
+      const std::optional<node2count_t>& node2count);
 
     result<reallocation_step> do_allocate_replica(
       allocated_partition&,

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -69,7 +69,7 @@ allocated_partition::allocated_partition(
   , _state(state.weak_from_this()) {}
 
 std::optional<allocated_partition::previous_replica>
-allocated_partition::prepare_move(model::node_id prev_node) {
+allocated_partition::prepare_move(model::node_id prev_node) const {
     previous_replica prev;
     auto it = std::find_if(
       _replicas.begin(), _replicas.end(), [prev_node](const auto& bs) {
@@ -80,44 +80,6 @@ allocated_partition::prepare_move(model::node_id prev_node) {
     }
     prev.bs = *it;
     prev.idx = it - _replicas.begin();
-    if (!_original_node2shard) {
-        _original_node2shard.emplace();
-        for (const auto& bs : _replicas) {
-            _original_node2shard->emplace(bs.node_id, bs.shard);
-        }
-    } else if (!_original_node2shard->contains(prev_node)) {
-        // if replica prev_node is not original, pick an arbitrary original one
-        // that is not present in the current set as the "source" for prev.bs
-        // (they are all interchangeable).
-        //
-        // Example (omitting shard ids for clarity):
-        // _original = [0, 1, 2], _replicas = [2, 3, 4], and we want to move
-        // replica 4 (so prev_node = 4). Because replica 4 is not in _original
-        // (i.e. it was reallocated earlier using the same allocated_partition
-        // object), we need to arbitrarily designate one of nodes 0 and 1 as the
-        // "original" for replica 4 (meaning that the replica on node 4 was
-        // originally on node 0 or 1).
-        for (const auto& [node_id, shard] : *_original_node2shard) {
-            model::broker_shard bs{.node_id = node_id, .shard = shard};
-            if (
-              std::find(_replicas.begin(), _replicas.end(), bs)
-              == _replicas.end()) {
-                prev.original = bs;
-                break;
-            }
-        }
-    }
-
-    // remove previous replica and its allocation contribution so that it
-    // doesn't interfere with allocation of the new replica.
-    std::swap(_replicas[prev.idx], _replicas.back());
-    _replicas.pop_back();
-    _state->remove_allocation(prev.bs, _domain);
-    _state->remove_final_count(prev.bs, _domain);
-    if (prev.original) {
-        _state->remove_allocation(*prev.original, _domain);
-    }
-
     return prev;
 }
 
@@ -131,11 +93,10 @@ model::broker_shard allocated_partition::add_replica(
     }
 
     if (prev) {
-        model::broker_shard original = prev->original.value_or(prev->bs);
-        // previous replica will still be present while partition move is in
-        // progress, so add its contribution (that we removed when preparing the
-        // move) back.
-        _state->add_allocation(original, _domain);
+        if (!_original_node2shard->contains(prev->bs.node_id)) {
+            _state->remove_allocation(prev->bs, _domain);
+        }
+        _state->remove_final_count(prev->bs, _domain);
     }
 
     model::broker_shard replica{.node_id = node};
@@ -149,19 +110,13 @@ model::broker_shard allocated_partition::add_replica(
         replica.shard = _state->allocate(node, _domain);
     }
 
-    _replicas.push_back(replica);
-    return replica;
-}
-
-void allocated_partition::cancel_move(const previous_replica& prev) {
-    // return substituted replica to its place
-    _replicas.push_back(prev.bs);
-    std::swap(_replicas[prev.idx], _replicas.back());
-    _state->add_allocation(prev.bs, _domain);
-    _state->add_final_count(prev.bs, _domain);
-    if (prev.original) {
-        _state->add_allocation(*prev.original, _domain);
+    if (prev) {
+        std::swap(_replicas[prev->idx], _replicas.back());
+        _replicas.back() = replica;
+    } else {
+        _replicas.push_back(replica);
     }
+    return replica;
 }
 
 std::vector<model::broker_shard> allocated_partition::release_new_partition() {

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -19,32 +19,6 @@
 
 namespace cluster {
 
-hard_constraint_evaluator hard_constraint::make_evaluator(
-  const model::ntp& ntp, const replicas_t& current_replicas) const {
-    auto ev = _impl->make_evaluator(ntp, current_replicas);
-    return [this, ev = std::move(ev)](const allocation_node& node) {
-        auto res = ev(node);
-        vlog(clusterlog.trace, "{}({}) = {}", name(), node.id(), res);
-        return res;
-    };
-}
-
-soft_constraint_evaluator
-soft_constraint::make_evaluator(const replicas_t& current_replicas) const {
-    auto ev = _impl->make_evaluator(current_replicas);
-    return [this, ev = std::move(ev)](const allocation_node& node) {
-        auto res = ev(node);
-        vlog(
-          clusterlog.trace,
-          "{}(node: {}) = {} ({})",
-          name(),
-          node.id(),
-          res,
-          (double)res / soft_constraint::max_score);
-        return res;
-    };
-};
-
 std::ostream& operator<<(std::ostream& o, const allocation_constraints& a) {
     fmt::print(
       o,

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -48,9 +48,9 @@ soft_constraint::make_evaluator(const replicas_t& current_replicas) const {
 std::ostream& operator<<(std::ostream& o, const allocation_constraints& a) {
     fmt::print(
       o,
-      "{{soft_constraints: {}, hard_constraints: {}}}",
-      a.soft_constraints,
-      a.hard_constraints);
+      "{{hard_constraints: {}, soft_constraints: {}}}",
+      a.hard_constraints,
+      a.soft_constraints);
     return o;
 }
 

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -163,6 +163,12 @@ struct allocation_constraints {
         return soft_constraints.push_back(std::move(c));
     }
 
+    void ensure_new_level() {
+        if (!soft_constraints.empty() && !soft_constraints.back().empty()) {
+            soft_constraints.emplace_back();
+        }
+    }
+
     void add(hard_constraint c) {
         return hard_constraints.push_back(
           ss::make_lw_shared<hard_constraint>(std::move(c)));

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -63,8 +63,10 @@ public:
 
     ~hard_constraint() noexcept = default;
 
-    hard_constraint_evaluator
-    make_evaluator(const model::ntp&, const replicas_t& current_replicas) const;
+    hard_constraint_evaluator make_evaluator(
+      const model::ntp& ntp, const replicas_t& current_replicas) const {
+        return _impl->make_evaluator(ntp, current_replicas);
+    }
 
     ss::sstring name() const { return _impl->name(); }
 
@@ -99,7 +101,9 @@ public:
     ~soft_constraint() noexcept = default;
 
     soft_constraint_evaluator
-    make_evaluator(const replicas_t& current_replicas) const;
+    make_evaluator(const replicas_t& current_replicas) const {
+        return _impl->make_evaluator(current_replicas);
+    }
 
     ss::sstring name() const { return _impl->name(); }
 

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -21,6 +21,7 @@
 #include <seastar/core/weak_ptr.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+#include <absl/container/flat_hash_map.h>
 #include <absl/container/node_hash_set.h>
 
 namespace cluster {
@@ -341,5 +342,7 @@ struct allocation_request {
 
     friend std::ostream& operator<<(std::ostream&, const allocation_request&);
 };
+
+using node2count_t = absl::flat_hash_map<model::node_id, size_t>;
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -278,13 +278,11 @@ private:
     struct previous_replica {
         model::broker_shard bs;
         size_t idx;
-        std::optional<model::broker_shard> original;
     };
 
-    std::optional<previous_replica> prepare_move(model::node_id previous);
+    std::optional<previous_replica> prepare_move(model::node_id previous) const;
     model::broker_shard
     add_replica(model::node_id, const std::optional<previous_replica>&);
-    void cancel_move(const previous_replica&);
 
     // used to move the allocation to allocation_units
     replicas_t release_new_partition();

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -324,6 +324,8 @@ struct partition_constraints {
     operator<<(std::ostream&, const partition_constraints&);
 };
 
+using node2count_t = absl::flat_hash_map<model::node_id, size_t>;
+
 struct allocation_request {
     allocation_request() = delete;
     explicit allocation_request(
@@ -339,10 +341,11 @@ struct allocation_request {
     model::topic_namespace _nt;
     ss::chunked_fifo<partition_constraints> partitions;
     partition_allocation_domain domain;
+    // if present, new partitions will be allocated using topic-aware counts
+    // objective.
+    std::optional<node2count_t> existing_replica_counts;
 
     friend std::ostream& operator<<(std::ostream&, const allocation_request&);
 };
-
-using node2count_t = absl::flat_hash_map<model::node_id, size_t>;
 
 } // namespace cluster

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -70,7 +70,7 @@ public:
 
 private:
     friend std::ostream& operator<<(std::ostream& o, const hard_constraint& c) {
-        fmt::print(o, "hard constraint: [{}]", c.name());
+        fmt::print(o, "hard: [{}]", c.name());
         return o;
     }
     std::unique_ptr<impl> _impl;
@@ -105,7 +105,7 @@ public:
 
 private:
     friend std::ostream& operator<<(std::ostream& o, const soft_constraint& c) {
-        fmt::print(o, "soft constraint: [{}]", c.name());
+        fmt::print(o, "soft: [{}]", c.name());
         return o;
     }
 

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -350,7 +350,8 @@ FIXTURE_TEST(decommission_node, partition_allocator_fixture) {
 cluster::hard_constraint make_throwing_hard_evaluator() {
     struct impl : cluster::hard_constraint::impl {
         cluster::hard_constraint_evaluator make_evaluator(
-          const model::ntp&, const cluster::replicas_t&) const final {
+          const cluster::allocated_partition&,
+          std::optional<model::node_id>) const final {
             return [](const cluster::allocation_node&) -> bool {
                 throw std::runtime_error("evaluation exception");
             };
@@ -366,7 +367,8 @@ cluster::hard_constraint make_throwing_hard_evaluator() {
 cluster::hard_constraint make_false_evaluator() {
     struct impl : cluster::hard_constraint::impl {
         cluster::hard_constraint_evaluator make_evaluator(
-          const model::ntp&, const cluster::replicas_t&) const final {
+          const cluster::allocated_partition&,
+          std::optional<model::node_id>) const final {
             return [](const cluster::allocation_node&) { return true; };
         }
         ss::sstring name() const final {
@@ -380,7 +382,8 @@ cluster::hard_constraint make_false_evaluator() {
 cluster::hard_constraint make_nop_evaluator() {
     struct impl : cluster::hard_constraint::impl {
         cluster::hard_constraint_evaluator make_evaluator(
-          const model::ntp&, const cluster::replicas_t&) const final {
+          const cluster::allocated_partition&,
+          std::optional<model::node_id>) const final {
             return [](const cluster::allocation_node&) { return true; };
         }
         ss::sstring name() const final { return "NOP evaluator"; }
@@ -960,7 +963,8 @@ static cluster::allocation_constraints on_node(model::node_id id) {
           : _id(id) {}
 
         cluster::hard_constraint_evaluator make_evaluator(
-          const model::ntp&, const cluster::replicas_t&) const final {
+          const cluster::allocated_partition&,
+          std::optional<model::node_id>) const final {
             return [this](const cluster::allocation_node& node) {
                 return node.id() == _id;
             };

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -170,28 +170,6 @@ struct partition_balancer_planner_fixture {
           workers.allocator.local());
     }
 
-    cluster::topic_configuration_assignment make_tp_configuration(
-      const ss::sstring& topic, int partitions, int16_t replication_factor) {
-        cluster::topic_configuration cfg(
-          test_ns, model::topic(topic), partitions, replication_factor);
-
-        cluster::allocation_request req(
-          cfg.tp_ns, cluster::partition_allocation_domains::common);
-        req.partitions.reserve(partitions);
-        for (auto p = 0; p < partitions; ++p) {
-            req.partitions.emplace_back(
-              model::partition_id(p), replication_factor);
-        }
-
-        auto pas = workers.allocator.local()
-                     .allocate(std::move(req))
-                     .get()
-                     .value()
-                     ->copy_assignments();
-
-        return {cfg, std::move(pas)};
-    }
-
     model::topic_namespace make_tp_ns(const ss::sstring& tp) {
         return {test_ns, model::topic(tp)};
     }

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -165,7 +165,9 @@ struct partition_balancer_planner_fixture {
             .max_concurrent_actions = max_concurrent_actions,
             .node_availability_timeout_sec = std::chrono::minutes(1),
             .segment_fallocation_step = 16,
-            .node_responsiveness_timeout = std::chrono::seconds(10)},
+            .node_responsiveness_timeout = std::chrono::seconds(10),
+            .topic_aware = true,
+          },
           workers.state.local(),
           workers.allocator.local());
     }

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -423,7 +423,9 @@ private:
             .max_concurrent_actions = 50,
             .node_availability_timeout_sec = std::chrono::minutes(1),
             .segment_fallocation_step = 16_MiB,
-            .node_responsiveness_timeout = std::chrono::seconds(10)},
+            .node_responsiveness_timeout = std::chrono::seconds(10),
+            .topic_aware = true,
+          },
           _workers.state.local(),
           _workers.allocator.local());
     }

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1526,10 +1526,6 @@ partition_constraints get_partition_constraints(
   const topics_frontend::capacity_info& info) {
     allocation_constraints allocation_constraints;
 
-    // Add constraint on least disk usage
-    allocation_constraints.add(
-      least_disk_filled(max_disk_usage_ratio, info.node_disk_reports));
-
     auto partition_size_it = info.ntp_sizes.find(id);
     if (partition_size_it == info.ntp_sizes.end()) {
         return {id, new_replication_factor, std::move(allocation_constraints)};
@@ -1537,6 +1533,10 @@ partition_constraints get_partition_constraints(
 
     // Add constraint on partition max_disk_usage_ratio overfill
     allocation_constraints.add(disk_not_overflowed_by_partition(
+      max_disk_usage_ratio, partition_size_it->second, info.node_disk_reports));
+
+    // Add constraint on least disk usage
+    allocation_constraints.add(least_disk_filled(
       max_disk_usage_ratio, partition_size_it->second, info.node_disk_reports));
 
     return {id, new_replication_factor, std::move(allocation_constraints)};

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -60,8 +60,9 @@ public:
       ss::sharded<shard_table>&,
       plugin_table&,
       metadata_cache&,
-      config::binding<unsigned>,
-      config::binding<int16_t>);
+      config::binding<unsigned> hard_max_disk_usage_ratio,
+      config::binding<int16_t> minimum_topic_replication,
+      config::binding<bool> partition_autobalancing_topic_aware);
 
     ss::future<std::vector<topic_result>> create_topics(
       custom_assignable_topic_configuration_vector,
@@ -282,6 +283,7 @@ private:
 
     config::binding<unsigned> _hard_max_disk_usage_ratio;
     config::binding<int16_t> _minimum_topic_replication;
+    config::binding<bool> _partition_autobalancing_topic_aware;
 
     static constexpr std::chrono::seconds _get_health_report_timeout = 10s;
 };

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2572,6 +2572,15 @@ configuration::configuration()
       "default this value is calculated automaticaly",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       std::nullopt)
+  , partition_autobalancing_topic_aware(
+      *this,
+      "partition_autobalancing_topic_aware",
+      "If true, Redpanda will prioritize balancing topic-wise number of "
+      "partitions on each node, as opposed to balancing the total number of "
+      "partitions. This should give better balancing results if topics with "
+      "diverse partition sizes and load profiles are present in the cluster.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
+      true)
   , enable_leader_balancer(
       *this,
       "enable_leader_balancer",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -467,6 +467,7 @@ struct configuration final : public config_store {
     property<size_t> partition_autobalancing_concurrent_moves;
     property<double> partition_autobalancing_tick_moves_drop_threshold;
     property<std::optional<size_t>> partition_autobalancing_min_size_threshold;
+    property<bool> partition_autobalancing_topic_aware;
 
     property<bool> enable_leader_balancer;
     enum_property<model::leader_balancer_mode> leader_balancer_mode;


### PR DESCRIPTION
Create new topics/partitions and balance partitions based on topic-wise node replica counts, not on total replica counts.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Features
* Create new topics/partitions and balance partitions based on topic-wise node replica counts, not on total replica counts. This behavior is controlled by the `partition_autobalancing_topic_aware` config property (enabled by default).

