### PR TITLE
Change information stored in ` _topic_node_index` to avoid oversized alloc

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer_constraints.cc
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.cc
@@ -64,85 +64,11 @@ void even_topic_distributon_constraint::update_index(const reassignment& r) {
 
 std::optional<reassignment>
 even_topic_distributon_constraint::recommended_reassignment() {
-    // Sort topics based on topic error here
-    std::vector<decltype(_topic_node_index)::const_iterator> sorted_topics;
-    sorted_topics.reserve(_topic_node_index.size());
-
-    for (auto it = _topic_node_index.cbegin(); it != _topic_node_index.cend();
-         ++it) {
-        sorted_topics.push_back(it);
-    }
-
-    std::sort(
-      sorted_topics.begin(),
-      sorted_topics.end(),
-      [this](const auto& a, const auto& b) {
-          return _topic_skew[a->first] > _topic_skew[b->first];
-      });
-
-    // Look for a topic with the most skew
-    for (const auto& topic : sorted_topics) {
-        const auto& nodes = topic->second;
-
-        if (nodes.size() == 0) {
-            continue;
-        }
-
-        std::vector<decltype(nodes.cbegin())> nodes_sorted;
-        nodes_sorted.reserve(nodes.size());
-
-        for (auto it = nodes.cbegin(); it != nodes.cend(); ++it) {
-            nodes_sorted.push_back(it);
-        }
-
-        std::sort(
-          nodes_sorted.begin(),
-          nodes_sorted.end(),
-          [](const auto& a, const auto& b) {
-              return a->second.size() > b->second.size();
-          });
-
-        // Try to move leadership off the node with the most leadership.
-        for (const auto& node : nodes_sorted) {
-            // Don't try moving a group from a muted node.
-            if (mi().muted_nodes().contains(node->first)) {
-                continue;
-            }
-
-            for (const auto& g_info : node->second) {
-                const auto& leader = g_info.leader;
-                const auto& group = g_info.group_id;
-                const auto& replicas = g_info.replicas;
-
-                // Don't try moving any groups that are currently muted.
-                if (mi().muted_groups().contains(
-                      static_cast<uint64_t>(group))) {
-                    continue;
-                }
-
-                for (const auto& replica : replicas) {
-                    // Don't try a move to a different shard to on the same
-                    // node. As it won't decrease error
-                    if (replica.node_id == node->first || leader == replica) {
-                        continue;
-                    }
-
-                    // Don't try moving group to a muted node.
-                    if (mi().muted_nodes().contains(replica.node_id)) {
-                        continue;
-                    }
-
-                    reassignment r{group, leader, replica};
-
-                    if (evaluate_internal(r) > error_jitter) {
-                        return r;
-                    }
-                }
-            }
-        }
-    }
-
-    return std::nullopt;
+    // This method is deprecated and is ony used in `leader_balancer_greedy`
+    // which doesn't use the `even_topic_distributon_constraint`. Hence there is
+    // no need to implement it here. Once the greedy balancer has been removed
+    // this should be removed as well.
+    vassert(false, "not implemented");
 }
 
 void even_topic_distributon_constraint::rebuild_indexes() {

--- a/src/v/cluster/scheduling/leader_balancer_constraints.h
+++ b/src/v/cluster/scheduling/leader_balancer_constraints.h
@@ -107,20 +107,6 @@ class even_topic_distributon_constraint final
     // more than this value.
     static constexpr double error_jitter = 0.000001;
 
-    struct group_info {
-        raft::group_id group_id;
-        model::broker_shard leader;
-        std::vector<model::broker_shard> replicas;
-
-        group_info(
-          const raft::group_id& gid,
-          const model::broker_shard& bs,
-          std::vector<model::broker_shard> r)
-          : group_id(gid)
-          , leader(bs)
-          , replicas(std::move(r)) {}
-    };
-
     using topic_id_t = model::revision_id::type;
 
     template<typename ValueType>
@@ -171,8 +157,8 @@ private:
     group_id_to_topic_revision_t _group_to_topic_rev;
     double _error{0};
 
-    topic_map<absl::flat_hash_map<model::node_id, std::vector<group_info>>>
-      _topic_node_index;
+    // Stores the number of leaders on a given node per topic.
+    topic_map<absl::flat_hash_map<model::node_id, size_t>> _topic_node_index;
     topic_map<size_t> _topic_partition_index;
     topic_map<absl::flat_hash_set<model::node_id>> _topic_replica_index;
     topic_map<double> _topic_skew;


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
 ` _topic_node_index` originally stored a bunch of metadata about every group a node led. However, this information was only ever used in `even_topic_distributon_constraint::recommended_reassignment`. A method which isn't used anywhere outside of unit tests.

This PR changes the information stored in `_topic_node_index` to be just the count of leaders on a given node. And removes the implementation of `even_topic_distributon_constraint::recommended_reassignment`.

Fixes #17349 
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
