### PR TITLE
PESDLC-1009 Bump latency for e2e p99

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -62,7 +62,7 @@ class OMBValidationTest(RedpandaCloudTest):
     EXPECTED_MAX_LATENCIES = {
         OMBSampleConfigurations.E2E_LATENCY_50PCT: 20.0,
         OMBSampleConfigurations.E2E_LATENCY_75PCT: 25.0,
-        OMBSampleConfigurations.E2E_LATENCY_99PCT: 50.0,
+        OMBSampleConfigurations.E2E_LATENCY_99PCT: 60.0,
         OMBSampleConfigurations.E2E_LATENCY_999PCT: 100.0,
     }
 


### PR DESCRIPTION
As discussed on latest meeting, bumping this value to 60 ms
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none