### PR TITLE
security: Wire up RBAC role to OCSF user::groups

### DIFF
--- a/src/v/security/audit/schemas/utils.cc
+++ b/src/v/security/audit/schemas/utils.cc
@@ -239,7 +239,10 @@ api_activity_unmapped unmapped_data(const security::auth_result& auth_result) {
 actor result_to_actor(const security::auth_result& result) {
     user user{
       .name = result.principal.name(),
-      .type_id = result.is_superuser ? user::type::admin : user::type::user};
+      .type_id = result.is_superuser ? user::type::admin : user::type::user,
+      .groups = result.role ? std::vector<group>{group{
+                  .type = group::type_id::role, .name = result.role.value()}}
+                            : std::vector<group>{}};
 
     policy policy;
     policy.name = "aclAuthorization";


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/core-internal/issues/1102

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
