### PR TITLE
Improve error response for invalid partition count

### DIFF
--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -104,7 +104,7 @@ struct errc_category final : public std::error_category {
         case errc::topic_invalid_replication_factor:
             return "Unable to allocate topic with given replication factor";
         case errc::topic_invalid_config:
-            return "Topic configuration is either bogus or not supported";
+            return "Configuration is invalid";
         case errc::not_leader_controller:
             return "This node is not raft-0 leader. i.e is not leader "
                    "controller";

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -83,6 +83,10 @@ enum class errc : int16_t {
     role_does_not_exist,
     inconsistent_stm_update,
     waiting_for_shard_placement_update,
+    topic_invalid_partitions_core_limit,
+    topic_invalid_partitions_memory_limit,
+    topic_invalid_partitions_fd_limit,
+    topic_invalid_partitions_decreased,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -241,6 +245,14 @@ struct errc_category final : public std::error_category {
             return "STM command can't be applied";
         case errc::waiting_for_shard_placement_update:
             return "Waiting for shard placement table update to finish";
+        case errc::topic_invalid_partitions_core_limit:
+            return "Can not increase partition count due to core limit";
+        case errc::topic_invalid_partitions_memory_limit:
+            return "Can not increase partition count due to memory limit";
+        case errc::topic_invalid_partitions_fd_limit:
+            return "Can not increase partition count due to FD limit";
+        case errc::topic_invalid_partitions_decreased:
+            return "Can not decrease the number of partitions";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/scheduling/partition_allocator.cc
+++ b/src/v/cluster/scheduling/partition_allocator.cc
@@ -211,7 +211,7 @@ std::error_code partition_allocator::check_cluster_limits(
           create_count,
           proposed_total_partitions,
           effective_cpu_count * _partitions_per_shard());
-        return errc::topic_invalid_partitions;
+        return errc::topic_invalid_partitions_core_limit;
     }
 
     // Refuse to create partitions that would violate the configured
@@ -232,7 +232,7 @@ std::error_code partition_allocator::check_cluster_limits(
               create_count,
               proposed_total_partitions,
               memory_limit);
-            return errc::topic_invalid_partitions;
+            return errc::topic_invalid_partitions_memory_limit;
         }
     }
 
@@ -254,7 +254,7 @@ std::error_code partition_allocator::check_cluster_limits(
                       create_count,
                       proposed_total_partitions,
                       fds_limit);
-                    return errc::topic_invalid_partitions;
+                    return errc::topic_invalid_partitions_fd_limit;
                 }
             }
         } else {

--- a/src/v/cluster/tests/create_partitions_test.cc
+++ b/src/v/cluster/tests/create_partitions_test.cc
@@ -80,5 +80,6 @@ FIXTURE_TEST(test_error_handling, rebalancing_tests_fixture) {
     BOOST_REQUIRE_EQUAL(res.size(), 1);
     BOOST_REQUIRE_EQUAL(
       res[0].ec,
-      cluster::make_error_code(cluster::errc::topic_invalid_partitions));
+      cluster::make_error_code(
+        cluster::errc::topic_invalid_partitions_decreased));
 }

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -27,26 +27,14 @@
 
 #include <seastar/core/chunked_fifo.hh>
 
+#include <limits>
+
 struct partition_allocator_fixture {
     static constexpr uint32_t partitions_per_shard = 1000;
     static constexpr uint32_t partitions_reserve_shard0 = 2;
 
     partition_allocator_fixture()
-      : allocator(
-        std::ref(members),
-        config::mock_binding<std::optional<size_t>>(std::nullopt),
-        config::mock_binding<std::optional<int32_t>>(std::nullopt),
-        config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
-        config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
-        kafka_internal_topics.bind(),
-        config::mock_binding<bool>(true)) {
-        members.start().get0();
-        ss::smp::invoke_on_all([] {
-            config::shard_local_cfg()
-              .get("partition_autobalancing_mode")
-              .set_value(model::partition_autobalancing_mode::node_add);
-        }).get0();
-    }
+      : partition_allocator_fixture(std::nullopt, std::nullopt) {}
 
     ~partition_allocator_fixture() { members.stop().get0(); }
 
@@ -139,4 +127,41 @@ struct partition_allocator_fixture {
     cluster::partition_allocator allocator;
 
     fast_prng prng;
+
+protected:
+    explicit partition_allocator_fixture(
+      std::optional<size_t> memory_per_partition,
+      std::optional<int32_t> fds_per_partition)
+      : allocator(
+        std::ref(members),
+        config::mock_binding<std::optional<size_t>>(memory_per_partition),
+        config::mock_binding<std::optional<int32_t>>(fds_per_partition),
+        config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
+        config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
+        kafka_internal_topics.bind(),
+        config::mock_binding<bool>(true)) {
+        members.start().get0();
+        ss::smp::invoke_on_all([] {
+            config::shard_local_cfg()
+              .get("partition_autobalancing_mode")
+              .set_value(model::partition_autobalancing_mode::node_add);
+        }).get0();
+    }
+};
+
+struct partition_allocator_memory_limited_fixture
+  : public partition_allocator_fixture {
+    static constexpr size_t memory_per_partition
+      = std::numeric_limits<size_t>::max();
+    partition_allocator_memory_limited_fixture()
+      : partition_allocator_fixture(memory_per_partition, std::nullopt) {}
+};
+
+struct partition_allocator_fd_limited_fixture
+  : public partition_allocator_fixture {
+    static constexpr int32_t fds_per_partition
+      = std::numeric_limits<int32_t>::max();
+
+    partition_allocator_fd_limited_fixture()
+      : partition_allocator_fixture(std::nullopt, fds_per_partition) {}
 };

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1295,7 +1295,7 @@ ss::future<topic_result> topics_frontend::do_create_partition(
     // we only support increasing number of partitions
     if (p_cfg.new_total_partition_count <= tp_cfg->partition_count) {
         co_return make_error_result(
-          p_cfg.tp_ns, errc::topic_invalid_partitions);
+          p_cfg.tp_ns, errc::topic_invalid_partitions_decreased);
     }
     if (_topics.local().is_fully_disabled(p_cfg.tp_ns)) {
         co_return make_error_result(p_cfg.tp_ns, errc::topic_disabled);

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -69,7 +69,11 @@ struct instance_generator<cluster::errc> {
            cluster::errc::feature_disabled,
            cluster::errc::invalid_request,
            cluster::errc::no_update_in_progress,
-           cluster::errc::unknown_update_interruption_error});
+           cluster::errc::unknown_update_interruption_error,
+           cluster::errc::topic_invalid_partitions_core_limit,
+           cluster::errc::topic_invalid_partitions_memory_limit,
+           cluster::errc::topic_invalid_partitions_fd_limit,
+           cluster::errc::topic_invalid_partitions_decreased});
     }
 
     static std::vector<cluster::errc> limits() { return {}; }

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -21,6 +21,10 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::topic_invalid_config:
         return error_code::invalid_config;
     case cluster::errc::topic_invalid_partitions:
+    case cluster::errc::topic_invalid_partitions_core_limit:
+    case cluster::errc::topic_invalid_partitions_memory_limit:
+    case cluster::errc::topic_invalid_partitions_fd_limit:
+    case cluster::errc::topic_invalid_partitions_decreased:
         return error_code::invalid_partitions;
     case cluster::errc::topic_invalid_replication_factor:
         return error_code::invalid_replication_factor;

--- a/src/v/kafka/server/handlers/create_partitions.cc
+++ b/src/v/kafka/server/handlers/create_partitions.cc
@@ -315,6 +315,7 @@ ss::future<response_ptr> create_partitions_handler::handle(
           return create_partitions_topic_result{
             .name = std::move(r.tp_ns.tp),
             .error_code = map_topic_error_code(r.ec),
+            .error_message = cluster::make_error_code(r.ec).message(),
           };
       });
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -146,7 +146,10 @@ struct topic_op_result {
 
 inline creatable_topic_result
 from_cluster_topic_result(const cluster::topic_result& err) {
-    return {.name = err.tp_ns.tp, .error_code = map_topic_error_code(err.ec)};
+    return {
+      .name = err.tp_ns.tp,
+      .error_code = map_topic_error_code(err.ec),
+      .error_message = cluster::make_error_code(err.ec).message()};
 }
 
 config_map_t config_map(const std::vector<createable_topic_config>& config);

--- a/src/v/kafka/server/tests/error_mapping_test.cc
+++ b/src/v/kafka/server/tests/error_mapping_test.cc
@@ -24,6 +24,22 @@ BOOST_AUTO_TEST_CASE(error_mapping_test) {
       kafka::error_code::invalid_partitions);
     BOOST_REQUIRE_EQUAL(
       kafka::map_topic_error_code(
+        cluster::errc::topic_invalid_partitions_core_limit),
+      kafka::error_code::invalid_partitions);
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_topic_error_code(
+        cluster::errc::topic_invalid_partitions_memory_limit),
+      kafka::error_code::invalid_partitions);
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_topic_error_code(
+        cluster::errc::topic_invalid_partitions_fd_limit),
+      kafka::error_code::invalid_partitions);
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_topic_error_code(
+        cluster::errc::topic_invalid_partitions_decreased),
+      kafka::error_code::invalid_partitions);
+    BOOST_REQUIRE_EQUAL(
+      kafka::map_topic_error_code(
         cluster::errc::topic_invalid_replication_factor),
       kafka::error_code::invalid_replication_factor);
     BOOST_REQUIRE_EQUAL(


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This change improves the error response for when Redpanda is provided an invalid number of partitions during either topic creation or when the user is requesting an increase in the number of partitions.  Now, instead of just returning back `invalid_partitions` and error message is also provided explaining why.

Fixes: #17368 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [X] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* Improves error feedback when Redpanda is given an invalid number of partitions during either topic creation or when the partition count for a topic is increased.
