### PR TITLE
CORE-2163: tests/e2e_iam_role_test: mock AKS and AzureVM credential test

### DIFF
--- a/tests/rptest/tests/e2e_iam_role_test.py
+++ b/tests/rptest/tests/e2e_iam_role_test.py
@@ -1,12 +1,16 @@
 from collections import defaultdict
 
+from rptest.clients.rpk import RpkTool
 from rptest.services.cluster import cluster
 
 from rptest.clients.types import TopicSpec
 from rptest.services.mock_iam_roles_server import MockIamRolesServer
-from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST
+from rptest.services.redpanda import CHAOS_LOG_ALLOW_LIST, CloudStorageType, SISettings, get_cloud_storage_type
 from rptest.tests.e2e_shadow_indexing_test import EndToEndShadowIndexingBase
+from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import produce_until_segments, wait_for_local_storage_truncate
+from ducktape.utils.util import wait_until
+from ducktape.mark import matrix, ignore
 
 
 class AWSRoleFetchTests(EndToEndShadowIndexingBase):
@@ -143,6 +147,165 @@ class STSRoleFetchTests(EndToEndShadowIndexingBase):
             assert f'RoleArn={self.role}' in request['payload']
             assert f'WebIdentityToken={self.token}' in request['payload']
             assert request['response_code'] == 200
+
+
+class AKSRoleFetchTests(RedpandaTest):
+    def __init__(self, test_context, *args, **kwargs):
+        self.iam_server = MockIamRolesServer(test_context,
+                                             'aws_iam_role_mock.py',
+                                             mock_target='aks')
+        self.token_path = '/tmp/token_file'
+        self.token = 'token'
+        self.client_id = 'tomato'
+        self.tenant_id = 'token-tomato'
+        self.endpoint_url = 'endpoint.url'
+
+        self.si_settings = SISettings(test_context,
+                                      cloud_storage_max_connections=5,
+                                      fast_uploads=True)
+
+        super().__init__(test_context,
+                         *args,
+                         si_settings=self.si_settings,
+                         extra_rp_conf={'log_segment_size': '1048576'},
+                         environment={
+                             'RP_SI_CREDS_API_ADDRESS':
+                             self.iam_server.address,
+                             'AZURE_CLIENT_ID': self.client_id,
+                             'AZURE_TENANT_ID': self.tenant_id,
+                             'AZURE_FEDERATED_TOKEN_FILE': self.token_path,
+                             'AZURE_AUTHORITY_HOST': self.endpoint_url,
+                         },
+                         **kwargs)
+
+        for node in self.redpanda.nodes:
+            node.account.create_file(self.token_path, self.token)
+        # need to set this after __init__ to overwrite SISettings
+        self.redpanda.add_extra_rp_conf(
+            {'cloud_storage_credentials_source': 'azure_aks_oidc_federation'})
+
+    def setUp(self):
+        self.iam_server.start()
+        self.redpanda.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.iam_server.stop()
+        self.iam_server.wait()
+        self.iam_server.clean()
+
+    @ignore
+    @cluster(num_nodes=2)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_basic(self, cloud_storage_type):
+        """
+        verify that this configuration will fetch a credential from the mock server and use it to upload to Azure
+        """
+        if cloud_storage_type != CloudStorageType.ABS:
+            return
+        RpkTool(self.redpanda).create_topic(topic="panda-aks-smoketest",
+                                            partitions=3,
+                                            config={
+                                                'redpanda.remote.read': 'true',
+                                                'redpanda.remote.write': 'true'
+                                            })
+        for i in range(3):
+            produce_until_segments(
+                redpanda=self.redpanda,
+                topic="panda-aks-smoketest",
+                partition_idx=i,
+                count=5,
+            )
+
+        wait_until(
+            lambda: len(self.iam_server.requests) > 0,
+            timeout_sec=300,
+            backoff_sec=1,
+            err_msg=lambda:
+            f"failed to collect enough requests to the Mock Server. {len(self.iam_server.requests)}"
+        )
+
+        req = self.iam_server.requests[-1]
+        assert req['path'] == '/token-tomato/oauth2/v2.0/token' and req[
+            'method'] == 'POST' and f"client_id={self.client_id}" in req[
+                'payload'] and f"client_assertion={self.token}" in req[
+                    'payload'], f"request not conforming to specs {self.iam_server.requests}"
+
+
+class AzureVMRoleFetchTests(RedpandaTest):
+    def __init__(self, test_context, *args, **kwargs):
+        self.iam_server = MockIamRolesServer(test_context,
+                                             'aws_iam_role_mock.py',
+                                             mock_target='azure_vm')
+        self.client_id = 'tomato'
+        self.si_settings = SISettings(test_context,
+                                      cloud_storage_max_connections=5,
+                                      fast_uploads=True)
+
+        super().__init__(test_context,
+                         *args,
+                         si_settings=self.si_settings,
+                         extra_rp_conf={'log_segment_size': '1048576'},
+                         environment={
+                             'RP_SI_CREDS_API_ADDRESS':
+                             self.iam_server.address,
+                         },
+                         **kwargs)
+
+        # need to set this after __init__ to overwrite SISettings
+        self.redpanda.add_extra_rp_conf({
+            'cloud_storage_credentials_source':
+            'azure_vm_instance_metadata',
+            'cloud_storage_azure_managed_identity_id':
+            self.client_id
+        })
+
+    def setUp(self):
+        self.iam_server.start()
+        self.redpanda.start()
+
+    def tearDown(self):
+        super().tearDown()
+        self.iam_server.stop()
+        self.iam_server.wait()
+        self.iam_server.clean()
+
+    @ignore
+    @cluster(num_nodes=2)
+    @matrix(cloud_storage_type=get_cloud_storage_type())
+    def test_basic(self, cloud_storage_type):
+        """
+        verify that this configuration will fetch a credential from the mock server and use it to upload to Azure
+        """
+        if cloud_storage_type != CloudStorageType.ABS:
+            return
+        RpkTool(self.redpanda).create_topic(topic="panda-avm-smoketest",
+                                            partitions=3,
+                                            config={
+                                                'redpanda.remote.read': 'true',
+                                                'redpanda.remote.write': 'true'
+                                            })
+        for i in range(3):
+            produce_until_segments(
+                redpanda=self.redpanda,
+                topic="panda-avm-smoketest",
+                partition_idx=i,
+                count=5,
+            )
+
+        wait_until(
+            lambda: len(self.iam_server.requests) > 0,
+            timeout_sec=300,
+            backoff_sec=1,
+            err_msg=lambda:
+            f"failed to collect enough requests to the Mock Server. {len(self.iam_server.requests)}"
+        )
+
+        req = self.iam_server.requests[-1]
+        assert req['path'].startswith(
+            '/metadata/identity/oauth2/token'
+        ) and req['method'] == 'GET' and f"client_id={self.client_id}" in req[
+            'path'], f"request not conforming to specs {self.iam_server.requests}"
 
 
 class ShortLivedCredentialsTests(EndToEndShadowIndexingBase):


### PR DESCRIPTION
followup for https://github.com/redpanda-data/redpanda/pull/17157

waiting for a fix for https://github.com/redpanda-data/redpanda/issues/17373


note to self: include followups from the comments here https://github.com/redpanda-data/redpanda/pull/17157 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->


* none
