### PR TITLE
Offset tracker invariants

### DIFF
--- a/src/go/rpk/pkg/tuners/iotune/data.go
+++ b/src/go/rpk/pkg/tuners/iotune/data.go
@@ -67,6 +67,7 @@ func ToJSON(props IoProperties) (string, error) {
 }
 
 func precompiledData() map[string]map[string]map[string]io {
+	// see IoProperties for field mapping
 	return map[string]map[string]map[string]io{
 		"aws": {
 			"i3.large": {
@@ -113,6 +114,141 @@ func precompiledData() map[string]map[string]map[string]io {
 			},
 			"i3en.metal": {
 				"default": {"", 257024 * 8, 2043674624 * 8, 174080 * 8, 1024458752 * 8},
+			},
+
+			// is4gen values are taken from measurements except where noted.
+			// For reference, the advertised IOPS values also also shown, these are from:
+			// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/storage-optimized-instances.html
+			// Except for is4gen.8xlarge the alignment between advertised and measured IOPS is very close.
+			// Test results on is4gen show that the BW/IOPS ratio is 8K for reads and 5K for writes.
+			"is4gen.medium": {
+				// advertised   31250             25000
+				"default": {"", 31407, 251665056, 25105, 125274040},
+			},
+
+			"is4gen.large": {
+				// advertised   62500             50000
+				"default": {"", 62804, 503442048, 50214, 251087344},
+			},
+
+			"is4gen.xlarge": {
+				// advertised   125000              100000
+				"default": {"", 125659, 1015560064, 100404, 502173344},
+			},
+
+			"is4gen.2xlarge": {
+				// advertised   250000              200000
+				"default": {"", 251076, 2066053248, 201105, 1012893056},
+			},
+
+			"is4gen.4xlarge": {
+				// advertised   500000              400000
+				"default": {"", 502117, 4132124160, 402148, 2025763456},
+			},
+
+			// The measured values for is4gen.8xlarge broke the expected pattern
+			// and compared to 4xlarge for IOPS were slightly lower (!!) on the read side and
+			// only slightly higher on the write side, rather than the expected 2x
+			// jump. Signs point towards a measurement limitation rather than a real
+			// limitation, so for now we use 2x the prior instance type values.
+			// See: https://github.com/redpanda-data/redpanda/issues/17162.
+			"is4gen.8xlarge": {
+				// advertised      1000000                      800000
+				// measured         457957,     7433367040,     433330,     4051469824
+				"default": {"", 2 * 502117, 2 * 4132124160, 2 * 402148, 2 * 2025763456},
+			},
+
+			"im4gn.large": {
+				// advertised   31250             25000
+				"default": {"", 31407, 251664976, 25105, 125273408},
+			},
+
+			"im4gn.xlarge": {
+				// advertised   62500             50000
+				"default": {"", 62809, 503439040, 50214, 251087600},
+			},
+
+			"im4gn.2xlarge": {
+				// advertised   125000              100000
+				"default": {"", 125664, 1015557248, 100411, 502192960},
+			},
+
+			"im4gn.4xlarge": {
+				// advertised   250000              200000
+				"default": {"", 251063, 2066157056, 201088, 1012886080},
+			},
+
+			"im4gn.8xlarge": {
+				// advertised   500000              400000
+				"default": {"", 502106, 4132167424, 402129, 2025818624},
+			},
+
+			// see comment on is4gen.8xlarge for what's going on here
+			"im4gn.16xlarge": {
+				// advertised      1000000                      800000
+				// measured         556572,     8128993280,     497509,    4051727616},
+				"default": {"", 2 * 502106, 2 * 4132167424, 2 * 402129, 2 * 2025818624},
+			},
+
+			// i4i values are taken from direct measurement with iotune except
+			// where noted.
+			// i4i has a ~7K read BW/IOPS ratio and a 10K write BW/IOPS ratio,
+			// where the write side is notably higher than other storage optimized
+			// instance types.
+			"i4i.large": {
+				// advertised:  50000             27500
+				"default": {"", 50203, 352041984, 27599, 275442496},
+			},
+
+			"i4i.xlarge": {
+				// advertised:  100000             55000
+				"default": {"", 100371, 707373312, 55269, 552871552},
+			},
+
+			"i4i.2xlarge": {
+				// advertised:  200000              110000
+				"default": {"", 200633, 1427463808, 110542, 1113520256},
+			},
+
+			// at 4xlarge and above the read-side IOPS values start to scale
+			// more poorly that advertised/expected, so use scaled values
+			// from 2xlarge instead, under the assumption it is a measurement
+			// limitation
+			"i4i.4xlarge": {
+				// advertised:      400000                  220000
+				// measured:        302635,     2853325312, 221201, 2259740160,
+				"default": {"", 2 * 200633, 2 * 1427463808, 2 * 110542, 2 * 1113520256},
+			},
+
+			"i4i.8xlarge": {
+				// advertised:      800000                      440000
+				// measured         519944,     5704762368,     442395,     4519457792},
+				"default": {"", 4 * 200633, 4 * 1427463808, 4 * 110542, 4 * 1113520256},
+			},
+
+			// 12x large was not measured
+			"i4i.12xlarge": {
+				// advertised:     1200000                      660000
+				"default": {"", 6 * 200633, 6 * 1427463808, 6 * 110542, 6 * 1113520256},
+			},
+
+			"i4i.16xlarge": {
+				// advertised:      16000000                    880000
+				// measured         752697,     8585068032,     750060,     8211869696},
+				"default": {"", 8 * 200633, 8 * 1427463808, 8 * 110542, 8 * 1113520256},
+			},
+
+			// 24x large was not measured
+			"i4i.24xlarge": {
+				// advertised:      2400000                       1320000
+				"default": {"", 12 * 200633, 12 * 1427463808, 12 * 110542, 12 * 1113520256},
+			},
+
+			// 32x large was not measured, iotune fails to start
+			// see https://github.com/redpanda-data/redpanda/issues/17154
+			"i4i.32xlarge": {
+				// advertised:      3200000                       1760000
+				"default": {"", 16 * 200633, 16 * 1427463808, 16 * 110542, 16 * 1113520256},
 			},
 		},
 	}

--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -441,6 +441,17 @@ command_batch_builder::read_write_fence(model::offset offset) {
     return *this;
 }
 
+command_batch_builder& command_batch_builder::update_highest_producer_id(
+  model::producer_id highest_pid) {
+    if (highest_pid != model::producer_id{}) {
+        iobuf key_buf = serde::to_iobuf(
+          archival_metadata_stm::update_highest_producer_id_cmd::key);
+        iobuf val_buf = serde::to_iobuf(highest_pid());
+        _builder.add_raw_kv(std::move(key_buf), std::move(val_buf));
+    }
+    return *this;
+}
+
 ss::future<std::error_code> command_batch_builder::replicate() {
     _as.check();
     return _stm.get()._lock.with([this]() {

--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -731,17 +731,29 @@ ss::future<std::error_code> archival_metadata_stm::process_anomalies(
     co_return co_await builder.replicate();
 }
 
-ss::future<bool>
+ss::future<std::optional<model::offset>>
 archival_metadata_stm::sync(model::timeout_clock::duration timeout) {
     return sync(timeout, nullptr);
 }
 
-ss::future<bool> archival_metadata_stm::sync(
+ss::future<std::optional<model::offset>> archival_metadata_stm::sync(
   model::timeout_clock::duration timeout, ss::abort_source* as) {
     return _lock
-      .with(timeout, [this, timeout, as] { return do_sync(timeout, as); })
+      .with(
+        timeout,
+        [this, timeout, as] {
+            return do_sync(timeout, as).then([this](bool synced) {
+                std::optional<model::offset> res;
+                if (synced) {
+                    res = _manifest->get_applied_offset();
+                }
+                return res;
+            });
+        })
       .handle_exception_type(
-        [](const ss::semaphore_timed_out&) { return false; });
+        [](const ss::semaphore_timed_out&) -> std::optional<model::offset> {
+            return std::nullopt;
+        });
 }
 
 ss::future<bool> archival_metadata_stm::do_sync(

--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -193,9 +193,13 @@ struct archival_metadata_stm::update_highest_producer_id_cmd {
     using value = model::producer_id;
 };
 
+// Serde format description
+// v5
+//  - add apply_offset field
+//
 struct archival_metadata_stm::snapshot
   : public serde::
-      envelope<snapshot, serde::version<4>, serde::compat_version<0>> {
+      envelope<snapshot, serde::version<5>, serde::compat_version<0>> {
     /// List of segments
     fragmented_vector<segment> segments;
     /// List of replaced segments
@@ -238,6 +242,8 @@ struct archival_metadata_stm::snapshot
     cloud_storage::anomalies detected_anomalies;
     // Highest producer ID used by this partition.
     model::producer_id highest_producer_id;
+    // Offset of the last applied command
+    model::offset applied_offset;
 
     auto serde_fields() {
         return std::tie(
@@ -256,7 +262,8 @@ struct archival_metadata_stm::snapshot
           last_partition_scrub,
           last_scrubbed_offset,
           detected_anomalies,
-          highest_producer_id);
+          highest_producer_id,
+          applied_offset);
     }
 };
 
@@ -583,6 +590,7 @@ ss::future<> archival_metadata_stm::make_snapshot(
       .start_kafka_offset = m.get_start_kafka_offset_override(),
       .spillover_manifests = std::move(spillover),
       .highest_producer_id = m.highest_producer_id(),
+      .applied_offset = m.get_applied_offset(),
     });
 
     auto snapshot = raft::stm_snapshot::create(
@@ -937,6 +945,7 @@ ss::future<> archival_metadata_stm::apply(const model::record_batch& b) {
         b.for_each_record(
           [this, base_offset = b.base_offset()](model::record&& r) {
               _last_dirty_at = base_offset + model::offset{r.offset_delta()};
+              _manifest->advance_applied_offset(_last_dirty_at);
               auto key = serde::from_iobuf<uint8_t>(r.release_key());
               auto val = serde::from_iobuf<prefix_truncate_record>(
                 r.release_value());
@@ -953,6 +962,9 @@ ss::future<> archival_metadata_stm::apply(const model::record_batch& b) {
             b.for_each_record([this, base_offset = b.base_offset()](
                                 model::record&& r) {
                 auto key = serde::from_iobuf<cmd_key>(r.release_key());
+
+                _manifest->advance_applied_offset(
+                  base_offset + model::offset{r.offset_delta()});
 
                 if (key != mark_clean_cmd::key) {
                     // All keys other than mark clean make the manifest dirty
@@ -1142,7 +1154,8 @@ ss::future<> archival_metadata_stm::apply_local_snapshot(
       snap.last_partition_scrub,
       snap.last_scrubbed_offset,
       snap.detected_anomalies,
-      snap.highest_producer_id);
+      snap.highest_producer_id,
+      snap.applied_offset);
 
     vlog(
       _logger.info,

--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -9,6 +9,7 @@
 
 #include "archival/archival_metadata_stm.h"
 
+#include "archival/logger.h"
 #include "base/vlog.h"
 #include "bytes/iobuf.h"
 #include "bytes/iostream.h"
@@ -27,6 +28,7 @@
 #include "model/record.h"
 #include "model/record_batch_types.h"
 #include "model/record_utils.h"
+#include "model/timeout_clock.h"
 #include "raft/consensus.h"
 #include "raft/persisted_stm.h"
 #include "resource_mgmt/io_priority.h"
@@ -39,6 +41,10 @@
 #include "utils/named_type.h"
 
 #include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/lowres_clock.hh>
+#include <seastar/core/semaphore.hh>
 #include <seastar/core/shared_future.hh>
 #include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
@@ -46,7 +52,9 @@
 #include <seastar/util/defer.hh>
 
 #include <algorithm>
+#include <exception>
 #include <optional>
+#include <utility>
 
 namespace cluster {
 
@@ -412,7 +420,7 @@ ss::future<std::error_code> command_batch_builder::replicate() {
           _stm.get()._logger.debug, "command_batch_builder::replicate called");
         auto now = ss::lowres_clock::now();
         auto timeout = now < _deadline ? _deadline - now : 0ms;
-        return _stm.get().sync(timeout).then([this](bool success) {
+        return _stm.get().do_sync(timeout, &_as).then([this](bool success) {
             if (!success) {
                 return ss::make_ready_future<std::error_code>(errc::not_leader);
             }
@@ -685,162 +693,79 @@ ss::future<std::error_code> archival_metadata_stm::process_anomalies(
 
 ss::future<bool>
 archival_metadata_stm::sync(model::timeout_clock::duration timeout) {
-    // If there's any replications pending, wait for them to complete.
-    // Note that we throw away the result and use Raft's committed offset
-    // below. If replication failed, exit unsuccessfully.
+    return sync(timeout, nullptr);
+}
 
-    if (_last_replicate) {
-        if (!_last_replicate->result.available()) {
-            vlog(
-              _logger.debug, "Waiting for ongoing replication before syncing");
-        }
+ss::future<bool> archival_metadata_stm::sync(
+  model::timeout_clock::duration timeout, ss::abort_source* as) {
+    return _lock
+      .with(timeout, [this, timeout, as] { return do_sync(timeout, as); })
+      .handle_exception_type(
+        [](const ss::semaphore_timed_out&) { return false; });
+}
 
-        try {
-            const auto before = model::timeout_clock::now();
-
-            const auto res = co_await _last_replicate->result.get_future(
-              before + timeout);
-
-            const auto after = model::timeout_clock::now();
-            // Update the timeout whille accounting for under/overflow.
-            const auto duration = after > before
-                                    ? after - before
-                                    : ss::lowres_clock::duration{0};
-
-            if (duration >= timeout) {
-                throw ss::timed_out_error{};
-            }
-
-            timeout -= duration;
-
-            // If we've got this far it means that the _last_replicate future
-            // was resolved. If it resolved successfully, then we can continue.
-            // If it failed for any reason, it is safe to "forget" about it in
-            // only if the term changed. Otherwise we can't make any assumptions
-            // about its state.
-            // Stepping down (liveness) is guaranteed by the logic in the
-            // `do_replicate_commands` method.
-            if (res || _last_replicate->term < _raft->term()) {
-                _last_replicate = std::nullopt;
-            }
-
-            if (!res) {
-                vlog(
-                  _logger.warn,
-                  "Replication failed for archival STM command: {}",
-                  res.error());
-
-                co_return false;
-            }
-        } catch (const ss::timed_out_error&) {
-            vlog(
-              _logger.warn,
-              "Replication wait for archival STM timed out (timeout = {})",
-              timeout);
-            co_return false;
-        } catch (...) {
-            vlog(
-              _logger.error,
-              "Replication failed for archival STM command: {}",
-              std::current_exception());
-            co_return false;
-        }
-    }
-
-    if (!_raft->is_leader()) {
+ss::future<bool> archival_metadata_stm::do_sync(
+  model::timeout_clock::duration timeout, ss::abort_source* as) {
+    if (!co_await raft::persisted_stm<>::sync(timeout)) {
         co_return false;
     }
 
-    const auto last_applied_term = _insync_term;
-    const auto last_applied_offset = _manifest->get_insync_offset();
-    const auto current_term = _raft->term();
-    const auto committed_offset = _raft->committed_offset();
+    vassert(
+      !_lock.try_get_units().has_value(),
+      "Attempt to replicate STM command while not under lock");
+    // This mutex is held during the replication of the record batch.
+    // After acquiring the mutex we can't have in-flight replication request but
+    // we can have some data in the log which is not applied to the STM yet.
+    // The code below simply waits until all record batches up to current
+    // committed offset are applied to the STM.
+    // The log eviction STM can also replicate its own batch without holding the
+    // lock but it's not critical.
 
-    if (
-      last_applied_term == current_term
-      && last_applied_offset < committed_offset) {
-        // Case 1: we have already synced (once or more) during the current
-        // term, but need to sync again (e.g. re-starting the archiver to
-        // apply topic configs)
-        vlog(
-          _logger.debug,
-          "Syncing archival STM from last applied offset {} to committed "
-          "offest {} in term {}",
-          last_applied_offset,
-          committed_offset,
-          current_term);
+    auto insync = _manifest->get_insync_offset();
 
-        const bool synced = co_await wait_no_throw(
-          committed_offset, model::timeout_clock::now() + timeout);
-
-        if (!synced) {
-            vlog(
-              _logger.warn,
-              "Failed to sync archival STM from offset {} to offest {} in "
-              "term {}",
-              last_applied_offset,
-              committed_offset,
-              current_term);
+    // all archival commands are replicated with acks=-1
+    // this is why we can use committed_offset
+    auto commit = _raft->committed_offset();
+    if (insync < commit) {
+        if (as == nullptr) {
+            co_return co_await wait_no_throw(
+              commit, ss::lowres_clock::now() + timeout);
+        } else {
+            co_return co_await wait_no_throw(
+              commit, ss::lowres_clock::now() + timeout, *as);
         }
-
-        co_return synced;
-    } else {
-        // Case 2: we have not synced since the last term (e.g. on
-        // leadership changes)
-        vlog(
-          _logger.debug,
-          "Syncing archival STM to latest term {} from term {}",
-          current_term,
-          last_applied_term);
-        const bool synced = co_await persisted_stm::sync(timeout);
-
-        if (!synced) {
-            vlog(_logger.warn, "Failed to sync archival STM to latest term");
-        }
-
-        co_return synced;
     }
+    // This should be impossible under lock
+    vassert(
+      _active_operation_res.has_value() == false, "Concurrency violation");
+    co_return true;
 }
 
 ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
   model::record_batch batch, ss::abort_source& as) {
     vassert(
-      !_last_replicate.has_value(),
-      "Concurrent replication of archival STM commands");
-    vassert(
       !_lock.try_get_units().has_value(),
       "Attempt to replicate STM command while not under lock");
+    vassert(
+      _active_operation_res.has_value() == false, "Concurrency violation");
 
     const auto current_term = _insync_term;
 
-    ss::shared_promise<result<raft::replicate_result>> replication_promise;
-    _last_replicate = last_replicate{
-      .term = current_term, .result = replication_promise.get_shared_future()};
+    // Create a promise to deliver the result of the batch application
+    _active_operation_res.emplace();
+    auto broken_promise_to_shutdown = [](const ss::broken_promise&) {
+        return errc::shutting_down;
+    };
+    auto apply_result = _active_operation_res->get_future()
+                          .handle_exception_type(broken_promise_to_shutdown);
+    auto op_state_reset = ss::defer([&] { _active_operation_res.reset(); });
 
     auto opts = raft::replicate_options(raft::consistency_level::quorum_ack);
     opts.set_force_flush();
-
-    auto fut
-      = _raft
-          ->replicate(
-            current_term,
-            model::make_memory_record_batch_reader(std::move(batch)),
-            opts)
-          .then_wrapped(
-            [replication_promise = std::move(replication_promise)](
-              auto f) mutable -> ss::future<result<raft::replicate_result>> {
-                if (f.failed()) {
-                    const auto ex_ptr = f.get_exception();
-                    replication_promise.set_exception(ex_ptr);
-                    return ss::make_exception_future<
-                      result<raft::replicate_result>>(ex_ptr);
-                } else {
-                    const auto res = f.get();
-                    replication_promise.set_value(res);
-                    return ss::make_ready_future<
-                      result<raft::replicate_result>>(res);
-                }
-            });
+    auto fut = _raft->replicate(
+      current_term,
+      model::make_memory_record_batch_reader(std::move(batch)),
+      opts);
 
     // Raft's replicate() doesn't take an external abort source, and
     // archiver is shut down before consensus, so we must wrap this
@@ -878,7 +803,10 @@ ss::future<std::error_code> archival_metadata_stm::do_replicate_commands(
         co_return errc::replication_error;
     }
 
-    co_return errc::success;
+    // We are under lock so it's guaranteed that the command that will
+    // trigger this is replicated by this call.
+    op_state_reset.cancel();
+    co_return co_await std::move(apply_result);
 }
 
 ss::future<std::error_code> archival_metadata_stm::mark_clean(
@@ -928,7 +856,7 @@ ss::future<std::error_code> archival_metadata_stm::do_add_segments(
     {
         auto now = ss::lowres_clock::now();
         auto timeout = now < deadline ? deadline - now : 0ms;
-        if (!co_await sync(timeout)) {
+        if (!co_await do_sync(timeout, &as)) {
             co_return errc::timeout;
         }
     }
@@ -1019,81 +947,94 @@ ss::future<> archival_metadata_stm::apply(const model::record_batch& b) {
               }
           });
     } else {
-        b.for_each_record([this,
-                           base_offset = b.base_offset()](model::record&& r) {
-            auto key = serde::from_iobuf<cmd_key>(r.release_key());
+        auto on_exit = ss::defer(
+          [this] { maybe_notify_waiter(errc::success); });
+        try {
+            b.for_each_record([this, base_offset = b.base_offset()](
+                                model::record&& r) {
+                auto key = serde::from_iobuf<cmd_key>(r.release_key());
 
-            if (key != mark_clean_cmd::key) {
-                // All keys other than mark clean make the manifest dirty
-                _last_dirty_at = base_offset + model::offset{r.offset_delta()};
-            }
+                if (key != mark_clean_cmd::key) {
+                    // All keys other than mark clean make the manifest dirty
+                    _last_dirty_at = base_offset
+                                     + model::offset{r.offset_delta()};
+                }
 
-            switch (key) {
-            case add_segment_cmd::key:
-                apply_add_segment(
-                  serde::from_iobuf<add_segment_cmd::value>(r.release_value()));
-                break;
-            case truncate_cmd::key:
-                apply_truncate(
-                  serde::from_iobuf<truncate_cmd::value>(r.release_value()));
-                break;
-            case update_start_offset_cmd::key:
-                apply_update_start_offset(
-                  serde::from_iobuf<update_start_offset_cmd::value>(
-                    r.release_value()));
-                break;
-            case cleanup_metadata_cmd::key:
-                apply_cleanup_metadata();
-                break;
-            case mark_clean_cmd::key:
-                apply_mark_clean(
-                  serde::from_iobuf<mark_clean_cmd::value>(r.release_value()));
-                break;
-            case truncate_archive_init_cmd::key:
-                apply_truncate_archive_init(
-                  serde::from_iobuf<truncate_archive_init_cmd::value>(
-                    r.release_value()));
-                break;
-            case truncate_archive_commit_cmd::key: {
-                auto cmd
-                  = serde::from_iobuf<truncate_archive_commit_cmd::value>(
-                    r.release_value());
-                apply_truncate_archive_commit(
-                  cmd.start_offset, cmd.bytes_removed);
-            } break;
-            case update_start_kafka_offset_cmd::key:
-                apply_update_start_kafka_offset(
-                  serde::from_iobuf<update_start_kafka_offset_cmd::value>(
-                    r.release_value()));
-                break;
-            case reset_metadata_cmd::key:
-                apply_reset_metadata();
-                break;
-            case spillover_cmd::key:
-                apply_spillover(
-                  serde::from_iobuf<spillover_cmd>(r.release_value()));
-                break;
-            case replace_manifest_cmd::key:
-                apply_replace_manifest(r.release_value());
-                break;
-            case process_anomalies_cmd::key:
-                apply_process_anomalies(r.release_value());
-                break;
-            case reset_scrubbing_metadata::key:
-                apply_reset_scrubbing_metadata();
-                break;
-            case update_highest_producer_id_cmd::key:
-                apply_update_highest_producer_id(
-                  serde::from_iobuf<update_highest_producer_id_cmd::value>(
-                    r.release_value()));
-                break;
-            default:
-                throw std::runtime_error(fmt_with_ctx(
-                  fmt::format,
-                  "Unknown archival metadata STM command {}",
-                  static_cast<int>(key)));
-            };
-        });
+                switch (key) {
+                case add_segment_cmd::key:
+                    apply_add_segment(serde::from_iobuf<add_segment_cmd::value>(
+                      r.release_value()));
+                    break;
+                case truncate_cmd::key:
+                    apply_truncate(serde::from_iobuf<truncate_cmd::value>(
+                      r.release_value()));
+                    break;
+                case update_start_offset_cmd::key:
+                    apply_update_start_offset(
+                      serde::from_iobuf<update_start_offset_cmd::value>(
+                        r.release_value()));
+                    break;
+                case cleanup_metadata_cmd::key:
+                    apply_cleanup_metadata();
+                    break;
+                case mark_clean_cmd::key:
+                    apply_mark_clean(serde::from_iobuf<mark_clean_cmd::value>(
+                      r.release_value()));
+                    break;
+                case truncate_archive_init_cmd::key:
+                    apply_truncate_archive_init(
+                      serde::from_iobuf<truncate_archive_init_cmd::value>(
+                        r.release_value()));
+                    break;
+                case truncate_archive_commit_cmd::key: {
+                    auto cmd
+                      = serde::from_iobuf<truncate_archive_commit_cmd::value>(
+                        r.release_value());
+                    apply_truncate_archive_commit(
+                      cmd.start_offset, cmd.bytes_removed);
+                } break;
+                case update_start_kafka_offset_cmd::key:
+                    apply_update_start_kafka_offset(
+                      serde::from_iobuf<update_start_kafka_offset_cmd::value>(
+                        r.release_value()));
+                    break;
+                case reset_metadata_cmd::key:
+                    apply_reset_metadata();
+                    break;
+                case spillover_cmd::key:
+                    apply_spillover(
+                      serde::from_iobuf<spillover_cmd>(r.release_value()));
+                    break;
+                case replace_manifest_cmd::key:
+                    apply_replace_manifest(r.release_value());
+                    break;
+                case process_anomalies_cmd::key:
+                    apply_process_anomalies(r.release_value());
+                    break;
+                case reset_scrubbing_metadata::key:
+                    apply_reset_scrubbing_metadata();
+                    break;
+                case update_highest_producer_id_cmd::key:
+                    apply_update_highest_producer_id(
+                      serde::from_iobuf<update_highest_producer_id_cmd::value>(
+                        r.release_value()));
+                    break;
+                default:
+                    throw std::runtime_error(fmt_with_ctx(
+                      fmt::format,
+                      "Unknown archival metadata STM command {}",
+                      static_cast<int>(key)));
+                };
+            });
+        } catch (...) {
+            vlog(
+              _logger.error,
+              "Unexpected error while applying changes to "
+              "archival_metadata_stm: {}",
+              std::current_exception());
+            on_exit.cancel();
+            maybe_notify_waiter(std::current_exception());
+        }
     }
 
     // The offset should only be advanced after all the changes are applied.
@@ -1292,6 +1233,20 @@ model::offset archival_metadata_stm::max_collectible_offset() {
     return lo;
 }
 
+void archival_metadata_stm::maybe_notify_waiter(cluster::errc err) noexcept {
+    if (_active_operation_res) {
+        auto p = std::exchange(_active_operation_res, std::nullopt);
+        p->set_value(err);
+    }
+}
+
+void archival_metadata_stm::maybe_notify_waiter(std::exception_ptr e) noexcept {
+    if (_active_operation_res) {
+        auto p = std::exchange(_active_operation_res, std::nullopt);
+        p->set_exception(e);
+    }
+}
+
 void archival_metadata_stm::apply_add_segment(const segment& segment) {
     auto meta = segment.meta;
     bool disable_safe_add
@@ -1315,6 +1270,7 @@ void archival_metadata_stm::apply_add_segment(const segment& segment) {
           "Can't add segment: {}, previous segment: {}",
           meta,
           last);
+        maybe_notify_waiter(errc::inconsistent_stm_update);
         return;
     }
     if (meta.ntp_revision == model::initial_revision_id{}) {

--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -235,8 +235,9 @@ public:
 
     /// This method guarantees that the STM applied all changes
     /// in the log to the in-memory state.
-    ss::future<bool> sync(model::timeout_clock::duration timeout);
-    ss::future<bool>
+    ss::future<std::optional<model::offset>>
+    sync(model::timeout_clock::duration timeout);
+    ss::future<std::optional<model::offset>>
     sync(model::timeout_clock::duration timeout, ss::abort_source* as);
 
     model::offset get_start_offset() const;

--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -102,6 +102,10 @@ public:
     /// concurrency-control mechanism.
     command_batch_builder& read_write_fence(model::offset offset);
 
+    /// Add update_highest_producer_id_cmd command
+    command_batch_builder&
+    update_highest_producer_id(model::producer_id highest_pid);
+
     /// Replicate the configuration batch
     ss::future<std::error_code> replicate();
 

--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -14,20 +14,26 @@
 #include "cloud_storage/fwd.h"
 #include "cloud_storage/partition_manifest.h"
 #include "cloud_storage/types.h"
+#include "cluster/errc.h"
 #include "cluster/state_machine_registry.h"
 #include "features/fwd.h"
 #include "model/fundamental.h"
 #include "model/record.h"
+#include "model/timeout_clock.h"
 #include "raft/persisted_stm.h"
 #include "storage/record_batch_builder.h"
 #include "utils/mutex.h"
 #include "utils/prefix_logger.h"
 
+#include <seastar/core/abort_source.hh>
 #include <seastar/core/circular_buffer.hh>
+#include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sstring.hh>
+#include <seastar/core/weak_ptr.hh>
 #include <seastar/util/log.hh>
 #include <seastar/util/noncopyable_function.hh>
 
+#include <exception>
 #include <functional>
 #include <system_error>
 
@@ -36,6 +42,7 @@ namespace cluster {
 namespace details {
 /// This class is supposed to be implemented in unit tests.
 class archival_metadata_stm_accessor;
+class command_batch_builder_accessor;
 } // namespace details
 
 class archival_metadata_stm;
@@ -45,6 +52,8 @@ using segment_validated = ss::bool_class<struct segment_validated_tag>;
 /// Batch builder allows to combine different archival_metadata_stm commands
 /// together in a single record batch
 class command_batch_builder {
+    friend class command_batch_builder_accessor;
+
 public:
     command_batch_builder(
       archival_metadata_stm& stm,
@@ -85,6 +94,7 @@ public:
       cloud_storage::scrub_status status,
       cloud_storage::anomalies detected);
     command_batch_builder& reset_scrubbing_metadata();
+
     /// Replicate the configuration batch
     ss::future<std::error_code> replicate();
 
@@ -212,10 +222,11 @@ public:
       model::term_id term,
       const cloud_storage::partition_manifest& manifest);
 
-    // Attempts to bring the archival STM in sync with the log.
-    // Returns "true" if it has synced succesfully *and* the replica
-    // is still the leader with the correct term.
+    /// This method guarantees that the STM applied all changes
+    /// in the log to the in-memory state.
     ss::future<bool> sync(model::timeout_clock::duration timeout);
+    ss::future<bool>
+    sync(model::timeout_clock::duration timeout, ss::abort_source* as);
 
     model::offset get_start_offset() const;
     model::offset get_last_offset() const;
@@ -228,7 +239,7 @@ public:
     fragmented_vector<cloud_storage::partition_manifest::lw_segment_meta>
     get_segments_to_cleanup() const;
 
-    /// Create batch builder that can be used to combine and replicate multipe
+    /// Create batch builder that can be used to combine and replicate multiple
     /// STM commands together
     command_batch_builder
     batch_start(ss::lowres_clock::time_point deadline, ss::abort_source&);
@@ -251,6 +262,9 @@ public:
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 private:
+    ss::future<bool>
+    do_sync(model::timeout_clock::duration timeout, ss::abort_source* as);
+
     ss::future<std::error_code> do_add_segments(
       std::vector<cloud_storage::segment_meta>,
       std::optional<model::offset> clean_offset,
@@ -317,6 +331,10 @@ private:
     void apply_reset_scrubbing_metadata();
     void apply_update_highest_producer_id(model::producer_id pid);
 
+    // Notify current waiter in the 'do_replicate'
+    void maybe_notify_waiter(cluster::errc) noexcept;
+    void maybe_notify_waiter(std::exception_ptr) noexcept;
+
 private:
     prefix_logger _logger;
 
@@ -332,12 +350,7 @@ private:
     // The offset of the last record that modified this stm
     model::offset _last_dirty_at;
 
-    // The last replication future
-    struct last_replicate {
-        model::term_id term;
-        ss::shared_future<result<raft::replicate_result>> result;
-    };
-    std::optional<last_replicate> _last_replicate;
+    std::optional<ss::promise<errc>> _active_operation_res;
 
     cloud_storage::remote& _cloud_storage_api;
     features::feature_table& _feature_table;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -362,9 +362,9 @@ ss::future<> ntp_archiver::upload_until_abort() {
         vlog(_rtclog.debug, "upload loop starting in term {}", _start_term);
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
-        bool is_synced = co_await _parent.archival_meta_stm()->sync(
+        auto is_synced = co_await _parent.archival_meta_stm()->sync(
           sync_timeout);
-        if (!is_synced) {
+        if (!is_synced.has_value()) {
             continue;
         }
         vlog(_rtclog.debug, "upload loop synced in term {}", _start_term);
@@ -667,9 +667,9 @@ ss::future<> ntp_archiver::upload_until_term_change() {
 
         auto sync_timeout = config::shard_local_cfg()
                               .cloud_storage_metadata_sync_timeout_ms.value();
-        bool is_synced = co_await _parent.archival_meta_stm()->sync(
+        auto is_synced = co_await _parent.archival_meta_stm()->sync(
           sync_timeout);
-        if (!is_synced) {
+        if (!is_synced.has_value()) {
             // This can happen on leadership changes, or on timeouts waiting
             // for stm to catch up: in either case, we should re-check our
             // loop condition: we will drop out if lost leadership, otherwise

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -494,6 +494,7 @@ FIXTURE_TEST(
         pm.add(name, s);
     }
     pm.advance_insync_offset(model::offset{4});
+    pm.advance_applied_offset(model::offset{4});
     archival_stm
       ->add_segments(
         m,

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -45,9 +45,14 @@ ss::logger logger{"archival_metadata_stm_test"};
 
 static ss::abort_source never_abort;
 
+namespace cluster::details {
+class command_batch_builder_accessor {};
+} // namespace cluster::details
+
 struct archival_metadata_stm_base_fixture
   : simple_raft_fixture
-  , http_imposter_fixture {
+  , http_imposter_fixture
+  , cluster::details::command_batch_builder_accessor {
     using simple_raft_fixture::start_raft;
     using simple_raft_fixture::wait_for_becoming_leader;
     using simple_raft_fixture::wait_for_confirmed_leader;

--- a/src/v/cloud_storage/fwd.h
+++ b/src/v/cloud_storage/fwd.h
@@ -21,7 +21,6 @@ class partition_manifest;
 class topic_manifest;
 class partition_probe;
 class async_manifest_view;
-class partition_probe;
 
 struct log_recovery_result;
 struct offset_range;

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -1193,7 +1193,8 @@ partition_manifest partition_manifest::clone() const {
       _last_partition_scrub,
       _last_scrubbed_offset,
       _detected_anomalies,
-      _highest_producer_id);
+      _highest_producer_id,
+      _applied_offset);
     return tmp;
 }
 
@@ -2053,7 +2054,8 @@ void partition_manifest::do_update(partition_manifest_handler&& handler) {
     if (
       handler._version != to_underlying(manifest_version::v1)
       && handler._version != to_underlying(manifest_version::v2)
-      && handler._version != to_underlying(manifest_version::v3)) {
+      && handler._version != to_underlying(manifest_version::v3)
+      && handler._version != to_underlying(manifest_version::v4)) {
         throw std::runtime_error(fmt_with_ctx(
           fmt::format,
           "partition manifest version {} is not supported",
@@ -2626,7 +2628,7 @@ partition_manifest::timequery(model::timestamp t) const {
 struct partition_manifest_serde
   : public serde::envelope<
       partition_manifest_serde,
-      serde::version<to_underlying(manifest_version::v3)>,
+      serde::version<to_underlying(manifest_version::v4)>,
       serde::compat_version<0>> {
     model::ntp _ntp;
     model::initial_revision_id _rev;
@@ -2650,6 +2652,7 @@ struct partition_manifest_serde
     model::timestamp _last_partition_scrub;
     std::optional<model::offset> _last_scrubbed_offset;
     model::producer_id _highest_producer_id;
+    model::offset _applied_offset;
 };
 
 static_assert(

--- a/src/v/cloud_storage/types.h
+++ b/src/v/cloud_storage/types.h
@@ -83,6 +83,7 @@ enum class manifest_version : int32_t {
     v1 = 1,
     v2 = 2,
     v3 = 3, // v23.3.x
+    v4 = 4, // add applied_offset field
 };
 
 enum class tx_range_manifest_version : int32_t {

--- a/src/v/cluster/cloud_storage_size_reducer.h
+++ b/src/v/cluster/cloud_storage_size_reducer.h
@@ -54,7 +54,7 @@ public:
       ss::sharded<partition_leaders_table>& leaders_table,
       ss::sharded<rpc::connection_cache>& conn_cache,
       size_t batch_size = topic_table_partition_generator::default_batch_size,
-      uint8_t retries_allowed = 3);
+      uint8_t retries_allowed = default_retries_allowed);
 
     ss::future<std::optional<uint64_t>> reduce();
 

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -81,6 +81,7 @@ enum class errc : int16_t {
     transform_count_limit_exceeded,
     role_exists,
     role_does_not_exist,
+    inconsistent_stm_update,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -235,6 +236,8 @@ struct errc_category final : public std::error_category {
             return "Role already exists";
         case errc::role_does_not_exist:
             return "Role does not exist";
+        case errc::inconsistent_stm_update:
+            return "STM command can't be applied";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/id_allocator.h
+++ b/src/v/cluster/id_allocator.h
@@ -24,10 +24,10 @@ public:
       ss::smp_service_group,
       ss::sharded<cluster::id_allocator_frontend>&);
 
-    virtual ss::future<allocate_id_reply>
+    ss::future<allocate_id_reply>
     allocate_id(allocate_id_request, rpc::streaming_context&) final;
 
-    virtual ss::future<reset_id_allocator_reply> reset_id_allocator(
+    ss::future<reset_id_allocator_reply> reset_id_allocator(
       reset_id_allocator_request, rpc::streaming_context&) final;
 
 private:

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1116,7 +1116,7 @@ partition::unsafe_reset_remote_partition_manifest_from_cloud(bool force) {
                           .cloud_storage_metadata_sync_timeout_ms.value();
     auto sync_result = co_await ss::coroutine::as_future(
       _archival_meta_stm->sync(sync_timeout));
-    if (sync_result.failed() || sync_result.get() == false) {
+    if (sync_result.failed() || sync_result.get() == std::nullopt) {
         vlog(
           clusterlog.warn,
           "[{}] Could not sync with log. Skipping unsafe reset ...",

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -1002,6 +1002,11 @@ partition::replicate_unsafe_reset(cloud_storage::partition_manifest manifest) {
     auto replication_deadline = ss::lowres_clock::now() + sync_timeout;
     std::vector<cluster::command_batch_builder> builders;
 
+    // TODO: move this logic to the ntp_archiver
+    // currently, the 'batch_start' method will work even if there is an
+    // active input queue instance. The batch replicated here may interrupt
+    // some operation in the archiver but the correctness will not be
+    // compromised.
     auto reset_builder = _archival_meta_stm->batch_start(
       replication_deadline, _as);
     reset_builder.replace_manifest(manifest.to_iobuf());

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -634,7 +634,7 @@ leader_balancer::build_group_id_to_topic_rev() const {
 ss::future<std::optional<leader_balancer::group_replicas_t>>
 leader_balancer::collect_group_replicas_from_health_report() {
     if (!_feature_table.is_active(
-          features::feature::node_local_core_assignment)) {
+          features::feature::partition_shard_in_health_report)) {
         co_return std::nullopt;
     }
 

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -28,6 +28,7 @@
 #include "random/generators.h"
 #include "reflection/adl.h"
 #include "reflection/async_adl.h"
+#include "security/tests/randoms.h"
 #include "storage/types.h"
 #include "test_utils/randoms.h"
 #include "test_utils/rpc.h"

--- a/src/v/compat/acls_generator.h
+++ b/src/v/compat/acls_generator.h
@@ -14,6 +14,7 @@
 #include "cluster/types.h"
 #include "compat/cluster_generator.h"
 #include "compat/generator.h"
+#include "security/tests/randoms.h"
 #include "test_utils/randoms.h"
 
 namespace compat {

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -99,8 +99,8 @@ std::string_view to_string_view(feature f) {
         return "audit_logging";
     case feature::compaction_placeholder_batch:
         return "compaction_placeholder_batch";
-    case feature::node_local_core_assignment:
-        return "node_local_core_assignment";
+    case feature::partition_shard_in_health_report:
+        return "partition_shard_in_health_report";
     case feature::role_based_access_control:
         return "role_base_access_control";
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -74,7 +74,7 @@ enum class feature : std::uint64_t {
     cloud_metadata_cluster_recovery = 1ULL << 40U,
     audit_logging = 1ULL << 41U,
     compaction_placeholder_batch = 1ULL << 42U,
-    node_local_core_assignment = 1ULL << 43U,
+    partition_shard_in_health_report = 1ULL << 43U,
     role_based_access_control = 1ULL << 44U,
 
     // Dummy features for testing only
@@ -375,8 +375,8 @@ constexpr static std::array feature_schema{
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{12},
-    "node_local_core_assignment",
-    feature::node_local_core_assignment,
+    "partition_shard_in_health_report",
+    feature::partition_shard_in_health_report,
     feature_spec::available_policy::always,
     feature_spec::prepare_policy::always},
   feature_spec{

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -472,6 +472,7 @@ override_member_container = {
     'creatable_topic_configs': 'chunked_vector',
     'creatable_topic_result': 'chunked_vector',
     'describe_configs_resource_result': 'chunked_vector',
+    'describe_configs_result': 'chunked_vector',
 }
 
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -470,6 +470,7 @@ override_member_container = {
     'offset_fetch_response_partition': 'small_fragment_vector',
     'creatable_topic': 'chunked_vector',
     'creatable_topic_configs': 'chunked_vector',
+    'describe_configs_resource_result': 'chunked_vector',
 }
 
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -470,6 +470,7 @@ override_member_container = {
     'offset_fetch_response_partition': 'small_fragment_vector',
     'creatable_topic': 'chunked_vector',
     'creatable_topic_configs': 'chunked_vector',
+    'creatable_topic_result': 'chunked_vector',
     'describe_configs_resource_result': 'chunked_vector',
 }
 

--- a/src/v/kafka/protocol/schemata/generator.py
+++ b/src/v/kafka/protocol/schemata/generator.py
@@ -468,7 +468,8 @@ override_member_container = {
     'metadata_response_topic': 'small_fragment_vector',
     'fetchable_partition_response': 'small_fragment_vector',
     'offset_fetch_response_partition': 'small_fragment_vector',
-    'creatable_topic': 'chunked_vector'
+    'creatable_topic': 'chunked_vector',
+    'creatable_topic_configs': 'chunked_vector',
 }
 
 

--- a/src/v/kafka/protocol/tests/protocol_test.cc
+++ b/src/v/kafka/protocol/tests/protocol_test.cc
@@ -216,21 +216,24 @@ template<>
 long create_default_and_non_default_data(
   decltype(create_topics_response::data)& non_default_data,
   decltype(create_topics_response::data)& default_data) {
+    auto make_topic_result = [](kafka::error_code ec) {
+        return creatable_topic_result{
+          model::topic{"topic1"},
+          {},
+          kafka::error_code{1},
+          "test_error_message",
+          3,
+          16,
+          std::nullopt,
+          ec};
+    };
+
     non_default_data.throttle_time_ms = std::chrono::milliseconds(1000);
+    non_default_data.topics.emplace_back(
+      make_topic_result(kafka::error_code{2}));
 
-    non_default_data.topics.emplace_back(creatable_topic_result{
-      model::topic{"topic1"},
-      {},
-      kafka::error_code{1},
-      "test_error_message",
-      3,
-      16,
-      std::nullopt,
-      kafka::error_code{2}});
-
-    default_data = non_default_data;
-
-    default_data.topics.at(0).topic_config_error_code = kafka::error_code{0};
+    default_data.throttle_time_ms = std::chrono::milliseconds(1000);
+    default_data.topics.emplace_back(make_topic_result(kafka::error_code{0}));
 
     // int16 (2 bytes) + tag (2 bytes)
     return 4;

--- a/src/v/kafka/protocol/wire.h
+++ b/src/v/kafka/protocol/wire.h
@@ -562,12 +562,12 @@ public:
         return _out->size_bytes() - start_size;
     }
 
-    template<typename T, typename ElementWriter>
-    requires requires(ElementWriter writer, encoder& rw, T& elem) {
+    template<typename C, typename ElementWriter>
+    requires requires(
+      ElementWriter writer, encoder& rw, typename C::value_type& elem) {
         { writer(elem, rw) } -> std::same_as<void>;
     }
-    uint32_t write_nullable_array(
-      std::optional<std::vector<T>>& v, ElementWriter&& writer) {
+    uint32_t write_nullable_array(std::optional<C>& v, ElementWriter&& writer) {
         if (!v) {
             return write(int32_t(-1));
         }
@@ -589,12 +589,13 @@ public:
         return _out->size_bytes() - start_size;
     }
 
-    template<typename T, typename ElementWriter>
-    requires requires(ElementWriter writer, encoder& rw, T& elem) {
+    template<typename C, typename ElementWriter>
+    requires requires(
+      ElementWriter writer, encoder& rw, typename C::value_type& elem) {
         { writer(elem, rw) } -> std::same_as<void>;
     }
-    uint32_t write_nullable_flex_array(
-      std::optional<std::vector<T>>& v, ElementWriter&& writer) {
+    uint32_t
+    write_nullable_flex_array(std::optional<C>& v, ElementWriter&& writer) {
         if (!v) {
             return write_unsigned_varint(0);
         }

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -99,6 +99,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::transform_count_limit_exceeded:
     case cluster::errc::role_exists:
     case cluster::errc::role_does_not_exist:
+    case cluster::errc::inconsistent_stm_update:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/kafka/server/handlers/configs/config_response_utils.h
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/types.h"
+#include "container/fragmented_vector.h"
 #include "kafka/protocol/describe_configs.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
 
@@ -35,7 +36,7 @@ struct config_response {
     creatable_topic_configs to_create_config();
 };
 
-using config_response_container_t = std::vector<config_response>;
+using config_response_container_t = chunked_vector<config_response>;
 using config_key_t = std::optional<std::vector<ss::sstring>>;
 
 config_response_container_t make_topic_configs(

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -197,7 +197,7 @@ ss::future<response_ptr> create_topics_handler::handle(
             append_topic_configs(ctx, err_resp);
         }
 
-        co_return co_await ctx.respond(err_resp);
+        co_return co_await ctx.respond(std::move(err_resp));
     }
 
     // fill in defaults if necessary
@@ -327,7 +327,7 @@ ss::future<response_ptr> create_topics_handler::handle(
         append_topic_configs(ctx, response);
     }
 
-    co_return co_await ctx.respond(response);
+    co_return co_await ctx.respond(std::move(response));
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -24,7 +24,7 @@ namespace kafka {
 
 void append_cluster_results(
   const std::vector<cluster::topic_result>& cluster_results,
-  std::vector<creatable_topic_result>& kafka_results) {
+  chunked_vector<creatable_topic_result>& kafka_results) {
     std::transform(
       cluster_results.begin(),
       cluster_results.end(),

--- a/src/v/kafka/server/handlers/topics/topic_utils.h
+++ b/src/v/kafka/server/handlers/topics/topic_utils.h
@@ -13,6 +13,7 @@
 #include "base/seastarx.h"
 #include "cluster/fwd.h"
 #include "cluster/types.h"
+#include "container/fragmented_vector.h"
 #include "kafka/server/handlers/topics/types.h"
 #include "kafka/server/handlers/topics/validators.h"
 #include "model/timeout_clock.h"
@@ -110,7 +111,7 @@ Iter validate_requests_range(
 // Kafka protocol error message
 void append_cluster_results(
   const std::vector<cluster::topic_result>&,
-  std::vector<creatable_topic_result>&);
+  chunked_vector<creatable_topic_result>&);
 
 // Converts objects representing KafkaAPI message to objects consumed
 // by cluster::controller API

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -230,7 +230,7 @@ to_cluster_type(const creatable_topic& t) {
 }
 
 static std::vector<kafka::creatable_topic_configs>
-convert_topic_configs(std::vector<kafka::config_response>&& topic_cfgs) {
+convert_topic_configs(config_response_container_t&& topic_cfgs) {
     auto configs = std::vector<kafka::creatable_topic_configs>();
     configs.reserve(topic_cfgs.size());
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "cluster/types.h"
+#include "container/fragmented_vector.h"
 #include "kafka/protocol/schemata/create_topics_request.h"
 #include "kafka/protocol/schemata/create_topics_response.h"
 #include "kafka/server/errors.h"
@@ -149,12 +150,12 @@ from_cluster_topic_result(const cluster::topic_result& err) {
 }
 
 config_map_t config_map(const std::vector<createable_topic_config>& config);
-config_map_t config_map(const std::vector<creatable_topic_configs>& config);
+config_map_t config_map(const chunked_vector<creatable_topic_configs>& config);
 
 cluster::custom_assignable_topic_configuration
 to_cluster_type(const creatable_topic& t);
 
-std::vector<kafka::creatable_topic_configs> report_topic_configs(
+chunked_vector<kafka::creatable_topic_configs> report_topic_configs(
   const cluster::metadata_cache& metadata_cache,
   const cluster::topic_properties& topic_properties);
 

--- a/src/v/kafka/server/tests/alter_config_test.cc
+++ b/src/v/kafka/server/tests/alter_config_test.cc
@@ -162,7 +162,7 @@ public:
     void assert_property_presented(
       const ss::sstring& resource_name,
       const ss::sstring& key,
-      const kafka::describe_configs_response resp,
+      const kafka::describe_configs_response& resp,
       const bool presented) {
         auto it = std::find_if(
           resp.data.results.begin(),
@@ -187,7 +187,7 @@ public:
 
     void assert_properties_amount(
       const ss::sstring& resource_name,
-      const kafka::describe_configs_response resp,
+      const kafka::describe_configs_response& resp,
       const size_t amount) {
         auto it = std::find_if(
           resp.data.results.begin(),
@@ -206,7 +206,7 @@ public:
       const model::topic& topic,
       const ss::sstring& key,
       const ss::sstring& value,
-      const kafka::describe_configs_response resp) {
+      const kafka::describe_configs_response& resp) {
         auto it = std::find_if(
           resp.data.results.begin(),
           resp.data.results.end(),

--- a/src/v/model/tests/randoms.h
+++ b/src/v/model/tests/randoms.h
@@ -18,6 +18,7 @@
 #include "model/metadata.h"
 #include "model/record.h"
 #include "model/timestamp.h"
+#include "net/tests/randoms.h"
 #include "pandaproxy/schema_registry/subject_name_strategy.h"
 #include "random/generators.h"
 #include "test_utils/randoms.h"
@@ -191,3 +192,34 @@ random_subject_name_strategy() {
 }
 
 } // namespace model
+
+namespace tests {
+
+inline model::record_batch_type random_batch_type() {
+    return random_generators::random_choice(
+      std::vector<model::record_batch_type>{
+        model::record_batch_type::raft_data,
+        model::record_batch_type::raft_configuration,
+        model::record_batch_type::controller,
+        model::record_batch_type::kvstore,
+        model::record_batch_type::checkpoint,
+        model::record_batch_type::topic_management_cmd,
+        model::record_batch_type::ghost_batch,
+        model::record_batch_type::id_allocator,
+        model::record_batch_type::tx_prepare,
+        model::record_batch_type::tx_fence,
+        model::record_batch_type::tm_update,
+        model::record_batch_type::user_management_cmd,
+        model::record_batch_type::acl_management_cmd,
+        model::record_batch_type::group_prepare_tx,
+        model::record_batch_type::group_commit_tx,
+        model::record_batch_type::group_abort_tx,
+        model::record_batch_type::node_management_cmd,
+        model::record_batch_type::data_policy_management_cmd,
+        model::record_batch_type::archival_metadata,
+        model::record_batch_type::cluster_config_cmd,
+        model::record_batch_type::feature_update,
+      });
+}
+
+} // namespace tests

--- a/src/v/net/tests/randoms.h
+++ b/src/v/net/tests/randoms.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "net/unresolved_address.h"
+#include "random/generators.h"
+
+namespace tests {
+
+inline net::unresolved_address random_net_address() {
+    return net::unresolved_address(
+      random_generators::gen_alphanum_string(
+        random_generators::get_int(1, 100)),
+      random_generators::get_int(1025, 65535));
+}
+
+} // namespace tests

--- a/src/v/raft/persisted_stm.cc
+++ b/src/v/raft/persisted_stm.cc
@@ -10,6 +10,7 @@
 #include "raft/persisted_stm.h"
 
 #include "bytes/iostream.h"
+#include "cluster/types.h"
 #include "raft/consensus.h"
 #include "raft/errc.h"
 #include "raft/offset_monitor.h"

--- a/src/v/raft/tests/configuration_serialization_test.cc
+++ b/src/v/raft/tests/configuration_serialization_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "bytes/iobuf_parser.h"
+#include "model/adl_serde.h"
 #include "model/metadata.h"
 #include "model/tests/random_batch.h"
 #include "model/tests/randoms.h"

--- a/src/v/security/tests/ephemeral_credential_store_test.cc
+++ b/src/v/security/tests/ephemeral_credential_store_test.cc
@@ -12,6 +12,7 @@
 #include "security/ephemeral_credential_store.h"
 #include "security/scram_authenticator.h"
 #include "security/scram_credential.h"
+#include "security/tests/randoms.h"
 #include "security/types.h"
 #include "test_utils/randoms.h"
 

--- a/src/v/security/tests/randoms.h
+++ b/src/v/security/tests/randoms.h
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "bytes/random.h"
+#include "random/generators.h"
+#include "security/acl.h"
+#include "security/scram_credential.h"
+#include "test_utils/randoms.h"
+
+namespace tests {
+
+inline security::scram_credential random_credential() {
+    return security::scram_credential(
+      random_generators::get_bytes(256),
+      random_generators::get_bytes(256),
+      random_generators::get_bytes(256),
+      random_generators::get_int(1, 10));
+}
+
+inline security::resource_type random_resource_type() {
+    return random_generators::random_choice<security::resource_type>(
+      {security::resource_type::cluster,
+       security::resource_type::group,
+       security::resource_type::topic,
+       security::resource_type::transactional_id});
+}
+
+inline security::pattern_type random_pattern_type() {
+    return random_generators::random_choice<security::pattern_type>(
+      {security::pattern_type::literal, security::pattern_type::prefixed});
+}
+
+inline security::resource_pattern random_resource_pattern() {
+    return {
+      random_resource_type(),
+      random_generators::gen_alphanum_string(10),
+      random_pattern_type()};
+}
+
+inline security::acl_principal random_acl_principal() {
+    return {
+      security::principal_type::user,
+      random_generators::gen_alphanum_string(12)};
+}
+
+inline security::acl_host create_acl_host() {
+    return security::acl_host(ss::net::inet_address("127.0.0.1"));
+}
+
+inline security::acl_operation random_acl_operation() {
+    return random_generators::random_choice<security::acl_operation>(
+      {security::acl_operation::all,
+       security::acl_operation::alter,
+       security::acl_operation::alter_configs,
+       security::acl_operation::describe_configs,
+       security::acl_operation::cluster_action,
+       security::acl_operation::create,
+       security::acl_operation::remove,
+       security::acl_operation::read,
+       security::acl_operation::idempotent_write,
+       security::acl_operation::describe});
+}
+
+inline security::acl_permission random_acl_permission() {
+    return random_generators::random_choice<security::acl_permission>(
+      {security::acl_permission::allow, security::acl_permission::deny});
+}
+
+inline security::acl_entry random_acl_entry() {
+    return {
+      random_acl_principal(),
+      create_acl_host(),
+      random_acl_operation(),
+      random_acl_permission()};
+}
+
+inline security::acl_binding random_acl_binding() {
+    return {random_resource_pattern(), random_acl_entry()};
+}
+
+inline security::resource_pattern_filter random_resource_pattern_filter() {
+    auto resource = tests::random_optional(
+      [] { return random_resource_type(); });
+
+    auto name = tests::random_optional(
+      [] { return random_generators::gen_alphanum_string(14); });
+
+    auto pattern = tests::random_optional([] {
+        using ret_t = std::variant<
+          security::pattern_type,
+          security::resource_pattern_filter::pattern_match>;
+        if (tests::random_bool()) {
+            return ret_t(random_pattern_type());
+        } else {
+            return ret_t(security::resource_pattern_filter::pattern_match{});
+        }
+    });
+
+    return {resource, std::move(name), pattern};
+}
+
+inline security::acl_entry_filter random_acl_entry_filter() {
+    auto principal = tests::random_optional(
+      [] { return random_acl_principal(); });
+
+    auto host = tests::random_optional([] { return create_acl_host(); });
+
+    auto operation = tests::random_optional(
+      [] { return random_acl_operation(); });
+
+    auto permission = tests::random_optional(
+      [] { return random_acl_permission(); });
+
+    return {std::move(principal), host, operation, permission};
+}
+
+inline security::acl_binding_filter random_acl_binding_filter() {
+    return {random_resource_pattern_filter(), random_acl_entry_filter()};
+}
+
+} // namespace tests

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -11,8 +11,6 @@
 
 #include "base/likely.h"
 #include "base/vlog.h"
-#include "cluster/cluster_utils.h"
-#include "cluster/topic_table.h"
 #include "config/configuration.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -65,6 +63,8 @@
 #include <exception>
 #include <filesystem>
 #include <optional>
+
+using namespace std::chrono_literals;
 
 namespace storage {
 using logs_type = absl::flat_hash_map<model::ntp, log_housekeeping_meta>;

--- a/src/v/storage/log_manager.h
+++ b/src/v/storage/log_manager.h
@@ -13,7 +13,6 @@
 
 #include "base/seastarx.h"
 #include "base/units.h"
-#include "cluster/topic_table.h"
 #include "config/property.h"
 #include "container/intrusive_list_helpers.h"
 #include "features/feature_table.h"

--- a/src/v/storage/offset_translator.cc
+++ b/src/v/storage/offset_translator.cc
@@ -12,6 +12,7 @@
 #include "storage/offset_translator.h"
 
 #include "base/vlog.h"
+#include "reflection/adl.h"
 #include "storage/api.h"
 #include "storage/kvstore.h"
 #include "storage/logger.h"

--- a/src/v/storage/tests/compaction_index_format_tests.cc
+++ b/src/v/storage/tests/compaction_index_format_tests.cc
@@ -11,6 +11,7 @@
 #include "bytes/bytes.h"
 #include "bytes/iobuf_parser.h"
 #include "bytes/random.h"
+#include "model/tests/randoms.h"
 #include "random/generators.h"
 #include "reflection/adl.h"
 #include "storage/compacted_index.h"

--- a/src/v/test_utils/randoms.h
+++ b/src/v/test_utils/randoms.h
@@ -8,17 +8,12 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
-
 #pragma once
+
 #include "bytes/random.h"
-#include "cluster/partition_balancer_types.h"
-#include "cluster/producer_state.h"
 #include "container/fragmented_vector.h"
-#include "model/metadata.h"
-#include "net/unresolved_address.h"
 #include "random/generators.h"
-#include "security/acl.h"
-#include "security/scram_credential.h"
+#include "tristate.h"
 
 #include <seastar/core/chunked_fifo.hh>
 #include <seastar/net/inet_address.hh>
@@ -37,13 +32,6 @@
 #include <vector>
 
 namespace tests {
-
-inline net::unresolved_address random_net_address() {
-    return net::unresolved_address(
-      random_generators::gen_alphanum_string(
-        random_generators::get_int(1, 100)),
-      random_generators::get_int(1025, 65535));
-}
 
 inline bool random_bool() { return random_generators::get_int(0, 100) > 50; }
 
@@ -203,17 +191,6 @@ inline absl::btree_set<Value> random_btree_set(Fn&& gen, size_t size = 20) {
     return random_set<absl::btree_set, Value>(std::forward<Fn>(gen), size);
 }
 
-inline cluster::producer_ptr
-random_producer_state(cluster::producer_state_manager& psm) {
-    return ss::make_lw_shared<cluster::producer_state>(
-      psm,
-      model::producer_identity{
-        random_generators::get_int<int64_t>(),
-        random_generators::get_int<int16_t>()},
-      random_named_int<raft::group_id>(),
-      ss::noncopyable_function<void()>{});
-}
-
 /*
  * Generate a random duration. Notice that random value is multiplied by 10^6.
  * This is so that roundtrip from ns->ms->ns will work as expected.
@@ -222,174 +199,6 @@ template<typename Dur>
 inline Dur random_duration() {
     return Dur(
       random_generators::get_int<typename Dur::rep>(-100000, 100000) * 1000000);
-}
-
-inline cluster::partition_balancer_status random_balancer_status() {
-    return random_generators::random_choice({
-      cluster::partition_balancer_status::off,
-      cluster::partition_balancer_status::starting,
-      cluster::partition_balancer_status::ready,
-      cluster::partition_balancer_status::in_progress,
-      cluster::partition_balancer_status::stalled,
-    });
-}
-
-inline cluster::partition_balancer_violations::unavailable_node
-random_unavailable_node() {
-    return {
-      tests::random_named_int<model::node_id>(),
-      model::timestamp(random_generators::get_int<int64_t>())};
-}
-
-inline cluster::partition_balancer_violations::full_node random_full_node() {
-    return {
-      tests::random_named_int<model::node_id>(),
-      random_generators::get_int<uint32_t>()};
-}
-
-inline cluster::partition_balancer_violations
-random_partition_balancer_violations() {
-    auto random_un_gen = tests::random_vector(
-      []() { return random_unavailable_node(); });
-    auto random_fn_gen = tests::random_vector(
-      []() { return random_full_node(); });
-    return {std::move(random_un_gen), std::move(random_fn_gen)};
-}
-
-inline security::scram_credential random_credential() {
-    return security::scram_credential(
-      random_generators::get_bytes(256),
-      random_generators::get_bytes(256),
-      random_generators::get_bytes(256),
-      random_generators::get_int(1, 10));
-}
-
-inline security::resource_type random_resource_type() {
-    return random_generators::random_choice<security::resource_type>(
-      {security::resource_type::cluster,
-       security::resource_type::group,
-       security::resource_type::topic,
-       security::resource_type::transactional_id});
-}
-
-inline security::pattern_type random_pattern_type() {
-    return random_generators::random_choice<security::pattern_type>(
-      {security::pattern_type::literal, security::pattern_type::prefixed});
-}
-
-inline security::resource_pattern random_resource_pattern() {
-    return {
-      random_resource_type(),
-      random_generators::gen_alphanum_string(10),
-      random_pattern_type()};
-}
-
-inline security::acl_principal random_acl_principal() {
-    return {
-      security::principal_type::user,
-      random_generators::gen_alphanum_string(12)};
-}
-
-inline security::acl_host create_acl_host() {
-    return security::acl_host(ss::net::inet_address("127.0.0.1"));
-}
-
-inline security::acl_operation random_acl_operation() {
-    return random_generators::random_choice<security::acl_operation>(
-      {security::acl_operation::all,
-       security::acl_operation::alter,
-       security::acl_operation::alter_configs,
-       security::acl_operation::describe_configs,
-       security::acl_operation::cluster_action,
-       security::acl_operation::create,
-       security::acl_operation::remove,
-       security::acl_operation::read,
-       security::acl_operation::idempotent_write,
-       security::acl_operation::describe});
-}
-
-inline model::record_batch_type random_batch_type() {
-    return random_generators::random_choice(
-      std::vector<model::record_batch_type>{
-        model::record_batch_type::raft_data,
-        model::record_batch_type::raft_configuration,
-        model::record_batch_type::controller,
-        model::record_batch_type::kvstore,
-        model::record_batch_type::checkpoint,
-        model::record_batch_type::topic_management_cmd,
-        model::record_batch_type::ghost_batch,
-        model::record_batch_type::id_allocator,
-        model::record_batch_type::tx_prepare,
-        model::record_batch_type::tx_fence,
-        model::record_batch_type::tm_update,
-        model::record_batch_type::user_management_cmd,
-        model::record_batch_type::acl_management_cmd,
-        model::record_batch_type::group_prepare_tx,
-        model::record_batch_type::group_commit_tx,
-        model::record_batch_type::group_abort_tx,
-        model::record_batch_type::node_management_cmd,
-        model::record_batch_type::data_policy_management_cmd,
-        model::record_batch_type::archival_metadata,
-        model::record_batch_type::cluster_config_cmd,
-        model::record_batch_type::feature_update,
-      });
-}
-
-inline security::acl_permission random_acl_permission() {
-    return random_generators::random_choice<security::acl_permission>(
-      {security::acl_permission::allow, security::acl_permission::deny});
-}
-
-inline security::acl_entry random_acl_entry() {
-    return {
-      random_acl_principal(),
-      create_acl_host(),
-      random_acl_operation(),
-      random_acl_permission()};
-}
-
-inline security::acl_binding random_acl_binding() {
-    return {random_resource_pattern(), random_acl_entry()};
-}
-
-inline security::resource_pattern_filter random_resource_pattern_filter() {
-    auto resource = tests::random_optional(
-      [] { return random_resource_type(); });
-
-    auto name = tests::random_optional(
-      [] { return random_generators::gen_alphanum_string(14); });
-
-    auto pattern = tests::random_optional([] {
-        using ret_t = std::variant<
-          security::pattern_type,
-          security::resource_pattern_filter::pattern_match>;
-        if (tests::random_bool()) {
-            return ret_t(random_pattern_type());
-        } else {
-            return ret_t(security::resource_pattern_filter::pattern_match{});
-        }
-    });
-
-    return {resource, std::move(name), pattern};
-}
-
-inline security::acl_entry_filter random_acl_entry_filter() {
-    auto principal = tests::random_optional(
-      [] { return random_acl_principal(); });
-
-    auto host = tests::random_optional([] { return create_acl_host(); });
-
-    auto operation = tests::random_optional(
-      [] { return random_acl_operation(); });
-
-    auto permission = tests::random_optional(
-      [] { return random_acl_permission(); });
-
-    return {std::move(principal), host, operation, permission};
-}
-
-inline security::acl_binding_filter random_acl_binding_filter() {
-    return {random_resource_pattern_filter(), random_acl_entry_filter()};
 }
 
 } // namespace tests

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -23,10 +23,13 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <cstdint>
 #include <exception>
 #include <iostream>
 #include <stdexcept>
+
+using namespace std::chrono_literals;
 
 namespace transform::testing {
 ss::future<> fake_sink::write(ss::chunked_fifo<model::record_batch> batches) {

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -32,8 +32,11 @@
 
 #include <fmt/chrono.h>
 
+#include <chrono>
 #include <memory>
 #include <stdexcept>
+
+using namespace std::chrono_literals;
 
 namespace {
 // NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables,cert-err58-cpp)

--- a/src/v/wasm/tests/wasm_transform_bench.cc
+++ b/src/v/wasm/tests/wasm_transform_bench.cc
@@ -28,8 +28,11 @@
 #include <seastar/testing/perf_tests.hh>
 #include <seastar/util/file.hh>
 
+#include <chrono>
 #include <cstdlib>
 #include <unistd.h>
+
+using namespace std::chrono_literals;
 
 template<size_t BatchSize, size_t RecordSize>
 class WasmBenchTest {


### PR DESCRIPTION
Changed `storage::segment::offset_tracker` from a `struct` to a `class`, made data fields private.

Added public "getter" and "setter" functions in order to `vassert` the necessary offset invariants.

Also packaged in some very minor changes (see commit `85d979bd79f7a9e41cb83237673f483c25e02ac1`).

## Backports Required

- [X]  none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

- None