### PR TITLE
transform/processor test: prevent batching flakes

### DIFF
--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -11,13 +11,11 @@
 
 #pragma once
 
-#include "base/units.h"
 #include "model/record.h"
 #include "model/tests/randoms.h"
 #include "model/transform.h"
 #include "ssx/semaphore.h"
 #include "transform/io.h"
-#include "utils/notification_list.h"
 #include "wasm/api.h"
 #include "wasm/transform_probe.h"
 
@@ -25,7 +23,6 @@
 #include <seastar/core/condition-variable.hh>
 
 #include <optional>
-#include <utility>
 
 namespace transform::testing {
 
@@ -93,8 +90,8 @@ class fake_sink : public sink {
 public:
     ss::future<> write(ss::chunked_fifo<model::record_batch> batches) override;
 
-    ss::future<model::record_batch> read();
-    bool empty() const { return _batches.empty(); }
+    ss::future<model::record> read();
+    bool empty() const { return _records.empty(); }
 
     /**
      * Pause writes for this sink. All calls to `write` will not resolve until
@@ -108,7 +105,7 @@ public:
     void uncork();
 
 private:
-    ss::chunked_fifo<model::record_batch> _batches;
+    ss::chunked_fifo<model::record> _records;
     ss::condition_variable _cond_var;
     ssx::semaphore _cork = {ssx::semaphore::max_counter(), "fake_sink"};
 };

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -10,14 +10,11 @@
  */
 
 #include "bytes/random.h"
-#include "container/zip.h"
 #include "gmock/gmock.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "model/record.h"
-#include "model/record_batch_reader.h"
 #include "model/tests/random_batch.h"
-#include "model/tests/randoms.h"
 #include "model/timestamp.h"
 #include "model/transform.h"
 #include "test_utils/async.h"
@@ -34,8 +31,6 @@
 #include <functional>
 #include <iterator>
 #include <memory>
-#include <ranges>
-#include <tuple>
 #include <unistd.h>
 #include <vector>
 
@@ -201,9 +196,8 @@ public:
     std::vector<model::record>
     read_records(model::output_topic_index idx, size_t n) {
         std::vector<model::record> records;
-        while (n > records.size()) {
-            auto read = _sinks[idx()]->read().get().copy_records();
-            std::move(read.begin(), read.end(), std::back_inserter(records));
+        for (size_t i = 0; i < n; ++i) {
+            records.push_back(_sinks[idx()]->read().get());
         }
         return records;
     }


### PR DESCRIPTION
We now batch variably in the processor, so if we schedule tasks just
right we can end up with a case where there is an unexpected size
according to our assertions, but that is still valid.

Fixes: https://github.com/redpanda-data/redpanda/issues/17367

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
