### PR TITLE
[v23.3.x] cluster: initialize eviction stm for tx coordinator

### DIFF
--- a/src/v/cluster/archival_metadata_stm.h
+++ b/src/v/cluster/archival_metadata_stm.h
@@ -104,6 +104,7 @@ class archival_metadata_stm final : public raft::persisted_stm<> {
     friend class details::archival_metadata_stm_accessor;
 
 public:
+    static constexpr const char* name = "archival_metadata_stm";
     friend class command_batch_builder;
 
     explicit archival_metadata_stm(
@@ -247,7 +248,6 @@ public:
 
     model::offset max_collectible_offset() override;
 
-    std::string_view get_name() const final { return "archival_metadata_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 private:

--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -78,6 +78,7 @@ requires std::is_trivially_copyable_v<Key>
          && std::is_trivially_copyable_v<Value>
 class distributed_kv_stm final : public raft::persisted_stm<> {
 public:
+    static constexpr const char* name = "distributed_kv_stm";
     explicit distributed_kv_stm(
       size_t max_partitions, ss::logger& logger, raft::consensus* raft)
       : persisted_stm<>("distributed_kv_stm.snapshot", logger, raft)
@@ -156,7 +157,6 @@ public:
         co_return;
     }
 
-    std::string_view get_name() const final { return "distributed_kv_stm"; }
     // TODO: implement delete retention with incremental raft snapshots.
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 

--- a/src/v/cluster/id_allocator_stm.h
+++ b/src/v/cluster/id_allocator_stm.h
@@ -34,6 +34,8 @@ namespace cluster {
 
 class id_allocator_stm final : public raft::persisted_stm<> {
 public:
+    static constexpr const char* name = "id_allocator_stm";
+
     struct stm_allocation_result {
         int64_t id;
         raft::errc raft_status{raft::errc::success};
@@ -47,7 +49,6 @@ public:
     ss::future<stm_allocation_result>
     allocate_id(model::timeout_clock::duration timeout);
 
-    std::string_view get_name() const final { return "id_allocator_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
     ss::future<stm_allocation_result>

--- a/src/v/cluster/log_eviction_stm.h
+++ b/src/v/cluster/log_eviction_stm.h
@@ -46,6 +46,8 @@ class consensus;
 class log_eviction_stm
   : public raft::persisted_stm<raft::kvstore_backed_stm_snapshot> {
 public:
+    static constexpr const char* name = "log_eviction_stm";
+
     using offset_result = result<model::offset, std::error_code>;
     log_eviction_stm(raft::consensus*, ss::logger&, storage::kvstore&);
 
@@ -103,7 +105,6 @@ public:
         return model::next_offset(_delete_records_eviction_offset);
     }
 
-    std::string_view get_name() const final { return "log_eviction_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 protected:

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -64,6 +64,7 @@ namespace cluster {
  */
 class rm_stm final : public raft::persisted_stm<> {
 public:
+    static constexpr const char* name = "rm_stm";
     using clock_type = ss::lowres_clock;
     using time_point_type = clock_type::time_point;
     using duration_type = clock_type::duration;
@@ -261,7 +262,6 @@ public:
 
     uint64_t get_local_snapshot_size() const override;
 
-    std::string_view get_name() const final { return "rm_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
     const producers_t& get_producers() const { return _producers; }

--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -65,8 +65,7 @@ set(srcs
         ephemeral_credential_test.cc
         health_monitor_test.cc
         metadata_dissemination_test.cc
-        replicas_rebalancing_tests.cc
-        tx_topic_test.cc)
+        replicas_rebalancing_tests.cc)
 
 foreach(cluster_test_src ${srcs})
     get_filename_component(test_name ${cluster_test_src} NAME_WE)
@@ -127,6 +126,19 @@ rp_test(
   BINARY_NAME partition_balancer
   SOURCES partition_balancer_bench.cc
   LIBRARIES Seastar::seastar_perf_testing v::seastar_testing_main v::cluster
+  LABELS cluster
+)
+
+rp_test(
+  FIXTURE_TEST
+  BINARY_NAME tx_coordinator
+  SOURCES
+    tx_topic_test.cc
+  DEFINITIONS BOOST_TEST_DYN_LINK
+  LIBRARIES
+    v::seastar_testing_main
+    v::application
+  ARGS "-- -c 1"
   LABELS cluster
 )
 

--- a/src/v/cluster/tests/tx_topic_test.cc
+++ b/src/v/cluster/tests/tx_topic_test.cc
@@ -10,9 +10,13 @@
 #include "cluster/tx_gateway_frontend.h"
 #include "config/configuration.h"
 #include "kafka/protocol/types.h"
+#include "model/fundamental.h"
 #include "model/namespace.h"
 #include "redpanda/application.h"
 #include "redpanda/tests/fixture.h"
+#include "test_utils/async.h"
+
+#include <seastar/core/io_priority_class.hh>
 
 #include <boost/test/tools/old/interface.hpp>
 
@@ -83,4 +87,59 @@ FIXTURE_TEST(test_tm_stm_new_tx, redpanda_thread_fixture) {
         return newer_retention_ms == cfg->properties.retention_duration.value()
                && cfg->properties.segment_size.value() == newer_segment_size;
     });
+}
+
+FIXTURE_TEST(test_tm_stm_eviction, redpanda_thread_fixture) {
+    // call find coordinator to initialize the topic
+    auto coordinator = app.tx_gateway_frontend.local()
+                         .find_coordinator(
+                           kafka::transactional_id{"test-tx-id"})
+                         .get();
+    auto tx_mgr_prts = app.partition_manager.local().get_topic_partition_table(
+      model::tx_manager_nt);
+    BOOST_REQUIRE(!tx_mgr_prts.empty());
+    auto tx_mgr_prt = tx_mgr_prts[model::ntp{
+      model::tx_manager_nt.ns,
+      model::tx_manager_topic,
+      model::partition_id{0}}];
+    BOOST_REQUIRE(tx_mgr_prt != nullptr);
+
+    // Start a tx and roll to the next segment.
+    auto tx_stm = tx_mgr_prt->raft()->stm_manager()->get<cluster::tm_stm>();
+    auto pid = model::producer_identity{1, 0};
+    auto op_code = tx_stm
+                     ->register_new_producer(
+                       tx_mgr_prt->raft()->term(),
+                       kafka::transactional_id{"tx-1"},
+                       std::chrono::milliseconds(0),
+                       pid)
+                     .get0();
+    BOOST_REQUIRE_EQUAL(op_code, cluster::tm_stm::op_status::success);
+    auto tx_mgr_log = tx_mgr_prt->log();
+    tx_mgr_log->flush().get();
+    tx_mgr_log->force_roll(ss::default_priority_class()).get();
+
+    // Start another tx and roll to the next segment.
+    op_code = tx_stm
+                ->register_new_producer(
+                  tx_mgr_prt->raft()->term(),
+                  kafka::transactional_id{"tx-2"},
+                  std::chrono::milliseconds(0),
+                  pid)
+                .get0();
+    BOOST_REQUIRE_EQUAL(op_code, cluster::tm_stm::op_status::success);
+    BOOST_REQUIRE_EQUAL(2, tx_mgr_log->segment_count());
+
+    tx_mgr_log->flush().get();
+    tx_mgr_log->force_roll(ss::default_priority_class()).get();
+    BOOST_REQUIRE_EQUAL(op_code, cluster::tm_stm::op_status::success);
+    BOOST_REQUIRE_EQUAL(3, tx_mgr_log->segment_count());
+
+    // Run GC such that we remove the first segment.
+    auto size_to_keep = tx_mgr_log->size_bytes()
+                        - tx_mgr_log->segments()[0]->size_bytes();
+    tx_mgr_log->gc(storage::gc_config{model::timestamp::max(), size_to_keep})
+      .get();
+    RPTEST_REQUIRE_EVENTUALLY(
+      5s, [&] { return tx_mgr_log->segment_count() == 2; });
 }

--- a/src/v/cluster/tm_stm.h
+++ b/src/v/cluster/tm_stm.h
@@ -115,6 +115,7 @@ public:
  */
 class tm_stm final : public raft::persisted_stm<> {
 public:
+    static constexpr const char* name = "tm_stm";
     using clock_type = ss::lowres_system_clock;
 
     enum op_status {
@@ -354,7 +355,6 @@ public:
     size_t tx_cache_size() const;
 
     std::optional<tm_transaction> oldest_tx() const;
-    std::string_view get_name() const final { return "tm_stm"; }
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
 protected:

--- a/src/v/raft/state_machine_base.h
+++ b/src/v/raft/state_machine_base.h
@@ -61,13 +61,6 @@ public:
     virtual ss::future<> apply_raft_snapshot(const iobuf&) = 0;
 
     /**
-     * Returns a unique identifier of this state machine. Each stm built on top
-     * of the same Raft group must have different id.
-     * Id is going to be used when logging and to mark parts of the snapshots.
-     */
-    virtual std::string_view get_name() const = 0;
-
-    /**
      * Returns a snapshot of an STM state with requested last included offset
      */
     virtual ss::future<iobuf>

--- a/src/v/raft/state_machine_manager.h
+++ b/src/v/raft/state_machine_manager.h
@@ -82,6 +82,24 @@ public:
     ss::future<> stop();
 
     model::offset last_applied() const { return model::prev_offset(_next); }
+    /**
+     * Returns a pointer to specific type of state machine.
+     *
+     * This API provides basic runtime validation verifying if requested STM
+     * type matches the name passed. It returns a nullptr if state machine with
+     * requested name is not registered in manager.
+     */
+    template<ManagableStateMachine T>
+    ss::shared_ptr<T> get() {
+        auto it = _machines.find(T::name);
+        if (it == _machines.end()) {
+            return nullptr;
+        }
+        auto ptr = ss::dynamic_pointer_cast<T>(it->second->stm);
+        vassert(
+          ptr != nullptr, "Incorrect STM type requested for STM {}", T::name);
+        return ptr;
+    }
 
     template<StateMachineIterateFunc Func>
     void for_each_stm(Func&& func) const {

--- a/src/v/raft/tests/persisted_stm_test.cc
+++ b/src/v/raft/tests/persisted_stm_test.cc
@@ -123,11 +123,10 @@ struct kv_state
 
 class persisted_kv : public persisted_stm<> {
 public:
+    static constexpr std::string_view name = "persited_kv_stm";
     explicit persisted_kv(raft_node_instance& rn)
       : persisted_stm<>("simple-kv", logger, rn.raft().get())
       , raft_node(rn) {}
-
-    std::string_view get_name() const final { return "persisted_kv"; };
 
     ss::future<> start() override { return persisted_stm<>::start(); }
     ss::future<> stop() override { return persisted_stm<>::stop(); }

--- a/src/v/raft/tests/stm_test_fixture.h
+++ b/src/v/raft/tests/stm_test_fixture.h
@@ -41,7 +41,6 @@
 
 using namespace raft;
 namespace {
-
 /**
  * We use value entry struct to make kv_store apply operations not
  * idempotent
@@ -71,6 +70,7 @@ struct value_entry
  */
 struct simple_kv : public raft::state_machine_base {
     using state_t = absl::flat_hash_map<ss::sstring, value_entry>;
+    static constexpr std::string_view name = "simple_kv";
     explicit simple_kv(raft_node_instance& rn)
       : raft_node(rn) {}
 
@@ -107,8 +107,6 @@ struct simple_kv : public raft::state_machine_base {
         state = serde::from_iobuf<state_t>(buffer.copy());
         co_return;
     };
-
-    std::string_view get_name() const override { return "simple_kv"; };
 
     ss::future<iobuf>
     take_snapshot(model::offset last_included_offset) override {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
We previously didn't register the eviction stm before returning from
partition creation of tx coordinator partitions. This meant that despite
the efforts of storage housekeeping and space management, tx coordinator
partitions would never evict data.

NOTE: this bug[1] doesn't exist on dev, but does in v23.3, and not in v23.2[2].

[1] https://github.com/redpanda-data/redpanda/blob/3ce012f9ccb64810eafcc4b8b2e0df7340172879/src/v/cluster/partition.cc#L446-L471
[2] https://github.com/redpanda-data/redpanda/blob/f1216cd484063a44e9b25d206a43a1eeda6d2155/src/v/cluster/partition.cc#L79-L94

Includes a backport of https://github.com/redpanda-data/redpanda/pull/17379
Partially includes a backport of https://github.com/redpanda-data/redpanda/pull/15424 for testing

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fixes a bug that would prevent the transaction coordinator topic from reclaiming disk space.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
