### PR TITLE
Offset tracker invariants

### DIFF
--- a/src/v/archival/archival_policy.cc
+++ b/src/v/archival/archival_policy.cc
@@ -285,7 +285,9 @@ static ss::future<std::optional<std::error_code>> get_file_range(
     upl->final_file_offset = fsize;
     upl->base_timestamp = segment->index().base_timestamp();
     upl->max_timestamp = segment->index().max_timestamp();
-    if (!end_inclusive && segment->offsets().get_base_offset() == begin_inclusive) {
+    if (
+      !end_inclusive
+      && segment->offsets().get_base_offset() == begin_inclusive) {
         // Fast path, the upload is started at the begining of the segment
         // and not truncted at the end.
         vlog(

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2056,7 +2056,7 @@ uint64_t ntp_archiver::estimate_backlog_size() {
       0UL,
       [last_offset](
         uint64_t acc, const ss::lw_shared_ptr<storage::segment>& s) {
-          if (s->offsets().dirty_offset > last_offset) {
+          if (s->offsets().get_dirty_offset() > last_offset) {
               return acc + s->size_bytes();
           }
           return acc;

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -599,8 +599,12 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
     // Self-compact the first segment and re-upload. One compacted
     // and one non-compacted segments are uploaded.
     reset_http_call_state();
-    auto seg = self_compact_next_segment(
-      disk_log_impl()->segments().begin()->get()->offsets().get_committed_offset());
+    auto seg = self_compact_next_segment(disk_log_impl()
+                                           ->segments()
+                                           .begin()
+                                           ->get()
+                                           ->offsets()
+                                           .get_committed_offset());
 
     // Fail the first compacted upload
     fail_request_if(

--- a/src/v/archival/tests/ntp_archiver_reupload_test.cc
+++ b/src/v/archival/tests/ntp_archiver_reupload_test.cc
@@ -325,7 +325,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),
-      seg->offsets().committed_offset);
+      seg->offsets().get_committed_offset());
 
     auto replaced = stm_manifest.replaced_segments();
     BOOST_REQUIRE_EQUAL(replaced.size(), 1);
@@ -347,7 +347,7 @@ FIXTURE_TEST(test_upload_compacted_segments, reupload_fixture) {
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),
-      seg->offsets().committed_offset);
+      seg->offsets().get_committed_offset());
 
     replaced = stm_manifest.replaced_segments();
     BOOST_REQUIRE_EQUAL(replaced.size(), 2);
@@ -397,7 +397,7 @@ FIXTURE_TEST(test_upload_compacted_segments_concat, reupload_fixture) {
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),
-      seg->offsets().committed_offset);
+      seg->offsets().get_committed_offset());
 
     auto replaced = stm_manifest.replaced_segments();
     BOOST_REQUIRE_EQUAL(replaced.size(), 2);
@@ -523,7 +523,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
 
     create_segment(
       {manifest_ntp,
-       last_segment->offsets().committed_offset + model::offset{1},
+       last_segment->offsets().get_committed_offset() + model::offset{1},
        model::term_id{4},
        1});
 
@@ -546,7 +546,7 @@ FIXTURE_TEST(test_upload_both_compacted_and_non_compacted, reupload_fixture) {
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),
-      seg->offsets().committed_offset);
+      seg->offsets().get_committed_offset());
 
     auto replaced = stm_manifest.replaced_segments();
     BOOST_REQUIRE_EQUAL(replaced.size(), 1);
@@ -592,7 +592,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
 
     create_segment(
       {manifest_ntp,
-       last_segment->offsets().committed_offset + model::offset{1},
+       last_segment->offsets().get_committed_offset() + model::offset{1},
        model::term_id{4},
        1});
 
@@ -600,7 +600,7 @@ FIXTURE_TEST(test_both_uploads_with_one_failing, reupload_fixture) {
     // and one non-compacted segments are uploaded.
     reset_http_call_state();
     auto seg = self_compact_next_segment(
-      disk_log_impl()->segments().begin()->get()->offsets().committed_offset);
+      disk_log_impl()->segments().begin()->get()->offsets().get_committed_offset());
 
     // Fail the first compacted upload
     fail_request_if(
@@ -776,7 +776,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
 
         create_segment(
           {manifest_ntp,
-           last_segment->offsets().committed_offset + model::offset{1},
+           last_segment->offsets().get_committed_offset() + model::offset{1},
            model::term_id{6},
            10});
     }
@@ -823,7 +823,7 @@ FIXTURE_TEST(test_upload_limit, reupload_fixture) {
 
     BOOST_REQUIRE_EQUAL(
       stm_manifest.get_last_uploaded_compacted_offset(),
-      seg->offsets().committed_offset);
+      seg->offsets().get_committed_offset());
 
     replaced = stm_manifest.replaced_segments();
     BOOST_REQUIRE_EQUAL(replaced.size(), 4);

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -853,7 +853,8 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload2.starting_offset() == offset2);
     BOOST_REQUIRE(upload2.exposed_name != upload1.exposed_name);
     BOOST_REQUIRE(upload2.sources.front() != upload1.sources.front());
-    BOOST_REQUIRE(upload2.sources.front()->offsets().get_base_offset() == offset2);
+    BOOST_REQUIRE(
+      upload2.sources.front()->offsets().get_base_offset() == offset2);
 
     start_offset = upload2.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
@@ -868,7 +869,8 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload3.starting_offset() == offset3);
     BOOST_REQUIRE(upload3.exposed_name != upload2.exposed_name);
     BOOST_REQUIRE(upload3.sources.front() != upload2.sources.front());
-    BOOST_REQUIRE(upload3.sources.front()->offsets().get_base_offset() == offset3);
+    BOOST_REQUIRE(
+      upload3.sources.front()->offsets().get_base_offset() == offset3);
 
     start_offset = upload3.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
@@ -1526,12 +1528,14 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
       manifest_ntp, archival::segment_name("0-1-v1.log"));
     auto& tracker1 = const_cast<storage::segment::offset_tracker&>(
       segment1->offsets());
-    tracker1.set_offset(storage::segment::offset_tracker::dirty_offset_t{offset2 - model::offset(1)});
+    tracker1.set_offset(storage::segment::offset_tracker::dirty_offset_t{
+      offset2 - model::offset(1)});
     auto segment2 = get_segment(
       manifest_ntp, archival::segment_name("1000-1-v1.log"));
     auto& tracker2 = const_cast<storage::segment::offset_tracker&>(
       segment2->offsets());
-    tracker2.set_offset(storage::segment::offset_tracker::dirty_offset_t{offset3 - model::offset(1)});
+    tracker2.set_offset(storage::segment::offset_tracker::dirty_offset_t{
+      offset3 - model::offset(1)});
 
     // Every segment should be returned once as we're calling the
     // policy to get next candidate.
@@ -1569,7 +1573,8 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload2.starting_offset == offset2);
     BOOST_REQUIRE(upload2.exposed_name != upload1.exposed_name);
     BOOST_REQUIRE(upload2.sources.front() != upload1.sources.front());
-    BOOST_REQUIRE(upload2.sources.front()->offsets().get_base_offset() == offset2);
+    BOOST_REQUIRE(
+      upload2.sources.front()->offsets().get_base_offset() == offset2);
 
     start_offset = upload2.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
@@ -1584,7 +1589,8 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload3.starting_offset == offset3);
     BOOST_REQUIRE(upload3.exposed_name != upload2.exposed_name);
     BOOST_REQUIRE(upload3.sources.front() != upload2.sources.front());
-    BOOST_REQUIRE(upload3.sources.front()->offsets().get_base_offset() == offset3);
+    BOOST_REQUIRE(
+      upload3.sources.front()->offsets().get_base_offset() == offset3);
 
     start_offset = upload3.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -74,8 +74,8 @@ static void log_segment(const storage::segment& s) {
       test_log.info,
       "Log segment {}. Offsets: {} {}. Is compacted: {}. Is sealed: {}.",
       s.filename(),
-      s.offsets().base_offset,
-      s.offsets().dirty_offset,
+      s.offsets().get_base_offset(),
+      s.offsets().get_dirty_offset(),
       s.is_compacted_segment(),
       !s.has_appender());
 }
@@ -111,8 +111,8 @@ void log_upload_candidate(const archival::upload_candidate& up) {
       "Upload candidate, exposed name: {} "
       "real offsets: {} {}",
       up.exposed_name,
-      first_source->offsets().base_offset,
-      first_source->offsets().dirty_offset);
+      first_source->offsets().get_base_offset(),
+      first_source->offsets().get_dirty_offset());
 }
 
 // NOLINTNEXTLINE
@@ -840,7 +840,7 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
 
     model::offset start_offset;
 
-    start_offset = upload1.sources.front()->offsets().dirty_offset
+    start_offset = upload1.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
     auto upload2 = require_upload_candidate(
                      policy
@@ -853,9 +853,9 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload2.starting_offset() == offset2);
     BOOST_REQUIRE(upload2.exposed_name != upload1.exposed_name);
     BOOST_REQUIRE(upload2.sources.front() != upload1.sources.front());
-    BOOST_REQUIRE(upload2.sources.front()->offsets().base_offset == offset2);
+    BOOST_REQUIRE(upload2.sources.front()->offsets().get_base_offset() == offset2);
 
-    start_offset = upload2.sources.front()->offsets().dirty_offset
+    start_offset = upload2.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
     auto upload3 = require_upload_candidate(
                      policy
@@ -868,9 +868,9 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(upload3.starting_offset() == offset3);
     BOOST_REQUIRE(upload3.exposed_name != upload2.exposed_name);
     BOOST_REQUIRE(upload3.sources.front() != upload2.sources.front());
-    BOOST_REQUIRE(upload3.sources.front()->offsets().base_offset == offset3);
+    BOOST_REQUIRE(upload3.sources.front()->offsets().get_base_offset() == offset3);
 
-    start_offset = upload3.sources.front()->offsets().dirty_offset
+    start_offset = upload3.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
     require_candidate_creation_error(
       policy
@@ -935,7 +935,7 @@ FIXTURE_TEST(
     BOOST_REQUIRE(!candidate.sources.empty());
     BOOST_REQUIRE_GT(candidate.starting_offset(), 0);
     BOOST_REQUIRE_GT(
-      candidate.sources.front()->offsets().base_offset, model::offset{0});
+      candidate.sources.front()->offsets().get_base_offset(), model::offset{0});
 }
 
 // NOLINTNEXTLINE
@@ -1113,7 +1113,7 @@ FIXTURE_TEST(test_upload_segments_leadership_transfer, archiver_fixture) {
       .is_compacted = false,
       .size_bytes = 100,
       .base_offset = model::offset(2),
-      .committed_offset = segment1->offsets().committed_offset
+      .committed_offset = segment1->offsets().get_committed_offset()
                           - model::offset(10),
       .segment_term = model::term_id{2},
       .delta_offset_end = model::offset_delta(0),
@@ -1526,12 +1526,12 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
       manifest_ntp, archival::segment_name("0-1-v1.log"));
     auto& tracker1 = const_cast<storage::segment::offset_tracker&>(
       segment1->offsets());
-    tracker1.dirty_offset = offset2 - model::offset(1);
+    tracker1.set_offset(storage::segment::offset_tracker::dirty_offset_t{offset2 - model::offset(1)});
     auto segment2 = get_segment(
       manifest_ntp, archival::segment_name("1000-1-v1.log"));
     auto& tracker2 = const_cast<storage::segment::offset_tracker&>(
       segment2->offsets());
-    tracker2.dirty_offset = offset3 - model::offset(1);
+    tracker2.set_offset(storage::segment::offset_tracker::dirty_offset_t{offset3 - model::offset(1)});
 
     // Every segment should be returned once as we're calling the
     // policy to get next candidate.
@@ -1556,7 +1556,7 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(!upload1.sources.empty());
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
-    start_offset = upload1.sources.front()->offsets().dirty_offset
+    start_offset = upload1.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
     auto upload2 = require_upload_candidate(
                      policy
@@ -1569,9 +1569,9 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload2.starting_offset == offset2);
     BOOST_REQUIRE(upload2.exposed_name != upload1.exposed_name);
     BOOST_REQUIRE(upload2.sources.front() != upload1.sources.front());
-    BOOST_REQUIRE(upload2.sources.front()->offsets().base_offset == offset2);
+    BOOST_REQUIRE(upload2.sources.front()->offsets().get_base_offset() == offset2);
 
-    start_offset = upload2.sources.front()->offsets().dirty_offset
+    start_offset = upload2.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
     auto upload3 = require_upload_candidate(
                      policy
@@ -1584,9 +1584,9 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     BOOST_REQUIRE(upload3.starting_offset == offset3);
     BOOST_REQUIRE(upload3.exposed_name != upload2.exposed_name);
     BOOST_REQUIRE(upload3.sources.front() != upload2.sources.front());
-    BOOST_REQUIRE(upload3.sources.front()->offsets().base_offset == offset3);
+    BOOST_REQUIRE(upload3.sources.front()->offsets().get_base_offset() == offset3);
 
-    start_offset = upload3.sources.front()->offsets().dirty_offset
+    start_offset = upload3.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
     require_candidate_creation_error(
       policy

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -336,8 +336,8 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_aligned_with_manifest_segment) {
     BOOST_REQUIRE_EQUAL(1, segments.size());
 
     const auto& seg = segments.front();
-    BOOST_REQUIRE_EQUAL(seg->offsets().base_offset, model::offset{10});
-    BOOST_REQUIRE_EQUAL(seg->offsets().committed_offset, model::offset{19});
+    BOOST_REQUIRE_EQUAL(seg->offsets().get_base_offset(), model::offset{10});
+    BOOST_REQUIRE_EQUAL(seg->offsets().get_committed_offset(), model::offset{19});
 }
 
 SEASTAR_THREAD_TEST_CASE(
@@ -374,8 +374,8 @@ SEASTAR_THREAD_TEST_CASE(
     BOOST_REQUIRE_EQUAL(1, segments.size());
 
     const auto& seg = segments.front();
-    BOOST_REQUIRE_EQUAL(seg->offsets().base_offset, model::offset{10});
-    BOOST_REQUIRE_EQUAL(seg->offsets().committed_offset, model::offset{14});
+    BOOST_REQUIRE_EQUAL(seg->offsets().get_base_offset(), model::offset{10});
+    BOOST_REQUIRE_EQUAL(seg->offsets().get_committed_offset(), model::offset{14});
 }
 
 SEASTAR_THREAD_TEST_CASE(
@@ -1120,7 +1120,7 @@ SEASTAR_THREAD_TEST_CASE(test_do_not_reupload_prefix_truncated) {
     collector.collect_segments();
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive()(), 500);
     BOOST_REQUIRE_EQUAL(collector.segments().size(), 3);
-    BOOST_REQUIRE_EQUAL(collector.segments()[0]->offsets().base_offset(), 0);
+    BOOST_REQUIRE_EQUAL(collector.segments()[0]->offsets().get_base_offset(), model::offset{0});
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
 }
 
@@ -1198,7 +1198,7 @@ SEASTAR_THREAD_TEST_CASE(test_bump_start_when_not_aligned) {
     collector.collect_segments();
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive()(), 500);
     BOOST_REQUIRE_EQUAL(collector.segments().size(), 3);
-    BOOST_REQUIRE_EQUAL(collector.segments()[0]->offsets().base_offset(), 0);
+    BOOST_REQUIRE_EQUAL(collector.segments()[0]->offsets().get_base_offset(), model::offset{0});
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
 }
 

--- a/src/v/archival/tests/segment_reupload_test.cc
+++ b/src/v/archival/tests/segment_reupload_test.cc
@@ -337,7 +337,8 @@ SEASTAR_THREAD_TEST_CASE(test_compacted_segment_aligned_with_manifest_segment) {
 
     const auto& seg = segments.front();
     BOOST_REQUIRE_EQUAL(seg->offsets().get_base_offset(), model::offset{10});
-    BOOST_REQUIRE_EQUAL(seg->offsets().get_committed_offset(), model::offset{19});
+    BOOST_REQUIRE_EQUAL(
+      seg->offsets().get_committed_offset(), model::offset{19});
 }
 
 SEASTAR_THREAD_TEST_CASE(
@@ -375,7 +376,8 @@ SEASTAR_THREAD_TEST_CASE(
 
     const auto& seg = segments.front();
     BOOST_REQUIRE_EQUAL(seg->offsets().get_base_offset(), model::offset{10});
-    BOOST_REQUIRE_EQUAL(seg->offsets().get_committed_offset(), model::offset{14});
+    BOOST_REQUIRE_EQUAL(
+      seg->offsets().get_committed_offset(), model::offset{14});
 }
 
 SEASTAR_THREAD_TEST_CASE(
@@ -1120,7 +1122,8 @@ SEASTAR_THREAD_TEST_CASE(test_do_not_reupload_prefix_truncated) {
     collector.collect_segments();
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive()(), 500);
     BOOST_REQUIRE_EQUAL(collector.segments().size(), 3);
-    BOOST_REQUIRE_EQUAL(collector.segments()[0]->offsets().get_base_offset(), model::offset{0});
+    BOOST_REQUIRE_EQUAL(
+      collector.segments()[0]->offsets().get_base_offset(), model::offset{0});
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
 }
 
@@ -1198,7 +1201,8 @@ SEASTAR_THREAD_TEST_CASE(test_bump_start_when_not_aligned) {
     collector.collect_segments();
     BOOST_REQUIRE_EQUAL(collector.begin_inclusive()(), 500);
     BOOST_REQUIRE_EQUAL(collector.segments().size(), 3);
-    BOOST_REQUIRE_EQUAL(collector.segments()[0]->offsets().get_base_offset(), model::offset{0});
+    BOOST_REQUIRE_EQUAL(
+      collector.segments()[0]->offsets().get_base_offset(), model::offset{0});
     BOOST_REQUIRE(collector.should_replace_manifest_segment());
 }
 

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -122,10 +122,10 @@ segment_layout write_random_batches(
     // If the segment already includes records, start at the next offset.
     auto full_batches = model::test::make_random_batches(
       model::test::record_batch_spec{
-        .offset = seg->offsets().get_committed_offset() == model::offset{}
-                    ? seg->offsets().get_base_offset()
-                    : (
-                      seg->offsets().get_committed_offset() + model::offset_delta{1}),
+        .offset
+        = seg->offsets().get_committed_offset() == model::offset{}
+            ? seg->offsets().get_base_offset()
+            : (seg->offsets().get_committed_offset() + model::offset_delta{1}),
         .allow_compression = true,
         .count = full_batches_count,
         .records = records_per_batch,

--- a/src/v/cloud_storage/fwd.h
+++ b/src/v/cloud_storage/fwd.h
@@ -21,7 +21,6 @@ class partition_manifest;
 class topic_manifest;
 class partition_probe;
 class async_manifest_view;
-class partition_probe;
 
 struct log_recovery_result;
 struct offset_range;

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -553,7 +553,7 @@ FIXTURE_TEST(test_concat_segment_upload, remote_fixture) {
     for (auto i = 0; i < 4; ++i) {
         b | add_segment(start_offset) | add_random_batch(start_offset, 10);
         auto& segment = b.get_segment(i);
-        start_offset = segment.offsets().dirty_offset + model::offset{1};
+        start_offset = segment.offsets().get_dirty_offset() + model::offset{1};
     }
 
     auto bucket = cloud_storage_clients::bucket_name("bucket");

--- a/src/v/cluster/cloud_storage_size_reducer.h
+++ b/src/v/cluster/cloud_storage_size_reducer.h
@@ -54,7 +54,7 @@ public:
       ss::sharded<partition_leaders_table>& leaders_table,
       ss::sharded<rpc::connection_cache>& conn_cache,
       size_t batch_size = topic_table_partition_generator::default_batch_size,
-      uint8_t retries_allowed = 3);
+      uint8_t retries_allowed = default_retries_allowed);
 
     ss::future<std::optional<uint64_t>> reduce();
 

--- a/src/v/cluster/id_allocator.h
+++ b/src/v/cluster/id_allocator.h
@@ -24,10 +24,10 @@ public:
       ss::smp_service_group,
       ss::sharded<cluster::id_allocator_frontend>&);
 
-    virtual ss::future<allocate_id_reply>
+    ss::future<allocate_id_reply>
     allocate_id(allocate_id_request, rpc::streaming_context&) final;
 
-    virtual ss::future<reset_id_allocator_reply> reset_id_allocator(
+    ss::future<reset_id_allocator_reply> reset_id_allocator(
       reset_id_allocator_request, rpc::streaming_context&) final;
 
 private:

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -537,9 +537,9 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
           logger.info,
           "Seg index {}, begin {}, end {}",
           segment_index,
-          offsets.base_offset,
-          offsets.dirty_offset);
-        return aborted_txs(offsets.base_offset, offsets.dirty_offset);
+          offsets.get_base_offset(),
+          offsets.get_dirty_offset());
+        return aborted_txs(offsets.get_base_offset(), offsets.get_dirty_offset());
     };
 
     BOOST_REQUIRE_EQUAL(

--- a/src/v/cluster/tests/rm_stm_tests.cc
+++ b/src/v/cluster/tests/rm_stm_tests.cc
@@ -539,7 +539,8 @@ FIXTURE_TEST(test_aborted_transactions, rm_stm_test_fixture) {
           segment_index,
           offsets.get_base_offset(),
           offsets.get_dirty_offset());
-        return aborted_txs(offsets.get_base_offset(), offsets.get_dirty_offset());
+        return aborted_txs(
+          offsets.get_base_offset(), offsets.get_dirty_offset());
     };
 
     BOOST_REQUIRE_EQUAL(

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -395,9 +395,9 @@ disk_log_impl::request_eviction_until_offset(model::offset max_offset) {
       config().ntp(),
       max_offset);
     // we only notify eviction monitor if there are segments to evict
-    auto have_segments_to_evict = _segs.size() > 1
-                                  && _segs.front()->offsets().get_committed_offset()
-                                       <= max_offset;
+    auto have_segments_to_evict
+      = _segs.size() > 1
+        && _segs.front()->offsets().get_committed_offset() <= max_offset;
 
     if (_eviction_monitor && have_segments_to_evict) {
         _eviction_monitor->promise.set_value(max_offset);
@@ -419,7 +419,9 @@ ss::future<> disk_log_impl::adjacent_merge_compact(
 
     // create a logging predicate for offsets..
     auto offsets_compactible = [&cfg, &new_start_offset, this](segment& s) {
-        if (new_start_offset && s.offsets().get_base_offset() < *new_start_offset) {
+        if (
+          new_start_offset
+          && s.offsets().get_base_offset() < *new_start_offset) {
             vlog(
               gclog.debug,
               "[{}] segment {} base offs {}, new start offset {}, "
@@ -2063,7 +2065,9 @@ disk_log_impl::offset_range_size(
         co_return std::nullopt;
     } else {
         auto lstat = base_it->get()->offsets();
-        if (first < lstat.get_base_offset() || first > lstat.get_committed_offset()) {
+        if (
+          first < lstat.get_base_offset()
+          || first > lstat.get_committed_offset()) {
             vlog(
               stlog.debug,
               "Offset {} is not present in the segment {}",
@@ -2244,7 +2248,8 @@ disk_log_impl::offset_range_size(
                   it->get()->offsets().get_committed_offset(),
                   truncate_after,
                   first_segment_file_pos);
-                last_included_offset = it->get()->offsets().get_committed_offset();
+                last_included_offset
+                  = it->get()->offsets().get_committed_offset();
             }
             break;
         } else if (current_size > target.min_size) {
@@ -2345,9 +2350,9 @@ disk_log_impl::make_reader(timequery_config config) {
                     index_entry->timestamp);
               }
 
-              auto offset_within_segment = index_entry
-                                             ? index_entry->offset
-                                             : segment->offsets().get_base_offset();
+              auto offset_within_segment
+                = index_entry ? index_entry->offset
+                              : segment->offsets().get_base_offset();
 
               // adjust for partial visibility of segment prefix
               start_offset = std::max(start_offset, offset_within_segment);
@@ -2476,7 +2481,8 @@ ss::future<> disk_log_impl::remove_full_segments(model::offset o) {
     return ss::do_until(
       [this, o] {
           return _segs.empty()
-                 || std::max(_segs.back()->offsets().get_base_offset(), _start_offset)
+                 || std::max(
+                      _segs.back()->offsets().get_base_offset(), _start_offset)
                       < o;
       },
       [this] {
@@ -2490,7 +2496,8 @@ disk_log_impl::remove_prefix_full_segments(truncate_prefix_config cfg) {
     return ss::do_until(
       [this, cfg] {
           return _segs.empty()
-                 || _segs.front()->offsets().get_dirty_offset() >= cfg.start_offset;
+                 || _segs.front()->offsets().get_dirty_offset()
+                      >= cfg.start_offset;
       },
       [this] {
           auto ptr = _segs.front();
@@ -3092,7 +3099,8 @@ disk_log_impl::disk_usage_and_reclaimable_space(gc_config input_cfg) {
           && is_cloud_retention_active() && seg != _segs.back()
           && seg->offsets().get_dirty_offset() <= max_collectible
           && local_retention_offset.has_value()
-          && seg->offsets().get_dirty_offset() <= local_retention_offset.value()) {
+          && seg->offsets().get_dirty_offset()
+               <= local_retention_offset.value()) {
             local_retention_segments.push_back(seg);
         }
     }
@@ -3516,7 +3524,8 @@ disk_log_impl::get_reclaimable_offsets(gc_config cfg) {
      */
     std::optional<model::offset> low_space_offset;
     if (segments.size() >= 2) {
-        low_space_offset = segments[segments.size() - 2]->offsets().get_base_offset();
+        low_space_offset
+          = segments[segments.size() - 2]->offsets().get_base_offset();
     }
 
     vlog(

--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -45,7 +45,7 @@ lock_manager::range_lock(const timequery_config& cfg) {
       std::back_inserter(tmp),
       [&cfg](ss::lw_shared_ptr<segment>& s) {
           // must be base offset
-          return s->offsets().base_offset <= cfg.max_offset;
+          return s->offsets().get_base_offset() <= cfg.max_offset;
       });
     return range(std::move(tmp));
 }
@@ -59,7 +59,7 @@ lock_manager::range_lock(const log_reader_config& cfg) {
       std::back_inserter(tmp),
       [&cfg](ss::lw_shared_ptr<segment>& s) {
           // must be base offset
-          return s->offsets().base_offset <= cfg.max_offset;
+          return s->offsets().get_base_offset() <= cfg.max_offset;
       });
     return range(std::move(tmp));
 }

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -186,7 +186,7 @@ public:
         if (_lease->range.empty()) {
             return model::offset{};
         }
-        return _lease->range.front()->offsets().base_offset;
+        return _lease->range.front()->offsets().get_base_offset();
     }
     /**
      * Last offset of last locked segment in read lock lease
@@ -195,7 +195,7 @@ public:
         if (_lease->range.empty()) {
             return model::offset{};
         }
-        return _lease->range.back()->offsets().dirty_offset;
+        return _lease->range.back()->offsets().get_dirty_offset();
     }
 
     /**

--- a/src/v/storage/offset_to_filepos.cc
+++ b/src/v/storage/offset_to_filepos.cc
@@ -106,7 +106,7 @@ ss::future<result<offset_to_file_pos_result>> convert_begin_offset_to_file_pos(
     auto ix_begin = segment->index().find_nearest(begin_inclusive);
     size_t scan_from = ix_begin ? ix_begin->filepos : 0;
     model::offset sto = ix_begin ? ix_begin->offset
-                                 : segment->offsets().base_offset;
+                                 : segment->offsets().get_base_offset();
 
     model::timestamp ts = base_timestamp;
     bool offset_found = false;
@@ -202,7 +202,7 @@ ss::future<result<offset_to_file_pos_result>> convert_end_offset_to_file_pos(
     }
 
     size_t scan_from = ix_end ? ix_end->filepos : 0;
-    model::offset fo = ix_end ? ix_end->offset : segment->offsets().base_offset;
+    model::offset fo = ix_end ? ix_end->offset : segment->offsets().get_base_offset();
     vlog(
       stlog.debug,
       "Segment index lookup returned: {}, scanning from pos {} - offset {}",

--- a/src/v/storage/offset_to_filepos.cc
+++ b/src/v/storage/offset_to_filepos.cc
@@ -202,7 +202,8 @@ ss::future<result<offset_to_file_pos_result>> convert_end_offset_to_file_pos(
     }
 
     size_t scan_from = ix_end ? ix_end->filepos : 0;
-    model::offset fo = ix_end ? ix_end->offset : segment->offsets().get_base_offset();
+    model::offset fo = ix_end ? ix_end->offset
+                              : segment->offsets().get_base_offset();
     vlog(
       stlog.debug,
       "Segment index lookup returned: {}, scanning from pos {} - offset {}",

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -198,7 +198,8 @@ readers_cache::evict_segment_readers(ss::lw_shared_ptr<segment> s) {
       _ntp,
       s->offsets().get_base_offset(),
       s->offsets().get_dirty_offset());
-    return evict_range(s->offsets().get_base_offset(), s->offsets().get_dirty_offset());
+    return evict_range(
+      s->offsets().get_base_offset(), s->offsets().get_dirty_offset());
 }
 
 ss::future<readers_cache::range_lock_holder>

--- a/src/v/storage/readers_cache.cc
+++ b/src/v/storage/readers_cache.cc
@@ -196,9 +196,9 @@ readers_cache::evict_segment_readers(ss::lw_shared_ptr<segment> s) {
       stlog.debug,
       "{} - evicting reader from cache, segment [{},{}] removal",
       _ntp,
-      s->offsets().base_offset,
-      s->offsets().dirty_offset);
-    return evict_range(s->offsets().base_offset, s->offsets().dirty_offset);
+      s->offsets().get_base_offset(),
+      s->offsets().get_dirty_offset());
+    return evict_range(s->offsets().get_base_offset(), s->offsets().get_dirty_offset());
 }
 
 ss::future<readers_cache::range_lock_holder>

--- a/src/v/storage/segment.h
+++ b/src/v/storage/segment.h
@@ -47,6 +47,13 @@ public:
           , committed_offset(model::prev_offset(base))
           , dirty_offset(model::prev_offset(base))
           , stable_offset(model::prev_offset(base)) {}
+
+        model::term_id get_term() const { return term; }
+        model::offset get_base_offset() const { return base_offset; }
+        model::offset get_committed_offset() const { return committed_offset; }
+        model::offset get_stable_offset() const { return stable_offset; }
+        model::offset get_dirty_offset() const { return dirty_offset; }
+
         model::term_id term;
         model::offset base_offset;
 

--- a/src/v/storage/segment_deduplication_utils.cc
+++ b/src/v/storage/segment_deduplication_utils.cc
@@ -164,7 +164,7 @@ ss::future<model::offset> build_offset_map(
             vlog(gclog.debug, "Segment not fully indexed: {}", seg->filename());
             break;
         }
-        min_segment_fully_indexed = seg->offsets().base_offset;
+        min_segment_fully_indexed = seg->offsets().get_base_offset();
         if (iter == segs.begin()) {
             break;
         }
@@ -199,7 +199,7 @@ ss::future<index_state> deduplicate_segment(
       features::feature::compaction_placeholder_batch);
     auto copy_reducer = internal::copy_data_segment_reducer(
       [&map,
-       segment_last_offset = seg->offsets().committed_offset,
+       segment_last_offset = seg->offsets().get_committed_offset(),
        compaction_placeholder_enabled](
         const model::record_batch& b,
         const model::record& r,
@@ -223,7 +223,7 @@ ss::future<index_state> deduplicate_segment(
       &appender,
       seg->path().is_internal_topic(),
       should_offset_delta_times,
-      seg->offsets().committed_offset,
+      seg->offsets().get_committed_offset(),
       &cmp_idx_writer,
       inject_reader_failure);
 

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -32,20 +32,20 @@ namespace storage {
 struct segment_ordering {
     using type = ss::lw_shared_ptr<segment>;
     bool operator()(const type& seg1, const type& seg2) const {
-        return seg1->offsets().base_offset < seg2->offsets().base_offset;
+        return seg1->offsets().get_base_offset() < seg2->offsets().get_base_offset();
     }
     bool operator()(const type& seg, model::offset value) const {
-        return seg->offsets().dirty_offset < value;
+        return seg->offsets().get_dirty_offset() < value;
     }
     bool operator()(const type& seg, model::timestamp value) const {
         return seg->index().max_timestamp() < value;
     }
 
     bool operator()(const type& seg, model::term_id value) const {
-        return seg->offsets().term < value;
+        return seg->offsets().get_term() < value;
     }
     bool operator()(model::term_id value, const type& seg) const {
-        return value < seg->offsets().term;
+        return value < seg->offsets().get_term();
     }
 };
 
@@ -59,11 +59,11 @@ segment_set::~segment_set() noexcept = default;
 void segment_set::add(ss::lw_shared_ptr<segment> h) {
     if (!_handles.empty()) {
         vassert(
-          h->offsets().base_offset > _handles.back()->offsets().dirty_offset,
+          h->offsets().get_base_offset() > _handles.back()->offsets().get_dirty_offset(),
           "New segments must be monotonically increasing. Assertion failure: "
           "({} > {}) Got:{} - Current:{}",
-          h->offsets().base_offset,
-          _handles.back()->offsets().dirty_offset,
+          h->offsets().get_base_offset(),
+          _handles.back()->offsets().get_dirty_offset(),
           *h,
           *this);
     }
@@ -84,7 +84,7 @@ struct needle_in_range {
             return false;
         }
         // must use max_offset
-        return o <= s.offsets().dirty_offset && o >= s.offsets().base_offset;
+        return o <= s.offsets().get_dirty_offset() && o >= s.offsets().get_base_offset();
     }
 };
 
@@ -204,15 +204,15 @@ static ss::future<segment_set> unsafe_do_recover(
             if (i > 0) {
                 auto& prev = *good[i - 1];
 
-                if (prev.offsets().dirty_offset >= s.offsets().base_offset) {
+                if (prev.offsets().get_dirty_offset() >= s.offsets().get_base_offset()) {
                     vlog(
                       stlog.warn,
                       "looks like segment index for segment {} is corrupted: "
                       "dirty offset {} is >= than the next base offset: {}, "
                       "will recover it",
                       prev,
-                      prev.offsets().dirty_offset,
-                      s.offsets().base_offset);
+                      prev.offsets().get_dirty_offset(),
+                      s.offsets().get_base_offset());
                     to_recover_set.insert(&prev);
                 }
             }
@@ -222,7 +222,7 @@ static ss::future<segment_set> unsafe_do_recover(
                 // the index directly to hydrate the max_offset state
                 if (s.materialize_index().get()) {
                     vassert(
-                      s.offsets().dirty_offset == s.index().max_offset(),
+                      s.offsets().get_dirty_offset() == s.index().max_offset(),
                       "dirty_offset and index max_offset must be equal for "
                       "segment {}",
                       s);

--- a/src/v/storage/segment_set.cc
+++ b/src/v/storage/segment_set.cc
@@ -32,7 +32,8 @@ namespace storage {
 struct segment_ordering {
     using type = ss::lw_shared_ptr<segment>;
     bool operator()(const type& seg1, const type& seg2) const {
-        return seg1->offsets().get_base_offset() < seg2->offsets().get_base_offset();
+        return seg1->offsets().get_base_offset()
+               < seg2->offsets().get_base_offset();
     }
     bool operator()(const type& seg, model::offset value) const {
         return seg->offsets().get_dirty_offset() < value;
@@ -59,7 +60,8 @@ segment_set::~segment_set() noexcept = default;
 void segment_set::add(ss::lw_shared_ptr<segment> h) {
     if (!_handles.empty()) {
         vassert(
-          h->offsets().get_base_offset() > _handles.back()->offsets().get_dirty_offset(),
+          h->offsets().get_base_offset()
+            > _handles.back()->offsets().get_dirty_offset(),
           "New segments must be monotonically increasing. Assertion failure: "
           "({} > {}) Got:{} - Current:{}",
           h->offsets().get_base_offset(),
@@ -84,7 +86,8 @@ struct needle_in_range {
             return false;
         }
         // must use max_offset
-        return o <= s.offsets().get_dirty_offset() && o >= s.offsets().get_base_offset();
+        return o <= s.offsets().get_dirty_offset()
+               && o >= s.offsets().get_base_offset();
     }
 };
 
@@ -204,7 +207,9 @@ static ss::future<segment_set> unsafe_do_recover(
             if (i > 0) {
                 auto& prev = *good[i - 1];
 
-                if (prev.offsets().get_dirty_offset() >= s.offsets().get_base_offset()) {
+                if (
+                  prev.offsets().get_dirty_offset()
+                  >= s.offsets().get_base_offset()) {
                     vlog(
                       stlog.warn,
                       "looks like segment index for segment {} is corrupted: "

--- a/src/v/storage/tests/CMakeLists.txt
+++ b/src/v/storage/tests/CMakeLists.txt
@@ -165,3 +165,17 @@ rp_test(
   LABELS storage
   ARGS "-- -c 1"
 )
+
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME segment_offset_tracker
+  SOURCES
+  segment_offset_tracker_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::storage
+  ARGS "-- -c 1"
+  LABELS storage
+)

--- a/src/v/storage/tests/compaction_e2e_multinode_test.cc
+++ b/src/v/storage/tests/compaction_e2e_multinode_test.cc
@@ -133,8 +133,8 @@ FIXTURE_TEST(replicate_after_compaction, compaction_multinode_test) {
     model::offset prev_last{-1};
     for (const auto& seg : new_log->segments()) {
         BOOST_REQUIRE_EQUAL(
-          seg->offsets().base_offset, model::next_offset(prev_last));
-        prev_last = seg->offsets().committed_offset;
+          seg->offsets().get_base_offset(), model::next_offset(prev_last));
+        prev_last = seg->offsets().get_committed_offset();
     }
 }
 

--- a/src/v/storage/tests/compaction_e2e_test.cc
+++ b/src/v/storage/tests/compaction_e2e_test.cc
@@ -173,7 +173,7 @@ TEST_P(CompactionFixtureParamTest, TestDedupeOnePass) {
     ss::abort_source never_abort;
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
-      disk_log.segments().back()->offsets().base_offset,
+      disk_log.segments().back()->offsets().get_base_offset(),
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -238,7 +238,7 @@ TEST_F(CompactionFixtureTest, TestDedupeMultiPass) {
     ss::abort_source never_abort;
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
-      disk_log.segments().back()->offsets().base_offset,
+      disk_log.segments().back()->offsets().get_base_offset(),
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -280,7 +280,7 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     ss::abort_source never_abort;
     auto& disk_log = dynamic_cast<storage::disk_log_impl&>(*log);
     storage::compaction_config cfg(
-      disk_log.segments().back()->offsets().base_offset,
+      disk_log.segments().back()->offsets().get_base_offset(),
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -299,7 +299,7 @@ TEST_P(CompactionFixtureBatchSizeParamTest, TestRecompactWithNewData) {
     // But once we add more data, we become eligible for compaction again.
     generate_data(1, cardinality, records_per_segment).get();
     storage::compaction_config new_cfg(
-      disk_log.segments().back()->offsets().base_offset,
+      disk_log.segments().back()->offsets().get_base_offset(),
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -347,7 +347,7 @@ TEST_F(CompactionFixtureTest, TestCompactWithNonDataBatches) {
     auto before_compaction_count
       = disk_log.get_probe().get_segments_compacted();
     storage::compaction_config new_cfg(
-      disk_log.segments().back()->offsets().base_offset,
+      disk_log.segments().back()->offsets().get_base_offset(),
       ss::default_priority_class(),
       never_abort,
       std::nullopt);
@@ -434,7 +434,7 @@ TEST_P(CompactionFilledReaderTest, ReadFilledGaps) {
     // Compaction should leave behind gaps, but those gaps should be filled
     // when reading.
     storage::compaction_config cfg(
-      disk_log.segments().back()->offsets().base_offset,
+      disk_log.segments().back()->offsets().get_base_offset(),
       ss::default_priority_class(),
       never_abort,
       std::nullopt,
@@ -492,7 +492,7 @@ TEST_F(CompactionFixtureTest, TestReadFilledGapsWithTerms) {
     }
 
     storage::compaction_config cfg(
-      disk_log.segments().back()->offsets().base_offset,
+      disk_log.segments().back()->offsets().get_base_offset(),
       ss::default_priority_class(),
       never_abort,
       std::nullopt,

--- a/src/v/storage/tests/concat_segment_reader_test.cc
+++ b/src/v/storage/tests/concat_segment_reader_test.cc
@@ -66,7 +66,7 @@ SEASTAR_THREAD_TEST_CASE(
         model::record_batch_type::acl_management_cmd);
 
     size_t start_pos = b.bytes_written();
-    start_offset = b.get_segment(0).offsets().dirty_offset + model::offset{1};
+    start_offset = b.get_segment(0).offsets().get_dirty_offset() + model::offset{1};
     b
       | add_random_batch(
         start_offset,
@@ -75,7 +75,7 @@ SEASTAR_THREAD_TEST_CASE(
         model::record_batch_type::user_management_cmd);
 
     // Add intermediate segments
-    start_offset = b.get_segment(0).offsets().dirty_offset + model::offset{1};
+    start_offset = b.get_segment(0).offsets().get_dirty_offset() + model::offset{1};
     for (auto i = 1; i < 4; ++i) {
         b | add_segment(start_offset)
           | add_random_batch(
@@ -83,7 +83,7 @@ SEASTAR_THREAD_TEST_CASE(
             10,
             maybe_compress_batches::yes,
             model::record_batch_type::user_management_cmd);
-        start_offset = b.get_segment(i).offsets().dirty_offset
+        start_offset = b.get_segment(i).offsets().get_dirty_offset()
                        + model::offset{1};
     }
 
@@ -94,7 +94,7 @@ SEASTAR_THREAD_TEST_CASE(
         10,
         maybe_compress_batches::yes,
         model::record_batch_type::user_management_cmd);
-    start_offset = b.get_segment(4).offsets().dirty_offset + model::offset{1};
+    start_offset = b.get_segment(4).offsets().get_dirty_offset() + model::offset{1};
 
     // Add a sentinel batch, view will read upto here
     auto final_segment = b.get_log_segments().back();
@@ -205,7 +205,7 @@ SEASTAR_THREAD_TEST_CASE(test_multiple_segments_read_full) {
     size_t start_offset = 0;
     for (auto i = 0; i < 5; ++i) {
         b | add_segment(start_offset) | add_random_batch(start_offset, 10);
-        start_offset = b.get_segment(i).offsets().dirty_offset
+        start_offset = b.get_segment(i).offsets().get_dirty_offset()
                        + model::offset{1};
     }
 

--- a/src/v/storage/tests/concat_segment_reader_test.cc
+++ b/src/v/storage/tests/concat_segment_reader_test.cc
@@ -66,7 +66,8 @@ SEASTAR_THREAD_TEST_CASE(
         model::record_batch_type::acl_management_cmd);
 
     size_t start_pos = b.bytes_written();
-    start_offset = b.get_segment(0).offsets().get_dirty_offset() + model::offset{1};
+    start_offset = b.get_segment(0).offsets().get_dirty_offset()
+                   + model::offset{1};
     b
       | add_random_batch(
         start_offset,
@@ -75,7 +76,8 @@ SEASTAR_THREAD_TEST_CASE(
         model::record_batch_type::user_management_cmd);
 
     // Add intermediate segments
-    start_offset = b.get_segment(0).offsets().get_dirty_offset() + model::offset{1};
+    start_offset = b.get_segment(0).offsets().get_dirty_offset()
+                   + model::offset{1};
     for (auto i = 1; i < 4; ++i) {
         b | add_segment(start_offset)
           | add_random_batch(
@@ -94,7 +96,8 @@ SEASTAR_THREAD_TEST_CASE(
         10,
         maybe_compress_batches::yes,
         model::record_batch_type::user_management_cmd);
-    start_offset = b.get_segment(4).offsets().get_dirty_offset() + model::offset{1};
+    start_offset = b.get_segment(4).offsets().get_dirty_offset()
+                   + model::offset{1};
 
     // Add a sentinel batch, view will read upto here
     auto final_segment = b.get_log_segments().back();

--- a/src/v/storage/tests/log_manager_test.cc
+++ b/src/v/storage/tests/log_manager_test.cc
@@ -37,7 +37,7 @@ void write_garbage(segment_appender& ptr) {
 
 void write_batches(ss::lw_shared_ptr<segment> seg) {
     auto batches = model::test::make_random_batches(
-      seg->offsets().base_offset + model::offset(1), 1);
+      seg->offsets().get_base_offset() + model::offset(1), 1);
     for (auto& b : batches) {
         b.header().header_crc = model::internal_header_only_crc(b.header());
         (void)seg->append(std::move(b)).get0();

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -502,7 +502,8 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
         BOOST_REQUIRE_EQUAL(next_offsets.get_base_offset(), truncate_offset);
         // segment commited offset has to be lower than next segment base
         // offset
-        BOOST_REQUIRE_LT(offsets.get_committed_offset(), next_offsets.get_base_offset());
+        BOOST_REQUIRE_LT(
+          offsets.get_committed_offset(), next_offsets.get_base_offset());
     }
 }
 

--- a/src/v/storage/tests/log_truncate_test.cc
+++ b/src/v/storage/tests/log_truncate_test.cc
@@ -496,13 +496,13 @@ FIXTURE_TEST(truncated_segment_recovery, storage_test_fixture) {
         auto truncate_offset = truncate_offsets[i_seg];
 
         BOOST_REQUIRE_EQUAL(
-          offsets.dirty_offset, truncate_offset - model::offset{1});
+          offsets.get_dirty_offset(), truncate_offset - model::offset{1});
 
         auto next_offsets = (*next)->offsets();
-        BOOST_REQUIRE_EQUAL(next_offsets.base_offset, truncate_offset);
+        BOOST_REQUIRE_EQUAL(next_offsets.get_base_offset(), truncate_offset);
         // segment commited offset has to be lower than next segment base
         // offset
-        BOOST_REQUIRE_LT(offsets.committed_offset, next_offsets.base_offset);
+        BOOST_REQUIRE_LT(offsets.get_committed_offset(), next_offsets.get_base_offset());
     }
 }
 
@@ -554,7 +554,7 @@ FIXTURE_TEST(test_concurrent_prefix_truncate_and_gc, storage_test_fixture) {
     f2.get0();
 
     BOOST_REQUIRE_EQUAL(
-      (*log->segments().begin())->offsets().base_offset,
+      (*log->segments().begin())->offsets().get_base_offset(),
       log->offsets().start_offset);
 }
 

--- a/src/v/storage/tests/offset_to_filepos_test.cc
+++ b/src/v/storage/tests/offset_to_filepos_test.cc
@@ -35,7 +35,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_begin_offset_not_found) {
         };
         b.add_random_batch(spec).get();
         curr_offset = model::next_offset(
-          b.get_log_segments().back()->offsets().committed_offset);
+          b.get_log_segments().back()->offsets().get_committed_offset());
         ts = model::timestamp{ts.value() + 1};
     }
 
@@ -69,7 +69,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_not_found) {
         };
         b.add_random_batch(spec).get();
         curr_offset = model::next_offset(
-          b.get_log_segments().back()->offsets().committed_offset);
+          b.get_log_segments().back()->offsets().get_committed_offset());
         ts = model::timestamp{ts.value() + 1};
     }
 
@@ -106,7 +106,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_begin_offset_found) {
         b.add_random_batch(spec).get();
         positions.push_back(b.bytes_written());
         curr_offset = model::next_offset(
-          b.get_log_segments().back()->offsets().committed_offset);
+          b.get_log_segments().back()->offsets().get_committed_offset());
         ts = model::timestamp{ts.value() + 1};
     }
 
@@ -147,7 +147,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_found) {
         b.add_random_batch(spec).get();
         positions.push_back(b.bytes_written());
         curr_offset = model::next_offset(
-          b.get_log_segments().back()->offsets().committed_offset);
+          b.get_log_segments().back()->offsets().get_committed_offset());
         ts = model::timestamp{ts.value() + 1};
     }
 
@@ -185,7 +185,7 @@ SEASTAR_THREAD_TEST_CASE(test_search_end_offset_allowed_to_be_missing) {
         };
         b.add_random_batch(spec).get();
         curr_offset = model::next_offset(
-          b.get_log_segments().back()->offsets().committed_offset);
+          b.get_log_segments().back()->offsets().get_committed_offset());
         ts = model::timestamp{ts.value() + 1};
     }
 

--- a/src/v/storage/tests/segment_deduplication_test.cc
+++ b/src/v/storage/tests/segment_deduplication_test.cc
@@ -101,19 +101,19 @@ TEST(FindSlidingRangeTest, TestCollectExcludesPrevious) {
       model::offset{30}, ss::default_priority_class(), never_abort);
     auto segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(3, segs.size());
-    ASSERT_EQ(segs.front()->offsets().base_offset(), 0);
+    ASSERT_EQ(segs.front()->offsets().get_base_offset(), model::offset{0});
 
     // Let's pretend the previous compaction indexed offsets [20, 30).
     // Subsequent compaction should ignore that last segment.
     disk_log.set_last_compaction_window_start_offset(model::offset(20));
     segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(2, segs.size());
-    ASSERT_EQ(segs.front()->offsets().base_offset(), 0);
+    ASSERT_EQ(segs.front()->offsets().get_base_offset(), model::offset{0});
 
     disk_log.set_last_compaction_window_start_offset(model::offset(10));
     segs = disk_log.find_sliding_range(cfg);
     ASSERT_EQ(1, segs.size());
-    ASSERT_EQ(segs.front()->offsets().base_offset(), 0);
+    ASSERT_EQ(segs.front()->offsets().get_base_offset(), model::offset{0});
 }
 
 // Even though segments with one record would be skipped over during

--- a/src/v/storage/tests/segment_offset_tracker_test.cc
+++ b/src/v/storage/tests/segment_offset_tracker_test.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "base/seastarx.h"
+#include "features/feature_table.h"
+#include "model/fundamental.h"
+#include "storage/fs_utils.h"
+#include "storage/segment.h"
+#include "storage/storage_resources.h"
+
+#include <gtest/gtest.h>
+
+namespace storage {
+
+struct segment_offset_tracker_fixture : public testing::Test {
+    segment make_segment(model::offset base_offset) {
+        segment_index idx(
+          segment_full_path::mock("mocked"),
+          base_offset,
+          1024,
+          features,
+          std::nullopt);
+        return segment(
+          segment::offset_tracker(model::term_id(0), base_offset),
+          nullptr,
+          std::move(idx),
+          nullptr,
+          std::nullopt,
+          std::nullopt,
+          resources);
+    }
+
+    ss::sharded<features::feature_table> features;
+    storage_resources resources;
+};
+
+TEST_F(segment_offset_tracker_fixture, get_and_set_offsets) {
+    auto segment = make_segment(model::offset{1});
+    auto& offsets = const_cast<segment::offset_tracker&>(segment.offsets());
+    EXPECT_EQ(offsets.get_term(), model::term_id{0});
+    EXPECT_EQ(offsets.get_base_offset(), model::offset{1});
+
+    EXPECT_EQ(offsets.get_committed_offset(), model::offset{0});
+    EXPECT_EQ(offsets.get_stable_offset(), model::offset{0});
+    EXPECT_EQ(offsets.get_dirty_offset(), model::offset{0});
+
+    using committed_offset_t = segment::offset_tracker::committed_offset_t;
+    using stable_offset_t = segment::offset_tracker::stable_offset_t;
+    using dirty_offset_t = segment::offset_tracker::dirty_offset_t;
+
+    offsets.set_offsets(
+      committed_offset_t{1}, stable_offset_t{2}, dirty_offset_t{3});
+
+    EXPECT_EQ(offsets.get_committed_offset(), model::offset{1});
+    EXPECT_EQ(offsets.get_stable_offset(), model::offset{2});
+    EXPECT_EQ(offsets.get_dirty_offset(), model::offset{3});
+
+    offsets.set_offset(dirty_offset_t{6});
+    EXPECT_EQ(offsets.get_dirty_offset(), model::offset{6});
+
+    offsets.set_offset(stable_offset_t{5});
+    EXPECT_EQ(offsets.get_stable_offset(), model::offset{5});
+
+    offsets.set_offset(committed_offset_t{4});
+    EXPECT_EQ(offsets.get_committed_offset(), model::offset{4});
+}
+
+}; // namespace storage

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -685,26 +685,32 @@ FIXTURE_TEST(test_time_based_eviction, storage_test_fixture) {
     compact_and_prefix_truncate(*disk_log, make_compaction_cfg(broker_t0 - 2s));
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 3);
     BOOST_REQUIRE_EQUAL(
-      disk_log->segments().front()->offsets().get_base_offset(), model::offset(0));
+      disk_log->segments().front()->offsets().get_base_offset(),
+      model::offset(0));
     BOOST_REQUIRE_EQUAL(
-      disk_log->segments().back()->offsets().get_dirty_offset(), model::offset(59));
+      disk_log->segments().back()->offsets().get_dirty_offset(),
+      model::offset(59));
 
     // gc with timestamp +sep/2, should evict first segment
     compact_and_prefix_truncate(
       *disk_log, make_compaction_cfg(broker_t0 + (broker_ts_sep / 2)));
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 2);
     BOOST_REQUIRE_EQUAL(
-      disk_log->segments().front()->offsets().get_base_offset(), model::offset(10));
+      disk_log->segments().front()->offsets().get_base_offset(),
+      model::offset(10));
     BOOST_REQUIRE_EQUAL(
-      disk_log->segments().back()->offsets().get_dirty_offset(), model::offset(59));
+      disk_log->segments().back()->offsets().get_dirty_offset(),
+      model::offset(59));
     // gc with timestamp +sep3/2, should evict another segment
     compact_and_prefix_truncate(
       *disk_log, make_compaction_cfg(broker_t0 + (3 * broker_ts_sep / 2)));
     BOOST_REQUIRE_EQUAL(disk_log->segments().size(), 1);
     BOOST_REQUIRE_EQUAL(
-      disk_log->segments().front()->offsets().get_base_offset(), model::offset(40));
+      disk_log->segments().front()->offsets().get_base_offset(),
+      model::offset(40));
     BOOST_REQUIRE_EQUAL(
-      disk_log->segments().back()->offsets().get_dirty_offset(), model::offset(59));
+      disk_log->segments().back()->offsets().get_dirty_offset(),
+      model::offset(59));
 };
 
 FIXTURE_TEST(test_size_based_eviction, storage_test_fixture) {
@@ -1675,7 +1681,8 @@ FIXTURE_TEST(adjacent_segment_compaction, storage_test_fixture) {
     // Check if it honors max_compactible offset by resetting it to the base
     // offset of first segment. Nothing should be compacted.
     const auto first_segment_offsets = log->segments().front()->offsets();
-    c_cfg.compact.max_collectible_offset = first_segment_offsets.get_base_offset();
+    c_cfg.compact.max_collectible_offset
+      = first_segment_offsets.get_base_offset();
     log->housekeeping(c_cfg).get0();
     BOOST_REQUIRE_EQUAL(log->segment_count(), 4);
 
@@ -1750,7 +1757,8 @@ FIXTURE_TEST(adjacent_segment_compaction_terms, storage_test_fixture) {
     BOOST_REQUIRE_EQUAL(disk_log->segment_count(), 5);
 
     for (int i = 0; i < 5; i++) {
-        BOOST_REQUIRE_EQUAL(disk_log->segments()[i]->offsets().get_term()(), i + 1);
+        BOOST_REQUIRE_EQUAL(
+          disk_log->segments()[i]->offsets().get_term()(), i + 1);
     }
 }
 
@@ -2242,7 +2250,8 @@ FIXTURE_TEST(committed_offset_updates, storage_test_fixture) {
               if (log->segment_count() == 0) {
                   return ss::now();
               }
-              auto stable = log->segments().back()->offsets().get_stable_offset();
+              auto stable
+                = log->segments().back()->offsets().get_stable_offset();
               BOOST_REQUIRE_LE(prev_stable_offset, stable);
               prev_stable_offset = stable;
 


### PR DESCRIPTION
Changed `storage::segment::offset_tracker` from a `struct` to a `class`, made data fields private.

Added public "getter" and "setter" functions in order to `vassert` the necessary offset invariants.

Also packaged in some very minor changes (see commit `85d979bd79f7a9e41cb83237673f483c25e02ac1`), including 

- removal of superfluous `partition_probe` forward declaration in `cloud_storage/fwd.h`
- correct usage of `static constexpr` variable in `cluster/cloud_storage_size_reducer.h`
- Unnecessary `virtual` specifier on a member function of a class marked `final` in `cluster/id_allocator.h`

## Backports Required

- [X]  none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

- None