### PR TITLE
storage: adopt offset_translator in namespace

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1736,7 +1736,7 @@ ss::future<std::error_code> controller_backend::transfer_partition(
     // TODO: copy, not move
     co_await raft::details::move_persistent_state(
       group, ss::this_shard_id(), destination, _storage);
-    co_await raft::offset_translator::move_persistent_state(
+    co_await storage::offset_translator::move_persistent_state(
       group, ss::this_shard_id(), destination, _storage);
     co_await raft::move_persistent_stm_state(
       ntp, ss::this_shard_id(), destination, _storage);

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -446,7 +446,7 @@ ss::future<> create_offset_translator_state_for_pre_existing_partition(
       max_rp_offset);
     co_await api.kvs().put(
       storage::kvstore::key_space::offset_translator,
-      raft::offset_translator::kvstore_offsetmap_key(group),
+      storage::offset_translator::kvstore_offsetmap_key(group),
       ot_state->serialize_map());
     vlog(
       raftlog.debug,
@@ -455,7 +455,7 @@ ss::future<> create_offset_translator_state_for_pre_existing_partition(
       max_rp_offset);
     co_await api.kvs().put(
       storage::kvstore::key_space::offset_translator,
-      raft::offset_translator::kvstore_highest_known_offset_key(group),
+      storage::offset_translator::kvstore_highest_known_offset_key(group),
       reflection::to_iobuf(max_rp_offset));
 }
 

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -195,7 +195,7 @@ ss::future<>
 disk_log_impl::start(std::optional<truncate_prefix_config> truncate_cfg) {
     auto is_new = is_new_log();
     co_await offset_translator().start(
-      raft::offset_translator::must_reset{is_new});
+      storage::offset_translator::must_reset{is_new});
     if (truncate_cfg.has_value()) {
         co_await truncate_prefix(truncate_cfg.value());
     }

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -115,7 +115,9 @@ public:
     get_offset_translator_state() const final {
         return _offset_translator.state();
     }
-    raft::offset_translator& offset_translator() { return _offset_translator; }
+    storage::offset_translator& offset_translator() {
+        return _offset_translator;
+    }
     model::offset_delta offset_delta(model::offset) const final;
     model::offset from_log_offset(model::offset) const final;
     model::offset to_log_offset(model::offset) const final;
@@ -333,7 +335,7 @@ private:
     // method.
     mutex _start_offset_lock{"disk_log_impl::start_offset_lock"};
     lock_manager _lock_mngr;
-    raft::offset_translator _offset_translator;
+    storage::offset_translator _offset_translator;
 
     std::unique_ptr<storage::probe> _probe;
     failure_probes _failure_probes;

--- a/src/v/storage/fwd.h
+++ b/src/v/storage/fwd.h
@@ -23,6 +23,7 @@ class ntp_config;
 class log;
 class log_manager;
 class probe;
+class offset_translator;
 class offset_translator_state;
 class readers_cache;
 class segment;
@@ -35,8 +36,3 @@ struct log_reader_config;
 struct timequery_config;
 
 } // namespace storage
-
-// TODO: a subsequent commit will move this into the storage namespace.
-namespace raft {
-class offset_translator;
-} // namespace raft

--- a/src/v/storage/offset_translator.cc
+++ b/src/v/storage/offset_translator.cc
@@ -21,7 +21,7 @@
 #include <seastar/core/coroutine.hh>
 #include <seastar/util/log.hh>
 
-namespace raft {
+namespace storage {
 
 static ss::logger logger{"offset_translator"};
 
@@ -446,4 +446,4 @@ ss::future<> offset_translator::move_persistent_state(
     });
 }
 
-} // namespace raft
+} // namespace storage

--- a/src/v/storage/offset_translator.h
+++ b/src/v/storage/offset_translator.h
@@ -26,7 +26,7 @@
 
 #include <absl/container/btree_map.h>
 
-namespace raft {
+namespace storage {
 
 /// See also comments for storage::offset_translator_state.
 ///
@@ -155,4 +155,4 @@ private:
     storage::storage_resources& _resources;
 };
 
-} // namespace raft
+} // namespace storage


### PR DESCRIPTION
Now that the build pieces have landed for storage:: taking ownership of the offset_translator, this updates its namespace to follow suit.

This is follow-up to https://github.com/redpanda-data/redpanda/pull/16892

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
