### PR TITLE
CORE-1722: compression: Use preallocated decompression buffers for lz4

### DIFF
--- a/src/v/compression/CMakeLists.txt
+++ b/src/v/compression/CMakeLists.txt
@@ -11,11 +11,13 @@ v_cc_library(
     "stream_zstd.cc"
     "async_stream_zstd.cc"
     "snappy_standard_compressor.cc"
+    "lz4_decompression_buffers.cc"
     "internal/snappy_java_compressor.cc"
     "internal/lz4_frame_compressor.cc"
     "internal/gzip_compressor.cc"
   DEPS
     v::bytes
+    v::ssx
     Zstd::zstd
     LZ4::LZ4
     Snappy::snappy

--- a/src/v/compression/include/compression/internal/lz4_frame_compressor.h
+++ b/src/v/compression/include/compression/internal/lz4_frame_compressor.h
@@ -11,10 +11,15 @@
 
 #pragma once
 #include "bytes/iobuf.h"
+
+#include <lz4frame.h>
+
 namespace compression::internal {
 
 struct lz4_frame_compressor {
     static iobuf compress(const iobuf&);
+    static iobuf
+    compress_with_block_size(const iobuf&, std::optional<LZ4F_blockSizeID_t>);
     static iobuf uncompress(const iobuf&);
 };
 

--- a/src/v/compression/include/compression/lz4_decompression_buffers.h
+++ b/src/v/compression/include/compression/lz4_decompression_buffers.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "base/units.h"
 
 #include <seastar/core/aligned_buffer.hh>
 #include <seastar/core/semaphore.hh>
@@ -24,6 +25,9 @@ namespace compression {
 
 class lz4_decompression_buffers {
 public:
+    static constexpr auto bufsize{4_MiB + 128_KiB};
+    static constexpr auto min_threshold{128_KiB + 1};
+
     explicit lz4_decompression_buffers(
       size_t buffer_size, size_t min_alloc_threshold, bool disabled = false);
 
@@ -108,6 +112,22 @@ private:
 
 std::ostream& operator<<(
   std::ostream&, lz4_decompression_buffers::alloc_ctx::allocation_state);
+
+// Initializes the buffer instance. If preallocation is disabled the instance
+// will pass through all calls to malloc and free. Two buffers of size
+// buffer_size are allocated. Calls below the min_alloc_threshold are passed
+// through to malloc.
+void init_lz4_decompression_buffers(
+  size_t buffer_size,
+  size_t min_alloc_threshold,
+  bool prealloc_disabled = false);
+
+// Resets the buffer instance, for use in tests.
+void reset_lz4_decompression_buffers();
+
+// Returns the static shard specific preallocated buffer instance. If the
+// instance is not created yet it will be initialized first.
+lz4_decompression_buffers& lz4_decompression_buffers_instance();
 
 } // namespace compression
 

--- a/src/v/compression/include/compression/lz4_decompression_buffers.h
+++ b/src/v/compression/include/compression/lz4_decompression_buffers.h
@@ -81,6 +81,7 @@ public:
         size_t deallocs{0};
         size_t pass_through_allocs{0};
         size_t pass_through_deallocs{0};
+        bool operator==(const stats&) const = default;
     };
 
     void allocated() { _allocation_stats.allocs += 1; }

--- a/src/v/compression/include/compression/lz4_decompression_buffers.h
+++ b/src/v/compression/include/compression/lz4_decompression_buffers.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/core/aligned_buffer.hh>
+#include <seastar/core/semaphore.hh>
+
+#define LZ4F_STATIC_LINKING_ONLY
+
+#include <lz4frame.h>
+
+namespace compression {
+
+class lz4_decompression_buffers {
+public:
+    explicit lz4_decompression_buffers(
+      size_t buffer_size, size_t min_alloc_threshold, bool disabled = false);
+
+    // LZ4 decompression requires two buffers during a single decompression
+    // operation. This struct carries the buffers and associated book-keeping
+    // state of allocation.
+    struct alloc_ctx {
+        // A typical transition cycle for this set of buffers is:
+        // no_buffers_allocated -> input_buffer_allocated ->
+        // output_buffer_allocated -> both_buffers_allocated
+        // During deallocation/free the reverse states are expected.
+        enum class allocation_state : uint8_t {
+            // No buffers have been allocated to the LZ4 decompression routine.
+            // The buffers are effectively not in use.
+            no_buffers_allocated,
+            // The input buffer has been allocated out to LZ4 decompression
+            // routine.
+            input_buffer_allocated,
+            // The output buffer has also been allocated. Note that output
+            // buffer will never be allocated alone.
+            output_buffer_allocated,
+            // Both buffers are allocated to decompression routine.
+            both_buffers_allocated,
+        };
+
+        std::unique_ptr<char[], ss::free_deleter> input_buffer;
+        std::unique_ptr<char[], ss::free_deleter> output_buffer;
+        allocation_state state;
+
+        // Checks if the address belongs to one of the two managed buffers. This
+        // address check is used when freeing an address. If the address is
+        // not managed by this context, then we fall back to `free()`.
+        [[nodiscard]] bool is_managed_address(const void* const address) const;
+    };
+
+    // Returns a reference to allocated buffer pair. The buffers must have been
+    // reserved before this call.
+    [[nodiscard]] alloc_ctx& buffers();
+
+    // Returns the minimum allocation threshold, allocation requests below this
+    // size are passed through to `malloc()`.
+    [[nodiscard]] size_t min_alloc_threshold() const;
+
+    struct stats {
+        size_t allocs{0};
+        size_t deallocs{0};
+        size_t pass_through_allocs{0};
+        size_t pass_through_deallocs{0};
+    };
+
+    void allocated() { _allocation_stats.allocs += 1; }
+
+    void deallocated() { _allocation_stats.deallocs += 1; }
+
+    void pass_through_allocated() {
+        _allocation_stats.pass_through_allocs += 1;
+    }
+
+    void pass_through_deallocated() {
+        _allocation_stats.pass_through_deallocs += 1;
+    }
+
+    stats allocation_stats() const { return _allocation_stats; }
+
+    void reset_stats() { _allocation_stats = {}; }
+
+private:
+    size_t _min_alloc_threshold;
+    bool _disabled{false};
+
+    alloc_ctx _buffers;
+    stats _allocation_stats;
+};
+
+std::ostream& operator<<(
+  std::ostream&, lz4_decompression_buffers::alloc_ctx::allocation_state);
+
+} // namespace compression

--- a/src/v/compression/lz4_decompression_buffers.cc
+++ b/src/v/compression/lz4_decompression_buffers.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "compression/lz4_decompression_buffers.h"
+
+#include "base/vassert.h"
+
+#include <seastar/coroutine/all.hh>
+
+namespace compression {
+
+std::ostream& operator<<(
+  std::ostream& os, lz4_decompression_buffers::alloc_ctx::allocation_state st) {
+    switch (st) {
+        using enum compression::lz4_decompression_buffers::alloc_ctx::
+          allocation_state;
+    case no_buffers_allocated:
+        return os << "no buffers allocated";
+    case input_buffer_allocated:
+        return os << "input buffer allocated";
+    case output_buffer_allocated:
+        return os << "output buffer allocated";
+    case both_buffers_allocated:
+        return os << "both buffers allocated";
+    }
+}
+
+lz4_decompression_buffers::lz4_decompression_buffers(
+  size_t buffer_size, size_t min_alloc_threshold, bool disabled)
+  : _min_alloc_threshold{min_alloc_threshold}
+  , _disabled{disabled} {
+    if (!_disabled) {
+        _buffers = {
+          .input_buffer = ss::allocate_aligned_buffer<char>(buffer_size, 8),
+          .output_buffer = ss::allocate_aligned_buffer<char>(buffer_size, 8),
+          .state = alloc_ctx::allocation_state::no_buffers_allocated,
+        };
+    }
+}
+
+bool lz4_decompression_buffers::alloc_ctx::is_managed_address(
+  const void* const address) const {
+    return address == input_buffer.get() || address == output_buffer.get();
+}
+
+lz4_decompression_buffers::alloc_ctx& lz4_decompression_buffers::buffers() {
+    return _buffers;
+}
+
+size_t lz4_decompression_buffers::min_alloc_threshold() const {
+    return _min_alloc_threshold;
+}
+
+} // namespace compression

--- a/src/v/compression/lz4_decompression_buffers.cc
+++ b/src/v/compression/lz4_decompression_buffers.cc
@@ -35,7 +35,8 @@ std::ostream& operator<<(
 
 lz4_decompression_buffers::lz4_decompression_buffers(
   size_t buffer_size, size_t min_alloc_threshold, bool disabled)
-  : _min_alloc_threshold{min_alloc_threshold}
+  : _buffer_size{buffer_size}
+  , _min_alloc_threshold{min_alloc_threshold}
   , _disabled{disabled} {
     if (!_disabled) {
         _buffers = {
@@ -59,4 +60,138 @@ size_t lz4_decompression_buffers::min_alloc_threshold() const {
     return _min_alloc_threshold;
 }
 
+LZ4F_CustomMem lz4_decompression_buffers::custom_mem_alloc() {
+    // If custom allocation is disabled, setting all alloc functions to null
+    // makes lz4 fall back to malloc, calloc and free.
+    if (_disabled) {
+        return {
+          .customAlloc = nullptr,
+          .customCalloc = nullptr,
+          .customFree = nullptr,
+          .opaqueState = nullptr};
+    }
+
+    return {
+      .customAlloc = alloc_lz4_obj,
+      .customCalloc = nullptr,
+      .customFree = free_lz4_obj,
+      .opaqueState = this};
+}
+
 } // namespace compression
+
+namespace {
+
+using alloc_st
+  = compression::lz4_decompression_buffers::alloc_ctx::allocation_state;
+using t = std::underlying_type_t<alloc_st>;
+
+alloc_st operator|(alloc_st a, alloc_st b) { return alloc_st(t(a) | t(b)); }
+
+void operator|=(alloc_st& a, alloc_st b) { a = (a | b); }
+
+alloc_st operator&(alloc_st a, alloc_st b) { return alloc_st(t(a) & t(b)); }
+
+void operator&=(alloc_st& a, alloc_st b) { a = (a & b); }
+
+alloc_st operator~(alloc_st a) { return alloc_st(~t(a)); }
+
+} // namespace
+
+// During a typical lz4 decompression operation the following LZ4F_malloc calls
+// will be processed via this alloc function:
+// 1. Allocation for the tmp input buffer: this can be a maximum of 4MiB + 4
+// bytes
+// 2. Allocation for the tmp output buffer: this can be a maximum of 4MiB +
+// 128KiB
+// These two calls will typically happen once per decompression context, and are
+// preceded by calls to LZ4F_free to first free up the two buffers.
+void* alloc_lz4_obj(void* state, size_t size) {
+    auto* st = static_cast<compression::lz4_decompression_buffers*>(state);
+    vassert(
+      size <= st->buffer_size(),
+      "Request to allocate {} bytes which is more than max buffer size "
+      "available: {} bytes",
+      size,
+      st->buffer_size());
+
+    if (size < st->min_alloc_threshold()) {
+        st->pass_through_allocated();
+        return malloc(size);
+    }
+
+    auto& bufs = st->buffers();
+
+    switch (bufs.state) {
+        using enum compression::lz4_decompression_buffers::alloc_ctx::
+          allocation_state;
+    case no_buffers_allocated:
+        bufs.state |= input_buffer_allocated;
+        st->allocated();
+        return bufs.input_buffer.get();
+    case input_buffer_allocated:
+        bufs.state |= output_buffer_allocated;
+        st->allocated();
+        return bufs.output_buffer.get();
+    case both_buffers_allocated:
+    case output_buffer_allocated:
+        vassert(
+          false, "invalid allocation request when both buffers allocated");
+    }
+}
+
+// During a decompression operation this function is called via the LZ4F_free
+// wrapper. The function is typically called in the following sequence:
+// 1. When freeing the decompression context:
+//    a. free the tmp out buffer
+//    b. free the tmp in buffer
+//    c. free the decompression context
+// 2. When initializing the decompression context, this function will be called
+// on the two buffer addresses.
+// In all cases we either pass the address straight through to `free()` or if
+// the address is managed, we update the state. The state update ensures that
+// the next decompression operation starts with the correct state (no buffers
+// allocated)
+void free_lz4_obj(void* state, void* address) {
+    auto* st = static_cast<compression::lz4_decompression_buffers*>(state);
+
+    auto& bufs = st->buffers();
+
+    // If the address being freed does not match one of the static addresses we
+    // manage, fall back to free. This can happen because:
+    //
+    // 1. LZ4 frees memory before performing each allocation, resulting in
+    // interspersed calls to free/malloc where the freed address was not
+    // allocated from our pool.
+    //
+    // 2. The allocation was not done via this allocator, eg for blocks
+    // small enough that they should not be managed by custom allocator.
+    //
+    // In both cases these memory addresses will not match our managed buffers.
+    if (!bufs.is_managed_address(address)) {
+        st->pass_through_deallocated();
+        free(address);
+        return;
+    }
+
+    // Buffers are released by lz4 in the order: input buffer, output buffer,
+    // decompression ctx. The first two calls update the state here. The third
+    // call is passed through to free because we do not allocate memory for the
+    // decompression ctx.
+    switch (bufs.state) {
+        using enum compression::lz4_decompression_buffers::alloc_ctx::
+          allocation_state;
+    case no_buffers_allocated:
+    case input_buffer_allocated:
+        vassert(
+          false, "unexpected buffer state {} during deallocation", bufs.state);
+    case output_buffer_allocated:
+        st->deallocated();
+        bufs.state &= (~output_buffer_allocated);
+        return;
+    case both_buffers_allocated:
+        st->deallocated();
+        bufs.state &= (~input_buffer_allocated);
+        return;
+    }
+}

--- a/src/v/compression/tests/CMakeLists.txt
+++ b/src/v/compression/tests/CMakeLists.txt
@@ -13,3 +13,13 @@ rp_test(
   LABELS compression
   ARGS "-- -c 1"
   )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME lz4_buf_tests
+  SOURCES lz4_buf_tests.cc
+  LIBRARIES v::compression v::gtest_main
+  LABELS compression
+  ARGS "-- -c 1"
+)

--- a/src/v/compression/tests/lz4_buf_tests.cc
+++ b/src/v/compression/tests/lz4_buf_tests.cc
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/units.h"
+#include "compression/lz4_decompression_buffers.h"
+
+#include <gmock/gmock.h>
+
+#include <lz4.h>
+
+using enum compression::lz4_decompression_buffers::alloc_ctx::allocation_state;
+
+TEST(AllocateBuffers, StateTransitions) {
+    auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
+    const auto& buffers = b.buffers();
+    EXPECT_EQ(buffers.state, no_buffers_allocated);
+    auto allocator = b.custom_mem_alloc();
+
+    auto* input = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold());
+    EXPECT_EQ(buffers.state, input_buffer_allocated);
+    EXPECT_EQ(input, buffers.input_buffer.get());
+
+    auto* output = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold());
+    EXPECT_EQ(buffers.state, both_buffers_allocated);
+    EXPECT_EQ(output, buffers.output_buffer.get());
+
+    allocator.customFree(allocator.opaqueState, input);
+    EXPECT_EQ(buffers.state, output_buffer_allocated);
+
+    allocator.customFree(allocator.opaqueState, output);
+    EXPECT_EQ(buffers.state, no_buffers_allocated);
+}
+
+TEST(FallbackForSmallAllocs, CustomAllocator) {
+    auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
+    auto allocator = b.custom_mem_alloc();
+    auto* allocated = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold() - 1);
+    EXPECT_NE(allocated, nullptr);
+    allocator.customFree(allocator.opaqueState, allocated);
+}
+
+TEST(MixedAllocations, CustomAllocator) {
+    auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
+    const auto& buffers = b.buffers();
+    auto allocator = b.custom_mem_alloc();
+
+    auto* input = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold());
+    EXPECT_EQ(input, buffers.input_buffer.get());
+    EXPECT_EQ(buffers.state, input_buffer_allocated);
+
+    auto* random_alloc = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold() - 1);
+    EXPECT_FALSE(buffers.is_managed_address(random_alloc));
+    EXPECT_EQ(buffers.state, input_buffer_allocated);
+
+    auto* output = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold());
+    EXPECT_EQ(output, buffers.output_buffer.get());
+    EXPECT_EQ(buffers.state, both_buffers_allocated);
+
+    allocator.customFree(allocator.opaqueState, input);
+    EXPECT_EQ(buffers.state, output_buffer_allocated);
+
+    allocator.customFree(allocator.opaqueState, random_alloc);
+    EXPECT_EQ(buffers.state, output_buffer_allocated);
+
+    allocator.customFree(allocator.opaqueState, output);
+    EXPECT_EQ(buffers.state, no_buffers_allocated);
+}
+
+TEST(MaxBufSizeDeathTest, CustomAllocator) {
+    auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
+    auto allocator = b.custom_mem_alloc();
+    ASSERT_DEATH(
+      { allocator.customAlloc(allocator.opaqueState, b.buffer_size() + 1); },
+      "Request to allocate 4194305 bytes which is more than max buffer size "
+      "available: 4194304 bytes");
+}

--- a/src/v/compression/tests/lz4_buf_tests.cc
+++ b/src/v/compression/tests/lz4_buf_tests.cc
@@ -10,7 +10,9 @@
  */
 
 #include "base/units.h"
+#include "compression/internal/lz4_frame_compressor.h"
 #include "compression/lz4_decompression_buffers.h"
+#include "random/generators.h"
 
 #include <gmock/gmock.h>
 
@@ -87,4 +89,23 @@ TEST(MaxBufSizeDeathTest, CustomAllocator) {
       { allocator.customAlloc(allocator.opaqueState, b.buffer_size() + 1); },
       "Request to allocate 4194305 bytes which is more than max buffer size "
       "available: 4194304 bytes");
+}
+
+TEST(CustomAllocDisabled, Configuration) {
+    compression::reset_lz4_decompression_buffers();
+    compression::init_lz4_decompression_buffers(4_MiB, 128_KiB + 1, true);
+    const auto data = random_generators::gen_alphanum_string(512);
+    iobuf input;
+    input.append(data.data(), data.size());
+
+    using compression::internal::lz4_frame_compressor;
+    auto& instance = compression::lz4_decompression_buffers_instance();
+    auto compressed = lz4_frame_compressor::compress(input);
+    auto uncompressed = lz4_frame_compressor::uncompress(compressed);
+    auto stats = instance.allocation_stats();
+    EXPECT_EQ(stats.allocs, 0);
+    EXPECT_EQ(stats.deallocs, 0);
+    EXPECT_EQ(stats.pass_through_allocs, 0);
+    EXPECT_EQ(stats.pass_through_deallocs, 0);
+    instance.reset_stats();
 }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2506,6 +2506,12 @@ configuration::configuration()
       "Size of the zstd decompression workspace",
       {.visibility = visibility::tunable},
       8_MiB)
+  , lz4_decompress_reusable_buffers_disabled(
+      *this,
+      "lz4_decompress_reusable_buffers_disabled",
+      "Disable reusable preallocated buffers for LZ4 decompression",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , full_raft_configuration_recovery_pattern(
       *this, "full_raft_configuration_recovery_pattern")
   , enable_auto_rebalance_on_node_add(

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -458,6 +458,7 @@ struct configuration final : public config_store {
     property<size_t> kafka_qdc_max_depth;
     property<std::chrono::milliseconds> kafka_qdc_depth_update_ms;
     property<size_t> zstd_decompress_workspace_bytes;
+    property<bool> lz4_decompress_reusable_buffers_disabled;
     deprecated_property full_raft_configuration_recovery_pattern;
     property<bool> enable_auto_rebalance_on_node_add;
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -70,6 +70,7 @@
 #include "cluster/tx_topic_manager.h"
 #include "cluster/types.h"
 #include "compression/async_stream_zstd.h"
+#include "compression/lz4_decompression_buffers.h"
 #include "compression/stream_zstd.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
@@ -534,6 +535,11 @@ void application::initialize(
 
         compression::initialize_async_stream_zstd(
           config::shard_local_cfg().zstd_decompress_workspace_bytes());
+
+        compression::init_lz4_decompression_buffers(
+          compression::lz4_decompression_buffers::bufsize,
+          compression::lz4_decompression_buffers::min_threshold,
+          config::shard_local_cfg().lz4_decompress_reusable_buffers_disabled());
     }).get0();
 
     if (config::shard_local_cfg().enable_pid_file()) {

--- a/src/v/storage/parser_utils.cc
+++ b/src/v/storage/parser_utils.cc
@@ -14,8 +14,6 @@
 #include "model/compression.h"
 #include "model/record.h"
 #include "model/record_utils.h"
-#include "reflection/adl.h"
-#include "storage/logger.h"
 
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/coroutine.hh>


### PR DESCRIPTION
LZ4 decompression uses malloc to allocate memory for temporary buffers. The size allocated depends on the input and can range upto two buffers of slightly over 4MiB each per decompression. 

In cases where contiguous space of 4MiB is not available after redpanda has been running for a while, this can result in a OOM. This is usually seen in context of compaction where a segment needs to be read through to discard old values for a key, requiring decompression of the record batches.

This PR switches LZ4 to use a custom memory allocator and a pair of preallocated 4MiB+128KiB buffers per shard. The custom memory allocator intercepts calls to malloc and returns the preallocated buffers if the allocation size is larger than a threshold. In corresponding calls to `free` the state of managed buffers is updated.

A caller must reserve buffers before starting decompression. The current decompression operation is synchronous so once a shard begins decompressing a record batch, it cannot suspend the operation, and the buffers are implicitly protected against parallel access; but the buffers in this PR are still accessed after reserving a semaphore unit to protect against future changes to the decompression routine. 

While this PR only allows for one decompression operation per shard, if we move to use the `object_pool` utility and support multiple buffer pairs per shard IE multiple decompression ops per shard in parallel, then the current reserve/release methods will serve as a base to control concurrency.

The following new settings are introduced to control the operation:

1. `lz4_decompress_buffer_size_bytes`: size per buffer (two are allocated per shard)
2. `lz4_decompress_malloc_min_threshold`: min threshold below which preallocated buffers are not used and we pass through to malloc for allocation
3. `lz4_decompress_reusable_buffers_enabled`: enables turning off preallocated buffers, all calls via lz4 are passed through to malloc.

FIXES https://github.com/redpanda-data/redpanda/issues/16179

[force push](https://github.com/redpanda-data/redpanda/compare/323e9d8731b89ca96e22584a6dca6a5979836bb6..755a6a8f5b528468e32099ccdd06277e38108940) - removes semaphore, removes settings for sizes

[force push](https://github.com/redpanda-data/redpanda/compare/9b2a03d4c347ecbe616e293e885c410cf80501f8..34860a98f53c9276775ab45885ab4fa869bb6fa6) - fixes semantics of deallocation order and state transition 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none