### PR TITLE
(fix): Handle EDITOR with options

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/hamba/avro/v2 v2.20.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/lestrrat-go/jwx v1.2.29
 	github.com/linkedin/goavro/v2 v2.12.0
 	github.com/lorenzosaino/go-sysctl v0.3.1
@@ -91,7 +92,6 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.2 // indirect

--- a/src/go/rpk/pkg/cli/cluster/config/edit_test.go
+++ b/src/go/rpk/pkg/cli/cluster/config/edit_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEditorAndOptions(t *testing.T) {
+	testCases := map[string]struct {
+		editor   string
+		fileName string
+		want     []string
+	}{
+		"default": {
+			editor:   "code -w",
+			fileName: "/tmp/one.yaml",
+			want:     []string{"code", "-w", "/tmp/one.yaml"},
+		},
+		"noOptions": {
+			editor:   "code",
+			fileName: "/tmp/one.yaml",
+			want:     []string{"code", "/tmp/one.yaml"},
+		},
+		"withQuotedOption": {
+			editor:   "foo 'why would I do this'",
+			fileName: "/tmp/one.yaml",
+			want:     []string{"foo", "why would I do this", "/tmp/one.yaml"},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := editorAndArguments(tc.editor, tc.fileName)
+			assert.NoError(t, err)
+			if !reflect.DeepEqual(tc.want, got) {
+				t.Fatalf("want %#v but got %#v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When doing `rpk cluster config edit` leverage the editor options. For example if the `EDITOR` is set to `code -w`, then the `rpk cluster config edit` should run a editor command like `code -w <cluster config tempfile`.

The commit splits the `EDITOR` environment variable with options and appends the tempfile as the last argument.

Fixes: 17386

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x


### Bug Fixes

Leverage the editor(`$EDITOR`) options  using comand`rpk cluster config edit`.

### Improvements

The developer can now set editor to something like EDITOR='code -w` and run the `rpk cluster config edit` to be able to make the editor wait for the editing to be saved/discarded.

