### PR TITLE
c/test: fix shard_placement_table_test

### DIFF
--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -21,6 +21,10 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/util/file.hh>
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 namespace cluster {
 
 namespace {


### PR DESCRIPTION
There is an issue with PRs that raced and the build is broken. Fix it by
explicitly adding in chrono literals

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
