### PR TITLE
admin/api-doc: Remove role_member_update def

### DIFF
--- a/src/v/redpanda/admin/api-doc/security.def.json
+++ b/src/v/redpanda/admin/api-doc/security.def.json
@@ -64,23 +64,6 @@
         }
     }
 },
-"role_member_update": {
-    "type"  : "object",
-    "properties": {
-        "to_add": {
-            "type": "array",
-            "items": {
-                "$ref": "role_member"
-            }
-        },
-        "to_remove": {
-            "type": "array",
-            "items": {
-                "$ref": "role_member"
-            }
-        }
-    }
-},
 "roles_list": {
     "type": "object",
     "properties": {

--- a/src/v/redpanda/admin/api-doc/security.json
+++ b/src/v/redpanda/admin/api-doc/security.json
@@ -412,8 +412,20 @@
                 "name": "role_member_update",
                 "in": "body",
                 "required": false,
-                "schema": {
-                    "$ref": "#/definitions/role_member_update"
+                "type": "object",
+                "properties": {
+                    "add": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/role_member"
+                        }
+                    },
+                    "remove": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/definitions/role_member"
+                        }
+                    }
                 }
             }
         ],


### PR DESCRIPTION
The motivation for this is that one of the properties specified in the outward facing API spec has a name collision in generated code, so the name used in the def didn't match. Since we don't actually use the generated code, we can remove the definition altogether and define the structure inline in security.json.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
