### PR TITLE
[v23.3.x] stm/dist_kv_stm: missing co_awaits on snapshot lock

### DIFF
--- a/src/v/cluster/distributed_kv_stm.h
+++ b/src/v/cluster/distributed_kv_stm.h
@@ -120,7 +120,7 @@ public:
     ss::future<> apply_local_snapshot(
       raft::stm_snapshot_header header, iobuf&& bytes) override {
         auto holder = _gate.hold();
-        auto units = _snapshot_lock.hold_write_lock();
+        auto units = co_await _snapshot_lock.hold_write_lock();
 
         iobuf_parser parser(std::move(bytes));
         auto snap = co_await serde::read_async<snapshot>(parser);
@@ -137,7 +137,7 @@ public:
 
     ss::future<raft::stm_snapshot> take_local_snapshot() override {
         auto holder = _gate.hold();
-        auto units = _snapshot_lock.hold_write_lock();
+        auto units = co_await _snapshot_lock.hold_write_lock();
         auto last_applied = last_applied_offset();
         snapshot result;
         if (_is_routing_partition) {


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17383
