### PR TITLE
treewide: address newer clang-tidy warnings

### DIFF
--- a/src/v/CMakeLists.txt
+++ b/src/v/CMakeLists.txt
@@ -24,7 +24,8 @@ if(REDPANDA_RUN_CLANG_TIDY)
         bugprone-stringview-nullptr
         bugprone-unused-return-value
         bugprone-suspicious-string-compare
-        cppcoreguidelines-rvalue-reference-param-not-moved
+        # TODO: Reenable this after fixing all the noise (and nuking ADL)
+        # cppcoreguidelines-rvalue-reference-param-not-moved
         misc-unused-using-decls
         misc-unused-alias-decls
         modernize-redundant-void-arg

--- a/src/v/cloud_roles/tests/credential_tests.cc
+++ b/src/v/cloud_roles/tests/credential_tests.cc
@@ -21,7 +21,7 @@ BOOST_AUTO_TEST_CASE(test_gcp_headers) {
 
     {
         bh::request_header<> h{};
-        applier.add_auth(h);
+        BOOST_REQUIRE_EQUAL(applier.add_auth(h), std::error_code{});
         BOOST_REQUIRE_EQUAL(h.at(bh::field::authorization), "Bearer a-token");
     }
 
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(test_gcp_headers) {
 
     {
         bh::request_header<> h{};
-        applier.add_auth(h);
+        BOOST_REQUIRE_EQUAL(applier.add_auth(h), std::error_code{});
         BOOST_REQUIRE_EQUAL(
           h.at(bh::field::authorization), "Bearer second-token");
     }
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(test_aws_headers) {
     {
         bh::request_header<> h{};
         h.method(bh::verb::put);
-        applier.add_auth(h);
+        BOOST_REQUIRE_EQUAL(applier.add_auth(h), std::error_code{});
         fmt::print("{}", h);
         BOOST_REQUIRE_EQUAL(h.at("x-amz-security-token"), "tok");
         // put request contains unsigned payload
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(test_aws_headers) {
     {
         bh::request_header<> h{};
         h.method(bh::verb::get);
-        applier.add_auth(h);
+        BOOST_REQUIRE_EQUAL(applier.add_auth(h), std::error_code{});
         fmt::print("{}", h);
         BOOST_REQUIRE_EQUAL(h.at("x-amz-security-token"), "tok2");
         // get request contains empty signature

--- a/src/v/cloud_roles/tests/signature_test.cc
+++ b/src/v/cloud_roles/tests/signature_test.cc
@@ -51,7 +51,7 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_1) {
     header.insert(boost::beast::http::field::host, host);
     header.insert(boost::beast::http::field::range, "bytes=0-9");
 
-    sign.sign_header(header, sha256);
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "
@@ -88,7 +88,7 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_2) {
     header.insert(
       boost::beast::http::field::date, "Fri, 24 May 2013 00:00:00 GMT");
 
-    sign.sign_header(header, sha256);
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "
@@ -123,7 +123,7 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_3) {
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
 
-    sign.sign_header(header, sha256);
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "
@@ -156,7 +156,7 @@ SEASTAR_THREAD_TEST_CASE(test_signature_computation_4) {
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
 
-    sign.sign_header(header, sha256);
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header, sha256), std::error_code{});
 
     std::string expected
       = "AWS4-HMAC-SHA256 "
@@ -186,7 +186,7 @@ SEASTAR_THREAD_TEST_CASE(test_abs_signature_computation) {
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
 
-    sign.sign_header(header);
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header), std::error_code{});
 
     std::string expected
       = "SharedKey "
@@ -214,7 +214,7 @@ SEASTAR_THREAD_TEST_CASE(test_abs_signature_computation_many_query_params) {
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
 
-    sign.sign_header(header);
+    BOOST_REQUIRE_EQUAL(sign.sign_header(header), std::error_code{});
 
     std::string expected
       = "SharedKey "

--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -203,7 +203,14 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd, model::offset offset) {
           [o = offset,
            m = cmd.value.recovery_state->manifest,
            b = cmd.value.recovery_state->bucket](auto& recovery_table) {
-              recovery_table.apply(o, m, b, wait_for_nodes::yes);
+              auto ec = recovery_table.apply(o, m, b, wait_for_nodes::yes);
+              if (ec) {
+                  throw std::runtime_error(fmt_with_ctx(
+                    fmt::format,
+                    "Failed to apply recovery state: {} ({})",
+                    ec.message(),
+                    ec));
+              }
           });
     }
 

--- a/src/v/cluster/tests/feature_barrier_test.cc
+++ b/src/v/cluster/tests/feature_barrier_test.cc
@@ -60,7 +60,8 @@ struct barrier_fixture {
               model::broker_properties{}));
         }
         for (auto& br : brokers) {
-            members.apply(model::offset(0), cluster::add_node_cmd(br.id(), br));
+            BOOST_REQUIRE(!members.apply(
+              model::offset(0), cluster::add_node_cmd(br.id(), br)));
         }
     }
 

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -64,8 +64,12 @@ struct partition_allocator_fixture {
             .available_memory_gb = 5 * core_count,
             .available_disk_gb = 10 * core_count});
 
-        members.local().apply(
+        auto ec = members.local().apply(
           model::offset(0), cluster::add_node_cmd(0, broker));
+        if (ec) {
+            throw std::runtime_error(
+              ss::format("unable to apply add node cmd: {}", ec.message()));
+        }
 
         allocator.register_node(std::make_unique<cluster::allocation_node>(
           broker.id(),

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -247,10 +247,7 @@ struct partition_balancer_planner_fixture {
         auto& members_table = workers.members.local();
 
         std::vector<model::broker> new_brokers;
-        for (auto [id, nm] : members_table.nodes()) {
-            new_brokers.push_back(nm.broker);
-        }
-
+        new_brokers.reserve(nodes_amount);
         for (size_t i = 0; i < nodes_amount; ++i) {
             std::optional<model::rack_id> rack_id;
             if (!rack_ids.empty()) {
@@ -259,7 +256,7 @@ struct partition_balancer_planner_fixture {
 
             workers.allocator.local().register_node(
               create_allocation_node(model::node_id(last_node_idx), 4));
-            new_brokers.push_back(model::broker(
+            new_brokers.emplace_back(
               model::node_id(last_node_idx),
               net::unresolved_address{},
               net::unresolved_address{},
@@ -267,7 +264,7 @@ struct partition_balancer_planner_fixture {
               model::broker_properties{
                 .cores = 4,
                 .available_memory_gb = 2,
-                .available_disk_gb = 100}));
+                .available_disk_gb = 100});
             last_node_idx++;
         }
         for (auto& b : new_brokers) {

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -115,8 +115,8 @@ public:
     }
 
     void set_maintenance_mode(model::node_id id) {
-        members.local().apply(
-          model::offset{}, cluster::maintenance_mode_cmd(id, true));
+        BOOST_REQUIRE(!members.local().apply(
+          model::offset{}, cluster::maintenance_mode_cmd(id, true)));
         auto broker = members.local().get_node_metadata_ref(id);
         BOOST_REQUIRE(broker);
         BOOST_REQUIRE(
@@ -125,8 +125,8 @@ public:
     }
 
     void set_decommissioning(model::node_id id) {
-        members.local().apply(
-          model::offset{}, cluster::decommission_node_cmd(id, 0));
+        BOOST_REQUIRE(!members.local().apply(
+          model::offset{}, cluster::decommission_node_cmd(id, 0)));
         allocator.local().decommission_node(id);
         auto broker = members.local().get_node_metadata_ref(id);
         BOOST_REQUIRE(broker);
@@ -268,8 +268,8 @@ struct partition_balancer_planner_fixture {
             last_node_idx++;
         }
         for (auto& b : new_brokers) {
-            members_table.apply(
-              model::offset{}, cluster::add_node_cmd(b.id(), b));
+            BOOST_REQUIRE(!members_table.apply(
+              model::offset{}, cluster::add_node_cmd(b.id(), b)));
         }
     }
 

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -58,8 +58,8 @@ public:
             .available_disk_gb = uint32_t(total_size / 1_GiB),
             .available_memory_bytes = 2 * 1_GiB});
 
-        _workers.members.local().apply(
-          model::offset{}, cluster::add_node_cmd(id, broker));
+        BOOST_REQUIRE(!_workers.members.local().apply(
+          model::offset{}, cluster::add_node_cmd(id, broker)));
         _workers.allocator.local().register_node(
           std::make_unique<cluster::allocation_node>(
             id,

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -46,19 +46,19 @@ FIXTURE_TEST(test_happy_path_create, topic_table_fixture) {
 FIXTURE_TEST(test_happy_path_delete, topic_table_fixture) {
     create_topics();
     // discard create delta
-    table.local().wait_for_changes(as).get0();
-    table.local()
-      .apply(
-        cluster::delete_topic_cmd(
-          make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2")),
-        model::offset(0))
-      .get0();
-    table.local()
-      .apply(
-        cluster::delete_topic_cmd(
-          make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3")),
-        model::offset(0))
-      .get0();
+    table.local().wait_for_changes(as).get();
+    BOOST_REQUIRE(!table.local()
+                     .apply(
+                       cluster::delete_topic_cmd(
+                         make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2")),
+                       model::offset(0))
+                     .get());
+    BOOST_REQUIRE(!table.local()
+                     .apply(
+                       cluster::delete_topic_cmd(
+                         make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3")),
+                       model::offset(0))
+                     .get());
 
     auto& md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);
@@ -153,11 +153,13 @@ FIXTURE_TEST(test_adding_partition, topic_table_fixture) {
     cluster::create_partitions_configuration_assignment pca(
       std::move(cfg), std::move(p_as));
 
-    table.local()
-      .apply(
-        cluster::create_partition_cmd(make_tp_ns("test_tp_2"), std::move(pca)),
-        model::offset(0))
-      .get0();
+    auto result = table.local()
+                    .apply(
+                      cluster::create_partition_cmd(
+                        make_tp_ns("test_tp_2"), std::move(pca)),
+                      model::offset(0))
+                    .get();
+    BOOST_REQUIRE(!result);
 
     auto md = table.local().get_topic_metadata(make_tp_ns("test_tp_2"));
 

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -114,14 +114,16 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   test_dispatching_happy_path_delete, topic_table_updates_dispatcher_fixture) {
     create_topics();
-    dispatcher
-      .apply_update(serde_serialize_cmd(cluster::delete_topic_cmd(
-        make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2"))))
-      .get0();
-    dispatcher
-      .apply_update(serde_serialize_cmd(cluster::delete_topic_cmd(
-        make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3"))))
-      .get0();
+    BOOST_REQUIRE(
+      !dispatcher
+         .apply_update(serde_serialize_cmd(cluster::delete_topic_cmd(
+           make_tp_ns("test_tp_2"), make_tp_ns("test_tp_2"))))
+         .get());
+    BOOST_REQUIRE(
+      !dispatcher
+         .apply_update(serde_serialize_cmd(cluster::delete_topic_cmd(
+           make_tp_ns("test_tp_3"), make_tp_ns("test_tp_3"))))
+         .get());
 
     auto& md = table.local().all_topics_metadata();
     BOOST_REQUIRE_EQUAL(md.size(), 1);

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -447,7 +447,10 @@ public:
     }
 
     binding(binding<T>&& rhs) noexcept
+      // The base move constructor doesn't touch _value
+      // so that's why it's safe to use `rhs` after.
       : binding_base<T>(std::move(rhs))
+      // NOLINTNEXTLINE(*-use-after-move)
       , _value(std::move(rhs._value)) {}
 
     const T& operator()() const {
@@ -535,8 +538,12 @@ public:
     }
 
     conversion_binding(conversion_binding&& rhs) noexcept
+      // The base move constructor doesn't touch _value or _convert
+      // so that's why it's safe to use `rhs` after.
       : binding_base<T>(std::move(rhs))
+      // NOLINTNEXTLINE(*-use-after-move)
       , _value(std::move(rhs._value))
+      // NOLINTNEXTLINE(*-use-after-move)
       , _convert(std::move(rhs._convert)) {}
 
     conversion_binding& operator=(conversion_binding&&) = delete;

--- a/src/v/storage/log_manager.cc
+++ b/src/v/storage/log_manager.cc
@@ -143,7 +143,7 @@ log_manager::log_manager(
   , _feature_table(feature_table)
   , _jitter(_config.compaction_interval())
   , _trigger_gc_jitter(0s, 5s)
-  , _batch_cache(config.reclaim_opts) {
+  , _batch_cache(_config.reclaim_opts) {
     _config.compaction_interval.watch([this]() {
         _jitter = simple_time_jitter<ss::lowres_clock>{
           _config.compaction_interval()};


### PR DESCRIPTION
Running the public build with clang 17 and clang-tidy picks up some new warnings.

There are way too many to fix the not used rvalue warnings, but hopefully we can chip away at those overtime.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
