### PR TITLE
stm/dist_kv_stm: fix locking sequence for remove_all

### DIFF
--- a/src/v/cluster/tests/distributed_kv_stm_tests.cc
+++ b/src/v/cluster/tests/distributed_kv_stm_tests.cc
@@ -120,7 +120,8 @@ FIXTURE_TEST(test_batched_actions, stm_test_fixture) {
     }
 
     // Delete the even keys
-    stm.remove_all([](int key) { return key % 2 == 0; }).get();
+    auto result = stm.remove_all([](int key) { return key % 2 == 0; }).get();
+    BOOST_REQUIRE_EQUAL(result, cluster::errc::success);
     for (int i = 0; i < 30; i++) {
         if (i % 2 == 0) {
             BOOST_REQUIRE(!stm.get(i).get().value().has_value());


### PR DESCRIPTION
Currently remove_all takes a write lock for the entire duration that
prevents replicate_and_wait() to make progress because it needs a read
lock. Fix this by making remove_all best effort, so it can just grab
a read lock.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
### Bug Fixes

* Fixes lock starvation during transform offset commits.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
