### PR TITLE
Feat/cluster metadata manifest age metric

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -183,7 +183,7 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
     // Write a controller snapshot and upload it.
     RPTEST_REQUIRE_EVENTUALLY(
       5s, [this] { return controller_stm.maybe_write_snapshot(); });
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     retry_chain_node retry_node(never_abort, 30s, 1s);
     cluster_metadata_manifest manifest;
     manifest.cluster_uuid = cluster_uuid;
@@ -370,7 +370,7 @@ TEST_F(ClusterRecoveryBackendTest, TestRecoverMissingTopicManifest) {
               .local()
               .maybe_write_snapshot();
         });
-        auto& uploader = app.controller->metadata_uploader();
+        auto& uploader = app.controller->metadata_uploader().value().get();
         retry_chain_node retry_node(never_abort, 30s, 1s);
         cluster_metadata_manifest manifest;
         manifest.cluster_uuid = cluster_uuid;
@@ -463,7 +463,7 @@ TEST_F(ClusterRecoveryBackendTest, TestRecoverFailedDownload) {
     // Upload the controller snapshot to set up a failure to create the table.
     RPTEST_REQUIRE_EVENTUALLY(
       5s, [this] { return controller_stm.maybe_write_snapshot(); });
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     retry_chain_node retry_node(never_abort, 60s, 1s);
     cluster_metadata_manifest manifest;
     manifest.cluster_uuid = cluster_uuid;

--- a/src/v/cluster/cloud_metadata/tests/offsets_recovery_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/offsets_recovery_test.cc
@@ -669,7 +669,7 @@ FIXTURE_TEST(test_controller_upload_offsets, offsets_recovery_fixture) {
       5s, [&] { return controller_stm.maybe_write_snapshot(); });
 
     // Now begin uploading metadata.
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     cluster::consensus_ptr raft0
       = app.partition_manager.local().get(model::controller_ntp)->raft();
     RPTEST_REQUIRE_EVENTUALLY(5s, [&] { return raft0->is_leader(); });
@@ -835,7 +835,7 @@ FIXTURE_TEST(test_cluster_recovery_with_offsets, offsets_recovery_fixture) {
       5s, [&controller_stm] { return controller_stm.maybe_write_snapshot(); });
     auto raft0
       = app.partition_manager.local().get(model::controller_ntp)->raft();
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     retry_chain_node retry_node(never_abort, 30s, 1s);
     cluster_metadata_manifest manifest;
     manifest.cluster_uuid = cluster_uuid;

--- a/src/v/cluster/cloud_metadata/tests/uploader_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/uploader_test.cc
@@ -134,7 +134,7 @@ protected:
 
 FIXTURE_TEST(
   test_download_highest_manifest, cluster_metadata_uploader_fixture) {
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::max(), 10ms);
 
@@ -173,7 +173,7 @@ FIXTURE_TEST(
 
 FIXTURE_TEST(
   test_download_highest_manifest_errors, cluster_metadata_uploader_fixture) {
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::min(), 10ms);
     auto down_res
@@ -183,7 +183,7 @@ FIXTURE_TEST(
 }
 
 FIXTURE_TEST(test_upload_next_metadata, cluster_metadata_uploader_fixture) {
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     retry_chain_node retry_node(
       never_abort, ss::lowres_clock::time_point::max(), 10ms);
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
@@ -283,7 +283,7 @@ FIXTURE_TEST(test_upload_in_term, cluster_metadata_uploader_fixture) {
 
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     cluster::cloud_metadata::cluster_metadata_id highest_meta_id{0};
 
     // Checks that metadata is uploaded a new term, stepping down in between
@@ -343,7 +343,7 @@ FIXTURE_TEST(
       5s, [this] { return controller_stm.maybe_write_snapshot(); });
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     RPTEST_REQUIRE_EVENTUALLY(5s, [this] { return raft0->is_leader(); });
 
     auto upload_in_term
@@ -388,7 +388,7 @@ FIXTURE_TEST(test_run_loop, cluster_metadata_uploader_fixture) {
       5s, [this] { return controller_stm.maybe_write_snapshot(); });
     test_local_cfg.get("cloud_storage_cluster_metadata_upload_interval_ms")
       .set_value(1000ms);
-    auto& uploader = app.controller->metadata_uploader();
+    auto& uploader = app.controller->metadata_uploader().value().get();
     // Run the upload loop and make sure that new leaders continue to upload.
     uploader.start();
     cluster::cloud_metadata::cluster_metadata_id highest_meta_id{-1};

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -138,8 +138,12 @@ public:
     }
     ss::sharded<controller_stm>& get_controller_stm() { return _stm; }
 
-    cloud_metadata::uploader& metadata_uploader() {
-        return *_metadata_uploader;
+    std::optional<std::reference_wrapper<cloud_metadata::uploader>>
+    metadata_uploader() {
+        if (_metadata_uploader) {
+            return std::ref<cloud_metadata::uploader>(*_metadata_uploader);
+        }
+        return std::nullopt;
     }
 
     ss::sharded<cluster_recovery_manager>& get_cluster_recovery_manager() {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

define a new metric `redpanda_cluster_latest_cluster_metadata_manifest_age`

To tracks the age (in seconds) of the cluster_metadata_manifest saved in cloud storage.

It's updated by the controller, and should result in a Sawtooth pattern, raising steadily and dropping to 0 when a new `cluster_metadata_manifest` in uploaded.

Fixes https://github.com/redpanda-data/core-internal/issues/1207

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Feature
* new public metric `redpanda_cluster_latest_cluster_metadata_manifest_age` to track the age of the cluster_metadata_manifest in cloud storage

