### PR TITLE
c/partition_balancer: don't copy topic metadata on each partition visit

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -886,13 +886,13 @@ auto partition_balancer_planner::request_context::do_with_partition(
     }
 
     // check if the ntp is to be force reconfigured.
-    auto topic_md = _parent._state.topics().get_topic_metadata(
+    auto topic_md = _parent._state.topics().get_topic_metadata_ref(
       model::topic_namespace_view{ntp});
     const auto& force_reconfigurable_partitions
       = _parent._state.topics().partitions_to_force_recover();
     auto force_it = force_reconfigurable_partitions.find(ntp);
     if (topic_md && force_it != force_reconfigurable_partitions.end()) {
-        auto topic_revision = topic_md.value().get_revision();
+        auto topic_revision = topic_md.value().get().get_revision();
         const auto& entries = force_it->second;
         auto it = std::find_if(
           entries.begin(), entries.end(), [&](const auto& entry) {


### PR DESCRIPTION
Previously we were copying the whole metadata (including partition assignments) just to query the topic revision.

`partition_balancer_bench` results before:
```
test                                                   iterations      median         mad         min         max      allocs       tasks        inst
partition_balancer_planner_fixture.unavailable_nodes           27    24.481ms   161.139us    24.320ms    35.441ms 1235710.104      93.852 425407989.4
partition_balancer_planner_fixture.counts_rebalancing           1      1.857s     7.421ms      1.846s      1.888s 118912546.400    7424.600 33427470288.6
```

and after:
```
test                                                   iterations      median         mad         min         max      allocs       tasks        inst
partition_balancer_planner_fixture.unavailable_nodes           91     8.695ms     1.429ms     5.078ms    10.124ms   68660.031      11.301 100617054.8
partition_balancer_planner_fixture.counts_rebalancing          19    54.006ms    56.923us    53.942ms    55.873ms 2172589.168     208.305 972473623.6
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
