### PR TITLE
RBAC: Fix use-after-free in security::acl_store

### DIFF
--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -247,7 +247,7 @@ std::vector<std::vector<acl_binding>> acl_store::remove_bindings(
         }
         // ensure that elements won't outlive the corresponding bindings
         // in enclosing scope.
-        maybe_roles.erase_to_end(maybe_roles.begin());
+        maybe_roles.clear();
     }
 
     std::vector<std::vector<acl_binding>> res;

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -17,6 +17,7 @@
 #include <seastar/coroutine/maybe_yield.hh>
 
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/node_hash_map.h>
 #include <container/fragmented_vector.h>
 #include <fmt/format.h>
 
@@ -206,7 +207,8 @@ std::vector<std::vector<acl_binding>> acl_store::remove_bindings(
     }
 
     // deleted binding index of deleted filter that matched
-    absl::flat_hash_map<acl_binding, size_t> deleted;
+    // NOTE: the algorithm below requires pointer stability of the key
+    absl::node_hash_map<acl_binding, size_t> deleted;
     // NOTE(oren): deleted bindings are held in this scope, so
     // non-owning references are safe to use as long as they are
     // accessed exclusively inside the loop body.


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

acl_store: Sub node_hash_map for flat_hash_map in remove_bindings

We maintain a running vector of roles principal views to delete from a small
cache maintained by each matched acl_entry_set. The value type is a view to
avoid excessive copying, but that view is always into the principal component
of a key entry (acl_binding) in a flat_hash_map.

This is problematic because any insertion into flat_hash_map might result in
a rehash, invalidating key pointers (including the pointer to key struct member
contained in the principal_view), resulting in use-after-free errors whenever
the following conditions are met:

  - More than one binding is deleted from the ACL store
     - i.e. > 1 binding matches the provided filters
  - One of those bindings is to a role principal

This commit also adds a test for this (common) situation. I've verified that
*without* this change, the test does indeed crash as expected.

Fixes https://github.com/redpanda-data/core-internal/issues/1202

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
