### PR TITLE
c/frag_vector: added `get_allocator()` method to fragmented vector

### DIFF
--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -146,6 +146,8 @@ public:
 
     fragmented_vector copy() const noexcept { return *this; }
 
+    auto get_allocator() const { return _frags.get_allocator(); }
+
     void swap(fragmented_vector& other) noexcept {
         std::swap(_size, other._size);
         std::swap(_capacity, other._capacity);

--- a/src/v/container/tests/chunked_hash_map_test.cc
+++ b/src/v/container/tests/chunked_hash_map_test.cc
@@ -54,3 +54,9 @@ TEST(chunked_hash_map, basic_compile_absl_hash) {
     map[{1, 2}] = 2;
     EXPECT_EQ(map.size(), 1);
 }
+
+TEST(chunked_hash_map, test_move_assignment) {
+    chunked_hash_map<foo_with_absl_hash, int> map;
+    chunked_hash_map<foo_with_absl_hash, int> other_map;
+    other_map = std::move(map);
+}


### PR DESCRIPTION
Added `get_allocator()` method to fragmented vector to be able to move the `chunked_hash_map` as in its move assignment operator it queries the allocator from index underlying data structure.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none 