### PR TITLE
[v23.3.x] Introduce chunked_hash_map

### DIFF
--- a/src/v/cluster/scheduling/leader_balancer_random.h
+++ b/src/v/cluster/scheduling/leader_balancer_random.h
@@ -16,12 +16,9 @@
 #include "model/metadata.h"
 #include "raft/types.h"
 #include "random/generators.h"
+#include "utils/chunked_hash_map.h"
 #include "utils/fragmented_vector.h"
 #include "vassert.h"
-
-#include <absl/container/btree_map.h>
-#include <absl/container/flat_hash_map.h>
-#include <absl/container/node_hash_map.h>
 
 #include <cmath>
 #include <cstddef>
@@ -34,7 +31,8 @@
 namespace cluster::leader_balancer_types {
 
 /*
- * Given a `shard_index` this class will generate every possible reassignment.
+ * Given a `shard_index` this class will generate every possible
+ * reassignment.
  */
 class random_reassignments {
 public:
@@ -98,7 +96,7 @@ private:
         raft::group_id group_id;
         model::broker_shard broker_shard;
     };
-    absl::node_hash_map<raft::group_id, model::broker_shard> _current_leaders;
+    chunked_hash_map<raft::group_id, model::broker_shard> _current_leaders;
 
     using replicas_t = fragmented_vector<replica>;
     replicas_t _replicas;

--- a/src/v/utils/CMakeLists.txt
+++ b/src/v/utils/CMakeLists.txt
@@ -1,5 +1,6 @@
 find_package(Hdrhistogram)
 find_package(Base64)
+find_package(unordered_dense REQUIRED)
 v_cc_library(
   NAME utils
   SRCS
@@ -21,6 +22,7 @@ v_cc_library(
     aklomp::base64
     absl::hash
     absl::random_seed_sequences
+    unordered_dense::unordered_dense
     v::bytes
     v::rphashing
     v::json)

--- a/src/v/utils/chunked_hash_map.h
+++ b/src/v/utils/chunked_hash_map.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <ankerl/unordered_dense.h>
+#include <utils/fragmented_vector.h>
+
+/**
+ * @brief A hash map that uses a chunked vector as the underlying storage.
+ *
+ * Use when the hash map is expected to have a large number of elements (e.g.:
+ * scales with partitions or topics). Performance wise it's equal to the abseil
+ * hashmaps.
+ *
+ * NB: References and iterators are not stable across insertions and deletions.
+ *
+ * For more info please see
+ * https://github.com/martinus/unordered_dense/?tab=readme-ov-file#1-overview
+ */
+template<
+  typename Key,
+  typename Value,
+  typename Hash = ankerl::unordered_dense::hash<Key>,
+  typename EqualTo = std::equal_to<Key>>
+using chunked_hash_map = ankerl::unordered_dense::segmented_map<
+  Key,
+  Value,
+  Hash,
+  EqualTo,
+  chunked_vector<std::pair<Key, Value>>,
+  ankerl::unordered_dense::bucket_type::standard,
+  chunked_vector<ankerl::unordered_dense::bucket_type::standard>>;

--- a/src/v/utils/chunked_hash_map.h
+++ b/src/v/utils/chunked_hash_map.h
@@ -10,8 +10,32 @@
  */
 #pragma once
 
+#include <absl/hash/hash.h>
 #include <ankerl/unordered_dense.h>
 #include <utils/fragmented_vector.h>
+
+#include <type_traits>
+
+namespace detail {
+
+template<typename T>
+concept has_absl_hash = requires(T val) {
+    { AbslHashValue(std::declval<absl::HashState>(), val) };
+};
+
+/// Wrapper around absl::Hash that disables the extra hash mixing in
+/// unordered_dense
+template<typename T>
+struct avalanching_absl_hash {
+    // absl always hash mixes itself so no need to do it again
+    using is_avalanching = void;
+
+    auto operator()(const T& x) const noexcept -> uint64_t {
+        return absl::Hash<T>()(x);
+    }
+};
+
+} // namespace detail
 
 /**
  * @brief A hash map that uses a chunked vector as the underlying storage.
@@ -22,13 +46,21 @@
  *
  * NB: References and iterators are not stable across insertions and deletions.
  *
+ * Both std::hash and abseil's AbslHashValue are supported. We dispatch to the
+ * latter if available. Given AbslHashValue also supports std::hash we could
+ * also unconditionally dispatch to it. However, absl's hash mixing seems more
+ * extensive (and hence less performant) so we only do that when needed.
+ *
  * For more info please see
  * https://github.com/martinus/unordered_dense/?tab=readme-ov-file#1-overview
  */
 template<
   typename Key,
   typename Value,
-  typename Hash = ankerl::unordered_dense::hash<Key>,
+  typename Hash = std::conditional_t<
+    detail::has_absl_hash<Key>,
+    detail::avalanching_absl_hash<Key>,
+    ankerl::unordered_dense::hash<Key>>,
   typename EqualTo = std::equal_to<Key>>
 using chunked_hash_map = ankerl::unordered_dense::segmented_map<
   Key,

--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -70,10 +70,15 @@ private:
 
 public:
     using this_type = fragmented_vector<T, fragment_size_bytes>;
+    using backing_type = std::vector<std::vector<T>>;
     using value_type = T;
     using reference = T&;
     using const_reference = const T&;
     using size_type = size_t;
+    using allocator_type = backing_type::allocator_type;
+    using difference_type = backing_type::difference_type;
+    using pointer = T*;
+    using const_pointer = const T*;
 
     /**
      * The maximum number of bytes per fragment as specified in
@@ -89,6 +94,8 @@ public:
       "max size of a fragment must be <= 128KiB");
 
     fragmented_vector() noexcept = default;
+    explicit fragmented_vector(allocator_type alloc)
+      : _frags(alloc) {}
     fragmented_vector& operator=(const fragmented_vector&) noexcept = delete;
     fragmented_vector(fragmented_vector&& other) noexcept {
         *this = std::move(other);
@@ -522,7 +529,7 @@ private:
 
     size_t _size{0};
     size_t _capacity{0};
-    std::vector<std::vector<T>> _frags;
+    backing_type _frags;
 #ifndef NDEBUG
     // Add a generation number that is incremented on every mutation to catch
     // invalidated iterator accesses.

--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ rp_test(
   BINARY_NAME utils_gunit
   SOURCES
     fragmented_vector_test.cc
+    chunked_hash_map_test.cc
     contiguous_range_map_test.cc
   LIBRARIES v::utils v::gtest_main
   LABELS utils

--- a/src/v/utils/tests/chunked_hash_map_test.cc
+++ b/src/v/utils/tests/chunked_hash_map_test.cc
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "utils/chunked_hash_map.h"
+
+struct foo_with_std_hash {
+    int a;
+    int b;
+    auto operator<=>(const foo_with_std_hash&) const = default;
+};
+
+namespace std {
+
+template<>
+struct hash<foo_with_std_hash> {
+    constexpr size_t operator()(const foo_with_std_hash& x) const {
+        return std::hash<int>()(x.a + x.b);
+    }
+};
+
+} // namespace std
+
+struct foo_with_absl_hash {
+    int a;
+    int b;
+
+    auto operator<=>(const foo_with_absl_hash&) const = default;
+
+    template<typename H>
+    friend H AbslHashValue(H h, const foo_with_absl_hash& x) {
+        return H::combine(std::move(h), x.a, x.b);
+    }
+};
+
+TEST(chunked_hash_map, basic_compile_std_hash) {
+    chunked_hash_map<foo_with_std_hash, int> map;
+    map[{1, 2}] = 2;
+    EXPECT_EQ(map.size(), 1);
+}
+
+TEST(chunked_hash_map, basic_compile_absl_hash) {
+    static_assert(detail::has_absl_hash<foo_with_absl_hash>);
+    chunked_hash_map<foo_with_absl_hash, int> map;
+    map[{1, 2}] = 2;
+    EXPECT_EQ(map.size(), 1);
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17182

Needs manual backporting because v::container is not a thing on v23.3 and it's all still in utils.