### PR TITLE
use chunked vector as batches cache in `raft::replicate_batcher`

### DIFF
--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -274,6 +274,9 @@ record_batch_reader
 record_batch_reader make_fragmented_memory_record_batch_reader(
   fragmented_vector<model::record_batch>);
 
+record_batch_reader make_fragmented_memory_record_batch_reader(
+  chunked_vector<model::record_batch>);
+
 inline record_batch_reader
 make_memory_record_batch_reader(model::record_batch b) {
     record_batch_reader::data_t batches;
@@ -319,6 +322,9 @@ record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   fragmented_vector<model::record_batch>);
 
 record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+  chunked_vector<model::record_batch>);
+
+record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch>);
 
 record_batch_reader make_fragmented_memory_record_batch_reader(
@@ -333,6 +339,10 @@ ss::future<record_batch_reader::data_t> consume_reader_to_memory(
 ss::future<fragmented_vector<model::record_batch>>
 consume_reader_to_fragmented_memory(
   record_batch_reader, timeout_clock::time_point timeout);
+
+ss::future<chunked_vector<model::record_batch>>
+consume_reader_to_chunked_vector(
+  record_batch_reader reader, timeout_clock::time_point timeout);
 
 /// \brief wraps a reader into a foreign_ptr<unique_ptr>
 record_batch_reader make_foreign_record_batch_reader(record_batch_reader&&);

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/outcome.h"
+#include "container/fragmented_vector.h"
 #include "model/record_batch_reader.h"
 #include "raft/types.h"
 #include "ssx/semaphore.h"
@@ -29,7 +30,7 @@ public:
     public:
         item(
           size_t record_count,
-          std::vector<model::record_batch> batches,
+          chunked_vector<model::record_batch> batches,
           ssx::semaphore_units u,
           std::optional<model::term_id> expected_term,
           replicate_options opts)
@@ -100,7 +101,7 @@ public:
             }
         }
         size_t _record_count;
-        std::vector<model::record_batch> _data;
+        chunked_vector<model::record_batch> _data;
         ssx::semaphore_units _units;
         std::optional<model::term_id> _expected_term;
         replicate_options _replicate_opts;
@@ -145,7 +146,7 @@ private:
 
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(
       std::optional<model::term_id>,
-      ss::circular_buffer<model::record_batch>,
+      chunked_vector<model::record_batch>,
       size_t,
       replicate_options);
 


### PR DESCRIPTION
Using `fragmented_vector` to store batches in `raft::replicate_batcher` to avoid large allocations.

Fixes: #16944
Fixes: #16945

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none