### PR TITLE
authorizer: add parens

### DIFF
--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -199,7 +199,8 @@ auth_result authorizer::do_authorized(
         std::optional<const security::acl_principal_base*> role
         = std::nullopt) -> std::optional<auth_result> {
         vassert(
-          !role || *role != nullptr && (*role)->type() == principal_type::role,
+          !role
+            || (*role != nullptr && (*role)->type() == principal_type::role),
           "Role principal should be non-null and have 'role' type if "
           "present");
         const acl_principal_base& to_check = *role.value_or(&user);


### PR DESCRIPTION
To silence -Wlogical-op-parentheses warning (which oddly only occurs on remote icecc machines though it looks to me like it should always fire).


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none