### PR TITLE
container/fragmented_vector: add comment about resize

### DIFF
--- a/src/v/container/include/container/fragmented_vector.h
+++ b/src/v/container/include/container/fragmented_vector.h
@@ -284,6 +284,12 @@ public:
                     frag.reserve(std::min(elems_per_frag, new_cap));
                     _capacity = frag.capacity();
                 }
+                // We only reserve the first fragment as all fragments after the
+                // first are allocated at the maximum size, so we don't save
+                // anything in terms of reallocs after fully allocating the
+                // first fragment. In addition, due to cache locality, it's
+                // better to delay the allocations of those other fragments
+                // until they're going to be used.
             }
         }
         update_generation();


### PR DESCRIPTION
Explain why we only reserve the first fragment in chunked_vector, as
it's a good question.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
