### PR TITLE
[v23.3.x] c/frag_vector: added `get_allocator()` method to fragmented vector

### DIFF
--- a/src/v/utils/fragmented_vector.h
+++ b/src/v/utils/fragmented_vector.h
@@ -146,6 +146,8 @@ public:
 
     fragmented_vector copy() const noexcept { return *this; }
 
+    auto get_allocator() const { return _frags.get_allocator(); }
+
     void swap(fragmented_vector& other) noexcept {
         std::swap(_size, other._size);
         std::swap(_capacity, other._capacity);

--- a/src/v/utils/tests/chunked_hash_map_test.cc
+++ b/src/v/utils/tests/chunked_hash_map_test.cc
@@ -54,3 +54,9 @@ TEST(chunked_hash_map, basic_compile_absl_hash) {
     map[{1, 2}] = 2;
     EXPECT_EQ(map.size(), 1);
 }
+
+TEST(chunked_hash_map, test_move_assignment) {
+    chunked_hash_map<foo_with_absl_hash, int> map;
+    chunked_hash_map<foo_with_absl_hash, int> other_map;
+    other_map = std::move(map);
+}


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17421
