### PR TITLE
PESDLC-1036 Wait for metrics at startup of producer_swarm

### DIFF
--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -115,8 +115,24 @@ class ProducerSwarm(Service):
             err_msg=
             f"producer_swarm service {node.account.hostname} failed to start within {600} sec",
         )
+        self._redpanda.wait_until(
+            lambda: self.is_metrics_available(node),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg=
+            f"producer_swarm metrics endpoint at {self._remote_url(node, 'metrics/summary')} failed to answer after {30} sec",
+        )
 
         self._node = node
+
+    def is_metrics_available(self, node):
+        path = f"metrics/summary"
+        path = f"{path}?seconds=1"
+        try:
+            self._get(node, path)
+            return True
+        except:
+            return False
 
     def is_alive(self, node):
         result = node.account.ssh_output(


### PR DESCRIPTION
    When is_alive check is done and gives YES the merics endpoint is not ready yet
    and subsequent try to get them with await_progress will result in Exception.
    This adds fake metrics getter/waiter that serves as an indication that metrics
    is available

Fixes: #16865

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none