### PR TITLE
perf: parameterize perf tests with write caching

### DIFF
--- a/tests/rptest/perf/small_batches_test.py
+++ b/tests/rptest/perf/small_batches_test.py
@@ -1,3 +1,4 @@
+from ducktape.mark import matrix
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurations
@@ -14,8 +15,15 @@ class SmallBatchesTest(RedpandaTest):
               self).__init__(test_context=ctx,
                              extra_rp_conf={"aggregate_metrics": True})
 
+    def setUp(self):
+        pass
+
     @cluster(num_nodes=6)
-    def omb_test(self):
+    @matrix(write_caching=["on", "off"])
+    def omb_test(self, write_caching):
+        self.redpanda.add_extra_rp_conf({"write_caching": write_caching})
+        self.redpanda.start()
+
         workload = {
             "name": "SmallBatchesWorkload",
             "topics": 1,

--- a/tests/rptest/perf/ts_read_openmessaging_test.py
+++ b/tests/rptest/perf/ts_read_openmessaging_test.py
@@ -11,7 +11,7 @@ from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurati
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 from rptest.services.redpanda import SISettings
 
 
@@ -36,14 +36,21 @@ class TSReadOpenmessagingTest(RedpandaTest):
                              si_settings=si_settings,
                              extra_rp_conf=extra_rp_conf)
 
+    def setUp(self):
+        pass
+
     @cluster(num_nodes=6)
-    @parametrize(driver_idx="ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT")
-    def test_perf(self, driver_idx):
+    @matrix(driver_idx="ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT",
+            write_caching=["on", "off"])
+    def test_perf(self, driver_idx, write_caching):
         """
         An OMB perf regression test that has TS reads.
         """
 
         assert self.redpanda.dedicated_nodes
+
+        self.redpanda.add_extra_rp_conf({"write_caching": write_caching})
+        self.redpanda.start()
 
         validator = {
             OMBSampleConfigurations.PUB_LATENCY_MIN:

--- a/tests/rptest/perf/ts_write_openmessaging_test.py
+++ b/tests/rptest/perf/ts_write_openmessaging_test.py
@@ -11,7 +11,7 @@ from rptest.services.openmessaging_benchmark_configs import OMBSampleConfigurati
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.cluster import cluster
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
-from ducktape.mark import parametrize
+from ducktape.mark import matrix
 from rptest.services.redpanda import SISettings
 
 
@@ -35,14 +35,21 @@ class TSWriteOpenmessagingTest(RedpandaTest):
                              si_settings=si_settings,
                              extra_rp_conf=extra_rp_conf)
 
+    def setUp(self):
+        pass
+
     @cluster(num_nodes=6)
-    @parametrize(driver_idx="ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT")
-    def test_perf(self, driver_idx):
+    @matrix(driver_idx=["ACK_ALL_GROUP_LINGER_1MS_IDEM_MAX_IN_FLIGHT"],
+            write_caching=["on", "off"])
+    def test_perf(self, driver_idx, write_caching):
         """
         This adds TS writes to the OMB perf regression tests
         """
 
         assert self.redpanda.dedicated_nodes
+
+        self.redpanda.add_extra_rp_conf({"write_caching": write_caching})
+        self.redpanda.start()
 
         validator = OMBSampleConfigurations.RELEASE_SMOKE_TEST_VALIDATOR | {
             OMBSampleConfigurations.E2E_LATENCY_75PCT:


### PR DESCRIPTION
Existing perf tests are parameterized with write_caching=[on, off]. So effectively the new runtime of the test suite is doubled. No perf metric validators were adjusted in this PR, currently the expecation is that the performance with write caching is no worse than without. The plan is to adjust them as we get more data in the coming weeks.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
