### PR TITLE
PESDLC-1021 Update cloud cleanup with options

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -568,18 +568,45 @@ def cleanup_entrypoint():
     # Init the cleaner class
     cleaner = CloudCleanup()
 
+    # Arguments parsing. Quick and head on. No fancy argparse needed
+    clean_namespaces = False
+    clean_buckets = False
+    clean_nats = False
+    # Copy the list
+    arguments = sys.argv[:]
+    arguments.pop(0)
+    if len(arguments) == 0:
+        clean_namespaces = True
+    else:
+        while len(arguments) > 0:
+            option = arguments.pop()
+            if option == 'ns':
+                clean_namespaces = True
+            elif option == 'nat':
+                clean_nats = True
+            elif option == 's3':
+                clean_buckets = True
+            else:
+                cleaner.log.error(
+                    f"ERROR: Wrong argument: '{option}'. Accepting "
+                    "only 's3'/'nat' to clean buckets or aws NATs")
+                sys.exit(1)
+
     # Namespaces
-    cleaner.clean_namespaces(ns_name_prefix, 8)
+    if clean_namespaces:
+        cleaner.clean_namespaces(ns_name_prefix, 8)
 
     # NAT Gateways cleaning routine
-    # Enable manually to cleanup redundancies
-    # cleaner.clean_aws_nat()
+    if clean_nats:
+        cleaner.clean_aws_nat()
 
     # Clean buckets for deleted clusters and networks
-    # Enable manually
-    # cleaner.clean_buckets(mask="panda-bucket-")
-    # cleaner.clean_buckets(mask="redpanda-cloud-storage-")
-    # cleaner.clean_buckets(mask="redpanda-network-logs-")
+    if clean_buckets:
+        cleaner.clean_buckets(mask="panda-bucket-")
+        cleaner.clean_buckets(mask="redpanda-cloud-storage-")
+        cleaner.clean_buckets(mask="redpanda-network-logs-")
+
+    cleaner.log.info("\n# Done.")
     return
 
 


### PR DESCRIPTION
Buckets and NATs need cleaning after actual test runs.
This commit adds option to call specific cleanup.

Before cleaning any NAT, it is checked that it is 36h old and is present in records of current Cloud API (preprod/integration). This is done in order to avoid cleaning wrong NATs.

Buckets will be cleaned after 36h and all of mentioned names hold no critical information to be preserved, only test data
```
        cleaner.clean_buckets(mask="panda-bucket-")
        cleaner.clean_buckets(mask="redpanda-cloud-storage-")
        cleaner.clean_buckets(mask="redpanda-network-logs-")
```
## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none