### PR TITLE
report cloud log size in redpanda_cloud_storage_cloud_log_size probe

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -866,6 +866,8 @@ void ntp_archiver::update_probe() {
 
     _probe->segments_to_delete(
       truncated_seg_count + man.replaced_segments_count());
+
+    _probe->cloud_log_size(man.cloud_log_size());
 }
 
 bool ntp_archiver::can_update_archival_metadata() const {

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -123,6 +123,13 @@ void ntp_level_probe::setup_public_metrics(const model::ntp& ntp) {
          sm::description("Total number of segments pending deletion from the "
                          "cloud for the topic"),
          labels)
+         .aggregate(aggregate_labels),
+       sm::make_gauge(
+         "cloud_log_size",
+         [this] { return _cloud_log_size; },
+         sm::description(
+           "Total size in bytes of the user-visible log for the topic"),
+         labels)
          .aggregate(aggregate_labels)});
 }
 

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -60,6 +60,8 @@ public:
 
     void segments_to_delete(int64_t count) { _segments_to_delete = count; };
 
+    void cloud_log_size(uint64_t size) { _cloud_log_size = size; }
+
 private:
     /// Uploaded offsets
     uint64_t _uploaded = 0;
@@ -75,6 +77,8 @@ private:
     int64_t _segments_in_manifest = 0;
     /// Number of segments awaiting deletion
     int64_t _segments_to_delete = 0;
+    /// size in byted of the user-visible log
+    uint64_t _cloud_log_size = 0;
 
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;


### PR DESCRIPTION
adds new probe `repdanda_cloud_storage_cloud_log_size` to report the total size of the user-visible log.

uses information already tracked in the partition manifest

Fixes https://github.com/redpanda-data/core-internal/issues/1214

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvement

* new metric redpanda_cloud_storage_cloud_log_size reports size in bytes of the log in cloud storage