### PR TITLE
PESDLC-1025 Retry when spikes occur in OMB

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -75,6 +75,72 @@ class OMBValidationTest(RedpandaCloudTest):
         "endToEndLatency999pct": OMBSampleConfigurations.E2E_LATENCY_999PCT,
     }
 
+    def run_benchmark_with_retries(self, benchmark, max_retries):
+        for try_count in range(1, max_retries + 1):
+            self.logger.info(
+                f"Starting benchmark attempt {try_count}/{max_retries}.")
+            benchmark.start()
+            benchmark_time_min = benchmark.benchmark_time() + 5
+            benchmark.wait(timeout_sec=benchmark_time_min * 60)
+
+            is_valid, validation_results = benchmark.check_succeed(
+                raise_exceptions=False)
+            if is_valid:
+                self.logger.info(
+                    "Benchmark passed without significant latency issues.")
+                return True
+            else:
+                self.handle_failed_attempt(try_count, max_retries, benchmark,
+                                           validation_results)
+
+        return False
+
+    def handle_failed_attempt(self, try_count, max_retries, benchmark,
+                              validation_results):
+        self.logger.info(f"Benchmark test attempt {try_count} failed.")
+        for result in validation_results:
+            self.logger.info(f"Result is: {result}")
+
+        self.logger.info("Checking test results for possible latency spikes.")
+        latency_metrics = self.extract_latency_metrics(benchmark)
+        spikes_detected = benchmark.detect_spikes_by_percentile(
+            latency_metrics, self.expected_max_latencies())
+
+        if spikes_detected and try_count < max_retries:
+            self.logger.info(
+                f"Latency spikes detected. Preparing for attempt {try_count+1}/{max_retries}."
+            )
+            self.logger.info("Stopping and freeing worker nodes and retrying.")
+            benchmark.stop()
+            benchmark.clean()
+            benchmark.workers.free()
+        else:
+            self.logger.info(
+                "Persistent high latency detected or maximum retries reached. No further retries."
+            )
+            benchmark.check_succeed()
+
+    def extract_latency_metrics(self, benchmark):
+        latency_metrics = {
+            key: benchmark.metrics[key]
+            for key in self.LATENCY_SERIES_AND_MAX if key in benchmark.metrics
+        }
+        self.log_latency_metrics(latency_metrics)
+        return latency_metrics
+
+    def log_latency_metrics(self, latency_metrics):
+        self.logger.info("Latency metrics for spikes detection:")
+        for key, value in latency_metrics.items():
+            series_values = ", ".join(str(v) for v in value)
+            self.logger.info(f"{key}: [{series_values}]")
+
+    def expected_max_latencies(self):
+        return {
+            series_key: OMBValidationTest.EXPECTED_MAX_LATENCIES[config_key]
+            for series_key, config_key in
+            OMBValidationTest.LATENCY_SERIES_AND_MAX.items()
+        }
+
     def __init__(self, test_ctx: TestContext, *args, **kwargs):
         self._ctx = test_ctx
 
@@ -442,72 +508,8 @@ class OMBValidationTest(RedpandaCloudTest):
                                            topology="ensemble")
         # Latency spikes detection and retry
         max_retries = 2
+        self.run_benchmark_with_retries(benchmark, max_retries)
 
-        for try_count in range(1, max_retries + 1):
-            self.logger.info(
-                f"Starting benchmark attempt {try_count}/{max_retries}.")
-
-            # Run the benchmark test
-            benchmark.start()
-            benchmark_time_min = benchmark.benchmark_time() + 5
-            benchmark.wait(timeout_sec=benchmark_time_min * 60)
-
-            is_valid, validation_results = benchmark.check_succeed(
-                raise_exceptions=False)
-
-            if is_valid:
-                self.logger.info(
-                    "Benchmark passed without significant latency issues.")
-                break
-
-            else:
-                self.logger.info(f"Benchmark test attempt {try_count} failed.")
-                for result in validation_results:
-                    self.logger.info(f"Result is: {result}")
-                self.logger.info(
-                    "Checking test results for possible latency spikes.")
-                latency_metrics = {
-                    key: benchmark.metrics[key]
-                    for key in self.LATENCY_SERIES_AND_MAX
-                    if key in benchmark.metrics
-                }
-
-                self.logger.info("Latency metrics for spikes detection:")
-                for key, value in latency_metrics.items():
-                    # Assuming value is a list of latency values for each series
-                    series_values = ", ".join(str(v) for v in value)
-                    self.logger.info(f"{key}: [{series_values}]")
-
-                # Prepare the expected_max_latencies dictionary for spike detection
-                expected_max_latencies_for_detection = {
-                    series_key:
-                    OMBValidationTest.EXPECTED_MAX_LATENCIES[config_key]
-                    for series_key, config_key in
-                    OMBValidationTest.LATENCY_SERIES_AND_MAX.items()
-                }
-
-                spikes_detected = benchmark.detect_spikes_by_percentile(
-                    latency_metrics,
-                    expected_max_latencies=expected_max_latencies_for_detection
-                )
-
-                if spikes_detected and try_count < max_retries:
-                    self.logger.info(
-                        f"Latency spikes detected. Preparing for attempt {try_count+1}/{max_retries}."
-                    )
-
-                    ## TODO Need to release nodes for retry
-                    self.logger.info(
-                        "Here we should release nodes and retry Benchmark test"
-                    )
-                    ## Temp fail the test and be able to see logs
-                    break
-                else:
-                    self.logger.info(
-                        "Persistent high latency detected or maximum retries reached. No further retries."
-                    )
-                    benchmark.check_succeed()
-                    break
         self.redpanda.assert_cluster_is_reusable()
 
     @cluster(num_nodes=CLUSTER_NODES)
@@ -571,8 +573,7 @@ class OMBValidationTest(RedpandaCloudTest):
                                            driver, (workload, validator),
                                            num_workers=self.CLUSTER_NODES - 1,
                                            topology="ensemble")
-        benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time() + 5
-        benchmark.wait(timeout_sec=benchmark_time_min * 60)
-        benchmark.check_succeed()
+
+        max_retries = 2
+        self.run_benchmark_with_retries(benchmark, max_retries)
         self.redpanda.assert_cluster_is_reusable()

--- a/tests/rptest/services/openmessaging_benchmark_configs.py
+++ b/tests/rptest/services/openmessaging_benchmark_configs.py
@@ -92,8 +92,18 @@ class OMBSampleConfigurations:
         AVG_THROUGHPUT_MBPS: [gte(600)]
     }
 
-    def validate_metrics(metrics, validator):
-        """ Validates some predefined metrics rules against the metrics data and throws if any of the rules fail."""
+    def validate_metrics(metrics, validator, raise_exceptions=True):
+        """Validates some predefined metrics rules against the metrics data.
+    
+        Args:
+            metrics: The metrics to validate.
+            validator: A dictionary containing the validation rules.
+            raise_exceptions: If True, raises an exception when validation fails. If False, returns the validation results.
+        
+        Returns:
+            A tuple (is_valid, results), where is_valid is a boolean indicating if all metrics passed validation,
+            and results is a list of validation failures.
+        """
         assert len(validator) > 0, "At least one metric should be validated"
 
         results = []
@@ -107,7 +117,11 @@ class OMBSampleConfigurations:
                 if not rule[0](val):
                     results.append(kv_str(key, val) + rule[1])
 
-        assert len(results) == 0, str(results)
+        is_valid = len(results) == 0
+
+        if raise_exceptions and not is_valid:
+            assert is_valid, str(results)
+        return is_valid, results
 
     # ------ Driver configurations --------
     SIMPLE_DRIVER = {


### PR DESCRIPTION
Detect latency spikes that could be due to underlying disks go through periods of 300-1000ms, and retry the test up to R number of times.

## Backports Required

- [x ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

### Improvements

* The issue is that the underlying disks go through periods of 300-1000ms where they have greatly reduced throughput and this produces a latency spike. This may eventually be solved by https://github.com/redpanda-data/core-internal/issues/1142 but in the meantime we should implement a workaround so that the tests can run giving a reasonable signal but not spuriously failing due to this issue.

My suggestion is that if a test fails due to p99/p999 threshold breach, we check if it looks like it has spikes using a simple heuristic based on the time-series percentiles (see eg https://github.com/redpanda-data/core-internal/issues/1016#issuecomment-1939676486) and if it has say 1-3 spikes we just retry, up to R times.

The primary goals:

Avoid the noise from these spikes which prevents us from keeping the test enabled the test as it is too flaky
Still catch regressions that are not of a "spike" nature but where the latency is bad during the whole run or a large portion of it
Only allow spikes like the ones we are seeing to trigger a retry: i.e., not too many of them, since then we could miss some change in RP which causes frequent spikes for a HW reason.

More details are at:
https://github.com/redpanda-data/core-internal/issues/1180

This is a DRAFT, that uses mocked data from previous runs with latency. Need to use actual data and perform more testing.