### PR TITLE
tests: do not run offsets for leader epoch test in debug mode

### DIFF
--- a/tests/rptest/tests/offset_for_leader_epoch_test.py
+++ b/tests/rptest/tests/offset_for_leader_epoch_test.py
@@ -20,6 +20,7 @@ from rptest.tests.prealloc_nodes import PreallocNodesTest
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.services.rpk_producer import RpkProducer
+from rptest.utils.mode_checks import skip_debug_mode
 
 
 class OffsetForLeaderEpochTest(PreallocNodesTest):
@@ -166,6 +167,7 @@ class OffsetForLeaderEpochTest(PreallocNodesTest):
             # but the requested
             assert o.error == '' and o.leader_epoch == 15000 and o.epoch_end_offset == -1
 
+    @skip_debug_mode
     @cluster(num_nodes=6, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_offset_for_leader_epoch_transfer(self):
 


### PR DESCRIPTION
Offset for leader epoch test uses large number of partitions, running it in debug mode is flaky as it may happen that the nodes will step down due to timeouts when receiving heartbeats leading to the test being unstable.

Fixes: #12062

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none