### PR TITLE
[CORE-2161] cloud_storage/topic_manifest: force negative retention to mean infinite retention

### DIFF
--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -123,9 +123,12 @@ struct topic_manifest_handler
                 _properties.retention_bytes = tristate<size_t>{
                   disable_tristate};
             } else if (_key == "retention_duration") {
+                // even though a negative number is valid for milliseconds,
+                // interpret any negative value as a request for infinite
+                // retention, that translates to a disabled tristate (like for
+                // retention_bytes)
                 _properties.retention_duration
-                  = tristate<std::chrono::milliseconds>(
-                    std::chrono::milliseconds(i));
+                  = tristate<std::chrono::milliseconds>(disable_tristate);
             } else {
                 return false;
             }


### PR DESCRIPTION
this mirrors what's done for retention_bytes. the reasoning is that if somebody performs a manual edit of the topic manifest and writes "retention_duration" : -1, it's probably done to mirror the retention.ms semantic of meaning infinite retention

this a followup on
https://github.com/redpanda-data/redpanda/pull/14355#discussion_r1428255190

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements

* allow interpreting `'retention_duration' = -1` in a topic_manifest.json file as infinite time retention
