### PR TITLE
security/rbac: Add metrics

### DIFF
--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -264,6 +264,13 @@ public:
     const acl_store& store() const&;
 
 private:
+    template<typename T>
+    auth_result do_authorized(
+      const T& resource_name,
+      acl_operation operation,
+      const acl_principal& principal,
+      const acl_host& host) const;
+
     /*
      * Compute whether the specified operation is allowed based on the implied
      * operations.
@@ -294,6 +301,8 @@ private:
 
     allow_empty_matches _allow_empty_matches;
     const role_store* _role_store;
+    class probe;
+    std::unique_ptr<probe> _probe;
 };
 
 } // namespace security


### PR DESCRIPTION
A metric for authorization duration / latency doesn't make much sense; it measures at around 1µs, and the cost of the measurement (based on a std::chrono::high_resolution_clock) possibly outweighs the cost of the operation.

We're better off using the CPU profiler to spot hotspots.

Fixes https://github.com/redpanda-data/core-internal/issues/1135

## New metrics

Note: `allow` is the only positive result, `empty` and `deny` are both authZ failures.

### Internal Metrics
```
 # HELP vectorized_authorization_result Total number of authorization results by type
 # TYPE vectorized_authorization_result counter
 vectorized_authorization_result{type="empty"} 16
 vectorized_authorization_result{type="deny"} 0
 vectorized_authorization_result{type="allow"} 22
```

### Public Metrics
```
 # HELP redpanda_authorization_result Total number of authorization results by type
 # TYPE redpanda_authorization_result counter
 redpanda_authorization_result{type="empty"} 16
 redpanda_authorization_result{type="deny"} 0
 redpanda_authorization_result{type="allow"} 22
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
