### PR TITLE
PESDLC-1021 Use bucket policy for cleanup by default

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -440,7 +440,7 @@ class SISettings:
                  cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
                      int] = None,
                  bypass_bucket_creation: bool = False,
-                 use_bucket_cleanup_policy: bool = False,
+                 use_bucket_cleanup_policy: bool = True,
                  cloud_storage_housekeeping_interval_ms: Optional[int] = None,
                  cloud_storage_spillover_manifest_max_segments: Optional[
                      int] = None,


### PR DESCRIPTION
This enables policy based cleanup by default for tests that uses SISettings class. Most of the tests creates a lot of data and it takes an effort to clean buckets one key at a time. Policy will do it faster.

For those tests that are not using SISettings - we have rp_cloud_cleanup.py running at CDT-Cloud jobs that will apply similar policy to all of the buckets.

And as a third line - the scheduled job to clean resources on either AWS or GCP

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none