### PR TITLE
admin/debug/leader_info: prevent reactor stalls

### DIFF
--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -219,7 +219,7 @@ ss::future<> metadata_cache::refresh_health_monitor() {
     co_await _health_monitor.local().refresh_info();
 }
 
-cluster::partition_leaders_table::leaders_info_t
+ss::future<cluster::partition_leaders_table::leaders_info_t>
 metadata_cache::get_leaders() const {
     return _leaders.local().get_leaders();
 }

--- a/src/v/cluster/metadata_cache.h
+++ b/src/v/cluster/metadata_cache.h
@@ -161,7 +161,14 @@ public:
 
     void reset_leaders();
     ss::future<> refresh_health_monitor();
-    cluster::partition_leaders_table::leaders_info_t get_leaders() const;
+
+    /**
+     * Get a snapshot of leaders from the partition_leaders_table.
+     *
+     * @throws if concurrent modification is detected.
+     */
+    ss::future<cluster::partition_leaders_table::leaders_info_t>
+    get_leaders() const;
 
     void set_is_node_isolated_status(bool is_node_isolated);
     bool is_node_isolated();

--- a/src/v/cluster/partition_leaders_table.h
+++ b/src/v/cluster/partition_leaders_table.h
@@ -149,7 +149,12 @@ public:
 
     using leaders_info_t = chunked_vector<leader_info_t>;
 
-    leaders_info_t get_leaders() const;
+    /**
+     * Get a snapshot of all the current leaders.
+     *
+     * @throws if the set of leaders changes during iteration.
+     */
+    ss::future<leaders_info_t> get_leaders() const;
 
     uint64_t leaderless_partition_count() const {
         return _leaderless_partition_count;

--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -14,6 +14,7 @@
 #include "cluster/controller_stm.h"
 #include "cluster/members_manager.h"
 #include "cluster/metadata_cache.h"
+#include "cluster/partition_leaders_table.h"
 #include "cluster/shard_table.h"
 #include "cluster/topics_frontend.h"
 #include "cluster/types.h"
@@ -29,6 +30,7 @@
 #include "storage/kvstore.h"
 
 #include <seastar/core/sstring.hh>
+#include <seastar/http/httpd.hh>
 #include <seastar/json/json_elements.hh>
 
 namespace {
@@ -247,29 +249,36 @@ void admin_server::register_debug_routes() {
       [this](std::unique_ptr<ss::http::request>) {
           vlog(adminlog.info, "Request to get leaders info");
           using result_t = ss::httpd::debug_json::leader_info;
-          // TODO(rockwood): get_leaders can lead to a reactor stall, fix to use
-          // an async version
-          auto leaders_info = _metadata_cache.local().get_leaders();
-          return ss::make_ready_future<ss::json::json_return_type>(
-            ss::json::stream_range_as_array(
-              admin::lw_shared_container(std::move(leaders_info)),
-              [](const auto& leader_info) {
-                  result_t info;
-                  info.ns = leader_info.tp_ns.ns;
-                  info.topic = leader_info.tp_ns.tp;
-                  info.partition_id = leader_info.pid;
-                  info.leader = leader_info.current_leader.has_value()
-                                  ? leader_info.current_leader.value()
-                                  : -1;
-                  info.previous_leader = leader_info.previous_leader.has_value()
-                                           ? leader_info.previous_leader.value()
-                                           : -1;
-                  info.last_stable_leader_term
-                    = leader_info.last_stable_leader_term;
-                  info.update_term = leader_info.update_term;
-                  info.partition_revision = leader_info.partition_revision;
-                  return info;
-              }));
+          using leaders = cluster::partition_leaders_table::leaders_info_t;
+          using cme
+            = cluster::partition_leaders_table::concurrent_modification_error;
+          return _metadata_cache.local()
+            .get_leaders()
+            .handle_exception_type([](const cme& ex) -> ss::future<leaders> {
+                throw ss::httpd::base_exception(
+                  ex.what(), ss::http::reply::status_type::service_unavailable);
+            })
+            .then([](leaders leaders_info) {
+                return ss::make_ready_future<ss::json::json_return_type>(
+                  ss::json::stream_range_as_array(
+                    admin::lw_shared_container(std::move(leaders_info)),
+                    [](const auto& leader_info) {
+                        result_t info;
+                        info.ns = leader_info.tp_ns.ns;
+                        info.topic = leader_info.tp_ns.tp;
+                        info.partition_id = leader_info.pid;
+                        info.leader = leader_info.current_leader.value_or(
+                          model::node_id(-1));
+                        info.previous_leader = leader_info.previous_leader
+                                                 .value_or(model::node_id(-1));
+                        info.last_stable_leader_term
+                          = leader_info.last_stable_leader_term;
+                        info.update_term = leader_info.update_term;
+                        info.partition_revision
+                          = leader_info.partition_revision;
+                        return info;
+                    }));
+            });
       });
 
     register_route<user>(


### PR DESCRIPTION
On a many topic/partition cluster this could lead to reactor stalls,
instead use the async version. This does mean that we could fail due to
concurrent modification, so return a 503 in that case to signal a retry.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Prevent reactor stalls querying leadership information for large clusters
