### PR TITLE
rptest: Fix throttling test

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1310,7 +1310,7 @@ class EndToEndThrottlingTest(RedpandaTest):
     def __init__(self, test_context):
         self.si_settings = SISettings(
             test_context,
-            log_segment_size=1024,
+            log_segment_size=1024 * 1024,
             fast_uploads=True,
             # Set small throughput limit to trigger throttling
             cloud_storage_max_throughput_per_shard=8 * 1024 * 1024)
@@ -1386,17 +1386,6 @@ class EndToEndThrottlingTest(RedpandaTest):
                                             timeout_sec=30)
 
         self.logger.info("Start consumer")
-        self.consume()
-
-        self.logger.info("Stop nodes")
-        for node in self.redpanda.nodes:
-            self.redpanda.stop_node(node, timeout=120)
-
-        self.logger.info("Start nodes")
-        for node in self.redpanda.nodes:
-            self.redpanda.start_node(node, timeout=120)
-
-        self.logger.info("Restart consumer")
         self.consume()
 
         times_throttled = self.get_throttling_metric()


### PR DESCRIPTION
Avoid restarting redpanda durint the e2e test. Restart resets the metrics and the second run of the consumer after restart is not guaranteed to hit throttling because the data is cached.

Fixes: https://github.com/redpanda-data/redpanda/issues/14139

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
