### PR TITLE
s/authorizer: Comments about allow_empty_matches

### DIFF
--- a/src/v/security/authorizer.cc
+++ b/src/v/security/authorizer.cc
@@ -181,13 +181,6 @@ auth_result authorizer::authorized(
         return std::move(result).value();
     }
 
-    // NOTE(oren): We know there isn't a match at this point, but I've left
-    // this as an opt_acl_match to preserve semantics, namely that this
-    // will return a non-authorized result irrespective of the
-    // allow_empty_matches flag. On the other hand, switching to an
-    // empty_match_result _should_ alter semantics but doesn't break any
-    // tests. Not clear whether this is a bug, intended behavior, a gap
-    // in test coverage, or a combination.
     return auth_result::opt_acl_match(
       principal, host, operation, resource_name, std::nullopt);
 }

--- a/src/v/security/authorizer.h
+++ b/src/v/security/authorizer.h
@@ -292,6 +292,8 @@ private:
         }
     }
 
+    // NOTE: _allow_empty_matches is used for testing purposes only. In normal
+    // operation, an empty match result is ALWAYS unauthorized.
     allow_empty_matches _allow_empty_matches;
     const role_store* _role_store;
 };


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/core-internal/issues/1185

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
