### PR TITLE
rptest: handle errors and retry them in list offsets request

### DIFF
--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -21,6 +21,7 @@ from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST, RedpandaService
 from rptest.services.rpk_producer import RpkProducer
 from rptest.services.verifiable_consumer import VerifiableConsumer
 from rptest.tests.redpanda_test import RedpandaTest
+from rptest.util import wait_until_result
 from rptest.utils.mode_checks import skip_debug_mode
 
 from ducktape.utils.util import wait_until
@@ -406,21 +407,28 @@ class ConsumerGroupTest(RedpandaTest):
         assert offsets[TopicPartition(self.topic_spec.name,
                                       0)].leader_epoch > 0
 
+        # Remember the old offsets to compare them after the restart.
+        prev_offsets = offsets
+
         # Restart the broker.
         self.logger.info("Restarting redpanda nodes.")
         self.redpanda.restart_nodes(self.redpanda.nodes)
-        self.redpanda._admin.await_stable_leader("controller",
-                                                 partition=0,
-                                                 namespace='redpanda',
-                                                 timeout_s=60,
-                                                 backoff_s=2)
-
-        prev_offsets = offsets
 
         # Validate that the group state is recovered.
-        test_admin = KafkaTestAdminClient(self.redpanda)
-        offsets = test_admin.list_offsets(
-            group_id, [TopicPartition(self.topic_spec.name, 0)])
+        def try_list_offsets():
+            try:
+                test_admin = KafkaTestAdminClient(self.redpanda)
+                return test_admin.list_offsets(
+                    group_id, [TopicPartition(self.topic_spec.name, 0)])
+            except Exception as e:
+                self.logger.debug(f"Failed to list offsets: {e}")
+                return None
+
+        offsets = wait_until_result(
+            try_list_offsets,
+            timeout_sec=30,
+            backoff_sec=3,
+            err_msg="Failed to make list_offsets request")
 
         self.logger.info(f"Got offsets after restart: {offsets}")
         assert len(offsets) == 1

--- a/tests/rptest/tests/consumer_group_test.py
+++ b/tests/rptest/tests/consumer_group_test.py
@@ -26,6 +26,7 @@ from rptest.utils.mode_checks import skip_debug_mode
 from ducktape.utils.util import wait_until
 from ducktape.mark import parametrize
 from kafka import KafkaConsumer, TopicPartition
+from kafka import errors as kerr
 from kafka.admin import KafkaAdminClient
 from kafka.protocol.commit import OffsetFetchRequest_v3
 from kafka.protocol.api import Request, Response
@@ -592,6 +593,10 @@ class KafkaTestAdminClient():
         return self._admin._send_request_to_node(coordinator, request)
 
     def _list_offsets_send_process_response(self, response):
+        error_type = kerr.for_code(response.error_code)
+        if error_type is not kerr.NoError:
+            raise error_type("Error in list_offsets response")
+
         offsets = {}
         for topic, partitions in response.topics:
             for partition, offset, leader_epoch, metadata, error_code in partitions:


### PR DESCRIPTION
After broker restart it might take a while before the group offsets are available during which redpanda will reply with
`error_code::not_coordinator`[^0]. The test didn't handle the top level error, now it does. We also retry it.

Introduced in #17260
Fixes #17466

[^0]: https://github.com/redpanda-data/redpanda/blob/501b9d35882a303def6061bdc522f67f0502ac1c/src/v/kafka/server/group_manager.cc#L1653

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
