### PR TITLE
Improved validation of Fetch requests when reading from follower

### DIFF
--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -585,13 +585,10 @@ ss::future<error_code> replicated_partition::validate_fetch_offset(
     if (reading_from_follower && !_partition->is_leader()) {
         auto ec = error_code::none;
 
-        const std::pair<model::offset, model::offset> bounds = std::minmax(
+        const auto available_to_read = std::min(
           leader_high_watermark(), log_end_offset());
-        const auto effective_log_end_offset = bounds.second;
-        const auto available_to_read = bounds.first;
-        if (
-          fetch_offset < start_offset()
-          || fetch_offset > effective_log_end_offset) {
+
+        if (fetch_offset < start_offset()) {
             ec = error_code::offset_out_of_range;
         } else if (fetch_offset > available_to_read) {
             /**

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -2019,11 +2019,11 @@ consensus::do_append_entries(append_entries_request&& r) {
 
     // section 3
     if (request_metadata.prev_log_index < last_log_offset) {
-        if (unlikely(request_metadata.prev_log_index < last_visible_index())) {
+        if (unlikely(request_metadata.prev_log_index < _commit_index)) {
             reply.result = reply_result::success;
             // clamp dirty offset to the current commit index not to allow
             // leader reasoning about follower log beyond that point
-            reply.last_dirty_log_index = last_visible_index();
+            reply.last_dirty_log_index = _commit_index;
             reply.last_flushed_log_index = _commit_index;
             vlog(
               _ctxlog.info,

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -355,13 +355,7 @@ TEST_P_CORO(
       [this, &last_visible] {
           for (auto& [id, node] : nodes()) {
               auto o = node->raft()->last_visible_index();
-              vassert(
-                last_visible[id] <= o,
-                "Visible offset moved back on node {}, current visible offset: "
-                "{}, last visible offset: {}",
-                id,
-                o,
-                last_visible[id]);
+
               auto dirty_offset = node->raft()->dirty_offset();
               vassert(
                 o <= dirty_offset,


### PR DESCRIPTION
Changed the way how we handle Raft log truncation beyond majority_replicated_index. This PR reverts the change where we disallowed truncating offsets which were made visible. This change makes recovery from the situation in which the newly elected leader has shorter log problematic as the node which prevented truncation will not make progress. This change doesn't really influence the end user view of partition replicas as the producers are able to produce immediately after the new leader is elected. 

```
+ entries from term n
- entries from term n + 1
$ entries from term n + 2 

node 0: +++---------
=========== <- isolated
node 1:  +++$$$$ \
                       selects a new leader
node 2:  +++$$$$ /
``` 
With the previous mechanism we wouldn't allow the node 0 to be truncated which would effectively prevent it from making progress. With this change the truncation is allowed. This will allow node 0 to make progress and eventually have the same data as the new majority. 

This PR change the way how fetch offset is validated on the followers. The follower now will not return an error leading to consumer offset reset. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none