### PR TITLE
gha: update lint-golang

### DIFF
--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -51,3 +51,8 @@ jobs:
       run: |
         go mod tidy
         git diff --exit-code -- go.mod go.sum
+
+    - name: Check goreleaser configuration file
+      uses: goreleaser/goreleaser-action@v5
+      with:
+        args: check src/go/.goreleaser.yaml

--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -19,15 +19,15 @@ jobs:
     steps:
 
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: stable
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4
       with:
         version: latest
         args: --timeout 5m

--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -75,7 +75,6 @@ builds:
     goarch:
       - amd64
       - arm64
-  # we need separate build for darwin to sign/notarize using quill
   - id: rpk-darwin
     dir: ./rpk/
     main: ./cmd/rpk


### PR DESCRIPTION
follow-on to PR #17230, this PR adds check for the goreleaser configuration file and updates to latest actions to bring in bug fixes and perf optimizations for lint-golang:
* https://github.com/actions/checkout/releases/tag/v4.1.1
* https://github.com/actions/setup-go/releases/tag/v5.0.0
* https://github.com/golangci/golangci-lint-action/releases/tag/v4.0.0
* https://github.com/goreleaser/goreleaser-action/releases/tag/v5.0.0

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none