### PR TITLE
k/topics: make write caching configs settable at creation

### DIFF
--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -267,6 +267,9 @@ storage::ntp_config topic_configuration::make_ntp_config(
             = properties.initial_retention_local_target_bytes,
             .initial_retention_local_target_ms
             = properties.initial_retention_local_target_ms,
+            .write_caching = properties.write_caching,
+            .flush_ms = properties.flush_ms,
+            .flush_bytes = properties.flush_bytes,
           });
     }
     return {

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -398,8 +398,11 @@ configuration::configuration()
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100ms,
       [](auto const& v) -> std::optional<ss::sstring> {
-          if (v < 1ms) {
-              return "flush delay should be atleast 1ms";
+          // maximum duration imposed by serde serialization.
+          if (v < 1ms || v > serde::max_serializable_ms) {
+              return fmt::format(
+                "flush delay should be in range: [1, {}]",
+                serde::max_serializable_ms);
           }
           return std::nullopt;
       })

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -279,7 +279,8 @@ create_topic_properties_update(
                   update.properties.flush_ms,
                   cfg.value,
                   kafka::config_resource_operation::set,
-                  flush_ms_validator{});
+                  flush_ms_validator{},
+                  true);
                 continue;
             }
             if (cfg.name == topic_property_flush_bytes) {

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -65,7 +65,10 @@ static constexpr auto supported_configs = std::to_array(
    topic_property_record_value_subject_name_strategy,
    topic_property_record_value_subject_name_strategy_compat,
    topic_property_initial_retention_local_target_bytes,
-   topic_property_initial_retention_local_target_ms});
+   topic_property_initial_retention_local_target_ms,
+   topic_property_write_caching,
+   topic_property_flush_ms,
+   topic_property_flush_bytes});
 
 bool is_supported(std::string_view name) {
     return std::any_of(

--- a/src/v/kafka/server/handlers/topics/validators.h
+++ b/src/v/kafka/server/handlers/topics/validators.h
@@ -314,7 +314,7 @@ struct write_caching_configs_validator {
             auto val = boost::lexical_cast<std::chrono::milliseconds::rep>(
               it->value.value());
             // atleast 1ms, anything less than that is suspiciously small.
-            return val >= 1;
+            return val >= 1 && val <= serde::max_serializable_ms.count();
         } catch (...) {
         }
         return false;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3941,7 +3941,7 @@ void consensus::notify_config_update() {
 ss::future<> consensus::background_flusher() {
     while (!_bg.is_closed()) {
         try {
-            co_await _background_flusher.wait(log_config().flush_ms());
+            co_await _background_flusher.wait(_max_flush_delay_ms);
         } catch (const ss::condition_variable_timed_out&) {
         }
         co_await maybe_flush_log().handle_exception(

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -147,7 +147,7 @@ consensus::consensus(
   , _append_requests_buffer(*this, 256)
   , _write_caching_enabled(log_config().write_caching())
   , _max_pending_flush_bytes(log_config().flush_bytes())
-  , _max_flush_delay_ms(compute_max_flush_delay())
+  , _max_flush_delay(compute_max_flush_delay())
   , _replication_monitor(this) {
     setup_metrics();
     setup_public_metrics();
@@ -3897,7 +3897,7 @@ ss::future<> consensus::maybe_flush_log() {
     // detect it and flush log.
     if (
       _pending_flush_bytes < _max_pending_flush_bytes
-      && time_since_last_flush() < _max_flush_delay_ms) {
+      && time_since_last_flush() < flush_ms()) {
         co_return;
     }
     try {
@@ -3925,15 +3925,42 @@ std::optional<model::offset> consensus::get_learner_start_offset() const {
     return std::nullopt;
 }
 
-std::chrono::milliseconds consensus::compute_max_flush_delay() const {
-    return flush_jitter_t{log_config().flush_ms(), flush_ms_jitter}
-      .next_duration();
+consensus::flush_delay_t consensus::compute_max_flush_delay() const {
+    auto delay = flush_jitter_t{log_config().flush_ms(), flush_ms_jitter}
+                   .next_duration();
+    if (delay > std::chrono::years{1}) {
+        // For large delays (eg: long max), the condition variable waiting
+        // on this delay runs into a UB because of an overflow. A total
+        // hack here is to convert it to a larger duration type so the
+        // integral value of the duration is much smaller thus avoiding
+        // the overflow. This is a pretty bad hack but needed to
+        // workaround seastar's inability to wait for arbitrary large yet
+        // valid durations supposedly used for indefinite waits.
+        auto delay_years = std::chrono::duration_cast<std::chrono::years>(
+          delay);
+        return flush_delay_t{delay_years};
+    }
+    return flush_delay_t{delay};
+}
+
+std::chrono::milliseconds consensus::flush_ms() const {
+    return std::visit(
+      [](auto&& delay) {
+          using T = std::decay_t<decltype(delay)>;
+          if constexpr (std::is_same_v<T, std::chrono::milliseconds>) {
+              return delay;
+          } else {
+              return std::chrono::duration_cast<std::chrono::milliseconds>(
+                delay);
+          }
+      },
+      _max_flush_delay);
 }
 
 void consensus::notify_config_update() {
     _write_caching_enabled = log_config().write_caching();
     _max_pending_flush_bytes = log_config().flush_bytes();
-    _max_flush_delay_ms = compute_max_flush_delay();
+    _max_flush_delay = compute_max_flush_delay();
     // let the flusher know that the tunables have changed, this may result
     // in an extra flush but that should be ok since this this is a rare
     // operation.
@@ -3943,7 +3970,11 @@ void consensus::notify_config_update() {
 ss::future<> consensus::background_flusher() {
     while (!_bg.is_closed()) {
         try {
-            co_await _background_flusher.wait(_max_flush_delay_ms);
+            co_await std::visit(
+              [&](auto&& flush_delay) {
+                  return _background_flusher.wait(flush_delay);
+              },
+              _max_flush_delay);
         } catch (const ss::condition_variable_timed_out&) {
         }
         co_await maybe_flush_log().handle_exception(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -515,7 +515,7 @@ public:
 
     bool write_caching_enabled() const { return _write_caching_enabled; }
     size_t flush_bytes() const { return _max_pending_flush_bytes; }
-    std::chrono::milliseconds flush_ms() const { return _max_flush_delay_ms; }
+    std::chrono::milliseconds flush_ms() const;
 
     replication_monitor& get_replication_monitor() {
         return _replication_monitor;
@@ -532,6 +532,8 @@ private:
     friend heartbeat_manager;
     using update_last_quorum_index
       = ss::bool_class<struct update_last_quorum_index>;
+    using flush_delay_t
+      = std::variant<std::chrono::milliseconds, std::chrono::years>;
     // all these private functions assume that we are under exclusive operations
     // via the _op_sem
     void do_step_down(std::string_view);
@@ -763,7 +765,7 @@ private:
         return _features.is_active(features::feature::raft_config_serde);
     }
 
-    std::chrono::milliseconds compute_max_flush_delay() const;
+    flush_delay_t compute_max_flush_delay() const;
     ss::future<> maybe_flush_log();
     ss::future<> background_flusher();
 
@@ -894,8 +896,9 @@ private:
     static constexpr std::chrono::milliseconds flush_ms_jitter{5};
     bool _write_caching_enabled;
     size_t _max_pending_flush_bytes;
-    std::chrono::milliseconds _max_flush_delay_ms;
-
+    // Its a variant to workaround a bug in cv::wait() method,
+    // check comment in compute_max_flush_delay() for details
+    flush_delay_t _max_flush_delay;
     ss::condition_variable _background_flusher;
 
     replication_monitor _replication_monitor;

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -763,6 +763,7 @@ private:
         return _features.is_active(features::feature::raft_config_serde);
     }
 
+    std::chrono::milliseconds compute_max_flush_delay() const;
     ss::future<> maybe_flush_log();
     ss::future<> background_flusher();
 

--- a/src/v/serde/rw/chrono.h
+++ b/src/v/serde/rw/chrono.h
@@ -17,6 +17,10 @@
 
 namespace serde {
 
+constexpr auto max_serializable_ms
+  = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::nanoseconds::max());
+
 template<class R, class P>
 int64_t checked_duration_cast_to_nanoseconds(
   const std::chrono::duration<R, P>& duration) {

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -35,6 +35,9 @@ class TopicSpec:
     PROPERTY_RETENTION_LOCAL_TARGET_MS = "retention.local.target.ms"
     PROPERTY_REMOTE_DELETE = "redpanda.remote.delete"
     PROPERTY_SEGMENT_MS = "segment.ms"
+    PROPERTY_WRITE_CACHING = "write.caching"
+    PROPERTY_FLUSH_MS = "flush.ms"
+    PROPERTY_FLUSH_BYTES = "flush.bytes"
 
     class CompressionTypes(str, Enum):
         """


### PR DESCRIPTION
Allows having write caching property overrides at topic creation time.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
