### PR TITLE
deps: Add lz4-static for fedora

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -80,6 +80,7 @@ fedora_deps=(
   lld
   llvm
   lz4-devel
+  lz4-static
   ninja-build
   numactl-devel
   openssl-devel


### PR DESCRIPTION
This is a prerequisite for PR #17385 which depends on lz4 being linked statically. The package list for debian already pulls in liblz4-dev which adds the static lib.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
