### PR TITLE
[v23.2.x] deps: Add lz4-static for fedora (manual backport)

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -31,6 +31,7 @@ deb_deps=(
   git
   golang-go
   libkrb5-dev
+  liblz4-dev
   libgssapi-krb5-2
   libsnappy-dev
   libxxhash-dev
@@ -58,6 +59,8 @@ fedora_deps=(
   libzstd-static
   llvm
   lld
+  lz4-devel
+  lz4-static
   pkg-config
   procps
   python3-jinja2


### PR DESCRIPTION
This is a prerequisite for PR 17385 which depends on lz4 being linked statically. The package list for debian already pulls in liblz4-dev which adds the static lib.

(cherry picked from commit 59a6be34524fc8d35475cd36022a03abeb769c03)

manual backport of https://github.com/redpanda-data/redpanda/pull/17520

FIXES https://github.com/redpanda-data/redpanda/issues/17521

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
