### PR TITLE
Update approach to kafka security for clients

### DIFF
--- a/tests/rptest/clients/kafka_cat.py
+++ b/tests/rptest/clients/kafka_cat.py
@@ -10,9 +10,12 @@
 import subprocess
 import time
 import json
-from typing import Optional
+from typing import Any, cast
 
+from rptest.services.redpanda_types import RedpandaServiceForClients
 from rptest.util import wait_until_result
+
+# pyright: strict
 
 
 class KafkaCat:
@@ -21,18 +24,18 @@ class KafkaCat:
 
     This tools is useful because it offers a JSON output format.
     """
-    def __init__(self, redpanda):
+    def __init__(self, redpanda: RedpandaServiceForClients):
         self._redpanda = redpanda
 
     def metadata(self):
         return self._cmd(["-L"])
 
     def consume_one(self,
-                    topic,
-                    partition,
-                    offset=None,
+                    topic: str,
+                    partition: int,
+                    offset: int | None = None,
                     *,
-                    first_timestamp: Optional[int] = None):
+                    first_timestamp: int | None = None):
         if offset is not None:
             # <value>  (absolute offset)
             query = offset
@@ -46,19 +49,19 @@ class KafkaCat:
             f"{query}", "-c1"
         ])
 
-    def produce_one(self, topic, msg, tx_id=None):
+    def produce_one(self, topic: str, msg: str, tx_id: int | None = None):
         cmd = ['-P', '-t', topic]
         if tx_id:
             cmd += ['-X', f'transactional.id={tx_id}']
         return self._cmd_raw(cmd, input=f"{msg}\n")
 
-    def _cmd(self, cmd, input=None):
+    def _cmd(self, cmd: list[str], input: str | None = None):
         res = self._cmd_raw(cmd + ['-J'], input=input)
         res = json.loads(res)
         self._redpanda.logger.debug(json.dumps(res, indent=2))
         return res
 
-    def _cmd_raw(self, cmd, input=None):
+    def _cmd_raw(self, cmd: list[str], input: str | None = None):
         for retry in reversed(range(10)):
             cfg = self._redpanda.kafka_client_security()
             if cfg.sasl_enabled:
@@ -91,8 +94,12 @@ class KafkaCat:
                     "kcat retrying after exit code {}: {}".format(
                         e.returncode, e.output))
                 time.sleep(2)
+        assert False, "unreachable"  # help the type checker
 
-    def get_partition_leader(self, topic, partition, timeout_sec=None):
+    def get_partition_leader(self,
+                             topic: str,
+                             partition: int,
+                             timeout_sec: int | None = None):
         """
         :param topic: string, topic name
         :param partition: integer
@@ -110,7 +117,7 @@ class KafkaCat:
                                  timeout_sec=timeout_sec,
                                  backoff_sec=2)
 
-    def _get_partition_leader(self, topic, partition):
+    def _get_partition_leader(self, topic: str, partition: int):
         topic_meta = None
         all_metadata = self.metadata()
         for t in all_metadata['topics']:
@@ -122,20 +129,20 @@ class KafkaCat:
         assert topic_meta is not None
 
         # Raise IndexError if user queried a partition that does not exist
-        partition = topic_meta['partitions'][partition]
+        partition_meta: dict[str, Any] = topic_meta['partitions'][partition]
 
-        leader_id = partition['leader']
-        replicas = [p['id'] for p in partition['replicas']]
+        leader_id = cast(int, partition_meta['leader'])
+        replicas = [cast(int, p['id']) for p in partition_meta['replicas']]
         if leader_id == -1:
             return None, replicas
         else:
             return leader_id, replicas
 
-    def list_offsets(self, topic, partition):
-        def cmd(ts):
+    def list_offsets(self, topic: str, partition: int):
+        def cmd(ts: int):
             return ["-Q", "-t", f"{topic}:{partition}:{ts}"]
 
-        def offset(res):
+        def offset(res: dict[str, Any]):
             # partition is a string in the output
             return res[topic][f"{partition}"]["offset"]
 
@@ -144,7 +151,7 @@ class KafkaCat:
 
         return (oldest, newest)
 
-    def query_offset(self, topic, partition, ts):
+    def query_offset(self, topic: str, partition: int, ts: int):
         res = self._cmd(["-Q", "-t", f"{topic}:{partition}:{ts}"])
 
         return res[topic][f"{partition}"]["offset"]

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -132,18 +132,6 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
         args += ["--partitions", f"{partitions}"]
         return self._run("kafka-topics.sh", args)
 
-    def create_topic_with_config(self, name, partitions, replication_factor,
-                                 configs):
-        cfgs = [f"{k}={v}" for k, v in configs.items()]
-        self._redpanda.logger.debug("Creating topic: %s", name)
-        args = ["--create"]
-        args += ["--topic", name]
-        args += ["--partitions", str(partitions)]
-        args += ["--replication-factor", str(replication_factor)]
-        for it in cfgs:
-            args += ["--config", it]
-        return self._run("kafka-topics.sh", args)
-
     def create_topic_with_assignment(self, name, assignments):
         self._redpanda.logger.debug(
             f"Creating topic: {name}, custom assignment: {assignments}")

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -16,6 +16,7 @@ from typing import Optional
 import os
 
 from rptest.services.keycloak import OAuthConfig
+from rptest.services.redpanda_types import KafkaClientSecurity, RedpandaServiceForClients, check_username_password
 
 
 class AuthenticationError(Exception):
@@ -53,30 +54,48 @@ class KafkaCliTools:
         self._version = version
         assert self._version is None or \
                 self._version in KafkaCliTools.VERSIONS
-        self._command_config = None
+
+        check_username_password(user, passwd)
+
+        if oauth_cfg:
+            assert not user, 'OATH cannot be combined with username/password authn'
         self._oauth_cfg = oauth_cfg
-        if user and passwd:
-            self._command_config = tempfile.NamedTemporaryFile(mode="w")
-            config = f"""
-sasl.mechanism=SCRAM-SHA-256
-security.protocol={protocol}
-sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{user}" password="{passwd}";
+
+        security_config_text = None
+        if self._oauth_cfg is None:
+            # plain or SASL authn: start with the redpanda default client credentials
+            # and then apply any passed-in overrides
+            security = cast(KafkaClientSecurity,
+                            redpanda.kafka_client_security())
+            if user:
+                security = security.override(user,
+                                             passwd,
+                                             'SCRAM-SHA-256',
+                                             tls_enabled=None)
+
+            if (sasl := security.simple_credentials()):
+                security_config_text = f"""
+sasl.mechanism={sasl.mechanism}
+security.protocol={security.security_protocol}
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="{sasl.username}" password="{sasl.password}";
 """
-            self._command_config.write(config)
-            self._command_config.flush()
-        elif self._oauth_cfg is not None:
-            self._command_config = tempfile.NamedTemporaryFile(mode="w")
-            config = f"""
+        else:
+            security_config_text = f"""
 sasl.mechanism=OAUTHBEARER
 security.protocol={protocol}
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
   oauth.client.id="{self._oauth_cfg.client_id}" \
   oauth.client.secret="{self._oauth_cfg.client_secret}" \
   oauth.token.endpoint.uri="{self._oauth_cfg.token_endpoint}";
-sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler                                  
+sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
 """
-            self._command_config.write(config)
+
+        if security_config_text:
+            self._command_config = tempfile.NamedTemporaryFile(mode="w")
+            self._command_config.write(security_config_text)
             self._command_config.flush()
+        else:
+            self._command_config = None
 
     @classmethod
     def instances(cls):

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -19,32 +19,19 @@ from rptest.services.keycloak import OAuthConfig
 
 
 class AuthenticationError(Exception):
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return repr(self.message)
+    pass
 
 
 class AuthorizationError(Exception):
-    def __init__(self, message):
-        self.message = message
+    pass
 
 
 class ClusterAuthorizationError(AuthorizationError):
-    def __init__(self, message):
-        super().__init__(message)
-
-    def __str__(self):
-        return repr(self.message)
+    pass
 
 
 class TopicAuthorizationError(AuthorizationError):
-    def __init__(self, message):
-        super().__init__(message)
-
-    def __str__(self):
-        return repr(self.message)
+    pass
 
 
 class KafkaCliTools:

--- a/tests/rptest/clients/python_librdkafka.py
+++ b/tests/rptest/clients/python_librdkafka.py
@@ -12,9 +12,10 @@ import functools
 
 from confluent_kafka import Consumer, Producer
 from confluent_kafka.admin import AdminClient, NewTopic
-from typing import Any, Optional
+from typing import Any, Optional, cast
 from rptest.services import tls
 from rptest.services.keycloak import OAuthConfig
+from rptest.services.redpanda_types import KafkaClientSecurity
 
 
 class PythonLibrdkafka:
@@ -30,9 +31,9 @@ class PythonLibrdkafka:
                  tls_cert: Optional[tls.Certificate] = None,
                  oauth_config: Optional[OAuthConfig] = None):
         self._redpanda = redpanda
-        self._username = username
-        self._password = password
-        self._algorithm = algorithm
+        self._security = cast(KafkaClientSecurity,
+                              redpanda.kafka_client_security()).override(
+                                  username, password, algorithm, None)
         self._tls_cert = tls_cert
         self._oauth_config = oauth_config
         self._oauth_count = 0
@@ -85,11 +86,10 @@ class PythonLibrdkafka:
             'bootstrap.servers': self._redpanda.brokers(),
         }
 
-        if self._redpanda.sasl_enabled():
-            if self._algorithm == 'OAUTHBEARER':
-                conf.update(self._get_oauth_config())
-            else:
-                conf.update(self._get_sasl_config())
+        if self._security.mechanism == 'OAUTHBEARER':
+            conf.update(self._get_oauth_config())
+        else:
+            conf.update(self._get_sasl_config())
 
         if self._tls_cert:
             conf.update({
@@ -123,17 +123,14 @@ class PythonLibrdkafka:
             self._redpanda.logger,
         }
 
-    def _get_sasl_config(self):
-        if self._username:
-            c = (self._username, self._password, self._algorithm)
-        else:
-            c = self._redpanda.SUPERUSER_CREDENTIALS
+    def _get_sasl_config(self) -> dict[str, str]:
+        c = self._security.simple_credentials()
         return {
-            'sasl.mechanism': c[2],
-            'security.protocol': 'sasl_plaintext',
-            'sasl.username': c[0],
-            'sasl.password': c[1],
-        }
+            'security.protocol': self._security.security_protocol.name.lower(),
+            'sasl.username': c.username,
+            'sasl.password': c.password,
+            'sasl.mechanism': c.mechanism
+        } if c else {}
 
     def _get_oauth_token(self, conf: OAuthConfig, _):
         # Better to wrap this whole thing in a try block, since the context where

--- a/tests/rptest/clients/python_librdkafka.py
+++ b/tests/rptest/clients/python_librdkafka.py
@@ -12,7 +12,7 @@ import functools
 
 from confluent_kafka import Consumer, Producer
 from confluent_kafka.admin import AdminClient, NewTopic
-from typing import Optional
+from typing import Any, Optional
 from rptest.services import tls
 from rptest.services.keycloak import OAuthConfig
 
@@ -24,9 +24,9 @@ class PythonLibrdkafka:
     def __init__(self,
                  redpanda,
                  *,
-                 username=None,
-                 password=None,
-                 algorithm=None,
+                 username: str | None = None,
+                 password: str | None = None,
+                 algorithm: str | None = None,
                  tls_cert: Optional[tls.Certificate] = None,
                  oauth_config: Optional[OAuthConfig] = None):
         self._redpanda = redpanda
@@ -74,7 +74,7 @@ class PythonLibrdkafka:
         self._redpanda.logger.debug(f"{producer_conf}")
         return Producer(producer_conf)
 
-    def get_consumer(self, extra_config: Optional[dict] = None):
+    def get_consumer(self, extra_config: dict[str, Any] = {}):
         conf = self._get_config()
         conf.update(extra_config)
         self._redpanda.logger.debug(f"{conf}")

--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -9,6 +9,9 @@
 from enum import Enum
 import random
 import string
+from typing import Literal
+
+# pyright: strict
 
 
 class TopicSpec:
@@ -60,6 +63,8 @@ class TopicSpec:
     TIMESTAMP_CREATE_TIME = "CreateTime"
     TIMESTAMP_LOG_APPEND_TIME = "LogAppendTime"
 
+    TIMESTAMP_TYPE = Literal["CreateTime", "LogAppendTime"]
+
     class SubjectNameStrategy(str, Enum):
         TOPIC_NAME = "TopicNameStrategy"
         RECORD_NAME = "RecordNameStrategy"
@@ -84,33 +89,38 @@ class TopicSpec:
     PROPERTY_INITIAL_RETENTION_LOCAL_TARGET_MS = "initial.retention.local.target.ms"
     PROPERTY_VIRTUAL_CLUSTER_ID = "redpanda.virtual.cluster.id"
 
-    def __init__(self,
-                 *,
-                 name: str | None = None,
-                 partition_count: int = 1,
-                 replication_factor: int = 3,
-                 cleanup_policy: str = CLEANUP_DELETE,
-                 compression_type: CompressionTypes = COMPRESSION_PRODUCER,
-                 message_timestamp_type=TIMESTAMP_CREATE_TIME,
-                 segment_bytes=None,
-                 retention_bytes=None,
-                 retention_ms=None,
-                 redpanda_remote_read=None,
-                 redpanda_remote_write=None,
-                 redpanda_remote_delete=None,
-                 segment_ms=None,
-                 max_message_bytes=None,
-                 record_key_schema_id_validation=None,
-                 record_key_schema_id_validation_compat=None,
-                 record_key_subject_name_strategy=None,
-                 record_key_subject_name_strategy_compat=None,
-                 record_value_schema_id_validation=None,
-                 record_value_schema_id_validation_compat=None,
-                 record_value_subject_name_strategy=None,
-                 record_value_subject_name_strategy_compat=None,
-                 initial_retention_local_target_bytes=None,
-                 initial_retention_local_target_ms=None,
-                 virtual_cluster_id=None):
+    def __init__(
+            self,
+            *,
+            name: str | None = None,
+            partition_count: int = 1,
+            replication_factor: int = 3,
+            cleanup_policy: str = CLEANUP_DELETE,
+            compression_type: CompressionTypes = COMPRESSION_PRODUCER,
+            message_timestamp_type: TIMESTAMP_TYPE = TIMESTAMP_CREATE_TIME,
+            segment_bytes: int | None = None,
+            retention_bytes: int | None = None,
+            retention_ms: int | None = None,
+            redpanda_remote_read: bool | None = None,
+            redpanda_remote_write: bool | None = None,
+            redpanda_remote_delete: bool | None = None,
+            segment_ms: int | None = None,
+            max_message_bytes: int | None = None,
+            record_key_schema_id_validation: bool | None = None,
+            record_key_schema_id_validation_compat: bool | None = None,
+            record_key_subject_name_strategy: SubjectNameStrategy
+        | None = None,
+            record_key_subject_name_strategy_compat: SubjectNameStrategyCompat
+        | None = None,
+            record_value_schema_id_validation: bool | None = None,
+            record_value_schema_id_validation_compat: bool | None = None,
+            record_value_subject_name_strategy: SubjectNameStrategy
+        | None = None,
+            record_value_subject_name_strategy_compat: SubjectNameStrategyCompat
+        | None = None,
+            initial_retention_local_target_bytes: int | None = None,
+            initial_retention_local_target_ms: int | None = None,
+            virtual_cluster_id: str | None = None):
         self.name = name or f"topic-{self._random_topic_suffix()}"
         self.partition_count = partition_count
         self.replication_factor = replication_factor
@@ -140,7 +150,7 @@ class TopicSpec:
     def __str__(self):
         return self.name
 
-    def __eq__(self, other):
+    def __eq__(self, other: object):
         if not isinstance(other, TopicSpec):
             return False
         return self.name == other.name and \
@@ -148,6 +158,6 @@ class TopicSpec:
                 self.replication_factor == other.replication_factor and \
                 self.cleanup_policy == other.cleanup_policy
 
-    def _random_topic_suffix(self, size=10):
+    def _random_topic_suffix(self, size: int = 10):
         return "".join(
             random.choice(string.ascii_lowercase) for _ in range(size))

--- a/tests/rptest/e2e_tests/flink_scale_test.py
+++ b/tests/rptest/e2e_tests/flink_scale_test.py
@@ -32,14 +32,7 @@ class FlinkScaleTests(RedpandaTest):
         self.test_context = test_context
 
         # Prepare client
-        config = self.redpanda.security_config()
-        user = config.get("sasl_plain_username")
-        passwd = config.get("sasl_plain_password")
-        protocol = config.get("security_protocol", "SASL_PLAINTEXT")
-        self.kafkacli = KafkaCliTools(self.redpanda,
-                                      user=user,
-                                      passwd=passwd,
-                                      protocol=protocol)
+        self.kafkacli = KafkaCliTools(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
         # Prepare Workloads
         self.workload_manager = WorkloadManager(self.logger)

--- a/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
+++ b/tests/rptest/redpanda_cloud_tests/cloud_self_test.py
@@ -9,6 +9,7 @@
 
 from typing import Any
 from ducktape.tests.test import TestContext
+from rptest.clients.rpk import RpkTool
 from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import RedpandaServiceCloud
@@ -65,3 +66,10 @@ class SelfRedpandaCloudTest(RedpandaCloudTest):
 
         count = self.redpanda.metric_sum('vectorized_application_uptime')
         assert count > 0, 'expected count greater than 0'
+
+    @cluster(num_nodes=0)
+    def test_rpk(self):
+        """Test that rpk works"""
+
+        rpk = RpkTool(self.redpanda)
+        rpk.list_topics()

--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -1,13 +1,18 @@
 import json
 from rptest.clients.rpk import RpkTool
+from rptest.services.redpanda_types import KafkaClientSecurity
 
 
 class FakePanda:
-    logger = None
-
+    """A mock for a RedpandaService-like class which we pass in to
+    RpkTool which allows access to some methods on RpkTool which do
+    not require access to a real redpanda instance."""
     def __init__(self, context, log):
         self._context = context
         self.logger = log
+
+    def kafka_client_security(self):
+        return KafkaClientSecurity(None, False)
 
 
 class CloudClusterUtils:
@@ -26,7 +31,6 @@ class CloudClusterUtils:
         :param oauth_url_origin: just scheme and hostname
         :param oauth_audience: audience for issued token
         """
-        # Create fake redpanda class with logger only
         self.fake_panda = FakePanda(context, logger)
         # Create rpk to use several functions that is isolated
         # from actual redpanda service

--- a/tests/rptest/services/kafka.py
+++ b/tests/rptest/services/kafka.py
@@ -1,9 +1,10 @@
 from ducktape.utils.util import wait_until
+from rptest.services.redpanda_types import PLAINTEXT_SECURITY, KafkaClientSecurity
 
 
 class KafkaServiceAdapter:
     '''
-        Simple adapter to match KafkaService interface with 
+        Simple adapter to match KafkaService interface with
         what is required by Redpanda test clients
     '''
     def __init__(self, test_context, kafka_service):
@@ -33,6 +34,12 @@ class KafkaServiceAdapter:
             return object.__getattribute__(self, name)
         except AttributeError:
             return getattr(self._kafka_service, name)
+
+    # required for RpkTool constructor, though we don't actually
+    # try to return the cluster's security settings, just assume
+    # they are plain text
+    def kafka_client_security(self) -> KafkaClientSecurity:
+        return PLAINTEXT_SECURITY
 
     # required for rpk
     def find_binary(self, name):

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1479,9 +1479,6 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
     def validate_controller_log(self):
         pass
 
-    def security_config(self):
-        return self._security_config
-
     def kafka_client_security(self):
         if self._security_config:
 

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -58,6 +58,7 @@ from rptest.clients.python_librdkafka import PythonLibrdkafka
 from rptest.clients.installpack import InstallPackClient
 from rptest.clients.rp_storage_tool import RpStorageTool
 from rptest.services import redpanda_types, tls
+from rptest.services.redpanda_types import KafkaClientSecurity
 from rptest.services.admin import Admin
 from rptest.services.redpanda_installer import RedpandaInstaller, VERSION_RE as RI_VERSION_RE, int_tuple as ri_int_tuple
 from rptest.services.redpanda_cloud import CloudCluster, CloudTierName, get_config_profile_name
@@ -899,6 +900,12 @@ class RedpandaServiceABC(ABC):
     def all_up(self):
         pass
 
+    @abstractmethod
+    def kafka_client_security(self) -> KafkaClientSecurity:
+        """Return a KafkaClientSecurity object suitable for connecting to the Kafka API
+         on this broker."""
+        pass
+
     def wait_until(self, fn, timeout_sec, backoff_sec, err_msg: str = None):
         """
         Cluster-aware variant of wait_until, which will fail out
@@ -1475,6 +1482,22 @@ class RedpandaServiceBase(RedpandaServiceABC, Service):
     def security_config(self):
         return self._security_config
 
+    def kafka_client_security(self):
+        if self._security_config:
+
+            def get_str(key: str):
+                v = self._security_config[key]
+                assert isinstance(v, str)
+                return v
+
+            creds = SaslCredentials(username=get_str('sasl_plain_username'),
+                                    password=get_str('sasl_plain_password'),
+                                    algorithm=get_str('sasl_mechanism'))
+        else:
+            creds = None
+
+        return KafkaClientSecurity(creds, tls_enabled=False)
+
     def set_skip_if_no_redpanda_log(self, v: bool):
         self._skip_if_no_redpanda_log = v
 
@@ -1721,6 +1744,9 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
                     sasl_plain_username=self._superuser.username,
                     sasl_plain_password=self._superuser.password,
                     enable_tls=True)
+
+    def kafka_client_security(self):
+        return KafkaClientSecurity(self._superuser, True)
 
     def rebuild_pods_classes(self):
         """Querry pods and create Classes fresh

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -1,7 +1,8 @@
 from copy import copy
 from dataclasses import astuple, dataclass
 from enum import Enum, auto
-from typing import Iterator
+from logging import Logger
+from typing import Iterator, Protocol
 
 # pyright: strict
 
@@ -211,3 +212,23 @@ PLAINTEXT_SECURITY = KafkaClientSecurity(None, False)
 # A KafkaClientSecurity constant presenting "SSL" security,
 # i.e., SASL and TLS enabled.
 SSL_SECURITY = KafkaClientSecurity(None, True)
+
+
+class RedpandaServiceForClients(Protocol):
+    """A protocol encoding some basic functionality of RedpandaService and similar
+    Service classes (like RedpandaCloudService), such that clients that take a
+    redpanda service object can be property typed, without depending on the full
+    class definitions (which might introduce a circular dependency in the typing
+    and which is otherwise undesirable since it would make the tool classes
+    more tightly tied to the service.
+
+    Method documentation lives on the service implementations themselves and is
+    not repeated here."""
+
+    logger: Logger
+
+    def kafka_client_security(self) -> KafkaClientSecurity:
+        ...
+
+    def brokers(self) -> str:
+        ...

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -235,7 +235,7 @@ class KafkaClientSecurity:
 PLAINTEXT_SECURITY = KafkaClientSecurity(None, False)
 
 # A KafkaClientSecurity constant presenting "SSL" security,
-# i.e., SASL and TLS enabled.
+# i.e., no SASL and TLS enabled.
 SSL_SECURITY = KafkaClientSecurity(None, True)
 
 

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -1,6 +1,9 @@
-import collections
+from copy import copy
 from dataclasses import astuple, dataclass
+from enum import Enum, auto
 from typing import Iterator
+
+# pyright: strict
 
 # Basic types shared between various redpanda service and test modes.
 
@@ -21,3 +24,190 @@ class SaslCredentials:
     # allow credentials to be unpacked for backwards compat
     def __iter__(self) -> Iterator[str]:
         return iter(astuple(self))
+
+    # allow credentials to be subscripted for backwards compat
+    def __getitem__(self, index: int) -> str:
+        return list(self)[index]
+
+    @property
+    def mechanism(self):
+        """The SASL authentication mechanism (an alias for self.algorithm)."""
+        return self.algorithm
+
+
+class SecurityProtocol(Enum):
+    """The four possible security protocol options for Kafka authentication."""
+    PLAINTEXT = auto()
+    """SASL and TLS disabled."""
+    SSL = auto()
+    """SASL disabled, TLS enabled."""
+    SASL_PLAINTEXT = auto()
+    """SASL enabled, TLS disabled."""
+    SASL_SSL = auto()
+    """SASL and TLS enabled."""
+
+    # Use the base name so we can use the formatted protocol directly
+    # in format contexts like f-strings.
+    def __str__(self):
+        return self.name
+
+
+SIMPLE_SASL_MECHANISMS = ['SCRAM-SHA-256', 'SCRAM-SHA-512']
+COMPLEX_SASL_MECHANISMS = ['GSSAPI', 'OAUTHBEARER']
+
+
+class InvalidKafkaSecurity(RuntimeError):
+    """Indicates a consistency check failed while creating or manipulating security
+    credentials. This is a local check and does not involve contacting the server."""
+    pass
+
+
+class NonSASL:
+    """Empty indicator class for KafkaClientSecurity objects that do no have SASL enabled."""
+    pass
+
+
+@dataclass
+class ComplexSASL:
+    """A class indicating that SASL is enabled, but it is not a simple mechanism
+    (e.g., SCRAM, PLAIN) that be be represented by SaslCredentials. Client wrappers
+    will generally need to switch on the mechanism and handle them specifically."""
+    mechanism: str
+
+
+def check_username_password(username: str | None, password: str | None):
+    """Check that either both username and password are set, or neither.
+    Empty string username is considered unset, but empty password is considered set"""
+    if username and password is None:
+        raise InvalidKafkaSecurity('username set but password not set')
+    if password is not None and not username:
+        raise InvalidKafkaSecurity('password set but username not set')
+
+
+class KafkaClientSecurity:
+    """A class that bundles up the security information necessary for a client to connect to
+    a broker."""
+    def __init__(self, simple_sasl: SaslCredentials | None, tls_enabled: bool):
+        if not simple_sasl:
+            self._sasl_credentials = NonSASL()
+        else:
+            assert isinstance(simple_sasl, SaslCredentials)
+            self._sasl_credentials = simple_sasl
+        self.tls_enabled = tls_enabled
+
+    _sasl_credentials: NonSASL | SaslCredentials | ComplexSASL
+
+    tls_enabled: bool
+    """True iff the Kafka listener has TLS enabled."""
+
+    #
+
+    @property
+    def sasl_enabled(self):
+        """Returns true if SASL is enabled, either simple or complex."""
+        return not isinstance(self._sasl_credentials, NonSASL)
+
+    @property
+    def is_simple(self):
+        """Determines if an the contained authentication method is "simple". An instance is simple
+        if SASL is disabled or if is enabled and is simple SASL mechanisms: i.e., those which can be handled
+        by generated configuration properties. Non-simple mechanisms (like OAUTH) require additional
+        handling by the client (e.g., registering an OAUTH callback) and this class throws in methods
+        which are documented as requiring simple configuration)."""
+        return isinstance(self._sasl_credentials, NonSASL) or isinstance(
+            self._sasl_credentials, SaslCredentials)
+
+    @property
+    def security_protocol(self):
+        lookup: dict[tuple[bool, bool], SecurityProtocol] = {
+            (False, False): SecurityProtocol.PLAINTEXT,
+            (False, True): SecurityProtocol.SASL_PLAINTEXT,
+            (True, False): SecurityProtocol.SSL,
+            (True, True): SecurityProtocol.SASL_SSL,
+        }
+
+        return lookup[(self.tls_enabled, self.sasl_enabled)]
+
+    @property
+    def username(self):
+        """The SASL username or None if SASL is not enabled or the SASL mechanism does not use a username."""
+        return self._sasl_credentials.username if isinstance(
+            self._sasl_credentials, SaslCredentials) else None
+
+    @property
+    def password(self):
+        """The SASL password or None if SASL is not enabled or the SASL mechanism does not use a password."""
+        return self._sasl_credentials.password if isinstance(
+            self._sasl_credentials, SaslCredentials) else None
+
+    @property
+    def mechanism(self):
+        """The SASL mechanism or None if SASL is not enabled."""
+        return None if isinstance(
+            self._sasl_credentials,
+            NonSASL) else self._sasl_credentials.mechanism
+
+    def override(self, username: str | None, password: str | None,
+                 sasl_mechanism: str | None, tls_enabled: bool | None):
+        """Return a new object with zero or more overridden values passed as
+           arguments to this function.
+
+           An override occurs if the argument is non-None (and not empty string
+           for username and mechanism). Only certain override configurations
+           are allowed:
+
+           Overriding both the username and password.
+           Overriding all of the username, password and sasl mechanism (mechanism must be simple).
+           Overriding only the sasl mechanism (mechanism must be non-simple and username and password are
+           cleared after this override).
+
+           In addition the tls_enabled value always may be overridden independently of
+           the above rules.
+        """
+
+        ret = copy(self)
+
+        check_username_password(username, password)
+
+        if sasl_mechanism and not username:
+            if sasl_mechanism in SIMPLE_SASL_MECHANISMS:
+                raise InvalidKafkaSecurity(
+                    'overriding mechanism without updating user/pass')
+            assert sasl_mechanism in COMPLEX_SASL_MECHANISMS, f'unknown SASL mechanism: {sasl_mechanism}'
+            ret._sasl_credentials = ComplexSASL(mechanism=sasl_mechanism)
+
+        if username and password:
+            if not sasl_mechanism:
+                if not isinstance(ret._sasl_credentials, SaslCredentials):
+                    raise InvalidKafkaSecurity(
+                        f'overriding user/pass but existing credentials are not simple SASL: {ret._sasl_credentials}'
+                    )
+                else:
+                    sasl_mechanism = ret._sasl_credentials.mechanism
+
+            ret._sasl_credentials = SaslCredentials(username, password,
+                                                    sasl_mechanism)
+
+        if tls_enabled is not None:
+            ret.tls_enabled = tls_enabled
+
+        return ret
+
+    def _require_simple(self):
+        """Check that auth is simple, otherwise throw then returns SaslCredentials if SASL is enabled
+        or None if SASL is disabled."""
+        if not self.is_simple:
+            raise RuntimeError(
+                f'Calling method requires simple security, but this is not simple: {self}'
+            )
+        c = self._sasl_credentials
+        return c if isinstance(c, SaslCredentials) else None
+
+
+# A KafkaClientSecurity constant presenting "PLAINTEXT" security,
+# i.e., no SASL and no TLS.
+PLAINTEXT_SECURITY = KafkaClientSecurity(None, False)
+
+# A KafkaClientSecurity constant presenting "SSL" security,
+# i.e., SASL and TLS enabled.
+SSL_SECURITY = KafkaClientSecurity(None, True)

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -130,19 +130,19 @@ class KafkaClientSecurity:
         return lookup[(self.tls_enabled, self.sasl_enabled)]
 
     @property
-    def username(self):
+    def username(self) -> str | None:
         """The SASL username or None if SASL is not enabled or the SASL mechanism does not use a username."""
         return self._sasl_credentials.username if isinstance(
             self._sasl_credentials, SaslCredentials) else None
 
     @property
-    def password(self):
+    def password(self) -> str | None:
         """The SASL password or None if SASL is not enabled or the SASL mechanism does not use a password."""
         return self._sasl_credentials.password if isinstance(
             self._sasl_credentials, SaslCredentials) else None
 
     @property
-    def mechanism(self):
+    def mechanism(self) -> str | None:
         """The SASL mechanism or None if SASL is not enabled."""
         return None if isinstance(
             self._sasl_credentials,

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -110,7 +110,7 @@ class KafkaClientSecurity:
 
     @property
     def is_simple(self):
-        """Determines if an the contained authentication method is "simple". An instance is simple
+        """Determines if the contained authentication method is "simple". An instance is simple
         if SASL is disabled or if is enabled and is simple SASL mechanisms: i.e., those which can be handled
         by generated configuration properties. Non-simple mechanisms (like OAUTH) require additional
         handling by the client (e.g., registering an OAUTH callback) and this class throws in methods

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -194,8 +194,33 @@ class KafkaClientSecurity:
 
         return ret
 
-    def _require_simple(self):
-        """Check that auth is simple, otherwise throw then returns SaslCredentials if SASL is enabled
+    def to_dict(self) -> dict[str, str | int]:
+        """Return the security configuration as a dictionary suitable for use by kafka-python.
+
+        This supports only SASL disabled (returns an empty dict) or simple SASL (SCRAM) mechanisms
+        and throws otherwise.
+
+        This is here for some existing use cases but try not to use this.
+        """
+
+        if (c := self.simple_credentials()):
+            return dict(security_protocol=self.security_protocol.name,
+                        sasl_mechanism=c.mechanism,
+                        sasl_plain_username=c.username,
+                        sasl_plain_password=c.password,
+                        request_timeout_ms=30000,
+                        api_version_auto_timeout_ms=3000)
+        else:
+            # by convention we return an empty dict when we are using PLAINTEXT
+            # since clients default to this protocol and so don't require an
+            # explicit security protocol configuration in that case
+            return dict(security_protocol=self.security_protocol.name
+                        ) if self.tls_enabled else {}
+
+    def simple_credentials(self) -> SaslCredentials | None:
+        """Return SaslCredentials for this configuration if possible.
+
+        Throws an exception if auth is not simple, otherwise returns SaslCredentials if SASL is enabled
         or None if SASL is disabled."""
         if not self.is_simple:
             raise RuntimeError(

--- a/tests/rptest/services/redpanda_types.py
+++ b/tests/rptest/services/redpanda_types.py
@@ -1,6 +1,23 @@
 import collections
+from dataclasses import astuple, dataclass
+from typing import Iterator
 
 # Basic types shared between various redpanda service and test modes.
 
-SaslCredentials = collections.namedtuple("SaslCredentials",
-                                         ["username", "password", "algorithm"])
+
+@dataclass
+class SaslCredentials:
+    """Credentials and algorithm for SASL authentication."""
+
+    username: str
+    """The username for SASL authentication."""
+
+    password: str
+    """The password for SASL authentication."""
+
+    algorithm: str
+    """The SASL authentication mechanism."""
+
+    # allow credentials to be unpacked for backwards compat
+    def __iter__(self) -> Iterator[str]:
+        return iter(astuple(self))

--- a/tests/rptest/services/serde_client.py
+++ b/tests/rptest/services/serde_client.py
@@ -38,7 +38,7 @@ class SerdeClient(BackgroundThreadService):
     def __init__(
             self,
             context: TestContext,
-            brokers: list[str],
+            brokers: str,
             schema_registry_url: str,
             schema_type: SchemaType,
             serde_client_type: SerdeClientType,

--- a/tests/rptest/tests/flink_basic_test.py
+++ b/tests/rptest/tests/flink_basic_test.py
@@ -33,14 +33,7 @@ class FlinkBasicTests(RedpandaTest):
         self.topics = [TopicSpec(name=self.topic_name)]
         self.flink = FlinkService(test_context)
         # Prepare client
-        config = self.redpanda.security_config()
-        user = config.get("sasl_plain_username")
-        passwd = config.get("sasl_plain_password")
-        protocol = config.get("security_protocol", "SASL_PLAINTEXT")
-        self.kafkacli = KafkaCliTools(self.redpanda,
-                                      user=user,
-                                      passwd=passwd,
-                                      protocol=protocol)
+        self.kafkacli = KafkaCliTools(self.redpanda)
         self.rpk = RpkTool(self.redpanda)
         # Prepare Workloads
         self.workload_manager = WorkloadManager(self.logger)

--- a/tests/rptest/tests/internal_topic_protection_test.py
+++ b/tests/rptest/tests/internal_topic_protection_test.py
@@ -10,6 +10,7 @@
 import subprocess
 import time
 
+from rptest.clients.types import TopicSpec
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.redpanda import SchemaRegistryConfig
@@ -118,7 +119,7 @@ class InternalTopicProtectionTest(RedpandaTest):
             assert False, "Unknown client type"
 
         test_topic = "noproduce_topic"
-        self.kafka_tools.create_topic_with_config(test_topic, 1, 3, {})
+        self.kafka_tools.create_topic(TopicSpec(name=test_topic))
         partition_id = 0
 
         wait_until(lambda: test_topic in self.rpk.list_topics(),
@@ -163,7 +164,8 @@ class InternalTopicProtectionTest(RedpandaTest):
             assert False, "Unknown client type"
 
         test_topic = "nodelete_topic"
-        self.kafka_tools.create_topic_with_config(test_topic, 3, 3, {})
+        self.kafka_tools.create_topic(
+            TopicSpec(name=test_topic, partition_count=3))
 
         wait_until(lambda: test_topic in client.list_topics(),
                    timeout_sec=90,

--- a/tests/rptest/tests/pandaproxy_test.py
+++ b/tests/rptest/tests/pandaproxy_test.py
@@ -231,11 +231,7 @@ class PandaProxyEndpoints(RedpandaTest):
         http.client.print = lambda *args: self.logger.debug(" ".join(args))
 
     def _get_kafka_cli_tools(self):
-        sasl_enabled = self.redpanda.sasl_enabled()
-        cfg = self.redpanda.security_config() if sasl_enabled else {}
-        return KafkaCliTools(self.redpanda,
-                             user=cfg.get('sasl_plain_username'),
-                             passwd=cfg.get('sasl_plain_password'))
+        return KafkaCliTools(self.redpanda)
 
     def _base_uri(self, hostname=None, tls_enabled: bool = False):
         hostname = hostname if hostname else self.redpanda.nodes[

--- a/tests/rptest/tests/redpanda_test.py
+++ b/tests/rptest/tests/redpanda_test.py
@@ -69,14 +69,7 @@ class RedpandaTestBase(ABC, Test):
         return os.environ.get('CI', None) != 'false'
 
     def _create_initial_topics(self):
-        config = self.__redpanda.security_config()
-        user = config.get("sasl_plain_username")
-        passwd = config.get("sasl_plain_password")
-        protocol = config.get("security_protocol", "SASL_PLAINTEXT")
-        client = KafkaCliTools(self.__redpanda,
-                               user=user,
-                               passwd=passwd,
-                               protocol=protocol)
+        client = KafkaCliTools(self.__redpanda)
         for spec in self.topics:
             self.logger.debug(f"Creating initial topic {spec}")
             client.create_topic(spec)

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -190,12 +190,7 @@ class SchemaRegistryEndpoints(RedpandaTest):
         return f"http://{self.redpanda.nodes[0].account.hostname}:8081"
 
     def _get_rpk_tools(self):
-        sasl_enabled = self.redpanda.sasl_enabled()
-        cfg = self.redpanda.security_config() if sasl_enabled else {}
-        return RpkTool(self.redpanda,
-                       username=cfg.get('sasl_plain_username'),
-                       password=cfg.get('sasl_plain_password'),
-                       sasl_mechanism=cfg.get('sasl_mechanism'))
+        return RpkTool(self.redpanda)
 
     def _get_serde_client(
             self,
@@ -208,8 +203,7 @@ class SchemaRegistryEndpoints(RedpandaTest):
             payload_class: Optional[str] = None,
             compression_type: Optional[TopicSpec.CompressionTypes] = None):
         schema_reg = self.redpanda.schema_reg().split(',', 1)[0]
-        sasl_enabled = self.redpanda.sasl_enabled()
-        sec_cfg = self.redpanda.security_config() if sasl_enabled else None
+        sec_cfg = self.redpanda.kafka_client_security().to_dict()
 
         return SerdeClient(self.test_context,
                            self.redpanda.brokers(),
@@ -218,7 +212,7 @@ class SchemaRegistryEndpoints(RedpandaTest):
                            client_type,
                            count,
                            topic=topic,
-                           security_config=sec_cfg,
+                           security_config=sec_cfg if sec_cfg else None,
                            skip_known_types=skip_known_types,
                            subject_name_strategy=subject_name_strategy,
                            payload_class=payload_class,

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -10,7 +10,7 @@
 import os
 import pprint
 from contextlib import contextmanager
-from typing import Optional, Any
+from typing import Callable, Optional, Any
 
 from ducktape.utils.util import wait_until
 from requests.exceptions import HTTPError
@@ -53,7 +53,8 @@ class Scale:
         return self._scale == Scale.RELEASE
 
 
-def wait_until_result(condition, *args, **kwargs) -> Any:
+def wait_until_result(condition: Callable[[], Any], *args: Any,
+                      **kwargs: Any) -> Any:
     """
     a near drop-in replacement for ducktape's wait_util except that when
     the condition passes a result from the condition is passed back to the


### PR DESCRIPTION
The primary thrust of this change is to consolidate the way our "client wrappers" (i.e., the python code that wraps a Kafka client) get their security credentials to authenticate to the Kafka endpoint. This change only changes ducktape test framework and test code, and does not touch Redpanda itself.

Specifically we want to:

 - Use a strongly typed class to represent credentials (`KafkaClientSecurity`)
 - Expose a method on RedpandaService which exposes "default" credentials that are suitable to connect to the cluster: these will depend on how the cluster is configured. This is similar to the existing `security_config()` method (removed in this series) but using `KafkaClientSecurity` and supporting more server-side configuration

The primary motivation is that ducktape tests running against the cloud have SASL and TLS on by default. This is the opposite of vanilla ducktape where TLS and SASL are disabled. For existing client wrappers (and hence existing tests) to "just work" when run against the cloud, we need a consistent and expanded way for client wrappers to handle their kafka credentials.

The basic approach that client wrappers will work after this change (before this change the behavior "varied"):

 - If no authn overrides are passed in the tool constructor, we use the _default_ kafka security config exposed by `RedpandaService.kafka_security_credentials()`.
 - _If_ authn information is passed to the constructor (most client wrappers offer this at least to some extend), this information overrides the _relevant_ part of the _default_ configuration. For example, if the username and password are passed to the client wrapper, they will override the default superuser credentials, but other default settings such as whether TLS is enabled will still be taken from the default configuration. This is implemented in a ~consistent way for all client wrappers: see `KafkaSecurityCredentials.override()` for details.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none
