### PR TITLE
rptest: delete vestigial datapolicy stuff

### DIFF
--- a/tests/rptest/clients/types.py
+++ b/tests/rptest/clients/types.py
@@ -29,8 +29,6 @@ class TopicSpec:
     PROPERTY_SEGMENT_SIZE = "segment.bytes"
     PROPERTY_RETENTION_BYTES = "retention.bytes"
     PROPERTY_RETENTION_TIME = "retention.ms"
-    PROPERTY_DATA_POLICY_FUNCTION_NAME = "redpanda.datapolicy.function.name"
-    PROPERTY_DATA_POLICY_SCRIPT_NAME = "redpanda.datapolicy.script.name"
     PROPERTY_RETENTION_LOCAL_TARGET_BYTES = "retention.local.target.bytes"
     PROPERTY_RETENTION_LOCAL_TARGET_MS = "retention.local.target.ms"
     PROPERTY_REMOTE_DELETE = "redpanda.remote.delete"
@@ -94,7 +92,6 @@ class TopicSpec:
                  segment_bytes=None,
                  retention_bytes=None,
                  retention_ms=None,
-                 redpanda_datapolicy=None,
                  redpanda_remote_read=None,
                  redpanda_remote_write=None,
                  redpanda_remote_delete=None,
@@ -120,7 +117,6 @@ class TopicSpec:
         self.segment_bytes = segment_bytes
         self.retention_bytes = retention_bytes
         self.retention_ms = retention_ms
-        self.redpanda_datapolicy = redpanda_datapolicy
         self.redpanda_remote_read = redpanda_remote_read
         self.redpanda_remote_write = redpanda_remote_write
         self.redpanda_remote_delete = redpanda_remote_delete


### PR DESCRIPTION
In https://github.com/redpanda-data/redpanda/commit/ce8095e10edc49ef1eb2b0a959ace6d10d084d53 we removed data policy support but there are a couple of pieces left in the test code.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
