### PR TITLE
ducktape: improve ubsan violation handling in dt tests

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -276,6 +276,9 @@ COPY --chown=0:0 --chmod=0755 tests/rptest/remote_scripts /opt/remote
 # copy lsan suppressions file
 COPY --chown=0:0 --chmod=0644 lsan_suppressions.txt /opt/lsan_suppressions.txt
 
+# copy ubsan suppressions file
+COPY --chown=0:0 --chmod=0644 ubsan_suppressions.txt /opt/ubsan_suppressions.txt
+
 # expose port 8080 for any http examples within clients
 EXPOSE 8080
 

--- a/tests/docker/Dockerfile.dockerignore
+++ b/tests/docker/Dockerfile.dockerignore
@@ -12,3 +12,4 @@
 !tests/rptest/remote_scripts
 !tests/protobuf
 !lsan_suppressions.txt
+!ubsan_suppressions.txt

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -100,13 +100,6 @@ DEFAULT_LOG_ALLOW_LIST = [
     # A client disconnecting is not bad behaviour on redpanda's part
     re.compile(r"kafka rpc protocol.*(Connection reset by peer|Broken pipe)"),
 
-    # ubsan supports supressions, but it appears to not support supressions for
-    # generic "undefined behavior", rather only specific ones like invalid
-    # value for type, overflow, alignment, etc...
-    re.compile(
-        r"SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior aead.c:(182|214)"
-    ),
-
     # Sometines we're getting 'Internal Server Error' from S3 on CDT and it doesn't
     # lead to any test failure because the error is transient (AWS weather).
     re.compile(r"unexpected REST API error \"Internal Server Error\" detected"
@@ -182,6 +175,9 @@ AUDIT_LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [
 
 # Path to the LSAN suppressions file
 LSAN_SUPPRESSIONS_FILE = "/opt/lsan_suppressions.txt"
+
+# Path to the UBSAN suppressions file
+UBSAN_SUPPRESSIONS_FILE = "/opt/ubsan_suppressions.txt"
 
 FAILURE_INJECTION_LOG_ALLOW_LIST = [
     re.compile(
@@ -2446,8 +2442,11 @@ class RedpandaService(RedpandaServiceBase):
 
         # ubsan, halt at first violation and include a stack trace
         # in the logs.
-        self._environment[
-            'UBSAN_OPTIONS'] = 'print_stacktrace=1:halt_on_error=1:abort_on_error=1'
+        ubsan_opts = 'print_stacktrace=1:halt_on_error=1:abort_on_error=1'
+        if os.path.exists(UBSAN_SUPPRESSIONS_FILE):
+            ubsan_opts += f":suppressions={UBSAN_SUPPRESSIONS_FILE}"
+
+        self._environment['UBSAN_OPTIONS'] = ubsan_opts
 
         if environment is not None:
             self._environment.update(environment)

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2444,6 +2444,11 @@ class RedpandaService(RedpandaServiceBase):
         else:
             self.logger.debug(f'{LSAN_SUPPRESSIONS_FILE} does not exist')
 
+        # ubsan, halt at first violation and include a stack trace
+        # in the logs.
+        self._environment[
+            'UBSAN_OPTIONS'] = 'print_stacktrace=1:halt_on_error=1:abort_on_error=1'
+
         if environment is not None:
             self._environment.update(environment)
 

--- a/ubsan_suppressions.txt
+++ b/ubsan_suppressions.txt
@@ -1,0 +1,2 @@
+pointer-overflow:aead.c
+nonnull-attribute:aead.c


### PR DESCRIPTION
Currently the test continues despite a violation and includes a single log line that the violation has occurred which makes it difficult to debug further especially narrowing down the exact source that caused it..

This change makes the test halt on first violation include a full stack trace in the broker logs.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
