### PR TITLE
io: fix clang-tidy warning

### DIFF
--- a/src/v/io/tests/pager_test.cc
+++ b/src/v/io/tests/pager_test.cc
@@ -73,7 +73,8 @@ public:
         for (auto& file : cleanup_files_) {
             try {
                 seastar::remove_file(file.string()).get();
-            } catch (...) {
+            } catch (const std::exception& ex) {
+                std::ignore = ex;
             }
         }
     }


### PR DESCRIPTION
By not having empty catches.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
