### PR TITLE
rptest: Increase backoff interval for GCS

### DIFF
--- a/tests/rptest/tests/cloud_storage_timing_stress_test.py
+++ b/tests/rptest/tests/cloud_storage_timing_stress_test.py
@@ -264,6 +264,11 @@ class CloudStorageTimingStressTest(RedpandaTest, PartitionMovementMixin):
             cloud_storage_enable_segment_merging=True,
             cloud_storage_cache_chunk_size=self.chunk_size,
             cloud_storage_spillover_manifest_size=None)
+        if "googleapis" in self.si_settings.cloud_storage_api_endpoint:
+            # If the test is running on GCS we shouldn't retry earlier than
+            # after 1s. GCS throttles uploads if they happen once per sencond
+            # or faster (per object).
+            extra_rp_conf['cloud_storage_initial_backoff_ms'] = 1000
 
         super(CloudStorageTimingStressTest,
               self).__init__(test_context=test_context,


### PR DESCRIPTION
The timeing_stress_test performs a lot of TS operations in short time and in some cases it has to upload manifest frequently (more often than once per second). The manifest uploads are driven by segment uploads and retention. Normally, we will try to upload less often (once per 60s or less) even if we're writing into the partition constantly. But under the local storage pressure the ntp-archiver is forced to upload the manifest mroe frequently. The local storage pressure means that the local storage wants to evict some data but it can't do this unless the manifest is uploaded and the clean offset is moved forward.

The timing stress test introduces local storage pressure and uploads manifests frequently. The GCS may throttle us when we're trying to reupload the manifest faster than once per second. If the initial backoff has default value of 100ms this is exactly what we will try to do once some throttling is applied. Redpanda receives SlowDown response and decides to retry after 100ms, after 200ms, 400ms etc. It never uploads the manifest and the test fails.

This fix increases the initial backoff to 1000ms if the test is running on GCS.

Fixes #15488

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none