### PR TITLE
Revert "Add a way to skip the test based on cloud_type GH:1169

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -47,7 +47,6 @@ from rptest.util import firewall_blocked
 from rptest.utils.si_utils import nodes_report_cloud_segments
 from rptest.redpanda_cloud_tests.cloudv2_object_store_blocked import cloudv2_object_store_blocked
 from rptest.utils.test_mixins import PreallocNodesMixin
-from rptest.utils.mode_checks import skip_unless_cloud_type_is
 
 KiB = 1024
 MiB = KiB * KiB
@@ -786,7 +785,6 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                    timeout_sec=restart_timeout,
                    backoff_sec=1)
 
-    @skip_if_cloud_type_is('CLOUD_TYPE_FMC')
     @cluster(num_nodes=2, log_allow_list=NOS3_LOG_ALLOW_LIST)
     def test_disrupt_cloud_storage(self):
         """

--- a/tests/rptest/utils/rpenv.py
+++ b/tests/rptest/utils/rpenv.py
@@ -39,20 +39,3 @@ class IsCIOrNotEmpty:
 
     def __eq__(self, other: str) -> bool:
         return bool(other) or self.is_ci
-
-
-def skip_if_cloud_type_is(disallowed_values):
-    """
-    Skip a test if the CLOUD_TYPE environment variable matches one of the disallowed values.
-
-    :param disallowed_values: List of string values. The test is skipped if CLOUD_TYPE's value is in this list.
-    
-    Example: @skip_if_cloud_type_is('CLOUD_TYPE_FMC')
-    """
-    def decorator(test_function):
-        # Directly check the 'CLOUD_TYPE' environment variable
-        if os.getenv('CLOUD_TYPE') in disallowed_values:
-            return ignore(test_function)
-        return test_function
-
-    return decorator


### PR DESCRIPTION
This reverts commit 01647218d4d12fbd65d027ef7da659762b49df81.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
