### PR TITLE
ssx: add sleep_aborted to shutdown errors

### DIFF
--- a/src/v/ssx/include/ssx/future-util.h
+++ b/src/v/ssx/include/ssx/future-util.h
@@ -274,6 +274,7 @@ ignore_shutdown_exceptions(seastar::future<> fut) noexcept {
     try {
         co_await std::move(fut);
     } catch (const seastar::abort_requested_exception&) {
+    } catch (const seastar::sleep_aborted&) {
     } catch (const seastar::gate_closed_exception&) {
     } catch (const seastar::broken_semaphore&) {
     } catch (const seastar::broken_promise&) {
@@ -286,6 +287,8 @@ inline bool is_shutdown_exception(const std::exception_ptr& e) {
     try {
         std::rethrow_exception(e);
     } catch (const seastar::abort_requested_exception&) {
+        return true;
+    } catch (const seastar::sleep_aborted&) {
         return true;
     } catch (const seastar::gate_closed_exception&) {
         return true;


### PR DESCRIPTION
ss::sleep_aborted is a subclass of ss::abort_requested_exception and wasn't being flagged as a shutdown error.

This previously showed up as an error log while deleting keys in remote::delete_objects_sequentially:

cloud_storage - [fiber28~216|0|29845ms] - remote.cc:1293 - Failed to delete keys: Sleep is aborted

Fixes #17506

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
