### PR TITLE
rptest: add ubsan suppressions

### DIFF
--- a/ubsan_suppressions.txt
+++ b/ubsan_suppressions.txt
@@ -1,2 +1,3 @@
 pointer-overflow:aead.c
 nonnull-attribute:aead.c
+alignment:crc32c_arm64.cc


### PR DESCRIPTION
Running ducktape on arm64 causes crc32 ubsan violations, so add a suppression file to track these.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
