### PR TITLE
iwyu: add pragma to always keep

### DIFF
--- a/src/v/base/include/base/seastarx.h
+++ b/src/v/base/include/base/seastarx.h
@@ -11,6 +11,8 @@
 
 #pragma once
 
+// IWYU pragma: always_keep
+
 namespace seastar {} // namespace seastar
 
 namespace ss = seastar;


### PR DESCRIPTION
IWYU in clangd always suggests to remove seastarx.h because it thinks no
symbols are being used (sort of correct), I guess it can't understand
the alias usage in this file. Add a suppression that clangd respects to
never remove the header.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
