### PR TITLE
rbac/roles: Enable the role store to survive controller snapshot

### DIFF
--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -11,6 +11,28 @@
 
 #include "cluster/controller_snapshot.h"
 
+#include "security/types.h"
+#include "serde/rw/rw.h"
+
+namespace serde {
+void tag_invoke(
+  tag_t<write_tag>,
+  iobuf& out,
+  cluster::controller_snapshot_parts::security_t::named_role t) {
+    write(out, std::move(t.name));
+    write(out, std::move(t.role));
+}
+
+void tag_invoke(
+  tag_t<read_tag>,
+  iobuf_parser& in,
+  cluster::controller_snapshot_parts::security_t::named_role& t,
+  std::size_t const bytes_left_limit) {
+    t.name = read_nested<security::role_name>(in, bytes_left_limit);
+    t.role = read_nested<security::role>(in, bytes_left_limit);
+}
+} // namespace serde
+
 namespace cluster {
 
 namespace controller_snapshot_parts {
@@ -157,6 +179,7 @@ topics_t::serde_async_read(iobuf_parser& in, serde::header const h) {
 ss::future<> security_t::serde_async_write(iobuf& out) {
     co_await write_vector_async(out, std::move(user_credentials));
     co_await write_vector_async(out, std::move(acls));
+    co_await write_vector_async(out, std::move(roles));
 }
 
 ss::future<>
@@ -165,6 +188,8 @@ security_t::serde_async_read(iobuf_parser& in, serde::header const h) {
       = co_await read_vector_async_nested<decltype(user_credentials)>(
         in, h._bytes_left_limit);
     acls = co_await read_vector_async_nested<decltype(acls)>(
+      in, h._bytes_left_limit);
+    roles = co_await read_vector_async_nested<decltype(roles)>(
       in, h._bytes_left_limit);
 
     if (in.bytes_left() > h._bytes_left_limit) {

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -16,6 +16,8 @@
 #include "container/chunked_hash_map.h"
 #include "container/fragmented_vector.h"
 #include "features/feature_table_snapshot.h"
+#include "security/role.h"
+#include "security/types.h"
 #include "serde/envelope.h"
 
 #include <absl/container/btree_map.h>
@@ -196,6 +198,11 @@ struct security_t
       envelope<security_t, serde::version<0>, serde::compat_version<0>> {
     fragmented_vector<user_and_credential> user_credentials;
     fragmented_vector<security::acl_binding> acls;
+    struct named_role {
+        security::role_name name;
+        security::role role;
+    };
+    chunked_vector<named_role> roles;
 
     friend bool operator==(const security_t&, const security_t&) = default;
 


### PR DESCRIPTION
 Enable the role store to survive controller snapshot

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none

