### PR TITLE
cluster: avoid throwing on duplicate recovery

### DIFF
--- a/src/v/cluster/bootstrap_backend.cc
+++ b/src/v/cluster/bootstrap_backend.cc
@@ -204,7 +204,16 @@ bootstrap_backend::apply(bootstrap_cluster_cmd cmd, model::offset offset) {
            m = cmd.value.recovery_state->manifest,
            b = cmd.value.recovery_state->bucket](auto& recovery_table) {
               auto ec = recovery_table.apply(o, m, b, wait_for_nodes::yes);
-              if (ec) {
+              // We don't expect this since recoveries can only be initialized
+              // at or after bootstrap time, but be conservative and handle
+              // possible error codes.
+              if (ec == errc::update_in_progress) {
+                  vlog(
+                    clusterlog.error,
+                    "Failed to apply recovery state: {} ({})",
+                    ec.message(),
+                    ec);
+              } else if (ec) {
                   throw std::runtime_error(fmt_with_ctx(
                     fmt::format,
                     "Failed to apply recovery state: {} ({})",


### PR DESCRIPTION
This adds a conservative check for in-progress recoveries at bootstrap time: if a recovery is in progress, we will log an error message instead of throwing.

In practice we don't expect this error code to be hit, but in case of a bug or somesuch, this seems preferable over throwing and blocking applying controller messages.

Note that update_in_progress is the only error code to come out of cluster_recovery_table::apply().

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
