### PR TITLE
[v23.3.x] use chunked vector as batches cache in `raft::replicate_batcher`

### DIFF
--- a/src/v/model/record_batch_reader.h
+++ b/src/v/model/record_batch_reader.h
@@ -274,6 +274,9 @@ record_batch_reader
 record_batch_reader make_fragmented_memory_record_batch_reader(
   fragmented_vector<model::record_batch>);
 
+record_batch_reader make_fragmented_memory_record_batch_reader(
+  chunked_vector<model::record_batch>);
+
 inline record_batch_reader
 make_memory_record_batch_reader(model::record_batch b) {
     record_batch_reader::data_t batches;
@@ -319,6 +322,9 @@ record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   fragmented_vector<model::record_batch>);
 
 record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
+  chunked_vector<model::record_batch>);
+
+record_batch_reader make_foreign_fragmented_memory_record_batch_reader(
   ss::chunked_fifo<model::record_batch>);
 
 record_batch_reader make_fragmented_memory_record_batch_reader(
@@ -333,6 +339,10 @@ ss::future<record_batch_reader::data_t> consume_reader_to_memory(
 ss::future<fragmented_vector<model::record_batch>>
 consume_reader_to_fragmented_memory(
   record_batch_reader, timeout_clock::time_point timeout);
+
+ss::future<chunked_vector<model::record_batch>>
+consume_reader_to_chunked_vector(
+  record_batch_reader reader, timeout_clock::time_point timeout);
 
 /// \brief wraps a reader into a foreign_ptr<unique_ptr>
 record_batch_reader make_foreign_record_batch_reader(record_batch_reader&&);

--- a/src/v/raft/replicate_batcher.h
+++ b/src/v/raft/replicate_batcher.h
@@ -16,6 +16,7 @@
 #include "raft/types.h"
 #include "ssx/semaphore.h"
 #include "units.h"
+#include "utils/fragmented_vector.h"
 #include "utils/mutex.h"
 
 #include <seastar/core/gate.hh>
@@ -30,7 +31,7 @@ public:
     public:
         item(
           size_t record_count,
-          std::vector<model::record_batch> batches,
+          chunked_vector<model::record_batch> batches,
           ssx::semaphore_units u,
           std::optional<model::term_id> expected_term,
           consistency_level c_lvl,
@@ -97,7 +98,7 @@ public:
             }
         }
         size_t _record_count;
-        std::vector<model::record_batch> _data;
+        chunked_vector<model::record_batch> _data;
         ssx::semaphore_units _units;
         std::optional<model::term_id> _expected_term;
         // consistency level is stored to distinguish when an item promise
@@ -146,7 +147,7 @@ private:
 
     ss::future<replicate_batcher::item_ptr> do_cache_with_backpressure(
       std::optional<model::term_id>,
-      ss::circular_buffer<model::record_batch>,
+      chunked_vector<model::record_batch>,
       size_t,
       consistency_level,
       std::optional<std::chrono::milliseconds>);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17425