### PR TITLE
CORE-2024: local storage probe for compacted away bytes `vectorized_storage_log_compaction_removed_bytes`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -773,6 +773,9 @@ ss::future<bool> disk_log_impl::sliding_window_compact(
 
         seg->mark_as_finished_windowed_compaction();
         _probe->segment_compacted();
+        _probe->add_compaction_removed_bytes(
+          ssize_t(size_before) - ssize_t(size_after));
+
         compaction_result res(size_before, size_after);
         _compaction_ratio.update(res.compaction_ratio());
         seg->advance_generation();

--- a/src/v/storage/probe.cc
+++ b/src/v/storage/probe.cc
@@ -157,6 +157,11 @@ void probe::setup_metrics(const model::ntp& ntp) {
           [this] { return _bytes_prefix_truncated; },
           sm::description("Number of bytes removed by prefix truncation."),
           labels),
+        sm::make_counter(
+          "compaction_removed_bytes",
+          [this] { return _compaction_removed_bytes; },
+          sm::description("Number of bytes removed by a compaction operation"),
+          labels),
       },
       {},
       {sm::shard_label, partition_label});

--- a/src/v/storage/probe.h
+++ b/src/v/storage/probe.h
@@ -86,6 +86,10 @@ public:
     void segment_compacted() { ++_segment_compacted; }
     auto get_segments_compacted() const { return _segment_compacted; }
 
+    void add_compaction_removed_bytes(ssize_t bytes) {
+        _compaction_removed_bytes += bytes;
+    }
+
     void batch_write_error(const std::exception_ptr& e) {
         stlog.error("Error writing record batch {}", e);
         ++_batch_write_errors;
@@ -136,6 +140,9 @@ private:
     uint32_t _batch_parse_errors = 0;
     uint32_t _batch_write_errors = 0;
     double _compaction_ratio = 1.0;
+
+    ssize_t _compaction_removed_bytes = 0;
+
     metrics::internal_metric_groups _metrics;
 };
 } // namespace storage

--- a/src/v/storage/segment_utils.cc
+++ b/src/v/storage/segment_utils.cc
@@ -714,6 +714,7 @@ ss::future<compaction_result> self_compact_segment(
         co_return compaction_result(sz_before);
     }
     pb.segment_compacted();
+    pb.add_compaction_removed_bytes(ssize_t(sz_before) - ssize_t(*sz_after));
     s->mark_as_finished_self_compaction();
     co_return compaction_result(sz_before, *sz_after);
 }


### PR DESCRIPTION
ntp metrics for compaction observability:

`vectorized_storage_log_compaction_removed_bytes`

a counter metric that hooks in `self_compact_segments()` `and sliding_window_compact()` to record `size_before - size_after` at each successful invocation. 

<!--
vectorized_ntp_archiver_compacted_away_cloud_bytes is a gauge metric updated inside ntp_archiver::upload_manifest after the manifest is observable in cloud storage.
The value is updated inside partition_manifest::add(segment_meta) when a new segment replaces a run of pre-existing segments, and the segment size is smaller than the replaced size.
The value is not serialized with the partition_manifest; it's only there for observability. 
The value will reset when the manifest is created or deserialized.
-->

Fixes https://github.com/redpanda-data/core-internal/issues/1232

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* new metric vectorized_storage_log_compacted_away_bytes for compaction observability in local storage