### PR TITLE
gha: lock to goreleaser v1.24.0

### DIFF
--- a/.github/workflows/lint-golang.yml
+++ b/.github/workflows/lint-golang.yml
@@ -55,4 +55,5 @@ jobs:
     - name: Check goreleaser configuration file
       uses: goreleaser/goreleaser-action@v5
       with:
+        version: v1.24.0
         args: check src/go/.goreleaser.yaml


### PR DESCRIPTION
latest goreleaser v1.25.0 deprecated things that need to be changed here and in vtools. this is a quick fix for now.

related: https://redpandadata.atlassian.net/browse/PLATENG-28

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none