### PR TITLE
[v23.3.x] k/group_manager: used chunked_vector when cleaning groups

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -2684,9 +2684,9 @@ ss::future<error_code> group::remove() {
     co_return error_code::none;
 }
 
-ss::future<>
-group::remove_topic_partitions(const std::vector<model::topic_partition>& tps) {
-    std::vector<std::pair<model::topic_partition, offset_metadata>> removed;
+ss::future<> group::remove_topic_partitions(
+  const chunked_vector<model::topic_partition>& tps) {
+    chunked_vector<std::pair<model::topic_partition, offset_metadata>> removed;
     for (const auto& tp : tps) {
         _pending_offset_commits.erase(tp);
         if (auto offset = _offsets.extract(tp); offset) {

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -28,6 +28,7 @@
 #include "model/record.h"
 #include "model/timestamp.h"
 #include "seastarx.h"
+#include "utils/fragmented_vector.h"
 #include "utils/mutex.h"
 #include "utils/rwlock.h"
 
@@ -644,7 +645,7 @@ public:
 
     // remove offsets associated with topic partitions
     ss::future<>
-    remove_topic_partitions(const std::vector<model::topic_partition>& tps);
+    remove_topic_partitions(const chunked_vector<model::topic_partition>& tps);
 
     const ss::lw_shared_ptr<cluster::partition> partition() const {
         return _partition;

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -34,6 +34,7 @@
 #include "raft/types.h"
 #include "resource_mgmt/io_priority.h"
 #include "ssx/future-util.h"
+#include "utils/fragmented_vector.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/coroutine.hh>
@@ -454,17 +455,17 @@ void group_manager::attach_partition(ss::lw_shared_ptr<cluster::partition> p) {
 }
 
 ss::future<> group_manager::cleanup_removed_topic_partitions(
-  const std::vector<model::topic_partition>& tps) {
+  const chunked_vector<model::topic_partition>& tps) {
     // operate on a light-weight copy of group pointers to avoid iterating over
     // the main index which is subject to concurrent modification.
-    std::vector<group_ptr> groups;
+    chunked_vector<group_ptr> groups;
     groups.reserve(_groups.size());
     for (auto& group : _groups) {
         groups.push_back(group.second);
     }
 
     return ss::do_with(
-      std::move(groups), [this, &tps](std::vector<group_ptr>& groups) {
+      std::move(groups), [this, &tps](chunked_vector<group_ptr>& groups) {
           return ss::do_for_each(groups, [this, &tps](group_ptr& group) {
               return group->remove_topic_partitions(tps).then(
                 [this, g = group] {
@@ -492,7 +493,7 @@ void group_manager::handle_topic_delta(
   cluster::topic_table::delta_range_t deltas) {
     // topic-partition deletions in the kafka namespace are the only deltas that
     // are relevant to the group manager
-    std::vector<model::topic_partition> tps;
+    chunked_vector<model::topic_partition> tps;
     for (const auto& delta : deltas) {
         if (
           delta.type == cluster::topic_table_delta_type::removed
@@ -511,7 +512,7 @@ void group_manager::handle_topic_delta(
           [this, tps = std::move(tps)]() mutable {
               return ss::do_with(
                 std::move(tps),
-                [this](const std::vector<model::topic_partition>& tps) {
+                [this](const chunked_vector<model::topic_partition>& tps) {
                     return cleanup_removed_topic_partitions(tps);
                 });
           })

--- a/src/v/kafka/server/group_manager.h
+++ b/src/v/kafka/server/group_manager.h
@@ -239,7 +239,7 @@ private:
     void handle_topic_delta(cluster::topic_table::delta_range_t);
 
     ss::future<> cleanup_removed_topic_partitions(
-      const std::vector<model::topic_partition>&);
+      const chunked_vector<model::topic_partition>&);
 
     ss::future<> handle_partition_leader_change(
       model::term_id,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/16920
Fixes: https://github.com/redpanda-data/redpanda/issues/17583,