### PR TITLE
[CORE-1198] cluster: cloud storage self test

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_debug.go
+++ b/src/go/rpk/pkg/adminapi/api_debug.go
@@ -56,6 +56,8 @@ type SelfTestNodeReport struct {
 	// If a status of idle is returned, the following `Results` variable will not
 	// be nil. In all other cases it will be nil.
 	Status string `json:"status"`
+	// One of { "idle", "net", "disk", "cloud" }
+	Stage string `json:"stage"`
 	// If value of `Status` is "idle", then this field will contain one result for
 	// each peer involved in the test. It represents the results of the last
 	// successful test run.

--- a/src/go/rpk/pkg/adminapi/api_debug.go
+++ b/src/go/rpk/pkg/adminapi/api_debug.go
@@ -18,11 +18,12 @@ import (
 )
 
 const (
-	debugEndpoint          = "/v1/debug"
-	selfTestEndpoint       = debugEndpoint + "/self_test"
-	cpuProfilerEndpoint    = debugEndpoint + "/cpu_profile"
-	DiskcheckTagIdentifier = "disk"
-	NetcheckTagIdentifier  = "network"
+	debugEndpoint           = "/v1/debug"
+	selfTestEndpoint        = debugEndpoint + "/self_test"
+	cpuProfilerEndpoint     = debugEndpoint + "/cpu_profile"
+	DiskcheckTagIdentifier  = "disk"
+	NetcheckTagIdentifier   = "network"
+	CloudcheckTagIdentifier = "cloud"
 )
 
 // A SelfTestNodeResult describes the results of a particular self-test run.
@@ -52,7 +53,6 @@ type SelfTestNodeResult struct {
 type SelfTestNodeReport struct {
 	NodeID int `json:"node_id"`
 	// One of { "idle", "running", "unreachable" }
-	//
 	// If a status of idle is returned, the following `Results` variable will not
 	// be nil. In all other cases it will be nil.
 	Status string `json:"status"`
@@ -94,6 +94,18 @@ type NetcheckParameters struct {
 	DurationMs uint `json:"duration_ms"`
 	// Number of fibers per shard used to make network requests
 	Parallelism uint `json:"parallelism"`
+	// Filled in automatically by the \ref StartSelfTest method
+	Type string `json:"type"`
+}
+
+// CloudcheckParameters describes what parameters redpanda will use when starting the netcheck benchmark.
+type CloudcheckParameters struct {
+	/// Descriptive name given to test run
+	Name string `json:"name"`
+	// Timeout duration of a network request
+	TimeoutMs uint `json:"timeout_ms"`
+	// Backoff duration of a network request
+	BackoffMs uint `json:"backoff_ms"`
 	// Filled in automatically by the \ref StartSelfTest method
 	Type string `json:"type"`
 }

--- a/src/go/rpk/pkg/cli/cluster/selftest/selftest_test.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/selftest_test.go
@@ -21,7 +21,7 @@ func TestClusterStatus(t *testing.T) {
 	for _, test := range []struct {
 		name            string
 		serverResponse  string
-		runningNodes    []int
+		runningNodes    map[int]string
 		isUninitialized bool
 	}{
 		{
@@ -29,18 +29,21 @@ func TestClusterStatus(t *testing.T) {
 			serverResponse: `[
                {
                  "node_id": 1,
-                 "status": "running"
+                 "status": "running",
+                 "stage": "disk"
                },
                {
                  "node_id": 0,
-                 "status": "running"
+                 "status": "running",
+                 "stage": "cloud"
                },
                {
                  "node_id": 2,
-                 "status": "running"
+                 "status": "running",
+                 "stage": "net"
                }
             ]`,
-			runningNodes:    []int{0, 1, 2},
+			runningNodes:    map[int]string{0: "cloud", 1: "disk", 2: "net"},
 			isUninitialized: false,
 		},
 		{
@@ -48,18 +51,21 @@ func TestClusterStatus(t *testing.T) {
 			serverResponse: `[
                {
                  "node_id": 1,
-                 "status": "running"
+                 "status": "running",
+                 "stage": "disk"
                },
                {
                  "node_id": 0,
-                 "status": "idle"
+                 "status": "idle",
+                 "stage": "idle"
                },
                {
                  "node_id": 2,
-                 "status": "idle"
+                 "status": "idle",
+                 "stage": "idle"
                }
             ]`,
-			runningNodes:    []int{1},
+			runningNodes:    map[int]string{1: "disk"},
 			isUninitialized: false,
 		},
 		{
@@ -67,18 +73,21 @@ func TestClusterStatus(t *testing.T) {
 			serverResponse: `[
                {
                  "node_id": 1,
-                 "status": "idle"
+                 "status": "idle",
+                 "stage": "idle"
                },
                {
                  "node_id": 0,
-                 "status": "idle"
+                 "status": "idle",
+                 "stage": "idle"
                },
                {
                  "node_id": 2,
-                 "status": "idle"
+                 "status": "idle",
+                 "stage": "idle"
                }
             ]`,
-			runningNodes:    []int{},
+			runningNodes:    map[int]string{},
 			isUninitialized: true,
 		},
 		{
@@ -87,18 +96,21 @@ func TestClusterStatus(t *testing.T) {
                {
                  "node_id": 1,
                  "status": "idle",
+                 "stage": "idle",
                  "results": [{}]
                },
                {
                  "node_id": 0,
-                 "status": "idle"
+                 "status": "idle",
+                 "stage": "idle"
                },
                {
                  "node_id": 2,
-                 "status": "idle"
+                 "status": "idle",
+                 "stage": "idle"
                }
             ]`,
-			runningNodes:    []int{},
+			runningNodes:    map[int]string{},
 			isUninitialized: false,
 		},
 	} {

--- a/src/go/rpk/pkg/cli/cluster/selftest/start.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/start.go
@@ -53,7 +53,11 @@ of the cluster. Available tests to run:
 
 * Cloud tests:
   * Latency test: 1024-bit object.
-    * Depending on read/write permissions, a series of cloud storage operations are performed.
+    * Depending on cluster read/write permissions (cloud_storage_enable_remote_read, cloud_storage_enable_remote_write), a series of cloud storage operations are performed:
+      * 1. Upload an object to an S3 bucket.
+      * 2. List objects in the bucket.
+      * 3. Download an object from the bucket.
+      * 4. Delete the original object from the bucket, if it was uploaded.
 
 
 This command immediately returns on success, and the tests run asynchronously. The

--- a/src/go/rpk/pkg/cli/cluster/selftest/status.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/status.go
@@ -72,7 +72,14 @@ the jobs launched. Possible results are:
 			// If there is outstanding work, indicate which nodes, then exit
 			running := runningNodes(reports)
 			if len(running) > 0 {
-				fmt.Printf("Nodes %v are still running jobs\n", running)
+				keys := make([]int, 0, len(running))
+				for k := range running {
+					keys = append(keys, k)
+				}
+				sort.Ints(keys)
+				for _, k := range keys {
+					fmt.Printf("Node %v is still running %v self test\n", k, running[k])
+				}
 				return
 			}
 
@@ -114,14 +121,13 @@ func rowDataAsInterface(row []string) []interface{} {
 	return iarr
 }
 
-func runningNodes(reports []adminapi.SelfTestNodeReport) []int {
-	running := []int{}
+func runningNodes(reports []adminapi.SelfTestNodeReport) map[int]string {
+	running := map[int]string{}
 	for _, report := range reports {
 		if report.Status == statusRunning {
-			running = append(running, report.NodeID)
+			running[report.NodeID] = report.Stage
 		}
 	}
-	sort.Ints(running)
 	return running
 }
 

--- a/src/v/cloud_storage/inventory/tests/common.h
+++ b/src/v/cloud_storage/inventory/tests/common.h
@@ -35,7 +35,8 @@ public:
        retry_chain_node&,
        std::optional<cloud_storage_clients::object_key>,
        std::optional<char>,
-       std::optional<cloud_storage_clients::client::item_filter>),
+       std::optional<cloud_storage_clients::client::item_filter>,
+       std::optional<size_t>),
       (override));
     MOCK_METHOD(
       ss::future<cloud_storage::download_result>,

--- a/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/fetch_report_tests.cc
@@ -53,6 +53,7 @@ void setup_and_validate_list_call(
         t::Ref(parent),
         t::Eq(list_prefix),
         t::Optional('/'),
+        t::Eq(std::nullopt),
         t::Eq(std::nullopt)))
       .Times(1)
       .WillOnce(

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -1348,7 +1348,8 @@ ss::future<remote::list_result> remote::list_objects(
   retry_chain_node& parent,
   std::optional<cloud_storage_clients::object_key> prefix,
   std::optional<char> delimiter,
-  std::optional<cloud_storage_clients::client::item_filter> item_filter) {
+  std::optional<cloud_storage_clients::client::item_filter> item_filter,
+  std::optional<size_t> max_keys) {
     ss::gate::holder gh{_gate};
     retry_chain_node fib(&parent);
     retry_chain_logger ctxlog(cst_log, fib);
@@ -1369,7 +1370,7 @@ ss::future<remote::list_result> remote::list_objects(
           bucket,
           prefix,
           std::nullopt,
-          std::nullopt,
+          max_keys,
           continuation_token,
           fib.get_timeout(),
           delimiter,

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -135,7 +135,8 @@ public:
       retry_chain_node&,
       std::optional<cloud_storage_clients::object_key> = std::nullopt,
       std::optional<char> = std::nullopt,
-      std::optional<cloud_storage_clients::client::item_filter> = std::nullopt)
+      std::optional<cloud_storage_clients::client::item_filter> = std::nullopt,
+      std::optional<size_t> = std::nullopt)
       = 0;
     virtual ss::future<download_result> object_exists(
       const cloud_storage_clients::bucket_name&,
@@ -455,7 +456,8 @@ public:
       std::optional<cloud_storage_clients::object_key> prefix = std::nullopt,
       std::optional<char> delimiter = std::nullopt,
       std::optional<cloud_storage_clients::client::item_filter> item_filter
-      = std::nullopt) override;
+      = std::nullopt,
+      std::optional<size_t> max_keys = std::nullopt) override;
 
     /// \brief Upload small objects to bucket. Suitable for uploading simple
     /// strings, does not check for leadership before upload like the segment

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -168,6 +168,7 @@ v_cc_library(
     self_test_frontend.cc
     self_test_rpc_handler.cc
     self_test_rpc_types.cc
+    self_test/cloudcheck.cc
     self_test/diskcheck.cc
     self_test/netcheck.cc
     bootstrap_service.cc

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -1,0 +1,407 @@
+/*
+ * Copyright 2023 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cluster/self_test/cloudcheck.h"
+
+#include "base/vlog.h"
+#include "cluster/logger.h"
+#include "config/configuration.h"
+#include "random/generators.h"
+#include "utils/uuid.h"
+
+#include <algorithm>
+
+namespace cluster::self_test {
+
+cloudcheck::cloudcheck(ss::sharded<cloud_storage::remote>& cloud_storage_api)
+  : _rtc(_as)
+  , _cloud_storage_api(cloud_storage_api) {}
+
+ss::future<> cloudcheck::start() { return ss::make_ready_future<>(); }
+
+ss::future<> cloudcheck::stop() {
+    _as.request_abort();
+    return _gate.close();
+}
+
+void cloudcheck::cancel() { _cancelled = true; }
+
+ss::future<std::vector<self_test_result>>
+cloudcheck::run(cloudcheck_opts opts) {
+    _cancelled = false;
+    _opts = std::move(opts);
+
+    if (_gate.is_closed()) {
+        vlog(clusterlog.debug, "cloudcheck - gate already closed");
+        auto result = self_test_result{
+          .name = _opts.name, .warning = "cloudcheck - gate already closed"};
+        co_return std::vector<self_test_result>{result};
+    }
+    auto g = _gate.hold();
+
+    vlog(
+      clusterlog.info,
+      "Starting redpanda self-test cloud benchmark, with options: {}",
+      opts);
+
+    const auto& cfg = config::shard_local_cfg();
+    if (!cfg.cloud_storage_enabled()) {
+        vlog(
+          clusterlog.warn,
+          "Cloud storage is not enabled, exiting cloud storage self-test.");
+        auto result = self_test_result{
+          .name = _opts.name, .warning = "Cloud storage is not enabled."};
+        co_return std::vector<self_test_result>{result};
+    }
+
+    if (!_cloud_storage_api.local_is_initialized()) {
+        vlog(
+          clusterlog.warn,
+          "_cloud_storage_api is not initialized, exiting cloud storage "
+          "self-test.");
+        auto result = self_test_result{
+          .name = _opts.name,
+          .warning = "cloud_storage_api is not initialized."};
+        co_return std::vector<self_test_result>{result};
+    }
+
+    _remote_read_enabled = cfg.cloud_storage_enable_remote_read();
+    _remote_write_enabled = cfg.cloud_storage_enable_remote_write();
+
+    co_return co_await ss::with_scheduling_group(
+      _opts.sg, [this]() mutable { return run_benchmarks(); });
+}
+
+ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
+    std::vector<self_test_result> results;
+
+    const auto bucket = cloud_storage_clients::bucket_name{
+      cloud_storage::configuration::get_bucket_config()().value()};
+
+    const auto self_test_prefix = cloud_storage_clients::object_key{
+      "self-test/"};
+
+    const auto uuid = cloud_storage_clients::object_key{
+      ss::sstring{uuid_t::create()}};
+    const auto self_test_key = cloud_storage_clients::object_key{
+      self_test_prefix / uuid};
+
+    const std::optional<iobuf> payload = (_remote_write_enabled)
+                                           ? make_random_payload()
+                                           : std::optional<iobuf>{};
+
+    // Test Upload
+    auto upload_test_result = co_await verify_upload(
+      bucket, self_test_key, payload);
+    const bool is_uploaded
+      = (!upload_test_result.warning && !upload_test_result.error);
+
+    results.push_back(std::move(upload_test_result));
+
+    // Test List
+    auto list_test_result_pair = co_await verify_list(bucket, self_test_prefix);
+    auto& [object_list, list_test_result] = list_test_result_pair;
+    if (is_uploaded && object_list) {
+        // Check that uploaded object exists in object_list contents.
+        auto& object_list_contents = object_list.value().contents;
+        auto payload_item_it = std::find_if(
+          object_list_contents.begin(),
+          object_list_contents.end(),
+          [self_test_key](const auto& item) {
+              return item.key == self_test_key();
+          });
+
+        if (payload_item_it == object_list_contents.end()) {
+            list_test_result.error = "Uploaded key/payload could not be found "
+                                     "in cloud storage item list.";
+        }
+    }
+
+    results.push_back(std::move(list_test_result));
+
+    // Test Download
+    // If we have uploaded our payload, we will attempt to get the written
+    // object. If we didn't, we will attempt to get the smallest object from the
+    // object list, if at least one exists.
+    auto get_min_object_key =
+      [&object_list]() -> std::optional<cloud_storage_clients::object_key> {
+        if (!object_list) {
+            return std::nullopt;
+        }
+
+        auto& object_list_contents = object_list.value().contents;
+        if (object_list_contents.empty()) {
+            return std::nullopt;
+        }
+
+        // Get the smallest file from object_list.
+        auto smallest_object = *std::min_element(
+          object_list_contents.begin(),
+          object_list_contents.end(),
+          [](const auto& a, const auto& b) {
+              return a.size_bytes < b.size_bytes;
+          });
+        return cloud_storage_clients::object_key{smallest_object.key};
+    };
+
+    const std::optional<cloud_storage_clients::object_key> download_key
+      = (is_uploaded) ? self_test_key : get_min_object_key();
+    auto download_test_result_pair = co_await verify_download(
+      bucket, download_key);
+    auto& [downloaded_object, download_test_result] = download_test_result_pair;
+    if (is_uploaded && downloaded_object) {
+        auto& downloaded_buf = downloaded_object.value();
+        if (downloaded_buf != payload.value()) {
+            download_test_result.error
+              = "Downloaded object differs from uploaded payload.";
+        }
+    }
+
+    results.push_back(std::move(download_test_result));
+
+    // Test Delete
+    auto delete_test_result = co_await verify_delete(bucket, self_test_key);
+    results.push_back(std::move(delete_test_result));
+
+    co_return results;
+}
+
+iobuf cloudcheck::make_random_payload(size_t size) const {
+    iobuf payload;
+    const auto random_data = random_generators::gen_alphanum_string(size);
+    payload.append(random_data.data(), size);
+    return payload;
+}
+
+cloud_storage::upload_request cloudcheck::make_upload_request(
+  const cloud_storage_clients::bucket_name& bucket,
+  const cloud_storage_clients::object_key& key,
+  iobuf payload,
+  retry_chain_node& rtc) {
+    cloud_storage::transfer_details transfer_details{
+      .bucket = bucket, .key = key, .parent_rtc = rtc};
+    cloud_storage::upload_request upload_request(
+      std::move(transfer_details),
+      cloud_storage::upload_type::object,
+      std::move(payload));
+    return upload_request;
+}
+
+cloud_storage::download_request cloudcheck::make_download_request(
+  const cloud_storage_clients::bucket_name& bucket,
+  const cloud_storage_clients::object_key& key,
+  iobuf& payload,
+  retry_chain_node& rtc) {
+    cloud_storage::transfer_details transfer_details{
+      .bucket = bucket, .key = key, .parent_rtc = rtc};
+    cloud_storage::download_request download_request(
+      std::move(transfer_details),
+      cloud_storage::download_type::object,
+      std::ref(payload));
+    return download_request;
+}
+
+ss::future<self_test_result> cloudcheck::verify_upload(
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage_clients::object_key key,
+  const std::optional<iobuf>& payload) {
+    auto result = self_test_result{
+      .name = _opts.name, .info = "upload", .test_type = "cloud_storage"};
+
+    if (_cancelled) {
+        result.warning = "Run was manually cancelled.";
+        co_return result;
+    }
+
+    if (!_remote_write_enabled) {
+        result.error = "Remote write is not enabled for this cluster.";
+        co_return result;
+    }
+
+    auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
+    cloud_storage::upload_request upload_request = make_upload_request(
+      bucket, key, payload.value().copy(), rtc);
+
+    const auto start = ss::lowres_clock::now();
+    try {
+        const cloud_storage::upload_result upload_result
+          = co_await _cloud_storage_api.local().upload_object(
+            std::move(upload_request));
+
+        switch (upload_result) {
+        case cloud_storage::upload_result::success:
+            break;
+        case cloud_storage::upload_result::timedout:
+            [[fallthrough]];
+        case cloud_storage::upload_result::failed:
+            [[fallthrough]];
+        case cloud_storage::upload_result::cancelled:
+            result.error = "Failed to upload to cloud storage.";
+            break;
+        }
+    } catch (const std::exception& e) {
+        result.error = e.what();
+    }
+
+    const auto end = ss::lowres_clock::now();
+    result.duration = end - start;
+
+    co_return result;
+}
+
+ss::future<std::pair<cloud_storage::remote::list_result, self_test_result>>
+cloudcheck::verify_list(
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage_clients::object_key prefix) {
+    auto result = self_test_result{
+      .name = _opts.name, .info = "list", .test_type = "cloud_storage"};
+
+    if (_cancelled) {
+        result.warning = "Run was manually cancelled.";
+        co_return std::make_pair(
+          cloud_storage_clients::error_outcome::fail, result);
+    }
+
+    if (!_remote_read_enabled) {
+        result.error = "Remote read is not enabled for this cluster.";
+        co_return std::make_pair(
+          cloud_storage_clients::error_outcome::fail, result);
+    }
+
+    auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
+
+    const auto start = ss::lowres_clock::now();
+    try {
+        static constexpr size_t max_keys = 10;
+        const cloud_storage::remote::list_result object_list
+          = co_await _cloud_storage_api.local().list_objects(
+            bucket, rtc, std::nullopt, std::nullopt, std::nullopt, max_keys);
+
+        if (!object_list) {
+            result.error = "Failed to list objects in cloud storage.";
+        }
+
+        co_return std::make_pair(std::move(object_list), std::move(result));
+    } catch (const std::exception& e) {
+        result.error = e.what();
+    }
+
+    const auto end = ss::lowres_clock::now();
+    result.duration = end - start;
+
+    co_return std::make_pair(
+      cloud_storage_clients::error_outcome::fail, std::move(result));
+}
+
+ss::future<std::pair<std::optional<iobuf>, self_test_result>>
+cloudcheck::verify_download(
+  cloud_storage_clients::bucket_name bucket,
+  std::optional<cloud_storage_clients::object_key> key) {
+    auto result = self_test_result{
+      .name = _opts.name, .info = "download", .test_type = "cloud_storage"};
+
+    if (_cancelled) {
+        result.warning = "Run was manually cancelled.";
+        co_return std::make_pair(std::nullopt, result);
+    }
+
+    if (!_remote_read_enabled) {
+        result.error = "Remote read is not enabled for this cluster.";
+        co_return std::make_pair(std::nullopt, result);
+    }
+
+    if (!key) {
+        result.warning = "Could not download from cloud storage (no file was "
+                         "found in the bucket).";
+        co_return std::make_pair(std::nullopt, result);
+    }
+
+    iobuf download_payload;
+    auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
+    cloud_storage::download_request download_request = make_download_request(
+      bucket, key.value(), std::ref(download_payload), rtc);
+
+    const auto start = ss::lowres_clock::now();
+    try {
+        const cloud_storage::download_result download_result
+          = co_await _cloud_storage_api.local().download_object(
+            std::move(download_request));
+
+        std::optional<iobuf> result_payload;
+        switch (download_result) {
+        case cloud_storage::download_result::success:
+            result_payload = std::move(download_payload);
+            break;
+        case cloud_storage::download_result::timedout:
+            [[fallthrough]];
+        case cloud_storage::download_result::failed:
+            [[fallthrough]];
+        case cloud_storage::download_result::notfound:
+            result.error = "Failed to download from cloud storage.";
+            break;
+        }
+
+        co_return std::make_pair(std::move(result_payload), std::move(result));
+    } catch (const std::exception& e) {
+        result.error = e.what();
+    }
+
+    const auto end = ss::lowres_clock::now();
+    result.duration = end - start;
+
+    co_return std::make_pair(std::nullopt, std::move(result));
+}
+
+ss::future<self_test_result> cloudcheck::verify_delete(
+  cloud_storage_clients::bucket_name bucket,
+  cloud_storage_clients::object_key key) {
+    auto result = self_test_result{
+      .name = _opts.name, .info = "delete", .test_type = "cloud_storage"};
+
+    if (_cancelled) {
+        result.warning = "Run was manually cancelled.";
+        co_return result;
+    }
+
+    if (!_remote_write_enabled) {
+        result.error = "Remote write is not enabled for this cluster.";
+        co_return result;
+    }
+
+    auto rtc = retry_chain_node(_opts.timeout, _opts.backoff, &_rtc);
+
+    const auto start = ss::lowres_clock::now();
+    try {
+        const cloud_storage::upload_result delete_result
+          = co_await _cloud_storage_api.local().delete_object(bucket, key, rtc);
+
+        switch (delete_result) {
+        case cloud_storage::upload_result::success:
+            break;
+        case cloud_storage::upload_result::timedout:
+            [[fallthrough]];
+        case cloud_storage::upload_result::failed:
+            [[fallthrough]];
+        case cloud_storage::upload_result::cancelled:
+            result.error = "Failed to delete from cloud storage.";
+            break;
+        }
+    } catch (const std::exception& e) {
+        result.error = e.what();
+    }
+
+    const auto end = ss::lowres_clock::now();
+    result.duration = end - start;
+
+    co_return result;
+}
+
+} // namespace cluster::self_test

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/types.h"
+#include "cluster/self_test/metrics.h"
+#include "cluster/self_test_rpc_types.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/gate.hh>
+
+#include <exception>
+#include <optional>
+#include <vector>
+
+namespace cluster::self_test {
+
+class cloudcheck_exception : public std::runtime_error {
+public:
+    explicit cloudcheck_exception(const std::string& msg)
+      : std::runtime_error(msg) {}
+};
+
+class cloudcheck {
+public:
+    cloudcheck(ss::sharded<cloud_storage::remote>& cloud_storage_api);
+
+    /// Initialize the benchmark
+    ss::future<> start();
+
+    /// Stops the benchmark
+    ss::future<> stop();
+
+    /// Sets member variables and runs the cloud benchmark.
+    ss::future<std::vector<self_test_result>> run(cloudcheck_opts opts);
+
+    /// Signal to stop all work as soon as possible
+    ///
+    /// Immediately returns, waiter can expect to wait on the results to be
+    /// returned by \run to be available shortly
+    void cancel();
+
+private:
+    // Invokes the various cloud storage operations for testing.
+    ss::future<std::vector<self_test_result>> run_benchmarks();
+
+    // Make a random payload to be uploaded to cloud storage, and to be verified
+    // once it is read back.
+    iobuf make_random_payload(size_t size = 1024) const;
+
+    // Generate an upload request.
+    cloud_storage::upload_request make_upload_request(
+      const cloud_storage_clients::bucket_name& bucket,
+      const cloud_storage_clients::object_key& key,
+      iobuf payload,
+      retry_chain_node& rtc);
+
+    // Generate a download request.
+    cloud_storage::download_request make_download_request(
+      const cloud_storage_clients::bucket_name& bucket,
+      const cloud_storage_clients::object_key& key,
+      iobuf& payload,
+      retry_chain_node& rtc);
+
+    // Verify that uploading (write operation) to cloud storage works.
+    ss::future<self_test_result> verify_upload(
+      cloud_storage_clients::bucket_name bucket,
+      cloud_storage_clients::object_key key,
+      const std::optional<iobuf>& payload);
+
+    // Verify that listing (read operation) from cloud storage works.
+    ss::future<std::pair<cloud_storage::remote::list_result, self_test_result>>
+    verify_list(
+      cloud_storage_clients::bucket_name bucket,
+      cloud_storage_clients::object_key prefix);
+
+    // Verify that downloading (read operation) from cloud storage works.
+    ss::future<std::pair<std::optional<iobuf>, self_test_result>>
+    verify_download(
+      cloud_storage_clients::bucket_name bucket,
+      std::optional<cloud_storage_clients::object_key> key);
+
+    // Verify that deleting (write operation) from cloud storage works.
+    ss::future<self_test_result> verify_delete(
+      cloud_storage_clients::bucket_name bucket,
+      cloud_storage_clients::object_key key);
+
+private:
+    bool _remote_read_enabled{false};
+    bool _remote_write_enabled{false};
+    bool _cancelled{false};
+    ss::abort_source _as;
+    ss::gate _gate;
+    retry_chain_node _rtc;
+    cloudcheck_opts _opts;
+
+private:
+    ss::sharded<cloud_storage::remote>& _cloud_storage_api;
+};
+
+} // namespace cluster::self_test

--- a/src/v/cluster/self_test/metrics.h
+++ b/src/v/cluster/self_test/metrics.h
@@ -70,14 +70,14 @@ public:
 
     self_test_result to_st_result() const {
         return self_test_result{
-          .p50 = (double)_hist.get_value_at(50.0),
-          .p90 = (double)_hist.get_value_at(90.0),
-          .p99 = (double)_hist.get_value_at(99.0),
-          .p999 = (double)_hist.get_value_at(99.9),
-          .max = (double)_hist.get_value_at(100.0),
+          .p50 = static_cast<double>(_hist.get_value_at(50.0)),
+          .p90 = static_cast<double>(_hist.get_value_at(90.0)),
+          .p99 = static_cast<double>(_hist.get_value_at(99.0)),
+          .p999 = static_cast<double>(_hist.get_value_at(99.9)),
+          .max = static_cast<double>(_hist.get_value_at(100.0)),
           .rps = iops(),
           .bps = throughput_bytes_sec(),
-          .timeouts = (uint32_t)_number_of_timeouts,
+          .timeouts = static_cast<uint32_t>(_number_of_timeouts),
           .duration = std::chrono::duration_cast<std::chrono::milliseconds>(
             _total_time)};
     }

--- a/src/v/cluster/self_test_backend.cc
+++ b/src/v/cluster/self_test_backend.cc
@@ -28,36 +28,45 @@ self_test_backend::self_test_backend(
   model::node_id self,
   ss::sharded<node::local_monitor>& nlm,
   ss::sharded<rpc::connection_cache>& connections,
+  ss::sharded<cloud_storage::remote>& cloud_storage_api,
   ss::scheduling_group sg)
   : _self(self)
   , _st_sg(sg)
   , _disk_test(nlm)
-  , _network_test(self, connections) {}
+  , _network_test(self, connections)
+  , _cloud_test(cloud_storage_api) {}
 
 ss::future<> self_test_backend::start() {
     co_await _disk_test.start();
     co_await _network_test.start();
+    co_await _cloud_test.start();
 }
 
 ss::future<> self_test_backend::stop() {
     auto f = _gate.close();
     co_await _disk_test.stop();
     co_await _network_test.stop();
+    co_await _cloud_test.stop();
     co_await _lock.get_units(); /// Ensure outstanding work is completed
     co_await std::move(f);
 }
 
 ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
-  std::vector<diskcheck_opts> dtos, std::vector<netcheck_opts> ntos) {
+  std::vector<diskcheck_opts> dtos,
+  std::vector<netcheck_opts> ntos,
+  std::vector<cloudcheck_opts> ctos) {
     auto gate_holder = _gate.hold();
     std::vector<self_test_result> results;
+
     for (auto& dto : dtos) {
         try {
             dto.sg = _st_sg;
             if (!_cancelling) {
-                auto dtr = co_await _disk_test.run(dto).then(
-                  [](auto result) { return result; });
-                std::copy(dtr.begin(), dtr.end(), std::back_inserter(results));
+                auto dtr = co_await _disk_test.run(dto);
+                results.insert(
+                  results.end(),
+                  std::make_move_iterator(dtr.begin()),
+                  std::make_move_iterator(dtr.end()));
             } else {
                 results.push_back(self_test_result{
                   .name = dto.name,
@@ -75,15 +84,17 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
               .name = dto.name, .test_type = "disk", .error = ex.what()});
         }
     }
+
     for (auto& nto : ntos) {
         try {
             if (!nto.peers.empty()) {
                 nto.sg = _st_sg;
                 if (!_cancelling) {
-                    auto ntr = co_await _network_test.run(nto).then(
-                      [](auto results) { return results; });
-                    std::copy(
-                      ntr.begin(), ntr.end(), std::back_inserter(results));
+                    auto ntr = co_await _network_test.run(nto);
+                    results.insert(
+                      results.end(),
+                      std::make_move_iterator(ntr.begin()),
+                      std::make_move_iterator(ntr.end()));
                 } else {
                     results.push_back(self_test_result{
                       .name = nto.name,
@@ -108,6 +119,34 @@ ss::future<std::vector<self_test_result>> self_test_backend::do_start_test(
               .name = nto.name, .test_type = "network", .error = ex.what()});
         }
     }
+
+    for (auto& cto : ctos) {
+        try {
+            cto.sg = _st_sg;
+            if (!_cancelling) {
+                auto ctr = co_await _cloud_test.run(cto);
+                results.insert(
+                  results.end(),
+                  std::make_move_iterator(ctr.begin()),
+                  std::make_move_iterator(ctr.end()));
+            } else {
+                results.push_back(self_test_result{
+                  .name = cto.name,
+                  .test_type = "cloud",
+                  .warning = "Cloud self test prevented from starting due to "
+                             "cancel signal"});
+            }
+        } catch (const std::exception& ex) {
+            vlog(
+              clusterlog.error,
+              "Cloud self test finished with error: {} - options: {}",
+              ex.what(),
+              cto);
+            results.push_back(self_test_result{
+              .name = cto.name, .test_type = "cloud", .error = ex.what()});
+        }
+    }
+
     co_return results;
 }
 
@@ -120,7 +159,10 @@ get_status_response self_test_backend::start_test(start_test_request req) {
           clusterlog.debug, "Request to start self-tests with id: {}", req.id);
         ssx::background
           = ssx::spawn_with_gate_then(_gate, [this, req = std::move(req)]() {
-                return do_start_test(req.dtos, req.ntos)
+                return do_start_test(
+                         std::move(req.dtos),
+                         std::move(req.ntos),
+                         std::move(req.ctos))
                   .then([this, id = req.id](auto results) {
                       for (auto& r : results) {
                           r.test_id = id;
@@ -148,6 +190,7 @@ ss::future<get_status_response> self_test_backend::stop_test() {
     _cancelling = true;
     _disk_test.cancel();
     _network_test.cancel();
+    _cloud_test.cancel();
     try {
         /// When lock is released, the 'then' block above will set the _prev_run
         /// var with the finalized test results from the cancelled run.

--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -90,13 +90,15 @@ private:
 private:
     // cached values
     uuid_t _id{};
-    get_status_response _prev_run{.status = self_test_status::idle};
+    get_status_response _prev_run{
+      .status = self_test_status::idle, .stage = self_test_stage::idle};
     previous_netcheck_entity _prev_nc;
 
     model::node_id _self;
     ss::gate _gate;
     ss::scheduling_group _st_sg;
     bool _cancelling{false};
+    self_test_stage _stage{self_test_stage::idle};
     mutex _lock{"self_test"};
     self_test::diskcheck _disk_test;
     self_test::netcheck _network_test;

--- a/src/v/cluster/self_test_backend.h
+++ b/src/v/cluster/self_test_backend.h
@@ -10,8 +10,10 @@
  */
 #pragma once
 
+#include "cloud_storage/remote.h"
 #include "cluster/node/local_monitor.h"
 #include "rpc/connection_cache.h"
+#include "self_test/cloudcheck.h"
 #include "self_test/diskcheck.h"
 #include "self_test/netcheck.h"
 #include "self_test_rpc_types.h"
@@ -38,6 +40,7 @@ public:
       model::node_id self,
       ss::sharded<node::local_monitor>& nlm,
       ss::sharded<rpc::connection_cache>& connections,
+      ss::sharded<cloud_storage::remote>& cloud_storage_api,
       ss::scheduling_group sg);
 
     ss::future<> start();
@@ -74,7 +77,9 @@ public:
 
 private:
     ss::future<std::vector<self_test_result>> do_start_test(
-      std::vector<diskcheck_opts> dtos, std::vector<netcheck_opts> ntos);
+      std::vector<diskcheck_opts> dtos,
+      std::vector<netcheck_opts> ntos,
+      std::vector<cloudcheck_opts> ctos);
 
     struct previous_netcheck_entity {
         static const inline model::node_id unassigned{-1};
@@ -95,5 +100,6 @@ private:
     mutex _lock{"self_test"};
     self_test::diskcheck _disk_test;
     self_test::netcheck _network_test;
+    self_test::cloudcheck _cloud_test;
 };
 } // namespace cluster

--- a/src/v/cluster/self_test_frontend.cc
+++ b/src/v/cluster/self_test_frontend.cc
@@ -133,7 +133,7 @@ ss::future<uuid_t> self_test_frontend::start_test(
     if (ids.empty()) {
         throw self_test_exception("No node ids provided");
     }
-    if (req.dtos.empty() && req.ntos.empty()) {
+    if (req.dtos.empty() && req.ntos.empty() && req.ctos.empty()) {
         throw self_test_exception("No tests specified to run");
     }
     /// Validate input
@@ -185,7 +185,10 @@ ss::future<uuid_t> self_test_frontend::start_test(
               }
           }
           return handle->start_test(start_test_request{
-            .id = test_id, .dtos = req.dtos, .ntos = new_ntos});
+            .id = test_id,
+            .dtos = std::move(req.dtos),
+            .ntos = std::move(new_ntos),
+            .ctos = std::move(req.ctos)});
       });
     co_return test_id;
 }

--- a/src/v/cluster/self_test_frontend.cc
+++ b/src/v/cluster/self_test_frontend.cc
@@ -43,6 +43,13 @@ self_test_status self_test_frontend::node_test_state::status() const {
     return response->status;
 }
 
+self_test_stage self_test_frontend::node_test_state::stage() const {
+    if (!response) {
+        return self_test_stage::idle;
+    }
+    return response->stage;
+}
+
 self_test_frontend::global_test_state::global_test_state(
   std::vector<underlying_t::value_type>&& rs)
   : _participants(rs.begin(), rs.end()) {}

--- a/src/v/cluster/self_test_frontend.h
+++ b/src/v/cluster/self_test_frontend.h
@@ -36,6 +36,7 @@ public:
     struct node_test_state {
         std::optional<get_status_response> response;
         self_test_status status() const;
+        self_test_stage stage() const;
     };
 
     /// Holds reported self_test results aquired from all brokers in a test

--- a/src/v/cluster/self_test_rpc_types.cc
+++ b/src/v/cluster/self_test_rpc_types.cc
@@ -35,6 +35,24 @@ std::ostream& operator<<(std::ostream& o, self_test_status sts) {
     return o;
 }
 
+ss::sstring self_test_stage_as_string(self_test_stage sts) {
+    switch (sts) {
+    case self_test_stage::idle:
+        return "idle";
+    case self_test_stage::disk:
+        return "disk";
+    case self_test_stage::net:
+        return "net";
+    case self_test_stage::cloud:
+        return "cloud";
+    }
+}
+
+std::ostream& operator<<(std::ostream& o, self_test_stage sts) {
+    fmt::print(o, "{}", self_test_stage_as_string(sts));
+    return o;
+}
+
 ss::future<cluster::netcheck_request>
 make_netcheck_request(model::node_id src, size_t sz) {
     static const size_t fragment_size = 8192;

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -191,7 +191,7 @@ struct cloudcheck_opts
     // Backoff duration for cloud storage requests.
     ss::lowres_clock::duration backoff{std::chrono::milliseconds(10)};
 
-    // Scheduling group that the benchmark will operate under
+    // Scheduling group that the benchmark will operate under.
     ss::scheduling_group sg;
 
     static cloudcheck_opts from_json(const json::Value& obj) {
@@ -321,7 +321,7 @@ struct get_status_response
     operator<<(std::ostream& o, const get_status_response& r) {
         fmt::print(
           o,
-          "{{id: {} status:{} test_results: {}}}",
+          "{{id: {} status: {} test_results: {}}}",
           r.id,
           r.status,
           r.results);

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -28,6 +28,12 @@ ss::sstring self_test_status_as_string(self_test_status sts);
 
 std::ostream& operator<<(std::ostream& o, self_test_status sts);
 
+enum class self_test_stage : int8_t { idle = 0, disk, net, cloud };
+
+ss::sstring self_test_stage_as_string(self_test_stage sts);
+
+std::ostream& operator<<(std::ostream& o, self_test_stage sts);
+
 struct diskcheck_opts
   : serde::
       envelope<diskcheck_opts, serde::version<0>, serde::compat_version<0>> {
@@ -315,15 +321,17 @@ struct get_status_response
 
     uuid_t id{};
     self_test_status status{};
+    self_test_stage stage{};
     std::vector<self_test_result> results;
 
     friend std::ostream&
     operator<<(std::ostream& o, const get_status_response& r) {
         fmt::print(
           o,
-          "{{id: {} status: {} test_results: {}}}",
+          "{{id: {} status: {} stage: {} test_results: {}}}",
           r.id,
           r.status,
+          r.stage,
           r.results);
         return o;
     }

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -179,6 +179,52 @@ struct netcheck_opts
     }
 };
 
+struct cloudcheck_opts
+  : serde::
+      envelope<cloudcheck_opts, serde::version<0>, serde::compat_version<0>> {
+    // Descriptive name given to test run
+    ss::sstring name{"Cloud credentials check"};
+
+    // Timeout duration for cloud storage requests.
+    ss::lowres_clock::duration timeout{std::chrono::milliseconds(5000)};
+
+    // Backoff duration for cloud storage requests.
+    ss::lowres_clock::duration backoff{std::chrono::milliseconds(10)};
+
+    // Scheduling group that the benchmark will operate under
+    ss::scheduling_group sg;
+
+    static cloudcheck_opts from_json(const json::Value& obj) {
+        // The application using these parameters will perform any validation
+        cloudcheck_opts opts;
+        if (obj.HasMember("name")) {
+            opts.name = obj["name"].GetString();
+        }
+        if (obj.HasMember("timeout_ms")) {
+            opts.timeout = std::chrono::milliseconds(
+              obj["timeout_ms"].GetInt());
+        }
+        if (obj.HasMember("backoff_ms")) {
+            opts.backoff = std::chrono::milliseconds(
+              obj["backoff_ms"].GetInt());
+        }
+        return opts;
+    }
+
+    auto serde_fields() { return std::tie(name, timeout, backoff); }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const cloudcheck_opts& opts) {
+        fmt::print(
+          o,
+          "{{name: {} timeout: {} backoff: {}}}",
+          opts.name,
+          opts.timeout,
+          opts.backoff);
+        return o;
+    }
+};
+
 struct self_test_result
   : serde::
       envelope<self_test_result, serde::version<0>, serde::compat_version<0>> {
@@ -241,15 +287,19 @@ struct start_test_request
     uuid_t id;
     std::vector<diskcheck_opts> dtos;
     std::vector<netcheck_opts> ntos;
+    std::vector<cloudcheck_opts> ctos;
 
     friend std::ostream&
     operator<<(std::ostream& o, const start_test_request& r) {
         std::stringstream ss;
-        for (auto& v : r.dtos) {
+        for (const auto& v : r.dtos) {
             fmt::print(ss, "diskcheck_opts: {}", v);
         }
-        for (auto& v : r.ntos) {
+        for (const auto& v : r.ntos) {
             fmt::print(ss, "netcheck_opts: {}", v);
+        }
+        for (const auto& v : r.ctos) {
+            fmt::print(ss, "cloudcheck_opts: {}", v);
         }
         fmt::print(o, "{{id: {} {}}}", r.id, ss.str());
         return o;

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -857,6 +857,10 @@
                     "type": "string",
                     "description": "One of either idle / running / unreachable"
                 },
+                "stage": {
+                    "type": "string",
+                    "description": "One of either idle / net / disk / cloud"
+                },
                 "results": {
                     "type": "array",
                     "items": {

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -829,7 +829,7 @@
                 },
                 "test_type": {
                     "type": "string",
-                    "description": "Type of self test, one of either disk/network"
+                    "description": "Type of self test, one of either disk/network/cloud"
                 },
                 "duration": {
                     "type": "long",

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2851,6 +2851,7 @@ admin_server::self_test_get_results_handler(
         dbg_ns::self_test_node_report nr;
         nr.node_id = id;
         nr.status = cluster::self_test_status_as_string(participant.status());
+        nr.stage = cluster::self_test_stage_as_string(participant.stage());
         if (participant.response) {
             for (const auto& r : participant.response->results) {
                 nr.results.push(self_test_result_to_json(r));

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2757,10 +2757,12 @@ admin_server::self_test_start_handler(std::unique_ptr<ss::http::request> req) {
                     r.dtos.push_back(cluster::diskcheck_opts::from_json(obj));
                 } else if (test_type == "network") {
                     r.ntos.push_back(cluster::netcheck_opts::from_json(obj));
+                } else if (test_type == "cloud") {
+                    r.ctos.push_back(cluster::cloudcheck_opts::from_json(obj));
                 } else {
                     throw ss::httpd::bad_param_exception(
-                      "Unknown self_test 'type', valid options are 'disk' or "
-                      "'network'");
+                      "Unknown self_test 'type', valid options are 'disk', "
+                      "'network', or 'cloud'.");
                 }
             }
         } else {
@@ -2768,6 +2770,7 @@ admin_server::self_test_start_handler(std::unique_ptr<ss::http::request> req) {
             /// default arguments
             r.dtos.push_back(cluster::diskcheck_opts{});
             r.ntos.push_back(cluster::netcheck_opts{});
+            r.ctos.push_back(cluster::cloudcheck_opts{});
         }
     }
     try {

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1604,6 +1604,7 @@ void application::wire_up_redpanda_services(
       node_id,
       std::ref(local_monitor),
       std::ref(_connection_cache),
+      std::ref(cloud_storage_api),
       sched_groups.self_test_sg())
       .get();
 

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -961,8 +961,11 @@ class RpkTool:
     def self_test_start(self,
                         disk_duration_ms=None,
                         network_duration_ms=None,
+                        cloud_timeout_ms=None,
+                        cloud_backoff_ms=None,
                         only_disk=False,
                         only_network=False,
+                        only_cloud=False,
                         node_ids=None):
         cmd = [
             self._rpk_binary(), '--api-urls',
@@ -972,10 +975,16 @@ class RpkTool:
             cmd += ['--disk-duration-ms', str(disk_duration_ms)]
         if network_duration_ms is not None:
             cmd += ['--network-duration-ms', str(network_duration_ms)]
+        if cloud_timeout_ms is not None:
+            cmd += ['--cloud-timeout-ms', str(cloud_timeout_ms)]
+        if cloud_backoff_ms is not None:
+            cmd += ['--cloud-backoff-ms', str(cloud_backoff_ms)]
         if only_disk is True:
             cmd += ['--only-disk-test']
         if only_network is True:
             cmd += ['--only-network-test']
+        if only_cloud is True:
+            cmd += ['--only-cloud-test']
         if node_ids is not None:
             ids = ",".join([str(x) for x in node_ids])
             cmd += ['--participants-node-ids', ids]


### PR DESCRIPTION
Adds a cloud storage check to the cluster self test, as requested in #9225.
Depending on read/write permissions, the cloud storage test uses the `cloud_storage::remote` object configured at the application layer to:

- Upload an object to S3.
- List objects in a bucket.
- Download an object from the bucket.
- Delete the original object, if it was uploaded.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* A cloud storage check as part of the cluster's self test.

To run, use `rpk cluster self-test start`. The following flags have also been added to `rpk` for use with the cloud storage test:

- `--cloud-backoff-ms uint`, the backoff in milliseconds for a cloud storage request.
- `--cloud-timeout-ms uint`, the timeout in milliseconds for a cloud storage request.
- `--only-cloud-test`, in order to run only the cloud storage test.
