### PR TITLE
rpk: add `UpdateRoleMembership` to admin API client

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_security.go
+++ b/src/go/rpk/pkg/adminapi/api_security.go
@@ -109,10 +109,20 @@ func (a *AdminAPI) AssignRole(ctx context.Context, roleName string, add []RoleMe
 	return res, a.sendAny(ctx, http.MethodPost, fmt.Sprintf("%v/%v/members", baseRoleEndpoint, roleName), body, &res)
 }
 
-// UnassignRole unasigns the role 'roleName' from the passed members.
+// UnassignRole unassigns the role 'roleName' from the passed members.
 func (a *AdminAPI) UnassignRole(ctx context.Context, roleName string, remove []RoleMember) (PatchRoleResponse, error) {
 	var res PatchRoleResponse
 	body := patchRoleRequest{
+		Remove: remove,
+	}
+	return res, a.sendAny(ctx, http.MethodPost, fmt.Sprintf("%v/%v/members", baseRoleEndpoint, roleName), body, &res)
+}
+
+// UpdateRoleMembership updates the role membership for 'roleName' adding and removing the passed members.
+func (a *AdminAPI) UpdateRoleMembership(ctx context.Context, roleName string, add, remove []RoleMember) (PatchRoleResponse, error) {
+	var res PatchRoleResponse
+	body := patchRoleRequest{
+		Add:    add,
 		Remove: remove,
 	}
 	return res, a.sendAny(ctx, http.MethodPost, fmt.Sprintf("%v/%v/members", baseRoleEndpoint, roleName), body, &res)


### PR DESCRIPTION
This commit includes a new function
`UpdateRoleMembership` to admin API client that
can be used to add and remove principals to a
role in a single operation.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Adds `UpdateRoleMembership` function to rpk admin API client.

