### PR TITLE
transforms: fix offset at deploy time

### DIFF
--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -19,6 +19,7 @@
 #include "utils/vint.h"
 
 #include <seastar/core/print.hh>
+#include <seastar/util/variant_utils.hh>
 
 #include <algorithm>
 #include <optional>
@@ -71,6 +72,19 @@ void append_vint_to_iobuf(iobuf& b, int64_t v) {
 }
 
 } // namespace
+
+std::ostream&
+operator<<(std::ostream& os, const transform_offset_options& opts) {
+    ss::visit(
+      opts.position,
+      [&os](transform_offset_options::latest_offset) {
+          fmt::print(os, "{{ latest_offset }}");
+      },
+      [&os](model::timestamp ts) {
+          fmt::print(os, "{{ timequery: {} }}", ts.value());
+      });
+    return os;
+}
 
 std::ostream& operator<<(std::ostream& os, const transform_metadata& meta) {
     fmt::print(

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -222,10 +222,12 @@ admin_server::deploy_transform(std::unique_ptr<ss::http::request> req) {
 
     // Now do the deploy!
     std::error_code ec = co_await _transform_service->local().deploy_transform(
-      {.name = name,
-       .input_topic = input_nt,
-       .output_topics = output_topics,
-       .environment = std::move(env)},
+      {
+        .name = name,
+        .input_topic = input_nt,
+        .output_topics = output_topics,
+        .environment = std::move(env),
+      },
       std::move(body));
 
     co_await throw_on_error(*req, ec, model::controller_ntp);

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -54,6 +54,13 @@ public:
     virtual kafka::offset latest_offset() = 0;
 
     /**
+     * The offset of a record the log for a given timestamp - if the log is
+     * empty then `kafka::offset::min()` is returned.
+     */
+    virtual ss::future<kafka::offset>
+    offset_at_timestamp(model::timestamp, ss::abort_source*) = 0;
+
+    /**
      * Read from the log starting at a given offset, aborting when requested.
      *
      * NOTE: It's important in terms of lifetimes that the source **always**

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -13,6 +13,7 @@
 
 #include "model/record.h"
 #include "model/tests/randoms.h"
+#include "model/timestamp.h"
 #include "model/transform.h"
 #include "ssx/semaphore.h"
 #include "transform/io.h"
@@ -76,6 +77,8 @@ public:
     ss::future<> start() override;
     ss::future<> stop() override;
     kafka::offset latest_offset() override;
+    ss::future<kafka::offset>
+    offset_at_timestamp(model::timestamp, ss::abort_source*) override;
     ss::future<model::record_batch_reader>
     read_batch(kafka::offset offset, ss::abort_source* as) override;
 

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -194,8 +194,9 @@ ss::future<> processor::poll_sleep() {
     try {
         co_await ss::sleep_abortable<ss::lowres_clock>(
           jitter.next_duration(), _as);
-    } catch (const ss::sleep_aborted&) {
+    } catch (const ss::sleep_aborted& ex) {
         // do nothing, the caller will handle exiting properly.
+        std::ignore = ex;
     }
 }
 

--- a/src/v/transform/transform_processor.cc
+++ b/src/v/transform/transform_processor.cc
@@ -205,14 +205,34 @@ processor::load_latest_committed() {
     co_await _offset_tracker->wait_for_previous_flushes(&_as);
     auto latest_committed = co_await _offset_tracker->load_committed_offsets();
     auto latest = _source->latest_offset();
+    std::optional<kafka::offset> initial_offset;
     for (const auto& [_, output] : _outputs) {
         auto it = latest_committed.find(output.index);
         if (it == latest_committed.end()) {
-            // If we have never committed, mark the end of the log as our
-            // starting place, and start processing from the next record that is
-            // produced.
-            co_await _offset_tracker->commit_offset(output.index, latest);
-            latest_committed[output.index] = latest;
+            // If we have never committed, determine where we need to start
+            // processing log records, from the end or at a specific timestamp.
+            if (!initial_offset) {
+                initial_offset = co_await ss::visit(
+                  _meta.offset_options.position,
+                  [this,
+                   &latest](model::transform_offset_options::latest_offset) {
+                      vlog(_logger.debug, "starting at latest: {}", latest);
+                      return ssx::now(latest);
+                  },
+                  [this](model::timestamp ts) {
+                      vlog(_logger.debug, "starting at timestamp: {}", ts);
+                      // We want to *start at* this timestamp, so record that
+                      // we're going to commit progress at the offset before, so
+                      // we start inclusive of this offset.
+                      return _source->offset_at_timestamp(ts, &_as).then(
+                        kafka::prev_offset);
+                  });
+                vlog(
+                  _logger.debug, "resolved start offset: {}", *initial_offset);
+            }
+            co_await _offset_tracker->commit_offset(
+              output.index, *initial_offset);
+            latest_committed[output.index] = *initial_offset;
             continue;
         }
         // The latest record is inclusive of the last record, so we want to

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -57,7 +57,8 @@ class BaseDataTransformsTest(RedpandaTest):
                      name: str,
                      input_topic: TopicSpec,
                      output_topic: TopicSpec | list[TopicSpec],
-                     file="tinygo/identity.wasm"):
+                     file="tinygo/identity.wasm",
+                     wait_running=True):
         """
         Deploy a wasm transform and wait for all processors to be running.
         """
@@ -78,6 +79,9 @@ class BaseDataTransformsTest(RedpandaTest):
             err_msg=f"unable to deploy wasm transform {name}",
             retry_on_exc=True,
         )
+
+        if not wait_running:
+            return
 
         def is_all_running():
             transforms = self._rpk.list_wasm()
@@ -236,8 +240,8 @@ class DataTransformsTest(BaseDataTransformsTest):
     topics = [TopicSpec(partition_count=9), TopicSpec(partition_count=9)]
 
     @cluster(num_nodes=4)
-    @matrix(transactional=[False, True])
-    def test_identity(self, transactional):
+    @matrix(transactional=[False, True], wait_running=[False, True])
+    def test_identity(self, transactional, wait_running):
         """
         Test that a transform that only copies records from the input to the output topic works as intended.
         """
@@ -245,7 +249,8 @@ class DataTransformsTest(BaseDataTransformsTest):
         output_topic = self.topics[1]
         self._deploy_wasm(name="identity-xform",
                           input_topic=input_topic,
-                          output_topic=output_topic)
+                          output_topic=output_topic,
+                          wait_running=wait_running)
         producer_status = self._produce_input_topic(
             topic=self.topics[0], transactional=transactional)
         consumer_status = self._consume_output_topic(topic=self.topics[1],


### PR DESCRIPTION
This makes testing transforms easier as the offset that we start from is relative to the deploy and not when the VM starts. This means you can do:

```
rpk transform deploy
rpk topic produce input-topic
rpk topic consume output-topic
```

Without dropping records (there is a 3 second injected delay between deploy and processor start, so today everything in the first 3 seconds is dropped).

Ducktape tests will be written in a followup.

Fixes: CORE-1927, https://github.com/redpanda-data/redpanda/issues/17370

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Transforms now start at a record relative to the deploy time instead of the time at which the VM starts.
  This allows for easier testing of transforms, as one does not have to wait for the VM to boot before producing.

