### PR TITLE
wasm: check schema registry ABI

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1149,8 +1149,13 @@ ss::future<> admin_server::throw_on_error(
         case wasm::errc::invalid_module_missing_abi:
             throw ss::httpd::bad_request_exception(
               "Invalid WebAssembly - the binary is missing required transform "
-              "functions. Does the broker support this version of the Data "
-              "Transforms SDK?");
+              "functions. Check the broker support for the version of the Data "
+              "Transforms SDK being used.");
+        case wasm::errc::invalid_module_unsupported_sr:
+            throw ss::httpd::bad_request_exception(
+              "Invalid WebAssembly - the binary is using an unsupported Schema "
+              "Registry client. Does the broker support this version of the "
+              "Data Transforms Schema Registry SDK?");
         case wasm::errc::invalid_module_missing_wasi:
             throw ss::httpd::bad_request_exception(
               "invalid WebAssembly - missing required WASI functions");

--- a/src/v/wasm/include/wasm/errc.h
+++ b/src/v/wasm/include/wasm/errc.h
@@ -28,8 +28,10 @@ enum class errc {
     engine_shutdown,
     // invalid module without wasi _start
     invalid_module_missing_wasi,
-    // invalid module without abi marker
+    // invalid module without known abi marker
     invalid_module_missing_abi,
+    // invalid module with unsupported schema registry support
+    invalid_module_unsupported_sr,
     // invalid module otherwise
     invalid_module,
 };
@@ -55,11 +57,12 @@ struct errc_category final : public std::error_category {
             return "invalid WebAssembly - not compiled for wasi/wasm32";
         case errc::invalid_module_missing_abi:
             return "invalid WebAssembly - invalid SDK";
+        case errc::invalid_module_unsupported_sr:
+            return "invalid WebAssembly - invalid schema registry SDK";
         case errc::invalid_module:
             return "invalid WebAssembly";
-        default:
-            return "wasm::errc::unknown(" + std::to_string(c) + ")";
         }
+        return "wasm::errc::unknown(" + std::to_string(c) + ")";
     }
 };
 

--- a/src/v/wasm/schema_registry_module.cc
+++ b/src/v/wasm/schema_registry_module.cc
@@ -105,6 +105,8 @@ constexpr int32_t SCHEMA_REGISTRY_ERROR = -2;
 schema_registry_module::schema_registry_module(schema_registry* sr)
   : _sr(sr) {}
 
+void schema_registry_module::check_abi_version_0() {}
+
 ss::future<int32_t> schema_registry_module::get_schema_definition_len(
   pandaproxy::schema_registry::schema_id schema_id, uint32_t* size_out) {
     if (!_sr->is_enabled()) {

--- a/src/v/wasm/schema_registry_module.h
+++ b/src/v/wasm/schema_registry_module.h
@@ -34,6 +34,7 @@ public:
     static constexpr std::string_view name = "redpanda_schema_registry";
 
     // Start ABI exports
+    void check_abi_version_0();
 
     ss::future<int32_t> get_schema_definition_len(
       pandaproxy::schema_registry::schema_id, uint32_t*);

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -1600,6 +1600,7 @@ wasmtime_error_t* wasmtime_runtime::allocate_heap_memory(
         size_t used_memory;
         wasm::heap_allocator* allocator;
     };
+    // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
     memory_ret->env = new linear_memory{
       .underlying = *std::move(memory),
       .used_memory = req.minimum,

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -1278,6 +1278,7 @@ void register_sr_module(
     // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define REG_HOST_FN(name)                                                      \
     host_function<&schema_registry_module::name>::reg(linker, #name, ssc)
+    REG_HOST_FN(check_abi_version_0);
     REG_HOST_FN(get_schema_definition);
     REG_HOST_FN(get_schema_definition_len);
     REG_HOST_FN(get_subject_schema);
@@ -1662,6 +1663,23 @@ bool is_transform_abi_check_fn(const parser::module_import& mod_import) {
     });
 }
 
+// Schema registry is optional, so only check that the function is not using an
+// unsupported version.
+bool is_invalid_sr_abi_check_fn(const parser::module_import& mod_import) {
+    if (mod_import.module_name != schema_registry_module::name) {
+        return false;
+    }
+    if (!mod_import.item_name.starts_with("check_abi_version_")) {
+        return false;
+    }
+    const auto void_fn = parser::import_description{
+      parser::declaration::function{}};
+    if (mod_import.description != void_fn) {
+        return true;
+    }
+    return mod_import.item_name != "check_abi_version_0";
+}
+
 ss::future<> wasmtime_runtime::validate(iobuf buf) {
     parser::module_declarations decls;
     try {
@@ -1707,7 +1725,12 @@ ss::future<> wasmtime_runtime::validate(iobuf buf) {
     for (const auto& module_import : decls.imports) {
         if (is_transform_abi_check_fn(module_import)) {
             has_abi_check_fn = true;
-            break;
+        }
+        if (is_invalid_sr_abi_check_fn(module_import)) {
+            vlog(wasm_log.warn, "invalid module: unsupported sr abi function");
+            throw wasm_exception(
+              "invalid module: unsupported schema registry ABI",
+              errc::invalid_module_unsupported_sr);
         }
         co_await ss::coroutine::maybe_yield();
     }

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -265,7 +265,8 @@ class DataTransformsTest(BaseDataTransformsTest):
         self._deploy_invalid(
             file="validation/wasi.wasm",
             expected_msg=
-            "Does the broker support this version of the Data Transforms SDK?")
+            "Check the broker support for the version of the Data Transforms SDK being used."
+        )
 
     @cluster(num_nodes=3)
     def test_tracked_offsets_cleaned_up(self):


### PR DESCRIPTION
Introduce a versioning schema to schema registry in data transforms, a [followup PR](https://github.com/redpanda-data/redpanda/pull/17593) will add these methods to the SDKs.

Fixes: CORE-2007

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Add error messages when an unsupported Schema Registry client is used in Data Transforms

