### PR TITLE
transform-sdk/sr: add ABI check

### DIFF
--- a/src/transform-sdk/go/transform/sr/abi.go
+++ b/src/transform-sdk/go/transform/sr/abi.go
@@ -23,6 +23,9 @@ import (
 // These are the host functions that go allows for wasm functions that are imported.
 // See: https://github.com/golang/go/issues/59149
 
+//go:wasmimport redpanda_schema_registry check_abi_version_0
+func checkAbi()
+
 //go:wasmimport redpanda_schema_registry get_schema_definition_len
 func getSchemaDefinitionLen(schemaId schemaId, length unsafe.Pointer) int32
 

--- a/src/transform-sdk/go/transform/sr/client.go
+++ b/src/transform-sdk/go/transform/sr/client.go
@@ -127,6 +127,7 @@ func NewClient(opts ...ClientOpt) (c SchemaRegistryClient) {
 	for _, opt := range opts {
 		opt.apply(&o)
 	}
+	checkAbi()
 	c = &clientImpl{}
 	if o.maxCacheSize <= 0 {
 		return c

--- a/src/transform-sdk/go/transform/sr/stub_abi.go
+++ b/src/transform-sdk/go/transform/sr/stub_abi.go
@@ -20,6 +20,10 @@ import (
 	"unsafe"
 )
 
+func checkAbi() {
+	panic("stub")
+}
+
 func getSchemaDefinitionLen(schemaId schemaId, length unsafe.Pointer) int32 {
 	panic("stub")
 }

--- a/src/transform-sdk/rust/sr-sys/src/abi.rs
+++ b/src/transform-sdk/rust/sr-sys/src/abi.rs
@@ -14,6 +14,8 @@
 
 #[link(wasm_import_module = "redpanda_schema_registry")]
 extern "C" {
+    #[link_name = "check_abi_version_0"]
+    pub(crate) fn check();
 
     #[link_name = "get_schema_definition_len"]
     pub(crate) fn get_schema_definition_len(schema_id: i32, len: *mut i32) -> i32;

--- a/src/transform-sdk/rust/sr-sys/src/lib.rs
+++ b/src/transform-sdk/rust/sr-sys/src/lib.rs
@@ -35,6 +35,7 @@ pub struct AbiSchemaRegistryClient {}
 
 impl AbiSchemaRegistryClient {
     pub fn new() -> AbiSchemaRegistryClient {
+        abi::check();
         Self {}
     }
 }

--- a/src/transform-sdk/rust/sr-sys/src/stub_abi.rs
+++ b/src/transform-sdk/rust/sr-sys/src/stub_abi.rs
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub(crate) fn check() {
+    panic!();
+}
+
 pub(crate) fn get_schema_definition_len(_schema_id: i32, _len: *mut i32) -> i32 {
     panic!();
 }


### PR DESCRIPTION
A followup to https://github.com/redpanda-data/redpanda/pull/17591

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Transform SDKs for Schema Registry now publish their ABI version for compatibility checks with the broker.

