### PR TITLE
rptest/transform: add multiple output topics test

### DIFF
--- a/tests/docker/ducktape-deps/tinygo-wasi-transforms
+++ b/tests/docker/ducktape-deps/tinygo-wasi-transforms
@@ -14,6 +14,10 @@ tinygo build -target wasi -opt=z \
   -panic print -scheduler none \
   -o "/opt/transforms/tinygo/identity_logging.wasm" ./identity_logging
 
+tinygo build -target wasi -opt=z \
+  -panic print -scheduler none \
+  -o "/opt/transforms/tinygo/tee.wasm" ./tee
+
 # The following are some invalid wasm binarys for Redpanda, they either are invalid
 # as they are invalid bytes, or don't adhere to our ABI contract somehow
 #

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1656,19 +1656,16 @@ class RpkTool:
     def deploy_wasm(self,
                     name,
                     input_topic,
-                    output_topic,
+                    output_topics,
                     file="tinygo/identity.wasm"):
-        self._run_wasm([
-            "deploy",
-            "--name",
-            name,
-            "--input-topic",
-            input_topic,
-            "--output-topic",
-            output_topic,
-            "--file",
-            f"/opt/transforms/{file}",
-        ])
+        cmd = [
+            "deploy", "--name", name, "--input-topic", input_topic, "--file",
+            f"/opt/transforms/{file}"
+        ]
+        assert len(output_topics) > 0, "missing output topics"
+        for topic in output_topics:
+            cmd += ["--output-topic", topic]
+        self._run_wasm(cmd)
 
     def delete_wasm(self, name):
         self._run_wasm(["delete", name, "--no-confirm"])

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -55,15 +55,18 @@ class BaseDataTransformsTest(RedpandaTest):
     def _deploy_wasm(self,
                      name: str,
                      input_topic: TopicSpec,
-                     output_topic: TopicSpec,
+                     output_topic: TopicSpec | list[TopicSpec],
                      file="tinygo/identity.wasm"):
         """
         Deploy a wasm transform and wait for all processors to be running.
         """
+        if not isinstance(output_topic, list):
+            output_topic = [output_topic]
+
         def do_deploy():
             self._rpk.deploy_wasm(name,
                                   input_topic.name,
-                                  output_topic.name,
+                                  [o.name for o in output_topic],
                                   file=file)
             return True
 
@@ -207,7 +210,7 @@ class BaseDataTransformsTest(RedpandaTest):
             try:
                 self._rpk.deploy_wasm("invalid",
                                       self.topics[0].name,
-                                      self.topics[1].name,
+                                      [self.topics[1].name],
                                       file=file)
                 raise AssertionError(
                     "Unexpectedly was able to deploy transform")


### PR DESCRIPTION
Add a ducktape test for multiple output topics

Fixes: CORE-1928

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
