### PR TITLE
rpk: generate script with sha256sum instead of md5sum

### DIFF
--- a/.github/workflows/rpk-build.yml
+++ b/.github/workflows/rpk-build.yml
@@ -29,10 +29,10 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: stable
 

--- a/src/go/rpk/pkg/tuners/executors/commands/backup_file.go
+++ b/src/go/rpk/pkg/tuners/executors/commands/backup_file.go
@@ -41,7 +41,7 @@ func (c *backupFileCommand) Execute() error {
 }
 
 func (c *backupFileCommand) RenderScript(w *bufio.Writer) error {
-	fmt.Fprintf(w, "md_5=$(md5sum %s | awk '{print $1}')\n", c.path)
-	fmt.Fprintf(w, "cp %s %s.vectorized.${md_5}.bk\n", c.path, c.path)
+	fmt.Fprintf(w, "file_hash=$(sha256sum %s | cut -c -32)\n", c.path)
+	fmt.Fprintf(w, "cp %s %s.vectorized.${file_hash}.bk\n", c.path, c.path)
 	return w.Flush()
 }


### PR DESCRIPTION
issue https://redpandadata.atlassian.net/browse/PESDLC-1040

follow-on to PR #17568, this PR changes the way tune scripts are generated so that `sha256sum` is used instead of `md5sum`.

```console
rpk redpanda tune disk_irq --output-script=tune_disk_irq.sh
```
```
bash$ head tune_disk_irq.sh
#!/bin/bash

# Redpanda Tuning Script
# ----------------------------------
# This file was autogenerated by RPK

file_hash=$(sha256sum /etc/default/irqbalance | cut -c -32)
cp /etc/default/irqbalance /etc/default/irqbalance.vectorized.${file_hash}.bk
cat << EOF > /etc/default/irqbalance
  # irqbalance is a daemon process that distributes interrupts across

```

this PR does not change dependency requirements of the user because like `md5sum`, `sha256sum` is also provided by `coreutils` package.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* rpk: tune script uses sha256sum instead of md5sum