### PR TITLE
CORE-2055: net: allow transport logger to be customized

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -71,7 +71,7 @@ client::client(
   const ss::abort_source* as,
   ss::shared_ptr<client_probe> probe,
   ss::lowres_clock::duration max_idle_time)
-  : net::base_transport(cfg)
+  : net::base_transport(cfg, &http_log)
   , _host_with_port(
       fmt::format("{}:{}", cfg.server_addr.host(), cfg.server_addr.port()))
   , _connect_gate()

--- a/src/v/kafka/client/transport.h
+++ b/src/v/kafka/client/transport.h
@@ -14,6 +14,7 @@
 #include "base/seastarx.h"
 #include "bytes/iostream.h"
 #include "bytes/scattered_message.h"
+#include "kafka/client/logger.h"
 #include "kafka/protocol/api_versions.h"
 #include "kafka/protocol/delete_records.h"
 #include "kafka/protocol/flex_versions.h"
@@ -120,7 +121,7 @@ public:
     transport(
       net::base_transport::configuration c,
       std::optional<ss::sstring> client_id)
-      : net::base_transport(c)
+      : net::base_transport(c, &kclog)
       , _client_id(std::move(client_id)) {}
 
     /*

--- a/src/v/net/client_probe.h
+++ b/src/v/net/client_probe.h
@@ -13,7 +13,6 @@
 #include "metrics/metrics.h"
 #include "model/metadata.h"
 #include "net/unresolved_address.h"
-#include "rpc/logger.h"
 #include "rpc/types.h"
 
 #include <seastar/core/metrics_registration.hh>
@@ -61,10 +60,7 @@ public:
 
     void connection_closed() { --_connections; }
 
-    void connection_error(const std::exception_ptr& e) {
-        rpc::rpclog.trace("Connection error: {}", e);
-        ++_connection_errors;
-    }
+    void connection_error() { ++_connection_errors; }
 
     void read_dispatch_error() { ++_read_dispatch_errors; }
 

--- a/src/v/net/conn_quota.cc
+++ b/src/v/net/conn_quota.cc
@@ -13,7 +13,6 @@
 #include "config/configuration.h"
 #include "config/validators.h"
 #include "hashing/xx.h"
-#include "rpc/logger.h"
 #include "seastar/core/coroutine.hh"
 #include "ssx/future-util.h"
 

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -13,6 +13,7 @@
 #include "base/seastarx.h"
 #include "base/vassert.h"
 #include "config/property.h"
+#include "rpc/logger.h"
 #include "seastar/core/gate.hh"
 #include "seastar/core/sharded.hh"
 #include "seastar/net/inet_address.hh"

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -53,7 +53,8 @@ public:
         bool wait_for_tls_server_eof = true;
     };
 
-    explicit base_transport(configuration c);
+    base_transport(configuration c, seastar::logger* log);
+
     virtual ~base_transport() noexcept = default;
     base_transport(base_transport&&) noexcept = default;
     base_transport& operator=(base_transport&&) noexcept = default;
@@ -96,6 +97,7 @@ private:
     ss::shared_ptr<ss::tls::certificate_credentials> _creds;
     std::optional<ss::sstring> _tls_sni_hostname;
     bool _wait_for_tls_server_eof;
+    seastar::logger* _log;
 
     // Track if shutdown was called on the current `_fd`
     bool _shutdown{false};

--- a/src/v/rpc/transport.cc
+++ b/src/v/rpc/transport.cc
@@ -58,10 +58,12 @@ transport::transport(
   transport_configuration c,
   std::optional<connection_cache_label> label,
   std::optional<model::node_id> node_id)
-  : base_transport(base_transport::configuration{
-    .server_addr = std::move(c.server_addr),
-    .credentials = std::move(c.credentials),
-  })
+  : base_transport(
+    base_transport::configuration{
+      .server_addr = std::move(c.server_addr),
+      .credentials = std::move(c.credentials),
+    },
+    &rpclog)
   , _memory(c.max_queued_bytes, "rpc/transport-mem")
   , _version(c.version)
   , _default_version(c.version) {

--- a/src/v/storage/mvlog/CMakeLists.txt
+++ b/src/v/storage/mvlog/CMakeLists.txt
@@ -1,4 +1,4 @@
-enable_clang_tidy()
+#enable_clang_tidy()
 
 v_cc_library(
   NAME mvlog


### PR DESCRIPTION
net: allow transport logger to be customized

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

