### PR TITLE
cluster: create default "Users" role when RBAC is activated

### DIFF
--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -19,6 +19,7 @@
 #include "cluster/members_table.h"
 #include "config/configuration.h"
 #include "config/validators.h"
+#include "features/feature_state.h"
 #include "features/feature_table.h"
 #include "model/timeout_clock.h"
 #include "pandaproxy/schema_registry/schema_id_validation.h"

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -25,6 +25,7 @@
 #include "pandaproxy/schema_registry/schema_id_validation.h"
 #include "raft/group_manager.h"
 #include "security/role_store.h"
+#include "security/types.h"
 
 #include <absl/algorithm/container.h>
 
@@ -225,15 +226,17 @@ ss::future<> feature_manager::maybe_log_license_check_info() {
                    != pandaproxy::schema_registry::schema_id_validation_mode::
                      none;
         };
-        auto has_roles = !_role_store.local()
-                            .range([](auto const&) { return true; })
-                            .empty();
+        auto n_roles = _role_store.local().size();
+        auto has_non_default_roles
+          = n_roles >= 2
+            || (n_roles == 1 && !_role_store.local().contains(security::default_role));
+
         if (
           cfg.audit_enabled || cfg.cloud_storage_enabled
           || cfg.partition_autobalancing_mode
                == model::partition_autobalancing_mode::continuous
           || has_gssapi() || has_oidc() || has_schma_id_validation()
-          || has_roles) {
+          || has_non_default_roles) {
             const auto& license = _feature_table.local().get_license();
             if (!license || license->is_expired()) {
                 vlog(

--- a/src/v/cluster/security_frontend.cc
+++ b/src/v/cluster/security_frontend.cc
@@ -122,8 +122,11 @@ ss::future<std::error_code> security_frontend::create_role(
   security::role_name name,
   security::role role,
   model::timeout_clock::time_point tout) {
-    if (!_features.local().is_active(
-          features::feature::role_based_access_control)) {
+    auto feature_enabled = _features.local().is_preparing(
+                             features::feature::role_based_access_control)
+                           || _features.local().is_active(
+                             features::feature::role_based_access_control);
+    if (!feature_enabled) {
         vlog(clusterlog.warn, "RBAC feature is not yet active");
         co_return cluster::errc::feature_disabled;
     }

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -102,7 +102,7 @@ std::string_view to_string_view(feature f) {
     case feature::partition_shard_in_health_report:
         return "partition_shard_in_health_report";
     case feature::role_based_access_control:
-        return "role_base_access_control";
+        return "role_based_access_control";
     case feature::cluster_topic_manifest_format_v2:
         return "cluster_topic_manifest_format_v2";
 

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -385,7 +385,7 @@ constexpr static std::array feature_schema{
     "role_based_access_control",
     feature::role_based_access_control,
     feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
+    feature_spec::prepare_policy::requires_migration},
   feature_spec{
     cluster::cluster_version{12},
     "cluster_topic_manifest_format_v2",

--- a/src/v/migrations/CMakeLists.txt
+++ b/src/v/migrations/CMakeLists.txt
@@ -1,8 +1,9 @@
 v_cc_library(
   NAME migrations
   SRCS
-    feature_migrator.cc
     cloud_storage_config.cc
+    feature_migrator.cc
+    rbac_migrator.cc
   DEPS
     Seastar::seastar
     v::model

--- a/src/v/migrations/rbac_migrator.cc
+++ b/src/v/migrations/rbac_migrator.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "migrations/rbac_migrator.h"
+
+#include "base/vlog.h"
+#include "cluster/controller.h"
+#include "cluster/security_frontend.h"
+#include "features/logger.h"
+#include "security/credential_store.h"
+#include "security/role.h"
+#include "security/types.h"
+
+using namespace std::chrono_literals;
+
+namespace features::migrators {
+
+ss::future<> rbac_migrator::do_mutate() {
+    auto to_role_member = [](const auto& cred) -> security::role_member {
+        return {security::role_member_type::user, cred.first};
+    };
+    auto users_view = _controller.get_credential_store().local().range(
+                        security::credential_store::is_not_ephemeral)
+                      | std::ranges::views::transform(to_role_member);
+
+    security::role role{{users_view.begin(), users_view.end()}};
+    security::role_name role_name{security::default_role_name};
+
+    vlog(
+      featureslog.info,
+      "Creating default role '{}' with {} users...",
+      security::default_role_name,
+      role.members().size());
+
+    auto err = co_await _controller.get_security_frontend().local().create_role(
+      role_name, std::move(role), model::timeout_clock::now() + 5s);
+
+    if (err) {
+        vlog(
+          featureslog.error,
+          "Error while creating default role '{}': {}",
+          security::default_role_name,
+          err);
+    } else {
+        vlog(
+          featureslog.info,
+          "Created default role '{}'",
+          security::default_role_name);
+    }
+}
+} // namespace features::migrators

--- a/src/v/migrations/rbac_migrator.h
+++ b/src/v/migrations/rbac_migrator.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "migrations/feature_migrator.h"
+
+namespace features::migrators {
+
+class rbac_migrator final : public feature_migrator {
+public:
+    rbac_migrator(cluster::controller& c)
+      : feature_migrator(c) {}
+
+    ~rbac_migrator() noexcept = default;
+
+private:
+    ss::future<> do_mutate() override;
+    features::feature get_feature() override { return _feature; }
+
+    features::feature _feature{features::feature::role_based_access_control};
+};
+} // namespace features::migrators

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -90,6 +90,7 @@
 #include "kafka/server/snc_quota_manager.h"
 #include "kafka/server/usage_manager.h"
 #include "migrations/migrators.h"
+#include "migrations/rbac_migrator.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "net/dns.h"
@@ -2464,6 +2465,8 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
         _migrators.push_back(
           std::make_unique<features::migrators::cloud_storage_config>(
             *controller));
+        _migrators.push_back(
+          std::make_unique<features::migrators::rbac_migrator>(*controller));
     }
 
     if (cd.is_cluster_founder().get()) {

--- a/src/v/security/types.h
+++ b/src/v/security/types.h
@@ -25,5 +25,6 @@ using credential_password
 using role_name = named_type<ss::sstring, struct role_name_type>;
 
 static constexpr std::string_view default_role_name = "Users";
+static const auto default_role = role_name{security::default_role_name};
 
 } // namespace security

--- a/src/v/security/types.h
+++ b/src/v/security/types.h
@@ -24,4 +24,6 @@ using credential_password
 
 using role_name = named_type<ss::sstring, struct role_name_type>;
 
+static constexpr std::string_view default_role_name = "Users";
+
 } // namespace security

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -977,7 +977,10 @@ class Admin:
         path = "partitions/force_recover_from_nodes"
         return self._request('post', path, node, json=payload)
 
-    def create_user(self, username, password, algorithm):
+    def create_user(self,
+                    username,
+                    password="12345678",
+                    algorithm="SCRAM-SHA-256"):
         self.redpanda.logger.debug(
             f"Creating user {username}:{password}:{algorithm}")
 

--- a/tests/rptest/tests/rbac_upgrade_test.py
+++ b/tests/rptest/tests/rbac_upgrade_test.py
@@ -1,0 +1,65 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Licensed as a Redpanda Enterprise file under the Redpanda Community
+# License (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+# https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+
+from rptest.services.admin import Admin, Role, RoleMember
+from rptest.util import wait_until_result
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RESTART_LOG_ALLOW_LIST
+from rptest.services.redpanda_installer import wait_for_num_versions
+
+
+class UpgradeMigrationCreatingDefaultRole(RedpandaTest):
+    """
+    Verify that the default role gets created when the RBAC feature is enabled
+    """
+
+    DEFAULT_ROLE_NAME = "Users"
+
+    def __init__(self, test_ctx, **kwargs):
+        super().__init__(test_ctx, **kwargs)
+        self.installer = self.redpanda._installer
+        self.admin = Admin(self.redpanda)
+
+    def setUp(self):
+        # 24.1.x is when license went live, so start with a 23.3.x version
+        self.installer.install(self.redpanda.nodes, (23, 3))
+        super().setUp()
+
+    @cluster(num_nodes=3, log_allow_list=RESTART_LOG_ALLOW_LIST)
+    def test_rbac_migration(self):
+        # Create some users to add to the default role
+        self.admin.create_user("alice")
+        self.admin.create_user("bob")
+
+        # Update all nodes to newest version
+        self.installer.install(self.redpanda.nodes, (24, 1))
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        _ = wait_for_num_versions(self.redpanda, 1)
+
+        def default_role_created():
+            res = self.admin.get_role(self.DEFAULT_ROLE_NAME)
+            role = Role.from_response(res)
+
+            expected_users = [
+                RoleMember.User("alice"),
+                RoleMember.User("bob"),
+                RoleMember.User("admin"),
+            ]
+
+            for member in expected_users:
+                assert member in role.members,\
+                    f"'{member}' missing from role members: {role.members}"
+            return True
+
+        wait_until_result(
+            default_role_created,
+            timeout_sec=30,
+            backoff_sec=1,
+            retry_on_exc=True,
+            err_msg="Timeout waiting for default role to be created")


### PR DESCRIPTION
This implements a one-time convenience functionality. On the first upgrade to an RBAC-supporting build, this creates a "Users" role that contains all the existing SASL/SCRAM users to help customers get started with RBAC.

It uses the already implemented feature migrator to create a role when the feature first becomes active.

Finally, it implements a suppression to the license nag to not show the license nag for this auto-generated role.

Closes https://github.com/redpanda-data/core-internal/issues/1205

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
