### PR TITLE
CORE-2070: cloud storage probe for compacted away bytes `vectorized_ntp_archiver_compacted_replaced_bytes`

### DIFF
--- a/src/v/archival/archival_metadata_stm.h
+++ b/src/v/archival/archival_metadata_stm.h
@@ -273,6 +273,10 @@ public:
 
     ss::future<iobuf> take_snapshot(model::offset) final { co_return iobuf{}; }
 
+    size_t get_compacted_replaced_bytes() const {
+        return _compacted_replaced_bytes;
+    }
+
 private:
     ss::future<bool>
     do_sync(model::timeout_clock::duration timeout, ss::abort_source* as);
@@ -371,6 +375,13 @@ private:
     cloud_storage::remote& _cloud_storage_api;
     features::feature_table& _feature_table;
     ss::abort_source _download_as;
+
+    // for observability: keep track of the number of cloud bytes "removed" by
+    // compaction. as in the size difference between the original segment(s) and
+    // compacted segment reuploaded note that this value does not correlate to
+    // the change in size in cloud storage until the original segment(s) are
+    // garbage collected.
+    size_t _compacted_replaced_bytes{0};
 };
 
 class archival_metadata_stm_factory : public state_machine_factory {

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1067,6 +1067,11 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
     auto result = co_await _remote.upload_manifest(
       get_bucket_name(), manifest(), fib);
 
+    // now that manifest() is updated in cloud, updated the
+    // compacted_away_cloud_bytes metric
+    _probe->compacted_replaced_bytes(
+      _parent.archival_meta_stm()->get_compacted_replaced_bytes());
+
     if (result == cloud_storage::upload_result::success) {
         _last_manifest_upload_time = ss::lowres_clock::now();
         _projected_manifest_clean_at = upload_insync_offset;

--- a/src/v/archival/probe.cc
+++ b/src/v/archival/probe.cc
@@ -70,6 +70,12 @@ void ntp_level_probe::setup_ntp_metrics(const model::ntp& ntp) {
           [this] { return _pending; },
           sm::description("Pending offsets"),
           labels),
+        sm::make_gauge(
+          "compacted_replaced_bytes",
+          [this] { return _compacted_replaced_bytes; },
+          sm::description("Bytes replaced due to compaction since this replica "
+                          "become leader for this partition"),
+          labels),
       },
       {},
       aggregate_labels);

--- a/src/v/archival/probe.h
+++ b/src/v/archival/probe.h
@@ -62,6 +62,10 @@ public:
 
     void cloud_log_size(uint64_t size) { _cloud_log_size = size; }
 
+    void compacted_replaced_bytes(size_t bytes) {
+        _compacted_replaced_bytes = bytes;
+    }
+
 private:
     /// Uploaded offsets
     uint64_t _uploaded = 0;
@@ -77,8 +81,10 @@ private:
     int64_t _segments_in_manifest = 0;
     /// Number of segments awaiting deletion
     int64_t _segments_to_delete = 0;
-    /// size in byted of the user-visible log
+    /// size in bytes of the user-visible log
     uint64_t _cloud_log_size = 0;
+    /// cloud bytes "removed" due to compaction operation
+    size_t _compacted_replaced_bytes = 0;
 
     metrics::internal_metric_groups _metrics;
     metrics::public_metric_groups _public_metrics;

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -343,9 +343,27 @@ public:
     bool segment_with_offset_range_exists(
       model::offset base, model::offset committed) const;
 
-    /// Add new segment to the manifest
-    bool add(segment_meta meta);
-    bool add(const segment_name& name, const segment_meta& meta);
+    struct add_segment_meta_result {
+        // size in bytes of the segment(s) that has been replaced by this
+        // operation (might be 0 for appends)
+        size_t bytes_replaced_range{};
+        // size in bytes of the segment referenced by the input segment_meta
+        size_t bytes_new_range{};
+    };
+
+    /// Add new segment to the manifest.
+    /// Returns the result of the operation,
+    /// in terms of delta of cloud storage size.
+    /// If `meta` causes an append operation, bytes_replaced will be 0,
+    /// and if it causes a replace operation, bytes_replaced will be
+    /// the size of the replaced segments.
+    /// The return value is std::nullopt if `meta` cannot be added.
+    /// Currently this is the case if the remote path for `meta` is the
+    /// same of a segment already in the manifest.
+    /// See safe_segment_meta_to_add()
+    std::optional<add_segment_meta_result> add(segment_meta meta);
+    std::optional<add_segment_meta_result>
+    add(const segment_name& name, const segment_meta& meta);
 
     /// Return 'true' if the segment meta can be added safely
     bool safe_segment_meta_to_add(const segment_meta& meta) const;

--- a/src/v/cloud_storage/tests/partition_manifest_test.cc
+++ b/src/v/cloud_storage/tests/partition_manifest_test.cc
@@ -2358,7 +2358,7 @@ SEASTAR_THREAD_TEST_CASE(test_readd_protection) {
     };
     BOOST_REQUIRE(m.add(s));
     auto size = m.cloud_log_size();
-    BOOST_REQUIRE(m.add(s) == false);
+    BOOST_REQUIRE(m.add(s) == std::nullopt);
     BOOST_REQUIRE(m.cloud_log_size() == size);
     auto backlog = m.replaced_segments();
     BOOST_REQUIRE(backlog.empty());

--- a/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
+++ b/tests/rptest/tests/shadow_indexing_compacted_topic_test.py
@@ -3,6 +3,7 @@ import pprint
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
+from rptest.services.metrics_check import MetricCheck
 from rptest.services.redpanda import CloudStorageType, SISettings, make_redpanda_service, LoggingConfig, get_cloud_storage_type
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.util import wait_until_segments, wait_for_removal_of_n_segments
@@ -52,6 +53,22 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
         # Set compaction to happen infrequently initially, so we have several log segments.
         self._rpk_client.cluster_config_set("log_compaction_interval_ms",
                                             f'{1000 * 60 * 60}')
+
+        # observe this metric about compaction removed bytes to check that it increases
+        metric = "vectorized_ntp_archiver_compacted_replaced_bytes"
+        original_topic_describe = list(
+            self._rpk_client.describe_topic(self.topic))[0]
+
+        m = MetricCheck(self.logger,
+                        self.redpanda,
+                        self.redpanda.nodes[original_topic_describe.leader -
+                                            1], [metric], {
+                                                "namespace": "kafka",
+                                                "topic": self.topic,
+                                                "partition": "0"
+                                            },
+                        reduce=sum)
+
         self.start_producer(throughput=5000, repeating_keys=10)
 
         expected_segment_count = 10
@@ -105,6 +122,19 @@ class ShadowIndexingCompactedTopicTest(EndToEndTest):
                    timeout_sec=180,
                    backoff_sec=2,
                    err_msg=lambda: f"Compacted segments not uploaded")
+
+        # check that the metric is increasing. the check needs to account for leadership changes (unlikely in this test),
+        # because the current implementation does not persist the value in the manifest or the log
+        compacted_replaced_bytes_increasing = m.evaluate([
+            (metric, lambda old, new: old < new)
+        ])
+        new_topic_describe = list(self._rpk_client.describe_topic(
+            self.topic))[0]
+        self.logger.info(
+            f"{compacted_replaced_bytes_increasing=}, original leader,epoch: {original_topic_describe.leader},{original_topic_describe.leader_epoch}. new leader,epoch:{new_topic_describe.leader},{new_topic_describe.leader_epoch}"
+        )
+        if original_topic_describe.leader_epoch == new_topic_describe.leader_epoch:
+            assert compacted_replaced_bytes_increasing, f"{metric=} is not increasing"
 
         s3_snapshot = BucketView(self.redpanda, topics=self.topics)
         s3_snapshot.assert_at_least_n_uploaded_segments_compacted(


### PR DESCRIPTION
`vectorized_ntp_archiver_compacted_replaced_bytes` is a gauge metric updated inside `ntp_archiver::upload_manifest` after the manifest is observable in cloud storage.

The value is updated when `archival_metadata_stm` adds a segment to the partition manifest and the operation results in a replacement operation.

The value is not part of the archival_metadata_stm state; it's only there for observability. As such, it is not replicated and is not part of the snapshot.
The value will reset when the manifest is created or deserialized.

Fixes https://github.com/redpanda-data/core-internal/issues/1236 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Features

* new metric vectorized_ntp_archiver_compacted_replaced_bytes