### PR TITLE
PESDLC-1064 Enable cloud network clean

### DIFF
--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -57,8 +57,8 @@ class FakeContext():
 class CloudCleanup():
     # At this point all is disabled except namespaces
     delete_clusters = True
-    delete_peerings = False
-    delete_networks = False
+    delete_peerings = True
+    delete_networks = True
     delete_namespaces = True
 
     def __init__(self, log_level=logging.INFO):

--- a/tests/rp_cloud_cleanup.py
+++ b/tests/rp_cloud_cleanup.py
@@ -181,8 +181,8 @@ class CloudCleanup():
 
             # If the cluster in deleleting_agent, we should clean it
             # regardless of time or anything else to clean up quota
+            _message += f"| status: '{_cluster['state']}' "
             if _cluster['state'] in ['deleting_agent']:
-                _message += f"| status: '{_cluster['state']}' "
                 # Login
                 try:
                     _message += "| cloud login "
@@ -208,9 +208,8 @@ class CloudCleanup():
                 _log_deleted(_message)
                 return True
             if _state in ['creating_agent']:
-                _message += f"| status: '{_cluster['state']}' "
                 # Check date, and delete only old ones
-                if _ensure_date(_createdDate):
+                if not _ensure_date(_createdDate):
                     _log_skip(_message)
                     return False
                 # Just delete the cluster resource
@@ -219,7 +218,7 @@ class CloudCleanup():
                 self.log.debug(f"Returned:\n{out}")
                 return True
             # All other states need to wait for 36h
-            if _ensure_date(_createdDate):
+            if not _ensure_date(_createdDate):
                 _log_skip(_message)
                 return False
             # TODO: Implement deletion on rare non-agent statuses


### PR DESCRIPTION
   Enabled cleaning of orphaned networks by default.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none