### PR TITLE
PESDLC-1069 Disable decomission tests

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -882,6 +882,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
                 f"Low throughput while preparing for the test: {_throughput} MB/s"
             ) from None
 
+    @ignore
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_decommission_and_add(self):
         """Decommission and add while under load.
@@ -1196,6 +1197,7 @@ class HighThroughputTest(PreallocNodesMixin, RedpandaCloudTest):
         # kubectl delete pvc shadow-index-cache-rp-clkd0n22nfn1jf7vd9t0-4 -n=redpanda
         self.redpanda.kubectl.cmd(['delete', 'pvc', pvc_name, '-n=redpanda'])
 
+    @ignore
     @cluster(num_nodes=5, log_allow_list=RESTART_LOG_ALLOW_LIST)
     def test_add_and_decommission(self):
         """Add a new node and then decommission it while under load.


### PR DESCRIPTION
Some investigation results on the above error
This error here prevents cluster from be connected to the CloudV2 API
```
test_id:    rptest.redpanda_cloud_tests.high_throughput_test.HighThroughputTest.test_add_and_decommission
status:     FAIL
run time:   17 minutes 48.719 seconds
...
subprocess.CalledProcessError: Command '['tsh', 'ssh', '--proxy=proxy.tp.redpanda.com:443', '--auth=okta', '--identity=/tmp/machine-id/identity', 'redpanda@co53q695otfeo26a3q80-agent', 'sudo', 'systemctl', 'enable', '--now', 'redpanda-agent.service', 'redpanda-agent-boot.service', 'redpanda-agent-init.service']' returned non-zero exit status 1.
```
As a result, cloud can't be deleted and stays intact on the account. This is happening for at least a week. So the actual Clusters in the CDT account were not deleted at all. Piling up, spending money and doing nothing. 
PR to fix this up: 

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none