### PR TITLE
k/fetch: correctly propagate initial_leader_epoch

### DIFF
--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "kafka/protocol/errors.h"
+#include "kafka/protocol/fetch.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/ktp.h"
@@ -30,6 +31,15 @@ struct fetch_session_partition {
     model::offset high_watermark;
     model::offset last_stable_offset;
     kafka::leader_epoch current_leader_epoch = invalid_leader_epoch;
+
+    fetch_session_partition(
+      const model::topic& tp, const fetch_request::partition& p)
+      : topic_partition(tp, p.partition_index)
+      , max_bytes(p.max_bytes)
+      , fetch_offset(p.fetch_offset)
+      , high_watermark(model::offset(-1))
+      , last_stable_offset(model::offset(-1))
+      , current_leader_epoch(p.current_leader_epoch) {}
 };
 /**
  * Map of partitions that is kept by fetch session. This map is using intrusive

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -14,18 +14,6 @@
 
 namespace kafka {
 
-static fetch_session_partition make_fetch_partition(
-  const model::topic& tp, const fetch_request::partition& p) {
-    return fetch_session_partition{
-      .topic_partition = {tp, p.partition_index},
-      .max_bytes = p.max_bytes,
-      .fetch_offset = p.fetch_offset,
-      .high_watermark = model::offset(-1),
-      .last_stable_offset = model::offset(-1),
-      .current_leader_epoch = p.current_leader_epoch,
-    };
-}
-
 void update_fetch_session(fetch_session& session, const fetch_request& req) {
     for (auto it = req.cbegin(); it != req.cend(); ++it) {
         auto& topic = *it->topic;
@@ -36,9 +24,10 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
             s_it != session.partitions().end()) {
             s_it->second->partition.max_bytes = partition.max_bytes;
             s_it->second->partition.fetch_offset = partition.fetch_offset;
+            s_it->second->partition.current_leader_epoch
+              = partition.current_leader_epoch;
         } else {
-            session.partitions().emplace(
-              make_fetch_partition(topic.name, partition));
+            session.partitions().emplace({topic.name, partition});
         }
     }
 

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1150,12 +1150,7 @@ void op_context::for_each_fetch_partition(Func&& f) const {
           request.cend(),
           [f = std::forward<Func>(f)](
             const fetch_request::const_iterator::value_type& p) {
-              auto& part = *p.partition;
-              f(fetch_session_partition{
-                .topic_partition = {p.topic->name, part.partition_index},
-                .max_bytes = part.max_bytes,
-                .fetch_offset = part.fetch_offset,
-              });
+              f(fetch_session_partition(p.topic->name, *p.partition));
           });
     } else {
         std::for_each(

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -41,11 +41,13 @@ using namespace std::chrono_literals; // NOLINT
 struct fixture {
     static kafka::fetch_session_partition make_fetch_partition(
       model::topic topic, model::partition_id p_id, model::offset offset) {
-        return kafka::fetch_session_partition{
-          .topic_partition = {std::move(topic), p_id},
-          .max_bytes = 1_MiB,
-          .fetch_offset = offset,
-          .high_watermark = offset};
+        return kafka::fetch_session_partition(
+          topic,
+          kafka::fetch_partition{
+            .partition_index = p_id,
+            .fetch_offset = offset,
+            .max_bytes = 1_MiB,
+          });
     }
 
     static kafka::fetch_request::topic

--- a/src/v/kafka/server/tests/fetch_session_test.cc
+++ b/src/v/kafka/server/tests/fetch_session_test.cc
@@ -29,11 +29,13 @@ using namespace std::chrono_literals; // NOLINT
 struct fixture {
     static kafka::fetch_session_partition make_fetch_partition(
       model::topic topic, model::partition_id p_id, model::offset offset) {
-        return kafka::fetch_session_partition{
-          .topic_partition = {topic, p_id},
-          .max_bytes = 1_MiB,
-          .fetch_offset = offset,
-          .high_watermark = offset};
+        return kafka::fetch_session_partition(
+          topic,
+          kafka::fetch_partition{
+            .partition_index = p_id,
+            .fetch_offset = offset,
+            .max_bytes = 1_MiB,
+          });
     }
 
     static kafka::fetch_request::topic


### PR DESCRIPTION
KIP-320 was broken for session-less clients as the initial_leader_epoch was not propagated.

Let's see CI. Will reword and decide on backports later.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
