### PR TITLE
raft: don't promote to voter if previous config is not committed

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -231,17 +231,17 @@ TEST_F_CORO(
       10s,
       [&reached_dispatch_append,
        &may_resume_append](raft::raft_node_instance& node) {
-          node.on_dispatch(
-            [&reached_dispatch_append, &may_resume_append](raft::msg_type t) {
-                if (t == raft::msg_type::append_entries) {
-                    if (!reached_dispatch_append.available()) {
-                        reached_dispatch_append.set_value(true);
-                    }
-                    return may_resume_append.get_shared_future();
-                }
+          node.on_dispatch([&reached_dispatch_append, &may_resume_append](
+                             model::node_id, raft::msg_type t) {
+              if (t == raft::msg_type::append_entries) {
+                  if (!reached_dispatch_append.available()) {
+                      reached_dispatch_append.set_value(true);
+                  }
+                  return may_resume_append.get_shared_future();
+              }
 
-                return ss::now();
-            });
+              return ss::now();
+          });
 
           return node.get_vnode();
       });

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -520,19 +520,34 @@ void consensus::maybe_promote_to_voter(vnode id) {
             return ss::now();
         }
 
-        vlog(_ctxlog.trace, "promoting node {} to voter", id);
-        return _op_lock.get_units()
-          .then([this, id](ssx::semaphore_units u) mutable {
-              auto latest_cfg = _configuration_manager.get_latest();
-              latest_cfg.promote_to_voter(id);
+        // do not promote if the previous configuration is still uncommitted,
+        // otherwise we may add several new voters in quick succession, that the
+        // old voters will not know of, resulting in a possibility of
+        // non-intersecting quorums.
+        if (_configuration_manager.get_latest_offset() > _commit_index) {
+            return ss::now();
+        }
 
-              return replicate_configuration(
-                std::move(u), std::move(latest_cfg));
-          })
-          .then([this, id](std::error_code ec) {
-              vlog(
-                _ctxlog.trace, "node {} promotion result {}", id, ec.message());
-          });
+        return _op_lock.get_units().then([this,
+                                          id](ssx::semaphore_units u) mutable {
+            // check once more under _op_lock to protect against races with
+            // concurrent voter promotions.
+            if (_configuration_manager.get_latest_offset() > _commit_index) {
+                return ss::now();
+            }
+
+            vlog(_ctxlog.trace, "promoting node {} to voter", id);
+            auto latest_cfg = _configuration_manager.get_latest();
+            latest_cfg.promote_to_voter(id);
+            return replicate_configuration(std::move(u), std::move(latest_cfg))
+              .then([this, id](std::error_code ec) {
+                  vlog(
+                    _ctxlog.trace,
+                    "node {} promotion result {}",
+                    id,
+                    ec.message());
+              });
+        });
     });
 }
 

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -273,7 +273,7 @@ TEST_P_CORO(
     co_await set_write_caching(params.write_caching);
 
     for (auto& [_, node] : nodes()) {
-        node->on_dispatch([](raft::msg_type t) {
+        node->on_dispatch([](model::node_id, raft::msg_type t) {
             if (
               t == raft::msg_type::append_entries
               && random_generators::get_int(1000) > 800) {
@@ -405,7 +405,7 @@ TEST_P_CORO(quorum_acks_fixture, test_progress_on_truncation) {
     // truncation.
     for (auto& [id, node] : nodes()) {
         if (id == leader_id) {
-            node->on_dispatch([](raft::msg_type t) {
+            node->on_dispatch([](model::node_id, raft::msg_type t) {
                 if (
                   t == raft::msg_type::append_entries
                   || t == raft::msg_type::vote) {

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -621,7 +621,7 @@ raft_fixture::stop_node(model::node_id id, remove_data_dir remove) {
 }
 
 raft_node_instance& raft_fixture::node(model::node_id id) {
-    return *_nodes.find(id)->second;
+    return *_nodes.at(id);
 }
 
 ss::future<model::node_id>

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -240,8 +240,7 @@ channel& in_memory_test_protocol::get_channel(model::node_id id) {
     return *it->second;
 }
 
-void in_memory_test_protocol::on_dispatch(
-  ss::noncopyable_function<ss::future<>(msg_type)> f) {
+void in_memory_test_protocol::on_dispatch(dispatch_callback_t f) {
     _on_dispatch_handlers.push_back(std::move(f));
 }
 
@@ -301,7 +300,7 @@ in_memory_test_protocol::dispatch(model::node_id id, ReqT req) {
 
     const auto msg_type = map_msg_type<ReqT>();
     for (const auto& f : _on_dispatch_handlers) {
-        co_await f(msg_type);
+        co_await f(id, msg_type);
     }
 
     try {
@@ -557,8 +556,7 @@ raft_node_instance::random_batch_base_offset(model::offset max) {
     co_return batches.front().base_offset();
 }
 
-void raft_node_instance::on_dispatch(
-  ss::noncopyable_function<ss::future<>(msg_type)> f) {
+void raft_node_instance::on_dispatch(dispatch_callback_t f) {
     _protocol->on_dispatch(std::move(f));
 }
 

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -567,6 +567,9 @@ seastar::future<> raft_fixture::TearDownAsync() {
     co_await seastar::coroutine::parallel_for_each(
       _nodes, [](auto& pair) { return pair.second->stop(); });
 
+    co_await seastar::coroutine::parallel_for_each(
+      _nodes, [](auto& pair) { return pair.second->remove_data(); });
+
     co_await _features.stop();
 }
 seastar::future<> raft_fixture::SetUpAsync() {

--- a/src/v/raft/tests/replication_monitor_tests.cc
+++ b/src/v/raft/tests/replication_monitor_tests.cc
@@ -90,7 +90,7 @@ TEST_P_CORO(monitor_test_fixture, truncation_detection) {
 
     for (auto& [id, node] : nodes()) {
         if (id == leader) {
-            node->on_dispatch([](raft::msg_type t) {
+            node->on_dispatch([](model::node_id, raft::msg_type t) {
                 if (
                   t == raft::msg_type::append_entries
                   || t == raft::msg_type::vote) {


### PR DESCRIPTION
Otherwise we may add several new voters in quick succession, that the old voters will not know of, resulting in a possibility of non-intersecting quorums.

Example scenario:
1. we start with leader id 1, committed configuration: voters:1,2,3; learners:4,5
2. 1,4,5 are partitioned from 2,3
3. 1 finishes recovery of 4 and 5 and adds them as voters
4. now 1 can remain the leader getting responses from 1,4,5 (that form a quorum in the new voter set 1,2,3,4,5) and 2,3 can elect a leader among themselves, say 2 (because 2,3 is a quorum in the old voter set 1,2,3)
5. now 1 and 2 both think that they are legitimate leaders and can commit new entries, resulting in divergent logs.

To prevent this, in step 3 we don't add 5 as voter until the configuration with voter 4 is committed (or vice versa).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes
### Bug Fixes
* Fix a bug that could lead to raft log inconsistencies when 2 out of 3 nodes in a configuration are changed.
