### PR TITLE
rpk/defaults: enable write caching in dev container by default

### DIFF
--- a/src/go/rpk/pkg/cli/redpanda/start.go
+++ b/src/go/rpk/pkg/cli/redpanda/start.go
@@ -961,6 +961,7 @@ func setContainerModeCfgFields(y *config.RedpandaYaml) {
 	y.Redpanda.Other["fetch_reads_debounce_timeout"] = 10
 	y.Redpanda.Other["group_initial_rebalance_delay"] = 0
 	y.Redpanda.Other["log_segment_size_min"] = 1
+	y.Redpanda.Other["write_caching"] = "on"
 }
 
 func getOrFindInstallDir(fs afero.Fs, installDir string) (string, error) {
@@ -991,6 +992,7 @@ environments:
         * fetch_reads_debounce_timeout: 10
         * group_initial_rebalance_delay: 0
         * log_segment_size_min: 1
+        * write_caching: on
 
 After redpanda starts you can modify the cluster properties using:
     rpk config set <key> <value>`

--- a/src/go/rpk/pkg/cli/redpanda/start_test.go
+++ b/src/go/rpk/pkg/cli/redpanda/start_test.go
@@ -251,6 +251,7 @@ func TestStartCommand(t *testing.T) {
 				"fetch_reads_debounce_timeout":  10,
 				"group_initial_rebalance_delay": 0,
 				"log_segment_size_min":          1,
+				"write_caching":                 "on",
 			}
 			expYAML, err := yaml.Marshal(c)
 			require.NoError(st, err)
@@ -1536,6 +1537,7 @@ func TestStartCommand(t *testing.T) {
 				"fetch_reads_debounce_timeout":  10,
 				"group_initial_rebalance_delay": 0,
 				"log_segment_size_min":          1,
+				"write_caching":                 "on",
 			}
 			require.Equal(st, expectedClusterFields, y.Redpanda.Other)
 		},
@@ -1588,6 +1590,7 @@ func TestStartCommand(t *testing.T) {
 				"fetch_reads_debounce_timeout":  10,
 				"group_initial_rebalance_delay": 0,
 				"log_segment_size_min":          1,
+				"write_caching":                 "on",
 			}
 			require.Nil(st, y.Redpanda.ID)
 			require.Equal(st, true, y.Redpanda.DeveloperMode)
@@ -1631,6 +1634,7 @@ func TestStartCommand(t *testing.T) {
 				"fetch_reads_debounce_timeout":  10,
 				"group_initial_rebalance_delay": 0,
 				"log_segment_size_min":          1,
+				"write_caching":                 "on",
 			}
 			require.Exactly(st, expectedClusterFields, y.Redpanda.Other)
 		},


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Enables write caching by default in dev container mode.


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
