### PR TITLE
CORE-2056: net: allow conn_quota logger to be configured 

### DIFF
--- a/src/v/net/conn_quota.cc
+++ b/src/v/net/conn_quota.cc
@@ -25,8 +25,7 @@ conn_quota::units::~units() noexcept {
     }
 }
 
-conn_quota::conn_quota(
-  conn_quota::config_fn cfg_f, seastar::logger* log) noexcept
+conn_quota::conn_quota(conn_quota::config_fn cfg_f, ss::logger* log) noexcept
   : _cfg(cfg_f())
   , _log(log) {
     if (ss::this_shard_id() == total_shard) {

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -13,16 +13,14 @@
 #include "base/seastarx.h"
 #include "base/vassert.h"
 #include "config/property.h"
-#include "rpc/logger.h"
-#include "seastar/core/gate.hh"
-#include "seastar/core/sharded.hh"
-#include "seastar/net/inet_address.hh"
 #include "utils/mutex.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/sharded.hh>
+#include <seastar/net/inet_address.hh>
 
 #include <absl/container/flat_hash_map.h>
 #include <absl/hash/hash.h>
-
-#include <stdint.h>
 
 namespace net {
 
@@ -91,7 +89,7 @@ public:
     };
 
     using config_fn = std::function<conn_quota_config()>;
-    conn_quota(config_fn) noexcept;
+    conn_quota(config_fn, seastar::logger*) noexcept;
 
     ss::future<units> get(ss::net::inet_address);
     void put(ss::net::inet_address);
@@ -238,6 +236,7 @@ private:
     conn_quota_config _cfg;
 
     ss::gate _gate;
+    seastar::logger* _log;
 };
 
 } // namespace net

--- a/src/v/net/conn_quota.h
+++ b/src/v/net/conn_quota.h
@@ -89,7 +89,7 @@ public:
     };
 
     using config_fn = std::function<conn_quota_config()>;
-    conn_quota(config_fn, seastar::logger*) noexcept;
+    conn_quota(config_fn, ss::logger*) noexcept;
 
     ss::future<units> get(ss::net::inet_address);
     void put(ss::net::inet_address);
@@ -236,7 +236,7 @@ private:
     conn_quota_config _cfg;
 
     ss::gate _gate;
-    seastar::logger* _log;
+    ss::logger* _log;
 };
 
 } // namespace net

--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -53,12 +53,15 @@ struct conn_quota_fixture {
         max_con_overrides.start(overrides).get();
 
         scq
-          .start([this]() {
-              return conn_quota_config{
-                .max_connections = max_con.local().bind(),
-                .max_connections_per_ip = max_con_per_ip.local().bind(),
-                .max_connections_overrides = max_con_overrides.local().bind()};
-          }, &logger)
+          .start(
+            [this]() {
+                return conn_quota_config{
+                  .max_connections = max_con.local().bind(),
+                  .max_connections_per_ip = max_con_per_ip.local().bind(),
+                  .max_connections_overrides
+                  = max_con_overrides.local().bind()};
+            },
+            &logger)
           .get();
     }
 

--- a/src/v/net/tests/conn_quota_test.cc
+++ b/src/v/net/tests/conn_quota_test.cc
@@ -1,4 +1,11 @@
-
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
 #include "base/vlog.h"
 #include "config/mock_property.h"
 #include "net/conn_quota.h"
@@ -51,7 +58,7 @@ struct conn_quota_fixture {
                 .max_connections = max_con.local().bind(),
                 .max_connections_per_ip = max_con_per_ip.local().bind(),
                 .max_connections_overrides = max_con_overrides.local().bind()};
-          })
+          }, &logger)
           .get();
     }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1908,7 +1908,7 @@ void application::wire_up_redpanda_services(
             .max_connections_overrides
             = config::shard_local_cfg().kafka_connections_max_overrides.bind(),
           };
-      })
+      }, &kafka::klog)
       .get();
 
     ss::sharded<net::server_configuration> kafka_cfg;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1899,16 +1899,19 @@ void application::wire_up_redpanda_services(
       }))
       .get();
     _kafka_conn_quotas
-      .start([]() {
-          return net::conn_quota_config{
-            .max_connections
-            = config::shard_local_cfg().kafka_connections_max.bind(),
-            .max_connections_per_ip
-            = config::shard_local_cfg().kafka_connections_max_per_ip.bind(),
-            .max_connections_overrides
-            = config::shard_local_cfg().kafka_connections_max_overrides.bind(),
-          };
-      }, &kafka::klog)
+      .start(
+        []() {
+            return net::conn_quota_config{
+              .max_connections
+              = config::shard_local_cfg().kafka_connections_max.bind(),
+              .max_connections_per_ip
+              = config::shard_local_cfg().kafka_connections_max_per_ip.bind(),
+              .max_connections_overrides
+              = config::shard_local_cfg()
+                  .kafka_connections_max_overrides.bind(),
+            };
+        },
+        &kafka::klog)
       .get();
 
     ss::sharded<net::server_configuration> kafka_cfg;


### PR DESCRIPTION
net: allow conn_quota logger to be configured 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

