### PR TITLE
goreleaser: default to CGO_ENABLED=0 allow override

### DIFF
--- a/src/go/.goreleaser.yaml
+++ b/src/go/.goreleaser.yaml
@@ -32,7 +32,7 @@ builds:
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
       - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
     env:
-      - CGO_ENABLED=1
+      - 'CGO_ENABLED={{ if index .Env "CGO_ENABLED" }}{{ .Env.CGO_ENABLED }}{{ else }}0{{ end }}'
     goos:
       - linux
     goarch:


### PR DESCRIPTION
follow-on to PR #17676, this PR fixes https://redpandadata.atlassian.net/browse/PESDLC-1079

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none