### PR TITLE
transform-sdk/cpp: add string conversion operators

### DIFF
--- a/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
+++ b/src/transform-sdk/cpp/include/redpanda/transform_sdk.h
@@ -21,6 +21,7 @@
 #include <ranges>
 #include <span>
 #include <string>
+#include <string_view>
 #include <system_error>
 #include <vector>
 
@@ -53,6 +54,10 @@ public:
     /** A view over an entire bytes range. */
     // NOLINTNEXTLINE(*-explicit-*)
     bytes_view(const bytes&);
+    /** A view over the bytes in a string. */
+    explicit bytes_view(const std::string& str);
+    /** A view over the bytes in a string view. */
+    explicit bytes_view(std::string_view str);
 
     /** The start of this range. */
     [[nodiscard]] bytes::const_pointer begin() const;

--- a/src/transform-sdk/cpp/src/transform_sdk.cc
+++ b/src/transform-sdk/cpp/src/transform_sdk.cc
@@ -390,6 +390,13 @@ void process_batch(const on_record_written_callback& callback) {
 bytes_view::bytes_view(const bytes& buf)
   : bytes_view(buf.begin(), buf.end()) {}
 
+bytes_view::bytes_view(const std::string& str)
+  : bytes_view(std::string_view{str}) {}
+
+bytes_view::bytes_view(std::string_view str)
+  // NOLINTNEXTLINE(*-reinterpret-cast)
+  : bytes_view(reinterpret_cast<const uint8_t*>(str.data()), str.size()) {}
+
 bytes_view::bytes_view(bytes::const_pointer start, size_t size)
   : bytes_view(start, start + static_cast<std::ptrdiff_t>(size)) {}
 


### PR DESCRIPTION
When working with external libraries (in my case a json library)
the output is often a string, so make it easy to write a string out to
the output topic.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
