### PR TITLE
rpk/security/acl/list: support --format=json

### DIFF
--- a/src/go/rpk/pkg/cli/security/acl/common.go
+++ b/src/go/rpk/pkg/cli/security/acl/common.go
@@ -61,23 +61,23 @@ type (
 	// Corresponding to the above, acl and aclWithMessage are the rows
 	// for PrintStructFields.
 	acl struct {
-		Principal           string
-		Host                string
-		ResourceType        kmsg.ACLResourceType
-		ResourceName        string
-		ResourcePatternType kmsg.ACLResourcePatternType
-		Operation           kmsg.ACLOperation
-		Permission          kmsg.ACLPermissionType
+		Principal           string                      `json:"principal"`
+		Host                string                      `json:"host"`
+		ResourceType        kmsg.ACLResourceType        `json:"resource_type"`
+		ResourceName        string                      `json:"resource_name"`
+		ResourcePatternType kmsg.ACLResourcePatternType `json:"resource_pattern_type"`
+		Operation           kmsg.ACLOperation           `json:"operation"`
+		Permission          kmsg.ACLPermissionType      `json:"permission"`
 	}
 	aclWithMessage struct {
-		Principal           string
-		Host                string
-		ResourceType        kmsg.ACLResourceType
-		ResourceName        string
-		ResourcePatternType kmsg.ACLResourcePatternType
-		Operation           kmsg.ACLOperation
-		Permission          kmsg.ACLPermissionType
-		Message             string
+		Principal           string                      `json:"principal"`
+		Host                string                      `json:"host"`
+		ResourceType        kmsg.ACLResourceType        `json:"resource_type"`
+		ResourceName        string                      `json:"resource_name"`
+		ResourcePatternType kmsg.ACLResourcePatternType `json:"resource_pattern_type"`
+		Operation           kmsg.ACLOperation           `json:"operation"`
+		Permission          kmsg.ACLPermissionType      `json:"permission"`
+		Message             string                      `json:"message"`
 	}
 )
 

--- a/src/go/rpk/pkg/cli/security/acl/delete.go
+++ b/src/go/rpk/pkg/cli/security/acl/delete.go
@@ -56,6 +56,7 @@ resource names:
 `,
 		Args: cobra.ExactArgs(0),
 		Run: func(cmd *cobra.Command, _ []string) {
+			f := p.Formatter // always text for now
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 
@@ -68,7 +69,7 @@ resource names:
 
 			var printDeletionsHeader bool
 			if !noConfirm || dry {
-				describeReqResp(adm, printAllFilters, true, b)
+				describeReqResp(adm, printAllFilters, true, b, f)
 				fmt.Println()
 
 				confirmed, err := out.Confirm("Confirm deletion of the above matching ACLs?")


### PR DESCRIPTION
Example output:

```
$ ./linux-amd64/rpk security acl list --format=text
PRINCIPAL  HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
User:bar   *     TOPIC          foo            LITERAL                ALL        ALLOW
User:bar   *     GROUP          g              LITERAL                ALL        ALLOW

$ ./linux-amd64/rpk security acl list -f --format=text
FILTERS
=======
PRINCIPAL  HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
                 ANY                           ANY                    ANY        ANY

MATCHES
=======
PRINCIPAL  HOST  RESOURCE-TYPE  RESOURCE-NAME  RESOURCE-PATTERN-TYPE  OPERATION  PERMISSION  ERROR
User:bar   *     TOPIC          foo            LITERAL                ALL        ALLOW
User:bar   *     GROUP          g              LITERAL                ALL        ALLOW

$ ./linux-amd64/rpk security acl list --format=json | jq
{
  "matches": [
    {
      "principal": "User:bar",
      "host": "*",
      "resource_type": "TOPIC",
      "resource_name": "foo",
      "resource_pattern_type": "LITERAL",
      "operation": "ALL",
      "permission": "ALLOW"
    },
    {
      "principal": "User:bar",
      "host": "*",
      "resource_type": "GROUP",
      "resource_name": "g",
      "resource_pattern_type": "LITERAL",
      "operation": "ALL",
      "permission": "ALLOW"
    }
  ]
}

$ ./linux-amd64/rpk security acl list -f --format=json | jq
{
  "filters": [
    {
      "principal": "",
      "host": "",
      "resource_type": "ANY",
      "resource_name": "",
      "resource_pattern_type": "ANY",
      "operation": "ANY",
      "permission": "ANY",
      "message": ""
    }
  ],
  "matches": [
    {
      "principal": "User:bar",
      "host": "*",
      "resource_type": "TOPIC",
      "resource_name": "foo",
      "resource_pattern_type": "LITERAL",
      "operation": "ALL",
      "permission": "ALLOW"
    },
    {
      "principal": "User:bar",
      "host": "*",
      "resource_type": "GROUP",
      "resource_name": "g",
      "resource_pattern_type": "LITERAL",
      "operation": "ALL",
      "permission": "ALLOW"
    }
  ]
}

```

Fixes: https://github.com/redpanda-data/redpanda/issues/17679

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


### Features

* `rpk security acl list` now supports `--format=json`

