### PR TITLE
rpk: doc updates and small QOL improvements

### DIFF
--- a/src/go/rpk/pkg/adminapi/admin.go
+++ b/src/go/rpk/pkg/adminapi/admin.go
@@ -651,3 +651,10 @@ func ClientTimeout(t time.Duration) Opt {
 		cl.Timeout = t
 	}}
 }
+
+// MaxRetries sets the client maxRetries, overriding the default of 3.
+func MaxRetries(r int) Opt {
+	return clientOpt{func(cl *pester.Client) {
+		cl.MaxRetries = r
+	}}
+}

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -167,7 +167,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	f.StringVarP(&namespace, "namespace", "n", "redpanda", "The namespace to use to collect the resources from (k8s only)")
 	f.StringArrayVarP(&labelSelector, "label-selector", "l", []string{"app.kubernetes.io/name=redpanda"}, "Comma-separated label selectors to filter your resources. e.g: <label>=<value>,<label>=<value> (k8s only)")
 	f.StringArrayVarP(&partitionFlag, "partition", "p", nil, "Comma-separated partition IDs; when provided, rpk saves extra admin API requests for those partitions. Check help for extended usage")
-	f.DurationVar(&cpuProfilerWait, "cpu-profiler-wait", 30*time.Second, "For how long to collect samples for the cpu profiler (e.g. 30s, 1.5m). Must be higher than 15s")
+	f.DurationVar(&cpuProfilerWait, "cpu-profiler-wait", 30*time.Second, "For how long to collect samples for the CPU profiler (e.g. 30s, 1.5m). Must be higher than 15s")
 
 	return cmd
 }
@@ -253,7 +253,7 @@ COMMON FILES
 
  - Admin API calls: Multiple requests to gather information such as: Cluster and
    broker configurations, cluster health data, balancer status, cloud storage
-   status, cpu profiles, and license key information.
+   status, CPU profiles, and license key information.
 
  - Broker metrics: The broker's Prometheus metrics, fetched through its
    admin API (/metrics and /public_metrics).

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -132,7 +132,7 @@ func Execute() {
 	// flag. We exec with the flag and then create a bunch of fake cobra
 	// commands within rpk. The plugin now looks like it is a part of rpk.
 	//
-	// We block plugins from overwriting actual rpk commands (rpk acl),
+	// We block plugins from overwriting actual rpk commands (rpk security acl),
 	// unless the plugin is specifically rpk managed.
 	//
 	// Managed plugins are slightly weirder and are documented below.

--- a/src/go/rpk/pkg/cli/security/acl/acl.go
+++ b/src/go/rpk/pkg/cli/security/acl/acl.go
@@ -90,8 +90,8 @@ present, it is treated as text rather than as principal type information.
 When you create a role, you must bind or associate ACLs to it before it can be
 used. You can create / delete / list ACLs for that role with "<name>" in the
 --allow-role and --deny-role flags. Note that the wildcard role name '*' is not
-permitted here. For example 'rpk acl create --allow-role '*' ...' will produce
-an error.
+permitted here. For example 'rpk security acl create --allow-role '*' ...' will 
+produce an error.
 
 HOSTS
 
@@ -137,7 +137,7 @@ Redpanda has the following operations:
 
 Check --help-operations to see which operations are required for which
 requests. In flag form to set up a general producing/consuming client, you can
-invoke 'rpk acl create' three times with the following (including your
+invoke 'rpk security acl create' three times with the following (including your
 --allow-principal):
 
     --operation write,read,describe --topic [topics]

--- a/src/go/rpk/pkg/cli/security/acl/acl.go
+++ b/src/go/rpk/pkg/cli/security/acl/acl.go
@@ -54,8 +54,8 @@ An ACL is made up of five components:
 
   * a principal (the user) or role
   * a host, which the principal (or role) is allowed or denied requests from
-  * what resource to access (topic name, group ID, ...)
-  * the operation (read, write, ...)
+  * what resource to access (such as topic name, group ID)
+  * the operation (such as read, write)
   * the permission: whether to allow or deny the above
 
 ACL commands work on a multiplicative basis. If creating, specifying two

--- a/src/go/rpk/pkg/cli/security/acl/create.go
+++ b/src/go/rpk/pkg/cli/security/acl/create.go
@@ -43,7 +43,7 @@ Allow all permissions to role bar on topic "foo" and group "g":
     --allow-role bar --operation all --topic foo --group g
 Allow read permissions to all users on topics biz and baz:
     --allow-principal '*' --operation read --topic biz,baz
-Allow write permissions to user buzz to transactional id "txn":
+Allow write permissions to user buzz to transactional ID "txn":
     --allow-principal User:buzz --operation write --transactional-id txn
 `,
 

--- a/src/go/rpk/pkg/cli/security/acl/create.go
+++ b/src/go/rpk/pkg/cli/security/acl/create.go
@@ -28,13 +28,13 @@ func newCreateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short: "Create ACLs",
 		Long: `Create ACLs.
 
-See the 'rpk acl' help text for a full write up on ACLs. Following the
+See the 'rpk security acl' help text for a full write up on ACLs. Following the
 multiplying effect of combining flags, the create command works on a
 straightforward basis: every ACL combination is a created ACL.
 
-As mentioned in the 'rpk acl' help text, if no host is specified, an allowed
-principal is allowed access from all hosts. The wildcard principal '*' allows
-all principals. At least one principal, one host, one resource, and one
+As mentioned in the 'rpk security acl' help text, if no host is specified, an
+allowed principal is allowed access from all hosts. The wildcard principal '*'
+allows all principals. At least one principal, one host, one resource, and one
 operation is required to create a single ACL.
 
 Allow all permissions to user bar on topic "foo" and group "g":

--- a/src/go/rpk/pkg/cli/security/acl/delete.go
+++ b/src/go/rpk/pkg/cli/security/acl/delete.go
@@ -34,13 +34,14 @@ func newDeleteCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short: "Delete ACLs",
 		Long: `Delete ACLs.
 
-See the 'rpk acl' help text for a full write up on ACLs. Delete flags work in a
-similar multiplying effect as creating ACLs, but delete is more advanced:
-deletion works on a filter basis. Any unspecified flag defaults to matching
-everything (all operations, or all allowed principals, etc). To ensure that you
-do not accidentally delete more than you intend, this command prints everything
-that matches your input filters and prompts for a confirmation before the
-delete request is issued. Anything matching more than 10 ACLs doubly confirms.
+See the 'rpk security acl' help text for a full write up on ACLs. Delete flags
+work in a similar multiplying effect as creating ACLs, but delete is more
+advanced: deletion works on a filter basis. Any unspecified flag defaults to
+matching everything (all operations, or all allowed principals, etc). To ensure
+that you do not accidentally delete more than you intend, this command prints
+everything that matches your input filters and prompts for a confirmation before
+the delete request is issued. Anything matching more than 10 ACLs doubly
+confirms.
 
 As mentioned, not specifying flags matches everything. If no resources are
 specified, all resources are matched. If no operations are specified, all

--- a/src/go/rpk/pkg/cli/security/acl/delete.go
+++ b/src/go/rpk/pkg/cli/security/acl/delete.go
@@ -114,10 +114,10 @@ func (a *acls) addDeleteFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(&a.operations, operationFlag, nil, "Operation to remove (repeatable)")
 
 	cmd.Flags().StringSliceVar(&a.allowPrincipals, allowPrincipalFlag, nil, "Allowed principal ACLs to remove (repeatable)")
-	cmd.Flags().StringSliceVar(&a.allowRoles, allowRoleFlag, nil, "Allowed role ACLs to remove (repeatable)")
+	cmd.Flags().StringSliceVar(&a.allowRoles, allowRoleFlag, nil, "Allowed role to remove this ACL from (repeatable)")
 	cmd.Flags().StringSliceVar(&a.allowHosts, allowHostFlag, nil, "Allowed host ACLs to remove (repeatable)")
 	cmd.Flags().StringSliceVar(&a.denyPrincipals, denyPrincipalFlag, nil, "Denied principal ACLs to remove (repeatable)")
-	cmd.Flags().StringSliceVar(&a.denyRoles, denyRoleFlag, nil, "Denied role ACLs to remove (repeatable)")
+	cmd.Flags().StringSliceVar(&a.denyRoles, denyRoleFlag, nil, "Denied role to remove this ACL from (repeatable)")
 	cmd.Flags().StringSliceVar(&a.denyHosts, denyHostFlag, nil, "Denied host ACLs to remove (repeatable)")
 }
 

--- a/src/go/rpk/pkg/cli/security/acl/list.go
+++ b/src/go/rpk/pkg/cli/security/acl/list.go
@@ -31,10 +31,10 @@ func newListCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short:   "List ACLs",
 		Long: `List ACLs.
 
-See the 'rpk acl' help text for a full write up on ACLs. List flags work in a
-similar multiplying effect as creating ACLs, but list is more advanced:
-listing works on a filter basis. Any unspecified flag defaults to matching
-everything (all operations, or all allowed principals, etc).
+See the 'rpk security acl' help text for a full write up on ACLs. List flags
+work in a similar multiplying effect as creating ACLs, but list is more
+advanced: listing works on a filter basis. Any unspecified flag defaults to
+matching everything (all operations, or all allowed principals, etc).
 
 As mentioned, not specifying flags matches everything. If no resources are
 specified, all resources are matched. If no operations are specified, all

--- a/src/go/rpk/pkg/cli/security/role/assign.go
+++ b/src/go/rpk/pkg/cli/security/role/assign.go
@@ -27,9 +27,9 @@ func assignCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short:   "Assign a Redpanda role to a principal",
 		Long: `Assign a Redpanda role to a principal.
 
-The '--principal' flag accepts principals with the format 
-<PrincipalPrefix>:<Principal>. It defaults to 'User:' if PrincipalPrefix is not
-provided.
+The '--principal' flag accepts principals with the format
+'<PrincipalPrefix>:<Principal>'. If 'PrincipalPrefix' is not provided, then
+defaults to 'User:'.
 `,
 		Example: `
 Assign role "redpanda-admin" to user "red"

--- a/src/go/rpk/pkg/cli/security/role/describe.go
+++ b/src/go/rpk/pkg/cli/security/role/describe.go
@@ -50,8 +50,8 @@ func describeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short:   "Describe a Redpanda role",
 		Long: `Describe a Redpanda role.
 
-This command describes a Role, including the ACLs associated to the role and 
-a list of members that have the role assigned.
+This command describes a role, including the ACLs associated to the role, and 
+lists members who are assigned the role.
 `,
 		Example: `
 Describe the role 'red' (print members and ACLs)

--- a/src/go/rpk/pkg/cli/security/role/list.go
+++ b/src/go/rpk/pkg/cli/security/role/list.go
@@ -35,10 +35,10 @@ func listCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 List all roles in Redpanda:
   rpk security role list
 
-List all roles where the user 'red' belongs to:
+List all roles assigned to the user 'red':
   rpk security role list --principal red
 
-List all roles that start with "agent-":
+List all roles with the prefix "agent-":
   rpk security role list --prefix "agent-"`,
 		Aliases: []string{"ls"},
 		Args:    cobra.ExactArgs(0),
@@ -78,8 +78,8 @@ List all roles that start with "agent-":
 		},
 	}
 
-	cmd.Flags().StringVar(&prefix, "prefix", "", "Return the roles that matches the given prefix")
-	cmd.Flags().StringVar(&principalFlag, "principal", "", "Return the roles that matches the given principal; if no principal prefix is given, 'User:' is assumed")
+	cmd.Flags().StringVar(&prefix, "prefix", "", "Return the roles matching the specified prefix")
+	cmd.Flags().StringVar(&principalFlag, "principal", "", "Return the roles matching the specified principal; if no principal prefix is given, `User:` is used")
 
 	return cmd
 }

--- a/src/go/rpk/pkg/cli/security/role/unassign.go
+++ b/src/go/rpk/pkg/cli/security/role/unassign.go
@@ -27,9 +27,9 @@ func unassignCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short:   "Unassign a Redpanda role from a principal",
 		Long: `Unassign a Redpanda role from a principal.
 
-The '--principal' flag accepts principals with the format 
-<PrincipalPrefix>:<Principal>. It defaults to 'User:' if PrincipalPrefix is not
-provided.
+The '--principal' flag accepts principals with the format
+'<PrincipalPrefix>:<Principal>'. If 'PrincipalPrefix' is not provided, then
+defaults to 'User:'.
 `,
 		Example: `
 Unassign role "redpanda-admin" from user "red"

--- a/src/go/rpk/pkg/cli/security/user/create.go
+++ b/src/go/rpk/pkg/cli/security/user/create.go
@@ -78,9 +78,9 @@ acl help text for more info.
 			pass = cmd.Flag("password").Value.String()
 			var generated bool
 			// We either run the command without password:
-			//   rpk acl user create foo
+			//   rpk security acl user create foo
 			// Or we run the command with user/password for basic auth:
-			//   rpk acl user create foo --user my_user --pass my_pass
+			//   rpk security acl user create foo --user my_user --pass my_pass
 			// In both cases, we auto-generate a random password:
 			if (newPass == "" && pass == "") || (newPass == "" && userFlag != "" && pass != "") {
 				gen, err := generatePassword(30)

--- a/src/go/rpk/pkg/cli/security/user/user.go
+++ b/src/go/rpk/pkg/cli/security/user/user.go
@@ -22,10 +22,10 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Long: `Manage SASL users.
 
 If SASL is enabled, a SASL user is what you use to talk to Redpanda, and ACLs
-control what your user has access to. See 'rpk acl --help' for more information
-about ACLs, and 'rpk acl user create --help' for more information about
-creating SASL users. Using SASL requires setting "enable_sasl: true" in the
-redpanda section of your redpanda.yaml.
+control what your user has access to. See 'rpk security  acl --help' for more
+information about ACLs, and 'rpk security acl user create --help' for more
+information about creating SASL users. Using SASL requires setting "enable_sasl:
+true" in the redpanda section of your redpanda.yaml.
 `,
 	}
 	p.InstallAdminFlags(cmd)

--- a/src/go/rpk/pkg/httpapi/httpapi.go
+++ b/src/go/rpk/pkg/httpapi/httpapi.go
@@ -310,9 +310,13 @@ func (cl *Client) do(ctx context.Context, method, path string, qps url.Values, b
 		for k, v := range cl.headers {
 			req.Header.Set(k, v)
 		}
-		zap.L().Sugar().Debugf("requesting %s", req.URL)
+		zap.L().Sugar().Debugf("requesting %s %s", req.Method, req.URL)
 		resp, err = cl.httpCl.Do(req)
-		zap.L().Sugar().Debugf("got response for %s", req.URL)
+		if resp != nil {
+			zap.L().Sugar().Debugf("got response for %s %s: %v", req.Method, req.URL, resp.Status)
+		} else {
+			zap.L().Sugar().Debugf("got response for %s", req.URL)
+		}
 
 		if isRetryable, err := backoff.maybeDo(ctx, resp, err); err != nil {
 			return err


### PR DESCRIPTION
This PR:

- Matches our internal help text to our online docs (see https://github.com/redpanda-data/docs/pull/393)
- Reduce the timeout and retries for `rpk version`
- Improves our logging of the `httpapi` package

**Logs examples:**
```
15:57:46.189  DEBUG  requesting POST https://cloud-api.prd.cloud.redpanda.com/oauth/token
15:57:46.262  DEBUG  got response for POST https://cloud-api.prd.cloud.redpanda.com/oauth/token: 400 Bad Request


15:57:53.409  DEBUG  requesting GET https://cloud-api.prd.cloud.redpanda.com/api/v1/organization
15:57:53.409  DEBUG  requesting GET https://cloud-api.prd.cloud.redpanda.com/api/v1/namespaces
15:57:53.409  DEBUG  requesting GET https://cloud-api.prd.cloud.redpanda.com/api/v1/virtual-clusters
15:57:53.498  DEBUG  got response for GET https://cloud-api.prd.cloud.redpanda.com/api/v1/namespaces: 200 OK
15:57:53.714  DEBUG  got response for GET https://cloud-api.prd.cloud.redpanda.com/api/v1/clusters: 200 OK
15:57:53.782  DEBUG  got response for GET https://cloud-api.prd.cloud.redpanda.com/api/v1/virtual-clusters: 200 OK
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
