### PR TITLE
wasm: reset call context on failure

### DIFF
--- a/src/v/wasm/tests/wasm_transform_test.cc
+++ b/src/v/wasm/tests/wasm_transform_test.cc
@@ -59,6 +59,9 @@ TEST_F(WasmTestFixture, HandlesTransformPanic) {
 TEST_F(WasmTestFixture, HandlesTransformErrors) {
     load_wasm("transform-error.wasm");
     EXPECT_THROW(transform(make_tiny_batch()), wasm::wasm_exception);
+    engine()->stop().get();
+    engine()->start().get();
+    EXPECT_THROW(transform(make_tiny_batch()), wasm::wasm_exception);
 }
 
 namespace {

--- a/src/v/wasm/transform_module.cc
+++ b/src/v/wasm/transform_module.cc
@@ -108,9 +108,8 @@ ss::future<> transform_module::for_each_record_async(
       .callback = cb,
     });
 
-    co_await host_wait_for_proccessing();
-
-    auto result = std::exchange(_call_ctx, std::nullopt);
+    return host_wait_for_proccessing().finally(
+      [this] { _call_ctx = std::nullopt; });
 }
 
 void transform_module::check_abi_version_1() {


### PR DESCRIPTION
In the case of an error we still need to reset the call context or things could break when restarting the module.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
