### PR TITLE
[v23.3.x] wasm: reset call context on error

### DIFF
--- a/src/v/wasm/tests/wasm_transform_test.cc
+++ b/src/v/wasm/tests/wasm_transform_test.cc
@@ -57,6 +57,9 @@ TEST_F(WasmTestFixture, HandlesTransformPanic) {
 TEST_F(WasmTestFixture, HandlesTransformErrors) {
     load_wasm("transform-error.wasm");
     EXPECT_THROW(transform(make_tiny_batch()), wasm::wasm_exception);
+    engine()->stop().get();
+    engine()->start().get();
+    EXPECT_THROW(transform(make_tiny_batch()), wasm::wasm_exception);
 }
 
 namespace {

--- a/src/v/wasm/transform_module.cc
+++ b/src/v/wasm/transform_module.cc
@@ -86,10 +86,9 @@ transform_module::for_each_record_async(
       .record_callback = std::move(cb),
     });
 
-    co_await host_wait_for_proccessing();
-
-    auto result = std::exchange(_call_ctx, std::nullopt);
-    co_return std::move(result->output_data);
+    return host_wait_for_proccessing()
+      .then([this] { return std::move(_call_ctx->output_data); })
+      .finally([this] { _call_ctx = std::nullopt; });
 }
 
 void transform_module::check_abi_version_1() {


### PR DESCRIPTION
Backport of #17695

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


### Bug Fixes

* Fixes a crash when data transforms error and restart
