### PR TITLE
[v23.3.x] Use `node_status_table` as a single source of truth about node liveness

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -174,6 +174,7 @@ cluster::errc map_update_interruption_error_code(std::error_code ec) {
         case rpc::errc::service_error:
         case rpc::errc::method_not_found:
         case rpc::errc::version_not_supported:
+        case rpc::errc::service_unavailable:
         case rpc::errc::unknown:
             return errc::replication_error;
         }

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -577,7 +577,14 @@ ss::future<> controller::start(
             std::ref(_partition_leaders),
             std::ref(_tp_state));
       })
-      .then([this] { return _hm_frontend.start(std::ref(_hm_backend)); })
+      .then([this] {
+          return _hm_frontend.start(
+            std::ref(_hm_backend),
+            std::ref(_node_status_table),
+            ss::sharded_parameter([]() {
+                return config::shard_local_cfg().alive_timeout_ms.bind();
+            }));
+      })
       .then([this] {
           return _hm_frontend.invoke_on_all(&health_monitor_frontend::start);
       })

--- a/src/v/cluster/feature_manager.cc
+++ b/src/v/cluster/feature_manager.cc
@@ -15,6 +15,8 @@
 #include "cluster/commands.h"
 #include "cluster/controller_service.h"
 #include "cluster/health_monitor_frontend.h"
+#include "cluster/health_monitor_types.h"
+#include "cluster/logger.h"
 #include "cluster/members_table.h"
 #include "config/configuration.h"
 #include "config/validators.h"
@@ -405,25 +407,6 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
     // B) All member nodes must be up
     // C) All versions must be >= the new active version
 
-    std::map<model::node_id, node_state> node_status;
-
-    // This call in principle can be a network fetch, but in practice
-    // we're only doing it immediately after cluster health has just
-    // been updated, so do not expect it to go remote.
-    auto node_status_v = co_await _hm_frontend.local().get_nodes_status(
-      model::timeout_clock::now() + 5s);
-    if (node_status_v.has_error()) {
-        // Raise exception to trigger backoff+retry
-        throw std::runtime_error(fmt::format(
-          "Can't update active cluster version, failed to get health "
-          "status: {}",
-          node_status_v.error()));
-    } else {
-        for (const auto& i : node_status_v.value()) {
-            node_status.emplace(i.id, i);
-        }
-    }
-
     // Ensure that our _node_versions contains versions for all
     // nodes in members_table & that they are all sufficiently recent
     const auto& member_table = _members.local();
@@ -449,8 +432,8 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
             co_return;
         }
 
-        auto state_iter = node_status.find(node_id);
-        if (state_iter == node_status.end()) {
+        auto is_alive_opt = _hm_frontend.local().is_alive(node_id);
+        if (!is_alive_opt.has_value()) {
             // Unexpected: the health monitor should be populating
             // state for all known members_table nodes, but this
             // could happen if we raced with a decom or node add.
@@ -462,7 +445,7 @@ ss::future<> feature_manager::do_maybe_update_active_version() {
               max_version,
               node_id));
 
-        } else if (!state_iter->second.is_alive) {
+        } else if (is_alive_opt == alive::no) {
             // Raise exception to trigger backoff+retry
             throw std::runtime_error(fmt_with_ctx(
               fmt::format,

--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -137,12 +137,10 @@ cluster_health_report health_monitor_backend::build_cluster_report(
 
         auto it = _status.find(node_id);
         if (it != _status.end()) {
-            statuses.push_back(node_state{
-              .id = node_id,
-              .membership_state
-              = node_metadata->get().state.get_membership_state(),
-              .is_alive = it->second.is_alive,
-            });
+            statuses.emplace_back(
+              node_id,
+              node_metadata->get().state.get_membership_state(),
+              it->second.is_alive);
         }
     }
 

--- a/src/v/cluster/health_monitor_frontend.cc
+++ b/src/v/cluster/health_monitor_frontend.cc
@@ -11,15 +11,24 @@
 #include "cluster/health_monitor_frontend.h"
 
 #include "cluster/logger.h"
+#include "config/property.h"
 #include "model/timeout_clock.h"
 
 #include <seastar/util/later.hh>
 
+#include <chrono>
+#include <ctime>
+#include <optional>
+
 namespace cluster {
 
 health_monitor_frontend::health_monitor_frontend(
-  ss::sharded<health_monitor_backend>& backend)
-  : _backend(backend) {}
+  ss::sharded<health_monitor_backend>& backend,
+  ss::sharded<node_status_table>& node_status_table,
+  config::binding<std::chrono::milliseconds> alive_timeout)
+  : _backend(backend)
+  , _node_status_table(node_status_table)
+  , _alive_timeout(std::move(alive_timeout)) {}
 
 ss::future<> health_monitor_frontend::start() {
     if (ss::this_shard_id() == refresher_shard) {
@@ -63,29 +72,15 @@ health_monitor_frontend::collect_node_health(node_report_filter f) {
           return be.collect_current_node_health(std::move(f));
       });
 }
-
-// Return status of single node
-ss::future<result<std::vector<node_state>>>
-health_monitor_frontend::get_nodes_status(
-  model::timeout_clock::time_point deadline) {
-    return dispatch_to_backend([deadline](health_monitor_backend& be) {
-        // build filter
-        cluster_report_filter filter{
-          .node_report_filter = node_report_filter{
-            .include_partitions = include_partitions_info::no,
-          }};
-        return be.get_cluster_health(filter, force_refresh::no, deadline)
-          .then([](result<cluster_health_report> res) {
-              using ret_t = result<std::vector<node_state>>;
-              if (!res) {
-                  return ret_t(res.error());
-              }
-
-              return ret_t(std::move(res.value().node_states));
-          });
-    });
+std::optional<alive>
+health_monitor_frontend::is_alive(model::node_id id) const {
+    auto status = _node_status_table.local().get_node_status(id);
+    if (!status) {
+        return std::nullopt;
+    }
+    return alive(
+      status->last_seen + _alive_timeout() >= model::timeout_clock::now());
 }
-
 ss::future<result<std::optional<cluster::drain_manager::drain_status>>>
 health_monitor_frontend::get_node_drain_status(
   model::node_id node_id, model::timeout_clock::time_point deadline) {

--- a/src/v/cluster/health_monitor_frontend.h
+++ b/src/v/cluster/health_monitor_frontend.h
@@ -12,6 +12,8 @@
 #include "cluster/fwd.h"
 #include "cluster/health_monitor_backend.h"
 #include "cluster/health_monitor_types.h"
+#include "cluster/node_status_table.h"
+#include "config/property.h"
 #include "controller_stm.h"
 #include "model/metadata.h"
 #include "model/timeout_clock.h"
@@ -19,6 +21,7 @@
 
 #include <seastar/core/sharded.hh>
 
+#include <chrono>
 #include <utility>
 
 namespace cluster {
@@ -31,6 +34,9 @@ namespace cluster {
  * health monitor backend which lives on single shard.
  * Most requests are forwarded to the backend shard, except cluster-level disk
  * health, which is kept cached on each core for fast access.
+ *
+ * Health monitor frontend is also an entry point for querying information about
+ * the node liveness status.
  */
 class health_monitor_frontend
   : public seastar::peering_sharded_service<health_monitor_frontend> {
@@ -40,7 +46,10 @@ public:
     static constexpr ss::shard_id refresher_shard
       = cluster::controller_stm_shard;
 
-    explicit health_monitor_frontend(ss::sharded<health_monitor_backend>&);
+    explicit health_monitor_frontend(
+      ss::sharded<health_monitor_backend>&,
+      ss::sharded<node_status_table>&,
+      config::binding<std::chrono::milliseconds>);
 
     ss::future<> start();
     ss::future<> stop();
@@ -58,10 +67,6 @@ public:
     // filters list
     ss::future<result<node_health_report>>
       collect_node_health(node_report_filter);
-
-    // Return status of all nodes
-    ss::future<result<std::vector<node_state>>>
-      get_nodes_status(model::timeout_clock::time_point);
 
     /**
      * Return drain status for a given node.
@@ -84,6 +89,11 @@ public:
       get_cluster_health_overview(model::timeout_clock::time_point);
 
     ss::future<bool> does_raft0_have_leader();
+    /**
+     * Method validating if a node is known and alive. It will return an empty
+     * optional if the node is not present in node status table.
+     */
+    std::optional<alive> is_alive(model::node_id) const;
 
 private:
     template<typename Func>
@@ -93,13 +103,14 @@ private:
     }
 
     ss::sharded<health_monitor_backend>& _backend;
+    ss::sharded<node_status_table>& _node_status_table;
+    config::binding<std::chrono::milliseconds> _alive_timeout;
 
     // Currently the worst / max of all nodes' disk space state
     storage::disk_space_alert _cluster_disk_health{
       storage::disk_space_alert::ok};
     ss::timer<ss::lowres_clock> _refresh_timer;
     ss::gate _refresh_gate;
-
     void disk_health_tick();
     ss::future<> update_other_shards(const storage::disk_space_alert);
     ss::future<> update_frontend_and_backend_cache();

--- a/src/v/cluster/health_monitor_types.cc
+++ b/src/v/cluster/health_monitor_types.cc
@@ -56,12 +56,18 @@ bool partitions_filter::matches(
     return false;
 }
 
+node_state::node_state(
+  model::node_id id, model::membership_state membership_state, alive is_alive)
+  : _id(id)
+  , _membership_state(membership_state)
+  , _is_alive(is_alive) {}
+
 std::ostream& operator<<(std::ostream& o, const node_state& s) {
     fmt::print(
       o,
       "{{membership_state: {}, is_alive: {}}}",
-      s.membership_state,
-      s.is_alive);
+      s._membership_state,
+      s._is_alive);
     return o;
 }
 

--- a/src/v/cluster/health_monitor_types.h
+++ b/src/v/cluster/health_monitor_types.h
@@ -44,15 +44,40 @@ using application_version = named_type<ss::sstring, struct version_number_tag>;
 struct node_state
   : serde::envelope<node_state, serde::version<0>, serde::compat_version<0>> {
     static constexpr int8_t current_version = 0;
+    node_state(
+      model::node_id id,
+      model::membership_state membership_state,
+      alive is_alive);
 
-    model::node_id id;
-    model::membership_state membership_state;
-    alive is_alive;
+    node_state() = default;
+    node_state(const node_state&) = default;
+    node_state(node_state&&) noexcept = default;
+    node_state& operator=(const node_state&) = default;
+    node_state& operator=(node_state&&) noexcept = default;
+    ~node_state() noexcept = default;
+
+    model::node_id id() const { return _id; }
+
+    model::membership_state membership_state() const {
+        return _membership_state;
+    }
+    // clang-format off
+    [[deprecated("please use health_monitor_frontend::is_alive() to query for "
+                 "liveness")]] 
+    alive is_alive() const {
+        return _is_alive;
+    }
+    // clang-format on
     friend std::ostream& operator<<(std::ostream&, const node_state&);
 
     friend bool operator==(const node_state&, const node_state&) = default;
 
-    auto serde_fields() { return std::tie(id, membership_state, is_alive); }
+    auto serde_fields() { return std::tie(_id, _membership_state, _is_alive); }
+
+private:
+    model::node_id _id;
+    model::membership_state _membership_state;
+    alive _is_alive;
 };
 
 struct partition_status

--- a/src/v/cluster/node_isolation_watcher.cc
+++ b/src/v/cluster/node_isolation_watcher.cc
@@ -75,30 +75,6 @@ ss::future<bool> node_isolation_watcher::is_node_isolated() {
         co_return false;
     }
 
-    auto nodes_status_res = co_await _health_monitor.local().get_nodes_status(
-      config::shard_local_cfg().metadata_status_wait_timeout_ms()
-      + model::timeout_clock::now());
-
-    if (nodes_status_res.has_value()) {
-        auto& nodes_status = nodes_status_res.value();
-
-        // All nodes from health report should be not alive for isolation
-        bool is_one_of_node_not_alive = std::any_of(
-          nodes_status.begin(),
-          nodes_status.end(),
-          [](const node_state& node_state) {
-              // Current node should not influence on answer.
-              if (config::node().node_id() == node_state.id) {
-                  return cluster::alive::no;
-              }
-              return node_state.is_alive;
-          });
-
-        if (is_one_of_node_not_alive) {
-            co_return false;
-        }
-    }
-
     co_return true;
 }
 

--- a/src/v/cluster/node_status_backend.cc
+++ b/src/v/cluster/node_status_backend.cc
@@ -16,6 +16,7 @@
 #include "cluster/logger.h"
 #include "cluster/node_status_table.h"
 #include "config/node_config.h"
+#include "model/metadata.h"
 #include "rpc/types.h"
 #include "ssx/future-util.h"
 
@@ -180,6 +181,11 @@ ss::future<> node_status_backend::collect_and_store_updates() {
       [updates = std::move(updates)](auto& table) {
           table.update_peers(updates);
       });
+}
+
+void node_status_backend::reset_node_backoff(model::node_id id) {
+    vlog(clusterlog.debug, "Resetting reconnect backoff for node: {}", id);
+    _node_connection_set.reset_client_backoff(id);
 }
 
 ss::future<std::vector<node_status>>

--- a/src/v/cluster/node_status_backend.h
+++ b/src/v/cluster/node_status_backend.h
@@ -60,6 +60,11 @@ public:
 
     ss::future<> start();
     ss::future<> stop();
+    /**
+     * Resets node connection backoff. This method is called when current node
+     * receives hello request.
+     */
+    void reset_node_backoff(model::node_id id);
 
 private:
     ss::future<> drain_notifications_queue();

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -41,7 +41,8 @@ public:
       ss::sharded<features::feature_table>&,
       ss::sharded<health_monitor_frontend>&,
       ss::sharded<rpc::connection_cache>&,
-      ss::sharded<partition_manager>&);
+      ss::sharded<partition_manager>&,
+      ss::sharded<node_status_backend>&);
 
     virtual ss::future<join_node_reply>
     join_node(join_node_request, rpc::streaming_context&) override;
@@ -189,5 +190,6 @@ private:
     ss::sharded<rpc::connection_cache>& _conn_cache;
     ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<plugin_frontend>& _plugin_frontend;
+    ss::sharded<node_status_backend>& _node_status_backend;
 };
 } // namespace cluster

--- a/src/v/cluster/tests/health_monitor_test.cc
+++ b/src/v/cluster/tests/health_monitor_test.cc
@@ -91,15 +91,14 @@ void check_states_the_same(
 
     auto by_id = [](
                    const cluster::node_state& lr,
-                   const cluster::node_state& rr) { return lr.id < rr.id; };
+                   const cluster::node_state& rr) { return lr.id() < rr.id(); };
     std::sort(lhs.begin(), lhs.end(), by_id);
     std::sort(rhs.begin(), rhs.end(), by_id);
 
     for (auto i = 0; i < lhs.size(); ++i) {
         auto& lr = lhs[i];
         auto& rr = rhs[i];
-        BOOST_TEST_REQUIRE(lr.is_alive == rr.is_alive);
-        BOOST_TEST_REQUIRE(lr.membership_state == rr.membership_state);
+        BOOST_TEST_REQUIRE(lr.membership_state() == rr.membership_state());
     }
 }
 
@@ -343,25 +342,9 @@ FIXTURE_TEST(test_alive_status, cluster_test_fixture) {
 
     // wait until the node will be reported as not alive
     tests::cooperative_spin_wait_with_timeout(10s, [&n1] {
-        return n1->controller->get_health_monitor()
-          .local()
-          .get_cluster_health(
-            get_all, cluster::force_refresh::yes, model::no_timeout)
-          .then([](result<cluster::cluster_health_report> res) {
-              if (!res) {
-                  return false;
-              }
-              if (res.value().node_reports.empty()) {
-                  return false;
-              }
-              auto it = std::find_if(
-                res.value().node_states.begin(),
-                res.value().node_states.end(),
-                [](cluster::node_state& s) {
-                    return s.id == model::node_id(1);
-                });
-              return it->is_alive == cluster::alive::no;
-          });
+        return n1->controller->get_health_monitor().local().is_alive(
+                 model::node_id(1))
+               == cluster::alive::no;
     }).get();
 }
 

--- a/src/v/cluster/tests/randoms.h
+++ b/src/v/cluster/tests/randoms.h
@@ -43,8 +43,7 @@ inline errc random_failed_errc() {
 }
 
 inline node_state random_node_state() {
-    return node_state{
-      {},
+    return {
       tests::random_named_int<model::node_id>(),
       model::random_membership_state(),
       cluster::alive(tests::random_bool())};

--- a/src/v/cluster/tests/serialization_rt_test.cc
+++ b/src/v/cluster/tests/serialization_rt_test.cc
@@ -728,11 +728,7 @@ cluster::node::local_state random_local_state() {
 cluster::cluster_health_report random_cluster_health_report() {
     std::vector<cluster::node_state> node_states;
     for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
-        node_states.push_back(cluster::node_state{
-          .id = tests::random_named_int<model::node_id>(),
-          .membership_state = model::membership_state::draining,
-          .is_alive = cluster::alive(tests::random_bool()),
-        });
+        node_states.push_back(cluster::random_node_state());
     }
     std::vector<cluster::node_health_report> node_reports;
     for (auto i = 0, mi = random_generators::get_int(20); i < mi; ++i) {
@@ -1675,14 +1671,7 @@ SEASTAR_THREAD_TEST_CASE(serde_reflection_roundtrip) {
         };
         roundtrip_test(data);
     }
-    {
-        cluster::node_state data{
-          .id = tests::random_named_int<model::node_id>(),
-          .membership_state = model::membership_state::draining,
-          .is_alive = cluster::alive(tests::random_bool()),
-        };
-        roundtrip_test(data);
-    }
+    { roundtrip_test(cluster::random_node_state()); }
     {
         auto data = random_cluster_health_report();
         roundtrip_test(data);

--- a/src/v/compat/cluster_json.h
+++ b/src/v/compat/cluster_json.h
@@ -313,11 +313,14 @@ inline void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const cluster::node_state& f) {
     w.StartObject();
     w.Key("id");
-    rjson_serialize(w, f.id);
+    rjson_serialize(w, f.id());
     w.Key("membership_state");
-    rjson_serialize(w, f.membership_state);
+    rjson_serialize(w, f.membership_state());
     w.Key("is_alive");
-    rjson_serialize(w, f.is_alive);
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    rjson_serialize(w, f.is_alive());
+#pragma clang diagnostic pop
     w.EndObject();
 }
 
@@ -449,7 +452,7 @@ inline void read_value(json::Value const& rd, cluster::node_state& obj) {
     read_member(rd, "membership_state", membership_state);
     read_member(rd, "is_alive", is_alive);
 
-    obj = cluster::node_state{{}, id, membership_state, is_alive};
+    obj = cluster::node_state(id, membership_state, is_alive);
 }
 
 inline void

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2625,6 +2625,13 @@ configuration::configuration()
       "the data directory. Redpanda will refuse to start if it is not found.",
       {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false)
+  , alive_timeout_ms(
+      *this,
+      "alive_timeout_ms",
+      "Time from the last node status heartbeat after which a node will be "
+      "considered offline and not alive",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      5s)
   , memory_abort_on_alloc_failure(
       *this,
       "memory_abort_on_alloc_failure",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -479,6 +479,7 @@ struct configuration final : public config_store {
     bounded_property<size_t> storage_space_alert_free_threshold_bytes;
     bounded_property<size_t> storage_min_free_bytes;
     property<bool> storage_strict_data_init;
+    property<std::chrono::milliseconds> alive_timeout_ms;
 
     // memory related settings
     property<bool> memory_abort_on_alloc_failure;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1169,6 +1169,7 @@ ss::future<> admin_server::throw_on_error(
         case rpc::errc::service_error:
         case rpc::errc::method_not_found:
         case rpc::errc::version_not_supported:
+        case rpc::errc::service_unavailable:
         case rpc::errc::unknown:
             throw ss::httpd::server_error_exception(
               fmt::format("Unexpected error: {}", ec.message()));

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -943,10 +943,11 @@ get_brokers(cluster::controller* const controller) {
               }
               b.membership_status = fmt::format(
                 "{}", nm.state.get_membership_state());
+              b.is_alive = controller->get_health_monitor().local().is_alive(id)
+                           == cluster::alive::yes;
 
               // These fields are defaults that will be overwritten with
               // data from the health report.
-              b.is_alive = true;
               b.maintenance_status = fill_maintenance_status(nm.state);
               b.internal_rpc_address = nm.broker.rpc_address().host();
               b.internal_rpc_port = nm.broker.rpc_address().port();
@@ -955,43 +956,32 @@ get_brokers(cluster::controller* const controller) {
           }
 
           // Enrich the broker information with data from the health report.
-          for (auto& ns : h_report.value().node_states) {
-              auto it = broker_map.find(ns.id);
+          for (auto& node_report : h_report.value().node_reports) {
+              auto it = broker_map.find(node_report.id);
               if (it == broker_map.end()) {
                   continue;
               }
 
-              it->second.is_alive = static_cast<bool>(ns.is_alive);
+              it->second.version = node_report.local_state.redpanda_version;
+              it->second.recovery_mode_enabled
+                = node_report.local_state.recovery_mode_enabled;
+              auto nm = members_table.get_node_metadata_ref(node_report.id);
+              if (nm && node_report.drain_status) {
+                  it->second.maintenance_status = fill_maintenance_status(
+                    nm.value().get().state, node_report.drain_status.value());
+              }
 
-              auto r_it = std::find_if(
-                h_report.value().node_reports.begin(),
-                h_report.value().node_reports.end(),
-                [id = ns.id](const cluster::node_health_report& nhr) {
-                    return nhr.id == id;
-                });
-
-              if (r_it != h_report.value().node_reports.end()) {
-                  it->second.version = r_it->local_state.redpanda_version;
-                  it->second.recovery_mode_enabled
-                    = r_it->local_state.recovery_mode_enabled;
-                  auto nm = members_table.get_node_metadata_ref(r_it->id);
-                  if (nm && r_it->drain_status) {
-                      it->second.maintenance_status = fill_maintenance_status(
-                        nm.value().get().state, r_it->drain_status.value());
-                  }
-
-                  auto add_disk = [&ds_list = it->second.disk_space](
-                                    const storage::disk& ds) {
-                      ss::httpd::broker_json::disk_space_info dsi;
-                      dsi.path = ds.path;
-                      dsi.free = ds.free;
-                      dsi.total = ds.total;
-                      ds_list.push(dsi);
-                  };
-                  add_disk(r_it->local_state.data_disk);
-                  if (!r_it->local_state.shared_disk()) {
-                      add_disk(r_it->local_state.get_cache_disk());
-                  }
+              auto add_disk =
+                [&ds_list = it->second.disk_space](const storage::disk& ds) {
+                    ss::httpd::broker_json::disk_space_info dsi;
+                    dsi.path = ds.path;
+                    dsi.free = ds.free;
+                    dsi.total = ds.total;
+                    ds_list.push(dsi);
+                };
+              add_disk(node_report.local_state.data_disk);
+              if (!node_report.local_state.shared_disk()) {
+                  add_disk(node_report.local_state.get_cache_disk());
               }
           }
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2599,8 +2599,8 @@ void application::start_runtime_services(
             std::ref(controller->get_feature_table()),
             std::ref(controller->get_health_monitor()),
             std::ref(_connection_cache),
-            std::ref(controller->get_partition_manager())));
-
+            std::ref(controller->get_partition_manager()),
+            std::ref(node_status_backend)));
           runtime_services.push_back(
             std::make_unique<cluster::metadata_dissemination_handler>(
               sched_groups.cluster_sg(),

--- a/src/v/rpc/errc.h
+++ b/src/v/rpc/errc.h
@@ -26,6 +26,7 @@ enum class errc {
     version_not_supported,
     connection_timeout,
     shutting_down,
+    service_unavailable,
 
     // Used when receiving an undefined errc (e.g. from a newer version of
     // Redpanda).
@@ -52,6 +53,8 @@ struct errc_category final : public std::error_category {
             return "rpc::errc::connection_timeout";
         case errc::shutting_down:
             return "rpc::errc::shutting_down";
+        case errc::service_unavailable:
+            return "rpc::errc::service_unavailable";
         default:
             return "rpc::errc::unknown(" + std::to_string(c) + ")";
         }

--- a/src/v/rpc/test/rpc_gen_cycling_test.cc
+++ b/src/v/rpc/test/rpc_gen_cycling_test.cc
@@ -688,7 +688,7 @@ FIXTURE_TEST(missing_method_test, rpc_integration_fixture) {
     // the server hasn't added all services, we should see a retriable error
     // instead of method_not_found.
     server().set_use_service_unavailable();
-    verify_bad_method_errors(rpc::errc::exponential_backoff);
+    verify_bad_method_errors(rpc::errc::service_unavailable);
 
     server().set_all_services_added();
     verify_bad_method_errors(rpc::errc::method_not_found);

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -248,7 +248,7 @@ inline errc map_server_error(status status) {
     case status::version_not_supported:
         return errc::version_not_supported;
     case status::service_unavailable:
-        return errc::exponential_backoff;
+        return errc::service_unavailable;
     default:
         return errc::unknown;
     };


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17625
