### PR TITLE
PESDLC-1095 Fix and check len limits when creating shell

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -321,7 +321,14 @@ class KubeNodeShell():
         self.logger = self.kubectl._redpanda.logger
         self.current_context = self.kubectl.cmd(
             f"config current-context").decode().strip()
-        self.pod_name = f"{node_name}-priviledged-shell"
+        # Make sure that name is not longer that 63 chars
+        # The Pod "gke-redpanda-co9uuq78jo-redpanda-6a66-fcfacc41-65mz-priviledged-shell" is invalid: metadata.labels:
+        # Invalid value: "gke-redpanda-co9uuq78jo-redpanda-6a66-fcfacc41-65mz-priviledged-shell": must be no more than 63 characters
+        self.pod_name = f"{node_name}-pshell"
+        if len(self.pod_name) > 63:
+            # Assume that our added chars broke the limit
+            # Cut them to fit
+            self.pod_name = self.pod_name[:63]
 
         # In case of concurrent tests, just reuse existing pod
         self.pod_reused = True if self._is_shell_running() else False


### PR DESCRIPTION
When creating pod in GKE long suffixes braking the limit of 63 chars enforced by K8s.
This shortens the name and adds a check for the future

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none