### PR TITLE
cmake: upgrade wasmtime

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -115,7 +115,7 @@ list(APPEND WASMTIME_USER_CARGO_BUILD_OPTIONS --features=wat)
 FetchContent_Declare(
   wasmtime
   GIT_REPOSITORY https://github.com/bytecodealliance/wasmtime
-  GIT_TAG v16.0.0
+  GIT_TAG v19.0.1
   GIT_PROGRESS TRUE
   USES_TERMINAL_DOWNLOAD TRUE
   OVERRIDE_FIND_PACKAGE

--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -48,7 +48,6 @@
 
 #include <absl/algorithm/container.h>
 #include <absl/strings/escaping.h>
-#include <wasmtime/store.h>
 
 #include <alloca.h>
 #include <csignal>
@@ -1496,7 +1495,12 @@ wasmtime_runtime::make_factory(model::transform_metadata meta, iobuf buf) {
           check_error(error.get());
 
           size_t start = 0, end = 0;
-          wasmtime_module_image_range(user_module.get(), &start, &end);
+          // NOLINTBEGIN(*-reinterpret-*)
+          wasmtime_module_image_range(
+            user_module.get(),
+            reinterpret_cast<void**>(&start),
+            reinterpret_cast<void**>(&end));
+          // NOLINTEND(*-reinterpret-*)
           return end - start;
       });
     _total_executable_memory += memory_usage_size;


### PR DESCRIPTION
Just staying on top of the latest version here  

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
