### PR TITLE
transform/rpc: prevent cross shard memory writes

### DIFF
--- a/src/v/transform/rpc/include/transform/rpc/deps.h
+++ b/src/v/transform/rpc/include/transform/rpc/deps.h
@@ -175,17 +175,30 @@ public:
      * Will return cluster::errc::not_leader if the shard_id is incorrect for
      * that ntp.
      */
-    virtual ss::future<cluster::errc> invoke_on_shard(
+    virtual ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
+      ss::shard_id shard_id,
+      const model::ktp& ktp,
+      ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
+        kafka::partition_proxy*)> fn)
+      = 0;
+    virtual ss::future<result<model::offset, cluster::errc>> invoke_on_shard(
+      ss::shard_id,
+      const model::ntp&,
+      ss::noncopyable_function<ss::future<result<model::offset, cluster::errc>>(
+        kafka::partition_proxy*)>)
+      = 0;
+
+    virtual ss::future<result<iobuf, cluster::errc>> invoke_on_shard(
       ss::shard_id shard_id,
       const model::ktp& ktp,
       ss::noncopyable_function<
-        ss::future<cluster::errc>(kafka::partition_proxy*)> fn);
-
-    virtual ss::future<cluster::errc> invoke_on_shard(
+        ss::future<result<iobuf, cluster::errc>>(kafka::partition_proxy*)>)
+      = 0;
+    virtual ss::future<result<iobuf, cluster::errc>> invoke_on_shard(
       ss::shard_id,
       const model::ntp&,
       ss::noncopyable_function<
-        ss::future<cluster::errc>(kafka::partition_proxy*)>)
+        ss::future<result<iobuf, cluster::errc>>(kafka::partition_proxy*)>)
       = 0;
 
     virtual ss::future<find_coordinator_response>

--- a/src/v/transform/rpc/include/transform/rpc/service.h
+++ b/src/v/transform/rpc/include/transform/rpc/service.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-#include "cluster/fwd.h"
 #include "model/fundamental.h"
 #include "model/record_batch_reader.h"
 #include "model/transform.h"


### PR DESCRIPTION
[transform/rpc: prevent cross shard memory writes](https://github.com/redpanda-data/redpanda/pull/17702/commits/aac5e671f8daa36f887ca130f4c76489992120d1)

Currently there is code in the transform/rpc layer that does something
along the following:

```
iobuf somedata;
co_await seastar::submit_to(shard_id, [&somedata] {
        somedata = fetch_some_data();
});
```

This executes a function on another CPU and writes memory to a stack
location on the requesting CPU. It's not clear if this is safe to do.

Instead change to use standard seastar mechanisms to pass memory between
cores:

```
iobuf somedata = co_await seastar::submit_to(shard_id, [] {
        return fetch_some_data();
});
```

The actual pieces here are more complicated than the above example, but
this is what motivates the change itself.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
