### PR TITLE
CORE-2061: net: remove rpc logger from server connection

### DIFF
--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -17,7 +17,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/net/tls.hh>
 
-#include <asm-generic/errno.h>
 #include <gnutls/gnutls.h>
 
 namespace net {
@@ -133,7 +132,8 @@ connection::connection(
   ss::socket_address a,
   server_probe& p,
   std::optional<size_t> in_max_buffer_size,
-  bool tls_enabled)
+  bool tls_enabled,
+  ss::logger* log)
   : addr(a)
   , _hook(hook)
   , _name(std::move(name))
@@ -142,7 +142,8 @@ connection::connection(
   , _in(_fd.input())
   , _out(_fd.output())
   , _probe(p)
-  , _tls_enabled(tls_enabled) {
+  , _tls_enabled(tls_enabled)
+  , _log(log) {
     if (in_max_buffer_size.has_value()) {
         auto in_config = ss::connected_socket_input_stream_config{};
         in_config.max_buffer_size = in_max_buffer_size.value();
@@ -162,7 +163,7 @@ void connection::shutdown_input() {
         _fd.shutdown_input();
     } catch (...) {
         _probe.connection_close_error();
-        rpc::rpclog.debug(
+        _log->debug(
           "Failed to shutdown connection: {}", std::current_exception());
     }
 }

--- a/src/v/net/connection.h
+++ b/src/v/net/connection.h
@@ -42,7 +42,8 @@ public:
       ss::socket_address a,
       server_probe& p,
       std::optional<size_t> in_max_buffer_size,
-      bool tls_enabled);
+      bool tls_enabled,
+      ss::logger*);
     ~connection() noexcept;
     connection(const connection&) = delete;
     connection& operator=(const connection&) = delete;
@@ -84,6 +85,7 @@ private:
     net::batched_output_stream _out;
     server_probe& _probe;
     bool _tls_enabled;
+    ss::logger* _log;
 };
 
 } // namespace net

--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -263,7 +263,8 @@ ss::future<ss::stop_iteration> server::accept_finish(
       ar.remote_address,
       *_probe,
       cfg.stream_recv_buf,
-      tls_enabled);
+      tls_enabled,
+      &_log);
     vlog(
       _log.trace,
       "{} - Incoming connection from {} on \"{}\"",


### PR DESCRIPTION
net: remove rpc logger from server connection

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

