### PR TITLE
Topic-aware replica placement in `partition_allocator::reallocate_partition`

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -568,6 +568,8 @@ ss::future<> controller::start(
             _raft0->self().id(),
             config::shard_local_cfg().internal_topic_replication_factor(),
             config::shard_local_cfg().health_manager_tick_interval(),
+            config::shard_local_cfg()
+              .partition_autobalancing_concurrent_moves.bind(),
             std::ref(_tp_state),
             std::ref(_tp_frontend),
             std::ref(_partition_allocator),

--- a/src/v/cluster/health_manager.h
+++ b/src/v/cluster/health_manager.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "base/seastarx.h"
 #include "cluster/fwd.h"
+#include "config/property.h"
 #include "model/metadata.h"
 
 #include <seastar/core/abort_source.hh>
@@ -37,6 +38,7 @@ public:
       model::node_id,
       size_t,
       std::chrono::milliseconds,
+      config::binding<size_t> max_concurrent_moves,
       ss::sharded<topic_table>&,
       ss::sharded<topics_frontend>&,
       ss::sharded<partition_allocator>&,
@@ -49,13 +51,13 @@ public:
 
 private:
     ss::future<bool> ensure_topic_replication(model::topic_namespace_view);
-    ss::future<bool> ensure_partition_replication(model::ntp);
     void tick();
     ss::future<> do_tick();
 
     model::node_id _self;
     size_t _target_replication_factor;
     std::chrono::milliseconds _tick_interval;
+    config::binding<size_t> _max_concurrent_moves;
     ss::sharded<topic_table>& _topics;
     ss::sharded<topics_frontend>& _topics_frontend;
     ss::sharded<partition_allocator>& _allocator;

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -51,12 +51,17 @@ public:
     /// replicas_to_reallocate will be reallocated, and a number of additional
     /// replicas to reach the requested replication factor will be allocated
     /// anew.
+    /// If existing_replica_counts is non-null, new replicas will be allocated
+    /// using topic-aware counts objective and (if all allocations are
+    /// successful) existing_replica_counts will be updated with newly allocated
+    /// replicas.
     result<allocated_partition> reallocate_partition(
       model::topic_namespace,
       partition_constraints,
       const partition_assignment&,
       partition_allocation_domain,
-      const std::vector<model::node_id>& replicas_to_reallocate = {});
+      const std::vector<model::node_id>& replicas_to_reallocate = {},
+      node2count_t* existing_replica_counts = nullptr);
 
     /// Create allocated_partition object from current replicas for use with the
     /// allocate_replica method.


### PR DESCRIPTION
Add topic awareness to `partition_allocator::reallocate_partition` and enable it in the usage sites of this API. Additionally, update `health_manager` to use `topics_frontend::do_update_topic_properties` instead of dispatching partition reconfigurations manually.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none