### PR TITLE
CORE-1705 rptest: filter abort strings from  GCP headers

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3323,6 +3323,11 @@ class RedpandaService(RedpandaServiceBase):
             return False
 
         crashes = []
+        # We log long encoded AWS/GCP headers that occasionally have 'SEGV' in
+        # them by chance
+        cloud_header_strings = [
+            'x-amz-id', 'x-amz-request', 'x-guploader-uploadid'
+        ]
         for node in self.nodes:
             self.logger.info(
                 f"Scanning node {node.account.hostname} log for errors...")
@@ -3331,9 +3336,8 @@ class RedpandaService(RedpandaServiceBase):
             for line in node.account.ssh_capture(
                     f"grep -e SEGV -e Segmentation\\ fault -e [Aa]ssert -e Sanitizer {RedpandaService.STDOUT_STDERR_CAPTURE} || true",
                     timeout_sec=30):
-                if 'SEGV' in line and ('x-amz-id' in line
-                                       or 'x-amz-request' in line):
-                    # We log long encoded AWS headers that occasionally have 'SEGV' in them by chance
+                if 'SEGV' in line and any(
+                    [h in line.lower() for h in cloud_header_strings]):
                     continue
 
                 if is_allowed_log_line(line):


### PR DESCRIPTION
```
WARN  2024-01-09 10:35:44,813 [shard 1:au  ] s3 - s3_client.cc:865 - S3 DeleteObject request failed: Not Found [X-GUploader-UploadID: ABPtcPrc00gQJdiBKftrKBkHq7lfgurC3j5DPPe1b4TgpjlI0EbSEGVEioXFhqISUy5IrVWlHOeZ94krXQ];[Content-Type: application/xml; charset=UTF-8];[Content-Length: 279];[Vary: Origin];[Date: Tue, 09 Jan 2024 10:35:44 GMT];[Expires: Tue, 09 Jan 2024 10:35:44 GMT];[Cache-Control: private, max-age=0];[Server: UploadServer];
```

Here,
`ABPtcPrc00gQJdiBKftrKBkHq7lfgurC3j5DPPe1b4TgpjlI0EbSEGVEioXFhqISUy5IrVWlHOeZ94krXQ` contains "SEGV", but is coming from GCP. This commit adds handling of such header strings tailored for GCP headers[1].

[1] https://cloud.google.com/storage/docs/xml-api/reference-headers#xguploaderuploadid

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
