### PR TITLE
tests: wait for partition leaders before querying hwm

### DIFF
--- a/tests/rptest/tests/recovery_mode_test.py
+++ b/tests/rptest/tests/recovery_mode_test.py
@@ -513,6 +513,22 @@ class DisablingPartitionsTest(RedpandaTest):
         self.redpanda.restart_nodes(self.redpanda.nodes)
         self.redpanda.wait_for_membership(first_start=False)
 
+        def all_have_leaders():
+            for n in self.redpanda.started_nodes():
+                all_partitions_have_leaders = all([
+                    partition['leader'] != -1
+                    for partition in admin.get_partitions(node=n)
+                ])
+                if not all_partitions_have_leaders:
+                    return False
+            return True
+
+        wait_until(
+            all_have_leaders,
+            30,
+            backoff_sec=1,
+            err_msg="Failed waiting for partition leadership to stabilize")
+
         # test that partitions are still disabled after restart
 
         assert all_disabled_shut_down()


### PR DESCRIPTION
In disabling partition test we were not waiting for stable partition leadership but we required the partition high-watermark to be reported. In some cases this lead to an error and made the test unstable.

Fixes: #17223

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none