### PR TITLE
gtest: set death_test_style=threadsafe

### DIFF
--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -70,7 +70,8 @@ TEST_F(raft_fixture, test_empty_writes) {
     auto reader = model::make_memory_record_batch_reader(
       std::move(builder).build());
 
-    EXPECT_DEATH(replicate(std::move(reader)).get(), "Aborting");
+    EXPECT_DEATH(
+      replicate(std::move(reader)).get(), "Assert failure.+Empty batch");
 }
 
 struct test_parameters {

--- a/src/v/test_utils/gtest_main.cc
+++ b/src/v/test_utils/gtest_main.cc
@@ -12,6 +12,7 @@
 
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
     seastar::testing::global_test_runner().start(argc, argv);
 
     int ret = 0;


### PR DESCRIPTION
Default death test style (fast) forks the test process and runs the test immediately after forking. This does not play well with the seastar environment, leading to hangs and weird errors. Switch to 'threadsafe' style instead that runs the test binary from the beginning in the child process.

Fixes (latest incarnation of) https://github.com/redpanda-data/redpanda/issues/14425

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none