### PR TITLE
CORE-1614 storage: Initialize timestamps in the compaction_placeholder

### DIFF
--- a/src/v/storage/compaction_reducers.cc
+++ b/src/v/storage/compaction_reducers.cc
@@ -135,6 +135,8 @@ model::record_batch copy_data_segment_reducer::make_placeholder_batch(
     new_hdr.type = model::record_batch_type::compaction_placeholder;
     new_hdr.base_offset = hdr.base_offset;
     new_hdr.last_offset_delta = hdr.last_offset_delta;
+    new_hdr.first_timestamp = hdr.first_timestamp;
+    new_hdr.max_timestamp = hdr.max_timestamp;
     auto no_records = iobuf{};
     reset_size_checksum_metadata(new_hdr, no_records);
     return model::record_batch(


### PR DESCRIPTION
The `compaction_placeholder` batch wasn't initialized properly and because of that the invalid timestamps equal to -1 leaked into the TS layer. The `rp-storage-tool` crashed while trying to parse the list of timestamps. 

Fixes #15312

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none