### PR TITLE
CORE-2059: net: separate rpc metrics from generic transport

### DIFF
--- a/src/v/archival/upload_housekeeping_service.cc
+++ b/src/v/archival/upload_housekeeping_service.cc
@@ -27,6 +27,8 @@
 #include <functional>
 #include <variant>
 
+using namespace std::chrono_literals;
+
 namespace archival {
 
 std::ostream& operator<<(std::ostream& o, housekeeping_state s) {

--- a/src/v/archival/upload_housekeeping_service.h
+++ b/src/v/archival/upload_housekeeping_service.h
@@ -31,6 +31,8 @@
 
 #include <chrono>
 
+using namespace std::chrono_literals;
+
 namespace archival {
 
 enum class housekeeping_state {

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -13,6 +13,10 @@
 #include "cloud_storage/logger.h"
 #include "cloud_storage/remote_segment.h"
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 namespace {
 constexpr auto cache_backoff_duration = 5s;
 constexpr auto eviction_duration = 10s;

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -23,6 +23,10 @@
 #include <boost/test/tools/old/interface.hpp>
 #include <boost/test/unit_test.hpp>
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 namespace cloud_storage {
 
 bool operator==(const anomalies& lhs, const anomalies& rhs) {

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -19,9 +19,12 @@
 #include <seastar/core/smp.hh>
 
 #include <algorithm>
+#include <chrono>
 #include <optional>
 #include <random>
 #include <utility>
+
+using namespace std::chrono_literals;
 
 namespace {
 constexpr auto self_configure_attempts = 3;

--- a/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/abs_test_client_main.cc
@@ -46,6 +46,8 @@
 #include <stdexcept>
 #include <string>
 
+using namespace std::chrono_literals;
+
 static ss::logger test_log{"test"};
 
 void cli_opts(boost::program_options::options_description_easy_init opt) {

--- a/src/v/cloud_storage_clients/tests/exception_test.cc
+++ b/src/v/cloud_storage_clients/tests/exception_test.cc
@@ -10,6 +10,8 @@
 
 #include "cloud_storage_clients/util.h"
 
+#include <seastar/core/sharded.hh>
+
 #include <boost/test/unit_test.hpp>
 
 BOOST_AUTO_TEST_CASE(test_nested_exception) {

--- a/src/v/cluster/cloud_metadata/offsets_uploader.cc
+++ b/src/v/cluster/cloud_metadata/offsets_uploader.cc
@@ -25,7 +25,10 @@
 
 #include <seastar/core/lowres_clock.hh>
 
+#include <chrono>
 #include <exception>
+
+using namespace std::chrono_literals;
 
 namespace cluster::cloud_metadata {
 

--- a/src/v/cluster/topic_recovery_validator.cc
+++ b/src/v/cluster/topic_recovery_validator.cc
@@ -14,6 +14,10 @@
 
 #include <seastar/coroutine/as_future.hh>
 
+#include <chrono>
+
+using namespace std::chrono_literals;
+
 namespace cluster {
 
 // Each partition gets a separate retry_chain_node and a logger tied to it.

--- a/src/v/net/client_probe.h
+++ b/src/v/net/client_probe.h
@@ -10,16 +10,16 @@
  */
 
 #pragma once
+
 #include "metrics/metrics.h"
-#include "model/metadata.h"
-#include "net/unresolved_address.h"
-#include "rpc/types.h"
 
 #include <seastar/core/metrics_registration.hh>
 
-#include <iosfwd>
-
 namespace net {
+
+/*
+ * Metrics probe that is common to all net::base_transport instances.
+ */
 class client_probe {
 public:
     client_probe() = default;
@@ -29,73 +29,32 @@ public:
     client_probe& operator=(client_probe&&) = delete;
     ~client_probe() = default;
 
-    void request() {
-        ++_requests;
-        ++_requests_pending;
-    }
-
-    void request_completed() {
-        ++_requests_completed;
-        --_requests_pending;
-    }
-
-    void request_timeout() {
-        ++_request_timeouts;
-        --_requests_pending;
-    }
-
-    void request_error() {
-        ++_request_errors;
-        --_requests_pending;
-    }
-
-    void add_bytes_sent(size_t sent) { _out_bytes += sent; }
-
-    void add_bytes_received(size_t recv) { _in_bytes += recv; }
-
     void connection_established() {
         ++_connects;
         ++_connections;
     }
 
-    void connection_closed() { --_connections; }
-
     void connection_error() { ++_connection_errors; }
 
-    void read_dispatch_error() { ++_read_dispatch_errors; }
+    void connection_closed() { --_connections; }
 
-    void header_corrupted() { ++_corrupted_headers; }
-
-    void client_correlation_error() { ++_client_correlation_errors; }
-
-    void server_correlation_error() { ++_server_correlation_errors; }
-
-    void waiting_for_available_memory() { ++_requests_blocked_memory; }
-
+    /*
+     * setup metrics
+     *
+     * name: name of the metrics group
+     * defs: additional metrics to register
+     */
     void setup_metrics(
-      metrics::internal_metric_groups& mgs,
-      const std::optional<rpc::connection_cache_label>& label,
-      const std::optional<model::node_id>& node_id,
-      const net::unresolved_address& target_addr);
+      std::string_view name,
+      const std::vector<ss::metrics::label_instance>& labels,
+      const std::vector<ss::metrics::label>& aggregate_labels,
+      std::vector<ss::metrics::metric_definition> defs);
 
-private:
-    uint64_t _requests = 0;
-    uint32_t _requests_pending = 0;
-    uint32_t _request_errors = 0;
-    uint64_t _request_timeouts = 0;
-    uint64_t _requests_completed = 0;
-    uint64_t _in_bytes = 0;
-    uint64_t _out_bytes = 0;
+protected:
     uint64_t _connects = 0;
     uint32_t _connections = 0;
     uint32_t _connection_errors = 0;
-    uint32_t _read_dispatch_errors = 0;
-    uint32_t _corrupted_headers = 0;
-    uint32_t _server_correlation_errors = 0;
-    uint32_t _client_correlation_errors = 0;
-    uint32_t _requests_blocked_memory = 0;
     metrics::internal_metric_groups _metrics;
-
-    friend std::ostream& operator<<(std::ostream& o, const client_probe& p);
 };
+
 }; // namespace net

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -186,134 +186,35 @@ std::ostream& operator<<(std::ostream& o, const server_probe& p) {
 }
 
 void client_probe::setup_metrics(
-  metrics::internal_metric_groups& mgs,
-  const std::optional<rpc::connection_cache_label>& label,
-  const std::optional<model::node_id>& node_id,
-  const net::unresolved_address& target_addr) {
+  std::string_view name,
+  const std::vector<ss::metrics::label_instance>& labels,
+  const std::vector<ss::metrics::label>& aggregate_labels,
+  std::vector<ss::metrics::metric_definition> defs) {
     namespace sm = ss::metrics;
-    auto target = sm::label("target");
-    std::vector<sm::label_instance> labels = {
-      target(ssx::sformat("{}:{}", target_addr.host(), target_addr.port()))};
-    if (label) {
-        labels.push_back(sm::label("connection_cache_label")((*label)()));
-    }
-    std::vector<sm::label> aggregate_labels;
-    // Label the metrics for a given server with the node ID so Seastar can
-    // differentiate between them, in case multiple node IDs start at the same
-    // address (e.g. in an ungraceful decommission). Aggregate on node ID so
-    // the user is presented metrics for each server regardless of node ID.
-    if (node_id) {
-        auto node_id_label = sm::label("node_id");
-        labels.push_back(node_id_label(*node_id));
-        aggregate_labels.push_back(node_id_label);
-    }
-    mgs.add_group(
-      prometheus_sanitize::metrics_name("rpc_client"),
-      {
-        sm::make_gauge(
-          "active_connections",
-          [this] { return _connections; },
-          sm::description("Currently active connections"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "connects",
-          [this] { return _connects; },
-          sm::description("Connection attempts"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "requests",
-          [this] { return _requests; },
-          sm::description("Number of requests"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_gauge(
-          "requests_pending",
-          [this] { return _requests_pending; },
-          sm::description("Number of requests pending"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "request_errors",
-          [this] { return _request_errors; },
-          sm::description("Number or requests errors"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "request_timeouts",
-          [this] { return _request_timeouts; },
-          sm::description("Number or requests timeouts"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_total_bytes(
-          "in_bytes",
-          [this] { return _out_bytes; },
-          sm::description("Total number of bytes sent (including headers)"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_total_bytes(
-          "out_bytes",
-          [this] { return _in_bytes; },
-          sm::description("Total number of bytes received"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "connection_errors",
-          [this] { return _connection_errors; },
-          sm::description("Number of connection errors"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "read_dispatch_errors",
-          [this] { return _read_dispatch_errors; },
-          sm::description("Number of errors while dispatching responses"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "corrupted_headers",
-          [this] { return _corrupted_headers; },
-          sm::description("Number of responses with corrupted headers"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "server_correlation_errors",
-          [this] { return _server_correlation_errors; },
-          sm::description("Number of responses with wrong correlation id"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "client_correlation_errors",
-          [this] { return _client_correlation_errors; },
-          sm::description("Number of errors in client correlation id"),
-          labels)
-          .aggregate(aggregate_labels),
-        sm::make_counter(
-          "requests_blocked_memory",
-          [this] { return _requests_blocked_memory; },
-          sm::description("Number of requests that are blocked because"
-                          " of insufficient memory"),
-          labels)
-          .aggregate(aggregate_labels),
-      });
-}
 
-std::ostream& operator<<(std::ostream& o, const client_probe& p) {
-    o << "{"
-      << " requests_sent: " << p._requests
-      << ", requests_pending: " << p._requests_pending
-      << ", requests_completed: " << p._requests_completed
-      << ", request_errors: " << p._request_errors
-      << ", request_timeouts: " << p._request_timeouts
-      << ", in_bytes: " << p._in_bytes << ", out_bytes: " << p._out_bytes
-      << ", connects: " << p._connects << ", connections: " << p._connections
-      << ", connection_errors: " << p._connection_errors
-      << ", read_dispatch_errors: " << p._read_dispatch_errors
-      << ", corrupted_headers: " << p._corrupted_headers
-      << ", server_correlation_errors: " << p._server_correlation_errors
-      << ", client_correlation_errors: " << p._client_correlation_errors
-      << ", requests_blocked_memory: " << p._requests_blocked_memory << " }";
-    return o;
+    defs.emplace_back(sm::make_gauge(
+                        "active_connections",
+                        [this] { return _connections; },
+                        sm::description("Currently active connections"),
+                        labels)
+                        .aggregate(aggregate_labels));
+
+    defs.emplace_back(sm::make_counter(
+                        "connects",
+                        [this] { return _connects; },
+                        sm::description("Connection attempts"),
+                        labels)
+                        .aggregate(aggregate_labels));
+
+    defs.emplace_back(sm::make_counter(
+                        "connection_errors",
+                        [this] { return _connection_errors; },
+                        sm::description("Number of connection errors"),
+                        labels)
+                        .aggregate(aggregate_labels));
+
+    _metrics.add_group(
+      prometheus_sanitize::metrics_name(ss::sstring(name)), defs);
 }
 
 ss::future<ss::shared_ptr<ss::tls::server_credentials>>

--- a/src/v/net/transport.h
+++ b/src/v/net/transport.h
@@ -35,9 +35,12 @@ namespace net {
  * with the socket. As such, superclasses must provide interfaces with which to
  * send and receive bytes using the socket.
  *
- * TODO:
- *  - client_probe needs to be split apart from simple_protocol
- *  - allow subclasses to provide logger
+ * Metric probes
+ * -------------
+ *
+ * A subclass should of net::base_transport should inherit from
+ * net::client_probe and add its own probes. A pointer to the superclass should
+ * be passed into base_transport::set_probe.
  */
 class base_transport {
 public:
@@ -81,13 +84,17 @@ public:
 
     const unresolved_address& server_address() const { return _server_addr; }
 
+    /*
+     * Sets the probe instance to use. Must only be called once.
+     */
+    void set_probe(client_probe*);
+
 protected:
     virtual void fail_outstanding_futures() {}
 
     ss::input_stream<char> _in;
     net::batched_output_stream _out;
     ss::gate _dispatch_gate;
-    std::unique_ptr<client_probe> _probe;
 
 private:
     ss::future<> do_connect(clock_type::time_point);
@@ -101,6 +108,7 @@ private:
 
     // Track if shutdown was called on the current `_fd`
     bool _shutdown{false};
+    std::optional<client_probe*> _probe;
 };
 
 } // namespace net

--- a/src/v/rpc/transport.h
+++ b/src/v/rpc/transport.h
@@ -104,6 +104,70 @@ struct timing_info {
     bool flushed = false;
 };
 
+class client_probe : public net::client_probe {
+public:
+    client_probe() = default;
+    client_probe(const client_probe&) = delete;
+    client_probe& operator=(const client_probe&) = delete;
+    client_probe(client_probe&&) = delete;
+    client_probe& operator=(client_probe&&) = delete;
+    ~client_probe() = default;
+
+    void request() {
+        ++_requests;
+        ++_requests_pending;
+    }
+
+    void request_completed() {
+        ++_requests_completed;
+        --_requests_pending;
+    }
+
+    void request_timeout() {
+        ++_request_timeouts;
+        --_requests_pending;
+    }
+
+    void request_error() {
+        ++_request_errors;
+        --_requests_pending;
+    }
+
+    void add_bytes_sent(size_t sent) { _out_bytes += sent; }
+
+    void add_bytes_received(size_t recv) { _in_bytes += recv; }
+
+    void read_dispatch_error() { ++_read_dispatch_errors; }
+
+    void header_corrupted() { ++_corrupted_headers; }
+
+    void client_correlation_error() { ++_client_correlation_errors; }
+
+    void server_correlation_error() { ++_server_correlation_errors; }
+
+    void waiting_for_available_memory() { ++_requests_blocked_memory; }
+
+    std::vector<ss::metrics::metric_definition> defs(
+      const std::vector<ss::metrics::label_instance>& labels,
+      const std::vector<ss::metrics::label>& aggregate_labels);
+
+private:
+    uint64_t _requests = 0;
+    uint32_t _requests_pending = 0;
+    uint32_t _request_errors = 0;
+    uint64_t _request_timeouts = 0;
+    uint64_t _requests_completed = 0;
+    uint64_t _in_bytes = 0;
+    uint64_t _out_bytes = 0;
+    uint32_t _read_dispatch_errors = 0;
+    uint32_t _corrupted_headers = 0;
+    uint32_t _server_correlation_errors = 0;
+    uint32_t _client_correlation_errors = 0;
+    uint32_t _requests_blocked_memory = 0;
+
+    friend std::ostream& operator<<(std::ostream& o, const client_probe& p);
+};
+
 /**
  * Transport implementation used for internal RPC traffic.
  *
@@ -202,7 +266,7 @@ private:
     absl::flat_hash_map<uint32_t, std::unique_ptr<response_entry>>
       _correlations;
     uint32_t _correlation_idx{0};
-    metrics::internal_metric_groups _metrics;
+
     /**
      * Ordered map containing requests to be sent over the wire. The map
      * preserves order of calling send_typed function. It is fine to use
@@ -231,6 +295,8 @@ private:
     void set_version(transport_version v) { _version = v; }
 
     friend std::ostream& operator<<(std::ostream&, const transport&);
+
+    std::unique_ptr<client_probe> _probe;
 };
 
 namespace internal {

--- a/src/v/security/oidc_service.cc
+++ b/src/v/security/oidc_service.cc
@@ -19,6 +19,7 @@
 #include "security/oidc_principal_mapping.h"
 #include "security/oidc_url_parser.h"
 #include "ssx/future-util.h"
+#include "utils/log_hist.h"
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sstring.hh>
@@ -31,6 +32,8 @@
 #include <boost/outcome/success_failure.hpp>
 
 #include <chrono>
+
+using namespace std::chrono_literals;
 
 namespace security::oidc {
 


### PR DESCRIPTION
The net::transport metrics managed a superset of metrics for all specializations (e.g. rpc, kafka client). This commit separates them so that the client transport specializations can manage their own metrics.

It's not pretty, but there is also only one user of it in the tree: the rpc transport. With at least one more example the pattern could likely be made more tasty.

The basic strategy is to have a transport probe inherit from the base transport probe. The specialization owns the probe, and passes in a reference to the base transport which will update the metrics common to all transports.

When the specialization sets up metrics it collects its own and passes them to the base transport metrics setup function which combines all of them together and registers them.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

