### PR TITLE
[v23.3.x] kafka: fix config source for default cleanup.policy config

### DIFF
--- a/src/v/kafka/server/handlers/configs/config_response_utils.cc
+++ b/src/v/kafka/server/handlers/configs/config_response_utils.cc
@@ -472,7 +472,8 @@ config_response_container_t make_topic_configs(
       maybe_make_documentation(
         include_documentation,
         config::shard_local_cfg().log_cleanup_policy.desc()),
-      &describe_as_string<model::cleanup_policy_bitflags>);
+      &describe_as_string<model::cleanup_policy_bitflags>,
+      true);
 
     const std::string_view docstring{
       topic_properties.is_compacted()

--- a/tests/rptest/services/redpanda_installer.py
+++ b/tests/rptest/services/redpanda_installer.py
@@ -33,6 +33,13 @@ RELEASES_CACHE_FILE_TTL = timedelta(minutes=30)
 # It's a ":"-separated list of versions, e.g.: v23.2.1:v23.1.12:v23.1.11
 RP_GIT_RELEASED_VERSIONS = "RP_GIT_RELEASED_VERSIONS"
 
+REDPANDA_INSTALLER_HEAD_TAG = "head"
+
+RedpandaVersionTriple = tuple[int, int, int]
+RedpandaVersionLine = tuple[int, int]
+RedpandaVersion = typing.Literal[
+    'head'] | RedpandaVersionLine | RedpandaVersionTriple
+
 
 def wait_for_num_versions(redpanda, num_versions):
     # Use a single node so the metadata about brokers have a consistent source
@@ -76,6 +83,14 @@ def ver_string(int_tuple):
     return f"v{'.'.join(str(i) for i in int_tuple)}"
 
 
+def ver_triple(version_line: RedpandaVersionLine) -> RedpandaVersionTriple:
+    """
+    Converts "v24.1.0-dev-1940-g8ae241e966 - 8ae241e966bd3d5811951a176fc40a7a77ce2a0c" into (24, 1, 0)
+    """
+    matches = VERSION_RE.findall(version_line)
+    return RedpandaVersionTriple(int_tuple(matches[0]))
+
+
 class InstallOptions:
     """
     Options with which to configure the installation of Redpanda in a cluster.
@@ -96,14 +111,6 @@ class InstallOptions:
         # cluster on an older version, e.g. to simulate a mixed-version
         # environment.
         self.num_to_upgrade = num_to_upgrade
-
-
-REDPANDA_INSTALLER_HEAD_TAG = "head"
-
-RedpandaVersionTriple = tuple[int, int, int]
-RedpandaVersionLine = tuple[int, int]
-RedpandaVersion = typing.Literal[
-    'head'] | RedpandaVersionLine | RedpandaVersionTriple
 
 
 class RedpandaInstaller:
@@ -307,8 +314,7 @@ class RedpandaInstaller:
         # use it to get older versions relative to the head version.
         # NOTE: installing this version may not yield the same binaries being
         # as 'head', e.g. if an unreleased source is checked out.
-        self._head_version: RedpandaVersionTriple = int_tuple(
-            VERSION_RE.findall(initial_version)[0])
+        self._head_version: RedpandaVersionTriple = ver_triple(initial_version)
 
         self._started = True
 

--- a/tests/rptest/tests/describe_topics_test.py
+++ b/tests/rptest/tests/describe_topics_test.py
@@ -76,8 +76,7 @@ class DescribeTopicsTest(RedpandaTest):
             "cleanup.policy":
             ConfigProperty(config_type="STRING",
                            value="DELETE",
-                           doc_string="Default topic cleanup policy",
-                           source_type="DYNAMIC_TOPIC_CONFIG"),
+                           doc_string="Default topic cleanup policy"),
             "compression.type":
             ConfigProperty(config_type="STRING",
                            value="producer",

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -652,7 +652,7 @@ class CreateSITopicsTest(RedpandaTest):
         # overriden.
         topic_config = rpk.describe_topic_configs(topic)
         value, src = topic_config["cleanup.policy"]
-        assert value == "delete" and src == "DYNAMIC_TOPIC_CONFIG"
+        assert value == "delete" and src == "DEFAULT_CONFIG"
 
         kcl.alter_topic_config({"cleanup.policy": "compact"},
                                incremental=False,


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17456
Fixes: https://github.com/redpanda-data/redpanda/issues/17718,