### PR TITLE
[v23.2.x] k/fetch: handle initial_leader_epoch correctly

### DIFF
--- a/src/v/kafka/server/fetch_session.h
+++ b/src/v/kafka/server/fetch_session.h
@@ -10,6 +10,7 @@
  */
 #pragma once
 #include "kafka/protocol/errors.h"
+#include "kafka/protocol/fetch.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
 #include "model/ktp.h"
@@ -31,6 +32,15 @@ struct fetch_session_partition {
     model::offset high_watermark;
     model::offset last_stable_offset;
     kafka::leader_epoch current_leader_epoch = invalid_leader_epoch;
+
+    fetch_session_partition(
+      const model::topic& tp, const fetch_request::partition& p)
+      : topic_partition(tp, p.partition_index)
+      , max_bytes(p.max_bytes)
+      , fetch_offset(p.fetch_offset)
+      , high_watermark(model::offset(-1))
+      , last_stable_offset(model::offset(-1))
+      , current_leader_epoch(p.current_leader_epoch) {}
 };
 /**
  * Map of partitions that is kept by fetch session. This map is using intrusive

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -2,6 +2,7 @@
 
 #include "config/configuration.h"
 #include "kafka/protocol/fetch.h"
+#include "kafka/server/fetch_session.h"
 #include "kafka/server/logger.h"
 #include "kafka/types.h"
 #include "model/fundamental.h"
@@ -13,18 +14,6 @@
 #include <chrono>
 
 namespace kafka {
-
-static fetch_session_partition make_fetch_partition(
-  const model::topic& tp, const fetch_request::partition& p) {
-    return fetch_session_partition{
-      .topic_partition = {tp, p.partition_index},
-      .max_bytes = p.max_bytes,
-      .fetch_offset = p.fetch_offset,
-      .high_watermark = model::offset(-1),
-      .last_stable_offset = model::offset(-1),
-      .current_leader_epoch = p.current_leader_epoch,
-    };
-}
 
 void update_fetch_session(fetch_session& session, const fetch_request& req) {
     for (auto it = req.cbegin(); it != req.cend(); ++it) {
@@ -40,7 +29,7 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
               = partition.current_leader_epoch;
         } else {
             session.partitions().emplace(
-              make_fetch_partition(topic.name, partition));
+              fetch_session_partition(topic.name, partition));
         }
     }
 

--- a/src/v/kafka/server/fetch_session_cache.cc
+++ b/src/v/kafka/server/fetch_session_cache.cc
@@ -36,6 +36,8 @@ void update_fetch_session(fetch_session& session, const fetch_request& req) {
             s_it != session.partitions().end()) {
             s_it->second->partition.max_bytes = partition.max_bytes;
             s_it->second->partition.fetch_offset = partition.fetch_offset;
+            s_it->second->partition.current_leader_epoch
+              = partition.current_leader_epoch;
         } else {
             session.partitions().emplace(
               make_fetch_partition(topic.name, partition));

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -700,13 +700,7 @@ void op_context::for_each_fetch_partition(Func&& f) const {
           request.cend(),
           [f = std::forward<Func>(f)](
             const fetch_request::const_iterator::value_type& p) {
-              auto& part = *p.partition;
-              f(fetch_session_partition{
-                .topic_partition = {p.topic->name, part.partition_index},
-                .max_bytes = part.max_bytes,
-                .fetch_offset = part.fetch_offset,
-                .current_leader_epoch = part.current_leader_epoch,
-              });
+              f(fetch_session_partition(p.topic->name, *p.partition));
           });
     } else {
         std::for_each(

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -705,6 +705,7 @@ void op_context::for_each_fetch_partition(Func&& f) const {
                 .topic_partition = {p.topic->name, part.partition_index},
                 .max_bytes = part.max_bytes,
                 .fetch_offset = part.fetch_offset,
+                .current_leader_epoch = part.current_leader_epoch,
               });
           });
     } else {

--- a/src/v/kafka/server/tests/fetch_plan_bench.cc
+++ b/src/v/kafka/server/tests/fetch_plan_bench.cc
@@ -39,15 +39,6 @@ static ss::logger fpt_logger("fpt_test");
 
 using namespace std::chrono_literals; // NOLINT
 struct fixture {
-    static kafka::fetch_session_partition make_fetch_partition(
-      model::topic topic, model::partition_id p_id, model::offset offset) {
-        return kafka::fetch_session_partition{
-          .topic_partition = {std::move(topic), p_id},
-          .max_bytes = 1_MiB,
-          .fetch_offset = offset,
-          .high_watermark = offset};
-    }
-
     static kafka::fetch_request::topic
     make_fetch_request_topic(model::topic tp, int partitions_count) {
         kafka::fetch_request::topic fetch_topic{

--- a/src/v/kafka/server/tests/fetch_session_test.cc
+++ b/src/v/kafka/server/tests/fetch_session_test.cc
@@ -9,6 +9,7 @@
  * by the Apache License, Version 2.0
  */
 #include "kafka/protocol/fetch.h"
+#include "kafka/protocol/schemata/fetch_request.h"
 #include "kafka/server/fetch_session.h"
 #include "kafka/server/fetch_session_cache.h"
 #include "kafka/types.h"
@@ -27,13 +28,24 @@
 
 using namespace std::chrono_literals; // NOLINT
 struct fixture {
-    static kafka::fetch_session_partition make_fetch_partition(
+    static kafka::fetch_session_partition make_fetch_sess_partition(
       model::topic topic, model::partition_id p_id, model::offset offset) {
         return kafka::fetch_session_partition{
           .topic_partition = {topic, p_id},
           .max_bytes = 1_MiB,
           .fetch_offset = offset,
           .high_watermark = offset};
+    }
+
+    static kafka::fetch_partition
+    make_fetch_partition(const model::partition_id p_id) {
+        return {
+          .partition_index = p_id,
+          .current_leader_epoch = kafka::leader_epoch(
+            random_generators::get_int(100)),
+          .fetch_offset = model::offset(random_generators::get_int(10000)),
+          .max_bytes = random_generators::get_int(1024, 1024 * 1024),
+        };
     }
 
     static kafka::fetch_request::topic
@@ -45,11 +57,7 @@ struct fixture {
 
         for (int i = 0; i < partitions_count; ++i) {
             fetch_topic.fetch_partitions.push_back(
-              kafka::fetch_request::partition{
-                .partition_index = model::partition_id(i),
-                .fetch_offset = model::offset(i * 10),
-                .max_bytes = 100_KiB,
-              });
+              make_fetch_partition(model::partition_id(i)));
         }
         return fetch_topic;
     }
@@ -87,7 +95,7 @@ FIXTURE_TEST(test_fetch_session_basic_operations, fixture) {
           model::offset(random_generators::get_int(10000))});
 
         auto& t = expected.back();
-        session.partitions().emplace(fixture::make_fetch_partition(
+        session.partitions().emplace(fixture::make_fetch_sess_partition(
           t.ktp.get_topic(), t.ktp.get_partition(), t.offset));
     }
 
@@ -157,6 +165,9 @@ FIXTURE_TEST(test_session_operations, fixture) {
               fp.topic_partition.get_partition(),
               req.data.topics[0].fetch_partitions[i].partition_index);
             BOOST_REQUIRE_EQUAL(
+              fp.current_leader_epoch,
+              req.data.topics[0].fetch_partitions[i].current_leader_epoch);
+            BOOST_REQUIRE_EQUAL(
               fp.fetch_offset,
               req.data.topics[0].fetch_partitions[i].fetch_offset);
             BOOST_REQUIRE_EQUAL(
@@ -170,13 +181,14 @@ FIXTURE_TEST(test_session_operations, fixture) {
 
     BOOST_TEST_MESSAGE("test updating session");
     {
+        // Remove and forget about the first partition.
         req.data.topics[0].fetch_partitions.erase(
           std::next(req.data.topics[0].fetch_partitions.begin()));
-        // add 2 partitons from new topic, forget one from the first topic
-        req.data.topics.push_back(
-          make_fetch_request_topic(model::topic("test-new"), 2));
         req.data.forgotten.push_back(kafka::fetch_request::forgotten_topic{
           .name = model::topic("test"), .forgotten_partition_indexes = {1}});
+        // Add 2 partitions from new topic.
+        req.data.topics.push_back(
+          make_fetch_request_topic(model::topic("test-new"), 2));
 
         auto ctx = cache.maybe_get_session(req);
 
@@ -203,6 +215,11 @@ FIXTURE_TEST(test_session_operations, fixture) {
             BOOST_REQUIRE_EQUAL(
               fp.topic_partition.get_partition(),
               req.data.topics[t_idx].fetch_partitions[p_idx].partition_index);
+            BOOST_REQUIRE_EQUAL(
+              fp.current_leader_epoch,
+              req.data.topics[t_idx]
+                .fetch_partitions[p_idx]
+                .current_leader_epoch);
             BOOST_REQUIRE_EQUAL(
               fp.fetch_offset,
               req.data.topics[t_idx].fetch_partitions[p_idx].fetch_offset);

--- a/src/v/kafka/server/tests/fetch_session_test.cc
+++ b/src/v/kafka/server/tests/fetch_session_test.cc
@@ -179,6 +179,9 @@ FIXTURE_TEST(test_session_operations, fixture) {
           std::next(req.data.topics[0].fetch_partitions.begin()));
         req.data.forgotten.push_back(kafka::fetch_request::forgotten_topic{
           .name = model::topic("test"), .forgotten_partition_indexes = {1}});
+        // Update the second partition.
+        req.data.topics[0].fetch_partitions[0] = make_fetch_partition(
+          req.data.topics[0].fetch_partitions[0].partition_index);
         // Add 2 partitions from new topic.
         req.data.topics.push_back(
           make_fetch_request_topic(model::topic("test-new"), 2));

--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -441,10 +441,9 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
     auto resp = client.dispatch(req, kafka::api_version(9)).get0();
     client.stop().then([&client] { client.shutdown(); }).get();
 
-    // This is a BUG! The fetch request must return an error when the request
-    // epoch is different from the current epoch.
     BOOST_REQUIRE_MESSAGE(
-      resp.data.topics[0].partitions[0].error_code == kafka::error_code::none,
+      resp.data.topics[0].partitions[0].error_code
+        == kafka::error_code::fenced_leader_epoch,
       fmt::format("error: {}", resp.data.topics[0].partitions[0].error_code));
 }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17674
