### PR TITLE
CORE-2212: test: do not start seastar for --gtest_list_tests

### DIFF
--- a/src/v/test_utils/gtest_main.cc
+++ b/src/v/test_utils/gtest_main.cc
@@ -13,6 +13,18 @@
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     GTEST_FLAG_SET(death_test_style, "threadsafe");
+
+    /*
+     * if the test is being passed --gtest_list_tests then do not start Seastar.
+     * this is an important optimization for using `gtest_discover_tests`
+     * because every test exectuable is queried in parallel, and the result is
+     * that listing would timeout or seastar would exhaust some kind of resource
+     * like aio-max-nr.
+     */
+    if (GTEST_FLAG_GET(list_tests)) {
+        return RUN_ALL_TESTS();
+    }
+
     seastar::testing::global_test_runner().start(argc, argv);
 
     int ret = 0;


### PR DESCRIPTION
```
    /*
     * if the test is being passed --gtest_list_tests then do not start Seastar.
     * this is an important optimization for using `gtest_discover_tests`
     * because every test exectuable is queried in parallel, and the result is
     * that listing would timeout or seastar would exhaust some kind of resource
     * like aio-max-nr.
     */
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

