### PR TITLE
test/compaction_e2e_test: strict check

### DIFF
--- a/tests/rptest/tests/compaction_e2e_test.py
+++ b/tests/rptest/tests/compaction_e2e_test.py
@@ -174,12 +174,8 @@ class CompactionE2EIdempotencyTest(RedpandaTest):
         rw_verifier.stop()
         rw_verifier.wait(timeout_sec=10)
 
-        if workload == Workload.TX_UNIQUE_KEYS:
-            # this workload with these test setting might generate non-compactible segments
-            m.expect([(metric, lambda old, new: old <= new)])
-        else:
-            # expect some level of compaction
-            m.expect([(metric, lambda old, new: old < new)])
+        # expect some level of compaction
+        m.expect([(metric, lambda old, new: old < new)])
 
 
 class CompactionWithRecoveryTest(RedpandaTest, PartitionMovementMixin):


### PR DESCRIPTION
previously, the TX_UNIQUE_KEYS workload would generate mostly non-compactible segments, 
so the metric check needed to be <=

This is not a bug but a known behavior of Kafka + compaction: We need to preserve "tx abort" batches across compaction, and the workload generator would generate mostly only "tx abort" batches without any intermediate data.

A recent pr https://github.com/redpanda-data/redpanda/pull/17773 fixes this behavior so this test can be strict

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none 