### PR TITLE
[v23.3.x] raft: don't promote to voter if previous config is not committed

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -215,17 +215,17 @@ TEST_F_CORO(
       10s,
       [&reached_dispatch_append,
        &may_resume_append](raft::raft_node_instance& node) {
-          node.on_dispatch(
-            [&reached_dispatch_append, &may_resume_append](raft::msg_type t) {
-                if (t == raft::msg_type::append_entries) {
-                    if (!reached_dispatch_append.available()) {
-                        reached_dispatch_append.set_value(true);
-                    }
-                    return may_resume_append.get_shared_future();
-                }
+          node.on_dispatch([&reached_dispatch_append, &may_resume_append](
+                             model::node_id, raft::msg_type t) {
+              if (t == raft::msg_type::append_entries) {
+                  if (!reached_dispatch_append.available()) {
+                      reached_dispatch_append.set_value(true);
+                  }
+                  return may_resume_append.get_shared_future();
+              }
 
-                return ss::now();
-            });
+              return ss::now();
+          });
 
           return node.get_vnode();
       });

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -217,7 +217,7 @@ TEST_F_CORO(
     // wait for leader
     co_await wait_for_leader(10s);
     for (auto& [_, node] : nodes()) {
-        node->on_dispatch([](raft::msg_type t) {
+        node->on_dispatch([](model::node_id, raft::msg_type t) {
             if (
               t == raft::msg_type::append_entries
               && random_generators::get_int(1000) > 800) {

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -564,6 +564,9 @@ seastar::future<> raft_fixture::TearDownAsync() {
     co_await seastar::coroutine::parallel_for_each(
       _nodes, [](auto& pair) { return pair.second->stop(); });
 
+    co_await seastar::coroutine::parallel_for_each(
+      _nodes, [](auto& pair) { return pair.second->remove_data(); });
+
     co_await _features.stop();
 }
 seastar::future<> raft_fixture::SetUpAsync() {

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -618,7 +618,7 @@ raft_fixture::stop_node(model::node_id id, remove_data_dir remove) {
 }
 
 raft_node_instance& raft_fixture::node(model::node_id id) {
-    return *_nodes.find(id)->second;
+    return *_nodes.at(id);
 }
 
 ss::future<model::node_id>

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -240,8 +240,7 @@ channel& in_memory_test_protocol::get_channel(model::node_id id) {
     return *it->second;
 }
 
-void in_memory_test_protocol::on_dispatch(
-  ss::noncopyable_function<ss::future<>(msg_type)> f) {
+void in_memory_test_protocol::on_dispatch(dispatch_callback_t f) {
     _on_dispatch_handlers.push_back(std::move(f));
 }
 
@@ -301,7 +300,7 @@ in_memory_test_protocol::dispatch(model::node_id id, ReqT req) {
 
     const auto msg_type = map_msg_type<ReqT>();
     for (const auto& f : _on_dispatch_handlers) {
-        co_await f(msg_type);
+        co_await f(id, msg_type);
     }
 
     try {
@@ -557,8 +556,7 @@ raft_node_instance::random_batch_base_offset(model::offset max) {
     co_return batches.front().base_offset();
 }
 
-void raft_node_instance::on_dispatch(
-  ss::noncopyable_function<ss::future<>(msg_type)> f) {
+void raft_node_instance::on_dispatch(dispatch_callback_t f) {
     _protocol->on_dispatch(std::move(f));
 }
 

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -91,6 +91,9 @@ struct raft_node_map {
       node_for(model::node_id) = 0;
 };
 
+using dispatch_callback_t
+  = ss::noncopyable_function<ss::future<>(model::node_id, msg_type)>;
+
 class in_memory_test_protocol : public consensus_client_protocol::impl {
 public:
     explicit in_memory_test_protocol(raft_node_map&, prefix_logger&);
@@ -128,7 +131,7 @@ public:
 
     channel& get_channel(model::node_id id);
 
-    void on_dispatch(ss::noncopyable_function<ss::future<>(msg_type)> f);
+    void on_dispatch(dispatch_callback_t f);
 
     ss::future<> stop();
 
@@ -137,8 +140,7 @@ private:
     ss::future<result<RespT>> dispatch(model::node_id, ReqT req);
     ss::gate _gate;
     absl::flat_hash_map<model::node_id, std::unique_ptr<channel>> _channels;
-    std::vector<ss::noncopyable_function<ss::future<>(msg_type)>>
-      _on_dispatch_handlers;
+    std::vector<dispatch_callback_t> _on_dispatch_handlers;
     raft_node_map& _nodes;
     prefix_logger& _logger;
 };
@@ -222,7 +224,7 @@ public:
     ///
     //// \param f The callback function to be invoked when a message is
     /// dispatched.
-    void on_dispatch(ss::noncopyable_function<ss::future<>(msg_type)> f);
+    void on_dispatch(dispatch_callback_t);
 
 private:
     model::node_id _id;

--- a/src/v/raft/tests/raft_reconfiguration_test.cc
+++ b/src/v/raft/tests/raft_reconfiguration_test.cc
@@ -25,6 +25,7 @@
 #include "serde/serde.h"
 #include "storage/record_batch_builder.h"
 #include "test_utils/async.h"
+#include "test_utils/randoms.h"
 #include "test_utils/test.h"
 
 #include <seastar/core/coroutine.hh>
@@ -35,6 +36,7 @@
 
 #include <absl/container/flat_hash_set.h>
 #include <fmt/core.h>
+#include <fmt/ranges.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -49,15 +51,29 @@ static ss::logger test_log("reconfiguration-test");
  */
 
 using use_snapshot = ss::bool_class<struct use_snapshot_tag>;
-using use_initial_learner_offset = ss::bool_class<struct use_snapshot_tag>;
-struct test_params {
-    use_snapshot snapshot;
-    int initial_size;
-    int nodes_to_add;
-    int nodes_to_remove;
-    use_initial_learner_offset learner_start_offset;
-    consistency_level consistency_level = raft::consistency_level::quorum_ack;
+using use_initial_learner_offset
+  = ss::bool_class<struct use_initial_learner_offset_tag>;
+
+enum class isolated_t {
+    none,
+    old_leader,
+    old_followers,
+    random,
 };
+
+std::ostream& operator<<(std::ostream& o, isolated_t pt) {
+    switch (pt) {
+    case isolated_t::none:
+        return o << "isolated::none";
+    case isolated_t::old_leader:
+        return o << "isolated::old_leader";
+    case isolated_t::old_followers:
+        return o << "isolated::old_followers";
+    case isolated_t::random:
+        return o << "isolated::random";
+    }
+    __builtin_unreachable();
+}
 
 struct reconfiguration_test
   : testing::WithParamInterface<std::tuple<
@@ -66,7 +82,8 @@ struct reconfiguration_test
       int,
       int,
       use_initial_learner_offset,
-      consistency_level>>
+      consistency_level,
+      isolated_t>>
   , raft_fixture {
     ss::future<> wait_for_reconfiguration_to_finish(
       const absl::flat_hash_set<model::node_id>& target_ids,
@@ -163,38 +180,43 @@ static void assert_offset_translator_state_is_consistent(
 
 TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
     const auto param = GetParam();
-    use_snapshot snapshot = std::get<0>(param);
+    auto snapshot = std::get<use_snapshot>(param);
     int initial_size = std::get<1>(param);
     int nodes_to_add = std::get<2>(param);
     int nodes_to_remove = std::get<3>(param);
-    use_initial_learner_offset use_learner_start_offset = std::get<4>(param);
-    consistency_level consistency_level = std::get<5>(param);
+    auto use_learner_start_offset = std::get<use_initial_learner_offset>(param);
+    auto consistency_lvl = std::get<consistency_level>(param);
+    auto isolated = std::get<isolated_t>(param);
     // skip test cases that makes no sense
     if (
       nodes_to_add + initial_size - nodes_to_remove <= 0
       || initial_size < nodes_to_remove) {
         co_return;
     }
+    if (initial_size == 1 && isolated == isolated_t::old_followers) {
+        co_return;
+    }
     fmt::print(
       "test parameters: {{snapshot: {}, initial_size: {}, "
       "nodes_to_add: {}, nodes_to_remove: {}, use_learner_start_offset: {}, "
-      "consistency_lvl: {}}}\n",
+      "consistency_lvl: {}, isolated: {}}}\n",
       snapshot,
       initial_size,
       nodes_to_add,
       nodes_to_remove,
       use_learner_start_offset,
-      consistency_level);
+      consistency_lvl,
+      isolated);
     // create group with initial configuration
     co_await create_simple_group(initial_size);
 
     // replicate batches
     auto result = co_await retry_with_leader(
       model::timeout_clock::now() + 30s,
-      [this, consistency_level](raft_node_instance& leader_node) {
+      [this, consistency_lvl](raft_node_instance& leader_node) {
           return leader_node.raft()
             ->replicate(
-              make_random_batches(), replicate_options(consistency_level))
+              make_random_batches(), replicate_options(consistency_lvl))
             .then([this](::result<replicate_result> r) {
                 if (!r) {
                     return ss::make_ready_future<::result<model::offset>>(
@@ -210,7 +232,7 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
     auto& leader_node = node(leader);
     model::offset start_offset = leader_node.raft()->start_offset();
     if (snapshot) {
-        if (consistency_level == consistency_level::leader_ack) {
+        if (consistency_lvl == consistency_level::leader_ack) {
             for (auto& [_, n] : nodes()) {
                 co_await n->raft()->refresh_commit_index();
             }
@@ -275,6 +297,12 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
     ASSERT_EQ_CORO(
       current_nodes.size(), initial_size + nodes_to_add - nodes_to_remove);
 
+    vlog(
+      test_log.info,
+      "dispatching reconfiguration: {} -> {}",
+      old_node_ids,
+      current_node_ids);
+
     // update group configuration
     auto success = co_await retry_with_leader(
       model::timeout_clock::now() + 30s,
@@ -290,10 +318,53 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
             });
       });
     ASSERT_TRUE_CORO(success);
+
+    auto isolated_nodes
+      = ss::make_lw_shared<absl::flat_hash_set<model::node_id>>();
+    switch (isolated) {
+    case isolated_t::none:
+        break;
+    case isolated_t::old_leader:
+        isolated_nodes->insert(leader);
+        break;
+    case isolated_t::old_followers:
+        *isolated_nodes = old_node_ids;
+        isolated_nodes->erase(leader);
+        break;
+    case isolated_t::random:
+        for (auto n : all_ids()) {
+            if (tests::random_bool()) {
+                isolated_nodes->insert(n);
+            }
+        }
+        break;
+    }
+
+    if (!isolated_nodes->empty()) {
+        vlog(test_log.info, "isolating nodes: {}", *isolated_nodes);
+
+        for (const auto& [source_id, node] : nodes()) {
+            node->on_dispatch([=](model::node_id dest_id, raft::msg_type) {
+                if (
+                  isolated_nodes->contains(source_id)
+                  != isolated_nodes->contains(dest_id)) {
+                    return ss::sleep(5s);
+                }
+                return ss::now();
+            });
+        }
+
+        // heal the partition 5s later
+        (void)ss::sleep(5s).then([isolated_nodes] {
+            vlog(test_log.info, "healing the network partition");
+            isolated_nodes->clear();
+        });
+    }
+
     co_await with_leader(
-      30s, [this, consistency_level](raft_node_instance& leader_node) {
+      30s, [this, consistency_lvl](raft_node_instance& leader_node) {
           // wait for committed offset to propagate
-          if (consistency_level == raft::consistency_level::quorum_ack) {
+          if (consistency_lvl == raft::consistency_level::quorum_ack) {
               return wait_for_committed_offset(
                 leader_node.raft()->committed_offset(), 30s);
           } else {
@@ -343,4 +414,19 @@ INSTANTIATE_TEST_SUITE_P(
     testing::Values(0, 1, 3), // to remove
     testing::Values(use_initial_learner_offset::yes),
     testing::Values(
-      consistency_level::quorum_ack, consistency_level::leader_ack)));
+      consistency_level::quorum_ack, consistency_level::leader_ack),
+    testing::Values(isolated_t::none)));
+
+INSTANTIATE_TEST_SUITE_P(
+  reconfiguration_with_isolated_nodes,
+  reconfiguration_test,
+  testing::Combine(
+    testing::Values(use_snapshot::no),
+    testing::Values(3),    // initial size
+    testing::Values(2),    // to add
+    testing::Values(0, 2), // to remove
+    testing::Values(use_initial_learner_offset::yes),
+    testing::Values(
+      consistency_level::quorum_ack, consistency_level::leader_ack),
+    testing::Values(
+      isolated_t::old_followers, isolated_t::old_leader, isolated_t::random)));

--- a/src/v/raft/tests/raft_reconfiguration_test.cc
+++ b/src/v/raft/tests/raft_reconfiguration_test.cc
@@ -68,12 +68,14 @@ struct reconfiguration_test
       use_initial_learner_offset,
       consistency_level>>
   , raft_fixture {
-    ss::future<>
-    wait_for_reconfiguration_to_finish(std::chrono::milliseconds timeout) {
-        RPTEST_REQUIRE_EVENTUALLY_CORO(timeout, [this] {
-            for (auto& [_, n] : nodes()) {
+    ss::future<> wait_for_reconfiguration_to_finish(
+      const absl::flat_hash_set<model::node_id>& target_ids,
+      std::chrono::milliseconds timeout) {
+        RPTEST_REQUIRE_EVENTUALLY_CORO(timeout, [this, target_ids] {
+            for (auto id : target_ids) {
+                auto& n = node(id);
                 if (
-                  n->raft()->config().get_state()
+                  n.raft()->config().get_state()
                   != raft::configuration_state::simple) {
                     return false;
                 }
@@ -130,16 +132,16 @@ wait_for_offset(model::offset expected, raft_fixture::raft_nodes_t& nodes) {
     co_return result<model::offset>(raft::errc::timeout);
 }
 
-void assert_offset_translator_state_is_consistent(
-  raft_fixture::raft_nodes_t& nodes) {
-    if (nodes.size() == 1) {
+static void assert_offset_translator_state_is_consistent(
+  const std::vector<raft_node_instance*>& nodes) {
+    if (nodes.size() <= 1) {
         return;
     }
     model::offset start_offset{};
-    auto first_raft = nodes.begin()->second->raft();
+    auto first_raft = nodes.front()->raft();
     model::offset dirty_offset = first_raft->dirty_offset();
     // get the max start offset
-    for (auto& [id, n] : nodes) {
+    for (auto* n : nodes) {
         start_offset = std::max(n->raft()->start_offset(), start_offset);
     }
     std::vector<int64_t> deltas;
@@ -153,7 +155,7 @@ void assert_offset_translator_state_is_consistent(
         for (model::offset o :
              boost::irange<model::offset>(start_offset, dirty_offset)) {
             ASSERT_EQ(
-              it->second->raft()->get_offset_translator_state()->delta(o),
+              (*it)->raft()->get_offset_translator_state()->delta(o),
               deltas[idx++]);
         }
     }
@@ -250,9 +252,13 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
         }
     }
 
+    auto old_node_ids = all_ids();
+
+    auto current_node_ids = old_node_ids;
     auto current_nodes = all_vnodes();
 
     for (int i = 0; i < nodes_to_remove; ++i) {
+        current_node_ids.erase(current_nodes.back().id());
         current_nodes.pop_back();
     }
     absl::flat_hash_set<raft::vnode> added_nodes;
@@ -261,6 +267,7 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
           auto& n = add_node(
             model::node_id(initial_size + i), model::revision_id(0));
           current_nodes.push_back(n.get_vnode());
+          current_node_ids.insert(n.get_vnode().id());
           added_nodes.emplace(n.get_vnode());
           return n.init_and_start({});
       });
@@ -295,7 +302,7 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
           }
       });
 
-    co_await wait_for_reconfiguration_to_finish(30s);
+    co_await wait_for_reconfiguration_to_finish(current_node_ids, 30s);
 
     co_await assert_logs_equal(start_offset);
 
@@ -303,8 +310,9 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
       current_nodes.begin(), current_nodes.end());
 
     // validate configuration
-    for (const auto& [_, n] : nodes()) {
-        auto cfg = n->raft()->config();
+    for (auto id : current_node_ids) {
+        auto& n = node(id);
+        auto cfg = n.raft()->config();
         auto cfg_vnodes = cfg.all_nodes();
         ASSERT_EQ_CORO(
           current_nodes_set,
@@ -313,11 +321,16 @@ TEST_P_CORO(reconfiguration_test, configuration_replace_test) {
         ASSERT_FALSE_CORO(cfg.old_config().has_value());
         ASSERT_TRUE_CORO(cfg.current_config().learners.empty());
 
-        if (learner_start_offset && added_nodes.contains(n->get_vnode())) {
-            ASSERT_EQ_CORO(n->raft()->start_offset(), learner_start_offset);
+        if (learner_start_offset && added_nodes.contains(n.get_vnode())) {
+            ASSERT_EQ_CORO(n.raft()->start_offset(), learner_start_offset);
         }
     }
-    assert_offset_translator_state_is_consistent(nodes());
+
+    std::vector<raft_node_instance*> current_node_ptrs;
+    for (auto id : current_node_ids) {
+        current_node_ptrs.push_back(&node(id));
+    }
+    assert_offset_translator_state_is_consistent(current_node_ptrs);
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17675

Fixes https://github.com/redpanda-data/redpanda/issues/17791