### PR TITLE
rbac_migrator: suppress error on role_exists

### DIFF
--- a/src/v/migrations/feature_migrator.h
+++ b/src/v/migrations/feature_migrator.h
@@ -43,6 +43,9 @@ protected:
      * If not overriding `start` and `do_migrate`, then implement
      * `do_mutate` to express the change that should be made to
      * the system during upgrade.
+     *
+     * `do_mutate` should be idempotent as it may be executed multiple times if
+     * there is a leader reelection while do_mutate is being executed.
      */
     virtual ss::future<> do_mutate() { return ss::now(); }
     ss::future<> do_migrate();


### PR DESCRIPTION
If the leader running the feature migration loses leadership after
the role is created but before the feature migration is successfully
completed, the next leader will redo the feature migration. In that
case, we will get a `role_exists` error, which we can safely ignore.

This was discovered through the following CI failure: https://ci-artifacts.dev.vectorized.cloud/redpanda/47611/018ec8a8-1fa5-49b2-8d82-1577c14d20bf/vbuild/ducktape/results/final/report.html

Fixes https://redpandadata.atlassian.net/browse/CORE-2287
Fixes https://github.com/redpanda-data/redpanda/issues/17736

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
