### PR TITLE
slash-cmds: add `/publish-to-install-pack` command

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -10,6 +10,7 @@ on:
       - test-arm64-command
       - dt-command
       - microbench-command
+      - publish-to-install-pack-command
 
 jobs:
   run-build:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -21,6 +21,7 @@ jobs:
             test-arm64
             dt
             microbench
+            publish-to-install-pack
           static-args: |
             org=redpanda-data
             repo=redpanda


### PR DESCRIPTION
used for PRs. It'll publish redpanda packages to repos, and it'll create install-packs that will reference that packages

ref
https://redpandadata.atlassian.net/browse/PESDLC-1057

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
