### PR TITLE
c/partition_allocator: fix bench test

### DIFF
--- a/src/v/cluster/tests/allocation_bench.cc
+++ b/src/v/cluster/tests/allocation_bench.cc
@@ -19,9 +19,14 @@
 #include <vector>
 
 PERF_TEST_F(partition_allocator_fixture, allocation_3) {
-    register_node(0, 24);
-    register_node(1, 24);
-    register_node(2, 24);
+    static bool initialized = false;
+    if (!initialized) {
+        register_node(0, 24);
+        register_node(1, 24);
+        register_node(2, 24);
+        initialized = true;
+    }
+
     auto req = make_allocation_request(1, 3);
 
     perf_tests::start_measuring_time();
@@ -31,9 +36,14 @@ PERF_TEST_F(partition_allocator_fixture, allocation_3) {
     });
 }
 PERF_TEST_F(partition_allocator_fixture, deallocation_3) {
-    register_node(0, 24);
-    register_node(1, 24);
-    register_node(2, 24);
+    static bool initialized = false;
+    if (!initialized) {
+        register_node(0, 24);
+        register_node(1, 24);
+        register_node(2, 24);
+        initialized = true;
+    }
+
     auto req = make_allocation_request(1, 3);
 
     std::vector<model::broker_shard> replicas;
@@ -56,9 +66,14 @@ PERF_TEST_F(partition_allocator_fixture, deallocation_3) {
     });
 }
 PERF_TEST_F(partition_allocator_fixture, recovery) {
-    register_node(0, 24);
-    register_node(1, 24);
-    register_node(2, 24);
+    static bool initialized = false;
+    if (!initialized) {
+        register_node(0, 24);
+        register_node(1, 24);
+        register_node(2, 24);
+        initialized = true;
+    }
+
     const auto node_capacity = max_capacity();
 
     std::vector<model::broker_shard> replicas;


### PR DESCRIPTION
Bench test is called many times, but register_node will throw if the node is registered the second time. Modify bench tests so that they register nodes only once at the beginning.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none