### PR TITLE
CORE-2321: cloud_storage: Fix remote_partition stuck reader

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -401,101 +401,58 @@ public:
                   "{}",
                   _seg_reader->config());
 
-                try {
-                    auto result = co_await _seg_reader->read_some(
-                      deadline, *_ot_state);
-                    throw_on_external_abort();
+                auto result = co_await _seg_reader->read_some(
+                  deadline, *_ot_state);
+                throw_on_external_abort();
 
-                    if (!result) {
-                        vlog(
-                          _ctxlog.debug,
-                          "Error while reading from stream '{}'",
-                          result.error());
-                        co_await set_end_of_stream();
-                        throw std::system_error(result.error());
-                    }
-                    data_t d = std::move(result.value());
-                    for (const auto& batch : d) {
-                        _partition->_probe.add_bytes_read(
-                          batch.header().size_bytes);
-                        _partition->_probe.add_records_read(
-                          batch.record_count());
-                    }
-                    if (
-                      _first_produced_offset == model::offset{} && !d.empty()) {
-                        _first_produced_offset = d.front().base_offset();
-                    } else {
-                        auto current_ko = _ot_state->from_log_offset(
-                          _seg_reader->current_rp_offset());
-                        vlog(
-                          _ctxlog.debug,
-                          "No results, current rp offset: {}, current kafka "
-                          "offset: {}, max rp offset: "
-                          "{}",
-                          _seg_reader->current_rp_offset(),
-                          current_ko,
-                          _seg_reader->config().max_offset);
-                        if (current_ko > _seg_reader->config().max_offset) {
-                            // Reader overshoot the offset. If we will not reset
-                            // the stream the loop inside the
-                            // record_batch_reader will keep calling this method
-                            // again and again. We will be returning empty
-                            // result every time because the current offset
-                            // overshoot the max allowed offset. Resetting the
-                            // segment reader fixes the issue.
-                            //
-                            // We can get into the situation when the current
-                            // reader returns empty result in several cases:
-                            // - we reached max_offset (covered here)
-                            // - we reached end of stream (covered above right
-                            //   after the 'read_some' call)
-                            //
-                            // If we reached max-bytes then the result won't be
-                            // empty. It will have at least one record batch.
-                            co_await set_end_of_stream();
-                        }
-                    }
-                    co_return storage_t{std::move(d)};
-                } catch (const stuck_reader_exception& ex) {
-                    // FIXME: the exception is no longer thrown
-                    // anywhere in the code
-                    throw_on_external_abort();
+                if (!result) {
                     vlog(
-                      _ctxlog.warn,
-                      "stuck reader: current rp offset: {}, max rp offset: {}",
-                      ex.rp_offset,
-                      _seg_reader->max_rp_offset());
-
-                    // If the reader is stuck because of a mismatch between
-                    // segment data and manifest entry, set reader to EOF and
-                    // try to reset reader on the next loop iteration. We only
-                    // do this when the reader has not reached eof. For example,
-                    // the segment ends at offset 10 but the manifest has max
-                    // offset at 11 for the segment, with offset 11 actually
-                    // present in the next segment. When the reader is stuck,
-                    // the current offset will be 10 which we will not be able
-                    // to read from. Switching to the next segment should enable
-                    // reads to proceed.
-                    if (
-                      model::next_offset(ex.rp_offset)
-                        >= _next_segment_base_offset
-                      && !_seg_reader->is_eof()) {
-                        vlog(
-                          _ctxlog.info,
-                          "mismatch between current segment end and manifest "
-                          "data: current rp offset {}, manifest max rp offset "
-                          "{}, next segment base offset {}, reader is EOF: {}. "
-                          "set EOF on reader and try to "
-                          "reset",
-                          ex.rp_offset,
-                          _seg_reader->max_rp_offset(),
-                          _next_segment_base_offset,
-                          _seg_reader->is_eof());
-                        _seg_reader->set_eof();
-                        continue;
-                    }
-                    throw;
+                      _ctxlog.debug,
+                      "Error while reading from stream '{}'",
+                      result.error());
+                    co_await set_end_of_stream();
+                    throw std::system_error(result.error());
                 }
+                data_t d = std::move(result.value());
+                for (const auto& batch : d) {
+                    _partition->_probe.add_bytes_read(
+                      batch.header().size_bytes);
+                    _partition->_probe.add_records_read(batch.record_count());
+                }
+                if (_first_produced_offset == model::offset{} && !d.empty()) {
+                    _first_produced_offset = d.front().base_offset();
+                } else {
+                    auto current_ko = _ot_state->from_log_offset(
+                      _seg_reader->current_rp_offset());
+                    vlog(
+                      _ctxlog.debug,
+                      "No results, current rp offset: {}, current kafka "
+                      "offset: {}, max rp offset: "
+                      "{}",
+                      _seg_reader->current_rp_offset(),
+                      current_ko,
+                      _seg_reader->config().max_offset);
+                    if (current_ko > _seg_reader->config().max_offset) {
+                        // Reader overshoot the offset. If we will not reset
+                        // the stream the loop inside the
+                        // record_batch_reader will keep calling this method
+                        // again and again. We will be returning empty
+                        // result every time because the current offset
+                        // overshoot the max allowed offset. Resetting the
+                        // segment reader fixes the issue.
+                        //
+                        // We can get into the situation when the current
+                        // reader returns empty result in several cases:
+                        // - we reached max_offset (covered here)
+                        // - we reached end of stream (covered above right
+                        //   after the 'read_some' call)
+                        //
+                        // If we reached max-bytes then the result won't be
+                        // empty. It will have at least one record batch.
+                        co_await set_end_of_stream();
+                    }
+                }
+                co_return storage_t{std::move(d)};
             }
         } catch (const ss::gate_closed_exception&) {
             vlog(

--- a/src/v/cloud_storage/remote_segment.h
+++ b/src/v/cloud_storage/remote_segment.h
@@ -37,19 +37,6 @@
 
 namespace cloud_storage {
 
-class stuck_reader_exception final : public std::runtime_error {
-public:
-    stuck_reader_exception(
-      model::offset cur_rp_offset,
-      size_t cur_bytes_consumed,
-      ss::sstring context)
-      : std::runtime_error{context}
-      , rp_offset(cur_rp_offset)
-      , bytes_consumed(cur_bytes_consumed) {}
-    const model::offset rp_offset;
-    const size_t bytes_consumed;
-};
-
 std::filesystem::path
 generate_index_path(const cloud_storage::remote_segment_path& p);
 

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -10,6 +10,7 @@
  */
 #include "cloud_storage/tests/util.h"
 
+#include "model/record.h"
 #include "model/record_batch_types.h"
 
 #include <seastar/core/lowres_clock.hh>
@@ -822,6 +823,89 @@ scan_result scan_remote_partition(
       .bytes_skip = probe.get_bytes_skip() - bytes_skip,
       .bytes_accept = probe.get_bytes_accept() - bytes_accept,
     };
+}
+
+std::vector<model::record_batch_header>
+scan_remote_partition_incrementally_with_closest_lso(
+  cloud_storage_fixture& imposter,
+  model::offset base,
+  model::offset max,
+  size_t maybe_max_segments,
+  size_t maybe_max_readers) {
+    ss::lowres_clock::update();
+    auto conf = imposter.get_configuration();
+    static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    if (maybe_max_segments) {
+        config::shard_local_cfg()
+          .cloud_storage_max_materialized_segments_per_shard.set_value(
+            maybe_max_segments);
+    }
+    if (maybe_max_readers) {
+        config::shard_local_cfg()
+          .cloud_storage_max_segment_readers_per_shard.set_value(
+            maybe_max_readers);
+    }
+    auto manifest = hydrate_manifest(imposter.api.local(), bucket);
+    partition_probe probe(manifest.get_ntp());
+
+    auto manifest_view = ss::make_shared<async_manifest_view>(
+      imposter.api, imposter.cache, manifest, bucket);
+
+    auto partition = ss::make_shared<remote_partition>(
+      manifest_view,
+      imposter.api.local(),
+      imposter.cache.local(),
+      bucket,
+      probe);
+
+    auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
+
+    partition->start().get();
+
+    std::vector<model::record_batch_header> headers;
+
+    storage::log_reader_config reader_config(
+      base, model::next_offset(base), ss::default_priority_class());
+
+    // starting max_bytes
+    reader_config.max_bytes = 1;
+
+    auto next = base;
+
+    int num_fetches = 0;
+    while (next < max) {
+        reader_config.start_offset = next;
+        reader_config.max_offset = model::next_offset(next);
+        vlog(test_util_log.info, "reader_config {}", reader_config);
+        auto reader = partition->make_reader(reader_config).get().reader;
+        auto headers_read
+          = reader.consume(test_consumer(), model::no_timeout).get();
+        if (headers_read.empty()) {
+            // If the reader returned the empty result then the offset
+            // corresponds to tx-batch. Our own tx-batches looks like offset
+            // gaps to the client. We're always adding tx-batches with only one
+            // record so we can increment the 'next' offset and continue.
+            next = model::next_offset(next);
+            vlog(
+              test_util_log.info,
+              "Reader config: {} produced empty result, next offset set to {}",
+              reader_config,
+              next);
+            // test is prepared to see the gaps in place of tx-fence batches
+            continue;
+        }
+        BOOST_REQUIRE(headers_read.size() == 1);
+        vlog(test_util_log.info, "header {}", headers_read.front());
+        next = headers_read.back().last_offset() + model::offset(1);
+        std::copy(
+          headers_read.begin(),
+          headers_read.end(),
+          std::back_inserter(headers));
+        num_fetches++;
+    }
+    BOOST_REQUIRE(num_fetches > 0);
+    vlog(test_util_log.info, "{} fetch operations performed", num_fetches);
+    return headers;
 }
 
 void reupload_compacted_segments(

--- a/src/v/cloud_storage/tests/util.h
+++ b/src/v/cloud_storage/tests/util.h
@@ -218,4 +218,14 @@ std::vector<in_memory_segment> replace_segments(
   model::offset_delta base_delta,
   const std::vector<std::vector<batch_t>>& batches);
 
+/// Read batches by one using max_bytes=1 and set max_offset to closes
+/// value in the 'possible_lso_values' list.
+std::vector<model::record_batch_header>
+scan_remote_partition_incrementally_with_closest_lso(
+  cloud_storage_fixture& imposter,
+  model::offset base,
+  model::offset max,
+  size_t maybe_max_segments,
+  size_t maybe_max_readers);
+
 } // namespace cloud_storage


### PR DESCRIPTION
This PR adds new fuzz test that reproduces that stuck reader problem and adds a fix. The fix resets the reader in case it reached the max_offset.

Fixes #17788

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Fix problem in Tiered-Storage that could potentially cause consumers to get stuck