### PR TITLE
CORE-2157: cloud_storage_clients: add support for path-style addressing

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -41,6 +41,7 @@ cloud_storage_clients::s3_configuration get_configuration() {
     conf.access_key = cloud_roles::public_key_str("acess-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
+    conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
     conf.server_addr = server_addr;
     conf.disable_metrics = net::metrics_disabled::yes;
     conf.disable_public_metrics = net::public_metrics_disabled::yes;

--- a/src/v/archival/tests/archival_metadata_stm_test.cc
+++ b/src/v/archival/tests/archival_metadata_stm_test.cc
@@ -78,6 +78,7 @@ struct archival_metadata_stm_base_fixture
         conf.access_key = cloud_roles::public_key_str("acess-key");
         conf.secret_key = cloud_roles::private_key_str("secret-key");
         conf.region = cloud_roles::aws_region_name("us-east-1");
+        conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
         conf.server_addr = server_addr;
         conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
           net::metrics_disabled::yes,

--- a/src/v/archival/tests/archival_service_fixture.h
+++ b/src/v/archival/tests/archival_service_fixture.h
@@ -10,6 +10,7 @@
 #include "archival/archiver_manager.h"
 #include "archival/tests/service_fixture.h"
 #include "archival/types.h"
+#include "cloud_storage_clients/types.h"
 #include "cluster/controller_api.h"
 #include "cluster/errc.h"
 #include "cluster/fwd.h"
@@ -59,6 +60,7 @@ class archiver_cluster_fixture
         s3_conf.access_key = cloud_roles::public_key_str("access-key");
         s3_conf.secret_key = cloud_roles::private_key_str("secret-key");
         s3_conf.region = cloud_roles::aws_region_name("us-east-1");
+        s3_conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
         s3_conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
           net::metrics_disabled::yes,
           net::public_metrics_disabled::yes,

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -179,6 +179,7 @@ archiver_fixture::get_configurations() {
     s3conf.access_key = cloud_roles::public_key_str("acess-key");
     s3conf.secret_key = cloud_roles::private_key_str("secret-key");
     s3conf.region = cloud_roles::aws_region_name("us-east-1");
+    s3conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
     s3conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,
       net::public_metrics_disabled::yes,

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -474,6 +474,7 @@ private:
         conf.access_key = cloud_roles::public_key_str("acess-key");
         conf.secret_key = cloud_roles::private_key_str("secret-key");
         conf.region = cloud_roles::aws_region_name("us-east-1");
+        conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
         conf.server_addr = server_addr;
         conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
           net::metrics_disabled::yes,

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -332,6 +332,7 @@ s3_imposter_fixture::get_configuration() {
     conf.access_key = cloud_roles::public_key_str("acess-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
+    conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
     conf.server_addr = server_addr;
     conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -28,6 +28,7 @@ cloud_storage_clients::default_overrides get_default_overrides() {
         optep.has_value()) {
         overrides.endpoint = cloud_storage_clients::endpoint_url(*optep);
     }
+    overrides.url_style = config::shard_local_cfg().cloud_storage_url_style();
     overrides.disable_tls = config::shard_local_cfg().cloud_storage_disable_tls;
     if (auto cert = config::shard_local_cfg().cloud_storage_trust_file.value();
         cert.has_value()) {

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -91,6 +91,8 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
     client_cfg.secret_key = skey;
     client_cfg.region = region;
     client_cfg.uri = access_point_uri(endpoint_uri);
+    client_cfg.url_style = overrides.url_style;
+
     if (overrides.disable_tls == false) {
         client_cfg.credentials = co_await build_tls_credentials(
           "s3", overrides.trust_file, s3_log);

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -26,6 +26,7 @@ struct default_overrides {
     std::optional<uint16_t> port = std::nullopt;
     std::optional<ca_trust_file> trust_file = std::nullopt;
     std::optional<ss::lowres_clock::duration> max_idle_time = std::nullopt;
+    s3_url_style url_style = s3_url_style::virtual_host;
     bool disable_tls = false;
 };
 
@@ -48,6 +49,8 @@ struct s3_configuration : common_configuration {
     std::optional<cloud_roles::public_key_str> access_key;
     /// AWS secret key, optional if configuration uses temporary credentials
     std::optional<cloud_roles::private_key_str> secret_key;
+    /// AWS URL style, either virtual-hosted-style or path-style.
+    s3_url_style url_style;
 
     /// \brief opinionated configuraiton initialization
     /// Generates uri field from region, initializes credentials for the

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -376,8 +376,7 @@ request_creator::make_delete_objects_request(
         std::make_unique<delete_objects_body>(std::move(body))}}};
 }
 
-std::string
-request_creator::make_host([[maybe_unused]] const bucket_name& name) const {
+std::string request_creator::make_host(const bucket_name& name) const {
     switch (_ap_style) {
     case s3_url_style::virtual_host:
         // Host: bucket-name.s3.region-code.amazonaws.com
@@ -389,7 +388,7 @@ request_creator::make_host([[maybe_unused]] const bucket_name& name) const {
 }
 
 std::string request_creator::make_target(
-  [[maybe_unused]] const bucket_name& name, const object_key& key) const {
+  const bucket_name& name, const object_key& key) const {
     switch (_ap_style) {
     case s3_url_style::virtual_host:
         // Target: /homepage.html

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -81,8 +81,13 @@ result<http::client::request_header> request_creator::make_get_object_request(
   object_key const& key,
   std::optional<http_byte_range> byte_range) {
     http::client::request_header header{};
+    // Virtual Style:
     // GET /{object-id} HTTP/1.1
-    // Host: {bucket-name}.s3.amazonaws.com
+    // Host: {bucket-name}.s3.{region}.amazonaws.com
+    // Path Style:
+    // GET /{bucket-name}/{object-id} HTTP/1.1
+    // Host: s3.{region}.amazonaws.com
+    //
     // x-amz-date:{req-datetime}
     // Authorization:{signature}
     // x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -112,8 +117,13 @@ result<http::client::request_header> request_creator::make_get_object_request(
 result<http::client::request_header> request_creator::make_head_object_request(
   bucket_name const& name, object_key const& key) {
     http::client::request_header header{};
+    // Virtual Style:
     // HEAD /{object-id} HTTP/1.1
-    // Host: {bucket-name}.s3.amazonaws.com
+    // Host: {bucket-name}.s3.{region}.amazonaws.com
+    // Path Style:
+    // HEAD /{bucket-name}/{object-id} HTTP/1.1
+    // Host: s3.{region}.amazonaws.com
+    //
     // x-amz-date:{req-datetime}
     // Authorization:{signature}
     // x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -135,8 +145,13 @@ result<http::client::request_header> request_creator::make_head_object_request(
 result<http::client::request_header>
 request_creator::make_unsigned_put_object_request(
   bucket_name const& name, object_key const& key, size_t payload_size_bytes) {
+    // Virtual Style:
     // PUT /my-image.jpg HTTP/1.1
-    // Host: myBucket.s3.<Region>.amazonaws.com
+    // Host: {bucket-name}.s3.{region}.amazonaws.com
+    // Path Style:
+    // PUT /{bucket-name}/{object-id} HTTP/1.1
+    // Host: s3.{region}.amazonaws.com
+    //
     // Date: Wed, 12 Oct 2009 17:50:00 GMT
     // Authorization: authorization string
     // Content-Type: text/plain
@@ -173,8 +188,13 @@ request_creator::make_list_objects_v2_request(
   std::optional<size_t> max_keys,
   std::optional<ss::sstring> continuation_token,
   std::optional<char> delimiter) {
+    // Virtual Style:
     // GET /?list-type=2&prefix=photos/2006/&delimiter=/ HTTP/1.1
-    // Host: example-bucket.s3.<Region>.amazonaws.com
+    // Host: {bucket-name}.s3.{region}.amazonaws.com
+    // Path Style:
+    // GET /{bucket-name}/?list-type=2&prefix=photos/2006/&delimiter=/ HTTP/1.1
+    // Host: s3.{region}.amazonaws.com
+    //
     // x-amz-date: 20160501T000433Z
     // Authorization: authorization string
     http::client::request_header header{};
@@ -226,8 +246,13 @@ result<http::client::request_header>
 request_creator::make_delete_object_request(
   bucket_name const& name, object_key const& key) {
     http::client::request_header header{};
+    // Virtual Style:
     // DELETE /{object-id} HTTP/1.1
     // Host: {bucket-name}.s3.amazonaws.com
+    // Path Style:
+    // DELETE /{bucket-name}/{object-id} HTTP/1.1
+    // Host: s3.{region}.amazonaws.com
+    //
     // x-amz-date:{req-datetime}
     // Authorization:{signature}
     // x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
@@ -264,8 +289,13 @@ request_creator::make_delete_objects_request(
     // https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteObjects.html
     // will generate this request:
     //
+    // Virtual Style:
     // POST /?delete HTTP/1.1
-    // Host: <Bucket>.s3.amazonaws.com
+    // Host: {bucket-name}.s3.{region}.amazonaws.com
+    // Path Style:
+    // POST /{bucket-name}/?delete HTTP/1.1
+    // Host: s3.{region}.amazonaws.com
+    //
     // Content-MD5: <Computer from body>
     // Authorization: <applied by _requestor>
     // Content-Length: <...>

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -107,10 +107,10 @@ public:
       std::optional<char> delimiter = std::nullopt);
 
 private:
-    std::string make_host([[maybe_unused]] const bucket_name& name) const;
+    std::string make_host(const bucket_name& name) const;
 
-    std::string make_target(
-      [[maybe_unused]] const bucket_name& name, const object_key& key) const;
+    std::string
+    make_target(const bucket_name& name, const object_key& key) const;
 
     access_point_uri _ap;
 

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -14,6 +14,7 @@
 #include "cloud_roles/apply_credentials.h"
 #include "cloud_storage_clients/client.h"
 #include "cloud_storage_clients/client_probe.h"
+#include "cloud_storage_clients/types.h"
 #include "http/client.h"
 #include "model/fundamental.h"
 
@@ -106,7 +107,14 @@ public:
       std::optional<char> delimiter = std::nullopt);
 
 private:
+    std::string make_host([[maybe_unused]] const bucket_name& name) const;
+
+    std::string make_target(
+      [[maybe_unused]] const bucket_name& name, const object_key& key) const;
+
     access_point_uri _ap;
+
+    s3_url_style _ap_style;
     /// Applies credentials to http requests by adding headers and signing
     /// request payload. Shared pointer so that the credentials can be rotated
     /// through the client pool.

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -44,6 +44,7 @@ static cloud_storage_clients::s3_configuration transport_configuration() {
     conf.access_key = cloud_roles::public_key_str("acess-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
+    conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
     conf.server_addr = server_addr;
     conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -38,6 +38,7 @@ static cloud_storage_clients::s3_configuration transport_configuration() {
     conf.access_key = cloud_roles::public_key_str("acess-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
+    conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
     conf.server_addr = server_addr;
     conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -305,6 +305,7 @@ static cloud_storage_clients::s3_configuration transport_configuration() {
     conf.access_key = cloud_roles::public_key_str("acess-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
+    conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
     conf.server_addr = server_addr;
     conf._probe = ss::make_shared<cloud_storage_clients::client_probe>(
       net::metrics_disabled::yes,

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -16,6 +16,7 @@
 #include <seastar/core/sstring.hh>
 
 #include <filesystem>
+#include <iostream>
 #include <system_error>
 
 namespace cloud_storage_clients {
@@ -60,6 +61,17 @@ inline const std::error_category& error_category() noexcept {
 
 inline std::error_code make_error_code(error_outcome e) noexcept {
     return {static_cast<int>(e), error_category()};
+}
+
+enum class s3_url_style { virtual_host = 0, path };
+
+inline std::ostream& operator<<(std::ostream& os, const s3_url_style& us) {
+    switch (us) {
+    case s3_url_style::virtual_host:
+        return os << "virtual_host";
+    case s3_url_style::path:
+        return os << "path";
+    }
 }
 
 } // namespace cloud_storage_clients

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1630,6 +1630,18 @@ configuration::configuration()
       {.visibility = visibility::user},
       std::nullopt,
       &validate_non_empty_string_opt)
+  , cloud_storage_url_style(
+      *this,
+      "cloud_storage_url_style",
+      "The addressing style to use for S3 requests.",
+      {.needs_restart = needs_restart::yes,
+       .example = "virtual_host",
+       .visibility = visibility::user},
+      cloud_storage_clients::s3_url_style::virtual_host,
+      {
+        cloud_storage_clients::s3_url_style::virtual_host,
+        cloud_storage_clients::s3_url_style::path,
+      })
   , cloud_storage_credentials_source(
       *this,
       "cloud_storage_credentials_source",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -10,6 +10,8 @@
  */
 
 #pragma once
+
+#include "cloud_storage_clients/types.h"
 #include "config/bounded_property.h"
 #include "config/broker_endpoint.h"
 #include "config/client_group_byte_rate_quota.h"
@@ -303,6 +305,7 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_region;
     property<std::optional<ss::sstring>> cloud_storage_bucket;
     property<std::optional<ss::sstring>> cloud_storage_api_endpoint;
+    enum_property<cloud_storage_clients::s3_url_style> cloud_storage_url_style;
     enum_property<model::cloud_credentials_source>
       cloud_storage_credentials_source;
     property<std::optional<ss::sstring>>

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cloud_storage_clients/types.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -219,6 +220,23 @@ struct convert<model::timestamp_type> {
     static bool decode(const Node& node, type& rhs) {
         auto value = node.as<std::string>();
         rhs = boost::lexical_cast<type>(value);
+
+        return true;
+    }
+};
+
+template<>
+struct convert<cloud_storage_clients::s3_url_style> {
+    using type = cloud_storage_clients::s3_url_style;
+    static Node encode(const type& rhs) {
+        Node node;
+        return node = fmt::format("{}", rhs);
+    }
+    static bool decode(const Node& node, type& rhs) {
+        auto value = node.as<std::string>();
+        rhs = string_switch<type>(std::string_view{value})
+                .match("virtual_host", type::virtual_host)
+                .match("path", type::path);
 
         return true;
     }

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "base/oncore.h"
+#include "cloud_storage_clients/types.h"
 #include "config/base_property.h"
 #include "config/rjson_serialization.h"
 #include "container/intrusive_list_helpers.h"
@@ -627,6 +628,10 @@ consteval std::string_view property_type_name() {
         return "integer";
     } else if constexpr (std::
                            is_same_v<type, model::cloud_credentials_source>) {
+        return "string";
+    } else if constexpr (std::is_same_v<
+                           type,
+                           cloud_storage_clients::s3_url_style>) {
         return "string";
     } else if constexpr (std::is_same_v<type, model::cloud_storage_backend>) {
         return "string";

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -140,6 +140,12 @@ void rjson_serialize(
 
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
+  const cloud_storage_clients::s3_url_style& v) {
+    stringize(w, v);
+}
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
   const model::cloud_credentials_source& v) {
     stringize(w, v);
 }

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -64,6 +64,10 @@ void rjson_serialize(
 
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,
+  const cloud_storage_clients::s3_url_style& v);
+
+void rjson_serialize(
+  json::Writer<json::StringBuffer>& w,
   const model::cloud_credentials_source& v);
 
 void rjson_serialize(

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -282,6 +282,7 @@ public:
         s3conf.access_key = cloud_roles::public_key_str("acess-key");
         s3conf.secret_key = cloud_roles::private_key_str("secret-key");
         s3conf.region = cloud_roles::aws_region_name("us-east-1");
+        s3conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;
         s3conf.server_addr = server_addr;
         return s3conf;
     }


### PR DESCRIPTION
Fixes #2183.

This PR adds support for path-style requests to S3 cloud storage.

`cloud_storage_url_style` is a configurable option in `redpanda`. It defaults to the existing `virtual_host` style, but can be set to `path`. The `s3_client` will now have its headers for requests generated based on the configured URL style.

Support for ducktape has been included, and path-style requests have been verified as working using the `s3_test_client_main` test. Ideally, the cloud storage self-test in PR #17586 would be integrated with these changes so as to verify both virtual-hosted style requests and path style requests.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* Adds path-style addressing to S3 client requests. 
* This option is configurable through `rpk cluster config edit`:

```
# The addressing style to use for S3 requests. (one of virtual_host, path, restart required)
cloud_storage_url_style: path
```
                                                                                                                                    



