### PR TITLE
c/balancer: store a balancer instance before planning

### DIFF
--- a/src/v/cluster/partition_balancer_backend.cc
+++ b/src/v/cluster/partition_balancer_backend.cc
@@ -355,24 +355,25 @@ ss::future<> partition_balancer_backend::do_tick() {
     // claim node unresponsive it doesn't responded to at least 7
     // status requests by default 700ms
     auto const node_responsiveness_timeout = _node_status_interval() * 7;
-    auto plan_data
-      = co_await partition_balancer_planner(
-          planner_config{
-            .mode = _mode(),
-            .soft_max_disk_usage_ratio = soft_max_disk_usage_ratio,
-            .hard_max_disk_usage_ratio = hard_max_disk_usage_ratio,
-            .max_concurrent_actions = _max_concurrent_actions(),
-            .node_availability_timeout_sec = _availability_timeout(),
-            .ondemand_rebalance_requested
-            = _cur_term->_ondemand_rebalance_requested,
-            .segment_fallocation_step = _segment_fallocation_step(),
-            .min_partition_size_threshold = get_min_partition_size_threshold(),
-            .node_responsiveness_timeout = node_responsiveness_timeout,
-            .topic_aware = _topic_aware(),
-          },
-          _state,
-          _partition_allocator)
-          .plan_actions(health_report.value(), _tick_in_progress.value());
+    partition_balancer_planner planner(
+      planner_config{
+        .mode = _mode(),
+        .soft_max_disk_usage_ratio = soft_max_disk_usage_ratio,
+        .hard_max_disk_usage_ratio = hard_max_disk_usage_ratio,
+        .max_concurrent_actions = _max_concurrent_actions(),
+        .node_availability_timeout_sec = _availability_timeout(),
+        .ondemand_rebalance_requested
+        = _cur_term->_ondemand_rebalance_requested,
+        .segment_fallocation_step = _segment_fallocation_step(),
+        .min_partition_size_threshold = get_min_partition_size_threshold(),
+        .node_responsiveness_timeout = node_responsiveness_timeout,
+        .topic_aware = _topic_aware(),
+      },
+      _state,
+      _partition_allocator);
+
+    auto plan_data = co_await planner.plan_actions(
+      health_report.value(), _tick_in_progress.value());
 
     _cur_term->last_tick_time = clock_t::now();
     _cur_term->last_violations = std::move(plan_data.violations);


### PR DESCRIPTION
Calling a function returning coroutine on a temporary may lead to issues.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none