### PR TITLE
transform: enforce subsystem memory limits

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -251,6 +251,30 @@ configuration::configuration()
       "after any character escaping.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       1_KiB)
+  , data_transforms_read_buffer_memory_percentage(
+      *this,
+      "data_transforms_read_buffer_memory_percentage",
+      "The percentage of available memory in the transform subsystem to use "
+      "for read buffers",
+      {
+        .needs_restart = needs_restart::yes,
+        .example = "25",
+        .visibility = visibility::tunable,
+      },
+      45,
+      {.min = 1, .max = 99})
+  , data_transforms_write_buffer_memory_percentage(
+      *this,
+      "data_transforms_write_buffer_memory_percentage",
+      "The percentage of available memory in the transform subsystem to use "
+      "for write buffers",
+      {
+        .needs_restart = needs_restart::yes,
+        .example = "25",
+        .visibility = visibility::tunable,
+      },
+      45,
+      {.min = 1, .max = 99})
   , topic_memory_per_partition(
       *this,
       "topic_memory_per_partition",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -81,6 +81,8 @@ struct configuration final : public config_store {
     property<std::chrono::milliseconds>
       data_transforms_logging_flush_interval_ms;
     property<size_t> data_transforms_logging_line_max_bytes;
+    bounded_property<size_t> data_transforms_read_buffer_memory_percentage;
+    bounded_property<size_t> data_transforms_write_buffer_memory_percentage;
 
     // Controller
     bounded_property<std::optional<std::size_t>> topic_memory_per_partition;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1273,7 +1273,8 @@ void application::wire_up_runtime_services(
           &partition_manager,
           &_transform_rpc_client,
           &metadata_cache,
-          sched_groups.transforms_sg())
+          sched_groups.transforms_sg(),
+          memory_groups().data_transforms_max_memory())
           .get();
     }
 

--- a/src/v/transform/CMakeLists.txt
+++ b/src/v/transform/CMakeLists.txt
@@ -8,6 +8,7 @@ v_cc_library(
     transform_manager.cc
     commit_batcher.cc
     txn_reader.cc
+    memory_limiter.cc
   DEPS
     v::wasm
     v::model

--- a/src/v/transform/include/transform/api.h
+++ b/src/v/transform/include/transform/api.h
@@ -61,7 +61,8 @@ public:
       ss::sharded<cluster::partition_manager>* partition_manager,
       ss::sharded<rpc::client>* rpc_client,
       ss::sharded<cluster::metadata_cache>* metadata_cache,
-      ss::scheduling_group sg);
+      ss::scheduling_group sg,
+      size_t memory_limit);
     service(const service&) = delete;
     service(service&&) = delete;
     service& operator=(const service&) = delete;
@@ -150,6 +151,9 @@ private:
       _notification_cleanups;
     ss::scheduling_group _sg;
     std::unique_ptr<logging::manager<ss::lowres_clock>> _log_manager;
+
+    // The total amount of memory available to transforms
+    size_t _total_memory_limit;
 };
 
 } // namespace transform

--- a/src/v/transform/memory_limiter.cc
+++ b/src/v/transform/memory_limiter.cc
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "memory_limiter.h"
+
+#include "base/vassert.h"
+#include "utils/human.h"
+
+#include <limits>
+
+namespace transform {
+
+namespace {
+// See: http://locklessinc.com/articles/sat_arithmetic/
+constexpr size_t saturating_add(size_t x, size_t y) {
+    size_t res = x + y;
+    res |= -static_cast<size_t>(res < x);
+    return res;
+}
+
+// Mini inline unit tests :D
+static_assert(saturating_add(1, 1) == 2);
+static_assert(saturating_add(0, 0) == 0);
+static_assert(saturating_add(0, 1) == 1);
+static_assert(saturating_add(1, 0) == 1);
+static_assert(
+  saturating_add(
+    std::numeric_limits<size_t>::max() / 2,
+    std::numeric_limits<size_t>::max() / 2)
+  == std::numeric_limits<size_t>::max() - 1);
+static_assert(
+  saturating_add(
+    std::numeric_limits<size_t>::max() / 2,
+    1 + std::numeric_limits<size_t>::max() / 2)
+  == std::numeric_limits<size_t>::max());
+static_assert(
+  saturating_add(
+    std::numeric_limits<size_t>::max() / 2,
+    2 + std::numeric_limits<size_t>::max() / 2)
+  == std::numeric_limits<size_t>::max());
+static_assert(
+  saturating_add(
+    std::numeric_limits<size_t>::max() / 2,
+    3 + std::numeric_limits<size_t>::max() / 2)
+  == std::numeric_limits<size_t>::max());
+static_assert(
+  saturating_add(std::numeric_limits<size_t>::max(), 1)
+  == std::numeric_limits<size_t>::max());
+static_assert(
+  saturating_add(std::numeric_limits<size_t>::max(), 0)
+  == std::numeric_limits<size_t>::max());
+static_assert(
+  saturating_add(std::numeric_limits<size_t>::max() - 1, 1)
+  == std::numeric_limits<size_t>::max());
+static_assert(
+  saturating_add(std::numeric_limits<size_t>::max() - 1, 2)
+  == std::numeric_limits<size_t>::max());
+static_assert(
+  saturating_add(std::numeric_limits<size_t>::max() - 1, 0)
+  == std::numeric_limits<size_t>::max() - 1);
+static_assert(
+  saturating_add(
+    std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max())
+  == std::numeric_limits<size_t>::max());
+} // namespace
+
+memory_limiter::memory_limiter(size_t limit)
+  : _available(limit)
+  , _max(limit) {}
+
+memory_limiter::~memory_limiter() {
+    vassert(
+      _waiters.empty(),
+      "must wait for all waiters to finish before destructing memory_limiter");
+}
+
+memory_limiter::units::units(memory_limiter* limiter, size_t amount)
+  : _limiter(limiter)
+  , _amount(amount) {}
+memory_limiter::units::units(units&& other) noexcept
+  : _limiter(std::exchange(other._limiter, nullptr))
+  , _amount(other._amount) {}
+
+void memory_limiter::units::release_all() {
+    if (_limiter != nullptr) {
+        _limiter->release(_amount);
+        _limiter = nullptr;
+    }
+}
+memory_limiter::units&
+memory_limiter::units::operator=(units&& other) noexcept {
+    if (&other == this) {
+        return *this;
+    }
+    release_all();
+    std::swap(other._limiter, _limiter);
+    _amount = other._amount;
+    return *this;
+}
+memory_limiter::units::~units() noexcept { release_all(); }
+
+ss::future<memory_limiter::units>
+memory_limiter::wait(size_t amount, ss::abort_source* as) {
+    co_await acquire(amount, as);
+    co_return units(this, amount);
+}
+ss::future<> memory_limiter::acquire(size_t amount, ss::abort_source* as) {
+    vassert(
+      amount <= _max,
+      "must not acquire more memory than available. requesting={}, max={}",
+      human::bytes(amount),
+      human::bytes(_max));
+    // Add a fast path if there are no waiters and there is available
+    // memory.
+    //
+    // We check for waiters so that this limiter is fair.
+    if (_waiters.empty() && has_available(amount)) {
+        _available -= amount;
+        return ss::now();
+    }
+    auto it = _waiters.emplace(_waiters.end(), amount);
+    auto sub = as->subscribe([it]() noexcept {
+        if (!it->state.has_value()) {
+            it->state = waiter::memory_acquired::no;
+            it->prom.set_value();
+        }
+    });
+    // erase from the linked list only in this acquire, this simplifies the
+    // lifetime requirements as this is the only function that mutates
+    // _waiters. Doing this means there are less async concurrent list
+    // modification issues to worry about.
+    if (!sub) {
+        _waiters.erase(it);
+        as->check(); // Will always throw
+    }
+    return it->prom.get_future().then([this, it, as, sub = std::move(sub)] {
+        auto state = it->state.value();
+        _waiters.erase(it);
+        // Throw if aborted, note that we can't do this unconditionally in the
+        // case that we "acquire" memory but then the abort is requested before
+        // this continuation runs.
+        if (state == waiter::memory_acquired::no) {
+            as->check();
+        }
+    });
+}
+void memory_limiter::release(size_t amount) {
+    // Guard against bugs by capping our limit and using saturating math.
+    _available = std::min(saturating_add(amount, _available), _max);
+    notify();
+}
+size_t memory_limiter::max_memory() const { return _max; }
+size_t memory_limiter::used_memory() const { return _max - _available; }
+size_t memory_limiter::available_memory() const { return _available; }
+bool memory_limiter::has_available(size_t amount) {
+    return amount <= _available;
+}
+void memory_limiter::notify() {
+    for (auto& waiter : _waiters) {
+        if (waiter.state.has_value()) {
+            continue;
+        }
+        // We have to check if the waiter has already been notified, as we
+        // don't mutate the _waiters list here so that there is a single
+        // owner in terms of who can mutate the list.
+        //
+        // Generally the number of waiters is expected to be low, so we
+        // don't anticipate reactor stalls or having to skip over already
+        // set promises to be an issue.
+        if (!has_available(waiter.amount)) {
+            // If we don't have memory available, our queue of waiters here
+            // is fair, we need to stop to preserve fairness.
+            break;
+        }
+        waiter.state = waiter::memory_acquired::yes;
+        waiter.prom.set_value();
+        // Decrement the memory here because we don't know when the
+        // waiter will be scheduled to wake up and remove itself from
+        // the list.
+        _available -= waiter.amount;
+        // Keep going until we run out of waiters or we don't have enough
+        // memory to free waiters.
+    }
+}
+} // namespace transform

--- a/src/v/transform/memory_limiter.h
+++ b/src/v/transform/memory_limiter.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/condition-variable.hh>
+#include <seastar/util/later.hh>
+
+#include <list>
+
+namespace transform {
+
+/**
+ * A semaphore for limiting memory usage.
+ *
+ * This construct should be used to limit memory in a system. Units allow RAII
+ * usage like so:
+ *
+ * ```
+ * {
+ *    auto units = co_await limiter.wait(100, &_as);
+ *    auto foo = load_foo();
+ * }
+ * // 100 bytes of memory returned to `limiter`
+ * ```
+ *
+ * We have this construct over seastar::semaphore because at the time of writing
+ * there is a stack-use-after-return issue with
+ * `seastar::semaphore::wait(ss::about_source&, size_t)`. Instead we manually
+ * implement a semaphore using a queue.
+ *
+ * Users of this class must wait for all outstanding waiters to complete before
+ * destructing this object.
+ */
+class memory_limiter {
+public:
+    explicit memory_limiter(size_t limit);
+    memory_limiter(const memory_limiter&) = delete;
+    memory_limiter(memory_limiter&&) = delete;
+    memory_limiter& operator=(const memory_limiter&) = delete;
+    memory_limiter& operator=(memory_limiter&&) = delete;
+    ~memory_limiter();
+
+    /**
+     * A holder of memory acquired from the limiter that automatically releases
+     * the memory when destructed.
+     *
+     * Memory can be manually released using `release_all`.
+     *
+     * Move-only.
+     */
+    class [[nodiscard]] units {
+    public:
+        units(memory_limiter* limiter, size_t amount);
+        units(const units&) = delete;
+        units& operator=(const units&) = delete;
+        units(units&& other) noexcept;
+        units& operator=(units&& other) noexcept;
+        void release_all();
+        ~units() noexcept;
+
+    private:
+        memory_limiter* _limiter;
+        size_t _amount;
+    };
+
+    /**
+     * Wait for `amount` of memory to be available and return units that release
+     * the memory when destructed.
+     *
+     * @param `amount` **must** be less than the maximum memory available to
+     * this limiter.
+     *
+     * @returns a failed future if the abort source fired before acquiring the
+     * memory.
+     */
+    [[nodiscard]] ss::future<units> wait(size_t amount, ss::abort_source* as);
+
+    /**
+     * Acquire `amount` bytes of memory from the limiter. This API requires
+     * manually calling `release` with the same `amount`. It is recommended that
+     * `wait` is used instead.
+     *
+     * @param `amount` **must** be less than the maximum memory available to
+     * this limiter.
+     *
+     * @returns a failed future if the abort source fired before acquiring the
+     * memory.
+     */
+    [[nodiscard]] ss::future<> acquire(size_t amount, ss::abort_source* as);
+
+    /**
+     * Return `amount` of memory to the limiter, freeing any waiters needing
+     * this memory.
+     */
+    void release(size_t amount);
+
+    // The maximum memory that this limiter can provide access too.
+    size_t max_memory() const;
+    // The amount of currently used memory for this limiter.
+    size_t used_memory() const;
+    // The remaining memory available for this limiter to hand out.
+    size_t available_memory() const;
+
+private:
+    bool has_available(size_t amount);
+
+    void notify();
+
+    struct waiter {
+        using memory_acquired = ss::bool_class<struct memory_acquired_tag>;
+        size_t amount;
+        std::optional<memory_acquired> state;
+        ss::promise<> prom;
+    };
+
+    std::list<waiter> _waiters;
+    size_t _available;
+    size_t _max;
+};
+} // namespace transform

--- a/src/v/transform/tests/CMakeLists.txt
+++ b/src/v/transform/tests/CMakeLists.txt
@@ -83,3 +83,18 @@ rp_test(
   ARGS "-- -c 1"
   LABELS transform
 )
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME
+    memory_limiter_test
+  SOURCES
+    memory_limiter_test.cc
+  LIBRARIES
+    v::gtest_main
+    v::model_test_utils
+    v::transform
+  ARGS "-- -c 1"
+  LABELS transform
+)

--- a/src/v/transform/tests/memory_limiter_test.cc
+++ b/src/v/transform/tests/memory_limiter_test.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "test_utils/async.h"
+#include "transform/memory_limiter.h"
+
+#include <seastar/core/abort_source.hh>
+
+#include <gtest/gtest.h>
+
+namespace transform {
+namespace {
+
+// NOLINTBEGIN(*-magic-*)
+
+TEST(MemoryLimiter, Works) {
+    ss::abort_source as;
+    memory_limiter limiter(10);
+    limiter.acquire(3, &as).get();
+    EXPECT_EQ(limiter.used_memory(), 3);
+    EXPECT_EQ(limiter.available_memory(), 7);
+    limiter.acquire(3, &as).get();
+    EXPECT_EQ(limiter.used_memory(), 6);
+    EXPECT_EQ(limiter.available_memory(), 4);
+    limiter.acquire(3, &as).get();
+    EXPECT_EQ(limiter.used_memory(), 9);
+    EXPECT_EQ(limiter.available_memory(), 1);
+    auto fut = limiter.acquire(3, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    limiter.release(1);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    limiter.release(1);
+    fut.get();
+}
+
+TEST(MemoryLimiter, IsFair) {
+    ss::abort_source as;
+    memory_limiter limiter(10);
+    limiter.acquire(7, &as).get();
+    auto fut1 = limiter.acquire(4, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut1.available());
+    auto fut2 = limiter.acquire(1, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut1.available());
+    EXPECT_FALSE(fut2.available());
+    limiter.release(2);
+    fut1.get();
+    fut2.get();
+}
+
+TEST(MemoryLimiter, IsFairWithMany) {
+    ss::abort_source as;
+    memory_limiter limiter(10);
+    std::vector<ss::future<>> acquired;
+    acquired.reserve(100);
+    for (int i = 0; i < 100; ++i) {
+        acquired.push_back(limiter.acquire(10, &as));
+    }
+    for (int i = 0; i < 100; ++i) {
+        tests::drain_task_queue().get();
+        EXPECT_TRUE(acquired[i].available());
+        for (int j = i + 1; j < 100; ++j) {
+            EXPECT_FALSE(acquired[j].available());
+        }
+        acquired[i].get();
+        limiter.release(10);
+    }
+}
+
+TEST(MemoryLimiter, CanAbortWaiting) {
+    ss::abort_source as;
+    memory_limiter limiter(10);
+    limiter.acquire(7, &as).get();
+    auto fut = limiter.acquire(4, &as);
+    as.request_abort();
+    EXPECT_THROW(fut.get(), ss::abort_requested_exception);
+    // Works with custom exceptions properly
+    as = {};
+    fut = limiter.acquire(4, &as);
+    struct custom_exception : public std::exception {};
+    as.request_abort_ex(custom_exception());
+    EXPECT_THROW(fut.get(), custom_exception);
+}
+
+TEST(MemoryLimiter, CanAbortManyWaiting) {
+    ss::abort_source as;
+    memory_limiter limiter(10);
+    limiter.acquire(10, &as).get();
+    std::vector<ss::future<>> waiting;
+    waiting.reserve(100);
+    for (int i = 0; i < 100; ++i) {
+        waiting.push_back(limiter.acquire(10, &as));
+    }
+    as.request_abort();
+    for (auto& fut : waiting) {
+        EXPECT_THROW(fut.get(), ss::abort_requested_exception);
+    }
+}
+
+TEST(MemoryLimiter, AbortDoesNotRaceWithAcquire) {
+    ss::abort_source as;
+    memory_limiter limiter(10);
+    limiter.acquire(10, &as).get();
+    // Release then abort is successful.
+    auto fut = limiter.acquire(1, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    limiter.release(1);
+    as.request_abort();
+    EXPECT_FALSE(fut.available());
+    tests::drain_task_queue().get();
+    EXPECT_NO_THROW(fut.get());
+    EXPECT_EQ(limiter.used_memory(), 10);
+    // Abort then release fails.
+    as = {};
+    fut = limiter.acquire(1, &as);
+    tests::drain_task_queue().get();
+    EXPECT_FALSE(fut.available());
+    as.request_abort();
+    limiter.release(1);
+    EXPECT_THROW(fut.get(), ss::abort_requested_exception);
+    EXPECT_EQ(limiter.used_memory(), 9);
+}
+
+TEST(MemoryLimiter, CannotReleaseExtra) {
+    memory_limiter limiter(10);
+    EXPECT_EQ(limiter.available_memory(), 10);
+    limiter.release(10);
+    EXPECT_EQ(limiter.available_memory(), 10);
+}
+
+TEST(MemoryLimiter, AlreadyAborted) {
+    memory_limiter limiter(10);
+    ss::abort_source as;
+    as.request_abort();
+    // The fast path doesn't check, which is fine
+    EXPECT_NO_THROW(limiter.acquire(5, &as).get());
+    // But a waiter always throws immediately
+    EXPECT_THROW(limiter.acquire(6, &as).get(), ss::abort_requested_exception);
+}
+
+// NOLINTEND(*-magic-*)
+
+} // namespace
+} // namespace transform

--- a/src/v/transform/tests/transform_processor_test.cc
+++ b/src/v/transform/tests/transform_processor_test.cc
@@ -113,13 +113,14 @@ public:
           std::move(src),
           std::move(sinks),
           std::move(offset_tracker),
-          &_probe);
+          &_probe,
+          &_memory_limits);
         if (param.autostart) {
             _p->start().get();
             // Wait for the initial offset to be committed so we know that the
-            // processor is actually ready, otherwise it could be possible that
-            // the processor picks up after the initial records are added to the
-            // partition.
+            // processor is actually ready, otherwise it could be possible
+            // that the processor picks up after the initial records are added
+            // to the partition.
             wait_for_committed_offset(kafka::offset{});
         }
     }
@@ -252,6 +253,8 @@ public:
 private:
     static constexpr kafka::offset start_offset = kafka::offset(0);
 
+    memory_limits _memory_limits = memory_limits(
+      memory_limits::config{.read = 10_MiB, .write = 10_MiB});
     kafka::offset _offset = start_offset;
     model::timestamp _fixed_time = model::timestamp::min();
     std::unique_ptr<transform::processor> _p;

--- a/src/v/transform/transfer_queue.h
+++ b/src/v/transform/transfer_queue.h
@@ -10,7 +10,6 @@
  */
 
 #include "base/seastarx.h"
-#include "ssx/semaphore.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/chunked_fifo.hh>

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -249,13 +249,15 @@ manager<ClockType>::manager(
   model::node_id self,
   std::unique_ptr<registry> r,
   std::unique_ptr<processor_factory> f,
-  ss::scheduling_group sg)
+  ss::scheduling_group sg,
+  memory_limits memory_limits)
   : _self(self)
   , _queue(
       sg,
       [](const std::exception_ptr& ex) {
           vlog(tlog.error, "unexpected transform manager error: {}", ex);
       })
+  , _memory_limits(std::move(memory_limits))
   , _registry(std::move(r))
   , _processors(std::make_unique<processor_table<ClockType>>())
   , _processor_factory(std::move(f)) {}

--- a/src/v/transform/transform_manager.cc
+++ b/src/v/transform/transform_manager.cc
@@ -250,7 +250,7 @@ manager<ClockType>::manager(
   std::unique_ptr<registry> r,
   std::unique_ptr<processor_factory> f,
   ss::scheduling_group sg,
-  memory_limits memory_limits)
+  std::unique_ptr<memory_limits> memory_limits)
   : _self(self)
   , _queue(
       sg,
@@ -428,7 +428,7 @@ ss::future<> manager<ClockType>::create_processor(
       };
     auto fut = co_await ss::coroutine::as_future(
       _processor_factory->create_processor(
-        id, ntp, meta, std::move(cb), p.get()));
+        id, ntp, meta, std::move(cb), p.get(), _memory_limits.get()));
     if (fut.failed()) {
         vlog(
           tlog.warn,

--- a/src/v/transform/transform_manager.h
+++ b/src/v/transform/transform_manager.h
@@ -10,22 +10,21 @@
  */
 #pragma once
 
-#include "cluster/types.h"
-#include "io.h"
 #include "model/fundamental.h"
-#include "model/ktp.h"
 #include "model/metadata.h"
 #include "model/transform.h"
+#include "ssx/semaphore.h"
 #include "ssx/work_queue.h"
 #include "transform/fwd.h"
 #include "transform_processor.h"
-#include "wasm/fwd.h"
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/manual_clock.hh>
 #include <seastar/core/scheduling.hh>
 #include <seastar/core/shared_ptr.hh>
 #include <seastar/util/bool_class.hh>
+
+#include <absl/container/flat_hash_set.h>
 
 namespace transform {
 
@@ -80,6 +79,24 @@ public:
       = 0;
 };
 
+// The limits to various buffers for this shard within the transform
+// subsystem. We have two main "buffers" we need to limit, the amount of
+// data we have ingress to the Wasm VM, and the amount of data we have
+// egress from the Wasm VM. We split statically the memory available between
+// these buffers so that there are starvation issues where we have to write
+// more data in order to get data out of our write buffers and the read
+// buffers have taken up all the memory.
+//
+// In addition to these semaphores, we also reserve 10% of this subsystem's
+// memory as flex space.
+//
+// All of these memory limits have tunable overrides in the case of a
+// miscalculation causing memory pressure on shards.
+struct memory_limits {
+    ssx::semaphore read_buffer_semaphore;
+    ssx::semaphore write_buffer_semaphore;
+};
+
 template<typename ClockType>
 class processor_table;
 
@@ -109,7 +126,8 @@ public:
       model::node_id self,
       std::unique_ptr<registry>,
       std::unique_ptr<processor_factory>,
-      ss::scheduling_group);
+      ss::scheduling_group,
+      memory_limits);
     manager(const manager&) = delete;
     manager& operator=(const manager&) = delete;
     manager(manager&&) = delete;
@@ -157,6 +175,7 @@ private:
 
     model::node_id _self;
     ssx::work_queue _queue;
+    memory_limits _memory_limits;
     std::unique_ptr<registry> _registry;
     std::unique_ptr<processor_table<ClockType>> _processors;
     std::unique_ptr<processor_factory> _processor_factory;


### PR DESCRIPTION
Currently all buffers in the transform subsystem (well the larger ones that hold the bulk of the data coming in and out of the transforms), have fixed size buffers that are overly small to prevent transforms from using too much memory. Allow using the full amount of memory for the transform subsystem but introducing a semaphore like accounting for memory. We can't use a real semaphore here due to a bug with semaphores and abort sources.

We split the transform subsystem's memory into two chunks. One for reads and writes so they can't starve each other (this is very bad if the read side starved writes as then we'd have a deadlock), these are tunables if set too high (45% of transform subsystem memory in general).

Fixes: CORE-2151

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Data transforms better respect overall system memory usage and go faster when more memory is available.

