### PR TITLE
wasm: use foreign_ptr for wasm binaries

### DIFF
--- a/src/v/model/transform.cc
+++ b/src/v/model/transform.cc
@@ -19,6 +19,7 @@
 #include "utils/vint.h"
 
 #include <seastar/core/print.hh>
+#include <seastar/core/smp.hh>
 #include <seastar/util/variant_utils.hh>
 
 #include <algorithm>
@@ -307,4 +308,40 @@ transformed_data transformed_data::copy() const {
     return transformed_data(_data.copy());
 }
 
+wasm_binary_iobuf share_wasm_binary(const wasm_binary_iobuf& b) {
+    vassert(
+      b().get_owner_shard() == ss::this_shard_id(),
+      "cannot share a wasm binary from another shard");
+    const auto& underlying = b();
+    return wasm_binary_iobuf(
+      std::make_unique<iobuf>(underlying->share(0, underlying->size_bytes())));
+}
+
+void tag_invoke(
+  serde::tag_t<serde::read_tag>,
+  iobuf_parser& in,
+  wasm_binary_iobuf& t,
+  std::size_t const bytes_left_limit) {
+    auto size = serde::read_nested<serde::serde_size_t>(in, bytes_left_limit);
+    t = wasm_binary_iobuf(std::make_unique<iobuf>(in.share(size)));
+}
+
+void tag_invoke(
+  serde::tag_t<serde::write_tag>, iobuf& out, wasm_binary_iobuf t) {
+    if (!t()) {
+        serde::write<serde::serde_size_t>(out, 0);
+        return;
+    }
+    serde::write<serde::serde_size_t>(out, t()->size_bytes());
+    // If we're on the same shard we can enable move fragment optimizations
+    if (t().get_owner_shard() == ss::this_shard_id()) {
+        out.append(std::move(*t()));
+    } else {
+        // Otherwise we can't touch the memory and we need to do a full copy to
+        // this core.
+        for (const auto& fragment : *t()) {
+            out.append(fragment.get(), fragment.size());
+        }
+    }
+}
 } // namespace model

--- a/src/v/redpanda/admin/transform.cc
+++ b/src/v/redpanda/admin/transform.cc
@@ -228,7 +228,7 @@ admin_server::deploy_transform(std::unique_ptr<ss::http::request> req) {
         .output_topics = output_topics,
         .environment = std::move(env),
       },
-      std::move(body));
+      model::wasm_binary_iobuf(std::make_unique<iobuf>(std::move(body))));
 
     co_await throw_on_error(*req, ec, model::controller_ntp);
     co_return ss::json::json_void();

--- a/src/v/transform/include/transform/api.h
+++ b/src/v/transform/include/transform/api.h
@@ -75,7 +75,7 @@ public:
      * Deploy a transform to the cluster.
      */
     ss::future<std::error_code>
-      deploy_transform(model::transform_metadata, iobuf);
+      deploy_transform(model::transform_metadata, model::wasm_binary_iobuf);
 
     /**
      * Delete a transform from the cluster.

--- a/src/v/transform/rpc/deps.cc
+++ b/src/v/transform/rpc/deps.cc
@@ -96,11 +96,12 @@ public:
         return invoke_on_shard_impl(shard, ktp, std::move(fn));
     }
 
-    ss::future<result<iobuf, cluster::errc>> invoke_on_shard(
+    ss::future<result<model::wasm_binary_iobuf, cluster::errc>> invoke_on_shard(
       ss::shard_id shard,
       const model::ktp& ktp,
-      ss::noncopyable_function<ss::future<result<iobuf, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
+      ss::noncopyable_function<
+        ss::future<result<model::wasm_binary_iobuf, cluster::errc>>(
+          kafka::partition_proxy*)> fn) final {
         return invoke_on_shard_impl(shard, ktp, std::move(fn));
     }
 
@@ -111,11 +112,12 @@ public:
         kafka::partition_proxy*)> fn) final {
         return invoke_on_shard_impl(shard, ntp, std::move(fn));
     }
-    ss::future<result<iobuf, cluster::errc>> invoke_on_shard(
+    ss::future<result<model::wasm_binary_iobuf, cluster::errc>> invoke_on_shard(
       ss::shard_id shard,
       const model::ntp& ntp,
-      ss::noncopyable_function<ss::future<result<iobuf, cluster::errc>>(
-        kafka::partition_proxy*)> fn) final {
+      ss::noncopyable_function<
+        ss::future<result<model::wasm_binary_iobuf, cluster::errc>>(
+          kafka::partition_proxy*)> fn) final {
         return invoke_on_shard_impl(shard, ntp, std::move(fn));
     }
 

--- a/src/v/transform/rpc/include/transform/rpc/client.h
+++ b/src/v/transform/rpc/include/transform/rpc/client.h
@@ -61,12 +61,13 @@ public:
       produce(model::topic_partition, ss::chunked_fifo<model::record_batch>);
 
     ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
-    store_wasm_binary(iobuf, model::timeout_clock::duration timeout);
+    store_wasm_binary(
+      model::wasm_binary_iobuf, model::timeout_clock::duration timeout);
 
     ss::future<cluster::errc>
     delete_wasm_binary(uuid_t key, model::timeout_clock::duration timeout);
 
-    ss::future<result<iobuf, cluster::errc>>
+    ss::future<result<model::wasm_binary_iobuf, cluster::errc>>
     load_wasm_binary(model::offset, model::timeout_clock::duration timeout);
 
     ss::future<result<model::partition_id, cluster::errc>>
@@ -113,12 +114,16 @@ private:
       do_remote_produce(model::node_id, produce_request);
 
     ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
-    do_store_wasm_binary_once(iobuf, model::timeout_clock::duration timeout);
+    do_store_wasm_binary_once(
+      model::wasm_binary_iobuf, model::timeout_clock::duration timeout);
     ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
-    do_local_store_wasm_binary(iobuf, model::timeout_clock::duration timeout);
+    do_local_store_wasm_binary(
+      model::wasm_binary_iobuf, model::timeout_clock::duration timeout);
     ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
     do_remote_store_wasm_binary(
-      model::node_id, iobuf, model::timeout_clock::duration timeout);
+      model::node_id,
+      model::wasm_binary_iobuf,
+      model::timeout_clock::duration timeout);
 
     ss::future<cluster::errc> do_delete_wasm_binary_once(
       uuid_t key, model::timeout_clock::duration timeout);
@@ -127,11 +132,14 @@ private:
     ss::future<cluster::errc> do_remote_delete_wasm_binary(
       model::node_id, uuid_t key, model::timeout_clock::duration timeout);
 
-    ss::future<result<iobuf, cluster::errc>> do_load_wasm_binary_once(
+    ss::future<result<model::wasm_binary_iobuf, cluster::errc>>
+    do_load_wasm_binary_once(
       model::offset, model::timeout_clock::duration timeout);
-    ss::future<result<iobuf, cluster::errc>> do_local_load_wasm_binary(
+    ss::future<result<model::wasm_binary_iobuf, cluster::errc>>
+    do_local_load_wasm_binary(
       model::offset, model::timeout_clock::duration timeout);
-    ss::future<result<iobuf, cluster::errc>> do_remote_load_wasm_binary(
+    ss::future<result<model::wasm_binary_iobuf, cluster::errc>>
+    do_remote_load_wasm_binary(
       model::node_id, model::offset, model::timeout_clock::duration timeout);
 
     ss::future<std::optional<model::node_id>> compute_wasm_binary_ntp_leader();

--- a/src/v/transform/rpc/include/transform/rpc/deps.h
+++ b/src/v/transform/rpc/include/transform/rpc/deps.h
@@ -188,17 +188,21 @@ public:
         kafka::partition_proxy*)>)
       = 0;
 
-    virtual ss::future<result<iobuf, cluster::errc>> invoke_on_shard(
+    virtual ss::future<result<model::wasm_binary_iobuf, cluster::errc>>
+    invoke_on_shard(
       ss::shard_id shard_id,
       const model::ktp& ktp,
       ss::noncopyable_function<
-        ss::future<result<iobuf, cluster::errc>>(kafka::partition_proxy*)>)
+        ss::future<result<model::wasm_binary_iobuf, cluster::errc>>(
+          kafka::partition_proxy*)>)
       = 0;
-    virtual ss::future<result<iobuf, cluster::errc>> invoke_on_shard(
+    virtual ss::future<result<model::wasm_binary_iobuf, cluster::errc>>
+    invoke_on_shard(
       ss::shard_id,
       const model::ntp&,
       ss::noncopyable_function<
-        ss::future<result<iobuf, cluster::errc>>(kafka::partition_proxy*)>)
+        ss::future<result<model::wasm_binary_iobuf, cluster::errc>>(
+          kafka::partition_proxy*)>)
       = 0;
 
     virtual ss::future<find_coordinator_response>

--- a/src/v/transform/rpc/include/transform/rpc/serde.h
+++ b/src/v/transform/rpc/include/transform/rpc/serde.h
@@ -114,7 +114,7 @@ struct store_wasm_binary_request
 
     store_wasm_binary_request() = default;
     explicit store_wasm_binary_request(
-      iobuf d, model::timeout_clock::duration t)
+      model::wasm_binary_iobuf d, model::timeout_clock::duration t)
       : data(std::move(d))
       , timeout(t) {}
 
@@ -123,7 +123,7 @@ struct store_wasm_binary_request
     friend std::ostream&
     operator<<(std::ostream&, const store_wasm_binary_request&);
 
-    iobuf data;
+    model::wasm_binary_iobuf data;
     model::timeout_clock::duration timeout{};
 };
 
@@ -241,7 +241,7 @@ struct load_wasm_binary_reply
     using rpc_adl_exempt = std::true_type;
 
     load_wasm_binary_reply() = default;
-    explicit load_wasm_binary_reply(cluster::errc e, iobuf b)
+    explicit load_wasm_binary_reply(cluster::errc e, model::wasm_binary_iobuf b)
       : ec(e)
       , data(std::move(b)) {}
 
@@ -251,7 +251,7 @@ struct load_wasm_binary_reply
     operator<<(std::ostream&, const load_wasm_binary_reply&);
 
     cluster::errc ec = cluster::errc::success;
-    iobuf data;
+    model::wasm_binary_iobuf data;
 };
 
 struct find_coordinator_request

--- a/src/v/transform/rpc/include/transform/rpc/service.h
+++ b/src/v/transform/rpc/include/transform/rpc/service.h
@@ -39,12 +39,13 @@ public:
       model::timeout_clock::duration timeout);
 
     ss::future<result<stored_wasm_binary_metadata, cluster::errc>>
-    store_wasm_binary(iobuf, model::timeout_clock::duration timeout);
+    store_wasm_binary(
+      model::wasm_binary_iobuf, model::timeout_clock::duration timeout);
 
     ss::future<cluster::errc>
     delete_wasm_binary(uuid_t key, model::timeout_clock::duration timeout);
 
-    ss::future<result<iobuf, cluster::errc>>
+    ss::future<result<model::wasm_binary_iobuf, cluster::errc>>
     load_wasm_binary(model::offset, model::timeout_clock::duration timeout);
 
     ss::future<find_coordinator_response>
@@ -69,8 +70,9 @@ private:
       ss::chunked_fifo<model::record_batch>,
       model::timeout_clock::duration);
 
-    ss::future<result<iobuf, cluster::errc>> consume_wasm_binary_reader(
-      model::record_batch_reader, model::timeout_clock::duration);
+    ss::future<result<model::wasm_binary_iobuf, cluster::errc>>
+      consume_wasm_binary_reader(
+        model::record_batch_reader, model::timeout_clock::duration);
 
     std::unique_ptr<topic_metadata_cache> _metadata_cache;
     std::unique_ptr<partition_manager> _partition_manager;

--- a/src/v/transform/rpc/serde.cc
+++ b/src/v/transform/rpc/serde.cc
@@ -112,7 +112,10 @@ operator<<(std::ostream& os, const load_wasm_binary_request& req) {
 std::ostream&
 operator<<(std::ostream& os, const load_wasm_binary_reply& reply) {
     fmt::print(
-      os, "{{ data_size: {}, errc: {} }}", reply.data.size_bytes(), reply.ec);
+      os,
+      "{{ data_size: {}, errc: {} }}",
+      reply.data()->size_bytes(),
+      reply.ec);
     return os;
 }
 
@@ -145,7 +148,7 @@ operator<<(std::ostream& os, const store_wasm_binary_request& req) {
     fmt::print(
       os,
       "{{ data_size: {}, timeout: {} }}",
-      req.data.size_bytes(),
+      req.data()->size_bytes(),
       req.timeout);
     return os;
 }

--- a/src/v/wasm/cache.cc
+++ b/src/v/wasm/cache.cc
@@ -12,6 +12,7 @@
 #include "wasm/cache.h"
 
 #include "logger.h"
+#include "model/transform.h"
 
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/sharded.hh>
@@ -296,8 +297,8 @@ ss::future<> caching_runtime::stop() {
     co_await _underlying->stop();
 }
 
-ss::future<ss::shared_ptr<factory>>
-caching_runtime::make_factory(model::transform_metadata meta, iobuf binary) {
+ss::future<ss::shared_ptr<factory>> caching_runtime::make_factory(
+  model::transform_metadata meta, model::wasm_binary_iobuf binary) {
     model::offset offset = meta.source_ptr;
     // Look in the cache outside the lock
     auto cached = get_cached_factory(meta);
@@ -361,7 +362,7 @@ ss::future<int64_t> caching_runtime::gc_engines() {
       &engine_cache::gc, int64_t(0), std::plus<>());
 }
 
-ss::future<> caching_runtime::validate(iobuf buf) {
+ss::future<> caching_runtime::validate(model::wasm_binary_iobuf buf) {
     return _underlying->validate(std::move(buf));
 }
 

--- a/src/v/wasm/include/wasm/api.h
+++ b/src/v/wasm/include/wasm/api.h
@@ -140,7 +140,7 @@ public:
      * can be used on any shard and is thread-safe.
      */
     virtual ss::future<ss::shared_ptr<factory>>
-      make_factory(model::transform_metadata, iobuf) = 0;
+      make_factory(model::transform_metadata, model::wasm_binary_iobuf) = 0;
 
     /**
      * Verify a WebAssembly module is valid and loosely adheres to our ABI
@@ -148,7 +148,7 @@ public:
      *
      * Throws an exception when validation fails.
      */
-    virtual ss::future<> validate(iobuf) = 0;
+    virtual ss::future<> validate(model::wasm_binary_iobuf) = 0;
 
     virtual ~runtime() = default;
 };

--- a/src/v/wasm/include/wasm/cache.h
+++ b/src/v/wasm/include/wasm/cache.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "model/transform.h"
 #include "utils/mutex.h"
 #include "wasm/api.h"
 
@@ -56,8 +57,8 @@ public:
     /**
      * Create a factory, must be called only on a single shard.
      */
-    ss::future<ss::shared_ptr<factory>>
-      make_factory(model::transform_metadata, iobuf) override;
+    ss::future<ss::shared_ptr<factory>> make_factory(
+      model::transform_metadata, model::wasm_binary_iobuf) override;
 
     /**
      * If a factory exists in cached, return it without needing the binary.
@@ -65,7 +66,7 @@ public:
     ss::optimized_optional<ss::shared_ptr<factory>>
     get_cached_factory(const model::transform_metadata&);
 
-    ss::future<> validate(iobuf) override;
+    ss::future<> validate(model::wasm_binary_iobuf) override;
 
 private:
     friend class WasmCacheTest;

--- a/src/v/wasm/tests/wasm_cache_test.cc
+++ b/src/v/wasm/tests/wasm_cache_test.cc
@@ -121,13 +121,13 @@ public:
     ss::future<> stop() override { co_return; }
 
     ss::future<ss::shared_ptr<factory>>
-    make_factory(model::transform_metadata, iobuf) override {
+    make_factory(model::transform_metadata, model::wasm_binary_iobuf) override {
         co_return ss::make_shared<fake_factory>(&_state);
     }
 
     state* get_state() { return &_state; }
 
-    ss::future<> validate(iobuf) override { co_return; }
+    ss::future<> validate(model::wasm_binary_iobuf) override { co_return; }
 
 private:
     state _state;
@@ -173,7 +173,9 @@ public:
     ss::future<ss::shared_ptr<factory>>
     make_factory_async(model::transform_metadata metadata) {
         return _caching_runtime->make_factory(
-          std::move(metadata), _wasm_module.copy());
+          std::move(metadata),
+          model::wasm_binary_iobuf(
+            std::make_unique<iobuf>(_wasm_module.copy())));
     }
 
     template<typename Func>

--- a/src/v/wasm/tests/wasm_fixture.cc
+++ b/src/v/wasm/tests/wasm_fixture.cc
@@ -183,11 +183,12 @@ void WasmTestFixture::TearDown() {
 
 void WasmTestFixture::load_wasm(const std::string& path) {
     auto wasm_file = ss::util::read_entire_file(path).get0();
-    iobuf buf;
+    auto buf = model::wasm_binary_iobuf(std::make_unique<iobuf>());
     for (auto& chunk : wasm_file) {
-        buf.append(std::move(chunk));
+        buf()->append(std::move(chunk));
     }
-    _runtime->validate(buf.share(0, buf.size_bytes())).get();
+
+    _runtime->validate(model::share_wasm_binary(buf)).get();
     _factory = _runtime->make_factory(_meta, std::move(buf)).get();
     if (_engine) {
         _engine->stop().get();

--- a/src/v/wasm/tests/wasm_transform_bench.cc
+++ b/src/v/wasm/tests/wasm_transform_bench.cc
@@ -30,6 +30,7 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <memory>
 #include <unistd.h>
 
 using namespace std::chrono_literals;
@@ -72,11 +73,11 @@ public:
           .environment = {},
           .source_ptr = model::offset(0),
         };
-        iobuf wasm_binary;
+        auto wasm_binary = model::wasm_binary_iobuf(std::make_unique<iobuf>());
         {
             auto data = co_await ss::util::read_entire_file_contiguous(
               filename);
-            wasm_binary.append(data.data(), data.size());
+            wasm_binary()->append(data.data(), data.size());
         }
         auto factory = co_await _runtime->make_factory(
           meta, std::move(wasm_binary));


### PR DESCRIPTION
Wasm binaries are large so we don't want to copy them between cores,
instead use a foreign_ptr instead of the slow cross core free memory
path in the seastar allocator

Fixes: CORE-2208

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
