### PR TITLE
[v23.2.x] CORE-1722: compression: Use preallocated decompression buffers for lz4

### DIFF
--- a/src/v/compression/CMakeLists.txt
+++ b/src/v/compression/CMakeLists.txt
@@ -15,11 +15,13 @@ v_cc_library(
     "stream_zstd.cc"
     "async_stream_zstd.cc"
     "snappy_standard_compressor.cc"
+    "lz4_decompression_buffers.cc"
     "internal/snappy_java_compressor.cc"
     "internal/lz4_frame_compressor.cc"
     "internal/gzip_compressor.cc"
   DEPS
     v::bytes
+    v::ssx
     Zstd::zstd
     LZ4::LZ4
     Snappy::snappy

--- a/src/v/compression/internal/lz4_frame_compressor.cc
+++ b/src/v/compression/internal/lz4_frame_compressor.cc
@@ -10,9 +10,8 @@
 #include "compression/internal/lz4_frame_compressor.h"
 
 #include "bytes/bytes.h"
+#include "compression/lz4_decompression_buffers.h"
 #include "static_deleter_fn.h"
-#include "units.h"
-#include "vassert.h"
 
 #include <seastar/core/temporary_buffer.hh>
 
@@ -59,9 +58,12 @@ using lz4_decompression_ctx = std::unique_ptr<
     &LZ4F_freeDecompressionContext>>;
 
 static lz4_decompression_ctx make_decompression_context() {
-    LZ4F_dctx* c = nullptr;
-    LZ4F_errorCode_t code = LZ4F_createDecompressionContext(&c, LZ4F_VERSION);
-    check_lz4_error("LZ4F_createDecompressionContext error: {}", code);
+    LZ4F_dctx* c = LZ4F_createDecompressionContext_advanced(
+      lz4_decompression_buffers_instance().custom_mem_alloc(), LZ4F_VERSION);
+    if (c == nullptr) {
+        throw std::runtime_error("Failed to initialize decompression context");
+    }
+
     return lz4_decompression_ctx(c);
 }
 

--- a/src/v/compression/internal/lz4_frame_compressor.h
+++ b/src/v/compression/internal/lz4_frame_compressor.h
@@ -11,10 +11,15 @@
 
 #pragma once
 #include "bytes/iobuf.h"
+
+#include <lz4frame.h>
+
 namespace compression::internal {
 
 struct lz4_frame_compressor {
     static iobuf compress(const iobuf&);
+    static iobuf
+    compress_with_block_size(const iobuf&, std::optional<LZ4F_blockSizeID_t>);
     static iobuf uncompress(const iobuf&);
 };
 

--- a/src/v/compression/lz4_decompression_buffers.cc
+++ b/src/v/compression/lz4_decompression_buffers.cc
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "compression/lz4_decompression_buffers.h"
+
+#include <seastar/coroutine/all.hh>
+
+namespace compression {
+
+std::ostream& operator<<(
+  std::ostream& os, lz4_decompression_buffers::alloc_ctx::allocation_state st) {
+    switch (st) {
+        using enum compression::lz4_decompression_buffers::alloc_ctx::
+          allocation_state;
+    case no_buffers_allocated:
+        return os << "no buffers allocated";
+    case input_buffer_allocated:
+        return os << "input buffer allocated";
+    case output_buffer_allocated:
+        return os << "output buffer allocated";
+    case both_buffers_allocated:
+        return os << "both buffers allocated";
+    }
+}
+
+lz4_decompression_buffers::lz4_decompression_buffers(
+  size_t buffer_size, size_t min_alloc_threshold, bool disabled)
+  : _min_alloc_threshold{min_alloc_threshold}
+  , _disabled{disabled} {
+    if (!_disabled) {
+        _buffers = {
+          .input_buffer = ss::allocate_aligned_buffer<char>(buffer_size, 8),
+          .output_buffer = ss::allocate_aligned_buffer<char>(buffer_size, 8),
+          .state = alloc_ctx::allocation_state::no_buffers_allocated,
+        };
+    }
+}
+
+bool lz4_decompression_buffers::alloc_ctx::is_managed_address(
+  const void* const address) const {
+    return address == input_buffer.get() || address == output_buffer.get();
+}
+
+lz4_decompression_buffers::alloc_ctx& lz4_decompression_buffers::buffers() {
+    return _buffers;
+}
+
+size_t lz4_decompression_buffers::min_alloc_threshold() const {
+    return _min_alloc_threshold;
+}
+
+} // namespace compression

--- a/src/v/compression/lz4_decompression_buffers.cc
+++ b/src/v/compression/lz4_decompression_buffers.cc
@@ -11,6 +11,8 @@
 
 #include "compression/lz4_decompression_buffers.h"
 
+#include "vassert.h"
+
 #include <seastar/coroutine/all.hh>
 
 namespace compression {
@@ -33,7 +35,8 @@ std::ostream& operator<<(
 
 lz4_decompression_buffers::lz4_decompression_buffers(
   size_t buffer_size, size_t min_alloc_threshold, bool disabled)
-  : _min_alloc_threshold{min_alloc_threshold}
+  : _buffer_size{buffer_size}
+  , _min_alloc_threshold{min_alloc_threshold}
   , _disabled{disabled} {
     if (!_disabled) {
         _buffers = {
@@ -57,4 +60,138 @@ size_t lz4_decompression_buffers::min_alloc_threshold() const {
     return _min_alloc_threshold;
 }
 
+LZ4F_CustomMem lz4_decompression_buffers::custom_mem_alloc() {
+    // If custom allocation is disabled, setting all alloc functions to null
+    // makes lz4 fall back to malloc, calloc and free.
+    if (_disabled) {
+        return {
+          .customAlloc = nullptr,
+          .customCalloc = nullptr,
+          .customFree = nullptr,
+          .opaqueState = nullptr};
+    }
+
+    return {
+      .customAlloc = alloc_lz4_obj,
+      .customCalloc = nullptr,
+      .customFree = free_lz4_obj,
+      .opaqueState = this};
+}
+
 } // namespace compression
+
+namespace {
+
+using alloc_st
+  = compression::lz4_decompression_buffers::alloc_ctx::allocation_state;
+using t = std::underlying_type_t<alloc_st>;
+
+alloc_st operator|(alloc_st a, alloc_st b) { return alloc_st(t(a) | t(b)); }
+
+void operator|=(alloc_st& a, alloc_st b) { a = (a | b); }
+
+alloc_st operator&(alloc_st a, alloc_st b) { return alloc_st(t(a) & t(b)); }
+
+void operator&=(alloc_st& a, alloc_st b) { a = (a & b); }
+
+alloc_st operator~(alloc_st a) { return alloc_st(~t(a)); }
+
+} // namespace
+
+// During a typical lz4 decompression operation the following LZ4F_malloc calls
+// will be processed via this alloc function:
+// 1. Allocation for the tmp input buffer: this can be a maximum of 4MiB + 4
+// bytes
+// 2. Allocation for the tmp output buffer: this can be a maximum of 4MiB +
+// 128KiB
+// These two calls will typically happen once per decompression context, and are
+// preceded by calls to LZ4F_free to first free up the two buffers.
+void* alloc_lz4_obj(void* state, size_t size) {
+    auto* st = static_cast<compression::lz4_decompression_buffers*>(state);
+    vassert(
+      size <= st->buffer_size(),
+      "Request to allocate {} bytes which is more than max buffer size "
+      "available: {} bytes",
+      size,
+      st->buffer_size());
+
+    if (size < st->min_alloc_threshold()) {
+        st->pass_through_allocated();
+        return malloc(size);
+    }
+
+    auto& bufs = st->buffers();
+
+    switch (bufs.state) {
+        using enum compression::lz4_decompression_buffers::alloc_ctx::
+          allocation_state;
+    case no_buffers_allocated:
+        bufs.state |= input_buffer_allocated;
+        st->allocated();
+        return bufs.input_buffer.get();
+    case input_buffer_allocated:
+        bufs.state |= output_buffer_allocated;
+        st->allocated();
+        return bufs.output_buffer.get();
+    case both_buffers_allocated:
+    case output_buffer_allocated:
+        vassert(
+          false, "invalid allocation request when both buffers allocated");
+    }
+}
+
+// During a decompression operation this function is called via the LZ4F_free
+// wrapper. The function is typically called in the following sequence:
+// 1. When freeing the decompression context:
+//    a. free the tmp out buffer
+//    b. free the tmp in buffer
+//    c. free the decompression context
+// 2. When initializing the decompression context, this function will be called
+// on the two buffer addresses.
+// In all cases we either pass the address straight through to `free()` or if
+// the address is managed, we update the state. The state update ensures that
+// the next decompression operation starts with the correct state (no buffers
+// allocated)
+void free_lz4_obj(void* state, void* address) {
+    auto* st = static_cast<compression::lz4_decompression_buffers*>(state);
+
+    auto& bufs = st->buffers();
+
+    // If the address being freed does not match one of the static addresses we
+    // manage, fall back to free. This can happen because:
+    //
+    // 1. LZ4 frees memory before performing each allocation, resulting in
+    // interspersed calls to free/malloc where the freed address was not
+    // allocated from our pool.
+    //
+    // 2. The allocation was not done via this allocator, eg for blocks
+    // small enough that they should not be managed by custom allocator.
+    //
+    // In both cases these memory addresses will not match our managed buffers.
+    if (!bufs.is_managed_address(address)) {
+        st->pass_through_deallocated();
+        free(address);
+        return;
+    }
+
+    // Buffers are released by lz4 in the order: input buffer, output buffer,
+    // decompression ctx. The first two calls update the state here. The third
+    // call is passed through to free because we do not allocate memory for the
+    // decompression ctx.
+    switch (bufs.state) {
+        using enum compression::lz4_decompression_buffers::alloc_ctx::
+          allocation_state;
+    case no_buffers_allocated:
+    case input_buffer_allocated:
+        vassert(
+          false, "unexpected buffer state {} during deallocation", bufs.state);
+    case output_buffer_allocated:
+        st->deallocated();
+        bufs.state &= (~output_buffer_allocated);
+        return;
+    case both_buffers_allocated:
+        st->deallocated();
+        bufs.state &= (~input_buffer_allocated);
+        return;
+    }
+}

--- a/src/v/compression/lz4_decompression_buffers.h
+++ b/src/v/compression/lz4_decompression_buffers.h
@@ -81,6 +81,7 @@ public:
         size_t deallocs{0};
         size_t pass_through_allocs{0};
         size_t pass_through_deallocs{0};
+        bool operator==(const stats&) const = default;
     };
 
     void allocated() { _allocation_stats.allocs += 1; }

--- a/src/v/compression/lz4_decompression_buffers.h
+++ b/src/v/compression/lz4_decompression_buffers.h
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "seastarx.h"
+
+#include <seastar/core/aligned_buffer.hh>
+#include <seastar/core/semaphore.hh>
+
+#define LZ4F_STATIC_LINKING_ONLY
+
+#include <lz4frame.h>
+
+namespace compression {
+
+class lz4_decompression_buffers {
+public:
+    explicit lz4_decompression_buffers(
+      size_t buffer_size, size_t min_alloc_threshold, bool disabled = false);
+
+    // LZ4 decompression requires two buffers during a single decompression
+    // operation. This struct carries the buffers and associated book-keeping
+    // state of allocation.
+    struct alloc_ctx {
+        // A typical transition cycle for this set of buffers is:
+        // no_buffers_allocated -> input_buffer_allocated ->
+        // output_buffer_allocated -> both_buffers_allocated
+        // During deallocation/free the reverse states are expected.
+        enum class allocation_state : uint8_t {
+            // No buffers have been allocated to the LZ4 decompression routine.
+            // The buffers are effectively not in use.
+            no_buffers_allocated,
+            // The input buffer has been allocated out to LZ4 decompression
+            // routine.
+            input_buffer_allocated,
+            // The output buffer has also been allocated. Note that output
+            // buffer will never be allocated alone.
+            output_buffer_allocated,
+            // Both buffers are allocated to decompression routine.
+            both_buffers_allocated,
+        };
+
+        std::unique_ptr<char[], ss::free_deleter> input_buffer;
+        std::unique_ptr<char[], ss::free_deleter> output_buffer;
+        allocation_state state;
+
+        // Checks if the address belongs to one of the two managed buffers. This
+        // address check is used when freeing an address. If the address is
+        // not managed by this context, then we fall back to `free()`.
+        [[nodiscard]] bool is_managed_address(const void* const address) const;
+    };
+
+    // Returns a reference to allocated buffer pair. The buffers must have been
+    // reserved before this call.
+    [[nodiscard]] alloc_ctx& buffers();
+
+    // Returns the minimum allocation threshold, allocation requests below this
+    // size are passed through to `malloc()`.
+    [[nodiscard]] size_t min_alloc_threshold() const;
+
+    struct stats {
+        size_t allocs{0};
+        size_t deallocs{0};
+        size_t pass_through_allocs{0};
+        size_t pass_through_deallocs{0};
+    };
+
+    void allocated() { _allocation_stats.allocs += 1; }
+
+    void deallocated() { _allocation_stats.deallocs += 1; }
+
+    void pass_through_allocated() {
+        _allocation_stats.pass_through_allocs += 1;
+    }
+
+    void pass_through_deallocated() {
+        _allocation_stats.pass_through_deallocs += 1;
+    }
+
+    stats allocation_stats() const { return _allocation_stats; }
+
+    void reset_stats() { _allocation_stats = {}; }
+
+private:
+    size_t _min_alloc_threshold;
+    bool _disabled{false};
+
+    alloc_ctx _buffers;
+    stats _allocation_stats;
+};
+
+std::ostream& operator<<(
+  std::ostream&, lz4_decompression_buffers::alloc_ctx::allocation_state);
+
+} // namespace compression

--- a/src/v/compression/lz4_decompression_buffers.h
+++ b/src/v/compression/lz4_decompression_buffers.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "seastarx.h"
+#include "units.h"
 
 #include <seastar/core/aligned_buffer.hh>
 #include <seastar/core/semaphore.hh>
@@ -24,6 +25,9 @@ namespace compression {
 
 class lz4_decompression_buffers {
 public:
+    static constexpr auto bufsize{4_MiB + 128_KiB};
+    static constexpr auto min_threshold{128_KiB + 1};
+
     explicit lz4_decompression_buffers(
       size_t buffer_size, size_t min_alloc_threshold, bool disabled = false);
 
@@ -108,6 +112,22 @@ private:
 
 std::ostream& operator<<(
   std::ostream&, lz4_decompression_buffers::alloc_ctx::allocation_state);
+
+// Initializes the buffer instance. If preallocation is disabled the instance
+// will pass through all calls to malloc and free. Two buffers of size
+// buffer_size are allocated. Calls below the min_alloc_threshold are passed
+// through to malloc.
+void init_lz4_decompression_buffers(
+  size_t buffer_size,
+  size_t min_alloc_threshold,
+  bool prealloc_disabled = false);
+
+// Resets the buffer instance, for use in tests.
+void reset_lz4_decompression_buffers();
+
+// Returns the static shard specific preallocated buffer instance. If the
+// instance is not created yet it will be initialized first.
+lz4_decompression_buffers& lz4_decompression_buffers_instance();
 
 } // namespace compression
 

--- a/src/v/compression/tests/CMakeLists.txt
+++ b/src/v/compression/tests/CMakeLists.txt
@@ -13,3 +13,12 @@ rp_test(
   LABELS compression
   ARGS "-- -c 1"
   )
+
+rp_test(
+  UNIT_TEST
+  BINARY_NAME lz4_buf_tests
+  SOURCES lz4_buf_tests.cc
+  LIBRARIES v::seastar_testing_main v::compression v::rprandom
+  LABELS compression
+  ARGS "-- -c 1"
+  )

--- a/src/v/compression/tests/lz4_buf_tests.cc
+++ b/src/v/compression/tests/lz4_buf_tests.cc
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "compression/internal/lz4_frame_compressor.h"
+#include "compression/lz4_decompression_buffers.h"
+#include "random/generators.h"
+#include "units.h"
+
+#include <seastar/util/defer.hh>
+
+#include <boost/test/unit_test.hpp>
+
+#include <lz4.h>
+
+using enum compression::lz4_decompression_buffers::alloc_ctx::allocation_state;
+
+BOOST_AUTO_TEST_CASE(state_transitions) {
+    auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
+    const auto& buffers = b.buffers();
+    BOOST_REQUIRE_EQUAL(buffers.state, no_buffers_allocated);
+    auto allocator = b.custom_mem_alloc();
+
+    auto* input = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold());
+    BOOST_REQUIRE_EQUAL(buffers.state, input_buffer_allocated);
+    BOOST_REQUIRE_EQUAL(input, buffers.input_buffer.get());
+
+    auto* output = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold());
+    BOOST_REQUIRE_EQUAL(buffers.state, both_buffers_allocated);
+    BOOST_REQUIRE_EQUAL(output, buffers.output_buffer.get());
+
+    allocator.customFree(allocator.opaqueState, input);
+    BOOST_REQUIRE_EQUAL(buffers.state, output_buffer_allocated);
+
+    allocator.customFree(allocator.opaqueState, output);
+    BOOST_REQUIRE_EQUAL(buffers.state, no_buffers_allocated);
+}
+
+BOOST_AUTO_TEST_CASE(fallback_small_allocs) {
+    auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
+    auto allocator = b.custom_mem_alloc();
+    auto* allocated = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold() - 1);
+    BOOST_REQUIRE_NE(allocated, nullptr);
+    allocator.customFree(allocator.opaqueState, allocated);
+}
+
+BOOST_AUTO_TEST_CASE(mixed_allocs) {
+    auto b = compression::lz4_decompression_buffers{4_MiB, 128_KiB + 1};
+    const auto& buffers = b.buffers();
+    auto allocator = b.custom_mem_alloc();
+
+    auto* input = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold());
+    BOOST_REQUIRE_EQUAL(input, buffers.input_buffer.get());
+    BOOST_REQUIRE_EQUAL(buffers.state, input_buffer_allocated);
+
+    auto* random_alloc = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold() - 1);
+    BOOST_REQUIRE(!buffers.is_managed_address(random_alloc));
+    BOOST_REQUIRE_EQUAL(buffers.state, input_buffer_allocated);
+
+    auto* output = allocator.customAlloc(
+      allocator.opaqueState, b.min_alloc_threshold());
+    BOOST_REQUIRE_EQUAL(output, buffers.output_buffer.get());
+    BOOST_REQUIRE_EQUAL(buffers.state, both_buffers_allocated);
+
+    allocator.customFree(allocator.opaqueState, input);
+    BOOST_REQUIRE_EQUAL(buffers.state, output_buffer_allocated);
+
+    allocator.customFree(allocator.opaqueState, random_alloc);
+    BOOST_REQUIRE_EQUAL(buffers.state, output_buffer_allocated);
+
+    allocator.customFree(allocator.opaqueState, output);
+    BOOST_REQUIRE_EQUAL(buffers.state, no_buffers_allocated);
+}
+
+void test_decompression_calls(
+  compression::lz4_decompression_buffers::stats expected,
+  bool disable_prealloc = false,
+  std::optional<LZ4F_blockSizeID_t> blocksize = std::nullopt) {
+    compression::reset_lz4_decompression_buffers();
+    auto deferred = ss::defer(
+      [] { compression::lz4_decompression_buffers_instance().reset_stats(); });
+
+    if (disable_prealloc) {
+        compression::init_lz4_decompression_buffers(
+          4_MiB, 128_KiB + 1, disable_prealloc);
+    }
+
+    const auto data = random_generators::gen_alphanum_string(512);
+
+    iobuf input;
+    input.append(data.data(), data.size());
+
+    using compression::internal::lz4_frame_compressor;
+    auto& instance = compression::lz4_decompression_buffers_instance();
+    auto compressed = blocksize.has_value()
+                        ? lz4_frame_compressor::compress_with_block_size(
+                          input, blocksize.value())
+                        : lz4_frame_compressor::compress(input);
+    auto uncompressed = lz4_frame_compressor::uncompress(compressed);
+    BOOST_REQUIRE(instance.allocation_stats() == expected);
+}
+
+BOOST_AUTO_TEST_CASE(decompress_large_blocks) {
+    test_decompression_calls(
+      {.allocs = 2,
+       .deallocs = 2,
+       .pass_through_allocs = 1,
+       .pass_through_deallocs = 3},
+      false,
+      LZ4F_max4MB);
+}
+
+BOOST_AUTO_TEST_CASE(decompresss_passthrough_blocks) {
+    test_decompression_calls(
+      {.allocs = 0,
+       .deallocs = 0,
+       .pass_through_allocs = 3,
+       .pass_through_deallocs = 5});
+}
+
+BOOST_AUTO_TEST_CASE(custom_alloc_disabled) {
+    test_decompression_calls(
+      {.allocs = 0,
+       .deallocs = 0,
+       .pass_through_allocs = 0,
+       .pass_through_deallocs = 0},
+      true);
+}

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2013,6 +2013,12 @@ configuration::configuration()
       "Size of the zstd decompression workspace",
       {.visibility = visibility::tunable},
       8_MiB)
+  , lz4_decompress_reusable_buffers_disabled(
+      *this,
+      "lz4_decompress_reusable_buffers_disabled",
+      "Disable reusable preallocated buffers for LZ4 decompression",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      false)
   , full_raft_configuration_recovery_pattern(
       *this,
       "full_raft_configuration_recovery_pattern",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -385,6 +385,7 @@ struct configuration final : public config_store {
     property<size_t> kafka_qdc_max_depth;
     property<std::chrono::milliseconds> kafka_qdc_depth_update_ms;
     property<size_t> zstd_decompress_workspace_bytes;
+    property<bool> lz4_decompress_reusable_buffers_disabled;
     one_or_many_property<ss::sstring> full_raft_configuration_recovery_pattern;
     property<bool> enable_auto_rebalance_on_node_add;
 

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -52,6 +52,7 @@
 #include "cluster/tx_gateway_frontend.h"
 #include "cluster/types.h"
 #include "compression/async_stream_zstd.h"
+#include "compression/lz4_decompression_buffers.h"
 #include "compression/stream_zstd.h"
 #include "config/configuration.h"
 #include "config/endpoint_tls_config.h"
@@ -448,6 +449,11 @@ void application::initialize(
 
         compression::initialize_async_stream_zstd(
           config::shard_local_cfg().zstd_decompress_workspace_bytes());
+
+        compression::init_lz4_decompression_buffers(
+          compression::lz4_decompression_buffers::bufsize,
+          compression::lz4_decompression_buffers::min_threshold,
+          config::shard_local_cfg().lz4_decompress_reusable_buffers_disabled());
     }).get0();
 
     if (config::shard_local_cfg().enable_pid_file()) {


### PR DESCRIPTION
Backport of PR #17385
Fixes https://github.com/redpanda-data/redpanda/issues/17816

Manual backport because of changes since v23.2.x and missing googletest support

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
