### PR TITLE
CORE-1752: cst: Downgrade error logs to debug

### DIFF
--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -220,7 +220,7 @@ ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
         }
     } catch (const std::exception& ex) {
         vlog(
-          _ctxlog.error,
+          _ctxlog.debug,
           "Failed to hydrate chunk start {}, error: {}",
           chunk_start,
           ex.what());

--- a/src/v/cloud_storage/segment_chunk_data_source.cc
+++ b/src/v/cloud_storage/segment_chunk_data_source.cc
@@ -106,7 +106,7 @@ ss::future<> chunk_data_source_impl::load_stream_for_chunk(
     } catch (...) {
         eptr = std::current_exception();
         vlog(
-          _ctxlog.error,
+          _ctxlog.debug,
           "Hydrating chunk {} failed with error {}",
           chunk_start,
           eptr);


### PR DESCRIPTION
Recently added error logs do not take into account sleep aborted and other shutdown related errors. Since the logs print exception details which are already logged down the call chain, and the new logs are for debugging hang in chunk read path, the new logs are downgraded to debug level in this change.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
