### PR TITLE
rpk/transform/logs: handle missing logs topic

### DIFF
--- a/src/go/rpk/pkg/cli/transform/logs.go
+++ b/src/go/rpk/pkg/cli/transform/logs.go
@@ -127,6 +127,9 @@ the Open Telemetry LogRecord protocol buffer.`,
 
 			topics, err := admin.ListTopics(cmd.Context(), "_redpanda.transform_logs")
 			out.MaybeDie(err, "unable to get logs topic: %v", err)
+			if len(topics.TopicsList()) == 0 {
+				out.Die("unable to find logs topic - is Redpanda on the right version with Data Transforms enabled?")
+			}
 			topic := topics.TopicsList()[0]
 			partition := computeLogPartition(transformName, topic)
 


### PR DESCRIPTION

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Handle missing data transform logs topic in `rpk transform logs`

