### PR TITLE
rpk/transform/init: fix --install-deps flag

### DIFF
--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -135,6 +135,7 @@ This initializes a transform project in the foobar directory.
 	}
 	cmd.Flags().VarP(&lang, "language", "l", "The language used to develop the transform")
 	cmd.Flags().Var(&install, "install-deps", "If dependencies should be installed for the project")
+	cmd.Flags().Lookup("install-deps").NoOptDefVal = "true"
 	cmd.Flags().StringVar(&name, "name", "", "The name of the transform")
 	return cmd
 }


### PR DESCRIPTION
Now you don't need to specify --install-deps=true but can use the naked
boolean flag version

Fixes: CORE-2210

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fixes `rpk transform init --install-deps` so that an explicit true value is not needed.
