### PR TITLE
rpk/transform/logs: don't hang if the topic is empty

### DIFF
--- a/src/go/rpk/pkg/cli/transform/logs.go
+++ b/src/go/rpk/pkg/cli/transform/logs.go
@@ -170,7 +170,7 @@ the Open Telemetry LogRecord protocol buffer.`,
 				}
 			}
 			zap.L().Sugar().Debugf("reading logs topic with bounds [%v, %v] on partition %d", startOffset, maxOffset, partition)
-			if startOffset > maxOffset {
+			if startOffset >= maxOffset {
 				return
 			}
 


### PR DESCRIPTION

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fix an issue where `rpk transform logs` waits for records without the `--follow` flag specified.
