### PR TITLE
rptest: fix flaky metric check by disabling leader balancer

### DIFF
--- a/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
+++ b/tests/rptest/tests/cloud_storage_chunk_read_path_test.py
@@ -185,7 +185,9 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
     def test_read_chunks(self):
         self.default_chunk_size = 1048576
         self._set_params_and_start_redpanda(
-            cloud_storage_cache_chunk_size=self.default_chunk_size)
+            cloud_storage_cache_chunk_size=self.default_chunk_size,
+            # Disable leader balancer to have stable node to fetch metrics from.
+            enable_leader_balancer=False)
 
         self._produce_baseline()
 
@@ -235,7 +237,9 @@ class CloudStorageChunkReadTest(PreallocNodesTest):
         self.log_segment_size = 1048576 * 10
         self.topics[0].segment_bytes = self.log_segment_size
         self._set_params_and_start_redpanda(
-            cloud_storage_chunk_prefetch=prefetch)
+            cloud_storage_chunk_prefetch=prefetch,
+            # Disable leader balancer to have stable node to fetch metrics from.
+            enable_leader_balancer=False)
 
         # Smaller messages mean chunks are closer to requested limit. We need more messages to be able
         # to produce the required number of segments


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/16342

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
