### PR TITLE
ducktape: more robust tinygo downloads

### DIFF
--- a/tests/docker/ducktape-deps/tinygo
+++ b/tests/docker/ducktape-deps/tinygo
@@ -6,4 +6,6 @@ if [ $(uname -m) = "aarch64" ]; then
 else
   export ARCHID="amd64"
 fi
-curl -sSLf --retry 3 --retry-connrefused --retry-delay 2 "https://github.com/redpanda-data/tinygo/releases/download/v0.30.0-rpk1/tinygo-linux-${ARCHID}.tar.gz" | tar -xz -C /usr/local/tinygo/ --strip 1
+curl -sSLf --retry 5 --retry-all-errors --retry-delay 2 "https://github.com/redpanda-data/tinygo/releases/download/v0.31.0-rpk2/tinygo-linux-${ARCHID}.tar.gz" -o /tmp/tinygo-linux.tar.gz
+cat /tmp/tinygo-linux.tar.gz | tar -xz -C /usr/local/tinygo/ --strip 1
+rm /tmp/tinygo-linux.tar.gz


### PR DESCRIPTION
When retrying we re-emit the data to gzip, which breaks gzip encoding.
Stream the data to a file first.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
