### PR TITLE
rpk: bump docker version

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/beevik/ntp v1.3.1
 	github.com/bufbuild/protocompile v0.9.0
 	github.com/coreos/go-systemd/v22 v22.5.0
-	github.com/docker/docker v25.0.4+incompatible
+	github.com/docker/docker v26.0.1+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/docker/go-units v0.5.0
 	github.com/fatih/color v1.16.0
@@ -111,6 +111,7 @@ require (
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -59,8 +59,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnN
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
-github.com/docker/docker v25.0.4+incompatible h1:XITZTrq+52tZyZxUOtFIahUf3aH367FLxJzt9vZeAF8=
-github.com/docker/docker v25.0.4+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v26.0.1+incompatible h1:t39Hm6lpXuXtgkF0dm1t9a5HkbUfdGy6XbWexmGr+hA=
+github.com/docker/docker v26.0.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
@@ -175,6 +175,8 @@ github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2Em
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
+github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
 github.com/moby/term v0.5.0/go.mod h1:8FzsFHVUBGZdbDsJw/ot+X+d5HLUbvklYLJ9uGfcI3Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/src/go/rpk/pkg/cli/container/common/client.go
+++ b/src/go/rpk/pkg/cli/container/common/client.go
@@ -14,6 +14,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/docker/docker/api/types/image"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -29,13 +31,13 @@ type Client interface {
 	ImagePull(
 		ctx context.Context,
 		ref string,
-		options types.ImagePullOptions,
+		options image.PullOptions,
 	) (io.ReadCloser, error)
 
 	ImageList(
 		ctx context.Context,
-		options types.ImageListOptions,
-	) ([]types.ImageSummary, error)
+		options image.ListOptions,
+	) ([]image.Summary, error)
 	ContainerCreate(
 		ctx context.Context,
 		config *container.Config,
@@ -48,7 +50,7 @@ type Client interface {
 	ContainerStart(
 		ctx context.Context,
 		containerID string,
-		options types.ContainerStartOptions,
+		options container.StartOptions,
 	) error
 
 	ContainerStop(
@@ -59,13 +61,13 @@ type Client interface {
 
 	ContainerList(
 		ctx context.Context,
-		options types.ContainerListOptions,
+		options container.ListOptions,
 	) ([]types.Container, error)
 
 	ContainerLogs(
 		ctx context.Context,
 		containerID string,
-		options types.ContainerLogsOptions,
+		options container.LogsOptions,
 	) (io.ReadCloser, error)
 
 	ContainerInspect(
@@ -76,7 +78,7 @@ type Client interface {
 	ContainerRemove(
 		ctx context.Context,
 		containerID string,
-		options types.ContainerRemoveOptions,
+		options container.RemoveOptions,
 	) error
 
 	NetworkCreate(

--- a/src/go/rpk/pkg/cli/container/common/common.go
+++ b/src/go/rpk/pkg/cli/container/common/common.go
@@ -92,7 +92,7 @@ func GetExistingNodes(c Client) ([]*NodeState, error) {
 	ctx, _ := DefaultCtx()
 	containers, err := c.ContainerList(
 		ctx,
-		types.ContainerListOptions{
+		container.ListOptions{
 			All:     true,
 			Filters: filters,
 		},

--- a/src/go/rpk/pkg/cli/container/common/test.go
+++ b/src/go/rpk/pkg/cli/container/common/test.go
@@ -13,6 +13,8 @@ import (
 	"context"
 	"io"
 
+	"github.com/docker/docker/api/types/image"
+
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
@@ -32,7 +34,7 @@ type MockClient struct {
 	MockImageList func(
 		ctx context.Context,
 		options types.ImageListOptions,
-	) ([]types.ImageSummary, error)
+	) ([]image.Summary, error)
 
 	MockContainerCreate func(
 		ctx context.Context,
@@ -46,7 +48,7 @@ type MockClient struct {
 	MockContainerStart func(
 		ctx context.Context,
 		containerID string,
-		options types.ContainerStartOptions,
+		options container.StartOptions,
 	) error
 
 	MockContainerStop func(
@@ -57,7 +59,7 @@ type MockClient struct {
 
 	MockContainerList func(
 		ctx context.Context,
-		options types.ContainerListOptions,
+		options container.ListOptions,
 	) ([]types.Container, error)
 
 	MockContainerInspect func(
@@ -68,7 +70,7 @@ type MockClient struct {
 	MockContainerRemove func(
 		ctx context.Context,
 		containerID string,
-		options types.ContainerRemoveOptions,
+		options container.RemoveOptions,
 	) error
 
 	MockNetworkCreate func(
@@ -137,15 +139,15 @@ func (c *MockClient) ImagePull(
 
 func (c *MockClient) ImageList(
 	ctx context.Context, options types.ImageListOptions,
-) ([]types.ImageSummary, error) {
+) ([]image.Summary, error) {
 	if c.MockImageList != nil {
 		return c.MockImageList(ctx, options)
 	}
-	return []types.ImageSummary{}, nil
+	return []image.Summary{}, nil
 }
 
 func (c *MockClient) ContainerStart(
-	ctx context.Context, containerID string, options types.ContainerStartOptions,
+	ctx context.Context, containerID string, options container.StartOptions,
 ) error {
 	if c.MockContainerStart != nil {
 		return c.MockContainerStart(
@@ -165,7 +167,7 @@ func (c *MockClient) ContainerStop(
 }
 
 func (c *MockClient) ContainerList(
-	ctx context.Context, options types.ContainerListOptions,
+	ctx context.Context, options container.ListOptions,
 ) ([]types.Container, error) {
 	if c.MockContainerList != nil {
 		return c.MockContainerList(ctx, options)
@@ -183,7 +185,7 @@ func (c *MockClient) ContainerInspect(
 }
 
 func (c *MockClient) ContainerRemove(
-	ctx context.Context, containerID string, options types.ContainerRemoveOptions,
+	ctx context.Context, containerID string, options container.RemoveOptions,
 ) error {
 	if c.MockContainerRemove != nil {
 		return c.MockContainerRemove(ctx, containerID, options)

--- a/src/go/rpk/pkg/cli/container/purge.go
+++ b/src/go/rpk/pkg/cli/container/purge.go
@@ -15,7 +15,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/profile"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -91,7 +92,7 @@ func purgeCluster(c common.Client) (purged bool, rerr error) {
 			err := c.ContainerRemove(
 				ctx,
 				name,
-				types.ContainerRemoveOptions{
+				container.RemoveOptions{
 					RemoveVolumes: true,
 					Force:         true,
 				},

--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -22,9 +22,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/avast/retry-go"
-	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
+
+	"github.com/avast/retry-go"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -322,7 +322,7 @@ func restartCluster(
 				err = c.ContainerStart(
 					ctx,
 					state.ContainerID,
-					types.ContainerStartOptions{},
+					container.StartOptions{},
 				)
 				if err != nil {
 					return err
@@ -358,7 +358,7 @@ func restartCluster(
 
 func startNode(c common.Client, containerID string) error {
 	ctx, _ := common.DefaultCtx()
-	err := c.ContainerStart(ctx, containerID, types.ContainerStartOptions{})
+	err := c.ContainerStart(ctx, containerID, container.StartOptions{})
 	return err
 }
 


### PR DESCRIPTION
This new version removed the previously deprecated type aliases. (see https://github.com/moby/moby/releases/tag/v26.0.0)

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
