### PR TITLE
archival: Start housekeeping jobs only on a leader

### DIFF
--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -415,7 +415,11 @@ ss::future<ResultT> parse_head_error_response(
           code, msg, ss::sstring(rid.data(), rid.size()), key().native());
         return ss::make_exception_future<ResultT>(err);
     } catch (...) {
-        vlog(s3_log.error, "!!error parse error {}", std::current_exception());
+        vlog(
+          s3_log.error,
+          "!!error parse error {}, header: {}",
+          std::current_exception(),
+          hdr);
         throw;
     }
 }

--- a/tests/rptest/tests/cloud_storage_scrubber_test.py
+++ b/tests/rptest/tests/cloud_storage_scrubber_test.py
@@ -183,7 +183,7 @@ class Anomalies:
 
 
 class CloudStorageScrubberTest(RedpandaTest):
-    scrub_timeout = 90
+    scrub_timeout = 200
     partition_count = 3
     message_size = 16 * 1024  # 16KiB
     segment_size = 1024 * 1024  # 1MiB
@@ -201,12 +201,11 @@ class CloudStorageScrubberTest(RedpandaTest):
         super().__init__(
             test_context=test_context,
             extra_rp_conf={
-                "cloud_storage_enable_scrubbing": True,
-                "cloud_storage_partial_scrub_interval_ms": 1000,
+                "cloud_storage_partial_scrub_interval_ms": 100,
                 "cloud_storage_full_scrub_interval_ms": 1000,
-                "cloud_storage_scrubbing_interval_jitter_ms": 100,
+                "cloud_storage_scrubbing_interval_jitter_ms": 50,
                 # Small quota forces partial scrubs
-                "cloud_storage_background_jobs_quota": 30,
+                "cloud_storage_background_jobs_quota": 40,
                 # Disable segment merging since it can reupload
                 # the deleted segment and remove the gap
                 "cloud_storage_enable_segment_merging": False,


### PR DESCRIPTION
Currently, the housekeeping jobs are enabled in the 'start' method. First the 'sync' method of the archival metadata stm is called. We don't check the result of the 'sync' call which is a mistake. Normally, we're calling 'start' method of the 'ntp_archiver' when the partition is already a leader so this code works as expected. But if the partition is moved to another shard we could potentially create and start archiver when the partition is not a leader yet. In this case the 'sync' call returns 'nullopt'. The housekeeping jobs are not enabled because _parent.is_leader() returns 'false' in this case.

Then, when the partition becomes a leader the 'notify_leadership' method is invoked. This method enables the housekeeping jobs. The problem is that the 'sync' method of the archival STM may not be called yet. So the adjacent_segment_merger starts reuploading segments based on stale manifest.

The fix delays creation of the housekeeping jobs until the background loop is started and 'sync' is successfully called. The 'notify_leadership' method can enable or disable the jobs after that.

Extend error logging for the HeadObject request

Fixes #17750 
Refs #15528

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none