### PR TITLE
CORE-2369: Fix/azure managed identities hns detection

### DIFF
--- a/src/v/cloud_roles/apply_abs_credentials.h
+++ b/src/v/cloud_roles/apply_abs_credentials.h
@@ -24,6 +24,7 @@ public:
 
     void reset_creds(credentials creds) override;
     std::ostream& print(std::ostream& os) const override;
+    bool is_oauth() const override { return false; }
 
 private:
     signature_abs _signature;

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.h
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.h
@@ -25,6 +25,7 @@ public:
 
     void reset_creds(credentials creds) override;
     std::ostream& print(std::ostream& os) const override;
+    bool is_oauth() const override { return true; }
 
 private:
     oauth_token_str _oauth_token;

--- a/src/v/cloud_roles/apply_aws_credentials.h
+++ b/src/v/cloud_roles/apply_aws_credentials.h
@@ -24,6 +24,7 @@ public:
 
     void reset_creds(credentials creds) override;
     std::ostream& print(std::ostream& os) const override;
+    bool is_oauth() const override { return false; }
 
 private:
     signature_v4 _signature;

--- a/src/v/cloud_roles/apply_gcp_credentials.h
+++ b/src/v/cloud_roles/apply_gcp_credentials.h
@@ -23,6 +23,7 @@ public:
 
     void reset_creds(credentials creds) override;
     std::ostream& print(std::ostream& os) const override;
+    bool is_oauth() const override { return true; }
 
 private:
     oauth_token_str _oauth_token;

--- a/src/v/cloud_roles/include/cloud_roles/apply_credentials.h
+++ b/src/v/cloud_roles/include/cloud_roles/apply_credentials.h
@@ -38,6 +38,10 @@ public:
 
         virtual std::ostream& print(std::ostream& os) const = 0;
 
+        /// Returns true if this implementation is based on oauth tokens.
+        /// meant to deal with API that do not support OAuth
+        virtual bool is_oauth() const = 0;
+
         virtual ~impl() = default;
     };
 
@@ -53,6 +57,8 @@ public:
     }
 
     std::ostream& print(std::ostream& os) const { return _impl->print(os); }
+
+    bool is_oauth() const { return _impl->is_oauth(); }
 
 private:
     std::unique_ptr<impl> _impl;

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -405,6 +405,16 @@ abs_client::abs_client(
 
 ss::future<result<client_self_configuration_output, error_outcome>>
 abs_client::self_configure() {
+    auto& cfg = config::shard_local_cfg();
+    auto hns_enabled
+      = cfg.cloud_storage_azure_hierarchical_namespace_enabled.value();
+
+    if (hns_enabled.has_value()) {
+        // use override cluster property to skip check
+        co_return abs_self_configuration_result{
+          .is_hns_enabled = hns_enabled.value()};
+    }
+
     auto result = co_await get_account_info(http::default_connect_timeout);
     if (!result) {
         co_return result.error();

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -86,6 +86,13 @@ public:
     /// \brief Init http header for 'Get Account Information' request
     result<http::client::request_header> make_get_account_info_request();
 
+    /// \brief Init http header for 'Set Expiry' request. the object will be
+    /// expired in `expires_in` ms after the request is received
+    result<http::client::request_header> make_set_expiry_to_blob_request(
+      bucket_name const& name,
+      object_key const& key,
+      ss::lowres_clock::duration expires_in) const;
+
     /// \brief Create a 'Filesystem Delete' request header
     ///
     /// \param adls_ap is the acces point for the Azure Data Lake Storage v2

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -286,6 +286,13 @@ private:
     ss::future<storage_account_info>
     do_get_account_info(ss::lowres_clock::duration timeout);
 
+    /// \brief test if Hierarchical Namespace is enabled in the storage account
+    /// by creating a test file and calling Set Expiry on this. Set Expiry is
+    /// available only when HNS is enabled. use the result to infer if HNS is
+    /// enabled.
+    ss::future<storage_account_info>
+    do_test_set_expiry_on_dummy_file(ss::lowres_clock::duration timeout);
+
     ss::future<> do_delete_path(
       bucket_name const& name,
       object_key path,

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -304,6 +304,14 @@ private:
       ss::lowres_clock::duration timeout);
 
     std::optional<abs_configuration> _data_lake_v2_client_config;
+
+    // currently the implementation supports Signing requests or OAuth.
+    // not all api are available for oauth, this variable is initialized at
+    // startup to allow alternative codepaths when using oauth this is fine
+    // because to change authentication method the user changes
+    // cloud_storage_credentials_source, and that requires a restart
+    bool _is_oauth;
+
     abs_request_creator _requestor;
     http::client _client;
 

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -229,7 +229,7 @@ void apply_self_configuration_result(
 
 std::ostream& operator<<(std::ostream& o, const abs_configuration& c) {
     o << "{storage_account_name: " << c.storage_account_name()
-      << ", shared_key:****"
+      << ", shared_key:" << (c.shared_key.has_value() ? "****" : "none")
       << ", access_point_uri:" << c.uri() << ", server_addr:" << c.server_addr
       << ", max_idle_time:"
       << std::chrono::duration_cast<std::chrono::milliseconds>(c.max_idle_time)

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2128,6 +2128,17 @@ configuration::configuration()
       "cloud_storage_azure_adls_endpoint.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
       std::nullopt)
+  , cloud_storage_azure_hierarchical_namespace_enabled(
+      *this,
+      "cloud_storage_azure_hierarchical_namespace_enabled",
+      "Whether or not Azure Hierarchical Namespaces are enabled on the "
+      "cloud_storage_azure_storage_account. If this property is not set, "
+      "cloud_storage_azure_shared_key must be set, and each node will try to "
+      "determine at startup if HNS is enabled. Setting this property to True "
+      "will disable the check and assume HNS is active. Setting to False will "
+      "disable the check and assume that HNS is not active.",
+      {.needs_restart = needs_restart::yes, .visibility = visibility::tunable},
+      std::nullopt)
   , cloud_storage_upload_ctrl_update_interval_ms(
       *this,
       "cloud_storage_upload_ctrl_update_interval_ms",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -390,6 +390,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_azure_shared_key;
     property<std::optional<ss::sstring>> cloud_storage_azure_adls_endpoint;
     property<std::optional<uint16_t>> cloud_storage_azure_adls_port;
+    property<std::optional<bool>>
+      cloud_storage_azure_hierarchical_namespace_enabled;
 
     // Archival upload controller
     property<std::chrono::milliseconds>

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1581,8 +1581,8 @@ void config_multi_property_validation(
             // azure_vm_instance_metadata requires an client_id to work
             // correctly
             config_properties_seq properties = {
-              std::ref(updated_config.cloud_storage_region),
-              std::ref(updated_config.cloud_storage_bucket),
+              std::ref(updated_config.cloud_storage_azure_storage_account),
+              std::ref(updated_config.cloud_storage_azure_container),
               std::ref(updated_config.cloud_storage_azure_managed_identity_id),
             };
 

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1559,15 +1559,30 @@ void config_multi_property_validation(
         } break;
         case model::cloud_credentials_source::aws_instance_metadata:
         case model::cloud_credentials_source::gcp_instance_metadata:
-        case model::cloud_credentials_source::sts:
-        case model::cloud_credentials_source::azure_aks_oidc_federation: {
-            // basic config checks for cloud_storage. for sts and
-            // azure_aks_oidc_federation it is expected to receive part of the
-            // configuration via env variables, while aws_instance_metadata and
-            // gcp_instance_metadata do not require extra configuration
+        case model::cloud_credentials_source::sts: {
+            // basic config checks for cloud_storage. for sts it is expected to
+            // receive part of the configuration via env variables, while
+            // aws_instance_metadata and gcp_instance_metadata do not require
+            // extra configuration
             config_properties_seq properties = {
               std::ref(updated_config.cloud_storage_region),
               std::ref(updated_config.cloud_storage_bucket),
+            };
+
+            for (auto& p : properties) {
+                if (p() == std::nullopt) {
+                    errors[ss::sstring(p.get().name())]
+                      = "Must be set when cloud storage enabled";
+                }
+            }
+        } break;
+        case model::cloud_credentials_source::azure_aks_oidc_federation: {
+            // for azure_aks_oidc_federation it is expected to receive part of
+            // the configuration via env variables. this check is just for
+            // related cluster properties
+            config_properties_seq properties = {
+              std::ref(updated_config.cloud_storage_azure_storage_account),
+              std::ref(updated_config.cloud_storage_azure_container),
             };
 
             for (auto& p : properties) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
summary:
- tunable cluster property `cloud_storage_azure_hierarchical_namespace_enabled` optional<bool>. If set, will skip abs_client::self_configure and use the value of the property (set it to true if the azure_container has HNS enabled)
- if using oauth on azure (`cloud_storage_credentials_source= azure_aks_oidc_federation or azure_vm_instance_metadata`) , discover if HNS is enabled via [Set Blob Expiry endpoint](https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-expiry?tabs=microsoft-entra-id)
- bugfixes in configuration validation

HNS (Hierarchical Namespace) is an ABS feature that changes the behavior of some APIs, like deleting/listing.

The current implementation for ABS checks with [Get Account Information](https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures) at startup if HNS is enabled for this account/container
https://github.com/redpanda-data/redpanda/pull/12632
https://learn.microsoft.com/en-us/rest/api/storageservices/get-account-information?tabs=shared-access-signatures

This rest endpoint is not compatible with OAuth, causing the cluster configured with 
`cloud_storage_credentials_source = azure_aks_oidc_federation | azure_vm_managed_identity`
to fail at a startup

This PR uses a different API, [Set Blob Expirty](https://learn.microsoft.com/en-us/rest/api/storageservices/set-blob-expiry?tabs=microsoft-entra-id), if the authentication is OAuth.
This API will return 400 if HNS is not enabled and 200/404 if enabled. It is run on a non-existing object, so it's expected to return 404 (not found)

related to this issue, cloud_storage_enable=true would cause `cloud_storage_credentials_source = azure_aks_oidc_federation | azure_vm_managed_identity` to check for cloud_storage_region/cloud_storage_bucket instead of their azure counterparts. 


Fixes: CORE-2369
Fixes: CORE-2375

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
