### PR TITLE
CORE-2347: net: remove dependence on rpc parsing exception type

### DIFF
--- a/cmake/FindLZ4.cmake
+++ b/cmake/FindLZ4.cmake
@@ -24,7 +24,7 @@ if(LZ4_INCLUDE_DIR AND EXISTS "${LZ4_INCLUDE_DIR}/lz4.h")
     "${LZ4_VERSION_MAJOR}.${LZ4_VERSION_MINOR}.${LZ4_VERSION_RELEASE}")
 endif()
 
-find_library(LZ4_LIBRARY NAMES lz4)
+find_library(LZ4_LIBRARY NAMES liblz4.a)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(LZ4

--- a/src/v/net/connection.cc
+++ b/src/v/net/connection.cc
@@ -11,7 +11,7 @@
 
 #include "base/seastarx.h"
 #include "net/exceptions.h"
-#include "rpc/service.h"
+#include "net/types.h"
 #include "ssx/abort_source.h"
 
 #include <seastar/core/future.hh>
@@ -85,7 +85,7 @@ std::optional<ss::sstring> is_disconnect_exception(std::exception_ptr e) {
         // Happens on unclean client disconnect, when io_iterator_consumer
         // gets fewer bytes than it wanted
         return "short read";
-    } catch (const rpc::rpc_internal_body_parsing_exception&) {
+    } catch (const net::parsing_exception&) {
         // Happens on unclean client disconnect, typically wrapping
         // an out_of_range
         return "parse error";

--- a/src/v/net/types.h
+++ b/src/v/net/types.h
@@ -32,4 +32,6 @@ protected:
       : std::runtime_error(m) {}
 };
 
+class parsing_exception : public std::exception {};
+
 } // namespace net

--- a/src/v/rpc/service.h
+++ b/src/v/rpc/service.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "net/types.h"
 #include "reflection/async_adl.h"
 #include "rpc/parse_utils.h"
 #include "rpc/types.h"
@@ -39,7 +40,7 @@ struct service {
     virtual void setup_metrics() = 0;
 };
 
-class rpc_internal_body_parsing_exception : public std::exception {
+class rpc_internal_body_parsing_exception : public net::parsing_exception {
 public:
     explicit rpc_internal_body_parsing_exception(const std::exception_ptr& e)
       : _what(


### PR DESCRIPTION
net: remove dependence on rpc parsing exception type

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

