### PR TITLE
transform-sdk: Introduce QuickJS based JS SDK

### DIFF
--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -258,6 +258,7 @@ jobs:
           cmake --preset release-static
           cmake --build --preset release-static -- redpanda_js_transform
           cat identity.js | ./generate_js_provider.py > identity_source.wat
+          cat identity_logging.js | ./generate_js_provider.py > logging_source.wat
           curl -SLO https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-x86_64-linux.tar.gz
           tar xf binaryen-version_117-x86_64-linux.tar.gz
           rm binaryen-version_117-x86_64-linux.tar.gz
@@ -266,6 +267,11 @@ jobs:
             ./identity_source.wat redpanda_js_provider \
             -mvp --enable-simd --enable-bulk-memory --enable-multimemory \
             -o identity.wasm
+          ./binaryen-version_117/bin/wasm-merge \
+            ./build/release-static/redpanda_js_transform js_vm \
+            ./logging_source.wat redpanda_js_provider \
+            -mvp --enable-simd --enable-bulk-memory --enable-multimemory \
+            -o logging.wasm
       - name: Download integration test suite
         uses: actions/download-artifact@v4
         with:
@@ -275,7 +281,7 @@ jobs:
         working-directory: src/transform-sdk/js
         env:
           IDENTITY: identity.wasm
-          LOGGING: "@UNIMPLEMENTED@"
+          LOGGING: logging.wasm
           TEE: "@UNIMPLEMENTED@"
           SCHEMA_REGISTRY: "@UNIMPLEMENTED@"
         run: |

--- a/.github/workflows/transform-sdk-build.yml
+++ b/.github/workflows/transform-sdk-build.yml
@@ -214,3 +214,70 @@ jobs:
         run: |
           chmod +x wasm-integration-test
           ./wasm-integration-test -test.v
+
+  test-js:
+    name: Test JS Transform SDK
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:40
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Clang
+        run: dnf install -y clang clang-tools-extra libcxx libcxxabi libcxx-devel libcxxabi-devel cmake git
+
+      - name: Run tests
+        working-directory: src/transform-sdk/js
+        env:
+          CC: clang
+          CXX: clang++
+        run: |
+          cmake --preset debug
+          cmake --build --preset debug
+          ctest --output-on-failure --test-dir build/debug
+
+      - name: Run clang-tidy
+        working-directory: src/transform-sdk/js
+        run: clang-tidy --quiet -p build/debug/compile_commands.json js_vm.cc js_vm_test.cc main.cc
+
+  integration-test-js:
+    name: Integration Test JS Transform SDK
+    needs: [test-js, build-integration-tests]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/webassembly/wasi-sdk:wasi-sdk-21
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build integration tests
+        working-directory: src/transform-sdk/js
+        run: |
+          apt update
+          apt install -y git curl
+          cmake --preset release-static
+          cmake --build --preset release-static -- redpanda_js_transform
+          cat identity.js | ./generate_js_provider.py > identity_source.wat
+          curl -SLO https://github.com/WebAssembly/binaryen/releases/download/version_117/binaryen-version_117-x86_64-linux.tar.gz
+          tar xf binaryen-version_117-x86_64-linux.tar.gz
+          rm binaryen-version_117-x86_64-linux.tar.gz
+          ./binaryen-version_117/bin/wasm-merge \
+            ./build/release-static/redpanda_js_transform js_vm \
+            ./identity_source.wat redpanda_js_provider \
+            -mvp --enable-simd --enable-bulk-memory --enable-multimemory \
+            -o identity.wasm
+      - name: Download integration test suite
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-integration-test
+          path: src/transform-sdk/js
+      - name: Run integration tests
+        working-directory: src/transform-sdk/js
+        env:
+          IDENTITY: identity.wasm
+          LOGGING: "@UNIMPLEMENTED@"
+          TEE: "@UNIMPLEMENTED@"
+          SCHEMA_REGISTRY: "@UNIMPLEMENTED@"
+        run: |
+          chmod +x wasm-integration-test
+          ./wasm-integration-test -test.v

--- a/src/transform-sdk/js/.clang-tidy
+++ b/src/transform-sdk/js/.clang-tidy
@@ -1,0 +1,1 @@
+../cpp/.clang-tidy

--- a/src/transform-sdk/js/.gitignore
+++ b/src/transform-sdk/js/.gitignore
@@ -1,0 +1,3 @@
+build
+.vim
+Testing

--- a/src/transform-sdk/js/.gitignore
+++ b/src/transform-sdk/js/.gitignore
@@ -1,3 +1,6 @@
-build
-.vim
-Testing
+build/
+.vim/
+Testing/
+*.wasm
+*.wat
+binaryen/

--- a/src/transform-sdk/js/CMakeLists.txt
+++ b/src/transform-sdk/js/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.22)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+project(RedpandaDataTransformJavaScriptSDK
+    VERSION 0.1
+    DESCRIPTION "Redpanda Data Transform JavaScript SDK"
+    LANGUAGES C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_compile_options(-Wall)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++ -fno-exceptions")
+
+if(Redpanda_ENABLE_SANITIZERS)
+  add_link_options(-fsanitize=address,leak,undefined)
+  add_compile_options(-fsanitize=address,leak,undefined)
+endif()
+
+include(FetchContent)
+set(FETCHCONTENT_QUIET FALSE)
+
+FetchContent_Declare(
+  quickjs
+  GIT_REPOSITORY https://github.com/quickjs-ng/quickjs.git
+  GIT_TAG        bb674c0c3b4c141be0e399b4c76e3530066a6dfd
+)
+
+FetchContent_Declare(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        9d43b27f7a873596496a2ea70721b3f9eb82df01
+)
+
+FetchContent_Declare(
+  redpanda-transform-sdk
+  SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/../cpp/"
+)
+
+FetchContent_MakeAvailable(quickjs redpanda-transform-sdk googletest)
+
+# JavaScript VM library
+set_source_files_properties(js_vm.h PROPERTIES LANGUAGE CXX)
+add_library(
+  redpanda_js_vm
+  js_vm.cc
+)
+target_link_libraries(
+  redpanda_js_vm
+  qjs
+)
+add_library(Redpanda::js_vm ALIAS redpanda_js_vm)
+
+# Main entry point that defines JavaScript Data Transforms
+# add_executable(
+#   redpanda_js_transform 
+#   main.cc
+# )
+# target_link_libraries(
+#   redpanda_js_transform
+#   qjs Redpanda::transform_sdk Redpanda::js_vm
+# )
+
+# Tests
+enable_testing()
+
+add_executable(
+  js_vm_test
+  js_vm_test.cc
+)
+target_link_libraries(
+  js_vm_test
+  GTest::gtest_main Redpanda::js_vm
+)
+
+include(GoogleTest)
+
+gtest_discover_tests(js_vm_test)
+

--- a/src/transform-sdk/js/CMakeLists.txt
+++ b/src/transform-sdk/js/CMakeLists.txt
@@ -56,14 +56,14 @@ target_link_libraries(
 add_library(Redpanda::js_vm ALIAS redpanda_js_vm)
 
 # Main entry point that defines JavaScript Data Transforms
-# add_executable(
-#   redpanda_js_transform 
-#   main.cc
-# )
-# target_link_libraries(
-#   redpanda_js_transform
-#   qjs Redpanda::transform_sdk Redpanda::js_vm
-# )
+add_executable(
+  redpanda_js_transform 
+  main.cc
+)
+target_link_libraries(
+  redpanda_js_transform
+  qjs Redpanda::transform_sdk Redpanda::js_vm
+)
 
 # Tests
 enable_testing()

--- a/src/transform-sdk/js/CMakeLists.txt
+++ b/src/transform-sdk/js/CMakeLists.txt
@@ -27,7 +27,7 @@ set(FETCHCONTENT_QUIET FALSE)
 FetchContent_Declare(
   quickjs
   GIT_REPOSITORY https://github.com/quickjs-ng/quickjs.git
-  GIT_TAG        bb674c0c3b4c141be0e399b4c76e3530066a6dfd
+  GIT_TAG        f227746c6ebe7f0c7ddb0e5152d52cd41f5a7cdd
 )
 
 FetchContent_Declare(
@@ -74,7 +74,7 @@ add_executable(
 )
 target_link_libraries(
   js_vm_test
-  GTest::gtest_main Redpanda::js_vm
+  GTest::gtest_main Redpanda::js_vm GTest::gmock
 )
 
 include(GoogleTest)

--- a/src/transform-sdk/js/CMakePresets.json
+++ b/src/transform-sdk/js/CMakePresets.json
@@ -1,0 +1,84 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER": "clang-17",
+        "CMAKE_CXX_COMPILER": "clang++-17"
+      }
+    },
+    {
+      "name": "sanitize",
+      "hidden": true,
+      "cacheVariables": {
+        "Redpanda_ENABLE_SANITIZERS": "ON"
+      }
+    },
+    {
+      "name": "release-type",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "debug-type",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "shared",
+      "hidden": true,
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "ON"
+      }
+    },
+    {
+      "name": "static",
+      "hidden": true,
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF"
+      }
+    },
+    {
+      "name": "release",
+      "inherits": ["base", "release-type", "shared"]
+    },
+    {
+      "name": "release-static",
+      "inherits": ["base", "release-type", "static"]
+    },
+    {
+      "name": "debug",
+      "inherits": ["base", "debug-type", "shared", "sanitize"]
+    },
+    {
+      "name": "debug-static",
+      "inherits": ["base", "debug-type", "static", "sanitize"]
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "release",
+      "configurePreset": "release"
+    },
+    {
+      "name": "release-static",
+      "configurePreset": "release-static"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "debug-static",
+      "configurePreset": "debug-static"
+    }
+  ]
+}

--- a/src/transform-sdk/js/CMakePresets.json
+++ b/src/transform-sdk/js/CMakePresets.json
@@ -5,10 +5,8 @@
       "name": "base",
       "hidden": true,
       "binaryDir": "${sourceDir}/build/${presetName}",
-      "generator": "Ninja",
+      "generator": "Unix Makefiles",
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "clang-17",
-        "CMAKE_CXX_COMPILER": "clang++-17"
       }
     },
     {

--- a/src/transform-sdk/js/README.md
+++ b/src/transform-sdk/js/README.md
@@ -1,0 +1,20 @@
+# Redpanda Data Transform JS SDK
+
+This holds the JS SDK code for Redpanda's Data Transforms. This SDK is implemented by
+compiling the QuickJS JavaScript VM into WebAssembly and running it within our C++ SDK.
+
+To use this SDK manually here are the steps:
+
+```shell
+# Compile the C++
+docker run -v `pwd`/..:/src -w /src/js ghcr.io/webassembly/wasi-sdk \
+  /bin/bash -c 'apt update && apt install -y git && cmake --preset release-static && cmake --build --preset release-static -- redpanda_js_transform -j32'
+# Convert the JavaScript file into a WebAssembly text file
+cat user_code.js | ./generate_js_provider.py > js_user_code.wat
+# Download wasm merge from Binaryen, and use it to merge the wasm files together, resolving the imports in C++ for the source code.
+wasm-merge build/release-static/redpanda_js_transform js_vm ./js_user_code.wat redpanda_js_provider -mvp --enable-simd --enable-bulk-memory --enable-multimemory -o js_transform.wasm
+# Deploy away!
+rpk transform deploy --file=js_transform.wasm --name=my-transform -i foo -o bar
+```
+
+There is still a lot of work todo to provide a full experience of NodeJS compatibility, but this is a start.

--- a/src/transform-sdk/js/generate_js_provider.py
+++ b/src/transform-sdk/js/generate_js_provider.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import sys
+
+WAT_TEMPLATE = """
+(module
+	(memory (import "js_vm" "memory") 0)
+
+	(func (export "file_length") (result i32)
+          (i32.const {length})
+        )
+
+	(func (export "get_file") (param $buffer_ptr i32)
+		;; Copy the bytecode from data segment 0.
+		(memory.init $bytecode
+			(local.get $buffer_ptr)       ;; Memory destination
+			(i32.const 0)                 ;; Start index
+			(i32.const {length})          ;; Length
+                )
+		(data.drop $bytecode)
+        )
+	(data $bytecode "\\{bytecode}"))
+"""
+
+source = sys.stdin.read()
+sys.stdout.write(
+    WAT_TEMPLATE.format(length=len(source),
+                        bytecode=source.encode().hex('\\')))

--- a/src/transform-sdk/js/identity.js
+++ b/src/transform-sdk/js/identity.js
@@ -1,0 +1,5 @@
+import {onRecordWritten} from "@redpanda-data/transform-sdk";
+
+onRecordWritten((event, writer) => {
+  writer.write(event.record);
+});

--- a/src/transform-sdk/js/identity_logging.js
+++ b/src/transform-sdk/js/identity_logging.js
@@ -1,0 +1,6 @@
+import {onRecordWritten} from "@redpanda-data/transform-sdk";
+
+onRecordWritten((event, writer) => {
+  console.warn(`${event.record.key.text()}:${event.record.value.text()}`);
+  writer.write(event.record);
+});

--- a/src/transform-sdk/js/js_vm.cc
+++ b/src/transform-sdk/js/js_vm.cc
@@ -291,6 +291,11 @@ std::string value::debug_string() const {
     return "[exception]";
 }
 
+bool operator==(const value& lhs, const value& rhs) {
+    return lhs._ctx == rhs._ctx
+           && JS_IsStrictEqual(lhs._ctx, lhs.raw(), rhs.raw()) != 0;
+}
+
 exception exception::current(JSContext* ctx) {
     return {value::current_exception(ctx)};
 }

--- a/src/transform-sdk/js/js_vm.cc
+++ b/src/transform-sdk/js/js_vm.cc
@@ -21,6 +21,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <expected>
 #include <print>
 #include <unordered_map>
 #include <utility>

--- a/src/transform-sdk/js/js_vm.h
+++ b/src/transform-sdk/js/js_vm.h
@@ -57,7 +57,7 @@ struct cstring {
 public:
     cstring(JSContext* context, const char* ptr, size_t size);
     cstring(const cstring&) = delete;
-    cstring(cstring&& other);
+    cstring(cstring&& other) noexcept;
     cstring& operator=(const cstring&) = delete;
     cstring& operator=(cstring&&) = delete;
     ~cstring();
@@ -122,7 +122,12 @@ public:
     string(JSContext* ctx, std::string_view);
     /** Create an error class */
     static value error(JSContext* ctx, std::string_view);
-    /** Parse a value from JSON. */
+    /**
+     * Parse a value from JSON.
+     *
+     * NOTE: This must be `std::string` because quickjs requires a trailing null
+     * byte.
+     */
     static std::expected<value, exception>
     parse_json(JSContext* ctx, const std::string&);
     /**
@@ -257,7 +262,7 @@ public:
     push_back(const value&);
 
     /**
-     * Append a property to a JavaScript array.
+     * Get a value at an index within a JavaScript array.
      *
      * Example: `arr[5]`
      */

--- a/src/transform-sdk/js/js_vm.h
+++ b/src/transform-sdk/js/js_vm.h
@@ -206,6 +206,8 @@ public:
     [[nodiscard]] bool is_null() const;
     /** Check if this is undefined */
     [[nodiscard]] bool is_undefined() const;
+    /** Check if this is an array */
+    [[nodiscard]] bool is_array() const;
 
     /** Get the number from the object. */
     [[nodiscard]] double as_number() const;
@@ -246,6 +248,26 @@ public:
      */
     [[nodiscard]] std::expected<std::monostate, exception>
     set_property(std::string_view, const value&);
+
+    /**
+     * Append a property to a JavaScript array.
+     *
+     * Example: `arr.push(5)`
+     */
+    [[nodiscard]] std::expected<std::monostate, exception>
+    push_back(const value&);
+
+    /**
+     * Append a property to a JavaScript array.
+     *
+     * Example: `arr[5]`
+     */
+    [[nodiscard]] value get_element(size_t) const;
+
+    /**
+     * Get the length of a JavaScript array.
+     */
+    [[nodiscard]] size_t array_length() const;
 
     /**
      * Call toString() on the Javascript value and return the resulting value as

--- a/src/transform-sdk/js/js_vm.h
+++ b/src/transform-sdk/js/js_vm.h
@@ -23,7 +23,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <type_traits>
 #include <unordered_map>
 #include <utility>
 #include <variant>
@@ -388,6 +387,9 @@ public:
 
     /** Add a native module that is accessible to javascript. */
     std::expected<std::monostate, exception> add_module(module_builder);
+
+    /** Add builtin functions like console.log */
+    std::expected<std::monostate, exception> create_builtins();
 
     [[nodiscard]] JSContext* context() const { return _ctx.get(); }
 

--- a/src/transform-sdk/js/js_vm.h
+++ b/src/transform-sdk/js/js_vm.h
@@ -1,0 +1,602 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <expected>
+#include <functional>
+#include <memory>
+#include <print>
+#include <quickjs.h>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <variant>
+#include <vector>
+
+template<typename T, auto fn>
+struct deleter {
+    void operator()(T* ptr) {
+        fn(ptr); // NOLINT
+    }
+};
+template<typename T, auto fn>
+using handle = std::unique_ptr<T, deleter<T, fn>>;
+
+/**
+ * Wrappers for the QuickJS JavaScript runtime.
+ *
+ * QuickJS API's have some quirks and are not currently well documented.
+ * Hopefully this documentation is sufficent, otherwise the tests should give an
+ * overview of functionality (as well as giving usage examples).
+ *
+ */
+namespace qjs {
+
+struct exception;
+class value;
+
+/**
+ * A small string wrapper that was allocated from C.
+ */
+struct cstring {
+public:
+    cstring(JSContext* context, const char* ptr, size_t size);
+    cstring(const cstring&) = delete;
+    cstring(cstring&& other);
+    cstring& operator=(const cstring&) = delete;
+    cstring& operator=(cstring&&) = delete;
+    ~cstring();
+
+    [[nodiscard]] std::string_view view() const;
+
+private:
+    JSContext* context;
+    const char* ptr;
+    size_t size;
+};
+
+/**
+ * A JavaScript function natively defined in C++
+ */
+using native_function = std::function<std::expected<value, exception>(
+  JSContext* ctx, value this_val, std::span<value> args)>;
+
+/**
+ * A class function natively defined in C++
+ *
+ * Used for custom (native) classes and defining functions for said classes.
+ */
+template<typename T>
+using native_class_function_ptr = std::expected<value, exception> (T::*)(
+  JSContext* ctx, std::span<value> args);
+
+/**
+ * A value within Javascript that is ref counted.
+ *
+ * Due to the reference counting, we always need to keep a pointer to the
+ * original JSContext the value is attached to. It's not valid to mix values
+ * from different contexts at the moment (although QuickJS supports it for
+ * primative types).
+ */
+class value {
+public:
+    value() noexcept;
+    value(JSContext* ctx, JSValue underlying) noexcept;
+    value(const value&) noexcept;
+    value& operator=(const value&) noexcept;
+    value(value&& other) noexcept;
+    value& operator=(value&& other) noexcept;
+    ~value() noexcept;
+
+    /** Create a null value. */
+    static value undefined(JSContext* ctx);
+    /** Create an empty plain object value. */
+    static value object(JSContext* ctx);
+    /** Create an empty array value. */
+    static value array(JSContext* ctx);
+    /** Create a null value. */
+    static value null(JSContext* ctx);
+    /** Create an int value. */
+    static value integer(JSContext* ctx, int32_t);
+    /** Create a double value. */
+    static value number(JSContext* ctx, double);
+    /** Create a bool value. */
+    static value boolean(JSContext* ctx, bool);
+    /** Create a string value (copy). */
+    static std::expected<value, exception>
+    string(JSContext* ctx, std::string_view);
+    /** Create an error class */
+    static value error(JSContext* ctx, std::string_view);
+    /** Parse a value from JSON. */
+    static std::expected<value, exception>
+    parse_json(JSContext* ctx, const std::string&);
+    /**
+     * Create an array buffer value (view - no copies).
+     *
+     * This should be used with care and one should always call `detach_buffer`
+     * when `data` is about to go out of scope to prevent the javascript side
+     * from accessing free'd memory.
+     *
+     */
+    static value array_buffer(JSContext* ctx, std::span<uint8_t> data);
+
+    /**
+     * Create an array buffer value (view - no copies).
+     *
+     * This should be used with care and one should always call
+     * `detach_uint8_array` when `data` is about to go out of scope to prevent
+     * the javascript side from accessing free'd memory.
+     *
+     */
+    static value uint8_array(JSContext* ctx, std::span<uint8_t> data);
+
+    /**
+     * Free the underlying memory to an array buffer.
+     */
+    void detach_buffer();
+
+    /**
+     * Free the underlying memory to an uint8 array.
+     */
+    [[nodiscard]] std::expected<std::monostate, exception> detach_uint8_array();
+
+    /**
+     * Return the data for an underlying array buffer object.
+     *
+     * Returns an empty span if not an array buffer or if it's detached.
+     */
+    [[nodiscard]] std::span<uint8_t> array_buffer_data() const;
+
+    /**
+     * Return the data for an underlying uint8 array object.
+     *
+     * Returns an empty span if not an array buffer or if it's detached.
+     */
+    [[nodiscard]] std::span<uint8_t> uint8_array_data() const;
+
+    /**
+     * Return the data for an underlying string object.
+     *
+     * Returns an empty string_view if not a string.
+     */
+    [[nodiscard]] cstring string_data() const;
+
+    /**
+     * Get the global object for this context.
+     */
+    static value global(JSContext* ctx);
+
+    /**
+     * Get the current exception (when an exception is thrown and detected via
+     * is_exception).
+     */
+    static value current_exception(JSContext* ctx);
+
+    /** Is this value a integer? */
+    [[nodiscard]] bool is_number() const;
+    /** Is this value an exception? */
+    [[nodiscard]] bool is_exception() const;
+    /** Is this value a function? */
+    [[nodiscard]] bool is_function() const;
+    /** Is this value a string? */
+    [[nodiscard]] bool is_string() const;
+    /** Check if this is an array buffer */
+    [[nodiscard]] bool is_array_buffer() const;
+    /** Check if this is an uint8 array */
+    [[nodiscard]] bool is_uint8_array() const;
+    /** Check if this is an object */
+    [[nodiscard]] bool is_object() const;
+    /** Check if this is null */
+    [[nodiscard]] bool is_null() const;
+    /** Check if this is undefined */
+    [[nodiscard]] bool is_undefined() const;
+
+    /** Get the number from the object. */
+    [[nodiscard]] double as_number() const;
+
+    /**
+     * Return a reference to the raw JSValue without incrementing the ref
+     * count.
+     *
+     * This is a low level API and mostly exposed for interop, it shouldn't be
+     * needed by consumers of this library.
+     */
+    [[nodiscard]] JSValue raw() const;
+    /**
+     * Return a reference to the raw JSValue, incrementing the ref
+     * count.
+     *
+     * This is a low level API and mostly exposed for interop, it shouldn't be
+     * needed by consumers of this library.
+     */
+    [[nodiscard]] JSValue raw_dup() const;
+
+    /**
+     * Call a javascript function with the given arguments.
+     */
+    [[nodiscard]] std::expected<value, exception> call(std::span<value> values);
+
+    /**
+     * Access a property on a javascript object, undefined if not set.
+     *
+     * Example: `obj["foo"]`
+     */
+    [[nodiscard]] value get_property(std::string_view) const;
+
+    /**
+     * Set a property on a javascript object.
+     *
+     * Example: `obj["foo"] = 5`
+     */
+    [[nodiscard]] std::expected<std::monostate, exception>
+    set_property(std::string_view, const value&);
+
+    /**
+     * Call toString() on the Javascript value and return the resulting value as
+     * a native string.
+     */
+    [[nodiscard]] std::string debug_string() const;
+
+private:
+    JSContext* _ctx;
+    JSValue _underlying;
+};
+
+/**
+ * An exception within the JavaScript runtime.
+ *
+ * JavaScript exceptions can be any arbitrary value - this struct mostly exists
+ * to provide clarity and typesafety for exceptions.
+ */
+struct exception {
+    value val;
+
+    /** Create an exception from the currently thrown one. */
+    static exception current(JSContext* ctx);
+
+    static exception make(JSContext* ctx, std::string_view message);
+};
+
+/**
+ * A builder of native modules.
+ *
+ * This class allows embedded natively (C++) defined APIs and exposing them as
+ * module imports to loaded JavaScript modules.
+ *
+ * Currently this only supports defining functions, because that is all that is
+ * needed.
+ */
+class module_builder {
+public:
+    /**
+     * Create a module with the given name.
+     */
+    explicit module_builder(std::string name);
+    module_builder(const module_builder&) = delete;
+    module_builder& operator=(const module_builder&) = delete;
+    module_builder(module_builder&&) = default;
+    module_builder& operator=(module_builder&&) = default;
+    ~module_builder() = default;
+
+    /**
+     * Add an exported function to this module.
+     */
+    module_builder& add_function(std::string name, native_function);
+
+    /** Build this module and make it available in this context. */
+    std::expected<std::monostate, exception> build(JSContext* ctx);
+
+private:
+    std::string _name;
+
+    std::unordered_map<std::string, native_function> _exports;
+};
+
+/**
+ * Precompiled bytecode for the QuickJS runtime. This is serializable and can be
+ * persisted to disk (or embedded in a Wasm binary).
+ */
+class compiled_bytecode {
+public:
+    using view = std::span<uint8_t>;
+
+    /**
+     * Takes ownership of `data`.
+     */
+    compiled_bytecode(JSContext*, uint8_t* data, size_t size) noexcept;
+    compiled_bytecode(const compiled_bytecode&) = delete;
+    compiled_bytecode& operator=(const compiled_bytecode&) = delete;
+    compiled_bytecode(compiled_bytecode&& other) noexcept;
+    compiled_bytecode& operator=(compiled_bytecode&& other) noexcept;
+    ~compiled_bytecode() noexcept;
+
+    [[nodiscard]] view raw() const;
+    [[nodiscard]] view::iterator begin() const;
+    [[nodiscard]] view::iterator end() const;
+
+private:
+    JSContext* _ctx;
+    uint8_t* _data;
+    size_t _size;
+};
+
+/**
+ * A single runtime/context for the JS engine.
+ *
+ * Technically QuickJS supports multiple contexts for a single runtime (like a
+ * browser supports multiple origins) but we don't use any of that
+ * functionality.
+ */
+class runtime {
+public:
+    runtime();
+    runtime(const runtime&) = delete;
+    runtime& operator=(const runtime&) = delete;
+    runtime(runtime&&) = default;
+    runtime& operator=(runtime&&) = default;
+    ~runtime();
+
+    /**
+     * Compile javascript into qjs bytecode.
+     */
+    std::expected<compiled_bytecode, exception>
+    compile(const std::string& module_src);
+
+    /**
+     * Load previously compiled bytecode into the runtime.
+     */
+    std::expected<std::monostate, exception>
+    load(compiled_bytecode::view bytecode);
+
+    /** Add a native module that is accessible to javascript. */
+    std::expected<std::monostate, exception> add_module(module_builder);
+
+    [[nodiscard]] JSContext* context() const { return _ctx.get(); }
+
+private:
+    struct state {
+        struct class_info {
+            JSClassID class_id;
+            std::vector<JSCFunctionListEntry> entries;
+        };
+        // It's important this gives pointer stability.
+        std::unordered_map<std::string, class_info> classes;
+    };
+
+    template<typename>
+    friend class class_builder;
+
+    handle<JSRuntime, JS_FreeRuntime> _rt;
+    handle<JSContext, JS_FreeContext> _ctx;
+};
+
+/**
+ * A helper to create instances of custom (defined in C++) JavaScript classes.
+ */
+template<typename T>
+class class_factory {
+public:
+    class_factory(const class_factory&) = delete;
+    class_factory(class_factory&&) = delete;
+    class_factory& operator=(const class_factory&) = delete;
+    class_factory& operator=(class_factory&&) = delete;
+    ~class_factory() = default;
+
+    /**
+     * Create a class wrapping and taking ownership of `ptr`.
+     *
+     * This allows grabbing a pointer to `ptr` to have access to the native
+     * along with the returned JavaScript value.
+     *
+     * Once the returned value is destroyed, then `ptr` will be deleted.
+     */
+    value create(std::unique_ptr<T> ptr) {
+        value result = {
+          _ctx, JS_CallConstructor(_ctx, _constructor.raw(), 0, nullptr)};
+        if (result.is_exception()) [[unlikely]] {
+            std::println(
+              "constructor error: {}",
+              exception::current(_ctx).val.debug_string());
+            std::abort();
+        }
+        assert(JS_GetClassID(result.raw()) == _class_id);
+        JS_SetOpaque(result.raw(), ptr.release());
+        return result;
+    }
+
+    /**
+     * Get the raw T associated with this value.
+     *
+     * If the value is not an instance of this class then `nullptr` is returned.
+     */
+    T* get_opaque(const qjs::value& val) {
+        return static_cast<T*>(JS_GetOpaque(val.raw(), _class_id));
+    }
+
+private:
+    class_factory(JSContext* ctx, value constructor, JSClassID class_id)
+      : _ctx(ctx)
+      , _constructor(std::move(constructor))
+      , _class_id(class_id) {}
+
+    template<typename>
+    friend class class_builder;
+
+    JSContext* _ctx;
+    value _constructor;
+    JSClassID _class_id;
+};
+
+/**
+ * Allows building and exposing new classes from C++ into JavaScript.
+ *
+ * Once built/defined, a class_factory can be used to construct new instances of
+ * the class.
+ *
+ * See the tests for usage.
+ */
+template<typename T>
+class class_builder {
+public:
+    /**
+     * Create a new class builder for a class with the given name.
+     *
+     * @param class_name should be a constant null-terminated string.
+     */
+    explicit class_builder(JSContext* ctx, const char* class_name)
+      : _class_name(class_name)
+      , _ctx(ctx) {}
+
+    /**
+     * Expose FuncPtr native method on T to JavaScript under the given
+     * `func_name`.
+     *
+     * @param func_name should be a constant null-terminated string.
+     */
+    template<native_class_function_ptr<T> FuncPtr>
+    class_builder& method(const char* func_name) {
+        register_class_function<FuncPtr>(func_name);
+        return *this;
+    }
+
+    /**
+     * Create a class factory from this classes' definition.
+     */
+    class_factory<T> build() {
+        auto* runtime = JS_GetRuntime(_ctx);
+        JSClassID class_id = JS_INVALID_CLASS_ID;
+        JS_NewClassID(runtime, &class_id);
+        JSClassDef def = {
+          .class_name = _class_name,
+          .finalizer = cleanup_class_state,
+          .gc_mark = nullptr,
+          .call = nullptr,
+          .exotic = nullptr,
+        };
+        auto* state = static_cast<runtime::state*>(
+          JS_GetRuntimeOpaque(runtime));
+        for (auto& entry : _entries) {
+            entry.magic = static_cast<int16_t>(class_id);
+        }
+        auto [it, inserted] = state->classes.emplace(
+          _class_name,
+          runtime::state::class_info{
+            .class_id = class_id,
+            .entries = std::move(_entries),
+          });
+        JS_NewClass(runtime, class_id, &def);
+        value class_proto = {_ctx, JS_NewObject(_ctx)};
+        JS_SetPropertyFunctionList(
+          _ctx,
+          class_proto.raw(),
+          it->second.entries.data(),
+          static_cast<int>(it->second.entries.size()));
+        value class_constructor_func = {
+          _ctx,
+          JS_NewCFunctionMagic(
+            _ctx,
+            constructor,
+            _class_name,
+            0,
+            JS_CFUNC_constructor_magic,
+            static_cast<int>(class_id)),
+        };
+        JS_SetConstructor(
+          _ctx, class_constructor_func.raw(), class_proto.raw());
+        JS_SetClassProto(_ctx, class_id, class_proto.raw_dup());
+        return class_factory<T>(_ctx, class_constructor_func, class_id);
+    }
+
+private:
+    template<native_class_function_ptr<T> FuncPtr>
+    void register_class_function(const char* func_name) {
+        _entries.push_back(JSCFunctionListEntry{
+              .name = func_name,
+              // NOLINTNEXTLINE(*-signed-bitwise)
+              .prop_flags = JS_PROP_WRITABLE | JS_PROP_CONFIGURABLE,
+              .def_type = JS_DEF_CFUNC,
+              .magic = 0, // Will be set to class ID later
+              .u = {
+                .func = {
+                  .length = 0,
+                  .cproto = JS_CFUNC_generic_magic,
+                  .cfunc = {
+                    .generic_magic = invoke_class_func_ptr<FuncPtr>,
+                  },
+                },
+              },
+            });
+    }
+
+    template<native_class_function_ptr<T> FuncPtr>
+    static JSValue invoke_class_func_ptr(
+      JSContext* ctx, JSValue this_val, int argc, JSValue* argv, int magic) {
+        JSClassID class_id = magic;
+        std::vector<value> args;
+        args.reserve(argc);
+        for (JSValue arg : std::span(argv, argc)) {
+            args.emplace_back(ctx, JS_DupValue(ctx, arg));
+        }
+        void* opaque = JS_GetOpaque2(ctx, this_val, class_id);
+        if (opaque == nullptr) {
+            // NOLINTNEXTLINE(*-vararg)
+            return JS_ThrowTypeError(
+              ctx, "missing opaque data for: %d", class_id);
+        }
+        T* obj = static_cast<T*>(opaque);
+        auto result = (obj->*FuncPtr)(ctx, args);
+        if (result.has_value()) {
+            return result.value().raw_dup();
+        }
+        return JS_Throw(ctx, result.error().val.raw_dup());
+    }
+
+    static void cleanup_class_state(JSRuntime* /*runtime*/, JSValue val) {
+        // NOLINTNEXTLINE(*-owning-memory)
+        delete static_cast<T*>(JS_GetOpaque(val, JS_GetClassID(val)));
+    }
+
+    static JSValue constructor(
+      JSContext* ctx,
+      JSValue new_target,
+      int /*paramc*/,
+      JSValue* /*paramv*/,
+      int magic) {
+        JSClassID class_id = magic;
+        auto proto = value(
+          ctx, JS_GetPropertyStr(ctx, new_target, "prototype"));
+        if (proto.is_exception()) {
+            return JS_EXCEPTION;
+        }
+        value obj = value(
+          ctx, JS_NewObjectProtoClass(ctx, proto.raw(), class_id));
+        if (obj.is_exception()) {
+            return JS_EXCEPTION;
+        }
+        return obj.raw_dup();
+    }
+
+    friend class runtime;
+
+    const char* _class_name;
+    JSContext* _ctx;
+    std::vector<JSCFunctionListEntry> _entries;
+};
+
+} // namespace qjs

--- a/src/transform-sdk/js/js_vm.h
+++ b/src/transform-sdk/js/js_vm.h
@@ -279,6 +279,8 @@ public:
      */
     [[nodiscard]] std::string debug_string() const;
 
+    friend bool operator==(const value&, const value&);
+
 private:
     JSContext* _ctx;
     JSValue _underlying;

--- a/src/transform-sdk/js/js_vm_test.cc
+++ b/src/transform-sdk/js/js_vm_test.cc
@@ -1,0 +1,183 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "js_vm.h"
+
+#include <gtest/gtest.h>
+
+#include <expected>
+#include <memory>
+
+// Disabled lint checks:
+// unchecked-optional: We ASSERT before, but clang-tidy doesn't understand that
+// function-cognitive-complexity: Takes into account expanded macros
+// NOLINTBEGIN(*-unchecked-optional-*,*-function-cognitive-complexity)
+
+namespace {
+
+testing::AssertionResult
+compile_and_load(qjs::runtime* runtime, const std::string& code) {
+    auto compile_result = runtime->compile(code);
+    if (!compile_result.has_value()) {
+        return testing::AssertionFailure() << std::format(
+                 "unable to compile module: {}",
+                 compile_result.error().val.debug_string());
+    }
+    auto load_result = runtime->load(compile_result.value().raw());
+    if (!load_result.has_value()) {
+        return testing::AssertionFailure() << std::format(
+                 "unable to load module: {}",
+                 load_result.error().val.debug_string());
+    }
+    return testing::AssertionSuccess();
+}
+
+struct native_object {
+    std::expected<qjs::value, qjs::exception>
+    add(JSContext* ctx, std::span<qjs::value> args) {
+        if (args.size() != 2) {
+            last_result.emplace(std::unexpected(
+              qjs::exception::make(ctx, "wrong number of args")));
+        } else if (!args.front().is_number() || !args.back().is_number()) {
+            last_result.emplace(
+              std::unexpected(qjs::exception::make(ctx, "wrong types")));
+        } else {
+            last_result.emplace(qjs::value::number(
+              ctx, args.front().as_number() + args.back().as_number()));
+        }
+        return last_result.value();
+    }
+
+    // NOLINTNEXTLINE
+    std::optional<std::expected<qjs::value, qjs::exception>> last_result;
+};
+
+} // namespace
+
+TEST(JavascriptVMTest, LoadingCanFail) {
+    qjs::runtime runtime;
+    EXPECT_FALSE(compile_and_load(&runtime, R"(
+      throw new Error("causes failure");
+})"));
+}
+
+TEST(JavascriptVMTest, NativeModule) {
+    qjs::runtime runtime;
+    qjs::module_builder mod_builder("@foo/bar");
+    std::optional<std::expected<qjs::value, qjs::exception>> last_result;
+    mod_builder.add_function(
+      "testing",
+      [&last_result](
+        JSContext* ctx, const qjs::value&, std::span<qjs::value> args) {
+          native_object obj;
+          auto result = obj.add(ctx, args);
+          last_result.emplace(result);
+          return result;
+      });
+    EXPECT_TRUE(runtime.add_module(std::move(mod_builder)));
+    EXPECT_TRUE(compile_and_load(&runtime, R"(
+      import {testing} from "@foo/bar";
+
+      testing(1, 2);
+)"));
+    EXPECT_NE(last_result, std::nullopt);
+    EXPECT_TRUE(last_result->has_value());
+    EXPECT_EQ(last_result->value().as_number(), 3.0);
+
+    EXPECT_TRUE(compile_and_load(&runtime, R"(
+      import {testing} from "@foo/bar";
+
+      try {
+        testing(1);
+      } catch {
+        // ignore
+      }
+)"));
+    EXPECT_FALSE(last_result->has_value());
+}
+
+TEST(JavascriptVMTest, NativeModuleAndClass) {
+    qjs::runtime runtime;
+    qjs::class_builder<native_object> class_builder(
+      runtime.context(), "NativeObject");
+    class_builder.method<&native_object::add>("add");
+    auto class_factory = class_builder.build();
+    auto owned_obj = std::make_unique<native_object>();
+    auto* unowned_obj = owned_obj.get();
+    qjs::value js_class = class_factory.create(std::move(owned_obj));
+    qjs::module_builder mod_builder("@foo/bar");
+    mod_builder.add_function(
+      "get_obj",
+      [&js_class](JSContext*, const qjs::value&, std::span<qjs::value>) {
+          return js_class;
+      });
+    EXPECT_TRUE(runtime.add_module(std::move(mod_builder)));
+    EXPECT_TRUE(compile_and_load(&runtime, R"(
+      import {get_obj} from "@foo/bar";
+
+      get_obj().add(1, 4);
+)"));
+    EXPECT_NE(unowned_obj->last_result, std::nullopt);
+    EXPECT_TRUE(unowned_obj->last_result->has_value());
+    EXPECT_EQ(unowned_obj->last_result->value().as_number(), 5.0);
+
+    EXPECT_TRUE(compile_and_load(&runtime, R"(
+      import {get_obj} from "@foo/bar";
+
+
+      try {
+        get_obj().add(1);
+      } catch {
+        // ignore
+      }
+)"));
+    EXPECT_FALSE(unowned_obj->last_result->has_value());
+}
+
+TEST(JavascriptVMTest, Object) {
+    qjs::runtime runtime;
+    qjs::module_builder mod_builder("@foo/bar");
+    std::optional<qjs::value> last_result;
+    constexpr int num = 42;
+    mod_builder.add_function(
+      "object",
+      [](JSContext* ctx, const qjs::value&, std::span<qjs::value>)
+        -> std::expected<qjs::value, qjs::exception> {
+          auto obj = qjs::value::object(ctx);
+          auto result = obj.set_property("foo", qjs::value::number(ctx, num));
+          if (!result.has_value()) {
+              return std::unexpected(result.error());
+          }
+          return obj;
+      });
+    mod_builder.add_function(
+      "testing",
+      [&last_result](
+        JSContext* ctx, const qjs::value&, std::span<qjs::value> args) {
+          if (args.size() == 1) {
+              last_result = args.front();
+          }
+          return qjs::value::undefined(ctx);
+      });
+    EXPECT_TRUE(runtime.add_module(std::move(mod_builder)));
+    EXPECT_TRUE(compile_and_load(&runtime, R"(
+      import {testing, object} from "@foo/bar";
+
+      testing(object().foo);
+)"));
+    ASSERT_NE(last_result, std::nullopt);
+    EXPECT_EQ(last_result->as_number(), num);
+}
+
+// NOLINTEND(*-unchecked-optional-*,*-function-cognitive-complexity)

--- a/src/transform-sdk/js/js_vm_test.cc
+++ b/src/transform-sdk/js/js_vm_test.cc
@@ -180,4 +180,36 @@ TEST(JavascriptVMTest, Object) {
     EXPECT_EQ(last_result->as_number(), num);
 }
 
+TEST(JavascriptVMTest, Array) {
+    const qjs::runtime runtime;
+    auto arr = qjs::value::array(runtime.context());
+    auto to_vector = [&arr]() {
+        std::vector<double> result;
+        for (size_t i = 0; i < arr.array_length(); ++i) {
+            result.push_back(arr.get_element(i).as_number());
+        }
+        return result;
+    };
+    std::vector<double> shadow;
+    EXPECT_EQ(to_vector(), shadow);
+    EXPECT_EQ(arr.array_length(), 0);
+    EXPECT_TRUE(arr.push_back(qjs::value::number(runtime.context(), 4)));
+    shadow.push_back(4);
+    EXPECT_EQ(to_vector(), shadow);
+    EXPECT_EQ(arr.array_length(), 1);
+    EXPECT_TRUE(arr.push_back(qjs::value::number(runtime.context(), 3)));
+    shadow.push_back(3);
+    EXPECT_EQ(to_vector(), shadow);
+    EXPECT_EQ(arr.array_length(), 2);
+    EXPECT_TRUE(arr.push_back(qjs::value::number(runtime.context(), 2)));
+    shadow.push_back(2);
+    EXPECT_EQ(to_vector(), shadow);
+    EXPECT_EQ(arr.array_length(), 3);
+    EXPECT_TRUE(arr.push_back(qjs::value::number(runtime.context(), 1)));
+    shadow.push_back(1);
+    EXPECT_EQ(to_vector(), shadow);
+    EXPECT_EQ(arr.array_length(), 4);
+    EXPECT_TRUE(arr.get_element(10).is_undefined());
+}
+
 // NOLINTEND(*-unchecked-optional-*,*-function-cognitive-complexity)

--- a/src/transform-sdk/js/main.cc
+++ b/src/transform-sdk/js/main.cc
@@ -1,0 +1,362 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "js_vm.h"
+
+#include <redpanda/transform_sdk.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <expected>
+#include <memory>
+#include <optional>
+#include <print>
+#include <quickjs.h>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace redpanda::js {
+
+extern "C" {
+
+// The following functions are how the user's code is injected into the Wasm
+// binary. We leave this imported functions, and RPK will inject these symbols
+// in `rpk transform build` after esbuild runs.
+
+#ifdef __wasi__
+
+#define WASM_IMPORT(mod, name)                                                 \
+    __attribute__((import_module(#mod), import_name(#name)))
+
+WASM_IMPORT(redpanda_js_provider, file_length)
+uint32_t redpanda_js_source_file_length();
+
+WASM_IMPORT(redpanda_js_provider, get_file)
+void redpanda_js_source_get_file(char* dst);
+
+#else
+
+constexpr std::string_view test_source_file = R"(
+import {onRecordWritten} from "@redpanda-data/transform-sdk";
+
+onRecordWritten((event, writer) => {
+  return writer.write(event.record);
+});
+)";
+
+uint32_t redpanda_js_source_file_length() { return test_source_file.size(); }
+
+void redpanda_js_source_get_file(char* dst) {
+    std::memcpy(dst, test_source_file.data(), test_source_file.size());
+}
+
+#endif
+}
+
+/**
+ * A custom JS class holding opaque bytes, easily convertable into common JS
+ * types.
+ */
+class record_data {
+public:
+    explicit record_data(bytes_view data)
+      : _data(data) {}
+    record_data(const record_data&) = delete;
+    record_data& operator=(const record_data&) = delete;
+    record_data(record_data&&) = default;
+    record_data& operator=(record_data&&) = default;
+
+    std::expected<qjs::value, qjs::exception>
+    text(JSContext* ctx, std::span<qjs::value> /*params*/) {
+        return qjs::value::string(ctx, std::string_view{_data});
+    }
+
+    std::expected<qjs::value, qjs::exception>
+    json(JSContext* ctx, std::span<qjs::value> /*params*/) {
+        // TODO(rockwood): This is going to be the most common case, this needs
+        // to be zero copy.
+        std::string str;
+        str.append_range(_data);
+        return qjs::value::parse_json(ctx, str);
+    }
+
+    std::expected<qjs::value, qjs::exception>
+    array(JSContext* ctx, std::span<qjs::value> /*params*/) {
+        const std::span data_view = {// NOLINTNEXTLINE(*-const-cast)
+                                     const_cast<uint8_t*>(_data.data()),
+                                     _data.size()};
+        auto array = qjs::value::uint8_array(ctx, data_view);
+        // This memory isn't copied so we need to make sure we
+        // invalid these arrays when the memory is gone.
+        _arrays.push_back(array);
+        return array;
+    }
+
+    ~record_data() {
+        for (qjs::value array : _arrays) {
+            std::ignore = array.detach_uint8_array();
+        }
+    }
+
+    [[nodiscard]] bytes_view data() const { return _data; }
+
+private:
+    bytes_view _data;
+    std::vector<qjs::value> _arrays;
+};
+
+/**
+ * A JS class representation of redpanda::record_writer
+ */
+class record_writer {
+public:
+    explicit record_writer(
+      redpanda::record_writer* writer,
+      qjs::class_factory<record_data>* record_data)
+      : _writer(writer)
+      , _record_data(record_data) {}
+
+    std::expected<qjs::value, qjs::exception>
+    write(JSContext* ctx, std::span<qjs::value> params) {
+        if (params.size() != 1) [[unlikely]] {
+            return std::unexpected(qjs::exception::make(
+              ctx,
+              std::format(
+                "invalid number of parameters to writer.write, got: {}, "
+                "expected: 1",
+                params.size())));
+        }
+        auto& param = params.front();
+        if (!param.is_object()) [[unlikely]] {
+            return std::unexpected(qjs::exception::make(
+              ctx, "expected only object parameters to writer.write"));
+        }
+        auto key = extract_data(ctx, param.get_property("key"));
+        if (!key) [[unlikely]] {
+            return std::unexpected(key.error());
+        }
+        auto value = extract_data(ctx, param.get_property("value"));
+        if (!value) [[unlikely]] {
+            return std::unexpected(value.error());
+        }
+        // TODO(rockwood): include headers
+        auto errc = _writer->write({
+          .key = *key,
+          .value = *value,
+          .headers = {},
+        });
+        _strings.clear(); // free any allocated strings
+        if (errc) [[unlikely]] {
+            return std::unexpected(qjs::exception::make(
+              ctx, std::format("error writing record: {}", errc.message())));
+        }
+        return qjs::value::undefined(ctx);
+    }
+
+    std::expected<std::optional<redpanda::bytes_view>, qjs::exception>
+    extract_data(JSContext* ctx, const qjs::value& val) {
+        if (val.is_string()) {
+            _strings.emplace_back(val.string_data());
+            const auto& data = _strings.back();
+            return redpanda::bytes_view(data.view());
+        }
+        if (val.is_uint8_array()) {
+            auto data = val.uint8_array_data();
+            if (data.data() == nullptr) [[unlikely]] {
+                return std::unexpected(qjs::exception::current(ctx));
+            }
+            return redpanda::bytes_view(data.data(), data.size());
+        }
+        if (val.is_array_buffer()) {
+            auto data = val.array_buffer_data();
+            if (data.data() == nullptr) [[unlikely]] {
+                return std::unexpected(qjs::exception::current(ctx));
+            }
+            return redpanda::bytes_view(data.data(), data.size());
+        }
+        if (val.is_null() || val.is_undefined()) {
+            return std::nullopt;
+        }
+        record_data* record_data = _record_data->get_opaque(val);
+        if (record_data == nullptr) [[unlikely]] {
+            return std::unexpected(
+              qjs::exception::make(ctx, "unexpected type for record data"));
+        }
+        return record_data->data();
+    }
+
+private:
+    redpanda::record_writer* _writer;
+    qjs::class_factory<record_data>* _record_data;
+    std::vector<qjs::cstring> _strings; // a place to temporarily hold data.
+};
+
+qjs::class_factory<record_writer>
+make_record_writer_class(qjs::runtime* runtime) {
+    qjs::class_builder<record_writer> builder(
+      runtime->context(), "RecordWriter");
+    builder.method<&record_writer::write>("write");
+    return builder.build();
+}
+
+qjs::class_factory<record_data> make_record_data_class(qjs::runtime* runtime) {
+    qjs::class_builder<record_data> builder(runtime->context(), "RecordData");
+    builder.method<&record_data::json>("json");
+    builder.method<&record_data::text>("text");
+    builder.method<&record_data::array>("array");
+    return builder.build();
+}
+
+std::expected<qjs::value, qjs::exception> make_write_event(
+  JSContext* ctx,
+  const write_event& evt,
+  qjs::class_factory<record_data>* data_factory) {
+    qjs::value record = qjs::value::object(ctx);
+    std::expected<std::monostate, qjs::exception> result;
+    if (evt.record.key) {
+        result = record.set_property(
+          "key",
+          data_factory->create(std::make_unique<record_data>(*evt.record.key)));
+    } else {
+        result = record.set_property("key", qjs::value::null(ctx));
+    }
+    if (!result) [[unlikely]] {
+        return std::unexpected(result.error());
+    }
+    if (evt.record.value) {
+        result = record.set_property(
+          "value",
+          data_factory->create(
+            std::make_unique<record_data>(*evt.record.value)));
+    } else {
+        result = record.set_property("value", qjs::value::null(ctx));
+    }
+    if (!result) [[unlikely]] {
+        return std::unexpected(result.error());
+    }
+    qjs::value write_event = qjs::value::object(ctx);
+    result = write_event.set_property("record", record);
+    if (!result) [[unlikely]] {
+        return std::unexpected(result.error());
+    }
+    // TODO(rockwood): Also add headers to record object
+    return write_event;
+}
+
+std::expected<std::monostate, qjs::exception>
+initial_native_modules(qjs::runtime* runtime, qjs::value* user_callback) {
+    auto mod = qjs::module_builder("@redpanda-data/transform-sdk");
+    mod.add_function(
+      "onRecordWritten",
+      [user_callback](
+        JSContext* ctx, const qjs::value&, std::span<qjs::value> args)
+        -> std::expected<qjs::value, qjs::exception> {
+          if (args.size() != 1 || !args.front().is_function()) [[unlikely]] {
+              return std::unexpected(qjs::exception::make(
+                ctx,
+                "invalid argument, onRecordWritten must take only a single "
+                "function as an argument"));
+          }
+          return {std::exchange(*user_callback, std::move(args.front()))};
+      });
+    return runtime->add_module(std::move(mod));
+}
+
+std::expected<std::monostate, qjs::exception>
+compile_and_load(qjs::runtime* runtime) {
+    std::string source;
+    source.resize(redpanda_js_source_file_length(), 'a');
+    redpanda_js_source_get_file(source.data());
+    auto compile_result = runtime->compile(source);
+    if (!compile_result.has_value()) [[unlikely]] {
+        auto msg = qjs::value::string(
+          runtime->context(),
+          std::format(
+            "unable to compile module: {}",
+            compile_result.error().val.debug_string()));
+        return std::unexpected(qjs::exception(msg.value()));
+    }
+    auto load_result = runtime->load(compile_result.value().raw());
+    if (!load_result.has_value()) [[unlikely]] {
+        auto msg = qjs::value::string(
+          runtime->context(),
+          std::format(
+            "unable to load module: {}",
+            load_result.error().val.debug_string()));
+        if (!msg) {
+            return std::unexpected(msg.error());
+        }
+        return std::unexpected(qjs::exception(msg.value()));
+    }
+    return {};
+}
+
+int run() {
+    qjs::runtime runtime;
+    auto writer_factory = make_record_writer_class(&runtime);
+    auto data_factory = make_record_data_class(&runtime);
+    qjs::value record_callback = qjs::value::undefined(runtime.context());
+    auto result = initial_native_modules(&runtime, &record_callback);
+    if (!result) [[unlikely]] {
+        std::println(
+          stderr,
+          "unable to install native modules: {}",
+          result.error().val.debug_string());
+        return 1;
+    }
+    result = compile_and_load(&runtime);
+    if (!result) [[unlikely]] {
+        std::println(
+          stderr,
+          "unable to load module: {}",
+          result.error().val.debug_string());
+        return 1;
+    }
+    if (!record_callback.is_function()) [[unlikely]] {
+        std::println(stderr, "module did not call onRecordWritten");
+        return 1;
+    }
+    redpanda::on_record_written(
+      [&runtime, &writer_factory, &record_callback, &data_factory](
+        const redpanda::write_event& evt, redpanda::record_writer* writer) {
+          const qjs::value js_writer = writer_factory.create(
+            std::make_unique<record_writer>(writer, &data_factory));
+          auto event_result = make_write_event(
+            runtime.context(), evt, &data_factory);
+          if (!event_result) [[unlikely]] {
+              std::println(
+                stderr,
+                "error creating event: {}",
+                event_result.error().val.debug_string());
+              return std::make_error_code(std::errc::bad_message);
+          }
+          auto args = std::to_array({event_result.value(), js_writer});
+          auto js_result = record_callback.call(args);
+          if (js_result.has_value()) {
+              // TODO(rockwood): if this is a promise we should await it.
+              return std::error_code();
+          }
+          std::println(
+            stderr,
+            "error processing record: {}",
+            js_result.error().val.debug_string());
+          return std::make_error_code(std::errc::interrupted);
+      });
+    return 0;
+}
+
+} // namespace redpanda::js
+
+int main() { return redpanda::js::run(); }

--- a/src/transform-sdk/js/main.cc
+++ b/src/transform-sdk/js/main.cc
@@ -361,10 +361,18 @@ compile_and_load(qjs::runtime* runtime) {
 
 int run() {
     qjs::runtime runtime;
+    auto result = runtime.create_builtins();
+    if (!result) {
+        std::println(
+          stderr,
+          "unable to install globals: {}",
+          result.error().val.debug_string());
+        return 1;
+    }
     auto writer_factory = make_record_writer_class(&runtime);
     auto data_factory = make_record_data_class(&runtime);
     qjs::value record_callback = qjs::value::undefined(runtime.context());
-    auto result = initial_native_modules(&runtime, &record_callback);
+    result = initial_native_modules(&runtime, &record_callback);
     if (!result) [[unlikely]] {
         std::println(
           stderr,


### PR DESCRIPTION
Implement a QuickJS VM based Data Transforms SDK building on top of our C++ SDK.

This is still experimental and not ready for consumption, there is a lot of work
to plug this into RPK and get it easy to use.

Fixes: CORE-2371

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
