### PR TITLE
rptest: propagate log level to verifiable services

### DIFF
--- a/tests/rptest/services/verifiable_consumer.py
+++ b/tests/rptest/services/verifiable_consumer.py
@@ -264,8 +264,10 @@ class VerifiableConsumer(BackgroundThreadService):
                  stop_timeout_sec=45,
                  on_record_consumed=None,
                  reset_policy="earliest",
-                 verify_offsets=True):
+                 verify_offsets=True,
+                 log_level="INFO"):
         super(VerifiableConsumer, self).__init__(context, num_nodes)
+
         self.redpanda = redpanda
         self.topic = topic
         self.group_id = group_id
@@ -279,6 +281,8 @@ class VerifiableConsumer(BackgroundThreadService):
         self.stop_timeout_sec = stop_timeout_sec
         self.on_record_consumed = on_record_consumed
         self.verify_offsets = verify_offsets
+        self.log_level = log_level
+
         self.last_consumed = None
 
         self.event_handlers = {}
@@ -303,7 +307,8 @@ class VerifiableConsumer(BackgroundThreadService):
 
         # Create and upload log properties
         log_config = self.render('tools_log4j.properties',
-                                 log_file=VerifiableConsumer.LOG_FILE)
+                                 log_file=VerifiableConsumer.LOG_FILE,
+                                 log_level=self.log_level)
         node.account.create_file(VerifiableConsumer.LOG4J_CONFIG, log_config)
 
         # Create and upload config file

--- a/tests/rptest/services/verifiable_producer.py
+++ b/tests/rptest/services/verifiable_producer.py
@@ -174,7 +174,8 @@ class VerifiableProducer(BackgroundThreadService):
 
         # Create and upload log properties
         log_config = self.render('tools_log4j.properties',
-                                 log_file=VerifiableProducer.LOG_FILE)
+                                 log_file=VerifiableProducer.LOG_FILE,
+                                 log_level=self.log_level)
         node.account.create_file(VerifiableProducer.LOG4J_CONFIG, log_config)
 
         # Create and upload config file


### PR DESCRIPTION
Handy for debugging. VerifiableProducer had the object property but it wasn't propagated.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
