### PR TITLE
Update handling of bad logs for cloud deployments

### DIFF
--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -33,6 +33,8 @@ class CloudBroker():
         # Backward compatibility
         # Various classes will use this var to hash and compare nodes
         self.account = self._meta
+        # Mimic Ducktape cluster node hostname field
+        self.hostname = f"{self._spec['nodeName']}/{self.name}"
 
     def _query_broker(self, path, port=None):
         """

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -2135,7 +2135,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
                                    self.logger,
                                    self.kubectl,
                                    test_start_time=test_start_time)
-        lsearcher.search_logs(self.get_redpanda_pods())
+        lsearcher.search_logs(self.pods)
 
 
 class RedpandaService(RedpandaServiceBase):

--- a/tests/rptest/services/utils.py
+++ b/tests/rptest/services/utils.py
@@ -6,11 +6,19 @@ from abc import ABC, abstractmethod
 from typing import Generator, Optional
 
 from rptest.clients.kubectl import KubectlTool, KubeNodeShell
+from rptest.services.cloud_broker import CloudBroker
 
 
 class BadLogLines(Exception):
     def __init__(self, node_to_lines):
         self.node_to_lines = node_to_lines
+
+    @staticmethod
+    def _get_hostname(node):
+        if isinstance(node, CloudBroker):
+            return node.hostname
+        else:
+            return node.account.hostname
 
     def __str__(self):
         # Pick the first line from the first node as an example, and include it
@@ -20,7 +28,7 @@ class BadLogLines(Exception):
         example = next(iter(example_lines))
 
         summary = ','.join([
-            f'{i[0].account.hostname}({len(i[1])})'
+            f'{self._get_hostname(i[0])}({len(i[1])})'
             for i in self.node_to_lines.items()
         ])
         return f"<BadLogLines nodes={summary} example=\"{example}\">"
@@ -93,6 +101,12 @@ class LogSearch(ABC):
         """
         return ""
 
+    @staticmethod
+    def _get_badlines_exception(bad_loglines):
+        """Method to raise correct Exception class.
+        """
+        return BadLogLines(bad_loglines)
+
     def _check_if_line_allowed(self, line):
         for a in self.allow_list:
             if a.search(line) is not None:
@@ -154,7 +168,8 @@ class LogSearch(ABC):
         bad_loglines = self._search(nodes)
         # If anything, raise exception
         if bad_loglines:
-            raise BadLogLines(bad_loglines)
+            # Call class overriden method to get proper Exception class
+            raise self._get_badlines_exception(bad_loglines)
 
 
 class LogSearchLocal(LogSearch):
@@ -195,8 +210,7 @@ class LogSearchCloud(LogSearch):
 
         # Load log, output is in binary form
         loglines = []
-        pod_name = self._get_hostname(pod)
-        node_name = pod['spec']['nodeName']
+        node_name = pod._spec['nodeName']
         tz = "+00:00"
         with KubeNodeShell(self.kubectl, node_name) as ksh:
             try:
@@ -208,16 +222,16 @@ class LogSearchCloud(LogSearch):
                 # Find all log files for target pod
                 logfiles = ksh(f"find /var/log/pods -type f")
                 for logfile in logfiles:
-                    if pod_name in logfile and \
+                    if pod.name in logfile and \
                         'redpanda-configurator' not in logfile:
                         self.logger.info(f"Inspecting '{logfile}'")
                         lines = ksh(f"cat {logfile} | grep {expr}")
                         loglines += lines
             except Exception as e:
-                self.logger.warning(f"Error getting logs for {pod_name}: {e}")
+                self.logger.warning(f"Error getting logs for {pod.name}: {e}")
             else:
                 _size = len(loglines)
-                self.logger.debug(f"Received {_size}B of data from {pod_name}")
+                self.logger.debug(f"Received {_size}B of data from {pod.name}")
 
         # check log lines for proper timing.
         # Log lines will have two timing objects:
@@ -238,4 +252,4 @@ class LogSearchCloud(LogSearch):
             yield line
 
     def _get_hostname(self, host) -> str:
-        return host['metadata']['name']
+        return host.hostname

--- a/tests/rptest/services/utils.py
+++ b/tests/rptest/services/utils.py
@@ -101,12 +101,6 @@ class LogSearch(ABC):
         """
         return ""
 
-    @staticmethod
-    def _get_badlines_exception(bad_loglines):
-        """Method to raise correct Exception class.
-        """
-        return BadLogLines(bad_loglines)
-
     def _check_if_line_allowed(self, line):
         for a in self.allow_list:
             if a.search(line) is not None:
@@ -169,7 +163,7 @@ class LogSearch(ABC):
         # If anything, raise exception
         if bad_loglines:
             # Call class overriden method to get proper Exception class
-            raise self._get_badlines_exception(bad_loglines)
+            raise BadLogLines(bad_loglines)
 
 
 class LogSearchLocal(LogSearch):


### PR DESCRIPTION
Original code for `raise_on_bad_logs` uses the BadlogLines class which assumes that it will be initialized with Ducktape's `node` object. And subsequent `__str__` methon, which is used in creating summary. For this it gets hostname from original ducktape `Node` object.

For Cloud deployments there is two ways to solve it similarly: 
- pass pod dict and prepare similar summary by detecting which type has been passed to the Original BadLogLines exception
- Use CloudBroker class that works as a comparable substitution for RP Nodes in local runs and use it in preparing summary.

Since RedpandaServiceCloud uses Cloud broker class to handle raise_on_crash, use it for bad log lines as well.
Also, when generating summary from Exception class's __str__ method add child class to override hostname getter

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none