### PR TITLE
CORE-2365: storage: increase size of offset key map fragment size

### DIFF
--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -179,7 +179,8 @@ private:
     hash_type::digest_type hash_key(const compaction_key&) const;
 
     mutable hash_type hasher_;
-    large_fragment_vector<entry> entries_;
+    chunked_vector<entry> entries_;
+
     size_t size_{0};
     model::offset max_offset_;
     size_t capacity_{0};


### PR DESCRIPTION
With a fragmented_vector configured with 32KB fragments, the actual fragment will be the largest (given T) that doesn't exceed 32KB. For the offset key map the size of T=entry gave a fragment size of 20KB.

The default target size of the entire offset key map is roughly 128KB which works out to a achieved capacity of 8192 fragments when adding entries to the fragmented vector. Given that a vector is 24 bytes, this means that the allocation was 8192 * 24 ~ 190K allocation and this triggered the large allocation warning.

This PR changes the fragmented vector used in the offset key map to have
be a chunked_vector, which end up being around 80KB allocations when
fragment vector decides on the actual fragment size, so the final
allocation for the default configuration is around 45K.

Of course choosing a large map size would negate this solution. We don't really expect large sizes to be configured. In any case, this should not pose a problem is practice because we perform the entire allocation on bootup when memory is not fragmented. If we observe large configurations in the future we can continue to reduce the size (e.g. we could probably bit pack some data in the entry to get a "better" fit of T=entry into the target fragment size).

Fixes: https://github.com/redpanda-data/redpanda/issues/17860

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

