### PR TITLE
rm_stm: fix fence_pid_epoch cleanup

### DIFF
--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -221,6 +221,24 @@ rm_stm::parse_tx_control_batch(const model::record_batch& b) {
     return parse_control_batch(b);
 }
 
+void rm_stm::log_state::forget(const model::producer_identity& pid) {
+    fence_pid_epoch.erase(pid.get_id());
+    ongoing_map.erase(pid);
+    current_txes.erase(pid);
+    expiration.erase(pid);
+}
+
+void rm_stm::log_state::reset() {
+    fence_pid_epoch.clear();
+    ongoing_map.clear();
+    ongoing_set.clear();
+    current_txes.clear();
+    expiration.clear();
+    aborted.clear();
+    abort_indexes.clear();
+    last_abort_snapshot = {model::offset(-1)};
+}
+
 rm_stm::rm_stm(
   ss::logger& logger,
   raft::consensus* c,

--- a/src/v/cluster/rm_stm.cc
+++ b/src/v/cluster/rm_stm.cc
@@ -222,7 +222,10 @@ rm_stm::parse_tx_control_batch(const model::record_batch& b) {
 }
 
 void rm_stm::log_state::forget(const model::producer_identity& pid) {
-    fence_pid_epoch.erase(pid.get_id());
+    auto it = fence_pid_epoch.find(pid.get_id());
+    if (it != fence_pid_epoch.end() && it->second == pid.get_epoch()) {
+        fence_pid_epoch.erase(pid.get_id());
+    }
     ongoing_map.erase(pid);
     current_txes.erase(pid);
     expiration.erase(pid);

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -469,23 +469,8 @@ private:
           expiration_info>
           expiration;
 
-        void forget(const model::producer_identity& pid) {
-            fence_pid_epoch.erase(pid.get_id());
-            ongoing_map.erase(pid);
-            current_txes.erase(pid);
-            expiration.erase(pid);
-        }
-
-        void reset() {
-            fence_pid_epoch.clear();
-            ongoing_map.clear();
-            ongoing_set.clear();
-            current_txes.clear();
-            expiration.clear();
-            aborted.clear();
-            abort_indexes.clear();
-            last_abort_snapshot = {model::offset(-1)};
-        }
+        void forget(const model::producer_identity& pid);
+        void reset();
     };
 
     struct mem_state {


### PR DESCRIPTION
fence_pid_epoch maps a producer id to its latest epoch. Current cleanup code does not do a epoch check before cleaning up the pid state. This can result in removing the state related to the latest epoch. Consider the following series of events..

[x, y] = pid[id=x, epoch=y]

[1, 0] begin_tx - fence_pid_epoch[1] = 0
[1, 1] begin_tx - fence_pid_epoch[1] = 1
evict [1, 0]
erase(fence_pid[1]) ==> removes (1)

This results in a messed up state stalling the state of the transaction because the partition cannot make progress until it verifies the epoch.

This is a long pending bug that was exposed by racy evictions.

note: this whole code is going to be revamped soon and the plan is to add a self contained unit test fixture that supports transactions end-to-end, that should have better test coverage.

Fixes https://github.com/redpanda-data/redpanda/issues/17827

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
### Bug Fixes

* fix a race between eviction and producer registration that results in an invalid transaction state.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
