### PR TITLE
[v23.2.x] k/replicated_partition: fixed querying end offset of an empty log

### DIFF
--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -36,7 +36,7 @@ static constexpr std::string_view override_address = "RP_SI_CREDS_API_ADDRESS";
 /// Multiplier to derive sleep duration from expiry time. Leaves 0.1 * expiry
 /// seconds as buffer to make API calls. For default expiry of 1 hour, this
 /// results in a fetch after 54 minutes.
-constexpr float sleep_from_expiry_multiplier = 0.9;
+constexpr double sleep_from_expiry_multiplier = 0.9;
 constexpr std::chrono::milliseconds max_retry_interval_ms{300000};
 
 refresh_credentials::refresh_credentials(
@@ -223,7 +223,8 @@ std::chrono::milliseconds
 refresh_credentials::impl::calculate_sleep_duration(uint32_t expiry_sec) const {
     vlog(
       clrl_log.trace, "calculating sleep duration from {} seconds", expiry_sec);
-    int sleep = std::floor(expiry_sec * sleep_from_expiry_multiplier);
+    auto sleep = static_cast<uint32_t>(
+      std::floor(expiry_sec * sleep_from_expiry_multiplier));
     vlog(
       clrl_log.trace, "sleep duration adjusted with buffer: {} seconds", sleep);
     return std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -232,10 +232,6 @@ refresh_credentials::impl::calculate_sleep_duration(uint32_t expiry_sec) const {
 
 std::chrono::milliseconds refresh_credentials::impl::calculate_sleep_duration(
   std::chrono::system_clock::time_point expires_at) const {
-    vlog(
-      clrl_log.trace,
-      "calculating sleep duration for credential expiry at: {}",
-      expires_at.time_since_epoch());
     auto now = std::chrono::system_clock::now();
     auto diff = std::chrono::duration_cast<std::chrono::seconds>(
                   expires_at - now)

--- a/src/v/cloud_roles/refresh_credentials.cc
+++ b/src/v/cloud_roles/refresh_credentials.cc
@@ -236,6 +236,13 @@ std::chrono::milliseconds refresh_credentials::impl::calculate_sleep_duration(
     auto diff = std::chrono::duration_cast<std::chrono::seconds>(
                   expires_at - now)
                   .count();
+    if (diff < 0) {
+        vlog(
+          clrl_log.warn,
+          "negative sleep duration changed from {} to 10 seconds",
+          diff);
+        diff = 10;
+    }
     vlog(
       clrl_log.trace,
       "calculating sleep duration for credential expiry at: {}, now: {}, diff "

--- a/src/v/compat/tests/compat_test.cc
+++ b/src/v/compat/tests/compat_test.cc
@@ -22,6 +22,8 @@
 
 #include <boost/test/unit_test.hpp>
 
+#include <limits>
+
 namespace {
 // NOLINTNEXTLINE(misc-no-recursion)
 std::optional<bool>
@@ -60,7 +62,9 @@ perturb(json::Value& value, json::Document& doc, std::string& path) {
             }
         }
         const auto orig = v;
-        const int modifier = v == 0 ? 1 : -1;
+        const int modifier = (v == 0 || v == std::numeric_limits<T>::min())
+                               ? 1
+                               : -1;
         v += modifier;
         path = fmt::format("{} = {} ({}/{})", path, v, orig, modifier);
         return v;

--- a/src/v/kafka/server/replicated_partition.h
+++ b/src/v/kafka/server/replicated_partition.h
@@ -108,8 +108,8 @@ public:
         /**
          * By default we return a dirty_offset + 1
          */
-        return model::next_offset(
-          _translator->from_log_offset(_partition->dirty_offset()));
+        return _translator->from_log_offset(
+          model::next_offset(_partition->dirty_offset()));
     }
 
     model::offset leader_high_watermark() const {

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -56,7 +56,8 @@ set(srcs
   alter_config_test.cc
   produce_consume_test.cc
   group_metadata_serialization_test.cc
-  partition_reassignments_test.cc)
+  partition_reassignments_test.cc
+  replicated_partition_test.cc)
 
 rp_test(
   FIXTURE_TEST

--- a/src/v/kafka/server/tests/replicated_partition_test.cc
+++ b/src/v/kafka/server/tests/replicated_partition_test.cc
@@ -1,0 +1,77 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/fwd.h"
+#include "cluster/types.h"
+#include "kafka/server/partition_proxy.h"
+#include "kafka/server/replicated_partition.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+#include "model/namespace.h"
+#include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
+#include "model/timeout_clock.h"
+#include "redpanda/tests/fixture.h"
+#include "storage/record_batch_builder.h"
+#include "test_utils/async.h"
+
+FIXTURE_TEST(test_replicated_partition_end_offset, redpanda_thread_fixture) {
+    wait_for_controller_leadership().get();
+
+    model::topic_namespace tp_ns(
+      model::kafka_namespace, model::topic("test-topic"));
+
+    add_topic(tp_ns).get();
+    model::ntp ntp(tp_ns.ns, tp_ns.tp, model::partition_id(0));
+    auto shard = app.shard_table.local().shard_for(ntp);
+
+    tests::cooperative_spin_wait_with_timeout(10s, [this, shard, &ntp] {
+        return app.partition_manager.invoke_on(
+          *shard, [&ntp](cluster::partition_manager& pm) {
+              auto p = pm.get(ntp);
+              return p->get_leader_id().has_value();
+          });
+    }).get();
+
+    app.partition_manager
+      .invoke_on(
+        *shard,
+        [&ntp](cluster::partition_manager& pm) {
+            auto p = pm.get(ntp);
+            kafka::replicated_partition rp(p);
+            auto p_info = rp.get_partition_info();
+            /**
+             * Since log is empty from Kafka client perspective (no data
+             * batches), the end offset which is exclusive must be equal to 0
+             */
+            BOOST_REQUIRE_EQUAL(rp.log_end_offset(), model::offset{0});
+            BOOST_REQUIRE_EQUAL(rp.high_watermark(), model::offset{0});
+
+            storage::record_batch_builder builder(
+              model::record_batch_type::version_fence, model::offset(0));
+            builder.add_raw_kv(iobuf{}, iobuf{});
+            builder.add_raw_kv(iobuf{}, iobuf{});
+            builder.add_raw_kv(iobuf{}, iobuf{});
+
+            // replicate a batch that is subjected to offset translation
+            return p
+              ->replicate(
+                model::make_memory_record_batch_reader(
+                  {std::move(builder).build()}),
+                raft::replicate_options(raft::consistency_level::quorum_ack))
+              .then([p, rp](result<cluster::kafka_result> rr) {
+                  BOOST_REQUIRE(rr.has_value());
+                  BOOST_REQUIRE_GT(p->dirty_offset(), model::offset{0});
+
+                  BOOST_REQUIRE_EQUAL(rp.log_end_offset(), model::offset{0});
+                  BOOST_REQUIRE_EQUAL(rp.high_watermark(), model::offset{0});
+              });
+        })
+      .get();
+}

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2518,7 +2518,7 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
       [&] { return cnt > max; },
       [&log, &log_mutex] {
           auto offset = log->offsets();
-          if (offset.dirty_offset <= model::offset(0)) {
+          if (offset.dirty_offset == model::offset{}) {
               return ss::now();
           }
           return log_mutex.with([&log] {
@@ -2610,7 +2610,7 @@ FIXTURE_TEST(write_truncate_compact, storage_test_fixture) {
           [&] { return done; },
           [&log, &log_mutex] {
               auto offset = log->offsets();
-              if (offset.dirty_offset <= model::offset(0)) {
+              if (offset.dirty_offset == model::offset{}) {
                   return ss::now();
               }
               return log_mutex.with([&log] {
@@ -3441,7 +3441,7 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
       [&] { return cnt > max; },
       [&log, &log_mutex, &last_truncate] {
           auto offset = log->offsets();
-          if (offset.dirty_offset <= model::offset(0)) {
+          if (offset.dirty_offset == model::offset{}) {
               return ss::now();
           }
           return log_mutex

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -2485,6 +2485,9 @@ FIXTURE_TEST(read_write_truncate, storage_test_fixture) {
       [&] { return cnt > max; },
       [&log, &cnt] {
           auto offset = log->offsets();
+          if (offset.dirty_offset == model::offset{}) {
+              return ss::now();
+          }
           storage::log_reader_config cfg(
             std::max(model::offset(0), offset.dirty_offset - model::offset(10)),
             cnt % 2 == 0 ? offset.dirty_offset - model::offset(2)

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -3406,6 +3406,9 @@ FIXTURE_TEST(issue_8091, storage_test_fixture) {
     auto read = ss::do_until(
       [&] { return cnt > max; },
       [&log, &last_truncate] {
+          if (last_truncate == model::offset{}) {
+              return ss::now();
+          }
           auto offset = log->offsets();
           storage::log_reader_config cfg(
             last_truncate - model::offset(1),


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17789
Backport of PR #17026
Fixes: https://github.com/redpanda-data/redpanda/pull/17881