### PR TITLE
[v23.3.x] CORE-2365: storage: increase size of offset key map fragment size

### DIFF
--- a/src/v/storage/key_offset_map.h
+++ b/src/v/storage/key_offset_map.h
@@ -179,7 +179,8 @@ private:
     hash_type::digest_type hash_key(const compaction_key&) const;
 
     mutable hash_type hasher_;
-    large_fragment_vector<entry> entries_;
+    chunked_vector<entry> entries_;
+
     size_t size_{0};
     model::offset max_offset_;
     size_t capacity_{0};


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17879
Fixes: https://github.com/redpanda-data/redpanda/issues/17887,