### PR TITLE
tests: Marking test_drain_audit_disabled as ok_to_fail

### DIFF
--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -23,7 +23,7 @@ from typing import Any, Optional
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.errors import TimeoutError
-from ducktape.mark import matrix, ok_to_fail_fips
+from ducktape.mark import matrix, ok_to_fail, ok_to_fail_fips
 from keycloak import KeycloakOpenID
 from rptest.clients.default import DefaultClient
 from rptest.clients.kcl import KCL
@@ -675,6 +675,7 @@ class AuditLogTestsAppLifecycle(AuditLogTestBase):
                     True), lambda record_count: record_count == 3,
             "Single redpanda start event per node")
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/16198
     @ok_to_fail_fips
     @cluster(num_nodes=5)
     def test_drain_on_audit_disabled(self):


### PR DESCRIPTION
After investigation its been determined that the failure isn't really an indication of auditing not working properly.

The test verifies that on shutdown all stop application_lifecycle messages are observed, and during shutdown there is a short grace period in which shutdown will be held until these messages can be successfully produced, however there is no guarantee that the produce will succeed as shutdown is random and it may be the case that nodes that host the audit partition to produce to have already been shutdown.

Therefore the produce fails after the grace period and the message fails to make it to the audit log, making the test fail.

A potential fix is to have the audit log subsystem be partition agnostic when producing messages, but this means it must have the ability to  reacting to failures in a smarter way then just retrying, currently our kafka client does not support this. Although attempts have been made to implement this: https://github.com/redpanda-data/redpanda/pull/15202

Linking to CI issue: https://github.com/redpanda-data/redpanda/issues/16198

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

