### PR TITLE
Fix KafkaCliTools.produce in cloud tests

### DIFF
--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -107,6 +107,9 @@ sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginMo
 sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthLoginCallbackHandler
 """
 
+        # security config can't be parsed by the basic props parser in many of the
+        # cli tools (e.g., because they split on whitespace but security properties may
+        # contain embedded whitespace) but we can use a config file to get around this
         if security_config_text:
             self._command_config = tempfile.NamedTemporaryFile(mode="w")
             self._command_config.write(security_config_text)
@@ -296,6 +299,8 @@ sasl.login.callback.handler.class=io.strimzi.kafka.oauth.client.JaasClientOauthL
             "batch.size=%d" % batch_size,
             "bootstrap.servers=%s" % self._redpanda.brokers()
         ]
+        if self._command_config:
+            cmd += ["--producer.config", self._command_config.name]
         return self._execute(cmd, "produce")
 
     def list_acls(self):

--- a/tests/rptest/clients/kafka_cli_tools.py
+++ b/tests/rptest/clients/kafka_cli_tools.py
@@ -90,7 +90,7 @@ class KafkaCliTools:
                                              'SCRAM-SHA-256',
                                              tls_enabled=None)
 
-            if (sasl := security.simple_credentials()):
+            if sasl := security.simple_credentials():
                 security_config_text = f"""
 sasl.mechanism={sasl.mechanism}
 security.protocol={security.security_protocol}


### PR DESCRIPTION
KafkaCliTools.produce didn't work if SASL or TLS was enabled because
it failed to pass along the relevant configuration. This command does
not accept a config file via --command-config like many other cli tools
(this is how we pass this information to those tools), but it does
accept a --producer.config argument which serves the same purpose.

Set if additional security config needs to be passed in this way,
which fixes this test in the cloud.

Fixes https://github.com/redpanda-data/core-internal/issues/1256

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none 

## Release Notes

* none
