### PR TITLE
[v23.3.x] id_allocator: do not forward requests beyond first hop

### DIFF
--- a/src/v/cluster/id_allocator.cc
+++ b/src/v/cluster/id_allocator.cc
@@ -31,15 +31,15 @@ id_allocator::allocate_id(allocate_id_request req, rpc::streaming_context&) {
     auto timeout = req.timeout;
     return _id_allocator_frontend.local()
       .allocator_router()
-      .allocate_router::process_or_dispatch(
-        std::move(req), model::id_allocator_ntp, timeout);
+      .find_shard_and_process(std::move(req), model::id_allocator_ntp, timeout);
 }
 
 ss::future<reset_id_allocator_reply> id_allocator::reset_id_allocator(
   reset_id_allocator_request req, rpc::streaming_context&) {
     auto timeout = req.timeout;
-    return _id_allocator_frontend.local().id_reset_router().process_or_dispatch(
-      std::move(req), model::id_allocator_ntp, timeout);
+    return _id_allocator_frontend.local()
+      .id_reset_router()
+      .find_shard_and_process(std::move(req), model::id_allocator_ntp, timeout);
 }
 
 } // namespace cluster


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17892
Fixes: https://github.com/redpanda-data/redpanda/issues/17897,