### PR TITLE
Schema Registry: Improve retries and tombstoning

### DIFF
--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -13,6 +13,12 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "defaultToGlobal",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "produces": ["application/vnd.schemaregistry.v1+json"],
@@ -20,12 +26,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibilityLevel": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/get_compatibility"
             }
           },
           "500": {
@@ -55,12 +56,7 @@
             "name": "config",
             "in": "body",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
             }
           }
         ],
@@ -69,12 +65,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
             }
           },
           "500": {
@@ -106,12 +97,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
             }
           },
           "404": {
@@ -144,12 +130,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibilityLevel": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/get_compatibility"
             }
           },
           "500": {
@@ -173,12 +154,7 @@
             "name": "config",
             "in": "body",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
             }
           }
         ],
@@ -187,12 +163,7 @@
           "200": {
             "description": "OK",
             "schema": {
-              "type": "object",
-              "properties": {
-                "compatibility": {
-                  "type": "string"
-                }
-              }
+              "$ref": "#/definitions/put_compatibility"
             }
           },
           "500": {

--- a/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry_definitions.def.json
@@ -74,4 +74,20 @@
           "type": "string"
         }
       }
+    },
+    "get_compatibility": {
+      "type": "object",
+      "properties": {
+          "compatibilityLevel": {
+            "type": "string"
+          }
+      }
+    },
+    "put_compatibility": {
+      "type": "object",
+      "properties": {
+          "compatibility": {
+            "type": "string"
+          }
+      }
     }

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -235,9 +235,8 @@ ss::future<bool> seq_writer::write_config(
       });
 }
 
-ss::future<std::optional<bool>>
-seq_writer::do_delete_config(subject sub, model::offset write_at) {
-    vlog(plog.debug, "delete config sub={} offset={}", sub, write_at);
+ss::future<std::optional<bool>> seq_writer::do_delete_config(subject sub) {
+    vlog(plog.debug, "delete config sub={}", sub);
 
     try {
         co_await _store.get_compatibility(sub, default_to_global::no);
@@ -297,8 +296,8 @@ seq_writer::do_delete_config(subject sub, model::offset write_at) {
 
 ss::future<bool> seq_writer::delete_config(subject sub) {
     return sequenced_write(
-      [sub{std::move(sub)}](model::offset write_at, seq_writer& seq) {
-          return seq.do_delete_config(sub, write_at);
+      [sub{std::move(sub)}](model::offset, seq_writer& seq) {
+          return seq.do_delete_config(sub);
       });
 }
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -446,7 +446,7 @@ seq_writer::delete_subject_permanent_inner(
 
     // Deleting the subject, or the last version, deletes the subject
     if (!version.has_value() || versions.size() == 1) {
-        sequences = co_await _store.get_subject_written_at(sub);
+        rb(co_await _store.get_subject_written_at(sub));
     }
     rb(sequences);
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.cc
+++ b/src/v/pandaproxy/schema_registry/seq_writer.cc
@@ -17,7 +17,9 @@
 #include "pandaproxy/schema_registry/exceptions.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
 #include "pandaproxy/schema_registry/storage.h"
+#include "pandaproxy/schema_registry/types.h"
 #include "ssx/future-util.h"
+#include "storage/record_batch_builder.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
@@ -27,6 +29,73 @@
 using namespace std::chrono_literals;
 
 namespace pandaproxy::schema_registry {
+
+namespace {
+
+struct batch_builder : public storage::record_batch_builder {
+    explicit batch_builder(
+      model::offset base_offset, std::optional<subject> sub)
+      : record_batch_builder{model::record_batch_type::raft_data, model::offset{base_offset}}
+      , sub{std::move(sub)} {}
+
+    using record_batch_builder::add_raw_kv;
+    using record_batch_builder::build;
+
+    void operator()(std::optional<iobuf>&& key, std::optional<iobuf>&& value) {
+        add_raw_kw(std::move(key), std::move(value), {});
+    }
+
+    template<typename K, typename V>
+    requires requires(K k, V v) {
+        to_json_iobuf(k);
+        to_json_iobuf(v);
+    }
+    void operator()(K&& key, V&& value) {
+        add_raw_kv(
+          to_json_iobuf(std::forward<K>(key)),
+          to_json_iobuf(std::forward<V>(value)));
+    }
+
+    void operator()(const seq_marker& s) {
+        vlog(
+          plog.debug,
+          "Delete {} tombstoning sub={} at {}",
+          to_string_view(s.key_type),
+          sub,
+          s);
+
+        // Assumption: magic is the same as it was when key was
+        // originally read.
+        switch (s.key_type) {
+        case seq_marker_key_type::schema: {
+            auto key = schema_key{
+              .seq{s.seq}, .node{s.node}, .sub{*sub}, .version{s.version}};
+            add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
+        } break;
+        case seq_marker_key_type::delete_subject: {
+            auto key = delete_subject_key{
+              .seq{s.seq}, .node{s.node}, .sub{*sub}};
+            add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
+        } break;
+        case seq_marker_key_type::config: {
+            auto key = config_key{.seq{s.seq}, .node{s.node}, .sub{sub}};
+            add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
+        } break;
+        default:
+            vassert(false, "Unknown key type");
+        }
+    }
+
+    void operator()(const std::vector<seq_marker>& sequences) {
+        for (const seq_marker& s : sequences) {
+            (*this)(s);
+        }
+    }
+
+    std::optional<subject> sub;
+};
+
+} // namespace
 
 /// Call this before reading from the store, if servicing
 /// a REST API endpoint that requires global knowledge of latest
@@ -70,37 +139,36 @@ ss::future<> seq_writer::wait_for(model::offset offset) {
 /// Helper for write methods that need to check + retry if their
 /// write landed where they expected it to.
 ///
-/// \param write_at Offset at which caller expects their write to land
+/// \param write_at Offset at which caller expects their write to land. If
+/// std::nullopt, the offset is not checked.
 /// \param batch Message to write
 /// \return true if the write landed at `write_at`, else false
-ss::future<bool> seq_writer::produce_and_check(
-  model::offset write_at, model::record_batch batch) {
-    // Because we rely on checking exactly where our message (singular) landed,
-    // only use this function with batches of a single message.
-    vassert(batch.record_count() == 1, "Only single-message batches allowed");
+ss::future<bool> seq_writer::produce_and_apply(
+  std::optional<model::offset> write_at, model::record_batch batch) {
+    vassert(
+      write_at.value_or(batch.base_offset()) == batch.base_offset(),
+      "Set the base_offset to the expected write_at");
 
     kafka::partition_produce_response res
       = co_await _client.local().produce_record_batch(
-        model::schema_registry_internal_tp, std::move(batch));
+        model::schema_registry_internal_tp, batch.copy());
 
-    // TODO(Ben): Check the error reporting here
     if (res.error_code != kafka::error_code::none) {
         throw kafka::exception(res.error_code, *res.error_message);
     }
 
-    auto wrote_at = res.base_offset;
-    if (wrote_at == write_at) {
-        vlog(plog.debug, "seq_writer: Successful write at {}", wrote_at);
-
-        co_return true;
+    auto success = write_at.value_or(res.base_offset) == res.base_offset;
+    if (success) {
+        vlog(plog.debug, "seq_writer: Successful write at {}", res.base_offset);
+        co_await consume_to_store(_store, *this)(std::move(batch));
     } else {
         vlog(
           plog.debug,
           "seq_writer: Failed write at {} (wrote at {})",
           write_at,
-          wrote_at);
-        co_return false;
+          res.base_offset);
     }
+    co_return success;
 };
 
 ss::future<> seq_writer::advance_offset(model::offset offset) {
@@ -162,16 +230,13 @@ ss::future<std::optional<schema_id>> seq_writer::do_write_subject_version(
           .id{projected.id},
           .deleted = is_deleted::no};
 
-        auto batch = as_record_batch(key, value);
+        batch_builder rb(write_at, schema.schema.sub());
+        rb(std::move(key), std::move(value));
 
-        auto success = co_await produce_and_check(write_at, std::move(batch));
-        if (success) {
-            auto applier = consume_to_store(_store, *this);
-            using Tag = decltype(value.schema)::tag;
-            co_await applier.apply<Tag>(write_at, key, value);
-            advance_offset_inner(write_at);
+        if (co_await produce_and_apply(write_at, std::move(rb).build())) {
             co_return projected.id;
         } else {
+            // Pass up a None, our caller's cue to retry
             co_return std::nullopt;
         }
     }
@@ -211,15 +276,12 @@ ss::future<std::optional<bool>> seq_writer::do_write_config(
         // ignore
     }
 
-    auto key = config_key{.seq{write_at}, .node{_node_id}, .sub{sub}};
-    auto value = config_value{.compat = compat};
-    auto batch = as_record_batch(key, value);
+    batch_builder rb(write_at, sub);
+    rb(
+      config_key{.seq{write_at}, .node{_node_id}, .sub{sub}},
+      config_value{.compat = compat});
 
-    auto success = co_await produce_and_check(write_at, std::move(batch));
-    if (success) {
-        auto applier = consume_to_store(_store, *this);
-        co_await applier.apply(write_at, key, value);
-        advance_offset_inner(write_at);
+    if (co_await produce_and_apply(write_at, std::move(rb).build())) {
         co_return true;
     } else {
         // Pass up a None, our caller's cue to retry
@@ -245,52 +307,10 @@ ss::future<std::optional<bool>> seq_writer::do_delete_config(subject sub) {
         co_return false;
     }
 
-    std::vector<seq_marker> sequences{
-      co_await _store.get_subject_config_written_at(sub)};
+    batch_builder rb{model::offset{0}, sub};
+    rb(co_await _store.get_subject_config_written_at(sub));
 
-    storage::record_batch_builder rb{
-      model::record_batch_type::raft_data, model::offset{0}};
-
-    std::vector<config_key> keys;
-    for (const auto& s : sequences) {
-        vlog(
-          plog.debug,
-          "Deleting config: tombstoning config_key for sub={} at {}",
-          sub,
-          s);
-
-        vassert(
-          s.key_type == seq_marker_key_type::config,
-          "Unexpected key type: {}",
-          s.key_type);
-
-        auto key = config_key{.seq{s.seq}, .node{s.node}, .sub{sub}};
-        keys.push_back(key);
-        rb.add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
-    }
-
-    auto ts_batch = std::move(rb).build();
-    kafka::partition_produce_response res
-      = co_await _client.local().produce_record_batch(
-        model::schema_registry_internal_tp, std::move(ts_batch));
-
-    if (res.error_code != kafka::error_code::none) {
-        vlog(
-          plog.error,
-          "Error writing to subject topic: {} {}",
-          res.error_code,
-          res.error_message);
-        throw kafka::exception(res.error_code, *res.error_message);
-    }
-
-    auto applier = consume_to_store(_store, *this);
-    auto offset = res.base_offset;
-    for (const auto& k : keys) {
-        co_await applier.apply(offset, k, std::nullopt);
-        advance_offset_inner(offset);
-        ++offset;
-    }
-
+    co_await produce_and_apply(std::nullopt, std::move(rb).build());
     co_return true;
 }
 
@@ -321,14 +341,10 @@ ss::future<std::optional<bool>> seq_writer::do_delete_subject_version(
       .id{ss.id},
       .deleted{is_deleted::yes}};
 
-    auto batch = as_record_batch(key, value);
+    batch_builder rb(write_at, sub);
+    rb(std::move(key), std::move(value));
 
-    auto success = co_await produce_and_check(write_at, std::move(batch));
-    if (success) {
-        auto applier = consume_to_store(_store, *this);
-        using Tag = decltype(value.schema)::tag;
-        co_await applier.apply<Tag>(write_at, key, value);
-        advance_offset_inner(write_at);
+    if (co_await produce_and_apply(write_at, std::move(rb).build())) {
         co_return true;
     } else {
         // Pass up a None, our caller's cue to retry
@@ -365,15 +381,12 @@ seq_writer::do_delete_subject_impermanent(subject sub, model::offset write_at) {
     }
 
     // Proceed to write
-    auto key = delete_subject_key{.seq{write_at}, .node{_node_id}, .sub{sub}};
-    auto value = delete_subject_value{.sub{sub}};
-    auto batch = as_record_batch(key, value);
+    batch_builder rb{write_at, sub};
+    rb(
+      delete_subject_key{.seq{write_at}, .node{_node_id}, .sub{sub}},
+      delete_subject_value{.sub{sub}});
 
-    auto success = co_await produce_and_check(write_at, std::move(batch));
-    if (success) {
-        auto applier = consume_to_store(_store, *this);
-        co_await applier.apply(write_at, key, value);
-        advance_offset_inner(write_at);
+    if (co_await produce_and_apply(write_at, std::move(rb).build())) {
         co_return versions;
     } else {
         // Pass up a None, our caller's cue to retry
@@ -407,6 +420,8 @@ ss::future<std::vector<schema_version>>
 seq_writer::delete_subject_permanent_inner(
   subject sub, std::optional<schema_version> version) {
     std::vector<seq_marker> sequences;
+    batch_builder rb{model::offset{0}, sub};
+
     /// Check for whether our victim is already soft-deleted happens
     /// within these store functions (will throw a 404-equivalent if so)
     vlog(plog.debug, "delete_subject_permanent sub={}", sub);
@@ -423,78 +438,9 @@ seq_writer::delete_subject_permanent_inner(
     if (!version.has_value() || versions.size() == 1) {
         sequences = co_await _store.get_subject_written_at(sub);
     }
+    rb(sequences);
 
-    storage::record_batch_builder rb{
-      model::record_batch_type::raft_data, model::offset{0}};
-
-    std::vector<std::variant<schema_key, delete_subject_key, config_key>> keys;
-    for (auto s : sequences) {
-        vlog(
-          plog.debug,
-          "Delete subject_permanent: tombstoning sub={} at {}",
-          sub,
-          s);
-
-        // Assumption: magic is the same as it was when key was
-        // originally read.
-        switch (s.key_type) {
-        case seq_marker_key_type::schema: {
-            auto key = schema_key{
-              .seq{s.seq}, .node{s.node}, .sub{sub}, .version{s.version}};
-            keys.push_back(key);
-            rb.add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
-        } break;
-        case seq_marker_key_type::delete_subject: {
-            auto key = delete_subject_key{
-              .seq{s.seq}, .node{s.node}, .sub{sub}};
-            keys.push_back(key);
-            rb.add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
-        } break;
-        case seq_marker_key_type::config: {
-            auto key = config_key{.seq{s.seq}, .node{s.node}, .sub{sub}};
-            keys.push_back(key);
-            rb.add_raw_kv(to_json_iobuf(std::move(key)), std::nullopt);
-        } break;
-        default:
-            vassert(false, "Unknown key type");
-        }
-    }
-
-    // Produce tombstones.  We do not need to check where they landed,
-    // because these can arrive in any order and be safely repeated.
-    auto batch = std::move(rb).build();
-
-    kafka::partition_produce_response res
-      = co_await _client.local().produce_record_batch(
-        model::schema_registry_internal_tp, std::move(batch));
-    if (res.error_code != kafka::error_code::none) {
-        vlog(
-          plog.error,
-          "Error writing to schema topic: {} {}",
-          res.error_code,
-          res.error_message);
-        throw kafka::exception(res.error_code, *res.error_message);
-    }
-
-    // Replay the persisted deletions into our store
-    auto applier = consume_to_store(_store, *this);
-    auto offset = res.base_offset;
-    for (auto k : keys) {
-        co_await ss::visit(
-          k,
-          [&applier, &offset](const schema_key& skey) {
-              using Tag = canonical_schema_definition_tag;
-              return applier.apply<Tag>(offset, skey, std::nullopt);
-          },
-          [&applier, &offset](const delete_subject_key& dkey) {
-              return applier.apply(offset, dkey, std::nullopt);
-          },
-          [&applier, &offset](const config_key& ckey) {
-              return applier.apply(offset, ckey, std::nullopt);
-          });
-        advance_offset_inner(offset);
-        offset++;
-    }
+    co_await produce_and_apply(std::nullopt, std::move(rb).build());
     co_return versions;
 }
 

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -85,7 +85,8 @@ private:
     ss::future<std::optional<std::vector<schema_version>>>
     do_delete_subject_impermanent(subject sub, model::offset write_at);
 
-    ss::future<std::vector<schema_version>> delete_subject_permanent_inner(
+    ss::future<std::optional<std::vector<schema_version>>>
+    delete_subject_permanent_inner(
       subject sub, std::optional<schema_version> version);
 
     simple_time_jitter<ss::lowres_clock> _jitter{std::chrono::milliseconds{50}};

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -69,27 +69,22 @@ private:
 
     void advance_offset_inner(model::offset offset);
 
-    ss::future<std::optional<schema_id>> do_write_subject_version(
-      subject_schema schema, model::offset write_at, seq_writer& seq);
+    ss::future<std::optional<schema_id>>
+    do_write_subject_version(subject_schema schema, model::offset write_at);
 
     ss::future<std::optional<bool>> do_write_config(
       std::optional<subject> sub,
       compatibility_level compat,
-      model::offset write_at,
-      seq_writer& seq);
+      model::offset write_at);
 
     ss::future<std::optional<bool>>
-    do_delete_config(subject sub, model::offset write_at, seq_writer& seq);
+    do_delete_config(subject sub, model::offset write_at);
 
     ss::future<std::optional<bool>> do_delete_subject_version(
-      subject sub,
-      schema_version version,
-      model::offset write_at,
-      seq_writer& seq);
+      subject sub, schema_version version, model::offset write_at);
 
     ss::future<std::optional<std::vector<schema_version>>>
-    do_delete_subject_impermanent(
-      subject sub, model::offset write_at, seq_writer& seq);
+    do_delete_subject_impermanent(subject sub, model::offset write_at);
 
     ss::future<std::vector<schema_version>> delete_subject_permanent_inner(
       subject sub, std::optional<schema_version> version);

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -159,8 +159,8 @@ private:
         }
     }
 
-    ss::future<bool>
-    produce_and_check(model::offset write_at, model::record_batch batch);
+    ss::future<bool> produce_and_apply(
+      std::optional<model::offset> write_at, model::record_batch batch);
 
     /// Block until this offset is available, fetching if necessary
     ss::future<> wait_for(model::offset offset);

--- a/src/v/pandaproxy/schema_registry/seq_writer.h
+++ b/src/v/pandaproxy/schema_registry/seq_writer.h
@@ -77,8 +77,7 @@ private:
       compatibility_level compat,
       model::offset write_at);
 
-    ss::future<std::optional<bool>>
-    do_delete_config(subject sub, model::offset write_at);
+    ss::future<std::optional<bool>> do_delete_config(subject sub);
 
     ss::future<std::optional<bool>> do_delete_subject_version(
       subject sub, schema_version version, model::offset write_at);


### PR DESCRIPTION
A few drive-by improvements and refactoring

1. Tidy up swagger for config
2. Refactor `seq_writer`
   1. Remove unusual "this" parameter
   2. Remove unused params
   3. Factor out seq_marker construction into batch_builder
   4. Simplify `consume_to_store` by reusing the batch
       1. This is slightly more work, due to decoding, but means a consistent code path is taken.
   5. Refactor all writes through `produce_and_apply`
3. Add retry logic for
    1. `delete_config`
    2. `delete_subject_permanent`
4. Improve tombstoning
   1. Remove config when soft deleting subject
   2. When permanantly deleting a subject, delete the subject version, even if it's the last one.

@BenPope

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Schema Registry: Improve retry logic for `delete_config` and `delete_subject_permanent`
* Schema Registry: Improve tombstoning when deleting a subject
