### PR TITLE
c/hm_backend: cache the collected report

### DIFF
--- a/src/v/cluster/health_monitor_backend.cc
+++ b/src/v/cluster/health_monitor_backend.cc
@@ -548,6 +548,10 @@ health_monitor_backend::get_current_node_health() {
     }
 
     auto u = _report_collection_mutex.try_get_units();
+    /**
+     * If units are not available it indicates that the other fiber is
+     * collecting node health. We wait for the report to be available
+     */
     if (!u) {
         vlog(
           clusterlog.debug,
@@ -558,8 +562,16 @@ health_monitor_backend::get_current_node_health() {
             co_return *it->second;
         }
     }
+    /**
+     * Current fiber will collect and cache the report
+     */
+    auto r = co_await collect_current_node_health();
+    if (r.has_value()) {
+        _reports.emplace(
+          _self, ss::make_lw_shared<node_health_report>(r.value()));
+    }
 
-    co_return co_await collect_current_node_health();
+    co_return std::move(r);
 }
 
 namespace {


### PR DESCRIPTION
When report is collected by the fiber requesting current node health report it should be cached in the reports cache to prevent the next collection. Added caching of the current node health report.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none