### PR TITLE
rptest: remove node from started list after kill

### DIFF
--- a/tests/rptest/tests/write_caching_fi_test.py
+++ b/tests/rptest/tests/write_caching_fi_test.py
@@ -200,7 +200,7 @@ class WriteCachingFailureInjectionTest(RedpandaTest):
 
         # Crash the second node. Since it didn't fsync the data, the data
         # some messages will be locally lost on the next restart.
-        self.redpanda.signal_redpanda(self.redpanda.nodes[1])
+        self.redpanda.stop_node(self.redpanda.nodes[1], forced=True)
 
         # Isolate the 3rd node. This is the only node that has all the data.
         fi.inject_failure(
@@ -234,7 +234,7 @@ class WriteCachingFailureInjectionTest(RedpandaTest):
 
         # Kill the first node just to make sure that second and third can form
         # a new quorum.
-        self.redpanda.signal_redpanda(self.redpanda.nodes[0])
+        self.redpanda.stop_node(self.redpanda.nodes[0], forced=True)
 
         third_quorum_hwm = wait_until_result(_hwm,
                                              timeout_sec=30,
@@ -265,7 +265,7 @@ class WriteCachingFailureInjectionTest(RedpandaTest):
         Crash all nodes and restart them.
         """
         def _crash_and_start_node(n):
-            self.redpanda.signal_redpanda(n)
+            self.redpanda.stop_node(n, forced=True)
             self.redpanda.start_node(n)
 
         self.redpanda.for_nodes(self.redpanda.nodes, _crash_and_start_node)
@@ -285,7 +285,7 @@ class WriteCachingFailureInjectionTest(RedpandaTest):
         node = self.redpanda.get_node(leader_id)
 
         self.logger.debug(f"Restarting leader node: {node.name}")
-        self.redpanda.signal_redpanda(node)
+        self.redpanda.stop_node(node, forced=True)
 
         def _wait_new_leader():
             new_leader_id = admin.get_partition_leader(namespace="kafka",


### PR DESCRIPTION
We have a wrapper RedpandaService.wait_until which is used to wait for
conditions as long as the cluster is "healthy". Healthy is defined as
all "started nodes" being up.

When we call signal_redpanda to kill a particular node on purpose. In
this case, we also need to remove the node from the started nodes list
otherwise the above check will trip thinking that a node is crashed or
something similar.

I have tried to add this logic inside the signal_redpanda method in
[https://github.com/redpanda-data/redpanda/pull/17889][1] but discovered that there are tests which rely on the
existing behavior already.

@bharathv noticed that stop_node can be used instead so this PR does
that.

Fixes https://github.com/redpanda-data/redpanda/issues/17886

[1]: https://github.com/redpanda-data/redpanda/pull/17889

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
