### PR TITLE
Added detection of the node with longest log during leader election process

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -406,6 +406,15 @@ configuration::configuration()
           }
           return std::nullopt;
       })
+  , raft_enable_longest_log_detection(
+      *this,
+      "raft_enable_longest_log_detection",
+      "Enables additional step in leader election where candidate is allowed "
+      "to wait for all the replies from node it requested votes from. This may "
+      "introduce a small delay when recovering from failure but will prevent "
+      "truncation if any of the replicas has more data than the majority.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      true)
   , enable_usage(
       *this,
       "enable_usage",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -107,6 +107,7 @@ struct configuration final : public config_store {
     property<std::optional<size_t>> raft_replica_max_pending_flush_bytes;
     property<std::chrono::milliseconds> raft_flush_timer_interval_ms;
     property<std::chrono::milliseconds> raft_replica_max_flush_delay_ms;
+    property<bool> raft_enable_longest_log_detection;
     // Kafka
     property<bool> enable_usage;
     bounded_property<size_t> usage_num_windows;

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -100,6 +100,7 @@ consensus::consensus(
   ss::shared_ptr<storage::log> l,
   scheduling_config scheduling_config,
   config::binding<std::chrono::milliseconds> disk_timeout,
+  config::binding<bool> enable_longest_log_detection,
   consensus_client_protocol client,
   consensus::leader_cb_t cb,
   storage::api& storage,
@@ -116,6 +117,7 @@ consensus::consensus(
   , _log(l)
   , _scheduling(scheduling_config)
   , _disk_timeout(std::move(disk_timeout))
+  , _enable_longest_log_detection(std::move(enable_longest_log_detection))
   , _client_protocol(client)
   , _leader_notification(std::move(cb))
   , _fstats(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -13,6 +13,7 @@
 
 #include "base/likely.h"
 #include "base/seastarx.h"
+#include "config/property.h"
 #include "features/feature_table.h"
 #include "hashing/crc32c.h"
 #include "metrics/metrics.h"
@@ -99,6 +100,7 @@ public:
       ss::shared_ptr<storage::log>,
       scheduling_config,
       config::binding<std::chrono::milliseconds> disk_timeout,
+      config::binding<bool> enable_longest_log_detection,
       consensus_client_protocol,
       leader_cb_t,
       storage::api&,
@@ -778,6 +780,7 @@ private:
     ss::shared_ptr<storage::log> _log;
     scheduling_config _scheduling;
     config::binding<std::chrono::milliseconds> _disk_timeout;
+    config::binding<bool> _enable_longest_log_detection;
     consensus_client_protocol _client_protocol;
     leader_cb_t _leader_notification;
 

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -111,6 +111,7 @@ ss::future<ss::lw_shared_ptr<raft::consensus>> group_manager::create_group(
       log,
       scheduling_config(_raft_sg, raft_priority()),
       _configuration.raft_io_timeout_ms,
+      _configuration.enable_longest_log_detection,
       _client,
       [this](raft::leadership_status st) {
           trigger_leadership_notification(std::move(st));

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "cluster/notification.h"
+#include "config/property.h"
 #include "metrics/metrics.h"
 #include "model/metadata.h"
 #include "raft/heartbeat_manager.h"
@@ -47,6 +48,7 @@ public:
         config::binding<model::write_caching_mode> write_caching;
         config::binding<std::chrono::milliseconds> write_caching_flush_ms;
         config::binding<std::optional<size_t>> write_caching_flush_bytes;
+        config::binding<bool> enable_longest_log_detection;
     };
     using config_provider_fn = ss::noncopyable_function<configuration()>;
 

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -163,14 +163,16 @@ public:
       ss::sstring base_directory,
       raft_node_map& node_map,
       ss::sharded<features::feature_table>& feature_table,
-      leader_update_clb_t leader_update_clb);
+      leader_update_clb_t leader_update_clb,
+      bool enable_longest_log_detection);
 
     raft_node_instance(
       model::node_id id,
       model::revision_id revision,
       raft_node_map& node_map,
       ss::sharded<features::feature_table>& feature_table,
-      leader_update_clb_t leader_update_clb);
+      leader_update_clb_t leader_update_clb,
+      bool enable_longest_log_detection);
 
     raft_node_instance(const raft_node_instance&) = delete;
     raft_node_instance(raft_node_instance&&) noexcept = delete;
@@ -248,6 +250,7 @@ private:
     leader_update_clb_t _leader_clb;
     ss::lw_shared_ptr<consensus> _raft;
     bool started = false;
+    bool _enable_longest_log_detection;
 };
 
 class raft_fixture
@@ -462,6 +465,10 @@ public:
     ss::future<> reset_background_flushing() const;
     ss::future<> set_write_caching(bool) const;
 
+    void set_enable_longest_log_detection(bool value) {
+        _enable_longest_log_detection = value;
+    }
+
 private:
     void validate_leaders();
 
@@ -471,6 +478,7 @@ private:
     absl::flat_hash_map<model::node_id, leadership_status> _leaders_view;
 
     ss::sharded<features::feature_table> _features;
+    bool _enable_longest_log_detection = true;
 };
 
 std::ostream& operator<<(std::ostream& o, msg_type type);

--- a/src/v/raft/tests/raft_group_fixture.h
+++ b/src/v/raft/tests/raft_group_fixture.h
@@ -177,6 +177,7 @@ struct raft_node {
             seastar::default_scheduling_group(),
             seastar::default_priority_class()),
           config::mock_binding<std::chrono::milliseconds>(10s),
+          config::mock_binding<bool>(true),
           raft::make_rpc_client_protocol(self_id, cache),
           [this](raft::leadership_status st) { leader_callback(st); },
           storage.local(),

--- a/src/v/raft/tests/replication_monitor_tests.cc
+++ b/src/v/raft/tests/replication_monitor_tests.cc
@@ -79,6 +79,7 @@ TEST_P_CORO(monitor_test_fixture, replication_monitor_wait) {
 }
 
 TEST_P_CORO(monitor_test_fixture, truncation_detection) {
+    set_enable_longest_log_detection(false);
     co_await create_simple_group(3);
     auto leader = co_await wait_for_leader(10s);
     co_await set_write_caching(write_caching());

--- a/src/v/raft/tests/simple_raft_fixture.h
+++ b/src/v/raft/tests/simple_raft_fixture.h
@@ -87,7 +87,9 @@ struct simple_raft_fixture {
                     model::write_caching_mode::default_false),
                   .write_caching_flush_ms = config::mock_binding(100ms),
                   .write_caching_flush_bytes
-                  = config::mock_binding<std::optional<size_t>>(std::nullopt)};
+                  = config::mock_binding<std::optional<size_t>>(std::nullopt),
+                  .enable_longest_log_detection = config::mock_binding<bool>(
+                    true)};
             },
             [] {
                 return raft::recovery_memory_quota::configuration{

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -181,7 +181,7 @@ ss::future<election_success> vote_stm::vote(bool leadership_transfer) {
 ss::future<election_success> vote_stm::do_vote() {
     // dispatch requests to all voters
     _config->for_each_voter([this](vnode id) { (void)dispatch_one(id); });
-
+    _requests_dispatched_ts = clock_type::now();
     co_await process_replies();
 
     auto u = co_await _ptr->_op_lock.get_units();
@@ -190,8 +190,59 @@ ss::future<election_success> vote_stm::do_vote() {
     co_return election_success(_success);
 }
 
+bool vote_stm::has_request_in_progress() const {
+    return std::any_of(
+      _replies.begin(),
+      _replies.end(),
+      [](const absl::flat_hash_map<vnode, vmeta>::value_type& p) {
+          return p.second.get_state() == vmeta::state::in_progress;
+      });
+}
+
+bool vote_stm::can_wait_for_all() const {
+    return clock_type::now()
+           < _requests_dispatched_ts + _ptr->_jit.base_duration();
+}
+
 ss::future<> vote_stm::process_replies() {
     return ss::repeat([this] {
+        const bool request_in_progress = has_request_in_progress();
+
+        /**
+         * Try to wait for vote replies from all of the nodes or use information
+         * from all replies if it is already available. Waiting for all the
+         * replies allow candidate to verify if any other protocol participant
+         * has log which is longer.
+         *
+         * If any of the replicas log is longer than current candidate the
+         * election is failed allowing the other node to become a leader.
+         */
+        if (
+          (!request_in_progress || can_wait_for_all())
+          && _ptr->_enable_longest_log_detection()) {
+            if (request_in_progress) {
+                return wait_for_next_reply().then(
+                  [] { return ss::stop_iteration::no; });
+            }
+            auto is_more_up_to_date_it = std::find_if(
+              _replies.begin(),
+              _replies.end(),
+              [](const absl::flat_hash_map<vnode, vmeta>::value_type& p) {
+                  return p.second.has_more_up_to_date_log();
+              });
+
+            if (is_more_up_to_date_it != _replies.end()) {
+                vlog(
+                  _ctxlog.info,
+                  "[pre-vote {}] vote failed - node {} has log which is more "
+                  "up to date than the current candidate",
+                  _prevote,
+                  is_more_up_to_date_it->first);
+                _success = false;
+                return ss::make_ready_future<ss::stop_iteration>(
+                  ss::stop_iteration::yes);
+            }
+        }
         /**
          * The check if the election is successful is different for prevote, for
          * prevote phase to be successful it is enough that followers reported
@@ -228,12 +279,7 @@ ss::future<> vote_stm::process_replies() {
         // neither majority votes granted nor failed, check if we have all
         // replies (is there any vote request in progress)
 
-        auto has_request_in_progress = std::any_of(
-          std::cbegin(_replies), std::cend(_replies), [](const auto& p) {
-              return p.second.get_state() == vmeta::state::in_progress;
-          });
-
-        if (!has_request_in_progress) {
+        if (!request_in_progress) {
             _success = false;
             return ss::make_ready_future<ss::stop_iteration>(
               ss::stop_iteration::yes);
@@ -243,6 +289,39 @@ ss::future<> vote_stm::process_replies() {
             return ss::stop_iteration::no;
         });
     });
+}
+
+ss::future<> vote_stm::wait_for_next_reply() {
+    vlog(
+      _ctxlog.debug,
+      "[pre-vote {}] trying to wait for vote replies from all of "
+      "the nodes",
+      _prevote);
+    auto h = _vote_bg.hold();
+    const auto timeout = std::max(
+      clock_type::duration(0),
+      _ptr->_jit.base_duration()
+        - (clock_type::now() - _requests_dispatched_ts));
+
+    /**
+     * Return early if we are not allowed to wait
+     */
+    if (timeout == clock_type::duration(0)) {
+        co_return;
+    }
+    /**
+     * The wait for all replies loop will exit if it can not longer wait for
+     * replies regardless of the result of this particular response semaphore
+     * wait.
+     */
+    try {
+        co_await _sem.wait(timeout, 1);
+    } catch (const ss::semaphore_timed_out&) {
+        vlog(
+          _ctxlog.debug,
+          "[pre-vote {}] timed out waiting for all the replies",
+          _prevote);
+    }
 }
 
 ss::future<> vote_stm::wait() { return _vote_bg.close(); }

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -199,7 +199,7 @@ ss::future<> vote_stm::process_replies() {
          * prevote phase to be successful it is enough that followers reported
          * log_ok flag. For the actual election we require that vote is granted.
          */
-        auto majority_granted = _config->majority([this](vnode id) {
+        auto majority_granted = _config->majority([this](const vnode& id) {
             const auto state = _replies.find(id)->second.get_state();
             if (_prevote) {
                 return state == vmeta::state::log_ok
@@ -215,7 +215,7 @@ ss::future<> vote_stm::process_replies() {
         }
 
         // majority votes not granted, election not successful
-        auto majority_failed = _config->majority([this](vnode id) {
+        auto majority_failed = _config->majority([this](const vnode& id) {
             auto state = _replies.find(id)->second.get_state();
             // vote not granted and not in progress, it is failed
             return state != vmeta::state::vote_granted

--- a/src/v/raft/vote_stm.cc
+++ b/src/v/raft/vote_stm.cc
@@ -10,12 +10,10 @@
 #include "raft/vote_stm.h"
 
 #include "base/vassert.h"
-#include "outcome_future_utils.h"
 #include "raft/consensus.h"
-#include "raft/consensus_utils.h"
 #include "raft/errc.h"
+#include "raft/fundamental.h"
 #include "raft/logger.h"
-#include "raft/raftgen_service.h"
 #include "rpc/types.h"
 #include "ssx/semaphore.h"
 

--- a/src/v/raft/vote_stm.h
+++ b/src/v/raft/vote_stm.h
@@ -95,8 +95,18 @@ private:
             // it is an error
             return state::error;
         }
+
+        bool has_more_up_to_date_log() const {
+            return value && value->has_value() && !value->value().log_ok;
+        }
         std::unique_ptr<result<vote_reply>> value;
     };
+
+    bool has_request_in_progress() const;
+
+    bool can_wait_for_all() const;
+
+    ss::future<> wait_for_next_reply();
 
     friend std::ostream& operator<<(std::ostream&, const vmeta&);
 
@@ -121,6 +131,7 @@ private:
     ss::gate _vote_bg;
     absl::flat_hash_map<vnode, vmeta> _replies;
     ctx_log _ctxlog;
+    clock_type::time_point _requests_dispatched_ts;
 };
 
 } // namespace raft

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1340,7 +1340,11 @@ void application::wire_up_redpanda_services(
                   .raft_replica_max_flush_delay_ms.bind(),
               .write_caching_flush_bytes
               = config::shard_local_cfg()
-                  .raft_replica_max_pending_flush_bytes.bind()};
+                  .raft_replica_max_pending_flush_bytes.bind(),
+              .enable_longest_log_detection
+              = config::shard_local_cfg()
+                  .raft_enable_longest_log_detection.bind(),
+            };
         },
         [] {
             return raft::recovery_memory_quota::configuration{


### PR DESCRIPTION
Making Raft leader election unsuccessful if one of the votes has log which is more up to data than the current candidate. This solution will allow us to minimise the data loss risk when using relaxed consistency writes. With the optimisation included in this PR a candidate will wait up to election timeout for the replies from all of the nodes and will fail the leader election if any of the voters log is more up to date. The solution included in this PR favour the nodes with longest log to become a leader without compromising availability as it is still enough for the majority to vote for the candidate for it to become a leader. 

Another way of seeing this solution is that the candidate will use information about voter logs if they are available instead of ignoring the one with longest log and moving on with the majority based decision. 

The detection mechanism can be controller in runtime with `raft_enable_longest_log_detection`  cluster configuration flag.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- minimising possibility of data loss when using relaxed conistency replication  