### PR TITLE
Backport of PR 17894 - tests: Marking test_drain_audit_disabled as ok_to_fail

### DIFF
--- a/tests/rptest/tests/audit_log_test.py
+++ b/tests/rptest/tests/audit_log_test.py
@@ -22,6 +22,7 @@ from typing import Any, Optional
 
 from ducktape.cluster.cluster import ClusterNode
 from ducktape.errors import TimeoutError
+from ducktape.mark import matrix, ok_to_fail
 from keycloak import KeycloakOpenID
 from rptest.clients.default import DefaultClient
 from rptest.clients.kcl import KCL
@@ -667,6 +668,7 @@ class AuditLogTestsAppLifecycle(AuditLogTestBase):
                     True), lambda record_count: record_count == 3,
             "Single redpanda start event per node")
 
+    @ok_to_fail  # https://github.com/redpanda-data/redpanda/issues/16198
     @cluster(num_nodes=5)
     def test_drain_on_audit_disabled(self):
         """


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/redpanda/issues/17907

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
