### PR TITLE
gh: Add docs team as CODEOWNERS for configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,3 +40,17 @@ licenses           @emaxerrno @dswang
 /tests/run.sh                       @redpanda-data/devprod
 /src/consistency-testing            @mmaslankaprv
 /tests/java/tx-verifier             @mmaslankaprv
+
+#
+# automatically tag docs team for configuration changes
+#
+/src/v/config/configuration.cc                      @redpanda-data/documentation
+/src/v/config/configuration.h                       @redpanda-data/documentation
+/src/v/config/node_config.cc                        @redpanda-data/documentation
+/src/v/config/node_config.h                         @redpanda-data/documentation
+/src/v/kafka/client/configuration.cc                @redpanda-data/documentation
+/src/v/kafka/client/configuration.h                 @redpanda-data/documentation
+/src/v/pandaproxy/rest/configuration.cc             @redpanda-data/documentation
+/src/v/pandaproxy/rest/configuration.h              @redpanda-data/documentation
+/src/v/pandaproxy/schema_registry/configuration.cc  @redpanda-data/documentation
+/src/v/pandaproxy/schema_registry/configuration.h   @redpanda-data/documentation


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Fixes: CORE-2406

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
