### PR TITLE
kafka: Reduced maximum log line size to 128KiB

### DIFF
--- a/src/v/kafka/protocol/logger.cc
+++ b/src/v/kafka/protocol/logger.cc
@@ -9,7 +9,10 @@
 
 #include "kafka/server/logger.h"
 
+#include "base/units.h"
+
 namespace kafka {
+static constexpr size_t max_log_line_bytes = 128_KiB;
 ss::logger klog("kafka");
-truncating_logger kwire(klog, 1048576);
+truncating_logger kwire(klog, max_log_line_bytes);
 } // namespace kafka


### PR DESCRIPTION
Fixes: CORE-2409

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v23.3.x
- [X] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* Reduces maximum log line size from `1MiB` to `128KiB` to reduce occurrences of memory allocation failures
