### PR TITLE
c/controller_backend: don't require cur_operation after reconciliation step

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -882,9 +882,10 @@ ss::future<> controller_backend::try_reconcile_ntp(
         }
 
         if (last_error != errc::success) {
-            vassert(rs.cur_operation, "[{}] expected current operation", ntp);
-            rs.cur_operation->last_error = last_error;
-            rs.cur_operation->retries += 1;
+            if (rs.cur_operation) {
+                rs.cur_operation->last_error = last_error;
+                rs.cur_operation->retries += 1;
+            }
             vlog(
               clusterlog.trace,
               "[{}] reconciliation attempt finished, state: {}",


### PR DESCRIPTION
In case when we need to wait before shard_placement_table and topic_table become consistent (i.e. the expected log_revision of an ntp is the same), the concept of "current operation" doesn't make much sense because we may not yet know what we are required to do for reconciliation. Therefore we shouldn't require the current_operation to be non-null after a reconciliation step returns an error.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
