### PR TITLE
CORE-2423 archival: Disable upload of the internal topics

### DIFF
--- a/src/v/archival/archival_metadata_stm.cc
+++ b/src/v/archival/archival_metadata_stm.cc
@@ -1298,6 +1298,7 @@ model::offset archival_metadata_stm::max_collectible_offset() {
     // archival is enabled is authoritative.
     bool collect_all = !_raft->log_config().is_archival_enabled();
     bool is_read_replica = _raft->log_config().is_read_replica_mode_enabled();
+    bool is_user_topic = model::is_user_topic(_raft->ntp());
 
     // In earlier versions, we should assume every topic is archival enabled
     // if the global cloud_storage_enable_remote_write is true.
@@ -1307,12 +1308,15 @@ model::offset archival_metadata_stm::max_collectible_offset() {
         collect_all = false;
     }
 
-    if (collect_all || is_read_replica) {
+    if (collect_all || is_read_replica || !is_user_topic) {
         // The archival is disabled but the state machine still exists so we
         // shouldn't stop eviction from happening.
         // In read-replicas the state machine exists and stores segments
         // from the remote manifest. Since nothing is uploaded there is no
         // need to interact with local retention.
+        // In case if topic is not the user topic we also don't want eviction
+        // to stop. This is because we don't use TS with non-user topics but
+        // we might have archival STM created for such topic.
         return model::offset::max();
     }
     auto lo = get_last_offset();

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -667,10 +667,10 @@ bool partition::should_construct_archiver() {
     // in the case of read replicas -- we still need the archiver to drive
     // manifest updates, etc.
     const auto& ntp_config = _raft->log()->config();
+    const auto is_user_topic = model::is_user_topic(_raft->ntp());
     return config::shard_local_cfg().cloud_storage_enabled()
            && config::shard_local_cfg().cloud_storage_disable_archiver_manager()
-           && _cloud_storage_api.local_is_initialized()
-           && _raft->ntp().ns == model::kafka_namespace
+           && _cloud_storage_api.local_is_initialized() && is_user_topic
            && (ntp_config.is_archival_enabled() || ntp_config.is_read_replica_mode_enabled());
 }
 

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -206,13 +206,17 @@ public:
     }
 
     bool is_archival_enabled() const {
-        return _overrides != nullptr && _overrides->shadow_indexing_mode
+        const bool is_user_topic = model::is_user_topic(_ntp);
+        return is_user_topic && _overrides != nullptr
+               && _overrides->shadow_indexing_mode
                && model::is_archival_enabled(
                  _overrides->shadow_indexing_mode.value());
     }
 
     bool is_remote_fetch_enabled() const {
-        return _overrides != nullptr && _overrides->shadow_indexing_mode
+        const bool is_user_topic = model::is_user_topic(_ntp);
+        return is_user_topic && _overrides != nullptr
+               && _overrides->shadow_indexing_mode
                && model::is_fetch_enabled(
                  _overrides->shadow_indexing_mode.value());
     }
@@ -227,7 +231,8 @@ public:
      * both reads and writes to S3, and is not a read replica.
      */
     bool is_tiered_storage() const {
-        return _overrides != nullptr
+        const bool is_user_topic = model::is_user_topic(_ntp);
+        return is_user_topic && _overrides != nullptr
                && !_overrides->read_replica.value_or(false)
                && _overrides->shadow_indexing_mode
                     == model::shadow_indexing_mode::full;


### PR DESCRIPTION
This PR disables uploading for topics in `kafka` namespace which are not user topics. We have several topics created and maintained by Redpanda itself. One of such topics is `__consumer_offsets` topic. This PR disables uploading of such topics in the `cluster::partition` code and also it excludes `archival_metadata_stm` from the calculation of `max_collectible_offset` for these topics. This is needed for existing clusters which will have archival STM created.

This is important because these topics are not supposed to be used with TS. The TS read path is only used to serve fetch requests. The code that works with the `__consumer_offsets` is incapable of using uploaded data. The read path is not compatible with the content of such topics as well. 

The content of such topics is uploaded as part of the cluster metadata upload. This subsystem uploads a snapshot of the `__consumer_offsets` so it can be used for recovery.

Fixes #17942
Fixes #16732
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes

* Disable Tiered Storage for `__consumer_offsets` and few other internal topics