### PR TITLE
cleanup: clang 18 fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter,-misc-include-cleaner'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,cert-*,cppcoreguidelines-*,hicpp-*,modernize-*,performance-*,misc-*,bugprone-*,-modernize-use-trailing-return-type,-modernize-use-nodiscard,-hicpp-named-parameter,-misc-include-cleaner,-clang-analyzer-optin.core.EnumCastOutOfRange'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle:    file

--- a/.clang-tidy-strict
+++ b/.clang-tidy-strict
@@ -2,8 +2,9 @@
 # llvm-header-guard: in redpanda we normally to use `#pragma once`
 # modernize-use-trailing-return-type: arbitrary style choice
 # misc-include-cleaner: the check has many false positives and is noisy
+# clang-analyzer-optin.core.EnumCastOutOfRange: Not recommended when using enums for bitwise flags
 ---
-Checks: '*,-altera-*,-fuchsia-*,-llvmlibc-*,-llvm-header-guard,-modernize-use-trailing-return-type,-misc-include-cleaner'
+Checks: '*,-altera-*,-fuchsia-*,-llvmlibc-*,-llvm-header-guard,-modernize-use-trailing-return-type,-misc-include-cleaner,-clang-analyzer-optin.core.EnumCastOutOfRange'
 WarningsAsErrors: false
 CheckOptions:
   - key:             readability-identifier-length.IgnoredVariableNames

--- a/.clang-tidy-strict-tests
+++ b/.clang-tidy-strict-tests
@@ -5,8 +5,9 @@
 # cppcoreguidelines-pointer-arithmetic: quality of life improvement
 # misc-non-private-member-variables-in-classes: quality of life improvement
 # misc-include-cleaner: the check has many false positives and is noisy
+# clang-analyzer-optin.core.EnumCastOutOfRange: Not recommended when using enums for bitwise flags
 ---
 Checks:
-'-readability-function-cognitive-complexity,-readability-identifier-length,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-misc-non-private-member-variables-in-classes,-misc-include-cleaner'
+'-readability-function-cognitive-complexity,-readability-identifier-length,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-misc-non-private-member-variables-in-classes,-misc-include-cleaner,-clang-analyzer-optin.core.EnumCastOutOfRange'
 InheritParentConfig: true
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,12 @@ if(Redpanda_ENABLE_SANITIZERS)
   add_compile_options(-fsanitize=address,leak,undefined)
 endif()
 
+# We use enums as bitflags in seastar and Redpanda, which
+# creating a constexpr enum value that is bitwise combination
+# of flags can trigger this warning as the resulting "enum",
+# isn't a valid value.
+add_compile_options(-Wno-enum-constexpr-conversion)
+
 include(dependencies)
 include(v_library)
 include(testing)

--- a/src/v/archival/async_data_uploader.cc
+++ b/src/v/archival/async_data_uploader.cc
@@ -132,7 +132,7 @@ public:
           _buffer.size_bytes());
         co_return head_buf;
     }
-    ss::future<ss::temporary_buffer<char>> skip(uint64_t n) override {
+    ss::future<ss::temporary_buffer<char>> skip(uint64_t) override {
         ss::temporary_buffer<char> empty;
         co_return empty;
     }

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -510,7 +510,7 @@ ss::future<get_cluster_health_reply> service::get_cluster_health_report(
 }
 
 ss::future<get_node_health_reply>
-service::do_collect_node_health_report(get_node_health_request req) {
+service::do_collect_node_health_report(get_node_health_request) {
     auto res = co_await _hm_frontend.local().get_current_node_health();
     if (res.has_error()) {
         co_return get_node_health_reply{

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -10,6 +10,7 @@
 #include "base/vlog.h"
 #include "cluster/health_monitor_types.h"
 #include "cluster/tests/partition_balancer_planner_fixture.h"
+#include "model/metadata.h"
 #include "random/generators.h"
 #include "test_utils/fixture.h"
 
@@ -739,14 +740,14 @@ FIXTURE_TEST(
 }
 
 FIXTURE_TEST(test_smol, partition_balancer_sim_fixture) {
-    for (size_t i = 0; i < 4; ++i) {
+    for (model::node_id::type i = 0; i < 4; ++i) {
         add_node(model::node_id{i}, 100_GiB);
     }
 
     add_topic("topic_1", 3, 3, 1_GiB, 100_MiB);
     add_topic("topic_2", 3, 3, 1_GiB, 100_MiB);
 
-    for (size_t i = 4; i < 6; ++i) {
+    for (model::node_id::type i = 4; i < 6; ++i) {
         add_node(model::node_id{i}, 100_GiB);
         add_node_to_rebalance(model::node_id{i});
     }
@@ -755,7 +756,7 @@ FIXTURE_TEST(test_smol, partition_balancer_sim_fixture) {
 }
 
 FIXTURE_TEST(test_heterogeneous_topics, partition_balancer_sim_fixture) {
-    for (size_t i = 0; i < 9; ++i) {
+    for (model::node_id::type i = 0; i < 9; ++i) {
         add_node(model::node_id{i}, 300_GiB);
     }
 
@@ -765,7 +766,7 @@ FIXTURE_TEST(test_heterogeneous_topics, partition_balancer_sim_fixture) {
     add_topic("topic_1", 200, 3, 2_GiB, 200_MiB);
     add_topic("topic_2", 800, 3, 10_MiB, 1_MiB);
 
-    for (size_t i = 9; i < 12; ++i) {
+    for (model::node_id::type i = 9; i < 12; ++i) {
         add_node(model::node_id{i}, 300_GiB);
         add_node_to_rebalance(model::node_id{i});
     }
@@ -777,7 +778,7 @@ FIXTURE_TEST(test_heterogeneous_topics, partition_balancer_sim_fixture) {
 }
 
 FIXTURE_TEST(test_many_topics, partition_balancer_sim_fixture) {
-    for (size_t i = 0; i < 4; ++i) {
+    for (model::node_id::type i = 0; i < 4; ++i) {
         add_node(model::node_id{i}, 100_GiB);
     }
 
@@ -801,7 +802,7 @@ FIXTURE_TEST(test_many_topics, partition_balancer_sim_fixture) {
           partition_size / 10);
     }
 
-    for (size_t i = 4; i < 6; ++i) {
+    for (model::node_id::type i = 4; i < 6; ++i) {
         add_node(model::node_id{i}, 100_GiB);
         add_node_to_rebalance(model::node_id{i});
     }

--- a/src/v/cluster/topic_recovery_validator.cc
+++ b/src/v/cluster/topic_recovery_validator.cc
@@ -112,7 +112,8 @@ partition_validator::do_validate_manifest_metadata() {
     auto anomalies_fut = co_await ss::coroutine::as_future(detector.run(
       op_rtc_,
       cloud_storage::anomalies_detector::segment_depth_t{
-        checks_.max_segment_depth}));
+        static_cast<cloud_storage::anomalies_detector::segment_depth_t::type>(
+          checks_.max_segment_depth)}));
 
     if (anomalies_fut.failed()) {
         // propagate shutdown exceptions, but treat other exceptions as hard


### PR DESCRIPTION
A variety of fixes so the OSS builds cleanly on clang-18

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
