### PR TITLE
CORE-2452 followup for azure managed identities #17840

### DIFF
--- a/src/v/cloud_roles/apply_abs_oauth_credentials.cc
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.cc
@@ -13,7 +13,8 @@
 namespace cloud_roles {
 apply_abs_oauth_credentials::apply_abs_oauth_credentials(
   abs_oauth_credentials const& credentials)
-  : _oauth_token{fmt::format("Bearer {}", credentials.oauth_token())} {}
+  : _oauth_token{fmt::format("Bearer {}", credentials.oauth_token())}
+  , _timesource{} {}
 
 std::error_code apply_abs_oauth_credentials::add_auth(
   http::client::request_header& header) const {
@@ -21,6 +22,8 @@ std::error_code apply_abs_oauth_credentials::add_auth(
     // x-ms-version requests a specific version for the abs api, the hardcoded
     // value is the one we test
     header.set("x-ms-version", azure_storage_api_version);
+    auto iso_ts = _timesource.format_http_datetime();
+    header.set("x-ms-date", {iso_ts.data(), iso_ts.size()});
     header.insert(
       boost::beast::http::field::authorization, {token.data(), token.size()});
     return {};

--- a/src/v/cloud_roles/apply_abs_oauth_credentials.h
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_roles/apply_credentials.h"
+#include "cloud_roles/signature.h"
 
 namespace cloud_roles {
 
@@ -29,6 +30,7 @@ public:
 
 private:
     oauth_token_str _oauth_token;
+    time_source _timesource;
 };
 
 } // namespace cloud_roles

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -889,7 +889,7 @@ abs_client::do_test_set_expiry_on_dummy_file(
   ss::lowres_clock::duration timeout) {
     // since this is one-off operation at startup, it's easier to read directly
     // cloud_storage_azure_container than to wire it in. this is ok because if
-    // we are in abs_client it means that the required property, like
+    // we are in abs_client it means that the required properties, like
     // azure_container, are set
     auto container_name
       = config::shard_local_cfg().cloud_storage_azure_container.value();

--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -55,6 +55,9 @@ constexpr boost::beast::string_view expiry_option_name = "x-ms-expiry-option";
 constexpr boost::beast::string_view expiry_option_value = "RelativeToNow";
 constexpr boost::beast::string_view expiry_time_name = "x-ms-expiry-time";
 
+constexpr std::string_view hierarchical_namespace_not_enabled_error_code
+  = "HierarchicalNamespaceNotEnabled";
+
 // filename for the set expiry test file
 constexpr std::string_view set_expiry_test_file = "testsetexpiry";
 
@@ -923,7 +926,13 @@ abs_client::do_test_set_expiry_on_dummy_file(
     auto const& headers = response_stream->get_headers();
 
     if (headers.result() == boost::beast::http::status::bad_request) {
-        co_return storage_account_info{.is_hns_enabled = false};
+        if (auto error_code_it = headers.find(error_code_name);
+            error_code_it->value()
+            == hierarchical_namespace_not_enabled_error_code) {
+            // if there is a match of error code, we can proceed, otherwise
+            // fallthrough
+            co_return storage_account_info{.is_hns_enabled = false};
+        }
     }
 
     if (

--- a/src/v/cloud_storage_clients/abs_client.h
+++ b/src/v/cloud_storage_clients/abs_client.h
@@ -305,11 +305,11 @@ private:
 
     std::optional<abs_configuration> _data_lake_v2_client_config;
 
-    // currently the implementation supports Signing requests or OAuth.
-    // not all api are available for oauth, this variable is initialized at
-    // startup to allow alternative codepaths when using oauth this is fine
+    // Currently the implementation supports Signing requests or OAuth.
+    // Not all api are available for oauth, this variable is initialized at
+    // startup to allow alternative codepaths when using oauth. This is fine
     // because to change authentication method the user changes
-    // cloud_storage_credentials_source, and that requires a restart
+    // cloud_storage_credentials_source, and that requires a restart.
     bool _is_oauth;
 
     abs_request_creator _requestor;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1571,8 +1571,10 @@ void config_multi_property_validation(
 
             for (auto& p : properties) {
                 if (p() == std::nullopt) {
-                    errors[ss::sstring(p.get().name())]
-                      = "Must be set when cloud storage enabled";
+                    errors[ss::sstring(p.get().name())] = ssx::sformat(
+                      "Must be set when cloud storage enabled with "
+                      "cloud_storage_credentials_source = {}",
+                      updated_config.cloud_storage_credentials_source.value());
                 }
             }
         } break;
@@ -1588,7 +1590,9 @@ void config_multi_property_validation(
             for (auto& p : properties) {
                 if (p() == std::nullopt) {
                     errors[ss::sstring(p.get().name())]
-                      = "Must be set when cloud storage enabled";
+                      = "Must be set when cloud storage enabled with "
+                        "cloud_storage_credentials_source = "
+                        "azure_aks_oidc_federation";
                 }
             }
         } break;
@@ -1604,7 +1608,9 @@ void config_multi_property_validation(
             for (auto& p : properties) {
                 if (p() == std::nullopt) {
                     errors[ss::sstring(p.get().name())]
-                      = "Must be set when cloud storage enabled";
+                      = "Must be set when cloud storage enabled with "
+                        "cloud_storage_credentials_source = "
+                        "azure_vm_instance_metadata";
                 }
             }
         } break;

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1292,9 +1292,9 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         }
     }
 
-    # need to use a string as the value for an update to not trigger this error
-    # when ducktape serialized a value to create the folder for a test run
+    # We need to use a string as the value for `update`, to not trigger
     # `OSError: [Errno 36] File name too long`
+    # caused by ducktape creating a folder for the run + parameters.
     @cluster(
         num_nodes=1,
         log_allow_list=IAM_ROLES_API_CALL_ALLOW_LIST + [


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

**abs_client::self_configure:**
Use Set Expiry header `x-ms-error-code:  HierarchicalNamespaceNotEnabled`  for a stricter check.
the current behavior is: HTTP 400 → HNS not enabled
with this PR:  HTTP 400 && `x-ms-error-code:  HierarchicalNamespaceNotEnabled`-> HNS not enabled
Otherwise, bubble up the error and let redpanda stop gracefully.
The escape hatch cloud_storage_azure_hierarchical_namespace_enabled can be used if this header response changes without notice. 

**apply_abs_oauth_credentials:**
add required header `x-ms-date`
https://learn.microsoft.com/en-us/rest/api/storageservices/delete-blob?tabs=microsoft-entra-id#request-headers 
ABS requires x-ms-date header, in our codebase is set by credential_applier and apply_abs_oauth_credentials does not set it.
Did not trigger errors in CI or Azure because it seems like it’s not actually required by the endpoints. (with signed requests, it’s part of the signature) 
Still, better to follow the documentation.

**mixed in**: comment fixes and better error message in config_multi_property_validation, as a follow-up for https://github.com/redpanda-data/redpanda/pull/17840


Fixes CORE-2451
Fixes CORE-2452

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none