### PR TITLE
Allocate and rebalance replicas for different partitions in random order

### DIFF
--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -1387,8 +1387,8 @@ void partition_balancer_planner::force_reassignable_partition::
     }
     _reallocation = _ctx._parent._partition_allocator.reallocate_partition(
       tn,
-      {_original_assignment.id, replicas_size, std::move(constraints)},
-      _original_assignment,
+      partition_constraints{
+        _original_assignment, replicas_size, std::move(constraints)},
       get_allocation_domain(tn),
       replicas_to_remove,
       node2count);

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -15,18 +15,6 @@
 
 namespace cluster {
 
-void allocation_state::rollback(
-  const ss::chunked_fifo<partition_assignment>& v,
-  const partition_allocation_domain domain) {
-    verify_shard();
-    for (auto& as : v) {
-        for (auto& bs : as.replicas) {
-            remove_allocation(bs, domain);
-            remove_final_count(bs, domain);
-        }
-    }
-}
-
 int16_t allocation_state::available_nodes() const {
     verify_shard();
     return std::count_if(

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -64,10 +64,6 @@ public:
     void
     remove_final_count(const model::broker_shard&, partition_allocation_domain);
 
-    void rollback(
-      const ss::chunked_fifo<partition_assignment>& pa,
-      partition_allocation_domain);
-
     bool validate_shard(model::node_id node, uint32_t shard) const;
 
     // Raft group id

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -47,20 +47,19 @@ public:
      */
     ss::future<result<allocation_units::pointer>> allocate(allocation_request);
 
-    /// Reallocate an already existing partition. Existing replicas from
-    /// replicas_to_reallocate will be reallocated, and a number of additional
-    /// replicas to reach the requested replication factor will be allocated
-    /// anew.
+    /// Reallocate some replicas of an already existing partition without
+    /// changing its replication factor.
+    ///
     /// If existing_replica_counts is non-null, new replicas will be allocated
     /// using topic-aware counts objective and (if all allocations are
     /// successful) existing_replica_counts will be updated with newly allocated
     /// replicas.
     result<allocated_partition> reallocate_partition(
-      model::topic_namespace,
-      partition_constraints,
-      partition_allocation_domain,
-      const std::vector<model::node_id>& replicas_to_reallocate = {},
-      node2count_t* existing_replica_counts = nullptr);
+      model::ntp ntp,
+      std::vector<model::broker_shard> current_replicas,
+      const std::vector<model::node_id>& replicas_to_reallocate,
+      allocation_constraints,
+      node2count_t* existing_replica_counts);
 
     /// Create allocated_partition object from current replicas for use with the
     /// allocate_replica method.

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -58,7 +58,6 @@ public:
     result<allocated_partition> reallocate_partition(
       model::topic_namespace,
       partition_constraints,
-      const partition_assignment&,
       partition_allocation_domain,
       const std::vector<model::node_id>& replicas_to_reallocate = {},
       node2count_t* existing_replica_counts = nullptr);

--- a/src/v/cluster/scheduling/types.cc
+++ b/src/v/cluster/scheduling/types.cc
@@ -41,11 +41,8 @@ void allocation_constraints::add(allocation_constraints other) {
 }
 
 allocation_units::allocation_units(
-  ss::chunked_fifo<partition_assignment> assignments,
-  allocation_state& state,
-  const partition_allocation_domain domain)
-  : _assignments(std::move(assignments))
-  , _state(state.weak_from_this())
+  allocation_state& state, const partition_allocation_domain domain)
+  : _state(state.weak_from_this())
   , _domain(domain) {}
 
 allocation_units::~allocation_units() {

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -198,10 +198,6 @@ struct allocation_units {
      */
     using pointer = ss::foreign_ptr<std::unique_ptr<allocation_units>>;
 
-    allocation_units(
-      ss::chunked_fifo<partition_assignment>,
-      allocation_state&,
-      partition_allocation_domain);
     allocation_units& operator=(allocation_units&&) = default;
     allocation_units& operator=(const allocation_units&) = delete;
     allocation_units(const allocation_units&) = delete;
@@ -220,6 +216,10 @@ struct allocation_units {
           _assignments.begin(), _assignments.end(), std::back_inserter(p_as));
         return p_as;
     }
+
+private:
+    friend class partition_allocator;
+    allocation_units(allocation_state&, partition_allocation_domain);
 
 private:
     ss::chunked_fifo<partition_assignment> _assignments;

--- a/src/v/cluster/scheduling/types.h
+++ b/src/v/cluster/scheduling/types.h
@@ -223,6 +223,7 @@ private:
 
 private:
     ss::chunked_fifo<partition_assignment> _assignments;
+    chunked_vector<model::broker_shard> _added_replicas;
     // keep the pointer to make this type movable
     ss::weak_ptr<allocation_state> _state;
     partition_allocation_domain _domain;
@@ -292,7 +293,8 @@ private:
     add_replica(model::node_id, const std::optional<previous_replica>&);
 
     // used to move the allocation to allocation_units
-    replicas_t release_new_partition();
+    replicas_t
+    release_new_partition(chunked_vector<model::broker_shard>& added_replicas);
 
 private:
     model::ntp _ntp;
@@ -312,14 +314,32 @@ private:
  * replica
  */
 struct partition_constraints {
-    partition_constraints(model::partition_id, uint16_t);
-
+    // Constructor for allocating a new partition
     partition_constraints(
-      model::partition_id, uint16_t, allocation_constraints);
+      model::partition_id id,
+      uint16_t rf,
+      allocation_constraints constraints = {})
+      : partition_id(id)
+      , replication_factor(rf)
+      , constraints(std::move(constraints)) {}
+
+    // Constructor for reallocating an partition
+    partition_constraints(
+      const partition_assignment& assignment,
+      uint16_t rf,
+      allocation_constraints constraints = {})
+      : partition_id(assignment.id)
+      , replication_factor(rf)
+      , constraints(std::move(constraints))
+      , existing_group(assignment.group)
+      , existing_replicas(assignment.replicas) {}
 
     model::partition_id partition_id;
     uint16_t replication_factor;
     allocation_constraints constraints;
+    std::optional<raft::group_id> existing_group;
+    replicas_t existing_replicas;
+
     friend std::ostream&
     operator<<(std::ostream&, const partition_constraints&);
 };

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -475,12 +475,12 @@ FIXTURE_TEST(change_replication_factor, partition_allocator_fixture) {
 
     BOOST_CHECK_EQUAL(res.has_value(), true);
 
+    cluster::partition_constraints reallocate_req(
+      res.value()->get_assignments().front(), 3);
+
     // try to allocate 3 replicas no 2 nodes - should fail
     auto expected_failure = allocator.reallocate_partition(
-      tn,
-      cluster::partition_constraints(model::partition_id(0), 3),
-      res.value()->get_assignments().front(),
-      cluster::partition_allocation_domains::common);
+      tn, reallocate_req, cluster::partition_allocation_domains::common);
 
     BOOST_CHECK_EQUAL(expected_failure.has_error(), true);
 
@@ -488,10 +488,7 @@ FIXTURE_TEST(change_replication_factor, partition_allocator_fixture) {
     register_node(3, 4);
 
     auto expected_success = allocator.reallocate_partition(
-      tn,
-      cluster::partition_constraints(model::partition_id(0), 3),
-      res.value()->get_assignments().front(),
-      cluster::partition_allocation_domains::common);
+      tn, reallocate_req, cluster::partition_allocation_domains::common);
 
     BOOST_CHECK_EQUAL(expected_success.has_value(), true);
     validate_replica_set_diversity({expected_success.value().replicas()});
@@ -814,8 +811,7 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
         auto res = allocator.reallocate_partition(
           tn,
           cluster::partition_constraints(
-            model::partition_id(0), 4, not_on_old_nodes),
-          original_assignment,
+            original_assignment, 4, not_on_old_nodes),
           domain,
           {model::node_id{0}});
         BOOST_REQUIRE(res.has_value());
@@ -836,8 +832,7 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
         auto res = allocator.reallocate_partition(
           tn,
           cluster::partition_constraints(
-            model::partition_id(0), 5, not_on_old_nodes),
-          original_assignment,
+            original_assignment, 5, not_on_old_nodes),
           domain,
           {model::node_id{0}});
         BOOST_REQUIRE(res.has_error());
@@ -849,8 +844,7 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
         auto res = allocator.reallocate_partition(
           tn,
           cluster::partition_constraints(
-            model::partition_id(0), 4, not_on_old_nodes),
-          original_assignment,
+            original_assignment, 4, not_on_old_nodes),
           domain,
           {model::node_id{3}});
         BOOST_REQUIRE(res.has_error());
@@ -1061,8 +1055,7 @@ FIXTURE_TEST(topic_aware_reallocate_partition, partition_allocator_fixture) {
 
     auto reallocated = allocator.reallocate_partition(
       tn,
-      cluster::partition_constraints(model::partition_id(0), 3),
-      topic2->get_assignments().front(),
+      cluster::partition_constraints(topic2->get_assignments().front(), 3),
       cluster::partition_allocation_domains::common,
       {},
       &topic2_counts);

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -247,7 +247,7 @@ FIXTURE_TEST(partial_assignment, partition_allocator_fixture) {
 
     BOOST_REQUIRE_EQUAL(3, max_capacity());
     BOOST_REQUIRE_EQUAL(
-      allocator.state().last_group_id()(), max_partitions_in_cluster);
+      allocator.state().last_group_id()(), max_partitions_in_cluster - 1);
 }
 FIXTURE_TEST(max_deallocation, partition_allocator_fixture) {
     register_node(0, 3);

--- a/src/v/cluster/tests/partition_balancer_planner_fixture.h
+++ b/src/v/cluster/tests/partition_balancer_planner_fixture.h
@@ -106,6 +106,8 @@ public:
             req.partitions.emplace_back(
               model::partition_id(p), replication_factor);
         }
+        // enable topic-aware placement
+        req.existing_replica_counts = cluster::node2count_t{};
 
         auto pas = allocator.local()
                      .allocate(std::move(req))

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -711,7 +711,7 @@ FIXTURE_TEST(test_counts_rebalancing, partition_balancer_sim_fixture) {
     add_node(model::node_id{4}, 1000_GiB, 8);
     add_node_to_rebalance(model::node_id{4});
 
-    BOOST_REQUIRE(run_to_completion(1000));
+    BOOST_REQUIRE(run_to_completion(2000));
     validate_even_replica_distribution();
     validate_even_topic_distribution();
 }

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -389,6 +389,23 @@ public:
         }
     }
 
+    /// Validate that all possible replica pairings are represented
+    /// approximately equally in topic partition assignments.
+    void validate_topic_replica_pair_frequencies(const ss::sstring& topic) {
+        do_validate_replica_pair_frequencies(topic);
+    }
+
+    /// Validate that all possible replica pairings are represented
+    /// approximately equally in overall partition assignments, as well as for
+    /// each topic assignments.
+    void validate_replica_pair_frequencies() {
+        for (const auto& [tp_ns, topic_md] :
+             _workers.table.local().all_topics_metadata()) {
+            do_validate_replica_pair_frequencies(tp_ns.tp());
+        }
+        do_validate_replica_pair_frequencies(std::nullopt);
+    }
+
     bool should_schedule_balancer_run() const {
         auto current_in_progress
           = _workers.table.local().updates_in_progress().size();
@@ -398,6 +415,66 @@ public:
     }
 
 private:
+    void
+    do_validate_replica_pair_frequencies(std::optional<ss::sstring> topic) {
+        absl::flat_hash_map<
+          model::node_id,
+          absl::flat_hash_map<model::node_id, size_t>>
+          pair_freqs;
+        size_t total_pairs = 0;
+        for (const auto& [tp_ns, topic_md] :
+             _workers.table.local().all_topics_metadata()) {
+            if (topic && tp_ns.tp() != topic) {
+                continue;
+            }
+
+            for (const auto& p_as : topic_md.get_assignments()) {
+                for (const auto& r1 : p_as.replicas) {
+                    for (const auto& r2 : p_as.replicas) {
+                        if (r1.node_id != r2.node_id) {
+                            pair_freqs[r1.node_id][r2.node_id] += 1;
+                            total_pairs += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        size_t node_count = allocation_nodes().size();
+        double expected_freq = double(total_pairs)
+                               / (node_count * (node_count - 1));
+
+        // Generous boundaries to allow for fluctuations. But they will catch
+        // pathological cases.
+        double expected_min = expected_freq - sqrt(expected_freq) * 3;
+        double expected_max = expected_freq + sqrt(expected_freq) * 3;
+
+        logger.info(
+          "validating replica pair frequencies, topic filter: {}, "
+          "expected: {:.4} (interval: [{:.4}, {:.4}])",
+          topic,
+          expected_freq,
+          expected_min,
+          expected_max);
+        std::optional<std::pair<model::node_id, model::node_id>> offending_pair;
+        for (const auto& [id1, _] : allocation_nodes()) {
+            for (const auto& [id2, _] : allocation_nodes()) {
+                if (id1 == id2) {
+                    continue;
+                }
+                size_t freq = pair_freqs[id1][id2];
+                logger.info("node pair {} - {} frequency: {}", id1, id2, freq);
+                if (freq < expected_min || freq > expected_max) {
+                    offending_pair = {id1, id2};
+                }
+            }
+        }
+        BOOST_REQUIRE_MESSAGE(
+          !offending_pair,
+          "validation failed, offending pair: " << offending_pair->first << ", "
+                                                << offending_pair->second);
+    }
+
     cluster::cluster_health_report create_health_report() const {
         cluster::cluster_health_report report;
         for (const auto& [id, state] : _nodes) {
@@ -810,4 +887,35 @@ FIXTURE_TEST(test_many_topics, partition_balancer_sim_fixture) {
     BOOST_REQUIRE(run_to_completion(1000));
 
     validate_even_replica_distribution();
+}
+
+FIXTURE_TEST(test_replica_pair_frequency, partition_balancer_sim_fixture) {
+    for (size_t i = 0; i < 3; ++i) {
+        add_node(model::node_id{i}, 300_GiB);
+    }
+    add_topic("topic_1", 150, 3, 1_GiB);
+
+    for (size_t i = 3; i < 6; ++i) {
+        add_node(model::node_id{i}, 300_GiB);
+        add_node_to_rebalance(model::node_id{i});
+    }
+
+    add_topic("topic_2", 150, 3, 1_GiB);
+    logger.info("topic_2 created");
+    validate_topic_replica_pair_frequencies("topic_2");
+
+    BOOST_REQUIRE(run_to_completion(1000));
+    logger.info("first rebalance finished");
+    validate_even_replica_distribution();
+    validate_replica_pair_frequencies();
+
+    for (size_t i = 6; i < 9; ++i) {
+        add_node(model::node_id{i}, 300_GiB);
+        add_node_to_rebalance(model::node_id{i});
+    }
+
+    BOOST_REQUIRE(run_to_completion(1000));
+    logger.info("second rebalance finished");
+    validate_even_replica_distribution();
+    validate_replica_pair_frequencies();
 }

--- a/src/v/cluster/tests/topic_updates_dispatcher_test.cc
+++ b/src/v/cluster/tests/topic_updates_dispatcher_test.cc
@@ -217,6 +217,7 @@ FIXTURE_TEST(
           });
         BOOST_REQUIRE(it != new_replicas.end());
         it->node_id = model::node_id{4};
+        it->shard = random_generators::get_int(3);
 
         return std::tuple{
           ntp,

--- a/src/v/cluster/topics_frontend.cc
+++ b/src/v/cluster/topics_frontend.cc
@@ -1586,97 +1586,53 @@ ss::future<topics_frontend::capacity_info> topics_frontend::get_health_info(
 }
 namespace {
 
-partition_constraints get_partition_constraints(
-  const partition_assignment& assignment,
-  cluster::replication_factor new_replication_factor,
-  double max_disk_usage_ratio,
-  const topics_frontend::capacity_info& info) {
-    allocation_constraints allocation_constraints;
-
-    auto partition_size_it = info.ntp_sizes.find(assignment.id);
-    if (partition_size_it != info.ntp_sizes.end()) {
-        // Add constraint on partition max_disk_usage_ratio overfill
-        allocation_constraints.add(disk_not_overflowed_by_partition(
-          max_disk_usage_ratio,
-          partition_size_it->second,
-          info.node_disk_reports));
-
-        // Add constraint on least disk usage
-        allocation_constraints.add(least_disk_filled(
-          max_disk_usage_ratio,
-          partition_size_it->second,
-          info.node_disk_reports));
-    }
-
-    return {
-      assignment, new_replication_factor, std::move(allocation_constraints)};
-}
-
 // Executed on the partition_allocator shard
-ss::future<
-  result<ss::foreign_ptr<std::unique_ptr<chunked_vector<allocated_partition>>>>>
-do_increase_replication_factor(
-  model::topic_namespace_view ns_tp,
+ss::future<result<allocation_units::pointer>> do_increase_replication_factor(
+  const model::topic_namespace& ns_tp,
   const assignments_set& assignments,
   partition_allocator& al,
   replication_factor new_rf,
   double max_disk_usage_ratio,
   const topics_frontend::capacity_info& capacity_info,
   std::optional<node2count_t> existing_replica_counts) {
-    chunked_vector<allocated_partition> units;
-    units.reserve(assignments.size());
-    std::error_code error = errc::success;
-
+    allocation_request req(ns_tp, get_allocation_domain(ns_tp));
+    req.partitions.reserve(assignments.size());
     co_await ssx::async_for_each(
       assignments.begin(),
       assignments.end(),
       [&](const partition_assignment& assignment) {
-          if (error) {
-              return;
+          allocation_constraints allocation_constraints;
+
+          auto partition_size_it = capacity_info.ntp_sizes.find(assignment.id);
+          if (partition_size_it != capacity_info.ntp_sizes.end()) {
+              // Add constraint on partition max_disk_usage_ratio overfill
+              allocation_constraints.add(disk_not_overflowed_by_partition(
+                max_disk_usage_ratio,
+                partition_size_it->second,
+                capacity_info.node_disk_reports));
+
+              // Add constraint on least disk usage
+              allocation_constraints.add(least_disk_filled(
+                max_disk_usage_ratio,
+                partition_size_it->second,
+                capacity_info.node_disk_reports));
           }
 
-          auto p_id = assignment.id;
-          if (assignment.replicas.size() > new_rf()) {
-              vlog(
-                clusterlog.warn,
-                "Current size of replicas {} > new_replication_factor {} for "
-                "topic {} and partition {}",
-                assignment.replicas.size(),
-                new_rf,
-                ns_tp,
-                p_id);
-              error = errc::topic_invalid_replication_factor;
-              return;
-          }
-
-          auto reallocated = al.reallocate_partition(
-            model::topic_namespace(ns_tp),
-            get_partition_constraints(
-              assignment, new_rf, max_disk_usage_ratio, capacity_info),
-            get_allocation_domain(ns_tp),
-            {},
-            existing_replica_counts ? &existing_replica_counts.value()
-                                    : nullptr);
-          if (!reallocated) {
-              vlog(
-                clusterlog.warn,
-                "attempt to find reallocation for topic {}, partition {} "
-                "failed, error: {}",
-                ns_tp,
-                p_id,
-                reallocated.error().message());
-              error = reallocated.error();
-              return;
-          }
-
-          units.push_back(std::move(reallocated.value()));
+          req.partitions.emplace_back(
+            assignment, new_rf, std::move(allocation_constraints));
       });
+    req.existing_replica_counts = existing_replica_counts;
 
-    if (error) {
-        co_return error;
+    auto units = co_await al.allocate(std::move(req));
+    if (units.has_error()) {
+        vlog(
+          clusterlog.warn,
+          "attempt to replication factor for topic {} to {} failed, error: {}",
+          ns_tp,
+          new_rf,
+          units.error().message());
     }
-    co_return ss::make_foreign(
-      std::make_unique<decltype(units)>(std::move(units)));
+    co_return units;
 }
 
 } // namespace
@@ -1747,10 +1703,9 @@ ss::future<std::error_code> topics_frontend::increase_replication_factor(
     }
 
     std::vector<move_topic_replicas_data> new_assignments;
-    new_assignments.reserve(units.value()->size());
-    for (const auto& reallocated : *units.value()) {
-        new_assignments.emplace_back(
-          reallocated.ntp().tp.partition, reallocated.replicas());
+    new_assignments.reserve(units.value()->get_assignments().size());
+    for (const auto& assignment : units.value()->get_assignments()) {
+        new_assignments.emplace_back(assignment.id, assignment.replicas);
     }
 
     move_topic_replicas_cmd cmd(topic, std::move(new_assignments));

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -824,4 +824,5 @@ class CreateTopicReplicaDistributionTest(RedpandaTest):
         # Check topic2 counts
         counts = topic2node_counts['topic2']
         expected_count = int(sum(counts.values()) / 5)
-        assert all(v == expected_count for v in counts.values())
+        # allow +/- 1 fluctuations that can arise from unlucky replica allocation order.
+        assert all(abs(v - expected_count) <= 1 for v in counts.values())


### PR DESCRIPTION
Previously, we allocated new replicas of a partition and rebalanced existing ones together - i.e. all replicas of a single partition one by one. This can lead to having some replica sets repeated over and over - and undesirable pattern because these nodes will replicate data mostly between each other.

To prevent this, allocate and rebalance replicas in true random order - a replica of partition P1, then a replica of partition P2, then maybe a replica of P1 again, etc.

Fixes https://github.com/redpanda-data/redpanda/issues/17925

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Improvements
* Allocate and rebalance partition replicas in random order to prevent an undesirable pattern when many partitions have the same replica set.