### PR TITLE
fetch: Avoid formatting client ip and port for each partition

### DIFF
--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1171,108 +1171,107 @@ class simple_fetch_planner final : public fetch_planner::impl {
         /**
          * group fetch requests by shard
          */
-        octx.for_each_fetch_partition([&resp_it,
-                                       &octx,
-                                       &plan,
-                                       &bytes_left_in_plan](
-                                        const fetch_session_partition& fp) {
-            // if this is not an initial fetch we are allowed to skip
-            // partions that aleready have an error or we have enough data
-            if (!octx.initial_fetch) {
-                bool has_enough_data = !resp_it->empty()
-                                       && octx.over_min_bytes();
+        octx.for_each_fetch_partition(
+          [&resp_it, &octx, &plan, &bytes_left_in_plan](
+            const fetch_session_partition& fp) {
+              // if this is not an initial fetch we are allowed to skip
+              // partions that aleready have an error or we have enough data
+              if (!octx.initial_fetch) {
+                  bool has_enough_data = !resp_it->empty()
+                                         && octx.over_min_bytes();
 
-                if (resp_it->has_error() || has_enough_data) {
-                    ++resp_it;
-                    return;
-                }
-            }
+                  if (resp_it->has_error() || has_enough_data) {
+                      ++resp_it;
+                      return;
+                  }
+              }
 
-            // We audit successful messages only on the initial fetch
-            audit_on_success audit{octx.initial_fetch};
+              // We audit successful messages only on the initial fetch
+              audit_on_success audit{octx.initial_fetch};
 
-            /**
-             * if not authorized do not include into a plan
-             */
-            if (!octx.rctx.authorized(
-                  security::acl_operation::read,
-                  fp.topic_partition.get_topic(),
-                  audit)) {
-                resp_it->set(make_partition_response_error(
-                  fp.topic_partition.get_partition(),
-                  error_code::topic_authorization_failed));
-                ++resp_it;
-                return;
-            }
+              /**
+               * if not authorized do not include into a plan
+               */
+              if (!octx.rctx.authorized(
+                    security::acl_operation::read,
+                    fp.topic_partition.get_topic(),
+                    audit)) {
+                  resp_it->set(make_partition_response_error(
+                    fp.topic_partition.get_partition(),
+                    error_code::topic_authorization_failed));
+                  ++resp_it;
+                  return;
+              }
 
-            auto& tp = fp.topic_partition;
+              auto& tp = fp.topic_partition;
 
-            if (unlikely(octx.rctx.metadata_cache().is_disabled(
-                  tp.as_tn_view(), tp.get_partition()))) {
-                resp_it->set(make_partition_response_error(
-                  fp.topic_partition.get_partition(),
-                  error_code::replica_not_available));
-                ++resp_it;
-                return;
-            }
+              if (unlikely(octx.rctx.metadata_cache().is_disabled(
+                    tp.as_tn_view(), tp.get_partition()))) {
+                  resp_it->set(make_partition_response_error(
+                    fp.topic_partition.get_partition(),
+                    error_code::replica_not_available));
+                  ++resp_it;
+                  return;
+              }
 
-            auto shard = octx.rctx.shards().shard_for(tp);
-            if (unlikely(!shard)) {
-                // there is given partition in topic metadata, return
-                // unknown_topic_or_partition error
+              auto shard = octx.rctx.shards().shard_for(tp);
+              if (unlikely(!shard)) {
+                  // there is given partition in topic metadata, return
+                  // unknown_topic_or_partition error
 
-                /**
-                 * no shard is found on current node, but topic exists in
-                 * cluster metadata, this mean that the partition was
-                 * moved but consumer has not updated its metadata yet. we
-                 * return not_leader_for_partition error to force metadata
-                 * update.
-                 */
-                auto ec = octx.rctx.metadata_cache().contains(tp.to_ntp())
-                            ? error_code::not_leader_for_partition
-                            : error_code::unknown_topic_or_partition;
-                resp_it->set(make_partition_response_error(
-                  fp.topic_partition.get_partition(), ec));
-                ++resp_it;
-                return;
-            }
+                  /**
+                   * no shard is found on current node, but topic exists in
+                   * cluster metadata, this mean that the partition was
+                   * moved but consumer has not updated its metadata yet. we
+                   * return not_leader_for_partition error to force metadata
+                   * update.
+                   */
+                  auto ec = octx.rctx.metadata_cache().contains(tp.to_ntp())
+                              ? error_code::not_leader_for_partition
+                              : error_code::unknown_topic_or_partition;
+                  resp_it->set(make_partition_response_error(
+                    fp.topic_partition.get_partition(), ec));
+                  ++resp_it;
+                  return;
+              }
 
-            auto fetch_md = octx.rctx.get_fetch_metadata_cache().get(tp);
-            auto max_bytes = std::min(bytes_left_in_plan, size_t(fp.max_bytes));
-            /**
-             * If offset is greater, assume that fetch will read max_bytes
-             */
-            if (fetch_md && fetch_md->high_watermark > fp.fetch_offset) {
-                bytes_left_in_plan -= max_bytes;
-            }
+              auto fetch_md = octx.rctx.get_fetch_metadata_cache().get(tp);
+              auto max_bytes = std::min(
+                bytes_left_in_plan, size_t(fp.max_bytes));
+              /**
+               * If offset is greater, assume that fetch will read max_bytes
+               */
+              if (fetch_md && fetch_md->high_watermark > fp.fetch_offset) {
+                  bytes_left_in_plan -= max_bytes;
+              }
 
-            const auto client_address = fmt::format(
-              "{}:{}",
-              octx.rctx.connection()->client_host(),
-              octx.rctx.connection()->client_port());
+              const auto client_address = fmt::format(
+                "{}:{}",
+                octx.rctx.connection()->client_host(),
+                octx.rctx.connection()->client_port());
 
-            fetch_config config{
-              .start_offset = fp.fetch_offset,
-              .max_offset = model::model_limits<model::offset>::max(),
-              .max_bytes = max_bytes,
-              .timeout = octx.deadline.value_or(model::no_timeout),
-              .current_leader_epoch = fp.current_leader_epoch,
-              .isolation_level = octx.request.data.isolation_level,
-              .strict_max_bytes = octx.response_size > 0,
-              .skip_read = bytes_left_in_plan == 0 && max_bytes == 0,
-              .read_from_follower = octx.request.has_rack_id(),
-              .consumer_rack_id = octx.request.has_rack_id()
-                                    ? std::make_optional(
-                                      octx.request.data.rack_id)
-                                    : std::nullopt,
-              .abort_source = octx.rctx.abort_source(),
-              .client_address = model::client_address_t{client_address},
-            };
+              fetch_config config{
+                .start_offset = fp.fetch_offset,
+                .max_offset = model::model_limits<model::offset>::max(),
+                .max_bytes = max_bytes,
+                .timeout = octx.deadline.value_or(model::no_timeout),
+                .current_leader_epoch = fp.current_leader_epoch,
+                .isolation_level = octx.request.data.isolation_level,
+                .strict_max_bytes = octx.response_size > 0,
+                .skip_read = bytes_left_in_plan == 0 && max_bytes == 0,
+                .read_from_follower = octx.request.has_rack_id(),
+                .consumer_rack_id = octx.request.has_rack_id()
+                                      ? std::make_optional(
+                                        octx.request.data.rack_id)
+                                      : std::nullopt,
+                .abort_source = octx.rctx.abort_source(),
+                .client_address = model::client_address_t{client_address},
+              };
 
-            plan.fetches_per_shard[*shard].push_back(
-              {tp, std::move(config)}, &(*resp_it));
-            ++resp_it;
-        });
+              plan.fetches_per_shard[*shard].push_back(
+                {tp, std::move(config)}, &(*resp_it));
+              ++resp_it;
+          });
         return plan;
     }
 };

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1269,7 +1269,8 @@ class simple_fetch_planner final : public fetch_planner::impl {
               .client_address = model::client_address_t{client_address},
             };
 
-            plan.fetches_per_shard[*shard].push_back({tp, config}, &(*resp_it));
+            plan.fetches_per_shard[*shard].push_back(
+              {tp, std::move(config)}, &(*resp_it));
             ++resp_it;
         });
         return plan;

--- a/src/v/kafka/server/handlers/fetch.cc
+++ b/src/v/kafka/server/handlers/fetch.cc
@@ -1168,11 +1168,16 @@ class simple_fetch_planner final : public fetch_planner::impl {
 
         plan.reserve_from_partition_count(octx.fetch_partition_count());
 
+        const auto client_address = fmt::format(
+          "{}:{}",
+          octx.rctx.connection()->client_host(),
+          octx.rctx.connection()->client_port());
+
         /**
          * group fetch requests by shard
          */
         octx.for_each_fetch_partition(
-          [&resp_it, &octx, &plan, &bytes_left_in_plan](
+          [&resp_it, &octx, &plan, &bytes_left_in_plan, &client_address](
             const fetch_session_partition& fp) {
               // if this is not an initial fetch we are allowed to skip
               // partions that aleready have an error or we have enough data
@@ -1244,11 +1249,6 @@ class simple_fetch_planner final : public fetch_planner::impl {
               if (fetch_md && fetch_md->high_watermark > fp.fetch_offset) {
                   bytes_left_in_plan -= max_bytes;
               }
-
-              const auto client_address = fmt::format(
-                "{}:{}",
-                octx.rctx.connection()->client_host(),
-                octx.rctx.connection()->client_port());
 
               fetch_config config{
                 .start_offset = fp.fetch_offset,


### PR DESCRIPTION
We were formatting the ip and port of the client for each partition in
the fetch plan. This is unneeded as it obviously doesn't change by topic
or partition.

The formatting is fairly expensive and amounts for ~2-3% of total
reactor time in a high partition count scenario.

This could be further optimized by moving the formatted version to the
connection context to avoid having this copy alive many times but that's
a bit larger change for another PR.

Before:

<img width="1993" alt="image" src="https://github.com/redpanda-data/redpanda/assets/2904723/970c5f1f-1736-4f93-a117-f75a6d3b2ebc">

After:

<img width="1993" alt="image" src="https://github.com/redpanda-data/redpanda/assets/2904723/8acc7980-d2bf-4d04-9f06-46059d23d193">


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none


