### PR TITLE
cloud_roles: fix includes

### DIFF
--- a/src/v/cloud_roles/apply_abs_oauth_credentials.h
+++ b/src/v/cloud_roles/apply_abs_oauth_credentials.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "cloud_roles/apply_credentials.h"
-#include "cloud_roles/signature.h"
+#include "signature.h"
 
 namespace cloud_roles {
 


### PR DESCRIPTION
Make the includes linter happy

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
