### PR TITLE
CORE-2451 cloud_storage_clients/abs_clients: fix iterator check

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -927,8 +927,9 @@ abs_client::do_test_set_expiry_on_dummy_file(
 
     if (headers.result() == boost::beast::http::status::bad_request) {
         if (auto error_code_it = headers.find(error_code_name);
-            error_code_it->value()
-            == hierarchical_namespace_not_enabled_error_code) {
+            error_code_it != headers.end()
+            && error_code_it->value()
+                 == hierarchical_namespace_not_enabled_error_code) {
             // if there is a match of error code, we can proceed, otherwise
             // fallthrough
             co_return storage_account_info{.is_hns_enabled = false};


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

fixed a missing error_code_it != headers.end() check

Normally on Azure, the HTTP 400 error response has a `x-ms-error-code` header, so `headers.find("x-ms-error-code")->value()` is well-behaved, but it's not safe to not check the iterator before accessing it. 

Fixes CORE-2451

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none