### PR TITLE
treewide: fix oss build with clang-18

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -55,7 +55,8 @@ constexpr boost::beast::string_view expiry_option_name = "x-ms-expiry-option";
 constexpr boost::beast::string_view expiry_option_value = "RelativeToNow";
 constexpr boost::beast::string_view expiry_time_name = "x-ms-expiry-time";
 
-constexpr std::string_view hierarchical_namespace_not_enabled_error_code
+constexpr boost::beast::string_view
+  hierarchical_namespace_not_enabled_error_code
   = "HierarchicalNamespaceNotEnabled";
 
 // filename for the set expiry test file

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -890,12 +890,12 @@ FIXTURE_TEST(test_many_topics, partition_balancer_sim_fixture) {
 }
 
 FIXTURE_TEST(test_replica_pair_frequency, partition_balancer_sim_fixture) {
-    for (size_t i = 0; i < 3; ++i) {
+    for (model::node_id::type i = 0; i < 3; ++i) {
         add_node(model::node_id{i}, 300_GiB);
     }
     add_topic("topic_1", 150, 3, 1_GiB);
 
-    for (size_t i = 3; i < 6; ++i) {
+    for (model::node_id::type i = 3; i < 6; ++i) {
         add_node(model::node_id{i}, 300_GiB);
         add_node_to_rebalance(model::node_id{i});
     }
@@ -909,7 +909,7 @@ FIXTURE_TEST(test_replica_pair_frequency, partition_balancer_sim_fixture) {
     validate_even_replica_distribution();
     validate_replica_pair_frequencies();
 
-    for (size_t i = 6; i < 9; ++i) {
+    for (model::node_id::type i = 6; i < 9; ++i) {
         add_node(model::node_id{i}, 300_GiB);
         add_node_to_rebalance(model::node_id{i});
     }


### PR DESCRIPTION
There is no == operator found for std::string_view and
boost::beast::string_view when using stdlibc++

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
