### PR TITLE
[v23.2.x] [CORE-2461] c/topics: use topic table revision to detect changes in generator

### DIFF
--- a/src/v/cluster/topic_table_partition_generator.cc
+++ b/src/v/cluster/topic_table_partition_generator.cc
@@ -19,7 +19,7 @@ topic_table_partition_generator_exception::
 topic_table_partition_generator::topic_table_partition_generator(
   ss::sharded<topic_table>& topic_table, size_t batch_size)
   : _topic_table(topic_table)
-  , _stable_revision_id(_topic_table.local().last_applied_revision())
+  , _stable_revision_id(_topic_table.local().topics_map_revision())
   , _batch_size(batch_size) {
     if (_topic_table.local()._topics.empty()) {
         _topic_iterator = _topic_table.local()._topics.end();
@@ -32,8 +32,7 @@ topic_table_partition_generator::topic_table_partition_generator(
 
 ss::future<std::optional<topic_table_partition_generator::generator_type_t>>
 topic_table_partition_generator::next_batch() {
-    const auto current_revision_id
-      = _topic_table.local().last_applied_revision();
+    const auto current_revision_id = _topic_table.local().topics_map_revision();
     if (current_revision_id != _stable_revision_id) {
         throw topic_table_partition_generator_exception(fmt::format(
           "Last applied revision id moved from {} to {} whilst "


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17975
