### PR TITLE
Add v24.1.x backport option.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,6 +21,7 @@ If this PR is a backport, link to the original with `Backport of PR`, e.g.
 - [ ] none - this is a backport
 - [ ] none - issue does not exist in previous branches
 - [ ] none - papercut/not impactful enough to backport
+- [ ] v24.1.x
 - [ ] v23.3.x
 - [ ] v23.2.x
 


### PR DESCRIPTION
Add v24.1.x backport option to PR template.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v23.3.x
- [ ] v23.2.x

## Release notes

* none