### PR TITLE
features: Upgrade latest to version 13

### DIFF
--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -151,12 +151,13 @@ std::string_view to_string_view(feature_state::state s) {
 //  23.2.1 -> 10
 //  23.3.1 -> 11
 //  24.1.1 -> 12
+//  24.2.1 -> 13
 //
 // Although some previous stable branches have included feature version
 // bumps, this is _not_ the intended usage, as stable branches are
 // meant to be safely downgradable within the branch, and new features
 // imply that new data formats may be written.
-static constexpr cluster_version latest_version = cluster_version{12};
+static constexpr cluster_version latest_version = cluster_version{13};
 
 // The earliest version we can upgrade from.  This is the version that
 // a freshly initialized node will start at: e.g. a 23.1 Redpanda joining


### PR DESCRIPTION
Mark 24.2 as version 13.

Needed for upgrade tests at this point.



## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none

