### PR TITLE
c/controller_backend: try to force-abort reconfiguration only on leaders

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1614,6 +1614,14 @@ controller_backend::force_abort_replica_set_update(
         }
         co_return errc::waiting_for_recovery;
     } else {
+        auto leader_id = partition->get_leader_id();
+        if (leader_id && leader_id != _self) {
+            // The leader is alive and we are a follower. Wait for the leader to
+            // replicate the aborting configuration, but don't append it
+            // ourselves to minimize the chance of log inconsistency.
+            co_return errc::not_leader;
+        }
+
         vlog(
           clusterlog.debug,
           "[{}] force-aborting reconfiguration",


### PR DESCRIPTION
Previously, when force-aborting a reconfiguration, we appended an aborting configuration on all replicas. This can lead to log inconsistencies as on followers the configuration will be duplicated (one from own append, one replicated by the leader). Although these inconsistencies are expected for force-abort, if the leader is alive we can minimize the chance of their appearance by waiting on followers for the aborting config to be replicated from the leader.

Fixes https://github.com/redpanda-data/redpanda/issues/17847

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes
* none