### PR TITLE
CORE-2490 cloud_storage_clients/client_pool: error->warn

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -121,7 +121,7 @@ client_pool::do_client_self_configure(http_client_ptr client) {
 
             if (result.error() == cloud_storage_clients::error_outcome::retry) {
                 vlog(
-                  pool_log.error,
+                  pool_log.warn,
                   "Self configuration attempt {}/{} failed with retryable "
                   "error. "
                   "Will retry in {}s.",


### PR DESCRIPTION
`client_pool::do_client_self_configure`:
In case of retriable failure, print a warning-level message instead of error-level.
This message does not need to be at error level, in case this function fails to produce a result, the caller will print an ERROR message anyway

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Fixes CORE-2490
Fixes #17995

JIRA Link: [CORE-2490](https://redpandadata.atlassian.net/browse/CORE-2490)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none 

[CORE-2490]: https://redpandadata.atlassian.net/browse/CORE-2490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ