### PR TITLE
[v24.1.x] CORE-2490 cloud_storage_clients/client_pool: error->warn

### DIFF
--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -121,7 +121,7 @@ client_pool::do_client_self_configure(http_client_ptr client) {
 
             if (result.error() == cloud_storage_clients::error_outcome::retry) {
                 vlog(
-                  pool_log.error,
+                  pool_log.warn,
                   "Self configuration attempt {}/{} failed with retryable "
                   "error. "
                   "Will retry in {}s.",


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18022
Fixes: https://github.com/redpanda-data/redpanda/issues/18024,