### PR TITLE
rpk: add transfer-leadership command

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/partitions.go
@@ -32,6 +32,7 @@ func NewPartitionsCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		newPartitionDisableCommand(fs, p),
 		newPartitionEnableCommand(fs, p),
 		newPartitionMovementsStatusCommand(fs, p),
+		newTransferLeaderCommand(fs, p),
 		newUnsafeRecoveryCommand(fs, p),
 	)
 	return cmd

--- a/src/go/rpk/pkg/cli/cluster/partitions/transfer_leadership.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/transfer_leadership.go
@@ -1,0 +1,154 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package partitions
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+)
+
+func newTransferLeaderCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var partitionArg string
+
+	cmd := &cobra.Command{
+		Use:   "transfer-leadership",
+		Short: "Transfer partition leadership between brokers",
+		Long: `Transfer partition leadership between brokers.
+
+This command allows you to transfer partition leadership.
+You can transfer only one partition leader at a time.
+
+To transfer partition leadership, use the following syntax:
+	rpk cluster partitions transfer-leadership foo --partition 0:2
+
+Here, the command transfers leadership for the partition "kafka/foo/0"
+to broker 2. By default, it assumes the "kafka" namespace, but you can specify
+an internal namespace using the "{namespace}/" prefix.
+
+Here is an equivalent command using different syntax:
+	rpk cluster partitions transfer-leadership --partition foo/0:2
+
+Warning: Redpanda tries to balance leadership distribution across brokers by default.
+If the distribution of leaders becomes uneven as a result of transferring leadership
+across brokers, the cluster may move leadership back to the original
+brokers automatically.
+`,
+
+		Args: cobra.MaximumNArgs(1),
+		Run: func(cmd *cobra.Command, topicArg []string) {
+			f := p.Formatter
+			if h, ok := f.Help([]string{}); ok {
+				out.Exit(h)
+			}
+
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+			config.CheckExitCloudAdmin(p)
+
+			cl, err := adminapi.NewClient(fs, p)
+			out.MaybeDie(err, "unable to initialize admin client: %v", err)
+
+			if len(topicArg) > 0 { // foo -p 0:1
+				_, _, partition, target, err := extractNTPTarget(topicArg[0], partitionArg)
+				out.MaybeDie(err, "failed to extract topic/partition: %s\n", err)
+
+				ns, topic := formatNT(topicArg[0])
+
+				partDetails, err := cl.GetPartition(cmd.Context(), ns, topic, partition)
+				out.MaybeDie(err, "failed to get partition details: %s\n", err)
+
+				source := partDetails.LeaderID
+
+				err = cl.TransferLeadership(cmd.Context(), fs, p, source, ns, topic, partition, target)
+				if err != nil {
+					fmt.Printf("failed to transfer the partition leadership: %v\n", err)
+				} else {
+					fmt.Println("Successfully began the partition leadership transfer(s).\n\nCheck the new leader assignment with 'rpk topic describe -p TOPIC'.")
+				}
+			} else { // -p foo/0:1
+				ns, topic, partition, target, err := extractNTPTarget("", partitionArg)
+				out.MaybeDie(err, "failed to extract topic/partition: %s\n", err)
+
+				partDetails, err := cl.GetPartition(cmd.Context(), ns, topic, partition)
+				out.MaybeDie(err, "failed to get partition details: %s\n", err)
+
+				source := partDetails.LeaderID
+
+				err = cl.TransferLeadership(cmd.Context(), fs, p, source, ns, topic, partition, target)
+				if err != nil {
+					fmt.Printf("failed to transfer the partition leader: %v\n", err)
+				} else {
+					fmt.Println("Successfully began the partition leadership transfer(s).\n\nCheck the new leader assignment with 'rpk topic describe -p TOPIC'.")
+				}
+			}
+		},
+	}
+	cmd.Flags().StringVarP(&partitionArg, "partition", "p", "", "Topic-partition to transfer leadership and new leader location")
+	p.InstallFormatFlag(cmd)
+	return cmd
+}
+
+// extractNTPTarget parses the partition flag with format; foo/0:1 or 0:1
+// and returns namespace', 'topic', 'partition', and 'target node' separately.
+func extractNTPTarget(topic string, ntp string) (ns string, t string, p int, target string, err error) {
+	ntpReOnce.Do(func() {
+		ntpRe = regexp.MustCompile(`^((?:[^:]+/)?\d+):(\d+)$`)
+	})
+	m := ntpRe.FindStringSubmatch(ntp)
+	if len(m) == 0 {
+		return "", "", -1, "", fmt.Errorf("invalid format for %s", ntp)
+	}
+	beforeColon := m[1]
+	target = m[2]
+	if topic != "" {
+		p, err = strconv.Atoi(beforeColon)
+		if err != nil {
+			return "", "", -1, "", fmt.Errorf("%s", err)
+		}
+	} else if n := strings.Split(beforeColon, "/"); len(n) == 3 {
+		ns = n[0]
+		t = n[1]
+		p, err = strconv.Atoi(n[2])
+		if err != nil {
+			return "", "", -1, "", fmt.Errorf("%s", err)
+		}
+	} else if len(n) == 2 {
+		ns = "kafka"
+		t = n[0]
+		p, err = strconv.Atoi(n[1])
+		if err != nil {
+			return "", "", -1, "", fmt.Errorf("%s", err)
+		}
+	} else {
+		return "", "", -1, "", fmt.Errorf("invalid format for %s", ntp)
+	}
+	return ns, t, p, target, nil
+}
+
+// formatNT parse a given '(namespace)/topic' string
+// and return 'namespace' and 'topic' separately.
+func formatNT(t string) (ns string, topic string) {
+	if nt := strings.Split(t, "/"); len(nt) == 1 {
+		ns = "kafka"
+		topic = nt[0]
+	} else {
+		ns = nt[0]
+		topic = nt[1]
+	}
+	return
+}


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda/issues/17418

In this implementation, I decided to make the functionality simple for a start. In #17418, I reckoned to support `--partition` and `--from` options, but only `--partition` flag is supported at this moment. 

Here's the help text:

```
This command allows you to transfer leaderships for given partitions.

To move a leadership, use the following syntax:
	rpk cluster partitions transfer-leadership foo --partition 0:2

Here, the command transfers the leadership for the partition "kafka/foo/0"
to broker 2. By default, it assumes the "kafka" namespace, but you can specify
an internal namespace using the "{namespace}/" prefix.

The following command transfers the leadership for the partition "kafka/foo/0"
to broker 2 and the leadership for the partition "kafka/bar/1" to broker 4
	rpk cluster partitions transfer-leadership --partition foo/0:2 -p bar/1:4

Caveat: Redpanda tries to balance leadership distribution across brokers by default.
If the distribution of leaders becomes uneven as a result of transferring leadership
across brokers, the cluster will possiblly move the leaderships back to the original
brokers automatically.
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* rpk: ability to transfer partition leadership