### PR TITLE
build: upgrade os for oss build

### DIFF
--- a/.github/workflows/build-redpanda.yml
+++ b/.github/workflows/build-redpanda.yml
@@ -15,13 +15,12 @@ on:
 
 jobs:
   build:
-    if: github.event.pull_request.draft == false
     name: build redpanda
     runs-on: ubuntu-latest-64
     timeout-minutes: 30
     strategy:
       matrix:
-        os: ["ubuntu:mantic", "fedora:38"]
+        os: ["ubuntu:noble", "fedora:40"]
     container:
       image: ${{ matrix.os }}
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ endif()
 # creating a constexpr enum value that is bitwise combination
 # of flags can trigger this warning as the resulting "enum",
 # isn't a valid value.
-add_compile_options(-Wno-enum-constexpr-conversion)
+# Currently boost causes some warnings in -Wdeprecated-declarations due to std::aligned_storage,
+# these crop up all over, so disable them globally.
+add_compile_options(-Wno-enum-constexpr-conversion -Wno-deprecated-declarations)
 
 include(dependencies)
 include(v_library)

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -37,10 +37,7 @@ fetch_dep(fmt
 # the add_subdirectory method of using Seastar.
 set(Seastar_TESTING ON CACHE BOOL "" FORCE)
 set(Seastar_API_LEVEL 6 CACHE STRING "" FORCE)
-set(Seastar_CXX_FLAGS 
-  -Wno-error
-  -Wno-deprecated-declarations
-)
+set(Seastar_CXX_FLAGS -Wno-error)
 fetch_dep(seastar
   REPO https://github.com/redpanda-data/seastar.git
   TAG v24.2.x

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -37,7 +37,10 @@ fetch_dep(fmt
 # the add_subdirectory method of using Seastar.
 set(Seastar_TESTING ON CACHE BOOL "" FORCE)
 set(Seastar_API_LEVEL 6 CACHE STRING "" FORCE)
-set(Seastar_CXX_FLAGS -Wno-error)
+set(Seastar_CXX_FLAGS 
+  -Wno-error
+  -Wno-deprecated-declarations
+)
 fetch_dep(seastar
   REPO https://github.com/redpanda-data/seastar.git
   TAG v24.2.x

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -40,7 +40,7 @@ set(Seastar_API_LEVEL 6 CACHE STRING "" FORCE)
 set(Seastar_CXX_FLAGS -Wno-error)
 fetch_dep(seastar
   REPO https://github.com/redpanda-data/seastar.git
-  TAG v24.1.x
+  TAG v24.2.x
   PATCH_COMMAND sed -i "s/add_subdirectory (tests/# add_subdirectory (tests/g" CMakeLists.txt)
 
 fetch_dep(avro

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -89,7 +89,7 @@ fedora_deps=(
   python3
   python3-jinja2
   python3-jsonschema
-  ragel-devel
+  ragel
   re2-devel
   rust
   snappy-devel

--- a/src/v/serde/serde_is_enum.h
+++ b/src/v/serde/serde_is_enum.h
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include <cstdint>
 #include <type_traits>
 
 #pragma once
@@ -17,12 +18,12 @@ using serde_enum_serialized_t = int32_t;
 
 template<typename T>
 inline constexpr bool serde_is_enum_v =
-#if __has_cpp_attribute(__cpp_lib_is_scoped_enum)
-  std::is_scoped_enum_v<T>
-  && sizeof(std::decay_t<T>) <= sizeof(serde_enum_serialized_t);
-#else
+  // #if __has_cpp_attribute(__cpp_lib_is_scoped_enum)
+  //  std::is_scoped_enum_v<T>
+  //  && sizeof(std::decay_t<T>) <= sizeof(serde_enum_serialized_t);
+  // #else
   std::is_enum_v<T>
   && sizeof(std::decay_t<T>) <= sizeof(serde_enum_serialized_t);
-#endif
+// #endif
 
 } // namespace serde


### PR DESCRIPTION
To move to clang 18

https://github.com/redpanda-data/redpanda/actions/runs/8803302480

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
