### PR TITLE
CORE-2627 fix AZURE_AUTHORITY_HOST parsing in azure_ask_refresh_impl

### DIFF
--- a/src/v/cloud_roles/CMakeLists.txt
+++ b/src/v/cloud_roles/CMakeLists.txt
@@ -25,6 +25,7 @@ v_cc_library(
     v::http
     v::model
     v::utils
+    ada
 )
 
 add_subdirectory(tests)

--- a/src/v/cloud_roles/azure_aks_refresh_impl.h
+++ b/src/v/cloud_roles/azure_aks_refresh_impl.h
@@ -44,6 +44,8 @@ private:
     ss::sstring client_id_;
     ss::sstring tenant_id_;
     ss::sstring federated_token_file_;
+
+    friend class aks_test_helper;
 };
 
 } // namespace cloud_roles


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

AZURE_AUTHORITY_HOST contains URLs in the form of "https://somehostname.com/"

use ada::parse to convert this string to net::unresolved_address.

Fixes CORE-2627

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* correctly convert URL strings  to net::unresolved_address in azure_aks_refresh_impl
