### PR TITLE
cloud_roles/role_clients_tests: use SEASTAR_THREAD_TEST_CASE

### DIFF
--- a/src/v/cloud_roles/tests/role_client_tests.cc
+++ b/src/v/cloud_roles/tests/role_client_tests.cc
@@ -143,7 +143,7 @@ public:
     }
 };
 
-BOOST_AUTO_TEST_CASE(ask_authority_host_read_test) {
+SEASTAR_THREAD_TEST_CASE(aks_authority_host_read_test) {
     // test that we can correctly read various forms of AZURE_AUTHORITY_HOST
 
     // boilerplate


### PR DESCRIPTION
use of setenv under seastar requires to run under a initialized seastar context, since internal memory management functions will be called

https://buildkite.com/redpanda/redpanda/builds/48184#018f0cd6-3087-493c-bed2-d02e69fc3496

```
TRACE 2024-04-23 23:14:55,759 [shard 0:main] http - / - client.cc:314 - chunk received, chunk length 505
DEBUG 2024-04-23 23:14:55,759 [shard 0:main] http - iobuf_body.cc:82 - reader - finish called
test_cloud_roles_rpunit: /v/build/v_deps_build/seastar-prefix/src/seastar/src/core/memory.cc:1155: void seastar::memory::cpu_pages::shrink(void *, size_t): Assertion `object_cpu_id(ptr) == cpu_id' failed.
Aborting.
Backtrace:
  0xac39f3
  0xb1850b
```

backported here: https://github.com/redpanda-data/redpanda/pull/18042

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none 