### PR TITLE
storage: add additional logging for deep log_reader recursion

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1254,6 +1254,13 @@ configuration::configuration()
        .visibility = visibility::tunable},
       2,
       {.min = 1})
+  , debug_load_slice_warning_depth(
+      *this,
+      "debug_load_slice_warning_depth",
+      "The recursion depth after which debug logging will be enabled "
+      "automatically for the log reader.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
   , tx_registry_log_capacity(*this, "tx_registry_log_capacity")
   , id_allocator_log_capacity(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -242,6 +242,7 @@ struct configuration final : public config_store {
       storage_ignore_timestamps_in_future_sec;
     property<bool> storage_ignore_cstore_hints;
     bounded_property<int16_t> storage_reserve_min_segments;
+    property<std::optional<uint32_t>> debug_load_slice_warning_depth;
 
     deprecated_property tx_registry_log_capacity;
     property<int16_t> id_allocator_log_capacity;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -235,6 +235,11 @@ private:
         const auto& offsets() const { return (*next_seg)->offsets(); }
     };
 
+    ss::future<storage_t> load_slice(model::timeout_clock::time_point);
+    unsigned _load_slice_depth{0};
+    bool log_load_slice_depth_warning() const;
+    void maybe_log_load_slice_depth_warning(std::string_view) const;
+
     std::unique_ptr<lock_manager::lease> _lease;
     iterator_pair _iterator;
 


### PR DESCRIPTION
We have observed an instance of deep recursion in the log reader followed by a segfault suspected of being a stack overflow. This commit tracks the recursion depth and uses a configured threshold depth to gate additional logging to aid in debugging.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

