### PR TITLE
[v24.1.x] storage: add additional logging for deep log_reader recursion

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1230,6 +1230,13 @@ configuration::configuration()
        .visibility = visibility::tunable},
       2,
       {.min = 1})
+  , debug_load_slice_warning_depth(
+      *this,
+      "debug_load_slice_warning_depth",
+      "The recursion depth after which debug logging will be enabled "
+      "automatically for the log reader.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      std::nullopt)
   , tx_registry_log_capacity(*this, "tx_registry_log_capacity")
   , id_allocator_log_capacity(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -238,6 +238,7 @@ struct configuration final : public config_store {
       storage_ignore_timestamps_in_future_sec;
     property<bool> storage_ignore_cstore_hints;
     bounded_property<int16_t> storage_reserve_min_segments;
+    property<std::optional<uint32_t>> debug_load_slice_warning_depth;
 
     deprecated_property tx_registry_log_capacity;
     property<int16_t> id_allocator_log_capacity;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -235,6 +235,11 @@ private:
         const auto& offsets() const { return (*next_seg)->offsets(); }
     };
 
+    ss::future<storage_t> load_slice(model::timeout_clock::time_point);
+    unsigned _load_slice_depth{0};
+    bool log_load_slice_depth_warning() const;
+    void maybe_log_load_slice_depth_warning(std::string_view) const;
+
     std::unique_ptr<lock_manager::lease> _lease;
     iterator_pair _iterator;
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18067
