### PR TITLE
gh: Adjust workflow for code blocks

### DIFF
--- a/.github/workflows/scripts/jira_helper.py
+++ b/.github/workflows/scripts/jira_helper.py
@@ -193,8 +193,12 @@ class JiraHelper():
         labels = self._get_gh_issue_labels()
         issue_type = self._get_issue_type(labels)
 
+        # Replace "```" with "{code}" because Jira's format is different than
+        # GitHubs
+        jira_issue_body = issue_body.replace("```", "{code}")
+
         fields = {
-            "description": f"{issue_body}",
+            "description": f"{jira_issue_body}",
             "summary": f"{issue_title}",
             "issuetype": {
                 "name": f"{issue_type}"
@@ -236,6 +240,7 @@ issue that triggered this issue's creation.
         return issue_id
 
     def _add_comment_to_issue(self, issue_id, comment):
+        comment = comment.replace("```", "{code}")
         self.logger.debug(
             f'Updating issue {issue_id} with comment "{comment}"')
         try:


### PR DESCRIPTION
Jira uses '{code}' for code blocks so convert all "```" to "{code}".

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
