### PR TITLE
PESDLC-1275 Use last modified date to clean bucket

### DIFF
--- a/tests/rptest/services/provider_clients/ec2_client.py
+++ b/tests/rptest/services/provider_clients/ec2_client.py
@@ -354,6 +354,16 @@ class EC2Client:
                     buckets.append(bucket)
             return buckets
 
+    def query_bucket_lastmodified_date(self, name):
+        """Function returns last modified date 
+           based on first object key in the bucket
+        """
+        objects = self._s3cli.list_objects_v2(Bucket=name, MaxKeys=1)
+        if objects['KeyCount'] == 0:
+            return None
+        else:
+            return objects['Contents'][0]['LastModified']
+
     def list_bucket_objects(self, name, max_objects=3000):
         # Numner of objects collected
         objects_collected = 0


### PR DESCRIPTION
Improve bucket cleaning and use key object date instead of bucket one. Bucket date hold latest bucket modification that includes policy updates, uploads of new oblects, etc.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none