### PR TITLE
tx/rm_stm: remove mem_state

### DIFF
--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -209,6 +209,8 @@ public:
         return _current_txn_start_offset;
     }
 
+    model::producer_identity id() const { return _id; }
+
     void update_current_txn_start_offset(std::optional<kafka::offset> offset) {
         _current_txn_start_offset = offset;
     }

--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -298,6 +298,7 @@ private:
     ss::future<raft::stm_snapshot> do_take_local_snapshot(uint8_t version);
     ss::future<std::optional<abort_snapshot>> load_abort_snapshot(abort_index);
     ss::future<> save_abort_snapshot(abort_snapshot);
+    void update_tx_offsets(producer_ptr, const model::record_batch_header&);
 
     ss::future<result<kafka_result>> do_replicate(
       model::batch_identity,


### PR DESCRIPTION
Another step towards consolidated state management.

This PR removes `mem_state` struct from rm_stm entirely. Main change in this PR is to get rid of mem_state::estimated map that is supposed to hold the estimated offset of the first data batch in a transaction while its replication is in progress. This estimate is in place so that any racy LSO computation on the partition does not exceed the (future) replicated offset.  We remove that by redefining the transaction boundary to include the begin/fence batch in the transaction. first data batch is guaranteed to `happen after` the fence batch, so clamping the LSO at the fence batch by redefining the transaction boundaries ensures that in replication batches are not accounted for LSO.

The advantage of removing mem state is that the entire transactional state left in the stm is replayed from the log, so it is easy it to port to the new consolidated producer state definitions. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
