### PR TITLE
rpk/transform: support javascript and typescript

### DIFF
--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -66,3 +66,26 @@ jobs:
           ./scripts/publish.py --version ${{github.ref_name}}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  publish-javascript:
+    name: Publish JavaScript Transform SDK
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Publish
+        run: |
+          VERSION=$(python -c "print('${{github.ref_name}}'.removeprefix('transform-sdk/v'), end='')")
+          yq -iP ".version=${VERSION}" package.json -o json
+          npm ci
+          npm publish
+        working-directory: src/transform-sdk/js/module
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/go/rpk/pkg/cli/transform/build.go
+++ b/src/go/rpk/pkg/cli/transform/build.go
@@ -114,8 +114,10 @@ type cargoMetadata struct {
 
 func buildRust(ctx context.Context, fs afero.Fs, cfg project.Config, extraArgs []string) error {
 	cargo, err := exec.LookPath("cargo")
-	if err != nil {
-		return errors.New("cargo is not available on $PATH, please download and install it: https://rustup.rs/")
+	if errors.Is(err, exec.ErrNotFound) {
+		return fmt.Errorf("cargo is not available on $PATH, please download and install it: https://rustup.rs/")
+	} else if err != nil {
+		return fmt.Errorf("unable to lookup cargo executable: %v", err)
 	}
 	cmd := exec.CommandContext(ctx, cargo, "metadata", "--format-version=1")
 	var b bytes.Buffer
@@ -188,8 +190,10 @@ func createWatFromJavaScript(code []byte) string {
 
 func buildJavaScript(ctx context.Context, fs afero.Fs, cfg project.Config) error {
 	npm, err := exec.LookPath("npm")
-	if err != nil {
+	if errors.Is(err, exec.ErrNotFound) {
 		return fmt.Errorf("npm is not available on $PATH, please download and install it: https://nodejs.org/")
+	} else if err != nil {
+		return fmt.Errorf("unable to lookup npm executable: %v", err)
 	}
 	cmd := exec.CommandContext(ctx, npm, "run", "build")
 	cmd.Stderr = os.Stderr

--- a/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
+++ b/src/go/rpk/pkg/cli/transform/buildpack/buildpack.go
@@ -50,6 +50,22 @@ var Tinygo = Buildpack{
 	},
 }
 
+var JavaScript = Buildpack{
+	Name: "javascript",
+	// TODO: Find a better place to host these binaries than the tinygo repo
+	baseURL: "https://github.com/redpanda-data/tinygo/releases/download/js-sdk-placeholder",
+	shaSums: map[string]map[string]string{
+		"darwin": {
+			"amd64": "a2a7af658e8b7bb5b213fbcd33c395ef95019c0ba018fabdc80cc4435b70b792",
+			"arm64": "3010f528ea16a212eb942fb82afd34e6af48122c494f4bb72c5333adde955c70",
+		},
+		"linux": {
+			"amd64": "cb657b042a32b04469acf92f33453757a137072b09c23a3fbb7e6cbe387a1d80",
+			"arm64": "80ff2e5c76da00a1ba2a5c310fa7bb31ea989fdeea8eadd8c7cda7e0534fa9b4",
+		},
+	},
+}
+
 // Buildpack is a "plugin" system for Wasm toolchains so we can manage them on behalf of users.
 type Buildpack struct {
 	// Name of the plugin, this will also be the command name.
@@ -90,13 +106,22 @@ func (bp *Buildpack) URL() string {
 
 // BinPath returns the path to the main binary for the buildpack that needs to be linked as a plugin.
 func (bp *Buildpack) BinPath() (string, error) {
-	p, err := BuildpackDir()
+	p, err := bp.RootPath()
 	if err != nil {
 		return "", err
 	}
 	// right now assume a single structure, this may need to be dynamic if other buildpacks
 	// use different structures.
-	return filepath.Join(p, bp.Name, "bin", bp.Name), nil
+	return filepath.Join(p, "bin", bp.Name), nil
+}
+
+// RootPath returns the path to the root of the unarchived buildpack.
+func (bp *Buildpack) RootPath() (string, error) {
+	p, err := BuildpackDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(p, bp.Name), nil
 }
 
 // BuildpackDir is the directory to which buildpacks are downloaded to.

--- a/src/go/rpk/pkg/cli/transform/init.go
+++ b/src/go/rpk/pkg/cli/transform/init.go
@@ -13,6 +13,7 @@ package transform
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -278,8 +279,10 @@ func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
 		fallthrough
 	case project.WasmLangTinygoWithGoroutines:
 		g, err := exec.LookPath("go")
-		if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
 			return fmt.Errorf("go is not available on $PATH, please download and install it: https://go.dev/doc/install")
+		} else if err != nil {
+			return fmt.Errorf("unable to lookup go executable: %v", err)
 		}
 		runGoCli := func(args ...string) error {
 			return runCli(g, args...)
@@ -296,15 +299,19 @@ func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
 		return nil
 	case project.WasmLangRust:
 		rustup, err := exec.LookPath("rustup")
-		if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
 			return fmt.Errorf("rustup is not available on $PATH, please download and install it: https://rustup.rs/")
+		} else if err != nil {
+			return fmt.Errorf("unable to lookup rustup executable: %v", err)
 		}
 		if err := runCli(rustup, "target", "add", "wasm32-wasi"); err != nil {
 			return fmt.Errorf("unable to install wasm toolchain: %v", err)
 		}
 		cargo, err := exec.LookPath("cargo")
-		if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
 			return fmt.Errorf("cargo is not available on $PATH, please download and install it: https://rustup.rs/")
+		} else if err != nil {
+			return fmt.Errorf("unable to lookup cargo executable: %v", err)
 		}
 		if err := runCli(cargo, "add", "redpanda-transform-sdk"); err != nil {
 			return fmt.Errorf("unable to add redpanda-transform-sdk crate: %v", err)
@@ -314,8 +321,10 @@ func installDeps(ctx context.Context, fs afero.Fs, p transformProject) error {
 		fallthrough
 	case project.WasmLangTypeScript:
 		npm, err := exec.LookPath("npm")
-		if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
 			return fmt.Errorf("npm is not available on $PATH, please download and install it: https://nodejs.org/")
+		} else if err != nil {
+			return fmt.Errorf("unable to lookup npm executable: %v", err)
 		}
 		if err := runCli(npm, "install"); err != nil {
 			return fmt.Errorf("unable to install node modules: %v", err)

--- a/src/go/rpk/pkg/cli/transform/project/project.go
+++ b/src/go/rpk/pkg/cli/transform/project/project.go
@@ -23,12 +23,16 @@ const (
 	WasmLangTinygoWithGoroutines WasmLang = "tinygo-with-goroutines"
 	WasmLangTinygoNoGoroutines   WasmLang = "tinygo-no-goroutines"
 	WasmLangRust                 WasmLang = "rust"
+	WasmLangJavaScript           WasmLang = "javascript"
+	WasmLangTypeScript           WasmLang = "typescript"
 )
 
 var AllWasmLangs = []string{
 	string(WasmLangTinygoNoGoroutines),
 	string(WasmLangTinygoWithGoroutines),
 	string(WasmLangRust),
+	string(WasmLangJavaScript),
+	string(WasmLangTypeScript),
 }
 
 // AllWasmLangsWithDescriptions is AllWasmLangs but with extended descriptions.
@@ -38,6 +42,8 @@ var AllWasmLangsWithDescriptions = []string{
 	"Tinygo (no goroutines) - higher throughput",
 	"Tinygo (with goroutines)",
 	"Rust",
+	"JavaScript",
+	"TypeScript",
 }
 
 func (l *WasmLang) Set(str string) error {

--- a/src/go/rpk/pkg/cli/transform/template/js/README.md
+++ b/src/go/rpk/pkg/cli/transform/template/js/README.md
@@ -1,0 +1,15 @@
+# Redpanda %s WASM Transform
+
+To get started you first need to have node and npm installed.
+
+You can get started by modifying the <code>src/index.%s</code> file
+with your logic.
+
+Once you're ready to test out your transform live you need to:
+
+1. Make sure you have a container running via <code>rpk container start</code>
+1. Run <code>rpk transform build</code>
+1. Create your topics via <code>rpk topic create</code>
+1. Run <code>rpk transform deploy</code>
+1. Then use <code>rpk topic produce</code> and <code>rpk topic consume</code>
+   to see your transformation live!

--- a/src/go/rpk/pkg/cli/transform/template/js/esbuild.js
+++ b/src/go/rpk/pkg/cli/transform/template/js/esbuild.js
@@ -1,0 +1,28 @@
+import * as esbuild from 'esbuild'
+import { polyfillNode } from "esbuild-plugin-polyfill-node";
+
+await esbuild.build({
+  entryPoints: ["src/index%s"],
+  outfile: "dist/%s",
+  bundle: true,
+  external: [
+    // This package is provided by the Redpanda JavaScript runtime.
+    "@redpanda-data/transform-sdk",
+  ],
+  target: "es2022",
+  platform: "neutral", // We're running in Wasm
+  plugins: [
+    polyfillNode({
+      globals: {
+        // Allow a global Buffer variable if referenced.
+        buffer: true,
+        // Don't inject the process global, the Redpanda JavaScript runtime
+        // does that.
+        process: false,
+      },
+      polyfills: {
+        // Any NodeJS APIs that need to polyfilled can be added here.
+      },
+    }),
+  ],
+});

--- a/src/go/rpk/pkg/cli/transform/template/js/transform.jssrc
+++ b/src/go/rpk/pkg/cli/transform/template/js/transform.jssrc
@@ -1,0 +1,5 @@
+import {onRecordWritten} from "@redpanda-data/transform-sdk";
+
+onRecordWritten((event, writer) => {
+  writer.write(event.record);
+});

--- a/src/go/rpk/pkg/cli/transform/template/js/transform.tssrc
+++ b/src/go/rpk/pkg/cli/transform/template/js/transform.tssrc
@@ -1,0 +1,5 @@
+import { onRecordWritten, OnRecordWrittenEvent, RecordWriter } from "@redpanda-data/transform-sdk"
+
+onRecordWritten((event: OnRecordWrittenEvent, writer: RecordWriter) => {
+  writer.write(event.record);
+});

--- a/src/go/rpk/pkg/cli/transform/template/js/tsconfig.json
+++ b/src/go/rpk/pkg/cli/transform/template/js/tsconfig.json
@@ -1,0 +1,103 @@
+{
+  "compilerOptions": {
+    /* Visit https://www.typescriptlang.org/tsconfig/ to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "esnext",                                  /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": false,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,                                      /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+  }
+}

--- a/src/go/rpk/pkg/cli/transform/template/js_template.go
+++ b/src/go/rpk/pkg/cli/transform/template/js_template.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+package template
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+)
+
+type packageJson struct {
+	Name            string            `json:"name"`
+	Type            string            `json:"type"`
+	Private         bool              `json:"private"`
+	Scripts         map[string]string `json:"scripts"`
+	Dependencies    map[string]string `json:"dependencies"`
+	DevDependencies map[string]string `json:"devDependencies"`
+}
+
+func WasmPackageJson(name string, typescript bool) string {
+	pkg := packageJson{
+		Name:    name,
+		Private: true,
+		Type:    "module",
+		Scripts: map[string]string{
+			"build": "node esbuild.js",
+		},
+		Dependencies: map[string]string{
+			"@redpanda-data/transform-sdk": "1.x",
+		},
+		DevDependencies: map[string]string{
+			// Our (excellent) bundler
+			"esbuild": "0.20.x",
+			// A plugin for node compat
+			"esbuild-plugin-polyfill-node": "0.3.x",
+		},
+	}
+	if typescript {
+		// Add typescript compiled if needed
+		pkg.DevDependencies["typescript"] = "5.x"
+	}
+	b, _ := json.MarshalIndent(&pkg, "", "  ")
+	return string(b)
+}
+
+//go:embed js/README.md
+var wasmJsReadme string
+
+func WasmJavaScriptReadme(typescript bool) string {
+	lang := "JavaScript"
+	ext := "js"
+	if typescript {
+		lang = "TypeScript"
+		ext = "ts"
+	}
+	return fmt.Sprintf(wasmJsReadme, lang, ext)
+}
+
+func WasmTypeScriptReadme() string {
+	return wasmJsReadme
+}
+
+//go:embed js/tsconfig.json
+var wasmTsConfig string
+
+func WasmTsConfig() string {
+	return wasmTsConfig
+}
+
+//go:embed js/transform.jssrc
+var wasmJsMain string
+
+func WasmJavaScriptMain() string {
+	return wasmJsMain
+}
+
+//go:embed js/transform.tssrc
+var wasmTsMain string
+
+func WasmTypeScriptMain() string {
+	return wasmTsMain
+}
+
+//go:embed js/esbuild.js
+var wasmEsbuildFile string
+
+func WasmEsbuildFile(name string, typescript bool) string {
+	ext := ".js"
+	if typescript {
+		ext = ".ts"
+	}
+	return fmt.Sprintf(wasmEsbuildFile, ext, name+".js")
+}

--- a/src/transform-sdk/js/CMakeLists.txt
+++ b/src/transform-sdk/js/CMakeLists.txt
@@ -65,13 +65,14 @@ target_link_libraries(
   qjs Redpanda::transform_sdk Redpanda::js_vm
 )
 
-if(CMAKE_BUILD_TYPE MATCHES Release)
-  include(CheckIPOSupported)
-  check_ipo_supported(RESULT ltosupported OUTPUT error)
-  if(ltosupported)
-    set_property(TARGET redpanda_js_transform PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
-  endif()
-endif()
+# TODO: Rename LTO builds when #18077 is merged
+# if(CMAKE_BUILD_TYPE MATCHES Release)
+#   include(CheckIPOSupported)
+#   check_ipo_supported(RESULT ltosupported OUTPUT error)
+#   if(ltosupported)
+#     set_property(TARGET redpanda_js_transform PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
+#   endif()
+# endif()
 
 # Tests
 enable_testing()

--- a/src/transform-sdk/js/CMakeLists.txt
+++ b/src/transform-sdk/js/CMakeLists.txt
@@ -65,6 +65,14 @@ target_link_libraries(
   qjs Redpanda::transform_sdk Redpanda::js_vm
 )
 
+if(CMAKE_BUILD_TYPE MATCHES Release)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT ltosupported OUTPUT error)
+  if(ltosupported)
+    set_property(TARGET redpanda_js_transform PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
+  endif()
+endif()
+
 # Tests
 enable_testing()
 

--- a/src/transform-sdk/js/module/index.d.ts
+++ b/src/transform-sdk/js/module/index.d.ts
@@ -111,7 +111,7 @@ export type OnRecordWrittenCallback = (event: OnRecordWrittenEvent, writer: Reco
 // This method should be called in your script's entrypoint.
 //
 // @example
-// import {onRecordWritten} from "@redpanda-data/transforms";
+// import {onRecordWritten} from "@redpanda-data/transform-sdk";
 //
 // // Copy the input data to the output topic.
 // onRecordWritten((event, writer) => {

--- a/src/transform-sdk/js/module/index.d.ts
+++ b/src/transform-sdk/js/module/index.d.ts
@@ -12,110 +12,132 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// RecordData is a wrapper around the underlying raw data
-// in a record.
-//
-// Similar to a JavaScript Response object.
+/**
+ * RecordData is a wrapper around the underlying raw data
+ * in a record.
+ *
+ * Similar to a JavaScript Response object.
+ */
 export interface RecordData {
-  // Parse the data as JSON.
-  //
-  // This is a more efficent version of JSON.parse(text());
-  //
-  // @throws if the payload is not valid JSON
-  // @returns the parsed JSON
+  /**
+   * Parse the data as JSON.
+   *
+   * This is a more efficent version of JSON.parse(text());
+   *
+   * @throws if the payload is not valid JSON
+   * @returns the parsed JSON
+   */
   json(): any;
-  // Parse the data as a UTF-8 string.
-  //
-  // @throws if the payload is not valid UTF-8
-  // @returns the parsed string
+  /**
+   * Parse the data as a UTF-8 string.
+   *
+   * @throws if the payload is not valid UTF-8
+   * @returns the parsed string
+   */
   text(): string;
-  // Return the data as a raw byte array.
+  /** Return the data as a raw byte array. */
   array(): Uint8Array;
 }
 
-// Records may have a collection of headers attached to them.
-//
-// Headers are opaque to the broker and are purely a mechanism for the
-// producer and consumers to pass information.
+/**
+ * Records may have a collection of headers attached to them.
+ *
+ * Headers are opaque to the broker and are purely a mechanism for the
+ * producer and consumers to pass information.
+ */
 export interface RecordHeader {
-  // The key of this header.
+  /** The key of this header. */
   readonly key?: string | ArrayBuffer | Uint8Array | RecordData | null;
-  // The value of this header.
+  /** The value of this header. */
   readonly value?: string | ArrayBuffer | Uint8Array | RecordData | null;
 }
 
-// A record within Redpanda.
-//
-// Records are generated as a result of any transforms that act upon
-// a WrittenRecord.
+/**
+ * A record within Redpanda.
+ *
+ * Records are generated as a result of any transforms that act upon
+ * a WrittenRecord.
+ */
 export interface Record {
-  // The key for this record.
+  /** The key for this record. */
   readonly key?: string | ArrayBuffer | Uint8Array | RecordData | null;
-  // The value for this record.
+  /** The value for this record. */
   readonly value?: string | ArrayBuffer | Uint8Array | RecordData | null;
-  // The headers attached to this record.
+  /** The headers attached to this record. */
   readonly headers?: RecordHeader[];
 }
 
-// Records may have a collection of headers attached to them.
-//
-// Headers are opaque to the broker and are purely a mechanism for the
-// producer and consumers to pass information.
-//
-// It is similar to a RecordHeader, expect that it only contains 
-// RecordData or null.
+/**
+ * Records may have a collection of headers attached to them.
+ *
+ * Headers are opaque to the broker and are purely a mechanism for the
+ * producer and consumers to pass information.
+ *
+ * It is similar to a RecordHeader, expect that it only contains
+ * RecordData or null.
+ */
 export interface WrittenRecordHeader {
-  // The key for this header.
-  readonly key?: RecordData | null
-  // The value for this header.
-  readonly value?: RecordData | null
+  /** The key for this header. */
+  readonly key?: RecordData | null;
+  /** The value for this header. */
+  readonly value?: RecordData | null;
 }
 
-// A persisted record written to a topic within Redpanda.
-//
-// It is similar to a Record, expect that it only contains RecordData 
-// or null.
+/**
+ * A persisted record written to a topic within Redpanda.
+ *
+ * It is similar to a Record, expect that it only contains RecordData
+ * or null.
+ */
 export interface WrittenRecord {
-  // The key for this record.
+  /** The key for this record. */
   readonly key: RecordData | null;
-  // The value for this record.
+  /** The value for this record. */
   readonly value: RecordData | null;
-  // The headers for this record.
+  /** The headers for this record. */
   readonly headers: RecordHeader[];
 }
 
-// An even generated after a write event within the broker.
+/** An event generated after a write event within the broker. */
 export interface OnRecordWrittenEvent {
-  // The record that was written as part of this event.
+  /** The record that was written as part of this event. */
   readonly record: WrittenRecord;
 }
 
-// A writer for transformed records that are output to the destination 
-// topic.
+/**
+ * A writer for transformed records that are output to the destination
+ * topic.
+ */
 export interface RecordWriter {
-  // Write a record to the output topic.
-  //
-  // @throws if there are errors writing the record.
+  /**
+   * Write a record to the output topic.
+   *
+   * @throws if there are errors writing the record.
+   */
   write(record: Record): void;
 }
 
-// The callback type for OnRecordWritten
-export type OnRecordWrittenCallback = (event: OnRecordWrittenEvent, writer: RecordWriter) => void;
+/** The callback type for OnRecordWritten. */
+export type OnRecordWrittenCallback = (
+  event: OnRecordWrittenEvent,
+  writer: RecordWriter,
+) => void;
 
-// Register a callback to be fired when a record is written to the 
-// input topic.
-//
-// This callback is triggered after the record has been written,
-// fsynced to disk and the producer acknowledged.
-//
-// This method should be called in your script's entrypoint.
-//
-// @example
-// import {onRecordWritten} from "@redpanda-data/transform-sdk";
-//
-// // Copy the input data to the output topic.
-// onRecordWritten((event, writer) => {
-//   writer.write(event.record);
-// });
+/**
+ * Register a callback to be fired when a record is written to the
+ * input topic.
+ *
+ * This callback is triggered after the record has been written,
+ * fsynced to disk and the producer acknowledged.
+ *
+ * This method should be called in your script's entrypoint.
+ *
+ * @example
+ * import {onRecordWritten} from "@redpanda-data/transform-sdk";
+ *
+ * // Copy the input data to the output topic.
+ * onRecordWritten((event, writer) => {
+ *   writer.write(event.record);
+ * });
+ */
 export function onRecordWritten(cb: OnRecordWrittenCallback): void;
-

--- a/src/transform-sdk/js/module/index.js
+++ b/src/transform-sdk/js/module/index.js
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // This is a stub that does nothing.
-// When deployed in broker this function is 
+// When deployed in broker this function is
 // provided by the JavaScript runtime.
 export function onRecordWritten(cb) {}

--- a/src/transform-sdk/js/module/package-lock.json
+++ b/src/transform-sdk/js/module/package-lock.json
@@ -1,0 +1,16 @@
+{
+  "name": "@redpanda-data/transform-sdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@redpanda-data/transform-sdk",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    }
+  }
+}

--- a/src/transform-sdk/js/module/package.json
+++ b/src/transform-sdk/js/module/package.json
@@ -8,7 +8,7 @@
   "module": "index.js",
   "files": [
     "index.js",
-    "index.d.ts",
+    "index.d.ts"
   ],
   "publishConfig": {
     "access": "public"
@@ -16,5 +16,5 @@
   "engines": {
     "node": ">=14"
   },
-  "repository": "github:redpanda-data/redpanda",
+  "repository": "github:redpanda-data/redpanda"
 }

--- a/src/transform-sdk/js/module/package.json
+++ b/src/transform-sdk/js/module/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@redpanda-data/transforms",
+  "name": "@redpanda-data/transform-sdk",
   "version": "0.1.0",
   "description": "A JavaScript/TypeScript library for authoring Redpanda Data Transforms",
   "license": "Apache-2.0",

--- a/src/transform-sdk/js/package_toolchain.py
+++ b/src/transform-sdk/js/package_toolchain.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""
+A small script that will download wasm-merge and create a tarball with wasm-merge and the JavaScript VM compiled as Wasm.
+
+This script assumes it's run from the JS SDK root directory (src/transform-sdk/js) and you must have already built the Wasm binary via:
+
+docker run -v `pwd`/..:/src -w /src/js ghcr.io/webassembly/wasi-sdk \
+  /bin/bash -c 'apt update && apt install -y git && cmake --preset release-static && cmake --build --preset release-static -- redpanda_js_transform'
+"""
+
+import subprocess
+import tempfile
+from pathlib import Path
+import tarfile
+import shutil
+
+
+def download_via_curl(url, file):
+    """
+    Download by shelling to curl. Simpler than than the pure python approach 🤷
+    """
+    subprocess.run(["curl", "-SL", "-o", file, url], check=True)
+
+
+BINARYEN_VERSION = 117
+BINARYEN_BASE_URL = f"https://github.com/WebAssembly/binaryen/releases/download/version_{BINARYEN_VERSION}/binaryen-version_{BINARYEN_VERSION}-"
+
+BINARYEN_TARGET_MAPPING = {
+    ("linux", "arm64"): "aarch64-linux",
+    ("linux", "amd64"): "x86_64-linux",
+    ("darwin", "arm64"): "arm64-macos",
+    ("darwin", "amd64"): "x86_64-macos",
+}
+
+install_dir = Path.cwd() / "build"
+# This script assumes you've already built the final binary
+js_wasm_vm = install_dir / "release-static" / "redpanda_js_transform"
+with tempfile.TemporaryDirectory() as temp_dir:
+    temp_dir = Path(temp_dir)
+    for os in ["darwin", "linux"]:
+        for arch in ["arm64", "amd64"]:
+            file = f"{BINARYEN_TARGET_MAPPING[(os, arch)]}.tar.gz"
+            download_via_curl(BINARYEN_BASE_URL + file, temp_dir / file)
+            with tarfile.open(temp_dir / file) as tar:
+                tar.extractall(path=temp_dir / f"{os}-{arch}")
+            output = install_dir / f"javascript-{os}-{arch}.tar.gz"
+            with tarfile.open(output, mode='w:gz') as tar:
+                wasm_merge = temp_dir / f"{os}-{arch}" / f"binaryen-version_{BINARYEN_VERSION}" / "bin" / "wasm-merge"
+                tar.add(wasm_merge, arcname=wasm_merge.name)
+                tar.add(js_wasm_vm, arcname=js_wasm_vm.name)


### PR DESCRIPTION
Support JS and TS for Data Transforms.

We still have work to do here, mainly a deploy pipeline for the JS buildpack, otherwise I have proof this is working end to end.

Closes: CORE-2370 and CORE-2373

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* Support JavaScript and TypeScript as languages for Data Transforms.
