### PR TITLE
gh: fix lint-cpp for ubuntu noble

### DIFF
--- a/.github/workflows/lint-cpp.yml
+++ b/.github/workflows/lint-cpp.yml
@@ -28,17 +28,9 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@v3
-
+    - name: Install clang-format
+      run: sudo apt install clang-format-16
     - name: Run clang-format
-      run: |
-        docker run \
-        -v $PWD:/redpanda ubuntu \
-        bash -c "cd /redpanda && \
-          apt update && \
-          apt install -y wget git lsb-release wget software-properties-common gnupg && \
-          wget https://apt.llvm.org/llvm.sh && \
-          chmod +x llvm.sh && \
-          ./llvm.sh 16 && \
-          apt-get install -y clang-format-16 && \
-          find . -type f -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format-16 -i -style=file -fallback-style=none"
-        git diff --exit-code
+      run:  find . -type f -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format-16 -i -style=file -fallback-style=none"
+    - name: Check results
+      run: git diff --exit-code

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -97,6 +97,7 @@
 #include "net/dns.h"
 #include "net/server.h"
 #include "net/tls_certificate_probe.h"
+
 #include "pandaproxy/rest/api.h"
 #include "pandaproxy/rest/configuration.h"
 #include "pandaproxy/schema_registry/api.h"
@@ -214,8 +215,7 @@ set_sr_kafka_client_defaults(kafka::client::configuration& client_config) {
 static void set_auditing_kafka_client_defaults(
   kafka::client::configuration& client_config) {
     if (!client_config.produce_batch_delay.is_overriden()) {
-        client_config.produce_batch_delay.set_value(0ms);
-    }
+        client_config.produce_batch_delay.set_value(0ms); }
     if (!client_config.produce_batch_record_count.is_overriden()) {
         client_config.produce_batch_record_count.set_value(int32_t(0));
     }


### PR DESCRIPTION
llvm doesn't seem to have clang16 package for ubuntu noble. but ubuntu noble has a clang16 package.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none
