### PR TITLE
Fixes for wait_ms cpu profiler mode

### DIFF
--- a/src/v/resource_mgmt/cpu_profiler.cc
+++ b/src/v/resource_mgmt/cpu_profiler.cc
@@ -190,7 +190,11 @@ ss::future<> cpu_profiler::collect_results_for_period_impl(
     _override_enabled--;
     // check if profiler should be disabled post-override.
     on_enabled_change();
-    // prof.poll_samples();
+
+    // The timer to reap events from seastar only fires ~128 * sample period so
+    // by default we would only collect samples every 13 seconds. To make sure
+    // we get samples for something like wait_ms=5s we reap explicitly.
+    poll_samples();
 }
 
 ss::future<std::vector<cpu_profiler::shard_samples>>

--- a/src/v/resource_mgmt/cpu_profiler.h
+++ b/src/v/resource_mgmt/cpu_profiler.h
@@ -89,6 +89,10 @@ public:
       std::chrono::milliseconds timeout, std::optional<ss::shard_id> shard_id);
 
 private:
+    // impl for the above
+    ss::future<>
+    collect_results_for_period_impl(std::chrono::milliseconds timeout);
+
     // Used to poll seastar at set intervals to capture all samples
     ss::timer<ss::lowres_clock> _query_timer;
     ss::gate _gate;


### PR DESCRIPTION
Fixes two bugs in the cpu profiler wait_ms implementation:

 - Actually enable the profiler on all shards not just the Admin API shard
 - Work for short and arbitrary sample periods. Previously it would only collect samples for multiples of ~13 seconds.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none

