### PR TITLE
c/controller_backend: bootstrap from shard_placement_table

### DIFF
--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -252,8 +252,7 @@ private:
       model::revision_id bootstrap_revision,
       absl::flat_hash_map<model::ntp, model::revision_id> topic_table_snapshot);
 
-    void start_fetch_deltas_loop();
-    ss::future<> fetch_deltas();
+    void process_delta(const topic_table::delta&);
 
     ss::future<> reconcile_ntp_fiber(
       model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>);
@@ -380,6 +379,7 @@ private:
     absl::btree_map<model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>>
       _states;
 
+    cluster::notification_id_type _topic_table_notify_handle;
     // Limits the number of concurrently executing reconciliation fibers.
     // Initially reconciliation is blocked and we deposit a non-zero amount of
     // units when we are ready to start reconciling.

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -230,7 +230,7 @@ public:
     std::optional<in_progress_operation>
     get_current_op(const model::ntp&) const;
 
-    void notify_reconciliation(const model::ntp&, model::shard_revision_id);
+    void notify_reconciliation(const model::ntp&);
 
 private:
     struct ntp_reconciliation_state;

--- a/src/v/cluster/shard_balancer.cc
+++ b/src/v/cluster/shard_balancer.cc
@@ -80,10 +80,9 @@ ss::future<> shard_balancer::stop() {
 ss::future<> shard_balancer::process_delta(const topic_table::delta& delta) {
     const auto& ntp = delta.ntp;
 
-    auto shard_callback =
-      [this](const model::ntp& ntp, model::shard_revision_id shard_rev) {
-          _controller_backend.local().notify_reconciliation(ntp, shard_rev);
-      };
+    auto shard_callback = [this](const model::ntp& ntp) {
+        _controller_backend.local().notify_reconciliation(ntp);
+    };
 
     auto maybe_replicas_view = _topics.local().get_replicas_view(ntp);
     if (!maybe_replicas_view) {

--- a/src/v/cluster/shard_placement_table.cc
+++ b/src/v/cluster/shard_placement_table.cc
@@ -292,7 +292,7 @@ ss::future<> shard_placement_table::set_assigned_on_this_shard(
     }
 
     // Notify the caller that something has changed on this shard.
-    shard_callback(ntp, shard_rev);
+    shard_callback(ntp);
     co_return;
 }
 
@@ -319,7 +319,7 @@ ss::future<> shard_placement_table::remove_assigned_on_this_shard(
     }
 
     // Notify the caller that something has changed on this shard.
-    shard_callback(ntp, shard_rev);
+    shard_callback(ntp);
 }
 
 std::optional<shard_placement_table::placement_state>

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -153,6 +153,11 @@ public:
 
     std::optional<placement_state> state_on_this_shard(const model::ntp&) const;
 
+    const absl::node_hash_map<model::ntp, placement_state>&
+    shard_local_states() const {
+        return _states;
+    }
+
     // partition lifecycle methods
 
     ss::future<std::error_code>

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -139,8 +139,7 @@ public:
     // must be called on each shard
     ss::future<> initialize(const topic_table&, model::node_id self);
 
-    using shard_callback_t
-      = std::function<void(const model::ntp&, model::shard_revision_id)>;
+    using shard_callback_t = std::function<void(const model::ntp&)>;
 
     /// Must be called only on assignment_shard_id. Shard callback will be
     /// called on shards that have been modified by this invocation.

--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -101,23 +101,18 @@ public:
 
     ss::future<> start() {
         for (const auto& [ntp, _] : _ntpt.ntp2meta) {
-            notify_reconciliation(ntp, model::shard_revision_id{0});
+            notify_reconciliation(ntp);
         }
         co_return;
     }
 
-    void
-    notify_reconciliation(const model::ntp& ntp, model::shard_revision_id rev) {
+    void notify_reconciliation(const model::ntp& ntp) {
         auto [rs_it, inserted] = _states.try_emplace(ntp);
         if (inserted) {
             rs_it->second = ss::make_lw_shared<ntp_reconciliation_state>();
         }
         auto& rs = *rs_it->second;
-        if (rs.changed_at) {
-            rs.changed_at = std::max(*rs.changed_at, rev);
-        } else {
-            rs.changed_at = rev;
-        }
+        rs.pending_notifies += 1;
         rs.wakeup_event.set();
         if (inserted) {
             ssx::background = reconcile_ntp_fiber(ntp, rs_it->second);
@@ -135,16 +130,17 @@ public:
 
 private:
     struct ntp_reconciliation_state {
-        std::optional<model::shard_revision_id> changed_at;
-
+        size_t pending_notifies = 0;
         ssx::event wakeup_event{"c/rb/rfwe"};
 
-        bool is_reconciled() const { return !changed_at.has_value(); }
+        bool is_reconciled() const { return pending_notifies == 0; }
 
-        void mark_reconciled(model::shard_revision_id rev) {
-            if (changed_at && *changed_at <= rev) {
-                changed_at = std::nullopt;
-            }
+        void mark_reconciled(size_t notifies) {
+            vassert(
+              pending_notifies >= notifies,
+              "unexpected pending_notifies: {}",
+              pending_notifies);
+            pending_notifies -= notifies;
         }
     };
 
@@ -185,8 +181,7 @@ private:
     ss::future<>
     try_reconcile_ntp(const model::ntp& ntp, ntp_reconciliation_state& rs) {
         while (!rs.is_reconciled() && !_gate.is_closed()) {
-            model::shard_revision_id changed_at = rs.changed_at.value_or(
-              model::shard_revision_id{});
+            size_t notifies = rs.pending_notifies;
             try {
                 auto res = co_await reconcile_ntp_step(ntp, rs);
                 if (res.has_value()) {
@@ -195,10 +190,10 @@ private:
                     } else {
                         vlog(
                           clusterlog.trace,
-                          "[{}] reconciled at {}",
+                          "[{}] reconciled, notify count: {}",
                           ntp,
-                          changed_at);
-                        rs.mark_reconciled(changed_at);
+                          notifies);
+                        rs.mark_reconciled(notifies);
                     }
                 } else {
                     vlog(
@@ -771,8 +766,8 @@ TEST_F_CORO(shard_placement_test_fixture, StressTest) {
                   ntp,
                   target,
                   cur_shard_revision++,
-                  [this](const model::ntp& ntp, model::shard_revision_id rev) {
-                      rb.local().notify_reconciliation(ntp, rev);
+                  [this](const model::ntp& ntp) {
+                      rb.local().notify_reconciliation(ntp);
                   });
             });
         };

--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -100,7 +100,7 @@ public:
     }
 
     ss::future<> start() {
-        for (const auto& [ntp, _] : _ntpt.ntp2meta) {
+        for (const auto& [ntp, _] : _shard_placement.shard_local_states()) {
             notify_reconciliation(ntp);
         }
         co_return;

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -25,7 +25,7 @@
 #include "test_utils/fixture.h"
 
 inline void validate_delta(
-  const fragmented_vector<cluster::topic_table::delta>& d,
+  const std::vector<cluster::topic_table::delta>& d,
   int new_partitions,
   int removed_partitions) {
     size_t additions = std::count_if(

--- a/src/v/cluster/topic_table.h
+++ b/src/v/cluster/topic_table.h
@@ -377,17 +377,6 @@ public:
 
     ss::future<> stop();
 
-    /// Delta API
-    /// NOTE: This API should only be consumed by a single entity, unless
-    /// careful consideration is taken. This is because once notifications are
-    /// fired, all events are consumed, and if both waiters aren't enqueued in
-    /// the \ref _waiters collection by the time the notify occurs, only one
-    /// waiter will recieve the updates, leaving the second one to observe
-    /// skipped events upon recieving its subsequent notification.
-    ss::future<fragmented_vector<delta>> wait_for_changes(ss::abort_source&);
-
-    bool has_pending_changes() const { return !_pending_deltas.empty(); }
-
     /// Query API
 
     /// Returns list of all topics that exists in the cluster.
@@ -685,15 +674,12 @@ private:
     model::revision_id _topics_map_revision{0};
 
     fragmented_vector<delta> _pending_deltas;
-    std::vector<std::unique_ptr<waiter>> _waiters;
     cluster::notification_id_type _notification_id{0};
     cluster::notification_id_type _lw_notification_id{0};
     std::vector<std::pair<cluster::notification_id_type, delta_cb_t>>
       _notifications;
     std::vector<std::pair<cluster::notification_id_type, lw_cb_t>>
       _lw_notifications;
-    uint64_t _waiter_id{0};
-    std::vector<delta>::difference_type _last_consumed_by_notifier_offset{0};
     topic_table_probe _probe;
     force_recoverable_partitions_t _partitions_to_force_reconfigure;
     model::revision_id _partitions_to_force_reconfigure_revision{0};


### PR DESCRIPTION
When bootstrapping controller_backend, we don't really need to try and reconcile all ntps in the cluster, we can start with the set that is in shard_placement_table (i.e. all ntps with some relation to the current shard). This also allows us to use non-consuming topic_table notifications.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none