### PR TITLE
[CORE-2581] cst: move chunk downloads to remote segment bg loop

### DIFF
--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -248,9 +248,10 @@ ss::future<> remote_segment::stop() {
         vlog(cst_log.error, "remote_segment {} stop operation stuck", path);
     });
 
-    vlog(_ctxlog.debug, "remote segment stop");
+    vlog(_ctxlog.debug, "remote segment stop: gate closing");
     _bg_cvar.broken();
     co_await _gate.close();
+    vlog(_ctxlog.debug, "remote segment stop: gate closed");
     if (_data_file) {
         co_await _data_file.close().handle_exception(
           [this](std::exception_ptr err) {
@@ -260,7 +261,9 @@ ss::future<> remote_segment::stop() {
     }
 
     if (_chunks_api) {
+        vlog(_ctxlog.debug, "waiting for chunk api to stop");
         co_await _chunks_api->stop();
+        vlog(_ctxlog.debug, "chunk api stopped");
     }
     _stopped = true;
 }

--- a/src/v/cloud_storage/remote_segment.cc
+++ b/src/v/cloud_storage/remote_segment.cc
@@ -765,10 +765,24 @@ void remote_segment::set_waiter_errors(const std::exception_ptr& err) {
         p.set_exception(err);
         _wait_list.pop_front();
     }
+
+    fragmented_vector<chunk_request> chunk_waiters;
+    chunk_waiters.swap(_chunk_waiters);
+    for (auto& w : chunk_waiters) {
+        w.promise.set_exception(err);
+    }
 };
 
 bool remote_segment::is_legacy_mode_engaged() const {
     return _fallback_mode || _sname_format <= segment_name_format::v2;
+}
+
+void remote_segment::switch_to_legacy_mode() {
+    _fallback_mode = fallback_mode::yes;
+    for (auto& waiter : _chunk_waiters) {
+        waiter.promise.set_exception(
+          std::runtime_error{"chunk download aborted"});
+    }
 }
 
 bool remote_segment::is_state_materialized() const {
@@ -805,8 +819,10 @@ ss::future<> remote_segment::run_hydrate_bg() {
 
     while (!_gate.is_closed()) {
         try {
-            co_await _bg_cvar.wait(
-              [this] { return !_wait_list.empty() || _gate.is_closed(); });
+            co_await _bg_cvar.wait([this] {
+                return !_wait_list.empty() || !_chunk_waiters.empty()
+                       || _gate.is_closed();
+            });
 
             if (is_legacy_mode_engaged()) {
                 vlog(
@@ -865,6 +881,18 @@ ss::future<> remote_segment::run_hydrate_bg() {
                 }
                 _wait_list.pop_front();
             }
+
+            // Only download chunks if we are not in legacy mode and the index
+            // is available.
+            if (
+              !is_legacy_mode_engaged() && is_state_materialized()
+              && !_chunk_waiters.empty()) {
+                vlog(
+                  _ctxlog.debug,
+                  "Processing {} chunk download request(s)",
+                  _chunk_waiters.size());
+                co_await service_chunk_requests();
+            }
         } catch (...) {
             const auto err = std::current_exception();
             set_waiter_errors(err);
@@ -881,8 +909,82 @@ ss::future<> remote_segment::run_hydrate_bg() {
     _hydration_loop_running = false;
 }
 
-namespace {
+ss::future<> remote_segment::service_chunk_requests() {
+    fragmented_vector<ss::future<ss::file>> chunk_op_results;
+    chunk_op_results.reserve(_chunk_waiters.size());
 
+    fragmented_vector<chunk_request> requests;
+    requests.swap(_chunk_waiters);
+
+    std::ranges::transform(
+      requests,
+      std::back_inserter(chunk_op_results),
+      [this](const auto& request) {
+          vlog(
+            _ctxlog.debug,
+            "Downloading chunk {} with prefetch {}",
+            request.start,
+            request.prefetch);
+          return hydrate_and_materialize_chunk(
+            {request.start, request.prefetch});
+      });
+
+    auto results = co_await ss::when_all(
+      chunk_op_results.begin(), chunk_op_results.end());
+
+    for (size_t i = 0; i < results.size(); ++i) {
+        auto request = std::move(requests[i]);
+        auto current_result = std::move(results[i]);
+
+        ss::file materialized_handle;
+        std::exception_ptr err;
+
+        if (current_result.failed()) {
+            err = current_result.get_exception();
+        } else {
+            materialized_handle = current_result.get();
+        }
+
+        // Materialization may fail due to cache eviction. In this case the
+        // materialized handle is default initialized. Re-queue waiter which
+        // will be processed again on the next iteration of run_hydrate_bg loop.
+        // Continue with other requests in queue.
+        if (!err && !materialized_handle) {
+            vlog(
+              _ctxlog.debug,
+              "Failed to materialize chunk start {}, retrying",
+              request.start);
+            _chunk_waiters.emplace_back(std::move(request));
+            continue;
+        }
+
+        if (err) {
+            request.promise.set_exception(err);
+        } else {
+            request.promise.set_value(materialized_handle);
+        }
+    }
+}
+
+ss::future<ss::file> remote_segment::hydrate_and_materialize_chunk(
+  start_and_prefetch_t start_and_prefetch) {
+    auto [chunk_start, prefetch] = start_and_prefetch;
+    vlog(_ctxlog.debug, "Hydrating chunk {}", chunk_start);
+    co_await hydrate_chunk({_chunks_api->chunk_map(), prefetch, chunk_start});
+    vlog(_ctxlog.debug, "Materializing chunk {}", chunk_start);
+    co_return co_await materialize_chunk(chunk_start);
+}
+
+ss::future<ss::file> remote_segment::download_chunk(
+  chunk_start_offset_t chunk_start, uint16_t prefetch) {
+    ss::promise<ss::file> p;
+    auto fut = p.get_future();
+    _chunk_waiters.push_back({chunk_start, prefetch, std::move(p)});
+    _bg_cvar.signal();
+    return fut;
+}
+
+namespace {
 void log_hydration_abort_cause(
   const retry_chain_logger& logger,
   const ss::lowres_clock::time_point& deadline,
@@ -890,8 +992,8 @@ void log_hydration_abort_cause(
     if (ss::lowres_clock::now() > deadline) {
         vlog(logger.warn, "timed out while waiting for hydration");
     } else if (as.has_value() && as->get().abort_requested()) {
-        // TODO it might be useful to be able to log the client info here from
-        // log reader config.
+        // TODO it might be useful to be able to log the client info here
+        // from log reader config.
         vlog(logger.debug, "consumer disconnected during hydration");
     }
 }
@@ -929,7 +1031,7 @@ ss::future<> remote_segment::do_hydrate(
                   "failed to download index with error [{}], switching to "
                   "fallback mode and retrying hydration.",
                   ex);
-                _fallback_mode = fallback_mode::yes;
+                switch_to_legacy_mode();
                 return do_hydrate(as, deadline).then([] {
                     // This is an empty file to match the type returned by
                     // `fut`. The result is discarded immediately so it is

--- a/src/v/cloud_storage/segment_chunk_api.cc
+++ b/src/v/cloud_storage/segment_chunk_api.cc
@@ -115,33 +115,6 @@ bool segment_chunks::downloads_in_progress() const {
     });
 }
 
-ss::future<ss::file> segment_chunks::do_hydrate_and_materialize(
-  chunk_start_offset_t chunk_start, std::optional<uint16_t> prefetch_override) {
-    auto g = _gate.hold();
-    vassert(_started, "chunk API is not started");
-
-    auto it = _chunks.find(chunk_start);
-    std::optional<chunk_start_offset_t> chunk_end = std::nullopt;
-    if (auto next = std::next(it); next != _chunks.end()) {
-        chunk_end = next->first - 1;
-    }
-
-    const auto prefetch = prefetch_override.value_or(
-      config::shard_local_cfg().cloud_storage_chunk_prefetch);
-
-    vlog(
-      _ctxlog.debug,
-      "hydrating chunk start: {}, prefetch: {}",
-      chunk_start,
-      prefetch);
-
-    co_await _segment.hydrate_chunk(
-      segment_chunk_range{_chunks, prefetch, chunk_start});
-
-    vlog(_ctxlog.debug, "materializing chunk start: {}", chunk_start, prefetch);
-    co_return co_await _segment.materialize_chunk(chunk_start);
-}
-
 ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
   chunk_start_offset_t chunk_start, std::optional<uint16_t> prefetch_override) {
     auto g = _gate.hold();
@@ -193,31 +166,11 @@ ss::future<segment_chunk::handle_t> segment_chunks::hydrate_chunk(
                 start);
           });
 
-        // Keep retrying if materialization fails.
-        bool done = false;
-        while (!done) {
-            vlog(
-              _ctxlog.debug,
-              "attempting do_hydrate_and_materialize for {}",
-              chunk_start);
-            auto handle = co_await do_hydrate_and_materialize(
-              chunk_start, prefetch_override);
-            if (handle) {
-                vlog(
-                  _ctxlog.debug,
-                  "do_hydrate_and_materialize for {} complete",
-                  chunk_start);
-                done = true;
-                chunk.handle = ss::make_lw_shared(std::move(handle));
-            } else {
-                vlog(
-                  _ctxlog.trace,
-                  "do_hydrate_and_materialize failed for chunk start offset {}",
-                  chunk_start);
-                co_await ss::sleep_abortable(
-                  _cache_backoff_jitter.next_jitter_duration(), _as);
-            }
-        }
+        auto handle = co_await _segment.download_chunk(
+          chunk_start,
+          prefetch_override.value_or(
+            config::shard_local_cfg().cloud_storage_chunk_prefetch));
+        chunk.handle = ss::make_lw_shared(std::move(handle));
     } catch (const std::exception& ex) {
         vlog(
           _ctxlog.debug,

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -80,13 +80,6 @@ public:
     const chunk_map_t& chunk_map() const { return _chunks; }
 
 private:
-    // Attempts to download chunk into cache and return the file handle for
-    // segment_chunk. Should be retried if there is a failure due to cache
-    // eviction between download and opening the file handle.
-    ss::future<ss::file> do_hydrate_and_materialize(
-      chunk_start_offset_t chunk_start,
-      std::optional<uint16_t> prefetch_override = std::nullopt);
-
     // Periodically closes chunk file handles for the space to be reclaimable by
     // cache eviction. The chunks are evicted when they are no longer opened for
     // reading by any readers. We also take into account any readers that may

--- a/src/v/cloud_storage/segment_chunk_api.h
+++ b/src/v/cloud_storage/segment_chunk_api.h
@@ -73,6 +73,12 @@ public:
     iterator_t begin();
     iterator_t end();
 
+    /// Returns a map of chunk start offset to metadata. The map is initialized
+    /// once per remote segment, when the segment chunk API is started. The
+    /// contents of the map are fixed and contain one entry per chunk in the
+    /// segment.
+    const chunk_map_t& chunk_map() const { return _chunks; }
+
 private:
     // Attempts to download chunk into cache and return the file handle for
     // segment_chunk. Should be retried if there is a failure due to cache


### PR DESCRIPTION
Chunk downloads are moved into the remote segment background loop. Previously any fiber could request chunk download directly by calling the API methods on remote segment.

The remote segment is structured so that its public API enables callers to enqueue downloads, which are serviced via a single download loop which starts in its c-tor. This enables the remote segment to abort pending downloads in case of an error, as well as managing the shut down process cleanly. 

Before this change chunk downloads did not follow this pattern, any chunk download request could directly trigger a download and materialization from any fiber without going through the loop. While this works ok in most cases, it spreads downloads across multiple fibers and makes it harder to debug hangs while downloading chunks, similar to the ones seen in https://github.com/redpanda-data/redpanda/issues/16465

This change moves chunk downloads to the same fiber as other downloads. The pending requests for a given chunk are stored in a fragmented vector, and downloads and materialization are performed in bg loop iteration at the end,  after the index is materialized.

We also want to eventually follow the pattern for chunk downloads where the download and the fiber waiting for it are decoupled. This way we can have the following scenario:

* download initiated via a consumer
* download is pushed to background
* more consumers request same chunk and are put into wait list
* the first consumer disconnects, and the future waiting for it is aborted by using the consumer's abort source
* the remaining consumers still get to use the download once it finishes without aborting

The changes are not all the way there with this PR, because the consumers in wait list are in chunk API, and they will be aborted if the first consumer times out, but the download for the chunk will now continue in the background. 

We can make further changes in the next PR to enable the segment chunk API to not abort all consumers when the first consumer times out. 

This also opens up the path to clean up the prefetch logic. Right now chunk prefetch works as following:

* if chunk N is requested by a consumer
* download byte range consisting of chunk N, N+1 and N+2
* once byte range is downloaded, write to disk as three chunks
* serve consumer request

This results in consumer being blocked until all three chunks are written to disk. With the current PR in place we can (in a follow up PR) simply enqueue chunks N and N+1 to be downloaded, while the consumer is unblocked once chunk N is downloaded successfully. 

This will also simplify the chunk download related code which right now has to handle splitting files when writing to disk etc.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
