### PR TITLE
CORE-2154: cloud_storage: path-style verification tests

### DIFF
--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -49,7 +49,6 @@ rp_test(
   SOURCES
     util.cc
     s3_imposter.cc
-    remote_test.cc
     remote_file_test.cc
     remote_segment_test.cc
     remote_partition_test.cc
@@ -62,6 +61,28 @@ rp_test(
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     Boost::unit_test_framework
+    v::seastar_testing_main
+    v::cloud_storage
+    v::storage_test_utils
+    v::cloud_roles
+    v::application
+    v::kafka_test_utils
+    v::http_test_utils
+  ARGS "-- -c 1"
+  LABELS cloud_storage
+)
+
+rp_test(
+  FIXTURE_TEST
+  GTEST
+  TIMEOUT 1000
+  BINARY_NAME gtest_cloud_storage
+  SOURCES
+    util.cc
+    s3_imposter.cc
+    remote_test.cc
+  LIBRARIES
+    v::gtest_main
     v::seastar_testing_main
     v::cloud_storage
     v::storage_test_utils

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -275,7 +275,7 @@ public:
         listen();
 
         _detector.emplace(
-          cloud_storage_clients::bucket_name{"test_bucket"},
+          cloud_storage_clients::bucket_name{"test-bucket"},
           _stm_manifest.get_ntp(),
           _stm_manifest.get_revision_id(),
           _remote.local(),

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -68,15 +68,11 @@ struct cloud_storage_fixture : s3_imposter_fixture {
             })
           .get();
 
-        auto conf = get_configuration();
-        pool
-          .start(
-            10, ss::sharded_parameter([this] { return get_configuration(); }))
-          .get();
+        pool.start(10, ss::sharded_parameter([this] { return conf; })).get();
         api
           .start(
             std::ref(pool),
-            ss::sharded_parameter([this] { return get_configuration(); }),
+            ss::sharded_parameter([this] { return conf; }),
             ss::sharded_parameter([] { return config_file; }))
           .get();
         api

--- a/src/v/cloud_storage/tests/remote_file_test.cc
+++ b/src/v/cloud_storage/tests/remote_file_test.cc
@@ -25,7 +25,6 @@
 
 namespace {
 
-const cloud_storage_clients::bucket_name bucket{"bucket"};
 ss::abort_source never_abort;
 cloud_storage::lazy_abort_source always_continue{[]() { return std::nullopt; }};
 constexpr model::cloud_credentials_source config_file{
@@ -87,7 +86,7 @@ public:
         ss::file f = ss::open_file_dma(file_path.string(), flags).get();
         return remote.local()
           .upload_controller_snapshot(
-            bucket, remote_path, f, retry_node, always_continue)
+            bucket_name, remote_path, f, retry_node, always_continue)
           .get();
     }
 
@@ -121,7 +120,7 @@ FIXTURE_TEST(test_cached_file, remote_file_fixture) {
     remote_file rfile(
       remote.local(),
       sharded_cache.local(),
-      bucket,
+      bucket_name,
       remote_path,
       retry_node,
       ss::sstring("log_prefix"));
@@ -152,7 +151,7 @@ FIXTURE_TEST(test_missing_file, remote_file_fixture) {
     remote_file rfile(
       remote.local(),
       sharded_cache.local(),
-      bucket,
+      bucket_name,
       remote_path,
       retry_node,
       ss::sstring("log_prefix"));

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -36,7 +36,6 @@ scan_remote_partition_incrementally_with_reuploads(
   size_t maybe_max_readers = 0) {
     ss::lowres_clock::update();
     auto conf = fixt.get_configuration();
-    static auto bucket = cloud_storage_clients::bucket_name("bucket");
     if (maybe_max_segments) {
         config::shard_local_cfg()
           .cloud_storage_max_materialized_segments_per_shard.set_value(
@@ -50,12 +49,16 @@ scan_remote_partition_incrementally_with_reuploads(
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);
 
-    auto manifest = hydrate_manifest(fixt.api.local(), bucket);
+    auto manifest = hydrate_manifest(fixt.api.local(), fixt.bucket_name);
     partition_probe probe(manifest.get_ntp());
     auto manifest_view = ss::make_shared<async_manifest_view>(
-      fixt.api, fixt.cache, manifest, bucket);
+      fixt.api, fixt.cache, manifest, fixt.bucket_name);
     auto partition = ss::make_shared<remote_partition>(
-      manifest_view, fixt.api.local(), fixt.cache.local(), bucket, probe);
+      manifest_view,
+      fixt.api.local(),
+      fixt.cache.local(),
+      fixt.bucket_name,
+      probe);
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 
     partition->start().get();
@@ -457,14 +460,12 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);
 
-    static auto bucket = cloud_storage_clients::bucket_name("bucket");
-
-    auto manifest = hydrate_manifest(api.local(), bucket);
+    auto manifest = hydrate_manifest(api.local(), bucket_name);
     partition_probe probe(manifest.get_ntp());
     auto manifest_view = ss::make_shared<async_manifest_view>(
-      api, cache, manifest, bucket);
+      api, cache, manifest, bucket_name);
     auto partition = ss::make_shared<remote_partition>(
-      manifest_view, api.local(), this->cache.local(), bucket, probe);
+      manifest_view, api.local(), this->cache.local(), bucket_name, probe);
     partition->start().get();
     auto partition_stop = ss::defer([&partition] { partition->stop().get(); });
 

--- a/src/v/cloud_storage/tests/remote_test.cc
+++ b/src/v/cloud_storage/tests/remote_test.cc
@@ -121,22 +121,18 @@ struct backend_override_mixin_t {
     }
     model::cloud_storage_backend _default_backend;
 };
-
 template<class Mixin>
 class remote_fixture_base
   : public s3_imposter_fixture
   , Mixin {
 public:
-    remote_fixture_base() {
-        auto conf = get_configuration();
-        pool
-          .start(
-            10, ss::sharded_parameter([this] { return get_configuration(); }))
-          .get();
+    remote_fixture_base(cloud_storage_clients::s3_url_style url_style)
+      : s3_imposter_fixture(url_style) {
+        pool.start(10, ss::sharded_parameter([this] { return conf; })).get();
         remote
           .start(
             std::ref(pool),
-            ss::sharded_parameter([this] { return get_configuration(); }),
+            ss::sharded_parameter([this] { return conf; }),
             ss::sharded_parameter([] { return config_file; }))
           .get();
     }
@@ -148,6 +144,10 @@ public:
 
     ss::sharded<cloud_storage_clients::client_pool> pool;
     ss::sharded<remote> remote;
+};
+
+struct remote_test_parameters {
+    cloud_storage_clients::s3_url_style url_style;
 };
 
 using remote_fixture = remote_fixture_base<noop_mixin_t>;
@@ -166,13 +166,29 @@ static auto run_manifest_download_and_check(
                         .try_download_partition_manifest(
                           bucket_name, actual, fib)
                         .get();
-    BOOST_TEST_INFO(test_context);
-    BOOST_CHECK(res == download_result::success);
-    BOOST_CHECK(fmt == expected_download_format);
-    BOOST_CHECK(expected_manifest == actual);
+
+    EXPECT_TRUE(res == download_result::success);
+    EXPECT_TRUE(fmt == expected_download_format);
+    EXPECT_TRUE(expected_manifest == actual);
 }
 
-FIXTURE_TEST(test_download_manifest_json, remote_fixture) {
+class all_types_remote_fixture
+  : public remote_fixture
+  , public testing::TestWithParam<remote_test_parameters> {
+public:
+    all_types_remote_fixture()
+      : remote_fixture(GetParam().url_style) {}
+};
+
+class all_types_gcs_remote_fixture
+  : public gcs_remote_fixture
+  , public testing::TestWithParam<remote_test_parameters> {
+public:
+    all_types_gcs_remote_fixture()
+      : gcs_remote_fixture(GetParam().url_style) {}
+};
+
+TEST_P(all_types_remote_fixture, test_download_manifest_json) {
     set_expectations_and_listen({expectation{
       .url = manifest_url, .body = ss::sstring(manifest_payload)}});
     auto subscription = remote.local().subscribe(allow_all);
@@ -182,12 +198,12 @@ FIXTURE_TEST(test_download_manifest_json, remote_fixture) {
       load_manifest_from_str(manifest_payload),
       manifest_format::json,
       "manifest load from json");
-    BOOST_CHECK(subscription.available());
-    BOOST_CHECK(
+    EXPECT_TRUE(subscription.available());
+    EXPECT_TRUE(
       subscription.get().type == api_activity_type::manifest_download);
 }
 
-FIXTURE_TEST(test_download_manifest_serde, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_download_manifest_serde) {
     auto translator = load_manifest_from_str(manifest_payload);
     auto serialized = translator.serialize().get();
     auto manifest_binary
@@ -205,12 +221,12 @@ FIXTURE_TEST(test_download_manifest_serde, remote_fixture) {
       manifest_format::serde,
       "manifest load from serde");
 
-    BOOST_CHECK(subscription.available());
-    BOOST_CHECK(
+    EXPECT_TRUE(subscription.available());
+    EXPECT_TRUE(
       subscription.get().type == api_activity_type::manifest_download);
 }
 
-FIXTURE_TEST(test_download_manifest_timeout, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_download_manifest_timeout) { // NOLINT
     partition_manifest actual(manifest_ntp, manifest_revision);
     auto subscription = remote.local().subscribe(allow_all);
     retry_chain_node fib(never_abort, 100ms, 20ms);
@@ -218,13 +234,13 @@ FIXTURE_TEST(test_download_manifest_timeout, remote_fixture) { // NOLINT
                  .download_manifest(
                    bucket_name, json_manifest_format_path, actual, fib)
                  .get();
-    BOOST_REQUIRE(res == download_result::timedout);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(
+    ASSERT_TRUE(res == download_result::timedout);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(
       subscription.get().type == api_activity_type::manifest_download);
 }
 
-FIXTURE_TEST(test_upload_segment, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_upload_segment) { // NOLINT
     set_expectations_and_listen({});
     auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
@@ -243,15 +259,16 @@ FIXTURE_TEST(test_upload_segment, remote_fixture) { // NOLINT
                  .upload_segment(
                    bucket_name, path, clen, reset_stream, fib, always_continue)
                  .get();
-    BOOST_REQUIRE(res == upload_result::success);
+    ASSERT_TRUE(res == upload_result::success);
     const auto& req = get_requests().front();
-    BOOST_REQUIRE_EQUAL(req.content_length, clen);
-    BOOST_REQUIRE_EQUAL(req.content, ss::sstring(manifest_payload));
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(subscription.get().type == api_activity_type::segment_upload);
+    ASSERT_EQ(req.content_length, clen);
+    ASSERT_EQ(req.content, ss::sstring(manifest_payload));
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
 }
 
-FIXTURE_TEST(test_upload_segment_lost_leadership, remote_fixture) { // NOLINT
+TEST_P(
+  all_types_remote_fixture, test_upload_segment_lost_leadership) { // NOLINT
     set_expectations_and_listen({});
     auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
@@ -273,13 +290,13 @@ FIXTURE_TEST(test_upload_segment_lost_leadership, remote_fixture) { // NOLINT
                  .upload_segment(
                    bucket_name, path, clen, reset_stream, fib, lost_leadership)
                  .get();
-    BOOST_REQUIRE_EQUAL(res, upload_result::cancelled);
-    BOOST_REQUIRE(get_requests().empty());
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(subscription.get().type == api_activity_type::segment_upload);
+    ASSERT_EQ(res, upload_result::cancelled);
+    ASSERT_TRUE(get_requests().empty());
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
 }
 
-FIXTURE_TEST(test_upload_segment_timeout, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_upload_segment_timeout) { // NOLINT
     auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
@@ -297,12 +314,12 @@ FIXTURE_TEST(test_upload_segment_timeout, remote_fixture) { // NOLINT
                  .upload_segment(
                    bucket_name, path, clen, reset_stream, fib, always_continue)
                  .get();
-    BOOST_REQUIRE(res == upload_result::timedout);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(subscription.get().type == api_activity_type::segment_upload);
+    ASSERT_TRUE(res == upload_result::timedout);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
 }
 
-FIXTURE_TEST(test_download_segment, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_download_segment) { // NOLINT
     set_expectations_and_listen({});
     auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
@@ -322,7 +339,7 @@ FIXTURE_TEST(test_download_segment, remote_fixture) { // NOLINT
           .upload_segment(
             bucket_name, path, clen, reset_stream, fib, always_continue)
           .get();
-    BOOST_REQUIRE(upl_res == upload_result::success);
+    ASSERT_TRUE(upl_res == upload_result::success);
 
     iobuf downloaded;
     auto try_consume = [&downloaded](uint64_t len, ss::input_stream<char> is) {
@@ -338,15 +355,15 @@ FIXTURE_TEST(test_download_segment, remote_fixture) { // NOLINT
                      .download_segment(bucket_name, path, try_consume, fib)
                      .get();
 
-    BOOST_REQUIRE(dnl_res == download_result::success);
+    ASSERT_TRUE(dnl_res == download_result::success);
     iobuf_parser p(std::move(downloaded));
     auto actual = p.read_string(p.bytes_left());
-    BOOST_REQUIRE(actual == manifest_payload);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(subscription.get().type == api_activity_type::segment_upload);
+    ASSERT_TRUE(actual == manifest_payload);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
 }
 
-FIXTURE_TEST(test_download_segment_timeout, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_download_segment_timeout) { // NOLINT
     auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
@@ -357,16 +374,16 @@ FIXTURE_TEST(test_download_segment_timeout, remote_fixture) { // NOLINT
     };
 
     retry_chain_node fib(never_abort, 100ms, 20ms);
+
     auto dnl_res = remote.local()
                      .download_segment(bucket_name, path, try_consume, fib)
                      .get();
-    BOOST_REQUIRE(dnl_res == download_result::timedout);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(
-      subscription.get().type == api_activity_type::segment_download);
+    ASSERT_TRUE(dnl_res == download_result::timedout);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_download);
 }
 
-FIXTURE_TEST(test_download_segment_range, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_download_segment_range) {
     auto subscription = remote.local().subscribe(allow_all);
 
     auto path = generate_remote_segment_path(
@@ -394,7 +411,7 @@ FIXTURE_TEST(test_download_segment_range, remote_fixture) {
             fib,
             always_continue)
           .get();
-    BOOST_REQUIRE_EQUAL(upl_res, upload_result::success);
+    ASSERT_EQ(upl_res, upload_result::success);
 
     iobuf downloaded;
     auto dnl_res = remote.local()
@@ -416,25 +433,23 @@ FIXTURE_TEST(test_download_segment_range, remote_fixture) {
                        fib,
                        {{0, 1}})
                      .get();
-    BOOST_REQUIRE_EQUAL(dnl_res, download_result::success);
+    ASSERT_EQ(dnl_res, download_result::success);
 
     iobuf_parser p(std::move(downloaded));
     auto actual = p.read_string(p.bytes_left());
 
-    BOOST_REQUIRE_EQUAL_COLLECTIONS(
-      actual.begin(),
-      actual.end(),
-      manifest_payload.begin(),
-      manifest_payload.begin() + 2);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(subscription.get().type == api_activity_type::segment_upload);
+    auto expected = ss::sstring{
+      manifest_payload.begin(), manifest_payload.begin() + 2};
+    ASSERT_EQ(actual, expected);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_upload);
 
     const auto& req = get_requests()[1];
-    BOOST_REQUIRE_EQUAL(req.method, "GET");
-    BOOST_REQUIRE_EQUAL(req.header("Range"), "bytes=0-1");
+    ASSERT_EQ(req.method, "GET");
+    ASSERT_EQ(req.header("Range"), "bytes=0-1");
 }
 
-FIXTURE_TEST(test_segment_exists, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_segment_exists) { // NOLINT
     set_expectations_and_listen({});
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
@@ -452,20 +467,21 @@ FIXTURE_TEST(test_segment_exists, remote_fixture) { // NOLINT
 
     auto expected_notfound
       = remote.local().segment_exists(bucket_name, path, fib).get();
-    BOOST_REQUIRE(expected_notfound == download_result::notfound);
-    auto upl_res = remote.local()
-                     .upload_segment(
-                       bucket, path, clen, reset_stream, fib, always_continue)
-                     .get();
-    BOOST_REQUIRE(upl_res == upload_result::success);
+    ASSERT_TRUE(expected_notfound == download_result::notfound);
+    auto upl_res
+      = remote.local()
+          .upload_segment(
+            bucket_name, path, clen, reset_stream, fib, always_continue)
+          .get();
+    ASSERT_TRUE(upl_res == upload_result::success);
 
     auto expected_success
       = remote.local().segment_exists(bucket_name, path, fib).get();
 
-    BOOST_REQUIRE(expected_success == download_result::success);
+    ASSERT_TRUE(expected_success == download_result::success);
 }
 
-FIXTURE_TEST(test_segment_exists_timeout, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_segment_exists_timeout) { // NOLINT
     auto name = segment_name("1-2-v1.log");
     auto path = generate_remote_segment_path(
       manifest_ntp, manifest_revision, name, model::term_id{123});
@@ -473,10 +489,10 @@ FIXTURE_TEST(test_segment_exists_timeout, remote_fixture) { // NOLINT
     retry_chain_node fib(never_abort, 100ms, 20ms);
     auto expect_timeout
       = remote.local().segment_exists(bucket_name, path, fib).get();
-    BOOST_REQUIRE(expect_timeout == download_result::timedout);
+    ASSERT_TRUE(expect_timeout == download_result::timedout);
 }
 
-FIXTURE_TEST(test_segment_delete, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_segment_delete) { // NOLINT
     set_expectations_and_listen({});
     auto name = segment_name("0-1-v1.log");
     auto path = generate_remote_segment_path(
@@ -496,7 +512,7 @@ FIXTURE_TEST(test_segment_delete, remote_fixture) { // NOLINT
           .upload_segment(
             bucket_name, path, clen, reset_stream, fib, always_continue)
           .get();
-    BOOST_REQUIRE(upl_res == upload_result::success);
+    ASSERT_TRUE(upl_res == upload_result::success);
 
     // NOTE: we have to upload something as segment in order for the
     // mock to work correctly.
@@ -509,16 +525,16 @@ FIXTURE_TEST(test_segment_delete, remote_fixture) { // NOLINT
                                 cloud_storage_clients::object_key(path),
                                 fib)
                               .get();
-    BOOST_REQUIRE(expected_success == upload_result::success);
+    ASSERT_TRUE(expected_success == upload_result::success);
 
     auto expected_notfound
       = remote.local().segment_exists(bucket_name, path, fib).get();
-    BOOST_REQUIRE(expected_notfound == download_result::notfound);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(subscription.get().type == api_activity_type::segment_delete);
+    ASSERT_TRUE(expected_notfound == download_result::notfound);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::segment_delete);
 }
 
-FIXTURE_TEST(test_concat_segment_upload, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_concat_segment_upload) {
     temporary_dir tmp_dir("concat_segment_read");
     auto data_path = tmp_dir.get_path();
     using namespace storage;
@@ -568,10 +584,10 @@ FIXTURE_TEST(test_concat_segment_upload, remote_fixture) {
           .upload_segment(
             bucket_name, path, upload_size, reset_stream, fib, always_continue)
           .get();
-    BOOST_REQUIRE_EQUAL(upl_res, upload_result::success);
+    ASSERT_EQ(upl_res, upload_result::success);
 }
 
-FIXTURE_TEST(test_list_bucket, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_list_bucket) {
     set_expectations_and_listen({});
     retry_chain_node fib(never_abort, 10s, 20ms);
 
@@ -590,17 +606,15 @@ FIXTURE_TEST(test_list_bucket, remote_fixture) {
                          = {.bucket = bucket_name, .key = path, .parent_rtc = fib},
                          .payload = iobuf{}})
                       .get();
-                BOOST_REQUIRE_EQUAL(
-                  cloud_storage::upload_result::success, result);
+                ASSERT_EQ(cloud_storage::upload_result::success, result);
             }
         }
     }
     {
         auto result = remote.local().list_objects(bucket_name, fib).get();
-        BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE_EQUAL(
-          result.value().contents.size(), first * second * third);
-        BOOST_REQUIRE(result.value().common_prefixes.empty());
+        ASSERT_TRUE(result.has_value());
+        ASSERT_EQ(result.value().contents.size(), first * second * third);
+        ASSERT_TRUE(result.value().common_prefixes.empty());
     }
     {
         auto result = remote.local()
@@ -610,29 +624,30 @@ FIXTURE_TEST(test_list_bucket, remote_fixture) {
                           cloud_storage_clients::object_key{url_base()},
                           '/')
                         .get();
-        BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE(result.value().contents.empty());
-        BOOST_REQUIRE_EQUAL(result.value().common_prefixes.size(), first);
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(result.value().contents.empty());
+        ASSERT_EQ(result.value().common_prefixes.size(), first);
     }
     {
         cloud_storage_clients::object_key prefix{url_base() + "1/"};
         auto result
           = remote.local().list_objects(bucket_name, fib, prefix).get();
-        BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE_EQUAL(result.value().contents.size(), second * third);
-        BOOST_REQUIRE(result.value().common_prefixes.empty());
+        ASSERT_TRUE(result.has_value());
+        ASSERT_EQ(result.value().contents.size(), second * third);
+        ASSERT_TRUE(result.value().common_prefixes.empty());
     }
     {
         cloud_storage_clients::object_key prefix{url_base() + "1/"};
         auto result
           = remote.local().list_objects(bucket_name, fib, prefix, '/').get();
-        BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE(result.value().contents.empty());
-        BOOST_REQUIRE_EQUAL(result.value().common_prefixes.size(), second);
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(result.value().contents.empty());
+        ASSERT_EQ(result.value().common_prefixes.size(), second);
     }
 }
 
-FIXTURE_TEST(test_list_bucket_with_max_keys, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_list_bucket_with_max_keys) {
     set_expectations_and_listen({});
     retry_chain_node fib(never_abort, 10s, 20ms);
 
@@ -647,7 +662,7 @@ FIXTURE_TEST(test_list_bucket_with_max_keys, remote_fixture) {
                  = {.bucket = bucket_name, .key = path, .parent_rtc = fib},
                  .payload = iobuf{}})
               .get();
-        BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
+        ASSERT_EQ(cloud_storage::upload_result::success, result);
     }
 
     {
@@ -664,15 +679,15 @@ FIXTURE_TEST(test_list_bucket_with_max_keys, remote_fixture) {
                           std::nullopt,
                           max_keys)
                         .get();
-        BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE(result.value().is_truncated);
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(result.value().is_truncated);
         // This continuation token is 54 because objects are sorted
         // lexicographically.
-        BOOST_REQUIRE_EQUAL(
+        ASSERT_EQ(
           result.value().next_continuation_token, "/" + url_base() + "54");
-        BOOST_REQUIRE_EQUAL(
-          result.value().contents.size(), s3_imposter_max_keys);
-        BOOST_REQUIRE(result.value().common_prefixes.empty());
+        ASSERT_EQ(result.value().contents.size(), s3_imposter_max_keys);
+        ASSERT_TRUE(result.value().common_prefixes.empty());
 
         // Now, we can use the next_continuation_token from the previous,
         // truncated result in order to query for the rest of the objects. We
@@ -688,11 +703,11 @@ FIXTURE_TEST(test_list_bucket_with_max_keys, remote_fixture) {
                                max_keys,
                                result.value().next_continuation_token)
                              .get();
-        BOOST_REQUIRE(next_result.has_value());
-        BOOST_REQUIRE(!next_result.value().is_truncated);
-        BOOST_REQUIRE_EQUAL(
+        ASSERT_TRUE(next_result.has_value());
+        ASSERT_TRUE(!next_result.value().is_truncated);
+        ASSERT_EQ(
           next_result.value().contents.size(), size - s3_imposter_max_keys);
-        BOOST_REQUIRE(next_result.value().common_prefixes.empty());
+        ASSERT_TRUE(next_result.value().common_prefixes.empty());
     }
     {
         // On the other hand, passing max_keys as std::nullopt means
@@ -709,10 +724,10 @@ FIXTURE_TEST(test_list_bucket_with_max_keys, remote_fixture) {
                           std::nullopt,
                           max_keys)
                         .get();
-        BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE(!result.value().is_truncated);
-        BOOST_REQUIRE_EQUAL(result.value().contents.size(), size);
-        BOOST_REQUIRE(result.value().common_prefixes.empty());
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(!result.value().is_truncated);
+        ASSERT_EQ(result.value().contents.size(), size);
+        ASSERT_TRUE(result.value().common_prefixes.empty());
     }
     {
         auto max_keys = 2;
@@ -725,17 +740,18 @@ FIXTURE_TEST(test_list_bucket_with_max_keys, remote_fixture) {
                           std::nullopt,
                           max_keys)
                         .get();
-        BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE(result.value().is_truncated);
-        // This continuation token is 10 because objects are sorted
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(result.value().is_truncated);
+        // This continuation token is /10 because objects are sorted
         // lexicographically.
-        BOOST_REQUIRE_EQUAL(
+        ASSERT_EQ(
           result.value().next_continuation_token, "/" + url_base() + "10");
         const auto& contents = result.value().contents;
-        BOOST_REQUIRE_EQUAL(contents.size(), max_keys);
-        BOOST_REQUIRE_EQUAL(contents[0].key, url_base() + "0");
-        BOOST_REQUIRE_EQUAL(contents[1].key, url_base() + "1");
-        BOOST_REQUIRE(result.value().common_prefixes.empty());
+        ASSERT_EQ(contents.size(), max_keys);
+        ASSERT_EQ(contents[0].key, url_base() + "0");
+        ASSERT_EQ(contents[1].key, url_base() + "1");
+        ASSERT_TRUE(result.value().common_prefixes.empty());
     }
     {
         // This will also be truncated, since size > s3_imposter_max_keys.
@@ -749,15 +765,15 @@ FIXTURE_TEST(test_list_bucket_with_max_keys, remote_fixture) {
                           std::nullopt,
                           max_keys)
                         .get();
-        BOOST_REQUIRE(result.has_value());
-        BOOST_REQUIRE(result.value().is_truncated);
-        BOOST_REQUIRE_EQUAL(
-          result.value().contents.size(), s3_imposter_max_keys);
+
+        ASSERT_TRUE(result.has_value());
+        ASSERT_TRUE(result.value().is_truncated);
+        ASSERT_EQ(result.value().contents.size(), s3_imposter_max_keys);
         // This continuation token is 54 because objects are sorted
         // lexicographically.
-        BOOST_REQUIRE_EQUAL(
+        ASSERT_EQ(
           result.value().next_continuation_token, "/" + url_base() + "54");
-        BOOST_REQUIRE(result.value().common_prefixes.empty());
+        ASSERT_TRUE(result.value().common_prefixes.empty());
 
         // Reissue another request with continuation-token. This should capture
         // the rest of the object keys, we expect a non-truncated result.
@@ -771,15 +787,15 @@ FIXTURE_TEST(test_list_bucket_with_max_keys, remote_fixture) {
                                max_keys,
                                result.value().next_continuation_token)
                              .get();
-        BOOST_REQUIRE(next_result.has_value());
-        BOOST_REQUIRE(!next_result.value().is_truncated);
-        BOOST_REQUIRE_EQUAL(
+        ASSERT_TRUE(next_result.has_value());
+        ASSERT_TRUE(!next_result.value().is_truncated);
+        ASSERT_EQ(
           next_result.value().contents.size(), size - s3_imposter_max_keys);
-        BOOST_REQUIRE(next_result.value().common_prefixes.empty());
+        ASSERT_TRUE(next_result.value().common_prefixes.empty());
     }
 }
 
-FIXTURE_TEST(test_list_bucket_with_prefix, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_list_bucket_with_prefix) {
     set_expectations_and_listen({});
     retry_chain_node fib(never_abort, 100ms, 20ms);
     for (const char first : {'x', 'y'}) {
@@ -793,7 +809,7 @@ FIXTURE_TEST(test_list_bucket_with_prefix, remote_fixture) {
                      = {.bucket = bucket_name, .key = path, .parent_rtc = fib},
                      .payload = iobuf{}})
                   .get();
-            BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
+            ASSERT_EQ(cloud_storage::upload_result::success, result);
         }
     }
 
@@ -803,18 +819,18 @@ FIXTURE_TEST(test_list_bucket_with_prefix, remote_fixture) {
                       fib,
                       cloud_storage_clients::object_key{url_base() + "x/"})
                     .get();
-    BOOST_REQUIRE(result.has_value());
+    ASSERT_TRUE(result.has_value());
     auto items = result.value().contents;
-    BOOST_REQUIRE_EQUAL(items.size(), 2);
-    BOOST_REQUIRE_EQUAL(items[0].key, url_base() + "x/a");
-    BOOST_REQUIRE_EQUAL(items[1].key, url_base() + "x/b");
+    ASSERT_EQ(items.size(), 2);
+    ASSERT_EQ(items[0].key, url_base() + "x/a");
+    ASSERT_EQ(items[1].key, url_base() + "x/b");
     auto request = get_requests().back();
-    BOOST_REQUIRE_EQUAL(request.method, "GET");
-    BOOST_REQUIRE_EQUAL(request.q_list_type, "2");
-    BOOST_REQUIRE_EQUAL(request.q_prefix, url_base() + "x/");
+    ASSERT_EQ(request.method, "GET");
+    ASSERT_EQ(request.q_list_type, "2");
+    ASSERT_EQ(request.q_prefix, url_base() + "x/");
 }
 
-FIXTURE_TEST(test_list_bucket_with_filter, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_list_bucket_with_filter) {
     set_expectations_and_listen({});
     retry_chain_node fib(never_abort, 100ms, 20ms);
     cloud_storage_clients::object_key path{"b"};
@@ -825,7 +841,7 @@ FIXTURE_TEST(test_list_bucket_with_filter, remote_fixture) {
              = {.bucket = bucket_name, .key = path, .parent_rtc = fib},
              .payload = iobuf{}})
           .get();
-    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, upl_result);
+    ASSERT_EQ(cloud_storage::upload_result::success, upl_result);
 
     auto path_with_prefix = ss::sstring{url_base() + "b"};
     auto result = remote.local()
@@ -838,13 +854,13 @@ FIXTURE_TEST(test_list_bucket_with_filter, remote_fixture) {
                           return item.key == path_with_prefix;
                       })
                     .get();
-    BOOST_REQUIRE(result.has_value());
+    ASSERT_TRUE(result.has_value());
     auto items = result.value().contents;
-    BOOST_REQUIRE_EQUAL(items.size(), 1);
-    BOOST_REQUIRE_EQUAL(items[0].key, path_with_prefix);
+    ASSERT_EQ(items.size(), 1);
+    ASSERT_EQ(items[0].key, path_with_prefix);
 }
 
-FIXTURE_TEST(test_put_string, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_put_string) {
     set_expectations_and_listen({});
     auto conf = get_configuration();
 
@@ -859,17 +875,17 @@ FIXTURE_TEST(test_put_string, remote_fixture) {
              = {.bucket = bucket_name, .key = path, .parent_rtc = fib},
              .payload = make_iobuf_from_string("p")})
           .get();
-    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
+    ASSERT_EQ(cloud_storage::upload_result::success, result);
 
     auto request = get_requests()[0];
-    BOOST_REQUIRE(request.method == "PUT");
-    BOOST_REQUIRE(request.content == "p");
+    ASSERT_TRUE(request.method == "PUT");
+    ASSERT_TRUE(request.content == "p");
 
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(subscription.get().type == api_activity_type::object_upload);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_upload);
 }
 
-FIXTURE_TEST(test_delete_objects, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_delete_objects) {
     set_expectations_and_listen({});
 
     retry_chain_node fib(never_abort, 100ms, 20ms);
@@ -879,14 +895,14 @@ FIXTURE_TEST(test_delete_objects, remote_fixture) {
       cloud_storage_clients::object_key{"b"}};
     auto result
       = remote.local().delete_objects(bucket_name, to_delete, fib).get();
-    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
+    ASSERT_EQ(cloud_storage::upload_result::success, result);
     auto request = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(request.method, "POST");
-    BOOST_REQUIRE_EQUAL(request.url, "/" + url_base() + "?delete");
-    BOOST_REQUIRE(request.has_q_delete);
+    ASSERT_EQ(request.method, "POST");
+    ASSERT_EQ(request.url, "/" + url_base() + "?delete");
+    ASSERT_TRUE(request.has_q_delete);
 }
 
-FIXTURE_TEST(test_delete_objects_multiple_batches, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_delete_objects_multiple_batches) {
     set_expectations_and_listen({});
 
     retry_chain_node fib(never_abort, 500ms, 20ms);
@@ -899,17 +915,16 @@ FIXTURE_TEST(test_delete_objects_multiple_batches, remote_fixture) {
 
     auto result
       = remote.local().delete_objects(bucket_name, to_delete, fib).get();
-    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
-
+    ASSERT_EQ(cloud_storage::upload_result::success, result);
     auto requests = get_requests();
-    BOOST_REQUIRE_EQUAL(requests.size(), 3);
+    ASSERT_EQ(requests.size(), 3);
 
     std::vector<cloud_storage_clients::object_key> deleted_keys;
 
     for (const auto& request : requests) {
-        BOOST_REQUIRE_EQUAL(request.method, "POST");
-        BOOST_REQUIRE_EQUAL(request.url, "/" + url_base() + "?delete");
-        BOOST_REQUIRE(request.has_q_delete);
+        ASSERT_EQ(request.method, "POST");
+        ASSERT_EQ(request.url, "/" + url_base() + "?delete");
+        ASSERT_TRUE(request.has_q_delete);
 
         auto request_keys = keys_from_delete_objects_request(request);
         deleted_keys.insert(
@@ -921,15 +936,12 @@ FIXTURE_TEST(test_delete_objects_multiple_batches, remote_fixture) {
     std::sort(to_delete.begin(), to_delete.end());
     std::sort(deleted_keys.begin(), deleted_keys.end());
 
-    BOOST_REQUIRE_EQUAL_COLLECTIONS(
-      to_delete.begin(),
-      to_delete.end(),
-      deleted_keys.begin(),
-      deleted_keys.end());
+    ASSERT_EQ(to_delete, deleted_keys);
 }
 
-FIXTURE_TEST(
-  test_delete_objects_multiple_batches_single_failure, remote_fixture) {
+TEST_P(
+  all_types_remote_fixture,
+  test_delete_objects_multiple_batches_single_failure) {
     set_expectations_and_listen({expectation{
       .url = "?delete", .body = ss::sstring(plural_delete_error)}});
 
@@ -943,16 +955,16 @@ FIXTURE_TEST(
 
     auto result
       = remote.local().delete_objects(bucket_name, to_delete, fib).get();
-    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::failed, result);
+    ASSERT_EQ(cloud_storage::upload_result::failed, result);
     auto requests = get_requests();
-    BOOST_REQUIRE_EQUAL(requests.size(), 3);
+    ASSERT_EQ(requests.size(), 3);
 
     std::vector<cloud_storage_clients::object_key> deleted_keys;
 
     for (const auto& request : requests) {
-        BOOST_REQUIRE_EQUAL(request.method, "POST");
-        BOOST_REQUIRE_EQUAL(request.url, "/" + url_base() + "?delete");
-        BOOST_REQUIRE(request.has_q_delete);
+        ASSERT_EQ(request.method, "POST");
+        ASSERT_EQ(request.url, "/" + url_base() + "?delete");
+        ASSERT_TRUE(request.has_q_delete);
 
         auto request_keys = keys_from_delete_objects_request(request);
         deleted_keys.insert(
@@ -964,14 +976,10 @@ FIXTURE_TEST(
     std::sort(to_delete.begin(), to_delete.end());
     std::sort(deleted_keys.begin(), deleted_keys.end());
 
-    BOOST_REQUIRE_EQUAL_COLLECTIONS(
-      to_delete.begin(),
-      to_delete.end(),
-      deleted_keys.begin(),
-      deleted_keys.end());
+    ASSERT_EQ(to_delete, deleted_keys);
 }
 
-FIXTURE_TEST(test_delete_objects_failure_handling, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_delete_objects_failure_handling) {
     // Test that the failure to delete one key via the plural form
     // fails the entire operation.
     set_expectations_and_listen({expectation{
@@ -984,20 +992,20 @@ FIXTURE_TEST(test_delete_objects_failure_handling, remote_fixture) {
       cloud_storage_clients::object_key{"1"}};
     auto result
       = remote.local().delete_objects(bucket_name, to_delete, fib).get();
-    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::failed, result);
+    ASSERT_EQ(cloud_storage::upload_result::failed, result);
 
     auto request = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(request.method, "POST");
-    BOOST_REQUIRE_EQUAL(request.url, "/" + url_base() + "?delete");
-    BOOST_REQUIRE(request.has_q_delete);
+    ASSERT_EQ(request.method, "POST");
+    ASSERT_EQ(request.url, "/" + url_base() + "?delete");
+    ASSERT_TRUE(request.has_q_delete);
 }
 
-FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
+TEST_P(all_types_gcs_remote_fixture, test_delete_objects_on_unknown_backend) {
     set_expectations_and_listen({});
 
     retry_chain_node fib(never_abort, 60s, 20ms);
 
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
@@ -1005,7 +1013,7 @@ FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
            = {.bucket = bucket_name, .key = cloud_storage_clients::object_key{"p"}, .parent_rtc = fib},
            .payload = make_iobuf_from_string("p")})
         .get());
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
@@ -1019,29 +1027,30 @@ FIXTURE_TEST(test_delete_objects_on_unknown_backend, gcs_remote_fixture) {
       cloud_storage_clients::object_key{"q"}};
     auto result
       = remote.local().delete_objects(bucket_name, to_delete, fib).get();
-    BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
+    ASSERT_EQ(cloud_storage::upload_result::success, result);
 
-    BOOST_REQUIRE_EQUAL(get_requests().size(), 4);
+    ASSERT_EQ(get_requests().size(), 4);
     auto first_delete = get_requests()[2];
 
     std::unordered_set<ss::sstring> expected_urls{
       "/" + url_base() + "p", "/" + url_base() + "q"};
-    BOOST_REQUIRE_EQUAL(first_delete.method, "DELETE");
-    BOOST_REQUIRE(expected_urls.contains(first_delete.url));
+    ASSERT_EQ(first_delete.method, "DELETE");
+    ASSERT_TRUE(expected_urls.contains(first_delete.url));
 
     expected_urls.erase(first_delete.url);
     auto second_delete = get_requests()[3];
-    BOOST_REQUIRE_EQUAL(second_delete.method, "DELETE");
-    BOOST_REQUIRE(expected_urls.contains(second_delete.url));
+    ASSERT_EQ(second_delete.method, "DELETE");
+    ASSERT_TRUE(expected_urls.contains(second_delete.url));
 }
 
-FIXTURE_TEST(
-  test_delete_objects_on_unknown_backend_result_reduction, gcs_remote_fixture) {
+TEST_P(
+  all_types_gcs_remote_fixture,
+  test_delete_objects_on_unknown_backend_result_reduction) {
     set_expectations_and_listen({});
 
     retry_chain_node fib(never_abort, 5s, 20ms);
 
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object(
@@ -1061,15 +1070,15 @@ FIXTURE_TEST(
     if (conf.url_style == cloud_storage_clients::s3_url_style::virtual_host) {
         // Due to virtual-host style addressing, this will timeout as DNS tries
         // to resolve the request with the provided bucket name.
-        BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::timedout, result);
+        ASSERT_EQ(cloud_storage::upload_result::timedout, result);
     } else {
         // But, if we have path style addressing, the object won't be found, a
         // warning will be issued, and the request will return success instead.
-        BOOST_REQUIRE_EQUAL(cloud_storage::upload_result::success, result);
+        ASSERT_EQ(cloud_storage::upload_result::success, result);
     }
 }
 
-FIXTURE_TEST(test_filter_by_source, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_filter_by_source) { // NOLINT
     set_expectations_and_listen({expectation{
       .url = manifest_url, .body = ss::sstring(manifest_payload)}});
     auto conf = get_configuration();
@@ -1087,8 +1096,8 @@ FIXTURE_TEST(test_filter_by_source, remote_fixture) { // NOLINT
                  .download_manifest(
                    bucket_name, json_manifest_format_path, actual, child_rtc)
                  .get();
-    BOOST_REQUIRE(res == download_result::success);
-    BOOST_REQUIRE(!subscription.available());
+    ASSERT_TRUE(res == download_result::success);
+    ASSERT_TRUE(!subscription.available());
 
     // In this case the caller is different and the manifest download
     // shold trigger notification.
@@ -1097,9 +1106,9 @@ FIXTURE_TEST(test_filter_by_source, remote_fixture) { // NOLINT
             .download_manifest(
               bucket_name, json_manifest_format_path, actual, other_rtc)
             .get();
-    BOOST_REQUIRE(res == download_result::success);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(
+    ASSERT_TRUE(res == download_result::success);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(
       subscription.get().type == api_activity_type::manifest_download);
 
     // Reuse filter for the next event
@@ -1108,9 +1117,9 @@ FIXTURE_TEST(test_filter_by_source, remote_fixture) { // NOLINT
             .download_manifest(
               bucket_name, json_manifest_format_path, actual, other_rtc)
             .get();
-    BOOST_REQUIRE(res == download_result::success);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(
+    ASSERT_TRUE(res == download_result::success);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(
       subscription.get().type == api_activity_type::manifest_download);
 
     // Remove the rtc node from the filter and re-subscribe. This time we should
@@ -1121,13 +1130,13 @@ FIXTURE_TEST(test_filter_by_source, remote_fixture) { // NOLINT
             .download_manifest(
               bucket_name, json_manifest_format_path, actual, child_rtc)
             .get();
-    BOOST_REQUIRE(res == download_result::success);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(
+    ASSERT_TRUE(res == download_result::success);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(
       subscription.get().type == api_activity_type::manifest_download);
 }
 
-FIXTURE_TEST(test_filter_by_type, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_filter_by_type) { // NOLINT
     set_expectations_and_listen({expectation{
       .url = manifest_url, .body = ss::sstring(manifest_payload)}});
     retry_chain_node root_rtc(never_abort, 100ms, 20ms);
@@ -1143,21 +1152,20 @@ FIXTURE_TEST(test_filter_by_type, remote_fixture) { // NOLINT
                       bucket_name, json_manifest_format_path, actual, root_rtc)
                     .get();
 
-    BOOST_REQUIRE(dl_res == download_result::success);
-    BOOST_REQUIRE(!subscription1.available());
-    BOOST_REQUIRE(subscription2.available());
-    BOOST_REQUIRE(
+    ASSERT_TRUE(dl_res == download_result::success);
+    ASSERT_TRUE(!subscription1.available());
+    ASSERT_TRUE(subscription2.available());
+    ASSERT_TRUE(
       subscription2.get().type == api_activity_type::manifest_download);
 
     auto upl_res
       = remote.local().upload_manifest(bucket_name, actual, root_rtc).get();
-    BOOST_REQUIRE(upl_res == upload_result::success);
-    BOOST_REQUIRE(subscription1.available());
-    BOOST_REQUIRE(
-      subscription1.get().type == api_activity_type::manifest_upload);
+    ASSERT_TRUE(upl_res == upload_result::success);
+    ASSERT_TRUE(subscription1.available());
+    ASSERT_TRUE(subscription1.get().type == api_activity_type::manifest_upload);
 }
 
-FIXTURE_TEST(test_filter_lifetime_1, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_filter_lifetime_1) { // NOLINT
     set_expectations_and_listen({expectation{
       .url = manifest_url, .body = ss::sstring(manifest_payload)}});
     retry_chain_node root_rtc(never_abort, 100ms, 20ms);
@@ -1174,18 +1182,18 @@ FIXTURE_TEST(test_filter_lifetime_1, remote_fixture) { // NOLINT
     flt.reset();
     // Notification should be received despite the fact that the filter object
     // is destroyed.
-    BOOST_REQUIRE(res == download_result::success);
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(
+    ASSERT_TRUE(res == download_result::success);
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(
       subscription.get().type == api_activity_type::manifest_download);
 }
 
-FIXTURE_TEST(test_filter_lifetime_2, remote_fixture) { // NOLINT
+TEST_P(all_types_remote_fixture, test_filter_lifetime_2) { // NOLINT
     std::optional<remote::event_filter> flt;
     flt.emplace();
     auto subscription = remote.local().subscribe(*flt);
     flt.reset();
-    BOOST_REQUIRE_THROW(subscription.get(), ss::broken_promise);
+    ASSERT_THROW(subscription.get(), ss::broken_promise);
 }
 
 struct throttle_low_limit {
@@ -1206,8 +1214,17 @@ struct throttle_low_limit {
 
 using throttle_remote_fixture = remote_fixture_base<throttle_low_limit>;
 
-FIXTURE_TEST(
-  test_download_segment_throttle, throttle_remote_fixture) { // NOLINT
+class all_types_throttle_remote_fixture
+  : public throttle_remote_fixture
+  , public testing::TestWithParam<remote_test_parameters> {
+public:
+    all_types_throttle_remote_fixture()
+      : throttle_remote_fixture(GetParam().url_style) {}
+};
+
+TEST_P(
+  all_types_throttle_remote_fixture,
+  test_download_segment_throttle) { // NOLINT
     set_expectations_and_listen({});
     auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
@@ -1227,7 +1244,7 @@ FIXTURE_TEST(
           .upload_segment(
             bucket_name, path, clen, reset_stream, fib, always_continue)
           .get();
-    BOOST_REQUIRE(upl_res == upload_result::success);
+    ASSERT_TRUE(upl_res == upload_result::success);
 
     auto download_one = [](cloud_storage::remote& api, auto path, auto bucket) {
         retry_chain_node fib(never_abort, 100ms, 20ms);
@@ -1247,24 +1264,24 @@ FIXTURE_TEST(
         auto dnl_res
           = api.download_segment(bucket, path, try_consume, fib).get();
 
-        BOOST_REQUIRE(dnl_res == download_result::success);
+        ASSERT_TRUE(dnl_res == download_result::success);
         iobuf_parser p(std::move(downloaded));
         auto actual = p.read_string(p.bytes_left());
         // segment and manifest has the same synthetic payload in this test
-        BOOST_REQUIRE(actual == manifest_payload);
+        ASSERT_TRUE(actual == manifest_payload);
     };
     download_one(remote.local(), path, bucket_name);
     auto s1 = remote.local()
                 .materialized()
                 .get_read_path_probe()
                 .get_downloads_throttled_sum();
-    BOOST_REQUIRE(s1 == 0);
+    ASSERT_TRUE(s1 == 0);
     download_one(remote.local(), path, bucket_name);
     auto s2 = remote.local()
                 .materialized()
                 .get_read_path_probe()
                 .get_downloads_throttled_sum();
-    BOOST_REQUIRE(s2 > 0);
+    ASSERT_TRUE(s2 > 0);
 }
 
 struct no_throttle {
@@ -1285,9 +1302,18 @@ struct no_throttle {
 
 using no_throttle_remote_fixture = remote_fixture_base<no_throttle>;
 
+class all_types_no_throttle_remote_fixture
+  : public no_throttle_remote_fixture
+  , public testing::TestWithParam<remote_test_parameters> {
+public:
+    all_types_no_throttle_remote_fixture()
+      : no_throttle_remote_fixture(GetParam().url_style) {}
+};
+
 // This test checks that the throttling can actually be disabled
-FIXTURE_TEST(
-  test_download_segment_no_throttle, no_throttle_remote_fixture) { // NOLINT
+TEST_P(
+  all_types_no_throttle_remote_fixture,
+  test_download_segment_no_throttle) { // NOLINT
     set_expectations_and_listen({});
     auto subscription = remote.local().subscribe(allow_all);
     auto name = segment_name("1-2-v1.log");
@@ -1309,7 +1335,7 @@ FIXTURE_TEST(
           .upload_segment(
             bucket_name, path, clen, reset_stream, fib, always_continue)
           .get();
-    BOOST_REQUIRE(upl_res == upload_result::success);
+    ASSERT_TRUE(upl_res == upload_result::success);
 
     auto download_one =
       [](cloud_storage::remote& api, auto path, auto bucket) { // NOLINT
@@ -1329,10 +1355,10 @@ FIXTURE_TEST(
           auto dnl_res
             = api.download_segment(bucket, path, try_consume, fib).get();
 
-          BOOST_REQUIRE(dnl_res == download_result::success);
+          ASSERT_TRUE(dnl_res == download_result::success);
           iobuf_parser p(std::move(*downloaded));
           auto actual = p.read_string(p.bytes_left());
-          BOOST_REQUIRE(actual == manifest_payload);
+          ASSERT_TRUE(actual == manifest_payload);
       };
     for (int i = 0; i < 100; i++) {
         download_one(remote.local(), path, bucket_name);
@@ -1340,11 +1366,11 @@ FIXTURE_TEST(
                                  .materialized()
                                  .get_read_path_probe()
                                  .get_downloads_throttled_sum();
-        BOOST_REQUIRE(times_throttled == 0);
+        ASSERT_TRUE(times_throttled == 0);
     }
 }
 
-FIXTURE_TEST(test_notification_retry_meta, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_notification_retry_meta) {
     set_expectations_and_listen(
       {expectation{.url = manifest_serde_url, .slowdown = true}});
 
@@ -1363,10 +1389,10 @@ FIXTURE_TEST(test_notification_retry_meta, remote_fixture) {
     });
 
     auto [res, fmt] = fut.get();
-    BOOST_CHECK(res == download_result::timedout);
+    EXPECT_TRUE(res == download_result::timedout);
 }
 
-FIXTURE_TEST(test_get_object, remote_fixture) {
+TEST_P(all_types_remote_fixture, test_get_object) {
     set_expectations_and_listen({});
     auto conf = get_configuration();
 
@@ -1374,7 +1400,7 @@ FIXTURE_TEST(test_get_object, remote_fixture) {
 
     cloud_storage_clients::object_key path{"p"};
 
-    BOOST_REQUIRE_EQUAL(
+    ASSERT_EQ(
       cloud_storage::upload_result::success,
       remote.local()
         .upload_object({
@@ -1395,15 +1421,50 @@ FIXTURE_TEST(test_get_object, remote_fixture) {
           .get();
 
     const auto requests = get_requests();
-    BOOST_REQUIRE_EQUAL(requests.size(), 2);
+    ASSERT_EQ(requests.size(), 2);
 
     const auto last_request = requests.back();
-    BOOST_REQUIRE_EQUAL(last_request.method, "GET");
-    BOOST_REQUIRE_EQUAL(last_request.url, "/" + url_base() + "p");
+    ASSERT_EQ(last_request.method, "GET");
+    ASSERT_EQ(last_request.url, "/" + url_base() + "p");
 
-    BOOST_REQUIRE(dl_res == download_result::success);
-    BOOST_REQUIRE_EQUAL(iobuf_to_bytes(buf), "p");
-    BOOST_REQUIRE(subscription.available());
-    BOOST_REQUIRE(
-      subscription.get().type == api_activity_type::object_download);
+    ASSERT_TRUE(dl_res == download_result::success);
+    ASSERT_EQ(iobuf_to_bytes(buf), "p");
+    ASSERT_TRUE(subscription.available());
+    ASSERT_TRUE(subscription.get().type == api_activity_type::object_download);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+  test_with_all_types_remote_fixture,
+  all_types_remote_fixture,
+  testing::Values(
+    remote_test_parameters{
+      .url_style = cloud_storage_clients::s3_url_style::virtual_host},
+    remote_test_parameters{
+      .url_style = cloud_storage_clients::s3_url_style::path}));
+
+INSTANTIATE_TEST_SUITE_P(
+  test_with_all_types_gcs_remote_fixture,
+  all_types_gcs_remote_fixture,
+  testing::Values(
+    remote_test_parameters{
+      .url_style = cloud_storage_clients::s3_url_style::virtual_host},
+    remote_test_parameters{
+      .url_style = cloud_storage_clients::s3_url_style::path}));
+
+INSTANTIATE_TEST_SUITE_P(
+  test_with_all_types_throttle_remote_fixture,
+  all_types_throttle_remote_fixture,
+  testing::Values(
+    remote_test_parameters{
+      .url_style = cloud_storage_clients::s3_url_style::virtual_host},
+    remote_test_parameters{
+      .url_style = cloud_storage_clients::s3_url_style::path}));
+
+INSTANTIATE_TEST_SUITE_P(
+  test_with_all_types_no_throttle_remote_fixture,
+  all_types_no_throttle_remote_fixture,
+  testing::Values(
+    remote_test_parameters{
+      .url_style = cloud_storage_clients::s3_url_style::virtual_host},
+    remote_test_parameters{
+      .url_style = cloud_storage_clients::s3_url_style::path}));

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -512,7 +512,7 @@ enable_cloud_storage_fixture::enable_cloud_storage_fixture() {
         cfg.cloud_storage_region.set_value(
           std::optional<ss::sstring>{"us-east1"});
         cfg.cloud_storage_bucket.set_value(
-          std::optional<ss::sstring>{test_bucket_name()});
+          std::optional<ss::sstring>{random_test_bucket_name()()});
     }).get();
 }
 

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -360,10 +360,11 @@ struct s3_imposter_fixture::content_handler {
 
             return R"xml(<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></DeleteResult>)xml";
         }
-        RPTEST_FAIL("Unexpected request");
+        RPTEST_ADD_FAIL("Unexpected request");
         return "";
     }
     expectation_map_t expectations;
+
     s3_imposter_fixture& fixture;
     std::optional<absl::flat_hash_set<ss::sstring>> headers = std::nullopt;
 };

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -14,6 +14,7 @@
 #include "cloud_storage_clients/client.h"
 #include "config/configuration.h"
 #include "http/tests/registered_urls.h"
+#include "utils/uuid.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -27,8 +28,10 @@
 #include <map>
 #include <vector>
 
-static const cloud_storage_clients::bucket_name test_bucket_name
-  = cloud_storage_clients::bucket_name{"test-bucket"};
+inline cloud_storage_clients::bucket_name random_test_bucket_name() {
+    return cloud_storage_clients::bucket_name{
+      "test-bucket-" + ss::sstring{uuid_t::create()}};
+}
 
 static constexpr cloud_storage_clients::s3_url_style default_url_style
   = cloud_storage_clients::s3_url_style::virtual_host;
@@ -104,7 +107,9 @@ public:
     void set_search_on_get_list(bool should) { _search_on_get_list = should; }
 
     ss::sstring url_base() const;
-    const cloud_storage_clients::bucket_name bucket_name = test_bucket_name;
+
+    const cloud_storage_clients::bucket_name bucket_name
+      = random_test_bucket_name();
 
 protected:
     cloud_storage_clients::s3_url_style url_style;

--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -80,22 +80,22 @@ const ss::sstring topic_manifest_json = R"JSON({
 const model::topic_namespace tp_ns{model::ns{"kafka"}, model::topic{"test"}};
 
 const s3_imposter_fixture::expectation root_level{
-  .url = "/?list-type=2&delimiter=/",
+  .url = "?list-type=2&delimiter=/",
   .body = top_level_result,
 };
 
 const s3_imposter_fixture::expectation meta_level{
-  .url = "/?list-type=2&prefix=b0000000/",
+  .url = "?list-type=2&prefix=b0000000/",
   .body = valid_manifest_list,
 };
 
 const s3_imposter_fixture::expectation manifest{
-  .url = "/b0000000/meta/kafka/test/topic_manifest.json",
+  .url = "b0000000/meta/kafka/test/topic_manifest.json",
   .body = topic_manifest_json,
 };
 
 const s3_imposter_fixture::expectation recovery_state{
-  .url = "/?list-type=2&prefix=recovery_state",
+  .url = "?list-type=2&prefix=recovery_state",
   .body = recovery_results,
 };
 
@@ -108,7 +108,7 @@ generate_no_manifests_expectations(
     std::vector<s3_imposter_fixture::expectation> expectations;
     for (int i = 0; i < 16; ++i) {
         expectations.emplace_back(s3_imposter_fixture::expectation{
-          .url = fmt::format("/?list-type=2&prefix={}0000000/", hex_chars[i]),
+          .url = fmt::format("?list-type=2&prefix={}0000000/", hex_chars[i]),
           .body = no_manifests,
         });
     }
@@ -119,7 +119,7 @@ generate_no_manifests_expectations(
 }
 
 bool is_manifest_list_request(const http_test_utils::request_info& req) {
-    return req.method == "GET" && req.url.starts_with("/?list-type=2&prefix=")
+    return req.method == "GET" && req.url.contains("?list-type=2&prefix=")
            && req.url.ends_with("0000000/");
 }
 
@@ -227,7 +227,8 @@ FIXTURE_TEST(recovery_with_no_topics_exits_early, fixture) {
     wait_for_n_requests(16, equals::yes, is_manifest_list_request);
 
     const auto& list_topics_req = get_requests()[0];
-    BOOST_REQUIRE_EQUAL(list_topics_req.url, "/?list-type=2&prefix=00000000/");
+    BOOST_REQUIRE_EQUAL(
+      list_topics_req.url, "/" + url_base() + "?list-type=2&prefix=00000000/");
 
     // Wait until recovery exits after finding no topics to create
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
@@ -254,7 +255,8 @@ void do_test(fixture& f) {
     f.wait_for_n_requests(17, fixture::equals::yes);
 
     const auto& get_manifest_req = f.get_requests()[16];
-    BOOST_REQUIRE_EQUAL(get_manifest_req.url, manifest.url);
+    BOOST_REQUIRE_EQUAL(
+      get_manifest_req.url, "/" + f.url_base() + manifest.url);
 
     // Wait until recovery exits after finding no topics to create
     tests::cooperative_spin_wait_with_timeout(10s, [&service] {
@@ -361,7 +363,7 @@ FIXTURE_TEST(recovery_result_clear_before_start, fixture) {
     // 16 to check each manifest prefix, 1 to download the topic manifest, 1 to
     // check recovery results, 1 to delete.
     const auto& delete_request = get_requests()[18];
-    BOOST_REQUIRE_EQUAL(delete_request.url, "/?delete");
+    BOOST_REQUIRE_EQUAL(delete_request.url, "/" + url_base() + "?delete");
     BOOST_REQUIRE_EQUAL(delete_request.method, "POST");
 }
 

--- a/src/v/test_utils/test_macros.h
+++ b/src/v/test_utils/test_macros.h
@@ -15,6 +15,7 @@
 #include <boost/test/unit_test.hpp>
 
 #define RPTEST_FAIL(m) BOOST_FAIL(m)
+#define RPTEST_ADD_FAIL(m) BOOST_FAIL(m)
 #define RPTEST_FAIL_CORO(m) BOOST_FAIL(m)
 #define RPTEST_REQUIRE(m) BOOST_REQUIRE(m)
 #define RPTEST_REQUIRE_CORO(m) BOOST_REQUIRE(m)
@@ -26,6 +27,7 @@
 #include "test_utils/test.h"
 
 #define RPTEST_FAIL(m) FAIL() << (m)
+#define RPTEST_ADD_FAIL(m) ADD_FAILURE() << (m)
 #define RPTEST_FAIL_CORO(m) ASSERT_TRUE_CORO(false) << (m)
 #define RPTEST_REQUIRE(m) ASSERT_TRUE(m)
 #define RPTEST_REQUIRE_CORO(m) ASSERT_TRUE_CORO(m)

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -13,7 +13,7 @@ import sys
 import time
 import traceback
 from collections import namedtuple, defaultdict
-from typing import DefaultDict
+from typing import DefaultDict, List
 
 from ducktape.mark import matrix
 
@@ -22,7 +22,7 @@ from rptest.clients.kafka_cli_tools import KafkaCliTools
 from rptest.clients.rpk import RpkTool
 from rptest.clients.types import TopicSpec
 from rptest.services.cluster import cluster
-from rptest.services.redpanda import RedpandaService, SISettings, get_cloud_storage_type
+from rptest.services.redpanda import RedpandaService, SISettings, CloudStorageTypeAndUrlStyle, get_cloud_storage_type, get_cloud_storage_type_and_url_style
 from rptest.tests.redpanda_test import RedpandaTest
 from rptest.util import (
     segments_count,
@@ -230,8 +230,13 @@ class ArchivalTest(RedpandaTest):
                                         'true')
 
     @cluster(num_nodes=3)
-    @matrix(cloud_storage_type=get_cloud_storage_type())
-    def test_write(self, cloud_storage_type):
+    @matrix(
+        cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(
+        ))
+    def test_write(
+            self,
+            cloud_storage_type_and_url_style: List[CloudStorageTypeAndUrlStyle]
+    ):
         """Simple smoke test, write data to redpanda and check if the
         data hit the S3 storage bucket"""
         self.kafka_tools.produce(self.topic, 10000, 1024)

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 from re import T
-from typing import NamedTuple, Optional
+from typing import NamedTuple, Optional, List
 from rptest.services.cluster import cluster
 
 from rptest.clients.default import DefaultClient
@@ -19,7 +19,7 @@ from rptest.util import expect_exception
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
 
-from rptest.services.redpanda import CloudStorageType, MetricsEndpoint, RedpandaService, get_cloud_storage_type, make_redpanda_service
+from rptest.services.redpanda import CloudStorageType, CloudStorageTypeAndUrlStyle, MetricsEndpoint, RedpandaService, get_cloud_storage_type, get_cloud_storage_url_style, get_cloud_storage_type_and_url_style, make_redpanda_service
 from rptest.services.redpanda_installer import InstallOptions, RedpandaInstaller
 from rptest.tests.end_to_end import EndToEndTest
 from rptest.utils.expect_rate import ExpectRate, RateTarget
@@ -408,12 +408,15 @@ class TestReadReplicaService(EndToEndTest):
             assert len(objects_after) >= len(objects_before)
 
     @cluster(num_nodes=9, log_allow_list=READ_REPLICA_LOG_ALLOW_LIST)
-    @matrix(partition_count=[10], cloud_storage_type=get_cloud_storage_type())
-    def test_simple_end_to_end(self, partition_count: int,
-                               cloud_storage_type: CloudStorageType) -> None:
-
+    @matrix(
+        partition_count=[10],
+        cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(
+        ))
+    def test_simple_end_to_end(
+        self, partition_count: int,
+        cloud_storage_type_and_url_style: List[CloudStorageTypeAndUrlStyle]
+    ) -> None:
         data_timeout = 300
-
         self._setup_read_replica(num_messages=100000,
                                  partition_count=partition_count,
                                  producer_timeout=300)

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -14,6 +14,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, Future
 from threading import Condition
 from collections import defaultdict
+from typing import List
 
 from ducktape.mark import matrix
 from ducktape.tests.test import TestContext
@@ -29,7 +30,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
 from rptest.services.kgo_verifier_services import KgoVerifierConsumerGroupConsumer, KgoVerifierProducer, KgoVerifierRandomConsumer, KgoVerifierSeqConsumer
-from rptest.services.redpanda import SISettings, get_cloud_storage_type, make_redpanda_service, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
+from rptest.services.redpanda import SISettings, CloudStorageTypeAndUrlStyle, get_cloud_storage_type, get_cloud_storage_type_and_url_style, make_redpanda_service, CHAOS_LOG_ALLOW_LIST, MetricsEndpoint
 from rptest.utils.si_utils import nodes_report_cloud_segments, BucketView, NTP
 from rptest.tests.tiered_storage_model import TestCase, TieredStorageEndToEndTest, get_tiered_storage_test_cases, TestRunStage, CONFIDENCE_THRESHOLD
 
@@ -546,9 +547,12 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         self.thread_pool.shutdown()
 
     @cluster(num_nodes=4)
-    @matrix(cloud_storage_type=get_cloud_storage_type(),
-            test_case=get_tiered_storage_test_cases(fast_run=True))
-    def test_tiered_storage(self, cloud_storage_type, test_case: TestCase):
+    @matrix(
+        cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(
+        ),
+        test_case=get_tiered_storage_test_cases(fast_run=True))
+    def test_tiered_storage(self, cloud_storage_type_and_url_style: List[
+        CloudStorageTypeAndUrlStyle], test_case: TestCase):
         """This is a main entry point of the test.
            The test runs if 5 phases:
             - Configuration phase


### PR DESCRIPTION
Adds path-style test coverage to existing tiered storage fixture and ducktape tests.

JIRA Issues: 

- https://redpandadata.atlassian.net/browse/CORE-2153
- https://redpandadata.atlassian.net/browse/CORE-2154
- https://redpandadata.atlassian.net/browse/CORE-2155
- https://redpandadata.atlassian.net/browse/CORE-2156
- https://redpandadata.atlassian.net/browse/CORE-2416

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
