### PR TITLE
CORE-2417: cloud_storage_clients: self configure `s3_url_style`

### DIFF
--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -28,7 +28,6 @@ cloud_storage_clients::default_overrides get_default_overrides() {
         optep.has_value()) {
         overrides.endpoint = cloud_storage_clients::endpoint_url(*optep);
     }
-    overrides.url_style = config::shard_local_cfg().cloud_storage_url_style();
     overrides.disable_tls = config::shard_local_cfg().cloud_storage_disable_tls;
     if (auto cert = config::shard_local_cfg().cloud_storage_trust_file.value();
         cert.has_value()) {
@@ -412,6 +411,8 @@ ss::future<configuration> configuration::get_s3_config() {
 
     auto region = cloud_roles::aws_region_name(get_value_or_throw(
       config::shard_local_cfg().cloud_storage_region, "cloud_storage_region"));
+    auto url_style = config::shard_local_cfg().cloud_storage_url_style.value();
+
     auto disable_metrics = net::metrics_disabled(
       config::shard_local_cfg().disable_metrics());
     auto disable_public_metrics = net::public_metrics_disabled(
@@ -422,6 +423,7 @@ ss::future<configuration> configuration::get_s3_config() {
         access_key,
         secret_key,
         region,
+        url_style,
         get_default_overrides(),
         disable_metrics,
         disable_public_metrics);

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -91,7 +91,7 @@ ss::future<> client_pool::client_self_configure(
         self_config_output = *result;
         vlog(
           pool_log.info,
-          "Client self configuration completed with result {} ",
+          "Client self configuration completed with result {}",
           *self_config_output);
     }
 

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -74,6 +74,7 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
   const std::optional<cloud_roles::public_key_str>& pkey,
   const std::optional<cloud_roles::private_key_str>& skey,
   const cloud_roles::aws_region_name& region,
+  const std::optional<cloud_storage_clients::s3_url_style>& url_style,
   const default_overrides& overrides,
   net::metrics_disabled disable_metrics,
   net::public_metrics_disabled disable_public_metrics) {
@@ -92,6 +93,10 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
     client_cfg.region = region;
     client_cfg.uri = access_point_uri(endpoint_uri);
     client_cfg.url_style = overrides.url_style;
+
+    if (url_style.has_value()) {
+        client_cfg.url_style = url_style.value();
+    }
 
     if (overrides.disable_tls == false) {
         client_cfg.credentials = co_await build_tls_credentials(

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -92,10 +92,13 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
     client_cfg.secret_key = skey;
     client_cfg.region = region;
     client_cfg.uri = access_point_uri(endpoint_uri);
-    client_cfg.url_style = overrides.url_style;
 
     if (url_style.has_value()) {
         client_cfg.url_style = url_style.value();
+    } else {
+        // If the url style is not specified, it will be determined with
+        // self configuration.
+        client_cfg.requires_self_configuration = true;
     }
 
     if (overrides.disable_tls == false) {
@@ -124,8 +127,8 @@ std::ostream& operator<<(std::ostream& o, const s3_configuration& c) {
     o << "{access_key:"
       << c.access_key.value_or(cloud_roles::public_key_str{""})
       << ",region:" << c.region() << ",secret_key:****"
-      << ",access_point_uri:" << c.uri() << ",server_addr:" << c.server_addr
-      << ",max_idle_time:"
+      << ",url_style:" << c.url_style << ",access_point_uri:" << c.uri()
+      << ",server_addr:" << c.server_addr << ",max_idle_time:"
       << std::chrono::duration_cast<std::chrono::milliseconds>(c.max_idle_time)
            .count()
       << "}";
@@ -216,7 +219,10 @@ void apply_self_configuration_result(
                 "result {}",
                 cfg,
                 res);
-              // No self configuration for S3 at this point
+
+              cfg.url_style
+                = std::get<s3_self_configuration_result>(res).url_style;
+
           } else if constexpr (std::is_same_v<abs_configuration, cfg_type>) {
               vassert(
                 std::holds_alternative<abs_self_configuration_result>(res),
@@ -251,8 +257,9 @@ operator<<(std::ostream& o, const abs_self_configuration_result& r) {
     return o;
 }
 
-std::ostream& operator<<(std::ostream& o, const s3_self_configuration_result&) {
-    o << "{}";
+std::ostream&
+operator<<(std::ostream& o, const s3_self_configuration_result& r) {
+    o << "{s3_url_style: " << r.url_style << "}";
     return o;
 }
 

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -26,7 +26,6 @@ struct default_overrides {
     std::optional<uint16_t> port = std::nullopt;
     std::optional<ca_trust_file> trust_file = std::nullopt;
     std::optional<ss::lowres_clock::duration> max_idle_time = std::nullopt;
-    s3_url_style url_style = s3_url_style::virtual_host;
     bool disable_tls = false;
 };
 
@@ -50,7 +49,7 @@ struct s3_configuration : common_configuration {
     /// AWS secret key, optional if configuration uses temporary credentials
     std::optional<cloud_roles::private_key_str> secret_key;
     /// AWS URL style, either virtual-hosted-style or path-style.
-    s3_url_style url_style;
+    s3_url_style url_style = s3_url_style::virtual_host;
 
     /// \brief opinionated configuraiton initialization
     /// Generates uri field from region, initializes credentials for the
@@ -111,7 +110,9 @@ struct abs_self_configuration_result {
     bool is_hns_enabled;
 };
 
-struct s3_self_configuration_result {};
+struct s3_self_configuration_result {
+    s3_url_style url_style;
+};
 
 using client_self_configuration_output
   = std::variant<abs_self_configuration_result, s3_self_configuration_result>;

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -67,6 +67,7 @@ struct s3_configuration : common_configuration {
       const std::optional<cloud_roles::public_key_str>& pkey,
       const std::optional<cloud_roles::private_key_str>& skey,
       const cloud_roles::aws_region_name& region,
+      const std::optional<cloud_storage_clients::s3_url_style>& url_style,
       const default_overrides& overrides = {},
       net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
       net::public_metrics_disabled disable_public_metrics

--- a/src/v/cloud_storage_clients/s3_client.h
+++ b/src/v/cloud_storage_clients/s3_client.h
@@ -107,6 +107,7 @@ public:
       std::optional<char> delimiter = std::nullopt);
 
 private:
+    friend class s3_client;
     std::string make_host(const bucket_name& name) const;
 
     std::string
@@ -244,6 +245,15 @@ private:
       ss::future<T> request_future,
       const bucket_name& bucket,
       const object_key& key);
+
+    // Performs testing as part of the self-configuration step.
+    // If remote_read is true, the test will use list_objects().
+    // If remote_read is false, the test will instead use put_object() and
+    // delete_object(). If both remote_read and remote_write are false, the test
+    // will fail a vassert() call.
+    // Returns true if the test ran was succesfully and false otherwise.
+    ss::future<bool> self_configure_test(
+      const bucket_name& bucket, bool remote_read, bool remote_write);
 
 private:
     request_creator _requestor;

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1685,15 +1685,23 @@ configuration::configuration()
   , cloud_storage_url_style(
       *this,
       "cloud_storage_url_style",
-      "The addressing style to use for S3 requests.",
+      "Specifies the addressing style to use for Amazon S3 requests. This "
+      "configuration determines how S3 bucket URLs are formatted. You can "
+      "choose between: `virtual_host`, (e.g. "
+      "`<bucket-name>.s3.amazonaws.com`), `path`, (e.g. "
+      "`s3.amazonaws.com/<bucket-name>`), and `null`. Path style is supported "
+      "for backward compatibility with legacy systems. When this property is "
+      "not set (`null`), the client tries to use `virtual_host` addressing. If "
+      "the initial request fails, the client automatically tries the `path` "
+      "style. If neither addressing style works, Redpanda terminates the "
+      "startup, requiring manual configuration to proceed.",
       {.needs_restart = needs_restart::yes,
        .example = "virtual_host",
        .visibility = visibility::user},
-      cloud_storage_clients::s3_url_style::virtual_host,
-      {
-        cloud_storage_clients::s3_url_style::virtual_host,
-        cloud_storage_clients::s3_url_style::path,
-      })
+      std::nullopt,
+      {cloud_storage_clients::s3_url_style::virtual_host,
+       cloud_storage_clients::s3_url_style::path,
+       std::nullopt})
   , cloud_storage_credentials_source(
       *this,
       "cloud_storage_credentials_source",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -309,7 +309,8 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_region;
     property<std::optional<ss::sstring>> cloud_storage_bucket;
     property<std::optional<ss::sstring>> cloud_storage_api_endpoint;
-    enum_property<cloud_storage_clients::s3_url_style> cloud_storage_url_style;
+    enum_property<std::optional<cloud_storage_clients::s3_url_style>>
+      cloud_storage_url_style;
     enum_property<model::cloud_credentials_source>
       cloud_storage_credentials_source;
     property<std::optional<ss::sstring>>

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -377,6 +377,8 @@ public:
                   .set_value(std::make_optional((*s3_config->access_key)()));
                 config.get("cloud_storage_secret_key")
                   .set_value(std::make_optional((*s3_config->secret_key)()));
+                config.get("cloud_storage_url_style")
+                  .set_value(std::make_optional((s3_config->url_style)));
                 config.get("cloud_storage_api_endpoint")
                   .set_value(std::make_optional(s3_config->server_addr.host()));
                 config.get("cloud_storage_api_endpoint_port")

--- a/tests/rptest/tests/cluster_self_config_test.py
+++ b/tests/rptest/tests/cluster_self_config_test.py
@@ -1,0 +1,94 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+import re
+
+from ducktape.mark import parametrize, matrix
+
+from rptest.services.admin import Admin
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import CloudStorageType, SISettings
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.utils import LogSearchLocal
+
+
+class ClusterSelfConfigTest(RedpandaTest):
+    def __init__(self, ctx):
+        si_settings = SISettings(
+            ctx,
+            #Force self configuration through setting cloud_storage_url_style to None.
+            cloud_storage_url_style=None,
+            cloud_storage_enable_remote_read=ctx.
+            injected_args["cloud_storage_enable_remote_read"],
+            cloud_storage_enable_remote_write=ctx.
+            injected_args["cloud_storage_enable_remote_write"])
+
+        super().__init__(ctx, si_settings=si_settings)
+
+        self.log_searcher = LogSearchLocal(ctx, [], self.redpanda.logger,
+                                           self.redpanda.STDOUT_STDERR_CAPTURE)
+        self.admin = Admin(self.redpanda)
+
+    @cluster(num_nodes=1)
+    @matrix(cloud_storage_enable_remote_read=[True, False],
+            cloud_storage_enable_remote_write=[True, False])
+    def test_s3_self_config(self, cloud_storage_enable_remote_read,
+                            cloud_storage_enable_remote_write):
+        """
+        Verify that cloud_storage_url_style self configuration occurs for the s3_client
+        when it is not specified. There aren't any endpoints for testing this, so
+        it will be manually checked for from the logs.
+        """
+
+        config = self.admin.get_cluster_config()
+
+        # Even after self-configuring, the cloud_storage_url_style setting will
+        # still be left unset at the cluster config level.
+        assert config['cloud_storage_url_style'] is None
+
+        def str_in_logs(node, s):
+            return any(s in log.strip()
+                       for log in self.log_searcher._capture_log(node, s))
+
+        def self_config_start_in_logs(node):
+            client_self_configuration_start_string = 'Client requires self configuration step'
+            return str_in_logs(node, client_self_configuration_start_string)
+
+        def self_config_default_in_logs(node):
+            client_self_configuration_default_string = 'Could not self-configure S3 Client'
+            return str_in_logs(node, client_self_configuration_default_string)
+
+        def self_config_result_from_logs(node):
+            client_self_configuration_complete_string = 'Client self configuration completed with result'
+            for log in self.log_searcher._capture_log(
+                    node, client_self_configuration_complete_string):
+                m = re.search(
+                    client_self_configuration_complete_string + r' (\{.*\})',
+                    log.strip())
+                if m:
+                    return m.group(1)
+            return None
+
+        for node in self.redpanda.nodes:
+            #Assert that self configuration started.
+            assert self_config_start_in_logs(node)
+
+            #If neither remote_read or remote_write are enabled, check for the "defaulting" output
+            if not cloud_storage_enable_remote_read and not cloud_storage_enable_remote_write:
+                assert self_config_default_in_logs(node)
+
+            #Assert that self configuration returned a result.
+            self_config_result = self_config_result_from_logs(node)
+
+            #Currently, virtual_host will succeed in all cases with MinIO.
+            self_config_expected_results = [
+                '{s3_self_configuration_result: {s3_url_style: virtual_host}}',
+                '{s3_self_configuration_result: {s3_url_style: path}}'
+            ]
+
+            assert self_config_result and self_config_result in self_config_expected_results


### PR DESCRIPTION
Allows the `s3_client` to self configure its addressing style for S3 requests.

If `cloud_storage_url_style` is not specified (left `nil` in cluster config), upon start-up, the `s3_client` will attempt to self configure a working addressing style.

First, `virtual_host` addressing is tested. 

 * A `list_objects()` request using is attempted, if `cloud_storage_enable_remote_read` is `true`. 
 * If `cloud_storage_enable_remote_write` is enabled, `put_object()` and `delete_object()` requests are used to verify instead.

If the request is unsuccessful, the client reattempts the request with `path` style. If both requests fail, start-up is terminated.

JIRA Issue: https://redpandadata.atlassian.net/browse/CORE-2417

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none