### PR TITLE
Fix timequery returning wrong offset after trim-prefix which could lead to stuck consumers

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1222,7 +1222,8 @@ remote_partition::timequery(storage::timequery_config cfg) {
     vlog(_ctxlog.debug, "timequery: {} batches", batches.size());
 
     if (batches.size()) {
-        co_return storage::batch_timequery(*(batches.begin()), cfg.time);
+        co_return storage::batch_timequery(
+          *(batches.begin()), cfg.min_offset, cfg.time, cfg.max_offset);
     } else {
         co_return std::nullopt;
     }

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1195,11 +1195,13 @@ remote_partition::timequery(storage::timequery_config cfg) {
         co_return std::nullopt;
     }
 
-    auto start_offset = stm_manifest.full_log_start_kafka_offset().value();
+    auto start_offset = std::max(
+      cfg.min_offset,
+      kafka::offset_cast(stm_manifest.full_log_start_kafka_offset().value()));
 
     // Synthesize a log_reader_config from our timequery_config
     storage::log_reader_config config(
-      kafka::offset_cast(start_offset),
+      start_offset,
       cfg.max_offset,
       0,
       2048, // We just need one record batch

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -711,7 +711,7 @@ FIXTURE_TEST(test_local_timequery, e2e_fixture) {
         bool expect_value = false,
         std::optional<model::offset> expected_o = std::nullopt) {
           auto timequery_conf = storage::timequery_config(
-            t, o, ss::default_priority_class(), std::nullopt);
+            model::offset(0), t, o, ss::default_priority_class(), std::nullopt);
 
           auto result = partition->timequery(timequery_conf).get();
 
@@ -798,7 +798,7 @@ FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
         bool expect_value = false,
         std::optional<model::offset> expected_o = std::nullopt) {
           auto timequery_conf = storage::timequery_config(
-            t, o, ss::default_priority_class(), std::nullopt);
+            model::offset(0), t, o, ss::default_priority_class(), std::nullopt);
 
           auto result = partition->timequery(timequery_conf).get();
 
@@ -904,7 +904,7 @@ FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
         bool expect_value = false,
         std::optional<model::offset> expected_o = std::nullopt) {
           auto timequery_conf = storage::timequery_config(
-            t, o, ss::default_priority_class(), std::nullopt);
+            model::offset(0), t, o, ss::default_priority_class(), std::nullopt);
 
           auto result = partition->timequery(timequery_conf).get();
 

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -506,7 +506,9 @@ partition::timequery(storage::timequery_config cfg) {
 
     const bool may_answer_from_cloud
       = may_read_from_cloud()
-        && _cloud_storage_partition->bounds_timestamp(cfg.time);
+        && _cloud_storage_partition->bounds_timestamp(cfg.time)
+        && cfg.min_offset < kafka::offset_cast(
+             _cloud_storage_partition->next_kafka_offset());
 
     if (_raft->log()->start_timestamp() <= cfg.time) {
         // The query is ahead of the local data's start_timestamp: this
@@ -520,7 +522,8 @@ partition::timequery(storage::timequery_config cfg) {
         local_query_cfg.min_offset = std::max(
           log()->from_log_offset(_raft->start_offset()),
           local_query_cfg.min_offset);
-        auto result = co_await local_timequery(local_query_cfg);
+        auto result = co_await local_timequery(
+          local_query_cfg, may_answer_from_cloud);
         if (result.has_value()) {
             co_return result;
         } else {
@@ -542,7 +545,7 @@ partition::timequery(storage::timequery_config cfg) {
             local_query_cfg.min_offset = std::max(
               log()->from_log_offset(_raft->start_offset()),
               local_query_cfg.min_offset);
-            co_return co_await local_timequery(local_query_cfg);
+            co_return co_await local_timequery(local_query_cfg, false);
         }
     }
 }
@@ -579,21 +582,19 @@ partition::cloud_storage_timequery(storage::timequery_config cfg) {
     co_return result;
 }
 
-ss::future<std::optional<storage::timequery_result>>
-partition::local_timequery(storage::timequery_config cfg) {
+ss::future<std::optional<storage::timequery_result>> partition::local_timequery(
+  storage::timequery_config cfg, bool allow_cloud_fallback) {
     vlog(clusterlog.debug, "timequery (raft) {} cfg(k)={}", _raft->ntp(), cfg);
 
     cfg.min_offset = _raft->log()->to_log_offset(cfg.min_offset);
     cfg.max_offset = _raft->log()->to_log_offset(cfg.max_offset);
 
+    vlog(clusterlog.debug, "timequery (raft) {} cfg(r)={}", _raft->ntp(), cfg);
+
     auto result = co_await _raft->timequery(cfg);
 
-    const bool may_answer_from_cloud
-      = may_read_from_cloud()
-        && _cloud_storage_partition->bounds_timestamp(cfg.time);
-
     if (result.has_value()) {
-        if (may_answer_from_cloud) {
+        if (allow_cloud_fallback) {
             // We need to test for cases in which we will fall back to querying
             // cloud storage.
             if (_raft->log()->start_timestamp() > cfg.time) {
@@ -647,7 +648,7 @@ partition::local_timequery(storage::timequery_config cfg) {
               _raft->log()->start_timestamp(),
               cfg.time);
 
-            if (may_answer_from_cloud) {
+            if (allow_cloud_fallback) {
                 // Even though we hit data with the desired timestamp, we
                 // cannot be certain that this is the _first_ batch with
                 // the desired timestamp: return null so that the caller

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -345,7 +345,7 @@ private:
     bool may_read_from_cloud() const;
 
     ss::future<std::optional<storage::timequery_result>>
-      local_timequery(storage::timequery_config);
+    local_timequery(storage::timequery_config, bool allow_cloud_fallback);
 
     consensus_ptr _raft;
     ss::shared_ptr<cluster::log_eviction_stm> _log_eviction_stm;

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -130,6 +130,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           kafka_partition->leader_epoch());
     }
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
+      kafka_partition->start_offset(),
       timestamp,
       offset,
       kafka_read_priority(),

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -132,7 +132,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
       kafka_partition->start_offset(),
       timestamp,
-      offset,
+      model::prev_offset(offset),
       kafka_read_priority(),
       {model::record_batch_type::raft_data},
       octx.rctx.abort_source().local()});

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -356,7 +356,8 @@ replicated_partition::timequery(storage::timequery_config cfg) {
     if (batches.empty()) {
         co_return std::nullopt;
     }
-    co_return storage::batch_timequery(*(batches.begin()), cfg.time);
+    co_return storage::batch_timequery(
+      *(batches.begin()), cfg.min_offset, cfg.time, cfg.max_offset);
 }
 
 ss::future<result<model::offset>> replicated_partition::replicate(

--- a/src/v/model/offset_interval.h
+++ b/src/v/model/offset_interval.h
@@ -1,0 +1,80 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "base/vassert.h"
+#include "model/fundamental.h"
+
+namespace model {
+/// A non-empty, bounded, closed interval of offsets [min offset, max offset].
+///
+/// This property helps to simplify the logic and the instructions required to
+/// check for overlaps, containment, etc. It is the responsibility of the caller
+/// to ensure these properties hold before constructing an instance of this
+/// class.
+///
+/// To represent a potentially empty range, wrap it in an optional.
+class bounded_offset_interval {
+public:
+    static bounded_offset_interval
+    unchecked(model::offset min, model::offset max) noexcept {
+        return {min, max};
+    }
+
+    static bounded_offset_interval
+    checked(model::offset min, model::offset max) {
+        if (min < model::offset(0) || max < model::offset(0) || min > max) {
+            throw std::invalid_argument(fmt::format(
+              "Invalid arguments for constructing a non-empty bounded offset "
+              "interval: min({}) <= max({})",
+              min,
+              max));
+        }
+
+        return {min, max};
+    }
+
+    inline bool overlaps(const bounded_offset_interval& other) const noexcept {
+        return _min <= other._max && _max >= other._min;
+    }
+
+    inline bool contains(model::offset o) const noexcept {
+        return _min <= o && o <= _max;
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const bounded_offset_interval& r) {
+        fmt::print(o, "{{min: {}, max: {}}}", r._min, r._max);
+        return o;
+    }
+
+    inline model::offset min() const noexcept { return _min; }
+    inline model::offset max() const noexcept { return _max; }
+
+private:
+    bounded_offset_interval(model::offset min, model::offset max) noexcept
+      : _min(min)
+      , _max(max) {
+#ifndef NDEBUG
+        vassert(
+          min >= model::offset(0), "Offset interval min({}) must be >= 0", min);
+        vassert(
+          min <= max,
+          "Offset interval invariant not satisfied: min({}) <= max({})",
+          min,
+          max);
+#endif
+    }
+
+    model::offset _min;
+    model::offset _max;
+};
+
+} // namespace model

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -119,7 +119,10 @@ make_random_batch(model::offset o, int num_records, bool allow_compression) {
 
 model::record_batch make_random_batch(record_batch_spec spec) {
     auto ts = spec.timestamp.value_or(model::timestamp::now());
-    auto max_ts = model::timestamp(ts() + spec.count - 1);
+    auto max_ts = ts;
+    if (!spec.all_records_have_same_timestamp) {
+        max_ts = model::timestamp(ts() + spec.count - 1);
+    }
     auto header = model::record_batch_header{
       .size_bytes = 0, // computed later
       .base_offset = spec.offset,
@@ -235,7 +238,9 @@ make_random_batches(record_batch_spec spec) {
         auto num_records = spec.records ? *spec.records : get_int(2, 30);
         auto batch_spec = spec;
         batch_spec.timestamp = ts;
-        ts = model::timestamp(ts() + num_records);
+        if (!batch_spec.all_records_have_same_timestamp) {
+            ts = model::timestamp(ts() + num_records);
+        }
         batch_spec.offset = o;
         batch_spec.count = num_records;
         if (spec.enable_idempotence) {

--- a/src/v/model/tests/random_batch.h
+++ b/src/v/model/tests/random_batch.h
@@ -34,6 +34,7 @@ struct record_batch_spec {
     bool is_transactional{false};
     std::optional<std::vector<size_t>> record_sizes;
     std::optional<model::timestamp> timestamp;
+    bool all_records_have_same_timestamp{false};
 };
 
 model::record make_random_record(int, iobuf);

--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2335,7 +2335,8 @@ disk_log_impl::make_reader(timequery_config config) {
     vassert(!_closed, "make_reader on closed log - {}", *this);
     return _lock_mngr.range_lock(config).then(
       [this, cfg = config](std::unique_ptr<lock_manager::lease> lease) {
-          auto start_offset = _start_offset;
+          auto start_offset = cfg.min_offset;
+
           if (!lease->range.empty()) {
               const ss::lw_shared_ptr<segment>& segment = *lease->range.begin();
               std::optional<segment_index::entry> index_entry = std::nullopt;
@@ -2450,7 +2451,8 @@ disk_log_impl::timequery(timequery_config cfg) {
               if (
                 !batches.empty()
                 && batches.front().header().max_timestamp >= cfg.time) {
-                  return ret_t(batch_timequery(batches.front(), cfg.time));
+                  return ret_t(batch_timequery(
+                    batches.front(), cfg.min_offset, cfg.time, cfg.max_offset));
               }
               return ret_t();
           });

--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -9,6 +9,7 @@
 
 #include "storage/lock_manager.h"
 
+#include "model/offset_interval.h"
 #include "storage/segment.h"
 
 #include <seastar/core/future-util.hh>
@@ -38,14 +39,27 @@ range(segment_set::underlying_t segs) {
 
 ss::future<std::unique_ptr<lock_manager::lease>>
 lock_manager::range_lock(const timequery_config& cfg) {
+    auto query_interval = model::bounded_offset_interval::checked(
+      cfg.min_offset, cfg.max_offset);
+
     segment_set::underlying_t tmp;
+    // Copy segments that have timestamps >= cfg.time and overlap with the
+    // offset range [min_offset, max_offset].
     std::copy_if(
       _set.lower_bound(cfg.time),
       _set.end(),
       std::back_inserter(tmp),
-      [&cfg](ss::lw_shared_ptr<segment>& s) {
-          // must be base offset
-          return s->offsets().get_base_offset() <= cfg.max_offset;
+      [&query_interval](ss::lw_shared_ptr<segment>& s) {
+          if (s->empty()) {
+              return false;
+          }
+
+          // Safety: unchecked is safe here because we did already check
+          // `!s->empty()` above to ensure that the segment has data.
+          auto segment_interval = model::bounded_offset_interval::unchecked(
+            s->offsets().get_base_offset(), s->offsets().get_dirty_offset());
+
+          return segment_interval.overlaps(query_interval);
       });
     return range(std::move(tmp));
 }

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "bytes/iobuf.h"
 #include "model/fundamental.h"
+#include "model/offset_interval.h"
 #include "model/record.h"
 #include "storage/logger.h"
 #include "storage/offset_translator_state.h"
@@ -533,23 +534,28 @@ bool log_reader::is_done() {
            || is_finished_offset(_lease->range, _config.start_offset);
 }
 
-timequery_result
-batch_timequery(const model::record_batch& b, model::timestamp t) {
+timequery_result batch_timequery(
+  const model::record_batch& b,
+  model::offset min_offset,
+  model::timestamp t,
+  model::offset max_offset) {
+    auto query_interval = model::bounded_offset_interval::checked(
+      min_offset, max_offset);
+
     // If the timestamp matches something mid-batch, then
     // parse into the batch far enough to find it: this
     // happens when we had CreateTime input, such that
     // records in the batch have different timestamps.
     model::offset result_o = b.base_offset();
     model::timestamp result_t = b.header().first_timestamp;
-    if (b.header().first_timestamp < t && !b.compressed()) {
+    if (!b.compressed()) {
         b.for_each_record(
-          [&result_o, &result_t, t, &b](
+          [&result_o, &result_t, &b, query_interval, t](
             const model::record& r) -> ss::stop_iteration {
+              auto record_o = model::offset{r.offset_delta()} + b.base_offset();
               auto record_t = model::timestamp(
                 b.header().first_timestamp() + r.timestamp_delta());
-              if (record_t >= t) {
-                  auto record_o = model::offset{r.offset_delta()}
-                                  + b.base_offset();
+              if (record_t >= t && query_interval.contains(record_o)) {
                   result_o = record_o;
                   result_t = record_t;
                   return ss::stop_iteration::yes;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -260,14 +260,33 @@ private:
 
 /**
  * Assuming caller has already determined that this batch contains
- * the record that should be the result to the timequery, traverse
- * the batch to find which record matches.
+ * the record that should be the result to the timequery (critical!),
+ * traverse the batch to find the record with with timestamp >= \ref t.
+ *
+ * The min and max offsets are used to limit the search to a specific
+ * range inside the batch. This is necessary to support the case where
+ * log was requested to be prefix-truncated (trim-prefix) to an offset
+ * which lies in the middle of a batch.
+ *
+ * If the preconditions aren't met, the result is the timestamp of the first
+ * record in the batch.
  *
  * This is used by both storage's disk_log_impl and by cloud_storage's
  * remote_partition, to seek to their final result after finding
  * the batch.
+ *
+ * To read more about trim-prefix:
+ * https://docs.redpanda.com/current/reference/rpk/rpk-topic/rpk-topic-trim-prefix/
+ *
+ * \param b The batch to search in.
+ * \param min_offset The minimum offset to consider
+ * \param t The timestamp to search for
+ * \param max_offset The maximum offset to consider
  */
-timequery_result
-batch_timequery(const model::record_batch& b, model::timestamp t);
+timequery_result batch_timequery(
+  const model::record_batch& b,
+  model::offset min_offset,
+  model::timestamp t,
+  model::offset max_offset);
 
 } // namespace storage

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -289,10 +289,20 @@ FIXTURE_TEST(test_reading_range_from_a_log, storage_test_fixture) {
     BOOST_REQUIRE_EQUAL(range.size(), 5);
     BOOST_REQUIRE_EQUAL(range.front().header().crc, batches[3].header().crc);
     BOOST_REQUIRE_EQUAL(range.back().header().crc, batches[7].header().crc);
-    // range from base of beging to the middle of end
+
+    // Range that starts and ends in the middle of the same batch.
     range = read_range_to_vector(
       log,
-      batches[3].base_offset(),
+      batches[3].base_offset() + model::offset(batches[3].record_count() / 3),
+      batches[3].base_offset()
+        + model::offset(batches[3].record_count() / 3 * 2LL));
+    BOOST_REQUIRE_EQUAL(range.size(), 1);
+    BOOST_REQUIRE_EQUAL(range.front().header().crc, batches[3].header().crc);
+
+    // Range that starts and ends in the middle of batches.
+    range = read_range_to_vector(
+      log,
+      batches[3].base_offset() + model::offset(batches[3].record_count() / 2),
       batches[7].base_offset() + model::offset(batches[7].record_count() / 2));
     BOOST_REQUIRE_EQUAL(range.size(), 5);
     BOOST_REQUIRE_EQUAL(range.front().header().crc, batches[3].header().crc);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -93,8 +93,8 @@ std::ostream& operator<<(std::ostream& o, const timequery_result& a) {
     return o << "{offset:" << a.offset << ", time:" << a.time << "}";
 }
 std::ostream& operator<<(std::ostream& o, const timequery_config& a) {
-    o << "{max_offset:" << a.max_offset << ", time:" << a.time
-      << ", type_filter:";
+    o << "{min_offset: " << a.min_offset << ", max_offset: " << a.max_offset
+      << ", time:" << a.time << ", type_filter:";
     if (a.type_filter) {
         o << *a.type_filter;
     } else {

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -226,20 +226,25 @@ using opt_abort_source_t
 
 using opt_client_address_t = std::optional<model::client_address_t>;
 
+/// A timequery configuration specifies the range of offsets to search for a
+/// record with a timestamp equal to or greater than the specified time.
 struct timequery_config {
     timequery_config(
+      model::offset min_offset,
       model::timestamp t,
-      model::offset o,
+      model::offset max_offset,
       ss::io_priority_class iop,
       std::optional<model::record_batch_type> type_filter,
       opt_abort_source_t as = std::nullopt,
       opt_client_address_t client_addr = std::nullopt) noexcept
-      : time(t)
-      , max_offset(o)
+      : min_offset(min_offset)
+      , time(t)
+      , max_offset(max_offset)
       , prio(iop)
       , type_filter(type_filter)
       , abort_source(as)
       , client_address(std::move(client_addr)) {}
+    model::offset min_offset;
     model::timestamp time;
     model::offset max_offset;
     ss::io_priority_class prio;

--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -150,6 +150,7 @@ public:
     ss::future<kafka::offset>
     offset_at_timestamp(model::timestamp ts, ss::abort_source* as) final {
         auto result = co_await _partition.timequery(storage::timequery_config(
+          _partition.start_offset(),
           ts,
           model::offset::max(),
           /*iop=*/wasm_read_priority(),


### PR DESCRIPTION
The fix works only if compression is not in use. We need follow-up work which would decompress the batches to find the exact offset to return, or (!) we could to prevent trim-offset inside a batch in that case.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fix a scenario where list_offset with a timestamp could return a lower offset than partition start after a trim-prefix command. This could lead to consumers being stuck with an out-of-range-offset exception if they began consuming from an offset below the one which was used in the trim-prefix command.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
