### PR TITLE
[v24.1.x] cluster_recovery_backend_test: fix unsafe iteration

### DIFF
--- a/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/cluster_recovery_backend_test.cc
@@ -166,7 +166,8 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
     cluster::tx_executor{}.run_random_workload(
       spec, remote_p->raft()->term(), remote_p->rm_stm(), remote_p->log());
 
-    for (const auto& [ntp, p] : app.partition_manager.local().partitions()) {
+    auto partitions = app.partition_manager.local().partitions();
+    for (const auto& [ntp, p] : partitions) {
         if (ntp == model::controller_ntp) {
             continue;
         }
@@ -180,6 +181,7 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
         archiver.upload_topic_manifest().get();
         archiver.upload_manifest("test").get();
     }
+    partitions.clear();
 
     // Write a controller snapshot and upload it.
     RPTEST_REQUIRE_EVENTUALLY(
@@ -259,8 +261,8 @@ TEST_P(ClusterRecoveryBackendLeadershipParamTest, TestRecoveryControllerState) {
         auto topic_count
           = app.controller->get_topics_state().local().all_topics_count();
         ASSERT_LE(2, topic_count);
-        for (const auto& [ntp, p] :
-             app.partition_manager.local().partitions()) {
+        auto partitions = app.partition_manager.local().partitions();
+        for (const auto& [ntp, p] : partitions) {
             if (!model::is_user_topic(ntp)) {
                 continue;
             }


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18119
Fixes: https://github.com/redpanda-data/redpanda/issues/18124,