### PR TITLE
cmake: Add support for sccache

### DIFF
--- a/cmake/sccache.cmake
+++ b/cmake/sccache.cmake
@@ -1,0 +1,6 @@
+option(WITH_SCCACHE "Distribute build with sccache." OFF)
+if(WITH_SCCACHE)
+    message(STATUS "Building with sccache")
+    set(CMAKE_C_COMPILER_LAUNCHER "sccache")
+    set(CMAKE_CXX_COMPILER_LAUNCHER "sccache")
+endif(WITH_SCCACHE)


### PR DESCRIPTION
Add cmake include file to enable sccache

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none
