### PR TITLE
slash-cmds: register /test-rc-pipeline

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -11,6 +11,7 @@ on:
       - dt-command
       - microbench-command
       - publish-to-install-pack-command
+      - test-rc-pipeline-command
 
 jobs:
   run-build:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -22,6 +22,7 @@ jobs:
             dt
             microbench
             publish-to-install-pack
+            test-rc-pipeline
           static-args: |
             org=redpanda-data
             repo=redpanda


### PR DESCRIPTION
Register `/test-tc-pipeline` slash command to exercise the RC pipeline

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
