### PR TITLE
[v23.3.x] cloud_storage: Implement "carryover" cache trimming mechanism

### DIFF
--- a/src/v/cloud_storage/cache_probe.cc
+++ b/src/v/cloud_storage/cache_probe.cc
@@ -103,6 +103,11 @@ cache_probe::cache_probe() {
                     "trim and had to fall back to a slower exhaustive trim."))
                   .aggregate(aggregate_labels),
                 sm::make_counter(
+                  "carryover_trims",
+                  [this] { return _carryover_trims; },
+                  sm::description("Number of times we invoked carryover trim."))
+                  .aggregate(aggregate_labels),
+                sm::make_counter(
                   "failed_trims",
                   [this] { return _failed_trims; },
                   sm::description(

--- a/src/v/cloud_storage/cache_probe.h
+++ b/src/v/cloud_storage/cache_probe.h
@@ -39,6 +39,7 @@ public:
 
     void fast_trim() { ++_fast_trims; }
     void exhaustive_trim() { ++_exhaustive_trims; }
+    void carryover_trim() { ++_carryover_trims; }
     void failed_trim() { ++_failed_trims; }
 
 private:
@@ -55,6 +56,7 @@ private:
 
     int64_t _fast_trims{0};
     int64_t _exhaustive_trims{0};
+    int64_t _carryover_trims{0};
     int64_t _failed_trims{0};
 
     metrics::internal_metric_groups _metrics;

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -11,9 +11,13 @@
 #include "bytes/iostream.h"
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/logger.h"
+#include "cloud_storage/recursive_directory_walker.h"
+#include "config/configuration.h"
 #include "seastar/util/file.hh"
 #include "ssx/future-util.h"
+#include "ssx/sformat.h"
 #include "storage/segment.h"
+#include "utils/human.h"
 #include "vassert.h"
 #include "vlog.h"
 
@@ -529,6 +533,99 @@ ss::future<> cache::trim(
     _last_trim_failed = false;
 }
 
+ss::future<cache::trim_result>
+cache::remove_segment_full(const file_list_item& file_stat) {
+    trim_result result;
+    try {
+        uint64_t this_segment_deleted_bytes{0};
+
+        auto deleted_parents = co_await delete_file_and_empty_parents(
+          file_stat.path);
+        result.deleted_size += file_stat.size;
+        this_segment_deleted_bytes += file_stat.size;
+        _current_cache_size -= file_stat.size;
+        _current_cache_objects -= 1;
+        result.deleted_count += 1;
+
+        // Determine whether we should delete indices along with the
+        // object we have just deleted
+        std::optional<std::string> tx_file;
+        std::optional<std::string> index_file;
+
+        if (RE2::FullMatch(file_stat.path.data(), segment_expr)) {
+            // If this was a legacy whole-segment item, delete the index
+            // and tx file along with the segment
+            tx_file = fmt::format("{}.tx", file_stat.path);
+            index_file = fmt::format("{}.index", file_stat.path);
+        } else if (deleted_parents) {
+            auto immediate_parent = std::string(
+              std::filesystem::path(file_stat.path).parent_path());
+            static constexpr std::string_view chunks_suffix{"_chunks"};
+            if (immediate_parent.ends_with(chunks_suffix)) {
+                // We just deleted the last chunk from a _chunks segment
+                // directory.  We may delete the index + tx state for
+                // that segment.
+                auto base_segment_path = immediate_parent.substr(
+                  0, immediate_parent.size() - chunks_suffix.size());
+                tx_file = fmt::format("{}.tx", base_segment_path);
+                index_file = fmt::format("{}.index", base_segment_path);
+            }
+        }
+
+        if (tx_file.has_value()) {
+            try {
+                auto sz = co_await ss::file_size(tx_file.value());
+                co_await ss::remove_file(tx_file.value());
+                result.deleted_size += sz;
+                this_segment_deleted_bytes += sz;
+                result.deleted_count += 1;
+                _current_cache_size -= sz;
+                _current_cache_objects -= 1;
+            } catch (std::filesystem::filesystem_error& e) {
+                if (e.code() != std::errc::no_such_file_or_directory) {
+                    throw;
+                }
+            }
+        }
+
+        if (index_file.has_value()) {
+            try {
+                auto sz = co_await ss::file_size(index_file.value());
+                co_await ss::remove_file(index_file.value());
+                result.deleted_size += sz;
+                this_segment_deleted_bytes += sz;
+                result.deleted_count += 1;
+                _current_cache_size -= sz;
+                _current_cache_objects -= 1;
+            } catch (std::filesystem::filesystem_error& e) {
+                if (e.code() != std::errc::no_such_file_or_directory) {
+                    throw;
+                }
+            }
+        }
+
+        // Remove key if possible to make sure there is no resource
+        // leak
+        _access_time_tracker.remove_timestamp(std::string_view(file_stat.path));
+
+        vlog(
+          cst_log.trace,
+          "trim: reclaimed(fast) {} bytes from {}",
+          this_segment_deleted_bytes,
+          file_stat.path);
+    } catch (const ss::gate_closed_exception&) {
+        // We are shutting down, stop iterating and propagate
+        throw;
+    } catch (const std::exception& e) {
+        vlog(
+          cst_log.error,
+          "trim: couldn't delete {}: {}.",
+          file_stat.path,
+          e.what());
+    }
+    co_return result;
+}
+
 ss::future<cache::trim_result> cache::trim_fast(
   const fragmented_vector<file_list_item>& candidates,
   uint64_t size_to_delete,
@@ -537,19 +634,17 @@ ss::future<cache::trim_result> cache::trim_fast(
 
     trim_result result;
 
-    size_t candidate_i = 0;
-    while (
-      candidate_i < candidates.size()
-      && (result.deleted_size < size_to_delete || result.deleted_count < objects_to_delete)) {
-        auto& file_stat = candidates[candidate_i++];
+    // Reset carryover list
+    _last_trim_carryover = std::nullopt;
 
+    auto need_to_skip = [this](const file_list_item& file_stat) {
         if (is_trim_exempt(file_stat.path)) {
-            continue;
+            return true;
         }
 
         // skip tmp files since someone may be writing to it
         if (std::string_view(file_stat.path).ends_with(tmp_extension)) {
-            continue;
+            return true;
         }
 
         // Doesn't make sense to demote these independent of the segment
@@ -558,97 +653,45 @@ ss::future<cache::trim_result> cache::trim_fast(
         if (
           std::string_view(file_stat.path).ends_with(".tx")
           || std::string_view(file_stat.path).ends_with(".index")) {
+            return true;
+        }
+        return false;
+    };
+
+    size_t candidate_i = 0;
+    while (
+      candidate_i < candidates.size()
+      && (result.deleted_size < size_to_delete || result.deleted_count < objects_to_delete)) {
+        auto& file_stat = candidates[candidate_i++];
+
+        if (need_to_skip(file_stat)) {
             continue;
         }
 
-        try {
-            uint64_t this_segment_deleted_bytes{0};
+        auto op_res = co_await this->remove_segment_full(file_stat);
+        result.deleted_count += op_res.deleted_count;
+        result.deleted_size += op_res.deleted_size;
+    }
 
-            auto deleted_parents = co_await delete_file_and_empty_parents(
-              file_stat.path);
-            result.deleted_size += file_stat.size;
-            this_segment_deleted_bytes += file_stat.size;
-            _current_cache_size -= file_stat.size;
-            _current_cache_objects -= 1;
-            result.deleted_count += 1;
-
-            // Determine whether we should delete indices along with the
-            // object we have just deleted
-            std::optional<std::string> tx_file;
-            std::optional<std::string> index_file;
-
-            if (RE2::FullMatch(file_stat.path.data(), segment_expr)) {
-                // If this was a legacy whole-segment item, delete the index
-                // and tx file along with the segment
-                tx_file = fmt::format("{}.tx", file_stat.path);
-                index_file = fmt::format("{}.index", file_stat.path);
-            } else if (deleted_parents) {
-                auto immediate_parent = std::string(
-                  std::filesystem::path(file_stat.path).parent_path());
-                static constexpr std::string_view chunks_suffix{"_chunks"};
-                if (immediate_parent.ends_with(chunks_suffix)) {
-                    // We just deleted the last chunk from a _chunks segment
-                    // directory.  We may delete the index + tx state for
-                    // that segment.
-                    auto base_segment_path = immediate_parent.substr(
-                      0, immediate_parent.size() - chunks_suffix.size());
-                    tx_file = fmt::format("{}.tx", base_segment_path);
-                    index_file = fmt::format("{}.index", base_segment_path);
-                }
-            }
-
-            if (tx_file.has_value()) {
-                try {
-                    auto sz = co_await ss::file_size(tx_file.value());
-                    co_await ss::remove_file(tx_file.value());
-                    result.deleted_size += sz;
-                    this_segment_deleted_bytes += sz;
-                    result.deleted_count += 1;
-                    _current_cache_size -= sz;
-                    _current_cache_objects -= 1;
-                } catch (std::filesystem::filesystem_error& e) {
-                    if (e.code() != std::errc::no_such_file_or_directory) {
-                        throw;
-                    }
-                }
-            }
-
-            if (index_file.has_value()) {
-                try {
-                    auto sz = co_await ss::file_size(index_file.value());
-                    co_await ss::remove_file(index_file.value());
-                    result.deleted_size += sz;
-                    this_segment_deleted_bytes += sz;
-                    result.deleted_count += 1;
-                    _current_cache_size -= sz;
-                    _current_cache_objects -= 1;
-                } catch (std::filesystem::filesystem_error& e) {
-                    if (e.code() != std::errc::no_such_file_or_directory) {
-                        throw;
-                    }
-                }
-            }
-
-            // Remove key if possible to make sure there is no resource
-            // leak
-            _access_time_tracker.remove_timestamp(
-              std::string_view(file_stat.path));
-
-            vlog(
-              cst_log.trace,
-              "trim: reclaimed(fast) {} bytes from {}",
-              this_segment_deleted_bytes,
-              file_stat.path);
-        } catch (const ss::gate_closed_exception&) {
-            // We are shutting down, stop iterating and propagate
-            throw;
-        } catch (const std::exception& e) {
-            vlog(
-              cst_log.error,
-              "trim: couldn't delete {}: {}.",
-              file_stat.path,
-              e.what());
+    auto max_carryover_files = config::shard_local_cfg()
+                                 .cloud_storage_cache_trim_carryover.value()
+                                 .value_or(0);
+    fragmented_vector<file_list_item> tmp;
+    auto estimated_size = std::min(
+      static_cast<size_t>(max_carryover_files),
+      candidates.size() - candidate_i);
+    tmp.reserve(estimated_size);
+    while (max_carryover_files > 0 && candidate_i < candidates.size()) {
+        const auto& fs = candidates[candidate_i++];
+        if (need_to_skip(fs)) {
+            continue;
         }
+        max_carryover_files--;
+        tmp.push_back(fs);
+    }
+
+    if (!tmp.empty()) {
+        _last_trim_carryover = std::move(tmp);
     }
 
     co_return result;
@@ -668,6 +711,8 @@ ss::future<cache::trim_result>
 cache::trim_exhaustive(uint64_t size_to_delete, size_t objects_to_delete) {
     probe.exhaustive_trim();
     trim_result result;
+
+    _last_trim_carryover = std::nullopt;
 
     // Enumerate ALL files in the cache (as opposed to trim_fast that strips out
     // indices/tx/tmp files)
@@ -1223,6 +1268,114 @@ bool cache::may_exceed_limits(uint64_t bytes, size_t objects) {
            && !would_fit_in_cache;
 }
 
+ss::future<cache::trim_result>
+cache::trim_carryover(uint64_t delete_bytes, uint64_t delete_objects) {
+    // During the normal trim we're doing the recursive directory walk to
+    // generate a exhaustive list of files stored in the cache. If we store very
+    // large number of files in the cache this operation could take long time.
+    // We have a limit for number of objects that the cache could support but
+    // it's often set to relatively high value. Also, when we reach the object
+    // count limit the cache blocks all new 'put' operations because it doesn't
+    // allow any overallocation in this case.
+    //
+    // This creates a corner case when every trim is caused by the object count
+    // limit being reached. In this case the trim is blocking readers every
+    // time.
+    //
+    // The solution is to quickly delete objects without doing the full
+    // recursive directory walk and unblock the readers proactively allowing
+    // them object count to overshoot for very brief period of time. In order to
+    // be able to do this we need to have the list of candidates for deletion.
+    // Such list is stored in the _last_trim_carryover field. This is a list of
+    // files with oldest access times from the last directory walk. The
+    // carryover trim compares the access times from the carryover list to their
+    // actual access times from the access time tracker. All objects with
+    // matching access times wasn't accessed since the last trim and can be
+    // deleted. This doesn't change the LRU behavior since the
+    // _last_trim_carryover stores objects in LRU order.
+    trim_result result;
+    vlog(
+      cst_log.trace,
+      "trim carryover: list available {}",
+      _last_trim_carryover.has_value());
+
+    if (!_last_trim_carryover.has_value()) {
+        co_return result;
+    }
+    auto it = _last_trim_carryover->begin();
+    for (; it < _last_trim_carryover->end(); it++) {
+        vlog(
+          cst_log.trace,
+          "carryover trim: check object {} ({})",
+          it->path,
+          it->size);
+        if (
+          result.deleted_size >= delete_bytes
+          && result.deleted_count >= delete_objects) {
+            vlog(
+              cst_log.trace,
+              "carryover trim: stop, deleted {} / {}, requested to delete {} / "
+              "{}",
+              human::bytes(result.deleted_size),
+              result.deleted_count,
+              human::bytes(delete_bytes),
+              delete_objects);
+            break;
+        }
+        auto& file_stat = *it;
+        // Don't hit access time tracker file/tmp
+        if (
+          is_trim_exempt(file_stat.path)
+          || std::string_view(file_stat.path).ends_with(tmp_extension)) {
+            continue;
+        }
+        // Both tx and index files are handled as part of the segment
+        // deletion.
+        if (
+          std::string_view(file_stat.path).ends_with(".tx")
+          || std::string_view(file_stat.path).ends_with(".index")) {
+            continue;
+        }
+        // Check that access time didn't change
+        auto rel_path = _cache_dir
+                        / std::filesystem::relative(
+                          std::filesystem::path(file_stat.path), _cache_dir);
+        auto estimate = _access_time_tracker.estimate_timestamp(
+          rel_path.native());
+        if (estimate != file_stat.access_time) {
+            vlog(
+              cst_log.trace,
+              "carryover file {} was accessed ({}) since the last trim ({}), "
+              "ignoring",
+              rel_path.native(),
+              estimate->time_since_epoch().count(),
+              file_stat.access_time.time_since_epoch().count());
+            // The file was accessed since we get the stats
+            continue;
+        }
+        auto op_res = co_await this->remove_segment_full(file_stat);
+        result.deleted_count += op_res.deleted_count;
+        result.deleted_size += op_res.deleted_size;
+    }
+    vlog(
+      cst_log.debug,
+      "carryover trim reclaimed {} bytes from {} files",
+      result.deleted_size,
+      result.deleted_count);
+
+    if (it == _last_trim_carryover->end()) {
+        _last_trim_carryover = std::nullopt;
+    } else {
+        fragmented_vector<file_list_item> tmp;
+        size_t estimate = _last_trim_carryover->end() - it;
+        tmp.reserve(estimate);
+        std::copy(it, _last_trim_carryover->end(), std::back_inserter(tmp));
+        _last_trim_carryover = std::move(tmp);
+    }
+
+    co_return result;
+}
+
 ss::future<> cache::do_reserve_space(uint64_t bytes, size_t objects) {
     vassert(ss::this_shard_id() == ss::shard_id{0}, "Only call on shard 0");
 
@@ -1232,12 +1385,6 @@ ss::future<> cache::do_reserve_space(uint64_t bytes, size_t objects) {
         _reserved_cache_objects += objects;
         co_return;
     }
-
-    // Slow path: register a pending need for bytes that will be used in
-    // clean_up_cache to make space available, and then proceed to cooperatively
-    // call clean_up_cache along with anyone else who is waiting.
-    _reservations_pending += bytes;
-    _reservations_pending_objects += objects;
 
     vlog(
       cst_log.trace,
@@ -1253,6 +1400,45 @@ ss::future<> cache::do_reserve_space(uint64_t bytes, size_t objects) {
 
     try {
         auto units = co_await ss::get_units(_cleanup_sm, 1);
+
+        if (_last_trim_carryover.has_value()) {
+            // Slow path: try to run carryover trim if we have data
+            // from the previous trim.
+
+            auto short_term_hydrations_estimate
+              = config::shard_local_cfg().cloud_storage_max_connections()
+                * ss::smp::count;
+
+            // Here we're trying to estimate how much space do we need to
+            // free to allow all TS resources to be used again to download
+            // data from S3. This is only a crude estimate.
+            auto trim_bytes = std::min(
+              config::shard_local_cfg().log_segment_size()
+                * short_term_hydrations_estimate / 3,
+              _max_bytes);
+            auto trim_objects = std::min(
+              short_term_hydrations_estimate * 3, _max_objects());
+
+            vlog(
+              cst_log.debug,
+              "Carryover trim list has {} elements, trying to remove {} bytes "
+              "and {} objects",
+              _last_trim_carryover->size(),
+              human::bytes(trim_bytes),
+              trim_objects);
+
+            co_await trim_carryover(trim_bytes, trim_objects);
+        } else {
+            vlog(cst_log.debug, "Carryover trim list is empty");
+        }
+
+        // Slowest path: register a pending need for bytes that will be used in
+        // clean_up_cache to make space available, and then proceed to
+        // cooperatively call clean_up_cache along with anyone else who is
+        // waiting.
+        _reservations_pending += bytes;
+        _reservations_pending_objects += objects;
+
         while (!may_reserve_space(bytes, objects)) {
             bool may_exceed = may_exceed_limits(bytes, objects)
                               && _last_trim_failed;

--- a/src/v/cloud_storage/cache_service.cc
+++ b/src/v/cloud_storage/cache_service.cc
@@ -1303,6 +1303,7 @@ cache::trim_carryover(uint64_t delete_bytes, uint64_t delete_objects) {
     if (!_last_trim_carryover.has_value()) {
         co_return result;
     }
+    probe.carryover_trim();
     auto it = _last_trim_carryover->begin();
     for (; it < _last_trim_carryover->end(); it++) {
         vlog(

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -253,6 +253,10 @@ private:
     /// (only runs on shard 0)
     ss::future<> do_reserve_space(uint64_t, size_t);
 
+    /// Trim cache using results from the previous recursive directory walk
+    ss::future<trim_result>
+    trim_carryover(uint64_t delete_bytes, uint64_t delete_objects);
+
     /// Return true if the sum of used space and reserved space is far enough
     /// below max size to accommodate a new reservation of `bytes`
     /// (only runs on shard 0)
@@ -272,6 +276,11 @@ private:
     /// called on all shards by shard 0 when handling a disk space status
     /// update.
     void set_block_puts(bool);
+
+    /// Remove segment or chunk subdirectory with all its auxilary files (tx,
+    /// index)
+    ss::future<cache::trim_result>
+    remove_segment_full(const file_list_item& file_stat);
 
     std::filesystem::path _cache_dir;
     size_t _disk_size;
@@ -337,6 +346,9 @@ private:
     ss::condition_variable _block_puts_cond;
 
     friend class cache_test_fixture;
+
+    // List of probable deletion candidates from the last trim.
+    std::optional<fragmented_vector<file_list_item>> _last_trim_carryover;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -177,6 +177,10 @@ public:
 
     uint64_t get_usage_bytes() { return _current_cache_size; }
 
+    uint64_t get_max_bytes() { return _max_bytes; }
+
+    uint64_t get_max_objects() { return _max_objects(); }
+
     /// Administrative trim, that specifies its own limits instead of using
     /// the configured limits (skips throttling, and can e.g. trim to zero bytes
     /// if they want to)

--- a/src/v/cloud_storage/materialized_resources.h
+++ b/src/v/cloud_storage/materialized_resources.h
@@ -179,6 +179,9 @@ private:
     config::binding<std::optional<size_t>> _relative_throughput;
     bool _throttling_disabled{false};
     std::optional<size_t> _device_throughput;
+    config::binding<uint32_t> _cache_carryover_bytes;
+    // Memory reserved for cache carryover mechanism
+    std::optional<ssx::semaphore_units> _carryover_units;
 };
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/recursive_directory_walker.cc
+++ b/src/v/cloud_storage/recursive_directory_walker.cc
@@ -12,12 +12,14 @@
 
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/logger.h"
+#include "ssx/watchdog.h"
 #include "vassert.h"
 #include "vlog.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/file.hh>
 #include <seastar/core/seastar.hh>
+#include <seastar/core/sleep.hh>
 #include <seastar/core/sstring.hh>
 
 #include <algorithm>
@@ -94,6 +96,13 @@ ss::future<walk_result> recursive_directory_walker::walk(
   std::optional<filter_type> collect_filter) {
     auto guard = _gate.hold();
 
+    watchdog wd1m(std::chrono::seconds(60), [] {
+        vlog(cst_log.info, "Directory walk is taking more than 1 min");
+    });
+    watchdog wd10m(std::chrono::seconds(600), [] {
+        vlog(cst_log.warn, "Directory walk is taking more than 10 min");
+    });
+
     // Object to accumulate data as we walk directories
     walk_accumulator state(start_dir, tracker, std::move(collect_filter));
 
@@ -103,7 +112,8 @@ ss::future<walk_result> recursive_directory_walker::walk(
         auto target = state.pop();
         vassert(
           std::string_view(target).starts_with(start_dir),
-          "Looking at directory {}, which is outside of initial dir {}.",
+          "Looking at directory {}, which is outside of initial dir "
+          "{}.",
           target,
           start_dir);
 

--- a/src/v/cloud_storage/tests/cache_test.cc
+++ b/src/v/cloud_storage/tests/cache_test.cc
@@ -8,14 +8,18 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
+#include "bytes/bytes.h"
 #include "bytes/iobuf.h"
 #include "bytes/iostream.h"
 #include "cache_test_fixture.h"
 #include "cloud_storage/access_time_tracker.h"
 #include "cloud_storage/cache_service.h"
+#include "random/generators.h"
+#include "ssx/sformat.h"
 #include "test_utils/fixture.h"
 #include "units.h"
 #include "utils/file_io.h"
+#include "utils/human.h"
 
 #include <seastar/core/fstream.hh>
 #include <seastar/core/seastar.hh>
@@ -30,6 +34,8 @@
 #include <stdexcept>
 
 using namespace cloud_storage;
+
+static ss::logger test_log("cache_test_logger");
 
 FIXTURE_TEST(put_creates_file, cache_test_fixture) {
     auto data_string = create_data_string('a', 1_MiB + 1_KiB);
@@ -537,4 +543,81 @@ FIXTURE_TEST(test_log_segment_cleanup, cache_test_fixture) {
       std::all_of(objects.cbegin(), objects.cend(), [](const auto& path) {
           return !std::filesystem::exists(path);
       }));
+}
+
+FIXTURE_TEST(test_cache_carryover_trim, cache_test_fixture) {
+    std::string write_buf(1_MiB, ' ');
+    random_generators::fill_buffer_randomchars(
+      write_buf.data(), write_buf.size());
+    size_t bytes_used = 0;
+    size_t num_objects = 0;
+    std::vector<std::filesystem::path> object_keys;
+    for (int i = 0; i < 10; i++) {
+        object_keys.emplace_back(fmt::format("test_{}.log.1", i));
+        std::ofstream segment{CACHE_DIR / object_keys.back()};
+        segment.write(
+          write_buf.data(), static_cast<std::streamsize>(write_buf.size()));
+        segment.flush();
+        bytes_used += write_buf.size();
+        num_objects++;
+        object_keys.emplace_back(fmt::format("test_{}.log.1.index", i));
+        std::ofstream index{CACHE_DIR / object_keys.back()};
+        index.write(
+          write_buf.data(), static_cast<std::streamsize>(write_buf.size()));
+        index.flush();
+        bytes_used += write_buf.size();
+        num_objects++;
+        object_keys.emplace_back(fmt::format("test_{}.log.1.tx", i));
+        std::ofstream tx{CACHE_DIR / object_keys.back()};
+        tx.write(
+          write_buf.data(), static_cast<std::streamsize>(write_buf.size()));
+        tx.flush();
+        bytes_used += write_buf.size();
+        num_objects++;
+    }
+    // Account all files in the cache (30 MiB).
+    clean_up_at_start().get();
+    for (const auto& key : object_keys) {
+        // Touch every object so they have access times assigned to them
+        auto item = sharded_cache.local().get(key).get();
+        item->body.close().get();
+    }
+
+    // Force trim to create a carryover list.
+    // Nothing is deleted by the trim.
+    vlog(test_log.info, "Initial trim");
+    auto cache_size_target_bytes = bytes_used;
+    auto cache_size_target_objects = num_objects;
+    trim_cache(cache_size_target_bytes, cache_size_target_objects);
+
+    // Start trim using only carryover data
+    auto before_bytes = sharded_cache.local().get_usage_bytes();
+    auto before_objects = sharded_cache.local().get_usage_objects();
+    vlog(
+      test_log.info,
+      "Trim {}, {} bytes used, {} objects",
+      human::bytes(bytes_used),
+      human::bytes(before_bytes),
+      before_objects);
+    BOOST_REQUIRE(before_bytes > 0);
+    BOOST_REQUIRE(before_objects > 0);
+
+    // Note that 'trim_carryover' accepts number of bytes/objects
+    // that has to be deleted. This is the opposite of how 'trim'
+    // method behaves which accepts target size for the cache.
+    // This behavior is similar to 'trim_fast'.
+    auto bytes_to_delete = before_bytes;
+    auto objects_to_delete = before_objects;
+    trim_carryover(bytes_to_delete, objects_to_delete);
+
+    // At this point we should be able to delete all objects
+    auto after_bytes = sharded_cache.local().get_usage_bytes();
+    auto after_objects = sharded_cache.local().get_usage_objects();
+    vlog(
+      test_log.info,
+      "After trim {} bytes used, {} objects",
+      human::bytes(after_bytes),
+      after_objects);
+    BOOST_REQUIRE_EQUAL(after_bytes, 0);
+    BOOST_REQUIRE_EQUAL(after_objects, 0);
 }

--- a/src/v/cloud_storage/tests/cache_test_fixture.h
+++ b/src/v/cloud_storage/tests/cache_test_fixture.h
@@ -119,6 +119,10 @@ public:
             })
           .get();
     }
+
+    void trim_carryover(uint64_t size_limit, uint64_t object_limit) {
+        sharded_cache.local().trim_carryover(size_limit, object_limit).get();
+    }
 };
 
 } // namespace cloud_storage

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2272,6 +2272,17 @@ configuration::configuration()
       // Enough for a >1TiB cache of 16MiB objects.  Decrease this in case
       // of issues with trim performance.
       100000)
+  , cloud_storage_cache_trim_carryover(
+      *this,
+      "cloud_storage_cache_trim_carryover",
+      "The cache performs a recursive directory inspection during the cache "
+      "trim. The information obtained during the inspection can be carried "
+      "over to the next trim operation. This parameter sets a limit on the "
+      "number of objects that can be carried over from one trim to next, and "
+      "allows cache to quickly unblock readers before starting the directory "
+      "inspection.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      512)
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2282,8 +2282,8 @@ configuration::configuration()
       "next, and allows cache to quickly unblock readers before starting the "
       "directory inspection.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      // This roughly translates to around 4000 carryover file names
-      1_MiB)
+      // This roughly translates to around 1000 carryover file names
+      256_KiB)
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2272,17 +2272,18 @@ configuration::configuration()
       // Enough for a >1TiB cache of 16MiB objects.  Decrease this in case
       // of issues with trim performance.
       100000)
-  , cloud_storage_cache_trim_carryover(
+  , cloud_storage_cache_trim_carryover_bytes(
       *this,
-      "cloud_storage_cache_trim_carryover",
+      "cloud_storage_cache_trim_carryover_bytes",
       "The cache performs a recursive directory inspection during the cache "
       "trim. The information obtained during the inspection can be carried "
       "over to the next trim operation. This parameter sets a limit on the "
-      "number of objects that can be carried over from one trim to next, and "
-      "allows cache to quickly unblock readers before starting the directory "
-      "inspection.",
+      "memory occupied by objects that can be carried over from one trim to "
+      "next, and allows cache to quickly unblock readers before starting the "
+      "directory inspection.",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
-      512)
+      // This roughly translates to around 4000 carryover file names
+      1_MiB)
   , cloud_storage_cache_check_interval_ms(
       *this,
       "cloud_storage_cache_check_interval",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -415,6 +415,7 @@ struct configuration final : public config_store {
     bounded_property<std::optional<double>, numeric_bounds>
       cloud_storage_cache_size_percent;
     property<uint32_t> cloud_storage_cache_max_objects;
+    property<std::optional<uint32_t>> cloud_storage_cache_trim_carryover;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
     property<std::optional<uint32_t>>
       cloud_storage_max_segment_readers_per_shard;

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -415,7 +415,7 @@ struct configuration final : public config_store {
     bounded_property<std::optional<double>, numeric_bounds>
       cloud_storage_cache_size_percent;
     property<uint32_t> cloud_storage_cache_max_objects;
-    property<std::optional<uint32_t>> cloud_storage_cache_trim_carryover;
+    property<uint32_t> cloud_storage_cache_trim_carryover_bytes;
     property<std::chrono::milliseconds> cloud_storage_cache_check_interval_ms;
     property<std::optional<uint32_t>>
       cloud_storage_max_segment_readers_per_shard;

--- a/src/v/utils/adjustable_semaphore.h
+++ b/src/v/utils/adjustable_semaphore.h
@@ -90,6 +90,14 @@ public:
         return ss::get_units(_sem, units, as);
     }
 
+    /**
+     * Attempts to immediately get units from the semaphore, returning
+     * std::nullopt if no units exist.
+     */
+    std::optional<ssx::semaphore_units> try_get_units(size_t units) {
+        return ss::try_get_units(_sem, units);
+    }
+
     size_t current() const noexcept { return _sem.current(); }
     ssize_t available_units() const noexcept { return _sem.available_units(); }
 


### PR DESCRIPTION
Backport of the #18056
Fixes #18133 

The `carryover` is a collection of deletion candidates found during the previous trim. The trim collects full list of objects in the directory and sorts them in LRU order. Then it deletes first N objects. We're saving first M objects that remain in the list after the trim. These objects are deletion candidates.

During the next trim the cache service first uses `carryover` list to a quick cache trim. This trim doesn't need a directory scan and it can quickly decrease bytes/objects counts so other readers could reserve space successfully. The trim doesn't delete objects from the `carryover` list blindly. It compares access time recorded in the carryover list to the access time stored in the `accesstime_tracker`. If the time is different then the object was accessed and the trim is not deleting it during this phase.

New configuration option `cloud_storage_cache_trim_carryover` is added. This config option sets the limit on the size of the carryover list. The list is stored on shard 0. The default value is 512. We are storing a file path for every object so this list shouldn't be too big. Even relatively small carryover list might be able to make a difference and prevent readers from being blocked. 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements

* Improve cloud storage cache to prevent readers from being blocked during cache eviction.