### PR TITLE
Fixed possible log discrepancy when using forced reconfiguration 

### DIFF
--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -209,6 +209,15 @@ std::error_code check_configuration_update(
           partition->ntp());
         return errc::partition_configuration_in_joint_mode;
     }
+
+    if (includes_self && partition->raft()->has_configuration_override()) {
+        vlog(
+          clusterlog.trace,
+          "[{}] contains current node and there is configuration override "
+          "active",
+          partition->ntp());
+        return errc::partition_configuration_in_joint_mode;
+    }
     /*
      * if replica set is a leader it must have configuration committed i.e. it
      * was successfully replicated to majority of followers.

--- a/src/v/raft/configuration_manager.cc
+++ b/src/v/raft/configuration_manager.cc
@@ -177,6 +177,7 @@ configuration_manager::add(std::vector<offset_configuration> configurations) {
             // handling backward compatibility i.e. revisionless configurations
             co.cfg.maybe_set_initial_revision(_initial_revision);
 
+            reset_override(co.cfg.revision_id());
             add_configuration(co.offset, std::move(co.cfg));
             _highest_known_offset = std::max(_highest_known_offset, co.offset);
         }
@@ -211,8 +212,29 @@ const group_configuration& configuration_manager::get_latest() const {
     vassert(
       !_configurations.empty(),
       "Configuration manager should always have at least one configuration");
+    if (_configuration_force_override) [[unlikely]] {
+        return *_configuration_force_override;
+    }
+
     return _configurations.rbegin()->second.cfg;
 }
+
+void configuration_manager::set_override(group_configuration cfg) {
+    vlog(_ctxlog.info, "Setting configuration override to {}", cfg);
+    _configuration_force_override = std::make_unique<group_configuration>(
+      std::move(cfg));
+}
+
+void configuration_manager::reset_override(
+  model::revision_id added_configuration_revision) {
+    if (
+      _configuration_force_override
+      && _configuration_force_override->revision_id()
+           <= added_configuration_revision) [[unlikely]] {
+        vlog(_ctxlog.info, "Resetting configuration override");
+        _configuration_force_override.reset();
+    }
+};
 
 model::offset configuration_manager::get_latest_offset() const {
     vassert(

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -524,6 +524,10 @@ public:
         return _replication_monitor;
     }
 
+    bool has_configuration_override() const {
+        return _configuration_manager.has_configuration_override();
+    }
+
 private:
     friend replication_monitor;
     friend replicate_entries_stm;

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ set(gsrcs
 rp_test(
   UNIT_TEST
   GTEST
-  TIMEOUT 1000
+  TIMEOUT 1500
   BINARY_NAME gtest_raft
   SOURCES ${gsrcs}
   LIBRARIES  v::raft v::storage_test_utils v::model_test_utils v::features v::gtest_main

--- a/src/v/raft/tests/raft_reconfiguration_test.cc
+++ b/src/v/raft/tests/raft_reconfiguration_test.cc
@@ -11,9 +11,6 @@
 #include "bytes/bytes.h"
 #include "gtest/gtest.h"
 #include "model/fundamental.h"
-#include "model/metadata.h"
-#include "model/record.h"
-#include "model/record_batch_reader.h"
 #include "model/record_batch_types.h"
 #include "model/timeout_clock.h"
 #include "raft/errc.h"
@@ -21,8 +18,9 @@
 #include "raft/tests/raft_fixture.h"
 #include "raft/types.h"
 #include "random/generators.h"
+#include "replicate.h"
 #include "serde/rw/rw.h"
-#include "serde/serde.h"
+#include "ssx/future-util.h"
 #include "storage/record_batch_builder.h"
 #include "test_utils/async.h"
 #include "test_utils/randoms.h"
@@ -37,6 +35,7 @@
 #include <absl/container/flat_hash_set.h>
 #include <fmt/core.h>
 #include <fmt/ranges.h>
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
 #include <algorithm>
@@ -428,3 +427,216 @@ INSTANTIATE_TEST_SUITE_P(
       consistency_level::quorum_ack, consistency_level::leader_ack),
     testing::Values(
       isolated_t::old_followers, isolated_t::old_leader, isolated_t::random)));
+
+namespace {
+ss::future<std::error_code> wait_for_offset(
+  model::offset expected,
+  std::vector<model::node_id> ids,
+  raft_fixture& fixture) {
+    auto start = model::timeout_clock::now();
+    // wait for visible offset to propagate
+    while (start + 10s > model::timeout_clock::now()) {
+        bool aligned = std::all_of(
+          ids.begin(), ids.end(), [&](model::node_id id) {
+              auto& rni = fixture.node(id);
+              vlog(
+                test_log.info,
+                "node: {}, last_visible_index: {}, expected_offset: {}",
+                id,
+                rni.raft()->last_visible_index(),
+                expected);
+              return rni.raft()->last_visible_index() >= expected;
+          });
+
+        if (aligned) {
+            co_return errc::success;
+        }
+        co_await ss::sleep(1s);
+    }
+    co_return raft::errc::timeout;
+}
+} // namespace
+
+TEST_F_CORO(raft_fixture, test_force_reconfiguration) {
+    /**
+     * This tests verifies the consistency of logs on all the replicas after a
+     * round of force reconfigurations.
+     */
+    co_await create_simple_group(5);
+    co_await wait_for_leader(10s);
+
+    bool stop = false;
+
+    auto replicate_fiber = ss::do_until(
+      [&stop] { return stop; },
+      [this] {
+          ss::lw_shared_ptr<consensus> raft;
+          for (auto& n : nodes()) {
+              if (n.second->raft()->is_leader()) {
+                  raft = n.second->raft();
+                  break;
+              }
+          }
+
+          if (!raft) {
+              return ss::sleep(100ms);
+          }
+          return raft
+            ->replicate(
+              make_batches(10, 10, 128),
+              replicate_options(raft::consistency_level::quorum_ack))
+            .then([this](result<replicate_result> result) {
+                if (result.has_error()) {
+                    vlog(
+                      logger().info,
+                      "error(replicating): {}",
+                      result.error().message());
+                }
+            });
+      });
+
+    std::vector<vnode> base_replica_set = all_vnodes();
+    size_t reconfiguration_count = 0;
+
+    auto current_replicas = base_replica_set;
+
+    vlog(logger().info, "initial replicas: {}", current_replicas);
+
+    auto reconfigure_all = [&, this]() {
+        /**
+         * Switch between all 5 replicas and randomly selected 3 of them
+         */
+        if (current_replicas.size() == 5) {
+            std::shuffle(
+              base_replica_set.begin(),
+              base_replica_set.end(),
+              random_generators::internal::gen);
+            current_replicas = {
+              base_replica_set.begin(), std::next(base_replica_set.begin(), 3)};
+        } else {
+            current_replicas = base_replica_set;
+        }
+
+        vlog(logger().info, "reconfiguring group to: {}", current_replicas);
+        auto to_skip = random_generators::random_choice(base_replica_set);
+
+        return ss::parallel_for_each(
+          nodes().begin(),
+          nodes().end(),
+          [&, to_skip](const raft_nodes_t::value_type& pair) {
+              auto raft = pair.second->raft();
+              model::revision_id rev = ++raft->config().revision_id();
+              if (
+                pair.second->get_vnode() == to_skip
+                && !pair.second->raft()->is_leader()) {
+                  return ss::now();
+              }
+              return raft
+                ->force_replace_configuration_locally(current_replicas, {}, rev)
+                .discard_result();
+          });
+    };
+
+    auto reconfigure_fiber = ss::do_until(
+      [&] { return stop; },
+      [&] {
+          return reconfigure_all()
+            .then([&]() {
+                reconfiguration_count++;
+
+                if (reconfiguration_count >= 50) {
+                    stop = true;
+                }
+                return ss::now();
+            })
+            .handle_exception([](const std::exception_ptr&) {
+                // ignore exception
+            })
+            .then([this] {
+                return wait_for_leader(10s).then([this](model::node_id id) {
+                    vlog(
+                      logger().info,
+                      "new leader {}, term: {}",
+                      id,
+                      nodes()[id]->raft()->term());
+                });
+            });
+      });
+
+    auto l_transfer_fiber = ss::do_until(
+      [&stop] { return stop; },
+      [&, this] {
+          std::vector<raft::vnode> not_leaders;
+          ss::lw_shared_ptr<consensus> raft;
+          for (auto& n : current_replicas) {
+              if (node(n.id()).raft()->is_leader()) {
+                  raft = node(n.id()).raft();
+              } else {
+                  not_leaders.push_back(n);
+              }
+          }
+
+          if (!raft) {
+              return ss::sleep(100ms);
+          }
+          auto target = random_generators::random_choice(not_leaders);
+          return raft
+            ->transfer_leadership(transfer_leadership_request{
+              .group = raft->group(),
+              .target = target.id(),
+              .timeout = 25ms,
+            })
+            .then([this](transfer_leadership_reply r) {
+                if (r.result != raft::errc::success) {
+                    vlog(logger().info, "error(transferring): {}", r);
+                }
+            })
+            .then([] { return ss::sleep(200ms); })
+            .handle_exception([](const std::exception_ptr&) {
+                // ignore exception
+            });
+      });
+
+    co_await ss::when_all(
+      std::move(replicate_fiber),
+      std::move(reconfigure_fiber),
+      std::move(l_transfer_fiber));
+
+    logger().info("Validating log consistency");
+    /**
+     * In the last step of the test we validate consistency of offset
+     * translation.
+     */
+    using offset_map_t
+      = absl::btree_map<model::offset, std::vector<model::offset>>;
+
+    auto dirty_offset = co_await retry_with_leader(
+      model::timeout_clock::now() + 30s, [](raft_node_instance& leader_node) {
+          return ::result<model::offset>(leader_node.raft()->dirty_offset());
+      });
+
+    logger().info(
+      "Waiting for all nodes to be up to date. Dirty offset: {}",
+      dirty_offset.value());
+
+    std::vector<model::node_id> node_ids;
+    node_ids.reserve(current_replicas.size());
+    for (auto& vn : current_replicas) {
+        node_ids.push_back(vn.id());
+    }
+    auto ec = co_await wait_for_offset(dirty_offset.value(), node_ids, *this);
+    ASSERT_EQ_CORO(ec, errc::success);
+
+    offset_map_t mapped_offsets;
+    for (auto& vn : current_replicas) {
+        auto& node = this->node(vn.id());
+
+        for (auto o = model::offset(0); o < dirty_offset.value(); ++o) {
+            mapped_offsets[o].push_back(node.raft()->log()->from_log_offset(o));
+        }
+    }
+    using namespace testing;
+    for (auto& [log_offset, kafka_offsets] : mapped_offsets) {
+        EXPECT_THAT(kafka_offsets, Each(Eq(kafka_offsets[0])));
+    }
+}


### PR DESCRIPTION
Changed the way how Redpanda raft handles force reconfigurations. Instead of appending configuration to the log we keep a volatile in memory override for the configuration that was forced. The override is dropped whenever a node receives different configuration. This approach allow us to avoid discrepancies as not data are appended to the log without the active leader. 

Fixes: #17847

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none 