### PR TITLE
[v24.1.x] CORE-1412: cluster: remote read check in partition timequery

### DIFF
--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -21,6 +21,7 @@
 #include "kafka/server/tests/list_offsets_utils.h"
 #include "kafka/server/tests/produce_consume_utils.h"
 #include "model/fundamental.h"
+#include "random/generators.h"
 #include "redpanda/tests/fixture.h"
 #include "storage/ntp_config.h"
 #include "test_utils/async.h"
@@ -671,4 +672,284 @@ FIXTURE_TEST(
 
     // health report never reported non-zero reclaimable sizes. bummer!
     BOOST_REQUIRE(false);
+}
+
+FIXTURE_TEST(test_local_timequery, e2e_fixture) {
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, model::partition_id{0});
+
+    // Force local timequeries only through archival mode.
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::archival;
+
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    auto log = partition->log();
+    auto& archiver = partition->archiver().value().get();
+    BOOST_REQUIRE(archiver.sync_for_tests().get());
+
+    const auto batches_per_segment = 1;
+    const auto num_segs = 5;
+    const auto batch_time_delta_ms = 10;
+    const auto base_timestamp = model::timestamp{0};
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto total_records = gen.num_segments(num_segs)
+                           .batches_per_segment(batches_per_segment)
+                           .base_timestamp(base_timestamp)
+                           .batch_time_delta_ms(batch_time_delta_ms)
+                           .produce()
+                           .get();
+    BOOST_REQUIRE_EQUAL(total_records, 5);
+
+    auto make_and_verify_timequery =
+      [partition](
+        model::timestamp t,
+        model::offset o,
+        bool expect_value = false,
+        std::optional<model::offset> expected_o = std::nullopt) {
+          auto timequery_conf = storage::timequery_config(
+            t, o, ss::default_priority_class(), std::nullopt);
+
+          auto result = partition->timequery(timequery_conf).get();
+
+          if (expect_value) {
+              BOOST_REQUIRE(result.has_value());
+              BOOST_REQUIRE_EQUAL(result.value().offset, expected_o.value());
+          } else {
+              BOOST_REQUIRE(!result.has_value());
+          }
+      };
+
+    make_and_verify_timequery(
+      base_timestamp, model::offset{0}, true, model::offset{0});
+
+    for (int i = 1; i < total_records; ++i) {
+        const auto min_timestamp = base_timestamp()
+                                   + batch_time_delta_ms * (i - 1);
+        const auto max_timestamp = min_timestamp + batch_time_delta_ms;
+        const auto query_timestamp = random_generators::get_int(
+          min_timestamp + 1, max_timestamp);
+        make_and_verify_timequery(
+          model::timestamp{query_timestamp},
+          model::offset{i},
+          true,
+          model::offset{i});
+    }
+
+    make_and_verify_timequery(
+      model::timestamp{
+        base_timestamp() + (batch_time_delta_ms * total_records)},
+      model::offset{total_records},
+      false);
+}
+
+FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, model::partition_id{0});
+
+    // Allow cloud storage timequeries with full shadow indexing mode.
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.retention_local_target_bytes = tristate<size_t>(0);
+
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    auto log = partition->log();
+    auto& archiver = partition->archiver().value().get();
+    BOOST_REQUIRE(archiver.sync_for_tests().get());
+
+    const auto batches_per_segment = 1;
+    const auto num_segs = 5;
+    const auto batch_time_delta_ms = 10;
+    const auto base_timestamp = model::timestamp{0};
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto total_records = gen.num_segments(num_segs)
+                           .batches_per_segment(batches_per_segment)
+                           .base_timestamp(base_timestamp)
+                           .batch_time_delta_ms(batch_time_delta_ms)
+                           .produce()
+                           .get();
+    BOOST_REQUIRE_EQUAL(total_records, 5);
+
+    // Force garbage collection of all local records, so that timequeries must
+    // go through cloud storage.
+    ss::abort_source as;
+    storage::housekeeping_config housekeeping_conf(
+      model::timestamp::max(),
+      0,
+      log->stm_manager()->max_collectible_offset(),
+      ss::default_priority_class(),
+      as);
+    partition->log()->housekeeping(housekeeping_conf).get();
+
+    RPTEST_REQUIRE_EVENTUALLY(
+      10s, [log = partition->log()] { return log->segments().size() == 1; });
+
+    auto make_and_verify_timequery =
+      [partition](
+        model::timestamp t,
+        model::offset o,
+        bool expect_value = false,
+        std::optional<model::offset> expected_o = std::nullopt) {
+          auto timequery_conf = storage::timequery_config(
+            t, o, ss::default_priority_class(), std::nullopt);
+
+          auto result = partition->timequery(timequery_conf).get();
+
+          if (expect_value) {
+              BOOST_REQUIRE(result.has_value());
+              BOOST_REQUIRE_EQUAL(result.value().offset, expected_o.value());
+          } else {
+              BOOST_REQUIRE(!result.has_value());
+          }
+      };
+
+    make_and_verify_timequery(
+      base_timestamp, model::offset{0}, true, model::offset{0});
+
+    for (int i = 1; i < total_records; ++i) {
+        const auto min_timestamp = base_timestamp()
+                                   + batch_time_delta_ms * (i - 1);
+        const auto max_timestamp = min_timestamp + batch_time_delta_ms;
+        const auto query_timestamp = random_generators::get_int(
+          min_timestamp + 1, max_timestamp);
+        make_and_verify_timequery(
+          model::timestamp{query_timestamp},
+          model::offset{i},
+          true,
+          model::offset{i});
+    }
+
+    // This will attempt to timequery from local disk since cloud storage cannot
+    // answer it, but won't have a value anyways.
+    make_and_verify_timequery(
+      model::timestamp{
+        base_timestamp() + (batch_time_delta_ms * total_records)},
+      model::offset{total_records},
+      false);
+}
+
+FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, model::partition_id{0});
+
+    // Enable full shadow indexing for now.
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+
+    add_topic({model::kafka_namespace, topic_name}, 1, props).get();
+
+    wait_for_leader(ntp).get();
+
+    auto partition = app.partition_manager.local().get(ntp);
+    auto log = partition->log();
+    auto& archiver = partition->archiver().value().get();
+    BOOST_REQUIRE(archiver.sync_for_tests().get());
+
+    // Generate batches [0, 10, 20, ..., 100]
+    const auto num_segs = 11;
+    const auto batches_per_segment = 1;
+    const auto batch_time_delta_ms = 10;
+    tests::remote_segment_generator gen(make_kafka_client().get(), *partition);
+    auto total_records = gen.num_segments(num_segs)
+                           .batches_per_segment(batches_per_segment)
+                           .base_timestamp(model::timestamp{0})
+                           .batch_time_delta_ms(batch_time_delta_ms)
+                           .produce()
+                           .get();
+    BOOST_REQUIRE_EQUAL(total_records, 11);
+
+    const auto base_timestamp = log->start_timestamp();
+    BOOST_REQUIRE_EQUAL(base_timestamp, model::timestamp{0});
+
+    const auto num_segments_to_keep = 2;
+    const auto upper_timestamp = base_timestamp()
+                                 + (num_segs - num_segments_to_keep)
+                                     * batch_time_delta_ms;
+    const auto max_timestamp = base_timestamp()
+                               + (num_segs - 1) * batch_time_delta_ms;
+
+    // Sum the sizes of trailing segments
+    const auto& segments = log->segments();
+    const size_t max_bytes = std::accumulate(
+      std::next(segments.begin(), segments.size() - num_segments_to_keep),
+      segments.end(),
+      size_t{0},
+      [](size_t size, const auto& seg) { return size + seg->file_size(); });
+
+    // Force garbage collection of all local records [0, upper_timestamp). Full
+    // records [0, max_timestamp] still exist in the cloud.
+    storage::gc_config gc_conf(model::timestamp{upper_timestamp}, max_bytes);
+    log->gc(gc_conf).get();
+
+    RPTEST_REQUIRE_EVENTUALLY(10s, [log = partition->log()] {
+        return log->segments().size() == num_segments_to_keep;
+    });
+
+    // Disable remote fetch, forcing local data usage only.
+    auto disable_fetch_override = storage::ntp_config::default_overrides{
+      .shadow_indexing_mode = model::shadow_indexing_mode::archival};
+    log->update_configuration(disable_fetch_override).get();
+
+    auto make_and_verify_timequery =
+      [partition](
+        model::timestamp t,
+        model::offset o,
+        bool expect_value = false,
+        std::optional<model::offset> expected_o = std::nullopt) {
+          auto timequery_conf = storage::timequery_config(
+            t, o, ss::default_priority_class(), std::nullopt);
+
+          auto result = partition->timequery(timequery_conf).get();
+
+          if (expect_value) {
+              BOOST_REQUIRE(result.has_value());
+              BOOST_REQUIRE_EQUAL(result.value().offset, expected_o.value());
+          } else {
+              BOOST_REQUIRE(!result.has_value());
+          }
+      };
+
+    // Queries for timestamps [0, upper_timestamp] should return
+    // [upper_timestamp], since we cannot read from cloud storage, and we have
+    // deleted local records [0, upper_timestamp)
+    for (int i = 0; i <= upper_timestamp; ++i) {
+        make_and_verify_timequery(
+          model::timestamp{i},
+          model::offset::max(),
+          true,
+          model::offset{num_segs - num_segments_to_keep + 1});
+    }
+
+    // Queries for timestamps (upper_timestamp, max_timestamp] should return
+    // [max_timestamp].
+    for (int i = upper_timestamp + 1; i < max_timestamp; ++i) {
+        make_and_verify_timequery(
+          model::timestamp{i},
+          model::offset::max(),
+          true,
+          model::offset{num_segs - 1});
+    }
+
+    // Enable remote fetch.
+    auto allow_fetch_override = storage::ntp_config::default_overrides{
+      .shadow_indexing_mode = model::shadow_indexing_mode::fetch};
+    log->update_configuration(allow_fetch_override).get();
+
+    // Now, timequeries should be able to read over the whole domain [0,
+    // max_timestamp]
+    for (int i = 0; i < num_segs; ++i) {
+        auto timestamp = base_timestamp() + i * batch_time_delta_ms;
+        make_and_verify_timequery(
+          model::timestamp{timestamp},
+          model::offset::max(),
+          true,
+          model::offset{i});
+    }
 }

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -504,23 +504,25 @@ partition::timequery(storage::timequery_config cfg) {
         co_return co_await cloud_storage_timequery(cfg);
     }
 
+    const bool may_answer_from_cloud
+      = may_read_from_cloud()
+        && _cloud_storage_partition->bounds_timestamp(cfg.time);
+
     if (_raft->log()->start_timestamp() <= cfg.time) {
         // The query is ahead of the local data's start_timestamp: this
         // means it _might_ hit on local data: start_timestamp is not
         // precise, so once we query we might still fall back to cloud
         // storage
         auto result = co_await local_timequery(cfg);
-        if (!result.has_value()) {
+        if (result.has_value()) {
+            co_return result;
+        } else {
             // The local storage hit a case where it needs to fall back
             // to querying cloud storage.
             co_return co_await cloud_storage_timequery(cfg);
-        } else {
-            co_return result;
         }
     } else {
-        if (
-          may_read_from_cloud()
-          && _cloud_storage_partition->bounds_timestamp(cfg.time)) {
+        if (may_answer_from_cloud) {
             // Timestamp is before local storage but within cloud storage
             co_return co_await cloud_storage_timequery(cfg);
         } else {
@@ -538,35 +540,35 @@ bool partition::may_read_from_cloud() const {
 
 ss::future<std::optional<storage::timequery_result>>
 partition::cloud_storage_timequery(storage::timequery_config cfg) {
-    if (may_read_from_cloud()) {
-        // We have data in the remote partition, and all the data in the
-        // raft log is ahead of the query timestamp or the topic is a read
-        // replica, so proceed to query the remote partition to try and
-        // find the earliest data that has timestamp >= the query time.
-        vlog(
-          clusterlog.debug,
-          "timequery (cloud) {} t={} max_offset(k)={}",
-          _raft->ntp(),
-          cfg.time,
-          cfg.max_offset);
-
-        // remote_partition pre-translates offsets for us, so no call into
-        // the offset translator here
-        auto result = co_await _cloud_storage_partition->timequery(cfg);
-        if (result) {
-            vlog(
-              clusterlog.debug,
-              "timequery (cloud) {} t={} max_offset(r)={} result(r)={}",
-              _raft->ntp(),
-              cfg.time,
-              cfg.max_offset,
-              result->offset);
-        }
-
-        co_return result;
+    if (!may_read_from_cloud()) {
+        co_return std::nullopt;
     }
 
-    co_return std::nullopt;
+    // We have data in the remote partition, and all the data in the
+    // raft log is ahead of the query timestamp or the topic is a read
+    // replica, so proceed to query the remote partition to try and
+    // find the earliest data that has timestamp >= the query time.
+    vlog(
+      clusterlog.debug,
+      "timequery (cloud) {} t={} max_offset(k)={}",
+      _raft->ntp(),
+      cfg.time,
+      cfg.max_offset);
+
+    // remote_partition pre-translates offsets for us, so no call into
+    // the offset translator here
+    auto result = co_await _cloud_storage_partition->timequery(cfg);
+    if (result.has_value()) {
+        vlog(
+          clusterlog.debug,
+          "timequery (cloud) {} t={} max_offset(r)={} result(r)={}",
+          _raft->ntp(),
+          cfg.time,
+          cfg.max_offset,
+          result->offset);
+    }
+
+    co_return result;
 }
 
 ss::future<std::optional<storage::timequery_result>>
@@ -582,46 +584,49 @@ partition::local_timequery(storage::timequery_config cfg) {
 
     auto result = co_await _raft->timequery(cfg);
 
-    bool may_answer_from_cloud = may_read_from_cloud()
-                                 && _cloud_storage_partition->bounds_timestamp(
-                                   cfg.time);
+    const bool may_answer_from_cloud
+      = may_read_from_cloud()
+        && _cloud_storage_partition->bounds_timestamp(cfg.time);
 
-    if (result) {
-        if (
-          _raft->log()->start_timestamp() > cfg.time && may_answer_from_cloud) {
-            // Query raced with prefix truncation
-            vlog(
-              clusterlog.debug,
-              "timequery (raft) {} ts={} raced with truncation "
-              "(start_timestamp {}, result {})",
-              _raft->ntp(),
-              cfg.time,
-              _raft->log()->start_timestamp(),
-              result->time);
-            co_return std::nullopt;
-        }
+    if (result.has_value()) {
+        if (may_answer_from_cloud) {
+            // We need to test for cases in which we will fall back to querying
+            // cloud storage.
+            if (_raft->log()->start_timestamp() > cfg.time) {
+                // Query raced with prefix truncation
+                vlog(
+                  clusterlog.debug,
+                  "timequery (raft) {} ts={} raced with truncation "
+                  "(start_timestamp {}, result {})",
+                  _raft->ntp(),
+                  cfg.time,
+                  _raft->log()->start_timestamp(),
+                  result->time);
+                co_return std::nullopt;
+            }
 
-        if (
-          _raft->log()->start_timestamp() <= cfg.time && result->time > cfg.time
-          && may_answer_from_cloud) {
-            // start_timestamp() points to the beginning of the oldest
-            // segment, but start_offset points to somewhere within a
-            // segment.  If our timequery hits the range between the start
-            // of segment and the start_offset, consensus::timequery may
-            // answer with the start offset rather than the
-            // pre-start-offset location where the timestamp is actually
-            // found. Ref
-            // https://github.com/redpanda-data/redpanda/issues/9669
-            vlog(
-              clusterlog.debug,
-              "Timequery (raft) {} ts={} miss on local log "
-              "(start_timestamp "
-              "{}, result {})",
-              _raft->ntp(),
-              cfg.time,
-              _raft->log()->start_timestamp(),
-              result->time);
-            co_return std::nullopt;
+            if (
+              _raft->log()->start_timestamp() <= cfg.time
+              && result->time > cfg.time) {
+                // start_timestamp() points to the beginning of the oldest
+                // segment, but start_offset points to somewhere within a
+                // segment.  If our timequery hits the range between the start
+                // of segment and the start_offset, consensus::timequery may
+                // answer with the start offset rather than the
+                // pre-start-offset location where the timestamp is actually
+                // found. Ref
+                // https://github.com/redpanda-data/redpanda/issues/9669
+                vlog(
+                  clusterlog.debug,
+                  "Timequery (raft) {} ts={} miss on local log "
+                  "(start_timestamp "
+                  "{}, result {})",
+                  _raft->ntp(),
+                  cfg.time,
+                  _raft->log()->start_timestamp(),
+                  result->time);
+                co_return std::nullopt;
+            }
         }
 
         if (result->offset == _raft->log()->offsets().start_offset) {
@@ -637,10 +642,8 @@ partition::local_timequery(storage::timequery_config cfg) {
               cfg.time,
               _raft->log()->start_timestamp(),
               cfg.time);
-            if (
-              _cloud_storage_partition
-              && _cloud_storage_partition->is_data_available()
-              && may_answer_from_cloud) {
+
+            if (may_answer_from_cloud) {
                 // Even though we hit data with the desired timestamp, we
                 // cannot be certain that this is the _first_ batch with
                 // the desired timestamp: return null so that the caller

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -532,8 +532,8 @@ partition::timequery(storage::timequery_config cfg) {
 }
 
 bool partition::may_read_from_cloud() const {
-    return _cloud_storage_partition
-           && _cloud_storage_partition->is_data_available();
+    return is_remote_fetch_enabled()
+           && (_cloud_storage_partition && _cloud_storage_partition->is_data_available());
 }
 
 ss::future<std::optional<storage::timequery_result>>


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/17533
Fixes: https://github.com/redpanda-data/redpanda/issues/18158,