### PR TITLE
rptest: capture tbot and ./breakglass output

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1977,7 +1977,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
 
         :param remote_cmd: The command to run on the agent node.
         """
-        return self.kubectl._cmd(remote_cmd)
+        return self.kubectl._ssh_cmd(remote_cmd)
 
     def scale_cluster(self, nodes_count):
         """Scale out/in cluster to specified number of nodes.


### PR DESCRIPTION
These commands didn't have their output captured so they were spamming stdout during test runs, drowning out the useful logs.

Switch them to using the _cmd helper which captures stdout and stderr and emits them to the log if the command fails.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
