### PR TITLE
CORE-2418: cluster/self_test: extend cloud storage self test

### DIFF
--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -260,7 +260,8 @@ ss::future<self_test_result> cloudcheck::verify_upload(
 ss::future<std::pair<cloud_storage::remote::list_result, self_test_result>>
 cloudcheck::verify_list(
   cloud_storage_clients::bucket_name bucket,
-  cloud_storage_clients::object_key prefix) {
+  cloud_storage_clients::object_key prefix,
+  size_t max_keys) {
     auto result = self_test_result{
       .name = _opts.name, .info = "list", .test_type = "cloud_storage"};
 
@@ -280,7 +281,6 @@ cloudcheck::verify_list(
 
     const auto start = ss::lowres_clock::now();
     try {
-        static constexpr size_t max_keys = 10;
         const cloud_storage::remote::list_result object_list
           = co_await _cloud_storage_api.local().list_objects(
             bucket, rtc, std::nullopt, std::nullopt, std::nullopt, max_keys);

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -99,7 +99,7 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
                                            ? make_random_payload()
                                            : std::optional<iobuf>{};
 
-    // Test Upload
+    // Test Put
     auto upload_test_result = co_await verify_upload(
       bucket, self_test_key, payload);
     const bool is_uploaded
@@ -128,9 +128,9 @@ ss::future<std::vector<self_test_result>> cloudcheck::run_benchmarks() {
 
     results.push_back(std::move(list_test_result));
 
-    // Test Download
-    // If we have uploaded our payload, we will attempt to get the written
-    // object. If we didn't, we will attempt to get the smallest object from the
+    // Test Get
+    // If the payloaded was uploaded, this attempts to get the written
+    // object. If it wasn't, it will attempt to get the smallest object from the
     // object list, if at least one exists.
     auto get_min_object_key =
       [&object_list]() -> std::optional<cloud_storage_clients::object_key> {
@@ -223,7 +223,7 @@ ss::future<self_test_result> cloudcheck::verify_upload(
   cloud_storage_clients::object_key key,
   const std::optional<iobuf>& payload) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "upload", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "Put", .test_type = "cloud_storage"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
@@ -271,7 +271,7 @@ cloudcheck::verify_list(
   cloud_storage_clients::object_key prefix,
   size_t max_keys) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "list", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "List", .test_type = "cloud_storage"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
@@ -367,7 +367,7 @@ cloudcheck::verify_download(
   cloud_storage_clients::bucket_name bucket,
   std::optional<cloud_storage_clients::object_key> key) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "download", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "Get", .test_type = "cloud_storage"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
@@ -418,14 +418,14 @@ cloudcheck::verify_download(
     const auto end = ss::lowres_clock::now();
     result.duration = end - start;
 
-    co_return std::make_pair(std::nullopt, std::move(result));
+    co_return std::make_pair(std::move(result_payload), std::move(result));
 }
 
 ss::future<self_test_result> cloudcheck::verify_delete(
   cloud_storage_clients::bucket_name bucket,
   cloud_storage_clients::object_key key) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "delete", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "Delete", .test_type = "cloud_storage"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -87,6 +87,12 @@ private:
       cloud_storage_clients::object_key prefix,
       size_t max_keys = 5);
 
+    // Verify that checking if an object exists (Head: read operation) from
+    // cloud storage works.
+    ss::future<self_test_result> verify_head(
+      cloud_storage_clients::bucket_name bucket,
+      std::optional<cloud_storage_clients::object_key> key);
+
     // Verify that downloading (read operation) from cloud storage works.
     ss::future<std::pair<std::optional<iobuf>, self_test_result>>
     verify_download(
@@ -97,6 +103,11 @@ private:
     ss::future<self_test_result> verify_delete(
       cloud_storage_clients::bucket_name bucket,
       cloud_storage_clients::object_key key);
+
+    // Verify that deleting multiple (Plural Delete: write operation) from cloud
+    // storage works.
+    ss::future<self_test_result> verify_deletes(
+      cloud_storage_clients::bucket_name bucket, size_t num_objects = 5);
 
 private:
     bool _remote_read_enabled{false};

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -74,13 +74,13 @@ private:
       iobuf& payload,
       retry_chain_node& rtc);
 
-    // Verify that uploading (write operation) to cloud storage works.
+    // Verify that uploading (Put: write operation) to cloud storage works.
     ss::future<self_test_result> verify_upload(
       cloud_storage_clients::bucket_name bucket,
       cloud_storage_clients::object_key key,
       const std::optional<iobuf>& payload);
 
-    // Verify that listing (read operation) from cloud storage works.
+    // Verify that listing (List: read operation) from cloud storage works.
     ss::future<std::pair<cloud_storage::remote::list_result, self_test_result>>
     verify_list(
       cloud_storage_clients::bucket_name bucket,
@@ -93,13 +93,13 @@ private:
       cloud_storage_clients::bucket_name bucket,
       std::optional<cloud_storage_clients::object_key> key);
 
-    // Verify that downloading (read operation) from cloud storage works.
+    // Verify that downloading (Get: read operation) from cloud storage works.
     ss::future<std::pair<std::optional<iobuf>, self_test_result>>
     verify_download(
       cloud_storage_clients::bucket_name bucket,
       std::optional<cloud_storage_clients::object_key> key);
 
-    // Verify that deleting (write operation) from cloud storage works.
+    // Verify that deleting (Delete: write operation) from cloud storage works.
     ss::future<self_test_result> verify_delete(
       cloud_storage_clients::bucket_name bucket,
       cloud_storage_clients::object_key key);

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -84,7 +84,7 @@ private:
     ss::future<std::pair<cloud_storage::remote::list_result, self_test_result>>
     verify_list(
       cloud_storage_clients::bucket_name bucket,
-      cloud_storage_clients::object_key prefix,
+      std::optional<cloud_storage_clients::object_key> prefix,
       size_t max_keys = 5);
 
     // Verify that checking if an object exists (Head: read operation) from

--- a/src/v/cluster/self_test/cloudcheck.h
+++ b/src/v/cluster/self_test/cloudcheck.h
@@ -84,7 +84,8 @@ private:
     ss::future<std::pair<cloud_storage::remote::list_result, self_test_result>>
     verify_list(
       cloud_storage_clients::bucket_name bucket,
-      cloud_storage_clients::object_key prefix);
+      cloud_storage_clients::object_key prefix,
+      size_t max_keys = 5);
 
     // Verify that downloading (read operation) from cloud storage works.
     ss::future<std::pair<std::optional<iobuf>, self_test_result>>
@@ -105,6 +106,9 @@ private:
     ss::gate _gate;
     retry_chain_node _rtc;
     cloudcheck_opts _opts;
+
+    const cloud_storage_clients::object_key self_test_prefix
+      = cloud_storage_clients::object_key{"self-test/"};
 
 private:
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -70,8 +70,8 @@ class SelfTestTest(EndToEndTest):
             assert 'error' in report
             assert report['error'] == error_msg
 
-        read_tests = ['list', 'download']
-        write_tests = ['upload', 'delete']
+        read_tests = ['List', 'Head', 'Get']
+        write_tests = ['Put', 'Delete', 'Plural Delete']
 
         for node in node_reports:
             assert node['status'] == 'idle'


### PR DESCRIPTION
Completes test coverage for remote object API by adding `verify_head()` and `verify_deletes()` to `cloudcheck.cc`.
Some stylistic changes to the other existing verification tests as well.

The cloud storage self test now covers:

* Get
* Put
* Head
* List
* Delete
* Plural Delete

JIRA Issue: https://redpandadata.atlassian.net/browse/CORE-2418

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* None
