### PR TITLE
[v23.2.x] gh: fix lint-cpp for ubuntu noble (manual backport)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -83,14 +83,10 @@ jobs:
     - name: Run clang-format
       run: |
         docker run \
-        -v $PWD:/redpanda ubuntu \
+        -v $PWD:/redpanda ubuntu:noble \
         bash -c "cd /redpanda && \
           apt update && \
-          apt install -y wget git lsb-release wget software-properties-common gnupg && \
-          wget https://apt.llvm.org/llvm.sh && \
-          chmod +x llvm.sh && \
-          ./llvm.sh 16 && \
-          apt-get install -y clang-format-16 && \
+          apt install -y git clang-format-16  && \
           find . -type f -regex '.*\.\(cpp\|h\|hpp\|cc\|proto\|java\)' | xargs -n1 clang-format-16 -i -style=file -fallback-style=none"
         git diff --exit-code
 


### PR DESCRIPTION
Manual backport of https://github.com/redpanda-data/redpanda/pull/18087.

[This backport could not be applied](https://github.com/redpanda-data/redpanda/pull/18087#issuecomment-2086991558) because `lint-cpp.yml` did not exist in `v23.2.x`.
I have made the same change found in the above PR to the appropriate command in `lint.yml`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none