### PR TITLE
rptest: fix feature-gating of `cloud_storage_url_style`

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3794,8 +3794,8 @@ class RedpandaService(RedpandaServiceBase):
                     self._extra_rp_conf))
             conf.update(self._extra_rp_conf)
 
-        if cur_ver != RedpandaInstaller.HEAD and cur_ver < (24, 1, 1):
-            # this configuration property was introduced in 24.1, ensure
+        if cur_ver != RedpandaInstaller.HEAD and cur_ver < (24, 2, 1):
+            # this configuration property was introduced in 24.2, ensure
             # it doesn't appear in older configurations
             conf.pop("cloud_storage_url_style", None)
 


### PR DESCRIPTION
Upgrade tests in ducktape are failing due to incorrect feature-gating around the configuration parameter `cloud_storage_url_style`. 

This PR corrects that.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none