### PR TITLE
PESDLC-1295  Remove unstable launchpad repo after install

### DIFF
--- a/tests/docker/ducktape-deps/ocsf-server
+++ b/tests/docker/ducktape-deps/ocsf-server
@@ -33,6 +33,10 @@ if [ $(uname -m) = "aarch64" ]; then
 fi
 
 ./build_server.sh
+
+# remove added repository for other packages stability
+add-apt-repository -ry ppa:rabbitmq/rabbitmq-erlang
+
 # The following is required because the server attempts to write logs
 # to the `dist/tmp` directory.  This is fine in docker ducktape as the user
 # who kicks it off is root, but in CDT, the user is not root so the server


### PR DESCRIPTION
  PPA repositories is occasionally returns 503 when overloaded
  preventing pipelines from normal run. These are queries in all
  subsequent dependencies and must be removed to eliminate
  instability

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none