### PR TITLE
transform-sdk/js: reverting "disable thinLTO"

### DIFF
--- a/src/transform-sdk/js/CMakeLists.txt
+++ b/src/transform-sdk/js/CMakeLists.txt
@@ -65,14 +65,13 @@ target_link_libraries(
   qjs Redpanda::transform_sdk Redpanda::js_vm
 )
 
-# TODO: Rename LTO builds when #18077 is merged
-# if(CMAKE_BUILD_TYPE MATCHES Release)
-#   include(CheckIPOSupported)
-#   check_ipo_supported(RESULT ltosupported OUTPUT error)
-#   if(ltosupported)
-#     set_property(TARGET redpanda_js_transform PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
-#   endif()
-# endif()
+if(CMAKE_BUILD_TYPE MATCHES Release)
+  include(CheckIPOSupported)
+  check_ipo_supported(RESULT ltosupported OUTPUT error)
+  if(ltosupported)
+    set_property(TARGET redpanda_js_transform PROPERTY INTERPROCEDURAL_OPTIMIZATION ON)
+  endif()
+endif()
 
 # Tests
 enable_testing()


### PR DESCRIPTION
This reverts commit bf885756e148becb261c69eaddd6abe4ffc8cc11.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
