### PR TITLE
gha: fix js sdk release

### DIFF
--- a/.github/workflows/transform-sdk-release.yml
+++ b/.github/workflows/transform-sdk-release.yml
@@ -83,7 +83,8 @@ jobs:
       - name: Publish
         run: |
           VERSION=$(python -c "print('${{github.ref_name}}'.removeprefix('transform-sdk/v'), end='')")
-          yq -iP ".version=${VERSION}" package.json -o json
+          sed -i "s/0.1.0/${VERSION}/g" package.json
+          sed -i "s/0.1.0/${VERSION}/g" package-lock.json
           npm ci
           npm publish
         working-directory: src/transform-sdk/js/module


### PR DESCRIPTION
yq has wildly different syntax depending on the version, so just use the dumb and simple sed.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
