### PR TITLE
c/shard_balancer: assign shards concurrently

### DIFF
--- a/src/v/cluster/shard_balancer.cc
+++ b/src/v/cluster/shard_balancer.cc
@@ -88,10 +88,7 @@ ss::future<> shard_balancer::process_delta(const topic_table::delta& delta) {
     if (!maybe_replicas_view) {
         if (delta.type == topic_table_delta_type::removed) {
             co_await _shard_placement.local().set_target(
-              ntp,
-              std::nullopt,
-              model::shard_revision_id{delta.revision()},
-              shard_callback);
+              ntp, std::nullopt, shard_callback);
         }
         co_return;
     }
@@ -100,18 +97,13 @@ ss::future<> shard_balancer::process_delta(const topic_table::delta& delta) {
     // Has value if the partition is expected to exist on this node.
     auto target = placement_target_on_node(replicas_view, _self);
 
-    auto shard_rev = model::shard_revision_id{
-      replicas_view.last_cmd_revision()};
-
     vlog(
       clusterlog.trace,
-      "[{}] setting placement target on on this node: {}, shard_rev: {}",
+      "[{}] setting placement target on on this node: {}",
       ntp,
-      target,
-      shard_rev);
+      target);
 
-    co_await _shard_placement.local().set_target(
-      ntp, target, shard_rev, shard_callback);
+    co_await _shard_placement.local().set_target(ntp, target, shard_callback);
 }
 
 } // namespace cluster

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -146,7 +146,6 @@ public:
     ss::future<> set_target(
       const model::ntp&,
       std::optional<shard_placement_target>,
-      model::shard_revision_id,
       shard_callback_t);
 
     // getters
@@ -191,8 +190,8 @@ private:
       bool is_initial,
       shard_callback_t);
 
-    ss::future<> remove_assigned_on_this_shard(
-      const model::ntp&, model::shard_revision_id, shard_callback_t);
+    ss::future<>
+    remove_assigned_on_this_shard(const model::ntp&, shard_callback_t);
 
     ss::future<> do_delete(const model::ntp&, placement_state&);
 
@@ -207,6 +206,7 @@ private:
     // only on shard 0, _ntp2target will hold targets for all ntps on this node.
     mutex _mtx{"shard_placement_table"};
     absl::node_hash_map<model::ntp, shard_placement_target> _ntp2target;
+    model::shard_revision_id _cur_shard_revision{0};
 };
 
 std::ostream& operator<<(std::ostream&, shard_placement_table::hosted_status);

--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -628,7 +628,6 @@ public:
               .set_target(
                 ntp,
                 target,
-                _cur_shard_revision++,
                 [this](const model::ntp& ntp) {
                     _rb.local().notify_reconciliation(ntp);
                 })
@@ -646,7 +645,6 @@ private:
 
     ssx::work_queue _work_queue;
     int _in_progress = 0;
-    model::shard_revision_id _cur_shard_revision{1};
 };
 
 } // namespace

--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -727,10 +727,13 @@ public:
               << "ntp: " << ntp;
             const auto& shard2state = states_it->second;
 
-            auto target_it = spt.local()._ntp2target.find(ntp);
-            ASSERT_TRUE_CORO(target_it != spt.local()._ntp2target.end())
+            auto entry_it = spt.local()._ntp2entry.find(ntp);
+            ASSERT_TRUE_CORO(entry_it != spt.local()._ntp2entry.end())
               << "ntp: " << ntp;
-            const auto& target = target_it->second;
+            ASSERT_TRUE_CORO(entry_it->second->target) << "ntp: " << ntp;
+            ASSERT_TRUE_CORO(entry_it->second->mtx.ready()) << "ntp: " << ntp;
+
+            const auto& target = entry_it->second->target.value();
             ASSERT_EQ_CORO(target.log_revision, meta.log_revision)
               << "ntp: " << ntp;
 

--- a/src/v/container/include/container/chunked_hash_map.h
+++ b/src/v/container/include/container/chunked_hash_map.h
@@ -70,3 +70,22 @@ using chunked_hash_map = ankerl::unordered_dense::segmented_map<
   chunked_vector<std::pair<Key, Value>>,
   ankerl::unordered_dense::bucket_type::standard,
   chunked_vector<ankerl::unordered_dense::bucket_type::standard>>;
+
+/**
+ * @brief A set counterpart of chunked_hash_map (uses a chunked vector as the
+ * underlying storage).
+ */
+template<
+  typename Key,
+  typename Hash = std::conditional_t<
+    detail::has_absl_hash<Key>,
+    detail::avalanching_absl_hash<Key>,
+    ankerl::unordered_dense::hash<Key>>,
+  typename EqualTo = std::equal_to<Key>>
+using chunked_hash_set = ankerl::unordered_dense::segmented_set<
+  Key,
+  Hash,
+  EqualTo,
+  chunked_vector<Key>,
+  ankerl::unordered_dense::bucket_type::standard,
+  chunked_vector<ankerl::unordered_dense::bucket_type::standard>>;


### PR DESCRIPTION
For now, when assigning shards only involves modifying in-memory state, we can get away with assigning each ntp sequentially. But in the future it will also involve kvstore writes (with their associated 10ms latency), and for the case of 1000s of partitions this will lead to noticeable delays. Assign shards concurrently to deal with this problem.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
