### PR TITLE
CORE-2752 - Fix Kafka quota throttling delay enforcement

### DIFF
--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -554,6 +554,12 @@ ss::future<session_resources> connection_context::throttle_request(
     auto tracker = std::make_unique<request_tracker>(_server.probe(), h_probe);
     auto fut = ss::now();
     if (delay.enforce > delay_t::clock::duration::zero()) {
+        vlog(
+          klog.trace,
+          "[{}:{}] enforcing throttling delay of {}",
+          _client_addr,
+          client_port(),
+          delay.enforce);
         fut = ss::sleep_abortable(delay.enforce, abort_source().local());
     }
     auto track = track_latency(hdr.key);

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -474,33 +474,49 @@ connection_context::record_tp_and_calculate_throttle(
     const auto now = clock::now();
 
     // Throttle on client based quotas
-    quota_manager::throttle_delay client_quota_delay{};
+    connection_context::delay_t client_quota_delay{};
     if (hdr.key == fetch_api::key) {
-        client_quota_delay = _server.quota_mgr().throttle_fetch_tp(
+        auto fetch_delay = _server.quota_mgr().throttle_fetch_tp(
           hdr.client_id, now);
+        auto fetch_enforced = _throttling_state.update_fetch_delay(
+          fetch_delay.duration, now);
+        client_quota_delay = delay_t{
+          .request = fetch_delay.duration,
+          .enforce = fetch_enforced,
+        };
     } else if (hdr.key == produce_api::key) {
-        client_quota_delay = _server.quota_mgr().record_produce_tp_and_throttle(
+        auto produce_delay = _server.quota_mgr().record_produce_tp_and_throttle(
           hdr.client_id, request_size, now);
+        auto produce_enforced = _throttling_state.update_produce_delay(
+          produce_delay.duration, now);
+        client_quota_delay = delay_t{
+          .request = produce_delay.duration,
+          .enforce = produce_enforced,
+        };
     }
 
     // Throttle on shard wide quotas
-    snc_quota_manager::delays_t shard_delays;
+    connection_context::delay_t snc_delay;
     if (_kafka_throughput_controlled_api_keys().at(hdr.key)) {
         _server.snc_quota_mgr().get_or_create_quota_context(
           _snc_quota_context, hdr.client_id);
         _server.snc_quota_mgr().record_request_receive(
           *_snc_quota_context, request_size, now);
-        shard_delays = _server.snc_quota_mgr().get_shard_delays(
+        auto shard_delays = _server.snc_quota_mgr().get_shard_delays(
           *_snc_quota_context, now);
+        auto snc_enforced = _throttling_state.update_snc_delay(
+          shard_delays.request, now);
+        snc_delay = delay_t{
+          .request = shard_delays.request,
+          .enforce = snc_enforced,
+        };
     }
 
     // Sum up
     const clock::duration delay_enforce = std::max(
-      shard_delays.enforce, client_quota_delay.enforce_duration());
+      {snc_delay.enforce, client_quota_delay.enforce, clock::duration::zero()});
     const clock::duration delay_request = std::max(
-      {shard_delays.request,
-       client_quota_delay.duration,
-       clock::duration::zero()});
+      {snc_delay.request, client_quota_delay.request, clock::duration::zero()});
     if (
       delay_enforce != clock::duration::zero()
       || delay_request != clock::duration::zero()) {
@@ -510,10 +526,10 @@ connection_context::record_tp_and_calculate_throttle(
           "enforce:{{snc:{}, client:{}}}, key:{}, request_size:{}",
           _client_addr,
           client_port(),
-          shard_delays.request,
-          client_quota_delay.duration,
-          shard_delays.enforce,
-          client_quota_delay.enforce_duration(),
+          snc_delay.request,
+          client_quota_delay.request,
+          snc_delay.enforce,
+          client_quota_delay.enforce,
           hdr.key,
           request_size);
     }

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -503,7 +503,7 @@ connection_context::record_tp_and_calculate_throttle(
         _server.snc_quota_mgr().record_request_receive(
           *_snc_quota_context, request_size, now);
         auto shard_delays = _server.snc_quota_mgr().get_shard_delays(
-          *_snc_quota_context, now);
+          *_snc_quota_context);
         auto snc_enforced = _throttling_state.update_snc_delay(
           shard_delays.request, now);
         snc_delay = delay_t{

--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -399,6 +399,38 @@ private:
         ss::lowres_clock::time_point _last_request_timestamp;
     };
 
+    class throttling_state {
+    public:
+        ss::lowres_clock::duration update_fetch_delay(
+          ss::lowres_clock::duration new_delay,
+          ss::lowres_clock::time_point now) {
+            auto result_enforced = fetch_throttled_until - now;
+            fetch_throttled_until = now + new_delay;
+            return result_enforced;
+        }
+
+        ss::lowres_clock::duration update_produce_delay(
+          ss::lowres_clock::duration new_delay,
+          ss::lowres_clock::time_point now) {
+            auto result_enforced = produce_throttled_until - now;
+            produce_throttled_until = now + new_delay;
+            return result_enforced;
+        }
+
+        ss::lowres_clock::duration update_snc_delay(
+          ss::lowres_clock::duration new_delay,
+          ss::lowres_clock::time_point now) {
+            auto result_enforced = snc_throttled_until - now;
+            snc_throttled_until = now + new_delay;
+            return result_enforced;
+        }
+
+    private:
+        ss::lowres_clock::time_point snc_throttled_until;
+        ss::lowres_clock::time_point produce_throttled_until;
+        ss::lowres_clock::time_point fetch_throttled_until;
+    };
+
     std::optional<
       std::reference_wrapper<boost::intrusive::list<connection_context>>>
       _hook;
@@ -433,6 +465,11 @@ private:
     ss::promise<> _wait_input_shutdown;
 
     bool _is_virtualized_connection = false;
+
+    /// What time the client on this conection should be throttled until
+    /// Used to enforce client quotas and ingress/egress quotas broker-side
+    /// if the client does not obey the ThrottleTimeMs in the response
+    throttling_state _throttling_state;
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -55,15 +55,7 @@ public:
     using clock = ss::lowres_clock;
 
     struct throttle_delay {
-        bool enforce{false};
         clock::duration duration{0};
-        clock::duration enforce_duration() const {
-            if (enforce) {
-                return duration;
-            } else {
-                return clock::duration::zero();
-            }
-        }
     };
 
     quota_manager();
@@ -125,7 +117,6 @@ private:
     // pm_rate: partition mutation quota tracking - only on home shard
     struct client_quota {
         clock::time_point last_seen;
-        clock::duration delay;
         rate_tracker tp_produce_rate;
         rate_tracker tp_fetch_rate;
         std::optional<token_bucket_rate_tracker> pm_rate;

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -346,17 +346,12 @@ void snc_quota_manager::get_or_create_quota_context(
     }
 }
 
-snc_quota_manager::delays_t snc_quota_manager::get_shard_delays(
-  snc_quota_context& ctx, const clock::time_point now) const {
+snc_quota_manager::delays_t
+snc_quota_manager::get_shard_delays(const snc_quota_context& ctx) const {
     delays_t res;
 
     if (ctx._exempt) {
         return res;
-    }
-
-    // force throttle whatever the client did not do on its side
-    if (now < ctx._throttled_until) {
-        res.enforce = ctx._throttled_until - now;
     }
 
     // throttling delay the connection should be requested to throttle
@@ -371,7 +366,6 @@ snc_quota_manager::delays_t snc_quota_manager::get_shard_delays(
           _max_kafka_throttle_delay(),
           std::max(eval_delay(_shard_quota.in), eval_delay(_shard_quota.eg)));
     }
-    ctx._throttled_until = now + res.request;
 
     _probe.record_throttle_time(
       std::chrono::duration_cast<std::chrono::microseconds>(res.request));

--- a/src/v/kafka/server/snc_quota_manager.cc
+++ b/src/v/kafka/server/snc_quota_manager.cc
@@ -350,6 +350,10 @@ snc_quota_manager::delays_t snc_quota_manager::get_shard_delays(
   snc_quota_context& ctx, const clock::time_point now) const {
     delays_t res;
 
+    if (ctx._exempt) {
+        return res;
+    }
+
     // force throttle whatever the client did not do on its side
     if (now < ctx._throttled_until) {
         res.enforce = ctx._throttled_until - now;
@@ -376,7 +380,7 @@ snc_quota_manager::delays_t snc_quota_manager::get_shard_delays(
 }
 
 void snc_quota_manager::record_request_receive(
-  snc_quota_context& ctx,
+  const snc_quota_context& ctx,
   const size_t request_size,
   const clock::time_point now) noexcept {
     if (ctx._exempt) {
@@ -393,7 +397,7 @@ void snc_quota_manager::record_request_receive(
 }
 
 void snc_quota_manager::record_request_intake(
-  snc_quota_context& ctx, const size_t request_size) noexcept {
+  const snc_quota_context& ctx, const size_t request_size) noexcept {
     if (ctx._exempt) {
         return;
     }
@@ -401,7 +405,7 @@ void snc_quota_manager::record_request_intake(
 }
 
 void snc_quota_manager::record_response(
-  snc_quota_context& ctx,
+  const snc_quota_context& ctx,
   const size_t request_size,
   const clock::time_point now) noexcept {
     if (ctx._exempt) {

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -150,18 +150,18 @@ public:
     /// This should be done before calling \ref get_shard_delays because the
     /// recorded request size is used to calculate throttling parameters.
     void record_request_receive(
-      snc_quota_context&,
+      const snc_quota_context&,
       size_t request_size,
       clock::time_point now = clock::now()) noexcept;
 
     /// Record the request size when the request data is about to be consumed.
     /// This data is used to represent throttled throughput.
-    void
-    record_request_intake(snc_quota_context&, size_t request_size) noexcept;
+    void record_request_intake(
+      const snc_quota_context&, size_t request_size) noexcept;
 
     /// Record the response size for all purposes
     void record_response(
-      snc_quota_context&,
+      const snc_quota_context&,
       size_t request_size,
       clock::time_point now = clock::now()) noexcept;
 

--- a/src/v/kafka/server/snc_quota_manager.h
+++ b/src/v/kafka/server/snc_quota_manager.h
@@ -92,12 +92,6 @@ private:
 
     /// Whether the connection belongs to an exempt tput control group
     bool _exempt{false};
-
-    // Operating
-
-    /// What time the client on this conection should throttle (be throttled)
-    /// until
-    ss::lowres_clock::time_point _throttled_until;
 };
 
 /// Isolates \ref quota_manager functionality related to
@@ -125,10 +119,8 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
-    /// @p enforce delay to enforce in this call
     /// @p request delay to request from the client via throttle_ms
     struct delays_t {
-        clock::duration enforce{0};
         clock::duration request{0};
     };
 
@@ -144,7 +136,7 @@ public:
       std::optional<std::string_view> client_id);
 
     /// Determine throttling required by shard level TP quotas.
-    delays_t get_shard_delays(snc_quota_context&, clock::time_point now) const;
+    delays_t get_shard_delays(const snc_quota_context&) const;
 
     /// Record the request size when it has arrived from the transport.
     /// This should be done before calling \ref get_shard_delays because the


### PR DESCRIPTION
Quota enforcement is currently done in a complicated and
not-Kafka-compatible way in Redpanda, and this intends to fix
that.

In Kafka >=2.0, client throttling is implemented in a simple way.
Brokers are meant to return how long the client is supposed to be
throttled when there is a quota violation. Then, the Kafka client is
supposed to wait until this throttling time passed, or else the broker
applies the throttle on its side.

However, currently in Redpanda the delay is enforced differently. For
produce, we enforce the throttle we would send in the response if there
was a throttle in the last response (regardless of whether the client
obeyed that throttle or not). For fetch, we always enforce the current
throttle. For ingress/egress quotas we correctly track how long the
client was supposed to be throttled, but we only do that for
ingress/egress throttling.

This fixes the throttling behaviour by tracking how long the
client is supposed to have waited and applying that throttle on the next
request if the client did not.

Fixes https://redpandadata.atlassian.net/browse/CORE-2752

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Enforce client quota throttling in a Kafka-compatible way, meaning we enforce the throttle delay on the next request if the client did not enforce it on its side.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
