### PR TITLE
wasm: fix host function arg translation

### DIFF
--- a/src/v/wasm/wasmtime.cc
+++ b/src/v/wasm/wasmtime.cc
@@ -895,37 +895,6 @@ public:
         handle<wasm_functype_t, wasm_functype_delete> functype{
           wasm_functype_new(&inputs, &outputs)};
 
-        if (ssc.enabled()) {
-            if constexpr (ss::is_future<ReturnType>::value) {
-                handle<wasmtime_error_t, wasmtime_error_delete> error(
-                  wasmtime_linker_define_async_func(
-                    linker,
-                    Module::name.data(),
-                    Module::name.size(),
-                    function_name.data(),
-                    function_name.size(),
-                    functype.get(),
-                    &invoke_async_host_fn_with_strict_stack_checking,
-                    /*data=*/ssc.allocator,
-                    /*finalizer=*/nullptr));
-                check_error(error.get());
-            } else {
-                handle<wasmtime_error_t, wasmtime_error_delete> error(
-                  wasmtime_linker_define_func(
-                    linker,
-                    Module::name.data(),
-                    Module::name.size(),
-                    function_name.data(),
-                    function_name.size(),
-                    functype.get(),
-                    &invoke_sync_host_fn_with_strict_stack_checking,
-                    /*data=*/ssc.allocator,
-                    /*finalizer=*/nullptr));
-                check_error(error.get());
-            }
-            return;
-        }
-
         if constexpr (ss::is_future<ReturnType>::value) {
             handle<wasmtime_error_t, wasmtime_error_delete> error(
               wasmtime_linker_define_async_func(
@@ -935,8 +904,9 @@ public:
                 function_name.data(),
                 function_name.size(),
                 functype.get(),
-                &invoke_async_host_fn,
-                /*data=*/nullptr,
+                ssc.enabled() ? &invoke_async_host_fn_with_strict_stack_checking
+                              : &invoke_async_host_fn,
+                /*data=*/ssc.allocator,
                 /*finalizer=*/nullptr));
             check_error(error.get());
         } else {
@@ -948,8 +918,9 @@ public:
                 function_name.data(),
                 function_name.size(),
                 functype.get(),
-                &invoke_sync_host_fn,
-                /*data=*/nullptr,
+                ssc.enabled() ? &invoke_sync_host_fn_with_strict_stack_checking
+                              : &invoke_sync_host_fn,
+                /*data=*/ssc.allocator,
                 /*finalizer=*/nullptr));
             check_error(error.get());
         }


### PR DESCRIPTION
Expand the try/catch block in async host functions to catch arg translation exceptions (from out of bounds buffers being passed).
Otherwise this gets bubbled up over an ABI boundary which is not good (causes an abort).

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fix a bug where an invalid buffer passed into the WebAssembly host from the guest could cause Redpanda to abort.
