### PR TITLE
[CORE-1912] mvlog: add basic segment reader

### DIFF
--- a/src/v/storage/mvlog/CMakeLists.txt
+++ b/src/v/storage/mvlog/CMakeLists.txt
@@ -9,7 +9,9 @@ v_cc_library(
     entry_stream.cc
     entry_stream_utils.cc
     logger.cc
+    readable_segment.cc
     segment_appender.cc
+    segment_reader.cc
     skipping_data_source.cc
   DEPS
     Seastar::seastar

--- a/src/v/storage/mvlog/CMakeLists.txt
+++ b/src/v/storage/mvlog/CMakeLists.txt
@@ -3,6 +3,7 @@
 v_cc_library(
   NAME mvlog
   SRCS
+    batch_collecting_stream_utils.cc
     batch_collector.cc
     entry.cc
     entry_stream.cc

--- a/src/v/storage/mvlog/CMakeLists.txt
+++ b/src/v/storage/mvlog/CMakeLists.txt
@@ -5,6 +5,7 @@ v_cc_library(
   SRCS
     batch_collector.cc
     entry.cc
+    entry_stream.cc
     entry_stream_utils.cc
     logger.cc
     segment_appender.cc

--- a/src/v/storage/mvlog/batch_collecting_stream_utils.cc
+++ b/src/v/storage/mvlog/batch_collecting_stream_utils.cc
@@ -1,0 +1,89 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "storage/mvlog/batch_collecting_stream_utils.h"
+
+#include "base/vlog.h"
+#include "storage/mvlog/batch_collector.h"
+#include "storage/mvlog/logger.h"
+#include "storage/record_batch_utils.h"
+
+namespace storage::experimental::mvlog {
+
+std::ostream& operator<<(std::ostream& o, collect_stream_outcome out) {
+    switch (out) {
+    case collect_stream_outcome::buffer_full:
+        return o << "collect_stream_outcome::buffer_full";
+    case collect_stream_outcome::end_of_stream:
+        return o << "collect_stream_outcome::end_of_stream";
+    case collect_stream_outcome::stop:
+        return o << "collect_stream_outcome::stop";
+    }
+}
+
+ss::future<result<collect_stream_outcome, errc>>
+collect_batches_from_stream(entry_stream& entries, batch_collector& collector) {
+    while (true) {
+        auto entry_res = co_await entries.next();
+        if (entry_res.has_error()) {
+            co_return entry_res.error();
+        }
+        auto& entry = entry_res.value();
+        if (!entry.has_value()) {
+            co_return collect_stream_outcome::end_of_stream;
+        }
+        switch (entry->hdr.type) {
+        case entry_type::record_batch: {
+            auto res = collect_batch_from_buf(
+              std::move(entry->body), collector);
+            if (res.has_error()) {
+                co_return res.error();
+            }
+            switch (res.value()) {
+            // Pass the result through so the collector can be reset if
+            // needed...
+            case reader_outcome::buffer_full:
+                co_return collect_stream_outcome::buffer_full;
+            case reader_outcome::stop:
+                co_return collect_stream_outcome::stop;
+
+            // ...otherwise, the stream is not done yet and we should continue.
+            case reader_outcome::success:
+                [[fallthrough]];
+            case reader_outcome::skip:
+                continue;
+            }
+            break;
+        }
+        }
+    }
+}
+
+result<reader_outcome, errc>
+collect_batch_from_buf(iobuf body_buf, batch_collector& collector) {
+    auto entry_body = serde::from_iobuf<record_batch_entry_body>(
+      std::move(body_buf));
+    auto batch_header = storage::batch_header_from_disk_iobuf(
+      std::move(entry_body.record_batch_header));
+    auto computed_crc = model::internal_header_only_crc(batch_header);
+    if (computed_crc != batch_header.header_crc) {
+        return errc::checksum_mismatch;
+    }
+    auto term_res = collector.set_term(entry_body.term);
+    if (term_res.has_error() || term_res.value() != reader_outcome::success) {
+        return term_res;
+    }
+    vlog(
+      log.trace,
+      "Collecting offsets [{}, {}]",
+      batch_header.base_offset,
+      batch_header.last_offset());
+    return collector.add_batch(batch_header, std::move(entry_body.records));
+}
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/batch_collecting_stream_utils.h
+++ b/src/v/storage/mvlog/batch_collecting_stream_utils.h
@@ -1,0 +1,42 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "storage/mvlog/entry_stream.h"
+#include "storage/mvlog/reader_outcome.h"
+
+namespace storage::experimental::mvlog {
+
+class batch_collector;
+class entry_stream;
+
+enum class collect_stream_outcome {
+    // The batch collector is full.
+    buffer_full,
+
+    // There are no more entries in the stream.
+    end_of_stream,
+
+    // The batch collection is complete, e.g. because we have reached the
+    // desired offset.
+    stop,
+};
+std::ostream& operator<<(std::ostream&, collect_stream_outcome);
+
+// Parses and collects the record batches from the given entry stream.
+// Ignores other kinds of entries.
+ss::future<result<collect_stream_outcome, errc>>
+collect_batches_from_stream(entry_stream& entries, batch_collector& collector);
+
+// Parses a record_batch_entry_body from the given iobuf, validates its
+// contents, and collects the underlying record batch.
+result<reader_outcome, errc>
+collect_batch_from_buf(iobuf body_buf, batch_collector& collector);
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/entry_stream.cc
+++ b/src/v/storage/mvlog/entry_stream.cc
@@ -1,0 +1,45 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#include "storage/mvlog/entry_stream.h"
+
+#include "base/outcome.h"
+#include "base/seastarx.h"
+#include "bytes/iostream.h"
+#include "storage/mvlog/entry.h"
+#include "storage/mvlog/entry_stream_utils.h"
+#include "storage/mvlog/errc.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+
+#include <memory>
+
+namespace storage::experimental::mvlog {
+
+ss::future<result<std::optional<entry>, errc>> entry_stream::next() {
+    auto header_buf = co_await read_iobuf_exactly(
+      stream_, packed_entry_header_size);
+    if (header_buf.size_bytes() != packed_entry_header_size) {
+        co_return std::nullopt;
+    }
+
+    auto entry_hdr = entry_header_from_iobuf(std::move(header_buf));
+    auto computed_crc = entry_header_crc(entry_hdr.body_size, entry_hdr.type);
+    if (entry_hdr.header_crc != computed_crc) {
+        co_return errc::checksum_mismatch;
+    }
+
+    auto body_buf = co_await read_iobuf_exactly(stream_, entry_hdr.body_size);
+    if (body_buf.size_bytes() != static_cast<size_t>(entry_hdr.body_size)) {
+        co_return std::nullopt;
+    }
+    co_return entry{entry_hdr, std::move(body_buf)};
+}
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/entry_stream.cc
+++ b/src/v/storage/mvlog/entry_stream.cc
@@ -26,7 +26,10 @@ ss::future<result<std::optional<entry>, errc>> entry_stream::next() {
     auto header_buf = co_await read_iobuf_exactly(
       stream_, packed_entry_header_size);
     if (header_buf.size_bytes() != packed_entry_header_size) {
-        co_return std::nullopt;
+        if (header_buf.size_bytes() == 0) {
+            co_return std::nullopt;
+        }
+        co_return errc::short_read;
     }
 
     auto entry_hdr = entry_header_from_iobuf(std::move(header_buf));
@@ -37,7 +40,7 @@ ss::future<result<std::optional<entry>, errc>> entry_stream::next() {
 
     auto body_buf = co_await read_iobuf_exactly(stream_, entry_hdr.body_size);
     if (body_buf.size_bytes() != static_cast<size_t>(entry_hdr.body_size)) {
-        co_return std::nullopt;
+        co_return errc::short_read;
     }
     co_return entry{entry_hdr, std::move(body_buf)};
 }

--- a/src/v/storage/mvlog/entry_stream.h
+++ b/src/v/storage/mvlog/entry_stream.h
@@ -1,0 +1,42 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "base/outcome.h"
+#include "base/seastarx.h"
+#include "storage/mvlog/entry.h"
+#include "storage/mvlog/errc.h"
+
+#include <seastar/core/future.hh>
+#include <seastar/core/iostream.hh>
+
+namespace storage::experimental::mvlog {
+
+// Wrapper around an input stream to produce entries. The given stream is
+// expected to be comprised of contiguous entries.
+class entry_stream {
+public:
+    explicit entry_stream(ss::input_stream<char> stream)
+      : stream_(std::move(stream)) {}
+
+    // Reads from the input stream, deserializing an entry and returning it.
+    // Returns a well-formed entry.
+    //
+    // Returns std::nullopt if there isn't a complete entry, signalling the end
+    // of the stream.
+    //
+    // Returns an error if there is a problem with the underlying stream (e.g.
+    // a bad checksum).
+    ss::future<result<std::optional<entry>, errc>> next();
+
+private:
+    ss::input_stream<char> stream_;
+};
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/errc.h
+++ b/src/v/storage/mvlog/errc.h
@@ -17,6 +17,9 @@ enum class errc {
 
     // Indicates that there is something unexpected about the logical data.
     broken_data_invariant,
+
+    // Checksum error, likely corruption.
+    checksum_mismatch,
 };
 
 struct errc_category final : public std::error_category {
@@ -30,6 +33,8 @@ struct errc_category final : public std::error_category {
             return "none";
         case errc::broken_data_invariant:
             return "broken_data_invariant";
+        case errc::checksum_mismatch:
+            return "checksum_mismatch";
         }
     }
 };

--- a/src/v/storage/mvlog/errc.h
+++ b/src/v/storage/mvlog/errc.h
@@ -20,6 +20,10 @@ enum class errc {
 
     // Checksum error, likely corruption.
     checksum_mismatch,
+
+    // Not enough data in a stream, potentially corruption.
+    short_read,
+
 };
 
 struct errc_category final : public std::error_category {
@@ -35,6 +39,8 @@ struct errc_category final : public std::error_category {
             return "broken_data_invariant";
         case errc::checksum_mismatch:
             return "checksum_mismatch";
+        case errc::short_read:
+            return "short_read";
         }
     }
 };

--- a/src/v/storage/mvlog/readable_segment.cc
+++ b/src/v/storage/mvlog/readable_segment.cc
@@ -1,0 +1,20 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "storage/mvlog/readable_segment.h"
+
+#include "storage/mvlog/segment_reader.h"
+
+namespace storage::experimental::mvlog {
+
+std::unique_ptr<segment_reader> readable_segment::make_reader() {
+    return std::make_unique<segment_reader>(this);
+}
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/readable_segment.h
+++ b/src/v/storage/mvlog/readable_segment.h
@@ -1,0 +1,39 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include <memory>
+
+namespace experimental::io {
+class pager;
+}
+
+namespace storage::experimental::mvlog {
+
+class segment_reader;
+
+// A readable segment file. This is a long-lived object, responsible for
+// passing out short-lived readers.
+class readable_segment {
+public:
+    explicit readable_segment(::experimental::io::pager* pager)
+      : pager_(pager) {}
+
+    std::unique_ptr<segment_reader> make_reader();
+    size_t num_readers() const { return num_readers_; }
+
+private:
+    friend class segment_reader;
+
+    ::experimental::io::pager* pager_;
+
+    size_t num_readers_{0};
+};
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/segment_reader.cc
+++ b/src/v/storage/mvlog/segment_reader.cc
@@ -1,0 +1,54 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "storage/mvlog/segment_reader.h"
+
+#include "base/vlog.h"
+#include "io/pager.h"
+#include "io/paging_data_source.h"
+#include "storage/mvlog/logger.h"
+#include "storage/mvlog/readable_segment.h"
+#include "storage/mvlog/skipping_data_source.h"
+
+namespace storage::experimental::mvlog {
+segment_reader::segment_reader(readable_segment* segment)
+  : segment_(segment) {
+    ++segment_->num_readers_;
+}
+segment_reader::~segment_reader() { --segment_->num_readers_; }
+
+skipping_data_source::read_list_t
+segment_reader::make_read_intervals(size_t start_pos, size_t length) const {
+    // TODO(awong): a future commit will build appropriate intervals for this
+    // reader's truncation id.
+    skipping_data_source::read_list_t read_intervals;
+    read_intervals.emplace_back(start_pos, length);
+    return read_intervals;
+}
+
+ss::input_stream<char> segment_reader::make_stream(size_t start_pos) const {
+    return make_stream(start_pos, segment_->pager_->size() - start_pos);
+}
+
+ss::input_stream<char>
+segment_reader::make_stream(size_t start_pos, size_t length) const {
+    auto read_intervals = make_read_intervals(start_pos, length);
+    for (const auto& interval : read_intervals) {
+        vlog(
+          log.trace,
+          "Reading interval [{}, {})",
+          interval.offset,
+          interval.offset + interval.length);
+    }
+    return ss::input_stream<char>(
+      ss::data_source(std::make_unique<skipping_data_source>(
+        segment_->pager_, std::move(read_intervals))));
+}
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/segment_reader.h
+++ b/src/v/storage/mvlog/segment_reader.h
@@ -1,0 +1,49 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "storage/mvlog/batch_collector.h"
+#include "storage/mvlog/skipping_data_source.h"
+#include "storage/types.h"
+
+namespace storage::experimental::mvlog {
+
+class readable_segment;
+
+// Class that encapsulates read IO for a segment file.
+class segment_reader {
+public:
+    segment_reader(segment_reader&) = delete;
+    segment_reader(segment_reader&&) = delete;
+    segment_reader& operator=(segment_reader&) = delete;
+    segment_reader& operator=(segment_reader&&) = delete;
+
+    explicit segment_reader(readable_segment* segment);
+    ~segment_reader();
+
+    // Returns a stream starting from the given file position, until the end of
+    // the segment file.
+    //
+    // The stream must be consumed while this segment_reader remains in scope.
+    ss::input_stream<char> make_stream(size_t start_pos = 0) const;
+
+private:
+    // Returns the set of file position intervals appropriate for this reader's
+    // truncation id.
+    skipping_data_source::read_list_t
+    make_read_intervals(size_t start_pos, size_t length) const;
+
+    // Returns a stream starting at the file position with the given length.
+    ss::input_stream<char> make_stream(size_t start_pos, size_t length) const;
+
+    // The underlying readable segment file.
+    readable_segment* segment_;
+};
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/tests/CMakeLists.txt
+++ b/src/v/storage/mvlog/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ rp_test(
     batch_collector_test.cc
     entry_stream_utils_test.cc
     segment_appender_test.cc
+    segment_io_test.cc
     segment_reader_test.cc
     skipping_data_source_test.cc
   LIBRARIES

--- a/src/v/storage/mvlog/tests/CMakeLists.txt
+++ b/src/v/storage/mvlog/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ rp_test(
     batch_collector_test.cc
     entry_stream_utils_test.cc
     segment_appender_test.cc
+    segment_reader_test.cc
     skipping_data_source_test.cc
   LIBRARIES
     v::gtest_main

--- a/src/v/storage/mvlog/tests/CMakeLists.txt
+++ b/src/v/storage/mvlog/tests/CMakeLists.txt
@@ -4,12 +4,14 @@ rp_test(
   USE_CWD
   BINARY_NAME mvlog
   SOURCES
+    batch_collecting_stream_utils_test.cc
     batch_collector_test.cc
     entry_stream_utils_test.cc
     segment_appender_test.cc
     skipping_data_source_test.cc
   LIBRARIES
     v::gtest_main
+    v::hashing
     v::model
     v::model_test_utils
     v::mvlog

--- a/src/v/storage/mvlog/tests/batch_collecting_stream_utils_test.cc
+++ b/src/v/storage/mvlog/tests/batch_collecting_stream_utils_test.cc
@@ -1,0 +1,69 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iostream.h"
+#include "hashing/crc32.h"
+#include "model/record_batch_types.h"
+#include "model/tests/random_batch.h"
+#include "storage/mvlog/batch_collecting_stream_utils.h"
+#include "storage/mvlog/batch_collector.h"
+#include "storage/mvlog/entry.h"
+#include "storage/mvlog/entry_stream.h"
+#include "storage/mvlog/entry_stream_utils.h"
+#include "storage/record_batch_utils.h"
+#include "storage/types.h"
+
+#include <seastar/core/io_priority_class.hh>
+
+#include <gtest/gtest.h>
+
+namespace storage::experimental::mvlog {
+
+TEST(BatchCollectingStreamTest, TestBasicStream) {
+    iobuf buf;
+    auto in_batches = model::test::make_random_batches(
+      model::offset{0}, 10, true);
+    for (int i = 0; i < 10; i++) {
+        in_batches[i].header().ctx.term = model::term_id{i};
+    }
+    for (const auto& b : in_batches) {
+        record_batch_entry_body entry_body;
+        entry_body.record_batch_header.append(
+          batch_header_to_disk_iobuf(b.header()));
+        entry_body.records.append(b.data().copy());
+        entry_body.term = model::term_id{1};
+
+        auto entry_body_buf = serde::to_iobuf(std::move(entry_body));
+        auto body_size = static_cast<int32_t>(entry_body_buf.size_bytes());
+        entry_header entry_hdr{
+          entry_header_crc(body_size, entry_type::record_batch),
+          body_size,
+          entry_type::record_batch,
+        };
+        buf.append(entry_header_to_iobuf(entry_hdr));
+        buf.append(std::move(entry_body_buf));
+    }
+
+    log_reader_config cfg{
+      model::offset{0}, model::offset::max(), ss::default_priority_class()};
+    batch_collector collector(cfg, model::term_id{1}, 128_MiB);
+    entry_stream entries(make_iobuf_input_stream(std::move(buf)));
+
+    auto res = collect_batches_from_stream(entries, collector).get();
+    ASSERT_TRUE(res.has_value()) << res.error();
+    ASSERT_EQ(res.value(), collect_stream_outcome::end_of_stream);
+
+    auto out_batches = collector.release_batches();
+    ASSERT_EQ(out_batches.size(), 10);
+    for (int i = 0; i < 10; i++) {
+        ASSERT_EQ(in_batches[i], out_batches[i]);
+    }
+}
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/tests/entry_stream_utils_test.cc
+++ b/src/v/storage/mvlog/tests/entry_stream_utils_test.cc
@@ -7,13 +7,23 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "bytes/iostream.h"
+#include "bytes/random.h"
 #include "random/generators.h"
 #include "storage/mvlog/entry.h"
+#include "storage/mvlog/entry_stream.h"
 #include "storage/mvlog/entry_stream_utils.h"
 
 #include <gtest/gtest.h>
 
 using namespace storage::experimental::mvlog;
+
+namespace {
+entry_header make_checksummed_header(size_t body_size, entry_type type) {
+    auto sz = static_cast<int32_t>(body_size);
+    return entry_header(entry_header_crc(sz, type), sz, type);
+}
+} // namespace
 
 TEST(EntryHeaderToFromIObuf, TestBasic) {
     entry_header orig_h{0, 0, entry_type::record_batch};
@@ -81,4 +91,88 @@ TEST(EntryHeaderToFromIObuf, TestUnknownEnum) {
     auto header = entry_header_from_iobuf(std::move(fake_header_buf));
     ASSERT_EQ(
       static_cast<int8_t>(header.type), std::numeric_limits<int8_t>::max());
+}
+
+TEST(EntryStream, TestShortHeader) {
+    iobuf hdr_buf;
+    entry_header hdr{0, 0, entry_type::record_batch};
+    hdr_buf.append(entry_header_to_iobuf(hdr));
+    ASSERT_GT(hdr_buf.size_bytes(), 1);
+    for (int i = 1; i < hdr_buf.size_bytes(); i++) {
+        auto copy_buf = hdr_buf.copy();
+        copy_buf.trim_back(i);
+        auto short_stream = make_iobuf_input_stream(std::move(copy_buf));
+        entry_stream entries(std::move(short_stream));
+        auto entry = entries.next().get();
+        ASSERT_FALSE(entry.has_error()) << entry.error();
+        ASSERT_FALSE(entry.value().has_value()) << "Expected no entry";
+    }
+}
+
+TEST(EntryStream, TestBadEntryHeaderChecksum) {
+    iobuf hdr_buf;
+    entry_header hdr{0, 0, entry_type::record_batch};
+    hdr_buf.append(entry_header_to_iobuf(hdr));
+    ASSERT_GT(hdr_buf.size_bytes(), 0);
+    auto& last_frag = *hdr_buf.rbegin();
+    ASSERT_GT(last_frag.size(), 0);
+    last_frag.get_write()[last_frag.size() - 1] += 1;
+
+    auto corrupted_stream = make_iobuf_input_stream(std::move(hdr_buf));
+    entry_stream entries(std::move(corrupted_stream));
+    auto entry = entries.next().get();
+    ASSERT_TRUE(entry.has_error());
+    ASSERT_EQ(errc::checksum_mismatch, entry.error());
+}
+
+TEST(EntryStream, TestShortBody) {
+    constexpr auto expected_body_size = 10;
+    iobuf hdr_buf;
+    auto hdr = make_checksummed_header(
+      expected_body_size, entry_type::record_batch);
+    hdr_buf.append(entry_header_to_iobuf(hdr));
+    for (int i = 0; i < expected_body_size; i++) {
+        auto copy_buf = hdr_buf.copy();
+        copy_buf.append(random_generators::make_iobuf(i));
+        auto short_stream = make_iobuf_input_stream(std::move(copy_buf));
+        entry_stream entries(std::move(short_stream));
+        auto entry = entries.next().get();
+        ASSERT_FALSE(entry.has_error()) << entry.error();
+        ASSERT_FALSE(entry.value().has_value()) << "Expected no entry";
+    }
+}
+
+TEST(EntryStream, TestRandom) {
+    iobuf entries_buf;
+    constexpr auto max_body_size = 100;
+    constexpr auto num_entries = 10;
+    std::vector<size_t> body_sizes;
+    body_sizes.reserve(num_entries);
+    for (int i = 0; i < num_entries; i++) {
+        auto body_size = random_generators::get_int(max_body_size);
+        body_sizes.emplace_back(body_size);
+
+        iobuf hdr_buf;
+        auto hdr = make_checksummed_header(body_size, entry_type::record_batch);
+        entries_buf.append(entry_header_to_iobuf(hdr));
+        entries_buf.append(random_generators::make_iobuf(body_size));
+    }
+    auto istream = make_iobuf_input_stream(std::move(entries_buf));
+    entry_stream entries(std::move(istream));
+    for (int i = 0; i < num_entries; i++) {
+        auto entry_res = entries.next().get();
+        ASSERT_FALSE(entry_res.has_error()) << entry_res.error();
+        ASSERT_TRUE(entry_res.value().has_value()) << "Expected an entry";
+
+        // Validate the header.
+        const auto& entry = entry_res.value().value();
+        ASSERT_EQ(body_sizes[i], entry.hdr.body_size);
+        ASSERT_EQ(entry_type::record_batch, entry.hdr.type);
+        ASSERT_EQ(
+          entry_header_crc(entry.hdr.body_size, entry_type::record_batch),
+          entry.hdr.header_crc);
+
+        // Validate the body.
+        ASSERT_EQ(body_sizes[i], entry.body.size_bytes());
+    }
 }

--- a/src/v/storage/mvlog/tests/entry_stream_utils_test.cc
+++ b/src/v/storage/mvlog/tests/entry_stream_utils_test.cc
@@ -104,8 +104,8 @@ TEST(EntryStream, TestShortHeader) {
         auto short_stream = make_iobuf_input_stream(std::move(copy_buf));
         entry_stream entries(std::move(short_stream));
         auto entry = entries.next().get();
-        ASSERT_FALSE(entry.has_error()) << entry.error();
-        ASSERT_FALSE(entry.value().has_value()) << "Expected no entry";
+        ASSERT_TRUE(entry.has_error());
+        ASSERT_EQ(entry.error(), errc::short_read);
     }
 }
 
@@ -137,8 +137,8 @@ TEST(EntryStream, TestShortBody) {
         auto short_stream = make_iobuf_input_stream(std::move(copy_buf));
         entry_stream entries(std::move(short_stream));
         auto entry = entries.next().get();
-        ASSERT_FALSE(entry.has_error()) << entry.error();
-        ASSERT_FALSE(entry.value().has_value()) << "Expected no entry";
+        ASSERT_TRUE(entry.has_error());
+        ASSERT_EQ(entry.error(), errc::short_read);
     }
 }
 

--- a/src/v/storage/mvlog/tests/segment_io_test.cc
+++ b/src/v/storage/mvlog/tests/segment_io_test.cc
@@ -1,0 +1,159 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/units.h"
+#include "io/page_cache.h"
+#include "io/pager.h"
+#include "io/persistence.h"
+#include "io/scheduler.h"
+#include "model/tests/random_batch.h"
+#include "storage/logger.h"
+#include "storage/mvlog/batch_collecting_stream_utils.h"
+#include "storage/mvlog/batch_collector.h"
+#include "storage/mvlog/entry.h"
+#include "storage/mvlog/entry_stream.h"
+#include "storage/mvlog/readable_segment.h"
+#include "storage/mvlog/segment_appender.h"
+#include "storage/mvlog/segment_reader.h"
+
+#include <seastar/core/seastar.hh>
+
+#include <gtest/gtest.h>
+
+using namespace storage::experimental::mvlog;
+using namespace experimental;
+
+class SegmentTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        storage_ = std::make_unique<io::disk_persistence>();
+        storage_->create(file_.string()).get()->close().get();
+        cleanup_files_.emplace_back(file_);
+
+        io::page_cache::config cache_config{
+          .cache_size = 2_MiB, .small_size = 1_MiB};
+        cache_ = std::make_unique<io::page_cache>(cache_config);
+        scheduler_ = std::make_unique<io::scheduler>(100);
+        pager_ = std::make_unique<io::pager>(
+          file_, 0, storage_.get(), cache_.get(), scheduler_.get());
+    }
+
+    void TearDown() override {
+        pager_->close().get();
+
+        for (auto& file : cleanup_files_) {
+            try {
+                ss::remove_file(file.string()).get();
+            } catch (...) {
+            }
+        }
+    }
+
+    ss::future<ss::circular_buffer<model::record_batch>>
+    write_random_batches(int num_batches) {
+        segment_appender appender(pager_.get());
+        auto in_batches = model::test::make_random_batches(
+          model::offset{0}, num_batches, true);
+        for (auto& b : in_batches) {
+            co_await appender.append(b.copy());
+        }
+        co_return in_batches;
+    }
+
+protected:
+    const std::filesystem::path file_{"segment"};
+    std::unique_ptr<io::persistence> storage_;
+    std::unique_ptr<io::page_cache> cache_;
+    std::unique_ptr<io::scheduler> scheduler_;
+    std::unique_ptr<io::pager> pager_;
+    std::vector<std::filesystem::path> cleanup_files_;
+};
+
+// Basic test that we can append and read some batches.
+TEST_F(SegmentTest, TestBasicRoundTrip) {
+    auto in_batches = write_random_batches(100).get();
+    readable_segment readable_seg(pager_.get());
+
+    ASSERT_GT(pager_->size(), 0);
+    storage::log_reader_config cfg{
+      model::offset{0}, model::offset::max(), ss::default_priority_class()};
+    batch_collector collector(cfg, model::term_id{0}, 128_MiB);
+    auto reader = readable_seg.make_reader();
+
+    entry_stream entries(reader->make_stream());
+    auto res = collect_batches_from_stream(entries, collector).get();
+    ASSERT_TRUE(res.has_value());
+    ASSERT_EQ(res.value(), collect_stream_outcome::end_of_stream);
+    auto out_batches = collector.release_batches();
+    ASSERT_EQ(100, out_batches.size());
+    for (int i = 0; i < 100; i++) {
+        ASSERT_EQ(in_batches[i], out_batches[i]);
+    }
+}
+
+// Test that we can append and read some batches even with a bounded size on
+// the batch collector.
+TEST_F(SegmentTest, TestFullCollector) {
+    auto in_batches = write_random_batches(100).get();
+    readable_segment readable_seg(pager_.get());
+
+    ASSERT_GT(pager_->size(), 0);
+    storage::log_reader_config cfg{
+      model::offset{0}, model::offset::max(), ss::default_priority_class()};
+    batch_collector collector(
+      cfg, model::term_id{0}, /*max_buffer_size*/ 0_MiB);
+    auto reader = readable_seg.make_reader();
+
+    // Since our max bytes is so low, each time we read, we will see the buffer
+    // as full.
+    entry_stream entries(reader->make_stream());
+    std::vector<model::record_batch> out_batches;
+    for (int i = 0; i < 100; i++) {
+        auto res = collect_batches_from_stream(entries, collector).get();
+        ASSERT_TRUE(res.has_value());
+        ASSERT_EQ(res.value(), collect_stream_outcome::buffer_full);
+        auto collected = collector.release_batches();
+        ASSERT_EQ(1, collected.size());
+        out_batches.emplace_back(std::move(collected[0]));
+    }
+    for (int i = 0; i < 100; i++) {
+        ASSERT_EQ(in_batches[i], out_batches[i]);
+    }
+}
+
+// Test that we can append and read some batches within a certain range.
+TEST_F(SegmentTest, TestBoundedOffsets) {
+    auto in_batches = write_random_batches(5).get();
+    readable_segment readable_seg(pager_.get());
+
+    ASSERT_GT(pager_->size(), 0);
+    auto reader = readable_seg.make_reader();
+    auto bounded_offset = model::prev_offset(in_batches.back().base_offset());
+
+    for (int min = 0; min <= bounded_offset(); min++) {
+        for (int max = min; max <= bounded_offset(); max++) {
+            storage::log_reader_config cfg{
+              model::offset{min},
+              model::offset{max},
+              ss::default_priority_class()};
+            batch_collector collector(cfg, model::term_id{0}, 128_MiB);
+            entry_stream entries(reader->make_stream());
+            auto res = collect_batches_from_stream(entries, collector).get();
+            ASSERT_TRUE(res.has_value());
+            ASSERT_EQ(res.value(), collect_stream_outcome::stop);
+            auto out_batches = collector.release_batches();
+
+            ASSERT_FALSE(out_batches.empty());
+            ASSERT_LT(out_batches.size(), 10);
+
+            ASSERT_TRUE(out_batches.begin()->contains(model::offset{min}));
+            ASSERT_TRUE(out_batches.back().contains(model::offset{max}));
+        }
+    }
+}

--- a/src/v/storage/mvlog/tests/segment_reader_test.cc
+++ b/src/v/storage/mvlog/tests/segment_reader_test.cc
@@ -1,0 +1,103 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/units.h"
+#include "io/page_cache.h"
+#include "io/pager.h"
+#include "io/persistence.h"
+#include "io/scheduler.h"
+#include "storage/mvlog/readable_segment.h"
+#include "storage/mvlog/segment_reader.h"
+
+#include <seastar/core/seastar.hh>
+#include <seastar/core/temporary_buffer.hh>
+
+#include <gtest/gtest.h>
+
+using namespace storage::experimental::mvlog;
+using namespace experimental;
+
+class SegmentReaderTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        storage_ = std::make_unique<io::disk_persistence>();
+        storage_->create(file_.string()).get()->close().get();
+        cleanup_files_.emplace_back(file_);
+
+        io::page_cache::config cache_config{
+          .cache_size = 2_MiB, .small_size = 1_MiB};
+        cache_ = std::make_unique<io::page_cache>(cache_config);
+        scheduler_ = std::make_unique<io::scheduler>(100);
+        pager_ = std::make_unique<io::pager>(
+          file_, 0, storage_.get(), cache_.get(), scheduler_.get());
+    }
+
+    void TearDown() override {
+        pager_->close().get();
+
+        for (auto& file : cleanup_files_) {
+            try {
+                ss::remove_file(file.string()).get();
+            } catch (...) {
+            }
+        }
+    }
+
+protected:
+    const std::filesystem::path file_{"segment"};
+    std::unique_ptr<io::persistence> storage_;
+    std::unique_ptr<io::page_cache> cache_;
+    std::unique_ptr<io::scheduler> scheduler_;
+    std::unique_ptr<io::pager> pager_;
+    std::vector<std::filesystem::path> cleanup_files_;
+};
+
+TEST_F(SegmentReaderTest, TestCountReaders) {
+    readable_segment readable_seg(pager_.get());
+    ASSERT_EQ(0, readable_seg.num_readers());
+    {
+        auto reader = readable_seg.make_reader();
+        ASSERT_EQ(1, readable_seg.num_readers());
+    }
+    ASSERT_EQ(0, readable_seg.num_readers());
+    std::vector<std::unique_ptr<segment_reader>> readers;
+    readers.reserve(10);
+    for (int i = 0; i < 10; i++) {
+        auto reader = readable_seg.make_reader();
+        ASSERT_EQ(i + 1, readable_seg.num_readers());
+        readers.emplace_back(std::move(reader));
+    }
+    ASSERT_EQ(10, readable_seg.num_readers());
+    readers.clear();
+    ASSERT_EQ(0, readable_seg.num_readers());
+}
+
+TEST_F(SegmentReaderTest, TestEmptyRead) {
+    readable_segment readable_seg(pager_.get());
+    auto reader = readable_seg.make_reader();
+    auto stream = reader->make_stream();
+    auto buf = stream.read().get();
+    ASSERT_TRUE(buf.empty());
+}
+
+TEST_F(SegmentReaderTest, TestBasicReads) {
+    ss::sstring data = "0123456789";
+    pager_->append(ss::temporary_buffer<char>{data.begin(), data.size()}).get();
+    readable_segment readable_seg(pager_.get());
+    for (int i = 0; i < data.size(); i++) {
+        auto reader = readable_seg.make_reader();
+        auto stream = reader->make_stream(i);
+        auto buf = stream.read_up_to(data.size()).get();
+
+        auto expected_str = data.substr(i);
+        ss::temporary_buffer<char> expected_buf{
+          expected_str.begin(), expected_str.size()};
+        ASSERT_EQ(buf, expected_buf);
+    }
+}


### PR DESCRIPTION
Introduces a few abstractions to be used as a part of the upcoming
new log_reader implementation. These abstractions are:
- entry_stream: A utility class to parse input_streams as a contiguous run of
  entries.
- readable_segment: A long-lived representation of a segment file, used to
  construct segment_readers.
- segment_reader: A short-lived accessor to the file used to construct
  input_streams. This doesn't enforce any lifecycle relationships
  between segment_readers and input_streams, but it is expected that the
  readers will outlive the streams.

These abstractions are pretty bare bones compared to the existing
storage::segment, storage::segment_reader, and reader handle. There is
some basic accounting done for the readers, but the complexity of a
ref-counted handle doesn't seem critical for now.

Some tests are added to exercise appends and reading record batch entries.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Fixes #17255

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
