### PR TITLE
rm_stm/tests: add test for producer expiration without data batches

### DIFF
--- a/src/v/cluster/rm_stm.h
+++ b/src/v/cluster/rm_stm.h
@@ -490,6 +490,8 @@ private:
     get_expiration_info(model::producer_identity pid) const;
     std::optional<int32_t> get_seq_number(model::producer_identity pid) const;
 
+    chunked_vector<model::producer_identity> get_expired_producers() const;
+
     uint8_t active_snapshot_version();
 
     template<class T>

--- a/src/v/cluster/tests/rm_stm_test_fixture.h
+++ b/src/v/cluster/tests/rm_stm_test_fixture.h
@@ -69,6 +69,8 @@ struct rm_stm_test_fixture : simple_raft_fixture {
         return _stm->wait(raft_offset, model::timeout_clock::now() + 10ms);
     }
 
+    auto get_expired_producers() const { return _stm->get_expired_producers(); }
+
     ss::sharded<cluster::tx_gateway_frontend> tx_gateway_frontend;
     ss::sharded<cluster::producer_state_manager> producer_state_manager;
     ss::shared_ptr<cluster::rm_stm> _stm;


### PR DESCRIPTION
In earlier versions we were not considering transactions without data
batches as candidates for expiry, thats not the case any more with
https://github.com/redpanda-data/redpanda/pull/18076, adding a regression test to future proof.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
