### PR TITLE
rpk: stop using args[0] in cloud cluster select

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/cluster/select.go
+++ b/src/go/rpk/pkg/cli/cloud/cluster/select.go
@@ -60,10 +60,10 @@ an existing self-hosted profile, please rename that profile or use the
 Either:
     rpk profile select %[1]q
     rpk profile rename-to $something_else
-    rpk cloud cluster select %[2]q
+    rpk cloud cluster select [NAME]
 Or:
-    rpk cloud cluster select %[2]q --profile $another_something
-`, ee.Name, args[0])
+    rpk cloud cluster select [NAME] --profile $another_something
+`, ee.Name)
 				os.Exit(1)
 			}
 			out.MaybeDieErr(err)


### PR DESCRIPTION
There might be cases where the user is using
rpk cloud cluster select in a single-cluster org
and args will be null, causing a panic.

Fixes #18270


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none
