### PR TITLE
archival: clamp uploads to committed offset

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -2036,9 +2036,9 @@ model::offset ntp_archiver::max_uploadable_offset_exclusive() const {
 }
 
 ss::future<ntp_archiver::batch_result> ntp_archiver::upload_next_candidates(
-  std::optional<model::offset> max_offset_override_exclusive) {
-    auto max_offset_exclusive = max_offset_override_exclusive
-                                  ? *max_offset_override_exclusive
+  std::optional<model::offset> unsafe_max_offset_override_exclusive) {
+    auto max_offset_exclusive = unsafe_max_offset_override_exclusive
+                                  ? *unsafe_max_offset_override_exclusive
                                   : max_uploadable_offset_exclusive();
     vlog(
       _rtclog.debug,

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -187,12 +187,14 @@ public:
     /// will pick not more than '_concurrency' candidates and start
     /// uploading them.
     ///
-    /// \param max_offset_override_exclusive Overrides the maximum offset
-    ///        that can be uploaded. If nullopt, the maximum offset is
-    ///        calculated automatically.
+    /// \param unsafe_max_offset_override_exclusive Overrides the maximum offset
+    ///        that can be uploaded. ONLY FOR TESTING. It is not clamped to a
+    ///        safe value/committed offset as some tests work directly with
+    ///        segments bypassing the raft thus not advancing the committed
+    ///        offset.
     /// \return future that returns number of uploaded/failed segments
     virtual ss::future<batch_result> upload_next_candidates(
-      std::optional<model::offset> max_offset_override_exclusive
+      std::optional<model::offset> unsafe_max_offset_override_exclusive
       = std::nullopt);
 
     ss::future<cloud_storage::download_result> sync_manifest();

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -415,7 +415,7 @@ private:
         /// The next scheduled upload will start from this offset
         model::offset start_offset;
         /// Uploads will stop at this offset
-        model::offset last_offset;
+        model::offset end_offset_exclusive;
         /// Controls checks for reuploads, compacted segments have this
         /// check disabled
         allow_reuploads_t allow_reuploads;

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -175,15 +175,25 @@ public:
         auto operator<=>(const batch_result&) const = default;
     };
 
+    /// Compute the maximum offset that is safe to be uploaded to the cloud.
+    ///
+    /// It must be guaranteed that this offset is monotonically increasing/
+    /// can never go backwards. Otherwise, the local and cloud logs will
+    /// diverge leading to undefined behavior.
+    model::offset max_uploadable_offset_exclusive() const;
+
     /// \brief Upload next set of segments to S3 (if any)
     /// The semaphore is used to track number of parallel uploads. The method
     /// will pick not more than '_concurrency' candidates and start
     /// uploading them.
     ///
-    /// \param lso_override last stable offset override
+    /// \param max_offset_override_exclusive Overrides the maximum offset
+    ///        that can be uploaded. If nullopt, the maximum offset is
+    ///        calculated automatically.
     /// \return future that returns number of uploaded/failed segments
     virtual ss::future<batch_result> upload_next_candidates(
-      std::optional<model::offset> last_stable_offset_override = std::nullopt);
+      std::optional<model::offset> max_offset_override_exclusive
+      = std::nullopt);
 
     ss::future<cloud_storage::download_result> sync_manifest();
 
@@ -422,7 +432,7 @@ private:
 
     /// Start all uploads
     ss::future<std::vector<scheduled_upload>>
-    schedule_uploads(model::offset last_stable_offset);
+    schedule_uploads(model::offset max_offset_exclusive);
 
     ss::future<std::vector<scheduled_upload>>
     schedule_uploads(std::vector<upload_context> loop_contexts);


### PR DESCRIPTION
The archival/tiered storage correctness assumption builds on the (wrong) assumption that LSO is monotonic. Tiered storage doesn't have a concept of suffix truncation so if that would happen it would lead violations of correctness properties and diverging logs/undefined behavior.

However, we have discovered that property does not hold if there are no in-progress transaction and acks=0/1 or write caching is in use because LSO falls back to "last visible index"[^1] which can get truncated.

Ref https://github.com/redpanda-data/redpanda/issues/18244

[^1]: https://github.com/redpanda-data/redpanda/blob/88ac775f9f7954330732024abfa6e9ed5c9c11fd/src/v/cluster/rm_stm.cc#L1322

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
