### PR TITLE
net/probes: Expect vector<byte> from cert_info

### DIFF
--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -36,6 +36,7 @@
 #include <ostream>
 #include <span>
 #include <string>
+#include <vector>
 
 namespace net {
 void server_probe::setup_metrics(
@@ -292,7 +293,7 @@ void tls_certificate_probe::loaded(
         return;
     }
 
-    auto to_tls_serial = [](const auto& b) {
+    auto to_tls_serial = [](const std::vector<std::byte>& b) {
         using T = tls_serial_number::type;
         T result = 0;
         const auto end = std::min(b.size(), sizeof(T));


### PR DESCRIPTION
`char_traits<unsigned T>` is deprecated in LLVM 18, slated for removal in LLVM 19. Having replaced the only instance of `basic_sstring<unsigned>` in seastar with a `vector<byte>`, we need to account for that change here.

Requires redpanda-data/seastar: d96474c6a96919b4f260dbd5ba22827948c4e000

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
