### PR TITLE
rpk: document --set flag in rpk container start

### DIFF
--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -188,6 +188,7 @@ You can retry profile creation by running:
 	command.Flags().StringVar(&consoleImage, "console-image", common.DefaultConsoleImage(), "An arbitrary container Redpanda Console image to use")
 	command.Flags().BoolVar(&pull, "pull", false, "Force pull the container image used")
 	command.Flags().BoolVar(&noProfile, "no-profile", false, "If true, rpk will not create an rpk profile after creating a cluster")
+	command.Flags().String("set", "", "Redpanda configuration property to set upon start. Follows 'rpk redpanda config set' format")
 	command.Flags().StringSliceVar(&kPorts, flagKafkaPorts, nil, "Kafka protocol ports to listen on; check help text for more information")
 	command.Flags().StringSliceVar(&aPorts, flagAdminPorts, nil, "Redpanda Admin API ports to listen on; check help text for more information")
 	command.Flags().StringSliceVar(&srPorts, flagSRPorts, nil, "Schema registry ports to listen on; check help text for more information")


### PR DESCRIPTION
This has always worked but it is hidden. We now document it.

This is unnecessary but may be a good alternative for testing config properties on start.


## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [X] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
