### PR TITLE
tools: tweaks to make public build dockerfile portable between fedora/ubuntu distros

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -128,12 +128,21 @@ case "$ID" in
   ubuntu | debian | pop)
     apt-get update
     DEBIAN_FRONTEND=noninteractive apt-get install -y "${deb_deps[@]}"
+    if [[ $CLEAN_PKG_CACHE == true ]]; then
+      rm -rf /var/lib/apt/lists/*
+    fi
     ;;
   fedora)
     dnf install -y "${fedora_deps[@]}"
+    if [[ $CLEAN_PKG_CACHE == true ]]; then
+      dnf clean all
+    fi
     ;;
   arch | manjaro)
     pacman -Sy --needed --noconfirm "${arch_deps[@]}"
+    if [[ $CLEAN_PKG_CACHE == true ]]; then
+      pacman -Sc
+    fi
     ;;
   *)
     echo "Please help us make the script better by sending patches with your OS $ID"

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,7 +1,8 @@
-FROM fedora:38
+ARG BASE_IMAGE_OS_NAME=fedora
+ARG BASE_IMAGE_OS_VERSION=38
+FROM ${BASE_IMAGE_OS_NAME}:${BASE_IMAGE_OS_VERSION}
 
 COPY --chown=0:0 install-dependencies.sh /
 
-RUN /install-dependencies.sh && \
-    dnf clean all && \
+RUN CLEAN_PKG_CACHE=true /install-dependencies.sh && \
     rm install-dependencies.sh


### PR DESCRIPTION
Changes to make public cpp toolchain dockerfile image portable on ubuntu and fedora

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
