### PR TITLE
http: Fix double call to stop() in http::client

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -190,6 +190,13 @@ ss::future<reconnect_result_t> client::get_connected(
 }
 
 ss::future<> client::stop() {
+    if (_stopped) {
+        // Prevent double call to stop() as constructs such as with_client()
+        // will unconditionally call stop(), while exception handlers in this
+        // file may also call stop()
+        co_return;
+    }
+    _stopped = true;
     co_await _connect_gate.close();
     // Can safely stop base_transport
     co_return co_await base_transport::stop();

--- a/src/v/http/include/http/client.h
+++ b/src/v/http/include/http/client.h
@@ -255,6 +255,7 @@ private:
     /// Throw exception if _as is aborted
     void check() const;
 
+    bool _stopped{false};
     std::string _host_with_port;
     ss::gate _connect_gate;
     const ss::abort_source* _as;


### PR DESCRIPTION
http::client::stop() can be called twice in the event the client is used via the `with_client` method.

The method had unconditionally called stop() in a finally clause with the intention to have users not have to manually do this and forget to call stop.

However stop() can also be called within certain exception handlers within methods invoked by http::client, ones that handle tls::verification_error exceptions.

This patch skips the call to stop() in the event a tls::verification_error exception was encountered.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

### Bug Fixes

* Fixes a bug in the http client where a crash may occur in the event certain tls verification errors are observed

