### PR TITLE
Wrap certain `wasm32-wasi` ABI unsafe calls in `unsafe` to fix the build.

### DIFF
--- a/src/transform-sdk/rust/sr-sys/src/lib.rs
+++ b/src/transform-sdk/rust/sr-sys/src/lib.rs
@@ -35,7 +35,9 @@ pub struct AbiSchemaRegistryClient {}
 
 impl AbiSchemaRegistryClient {
     pub fn new() -> AbiSchemaRegistryClient {
-        abi::check();
+        unsafe {
+            abi::check();
+        }
         Self {}
     }
 }
@@ -43,12 +45,13 @@ impl AbiSchemaRegistryClient {
 impl SchemaRegistryClientImpl for AbiSchemaRegistryClient {
     fn lookup_schema_by_id(&self, id: SchemaId) -> Result<Schema> {
         let mut length: i32 = 0;
-        let errno = abi::get_schema_definition_len(id.0, &mut length);
+        let errno = unsafe { abi::get_schema_definition_len(id.0, &mut length) };
         if errno != 0 {
             return Err(SchemaRegistryError::Unknown(errno));
         }
         let mut buf = vec![0; length as usize];
-        let errno_or_amt = get_schema_definition(id.0, buf.as_mut_ptr(), buf.len() as i32);
+        let errno_or_amt =
+            unsafe { get_schema_definition(id.0, buf.as_mut_ptr(), buf.len() as i32) };
         if errno_or_amt < 0 {
             return Err(SchemaRegistryError::Unknown(errno_or_amt));
         }
@@ -61,23 +64,27 @@ impl SchemaRegistryClientImpl for AbiSchemaRegistryClient {
         version: SchemaVersion,
     ) -> Result<SubjectSchema> {
         let mut length: i32 = 0;
-        let errno = abi::get_schema_subject_len(
-            subject.as_ptr(),
-            subject.len() as i32,
-            version.0,
-            &mut length,
-        );
+        let errno = unsafe {
+            abi::get_schema_subject_len(
+                subject.as_ptr(),
+                subject.len() as i32,
+                version.0,
+                &mut length,
+            )
+        };
         if errno != 0 {
             return Err(SchemaRegistryError::Unknown(errno));
         }
         let mut buf = vec![0; length as usize];
-        let errno_or_amt = get_schema_subject(
-            subject.as_ptr(),
-            subject.len() as i32,
-            version.0,
-            buf.as_mut_ptr(),
-            buf.len() as i32,
-        );
+        let errno_or_amt = unsafe {
+            get_schema_subject(
+                subject.as_ptr(),
+                subject.len() as i32,
+                version.0,
+                buf.as_mut_ptr(),
+                buf.len() as i32,
+            )
+        };
         if errno_or_amt < 0 {
             return Err(SchemaRegistryError::Unknown(errno_or_amt));
         }
@@ -96,13 +103,15 @@ impl SchemaRegistryClientImpl for AbiSchemaRegistryClient {
         // version here (take it as a parameter to this method), we should bump the ABI and
         // expose that method.
         let schema_version: i32 = 0;
-        let errno = abi::create_subject_schema(
-            subject.as_ptr(),
-            subject.len() as i32,
-            buf.as_ptr(),
-            buf.len() as i32,
-            &mut schema_id,
-        );
+        let errno = unsafe {
+            abi::create_subject_schema(
+                subject.as_ptr(),
+                subject.len() as i32,
+                buf.as_ptr(),
+                buf.len() as i32,
+                &mut schema_id,
+            )
+        };
         if errno != 0 {
             return Err(SchemaRegistryError::Unknown(errno));
         }

--- a/src/transform-sdk/rust/sr-sys/src/stub_abi.rs
+++ b/src/transform-sdk/rust/sr-sys/src/stub_abi.rs
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub(crate) fn check() {
+pub(crate) unsafe fn check() {
     panic!();
 }
 
-pub(crate) fn get_schema_definition_len(_schema_id: i32, _len: *mut i32) -> i32 {
+pub(crate) unsafe fn get_schema_definition_len(_schema_id: i32, _len: *mut i32) -> i32 {
     panic!();
 }
 
-pub(crate) fn get_schema_definition(_schema_id: i32, _buf: *mut u8, _len: i32) -> i32 {
+pub(crate) unsafe fn get_schema_definition(_schema_id: i32, _buf: *mut u8, _len: i32) -> i32 {
     panic!();
 }
 
-pub(crate) fn get_schema_subject_len(
+pub(crate) unsafe fn get_schema_subject_len(
     _subject: *const u8,
     _subject_len: i32,
     _version: i32,
@@ -33,7 +33,7 @@ pub(crate) fn get_schema_subject_len(
     panic!();
 }
 
-pub(crate) fn get_schema_subject(
+pub(crate) unsafe fn get_schema_subject(
     _subject: *const u8,
     _subject_len: i32,
     _version: i32,
@@ -43,7 +43,7 @@ pub(crate) fn get_schema_subject(
     panic!();
 }
 
-pub(crate) fn create_subject_schema(
+pub(crate) unsafe fn create_subject_schema(
     _subject: *const u8,
     _subject_len: i32,
     _buf: *const u8,


### PR DESCRIPTION
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
n/a

### Bug Fixes

* Unbreak building `sr-sys` crate for `wasm32-wasi` target

### Features
n/a

### Improvements
n/a

