### PR TITLE
model: make next_offset saturate rather than overflow

### DIFF
--- a/src/v/model/fundamental.h
+++ b/src/v/model/fundamental.h
@@ -239,6 +239,8 @@ inline constexpr model::offset_delta offset_delta_cast(model::offset r) {
 inline constexpr model::offset next_offset(model::offset o) {
     if (o < model::offset{0}) {
         return model::offset{0};
+    } else if (o == model::offset::max()) {
+        return model::offset::max();
     }
     return o + model::offset{1};
 }


### PR DESCRIPTION
model::offset::max() is often used to indicate "no upper bound" on operations. E.g. for tiered storage uploads[^1], for reading from local storage[^2], etc.

We also do often convert from closed to opened offset intervals representations. E.g. committed offset to LSO and the other way around.

When combined, these can result in unexpected behaviors. In particular, if on a read path the max offset is specified as model::offset_max() but at lower level this is converted into an exclusive offset by calling next_offset(model::offset::max()), the result is model::offset::min() aka -2^63.

This is dangerous. Let's instead saturate the offset similar to how we saturate prev_offset.

We also have a few cases where we just do `o + model::offset(1)`. These should be refactored to use next_offset too.

This isn't fixing any existing known bug. Discovered this while trying to rewrite some logic related to tiered storage uploads.

[^1]: https://github.com/redpanda-data/redpanda/blob/79bf7eed6e04da1d0987b5abd719c4b289dde761/src/v/archival/ntp_archiver_service.cc#L1656
[^2]: https://github.com/redpanda-data/redpanda/blob/79bf7eed6e04da1d0987b5abd719c4b289dde761/src/v/cluster/migrations/tx_manager_migrator.cc#L219

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
