### PR TITLE
Add missing paths to GHA shell linter workflow

### DIFF
--- a/.github/workflows/lint-sh.yml
+++ b/.github/workflows/lint-sh.yml
@@ -11,6 +11,7 @@ on:
   pull_request:
     paths:
       - '**.sh'
+      -  tests/docker/ducktape-deps/tinygo-wasi-transforms
 
 jobs:
   sh:


### PR DESCRIPTION
Adds missing path to shell linter GHA workflow

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
