### PR TITLE
[CORE-1507] SR: Add support for `?verbose` compatibility checks

### DIFF
--- a/src/go/rpk/pkg/cli/registry/schema/check_compatibility.go
+++ b/src/go/rpk/pkg/cli/registry/schema/check_compatibility.go
@@ -66,7 +66,8 @@ func newCheckCompatibilityCommand(fs afero.Fs, p *config.Params) *cobra.Command 
 				Type:       t,
 				References: references,
 			}
-			compatible, err := cl.CheckCompatibility(cmd.Context(), subject, version, schema)
+			ctx := sr.WithParams(cmd.Context(), sr.Verbose)
+			compatible, err := cl.CheckCompatibility(ctx, subject, version, schema)
 			out.MaybeDie(err, "unable to check compatibility: %v", err)
 			if isText, _, s, err := f.Format(compatCheckResponse{compatible.Is}); !isText {
 				out.MaybeDie(err, "unable to print in the required format %q: %v", f.Kind, err)
@@ -76,6 +77,8 @@ func newCheckCompatibilityCommand(fs afero.Fs, p *config.Params) *cobra.Command 
 				fmt.Println("Schema is compatible.")
 			} else {
 				fmt.Println("Schema is not compatible.")
+				messages := strings.Join(compatible.Messages, "\n")
+				fmt.Println(messages)
 			}
 		},
 	}

--- a/src/v/pandaproxy/api/api-doc/schema_registry.json
+++ b/src/v/pandaproxy/api/api-doc/schema_registry.json
@@ -1136,6 +1136,12 @@
             "schema":  {
               "$ref": "#/definitions/schema_def"
             }
+          },
+          {
+            "name": "verbose",
+            "in": "query",
+            "required": false,
+            "type": "boolean"
           }
         ],
         "produces": ["application/vnd.schemaregistry.v1+json"],
@@ -1145,8 +1151,14 @@
             "schema": {
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "integer"
+                "is_compatible": {
+                  "type": "boolean"
+                },
+                "messages": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               }
             }

--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -13,6 +13,7 @@ v_cc_library(
   SRCS
     api.cc
     configuration.cc
+    compatibility.cc
     handlers.cc
     error.cc
     service.cc

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -17,6 +17,7 @@
 #include "json/stringbuffer.h"
 #include "json/types.h"
 #include "json/writer.h"
+#include "pandaproxy/schema_registry/compatibility.h"
 #include "pandaproxy/schema_registry/error.h"
 #include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/sharded_store.h"
@@ -47,24 +48,57 @@ namespace pandaproxy::schema_registry {
 
 namespace {
 
-bool check_compatible(avro::Node& reader, avro::Node& writer) {
+using avro_compatibility_result = raw_compatibility_result;
+
+avro_compatibility_result check_compatible(
+  avro::Node& reader, avro::Node& writer, std::filesystem::path p = {}) {
+    auto type_to_upper = [](avro::Type t) {
+        auto s = toString(t);
+        std::transform(s.begin(), s.end(), s.begin(), ::toupper);
+        return s;
+    };
+    avro_compatibility_result compat_result;
     if (reader.type() == writer.type()) {
-        // Do a quick check first
-        if (!writer.resolve(reader)) {
-            return false;
+        // Do some quick checks first
+        // These are detectable by the blunt `resolve` check below, but we want
+        // to extract as much error info as possible.
+        if (reader.type() == avro::Type::AVRO_ARRAY) {
+            compat_result.merge(check_compatible(
+              *reader.leafAt(0), *writer.leafAt(0), p / "items"));
+        } else if (reader.hasName() && reader.name() != writer.name()) {
+            compat_result.emplace<avro_incompatibility>(
+              p / "name",
+              avro_incompatibility::Type::name_mismatch,
+              fmt::format("expected: {}", writer.name()));
+        } else if (
+          reader.type() == avro::Type::AVRO_FIXED
+          && reader.fixedSize() != writer.fixedSize()) {
+            compat_result.emplace<avro_incompatibility>(
+              p / "size",
+              avro_incompatibility::Type::fixed_size_mismatch,
+              fmt::format(
+                "expected: {}, found: {}",
+                writer.fixedSize(),
+                reader.fixedSize()));
+        } else if (!writer.resolve(reader)) {
+            // ?? - emplace an UNKNOWN error with the current path
+            compat_result.emplace<avro_incompatibility>(
+              std::move(p), avro_incompatibility::Type::unknown);
+            return compat_result;
         }
+
         if (reader.type() == avro::Type::AVRO_RECORD) {
             // Recursively check fields
+            auto fields_p = p / "fields";
             for (size_t r_idx = 0; r_idx < reader.names(); ++r_idx) {
                 size_t w_idx{0};
                 if (writer.nameIndex(reader.nameAt(int(r_idx)), w_idx)) {
-                    // schemas for fields with the same name in both records are
-                    // resolved recursively.
-                    if (!check_compatible(
-                          *reader.leafAt(int(r_idx)),
-                          *writer.leafAt(int(w_idx)))) {
-                        return false;
-                    }
+                    // schemas for fields with the same name in both records
+                    // are resolved recursively.
+                    compat_result.merge(check_compatible(
+                      *reader.leafAt(int(r_idx)),
+                      *writer.leafAt(int(w_idx)),
+                      fields_p / std::to_string(r_idx) / "type"));
                 } else if (
                   reader.defaultValueAt(int(r_idx)).type() == avro::AVRO_NULL) {
                     // if the reader's record schema has a field with no default
@@ -77,22 +111,32 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
                     if (
                       r_leaf->type() != avro::Type::AVRO_UNION
                       || r_leaf->leafAt(0)->type() != avro::Type::AVRO_NULL) {
-                        return false;
+                        compat_result.emplace<avro_incompatibility>(
+                          fields_p / std::to_string(r_idx),
+                          avro_incompatibility::Type::
+                            reader_field_missing_default_value,
+                          reader.nameAt(r_idx));
                     }
                 }
             }
-            return true;
         } else if (reader.type() == avro::AVRO_ENUM) {
             // if the writer's symbol is not present in the reader's enum and
             // the reader has a default value, then that value is used,
             // otherwise an error is signalled.
-            if (reader.defaultValueAt(0).type() != avro::AVRO_NULL) {
-                return true;
-            }
-            for (size_t w_idx = 0; w_idx < writer.names(); ++w_idx) {
-                size_t r_idx{0};
-                if (!reader.nameIndex(writer.nameAt(int(w_idx)), r_idx)) {
-                    return false;
+            if (reader.defaultValueAt(0).type() == avro::AVRO_NULL) {
+                std::vector<std::string_view> missing;
+                for (size_t w_idx = 0; w_idx < writer.names(); ++w_idx) {
+                    size_t r_idx{0};
+                    if (const auto& n = writer.nameAt(int(w_idx));
+                        !reader.nameIndex(n, r_idx)) {
+                        missing.emplace_back(n);
+                    }
+                }
+                if (!missing.empty()) {
+                    compat_result.emplace<avro_incompatibility>(
+                      p / "symbols",
+                      avro_incompatibility::Type::missing_enum_symbols,
+                      fmt::format("[{}]", fmt::join(missing, ", ")));
                 }
             }
         } else if (reader.type() == avro::AVRO_UNION) {
@@ -104,17 +148,22 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
             for (size_t w_idx = 0; w_idx < writer.leaves(); ++w_idx) {
                 bool is_compat = false;
                 for (size_t r_idx = 0; r_idx < reader.leaves(); ++r_idx) {
-                    if (check_compatible(
-                          *reader.leafAt(int(r_idx)),
-                          *writer.leafAt(int(w_idx)))) {
+                    if (!check_compatible(
+                           *reader.leafAt(int(r_idx)),
+                           *writer.leafAt(int(w_idx)))
+                           .has_error()) {
                         is_compat = true;
                     }
                 }
                 if (!is_compat) {
-                    return false;
+                    compat_result.emplace<avro_incompatibility>(
+                      p / std::to_string(w_idx),
+                      avro_incompatibility::Type::missing_union_branch,
+                      fmt::format(
+                        "reader union lacking writer type: {}",
+                        type_to_upper(writer.leafAt(w_idx)->type())));
                 }
             }
-            return true;
         }
     } else if (reader.type() == avro::AVRO_UNION) {
         // The first schema in the reader's union that matches the writer's
@@ -122,12 +171,21 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
         // signalled.
         //
         // Alternatively, any schema in the reader union must match writer.
+        bool is_compat = false;
         for (size_t r_idx = 0; r_idx < reader.leaves(); ++r_idx) {
-            if (check_compatible(*reader.leafAt(int(r_idx)), writer)) {
-                return true;
+            if (!check_compatible(*reader.leafAt(int(r_idx)), writer)
+                   .has_error()) {
+                is_compat = true;
             }
         }
-        return false;
+        if (!is_compat) {
+            compat_result.emplace<avro_incompatibility>(
+              std::move(p),
+              avro_incompatibility::Type::missing_union_branch,
+              fmt::format(
+                "reader union lacking writer type: {}",
+                type_to_upper(writer.type())));
+        }
     } else if (writer.type() == avro::AVRO_UNION) {
         // If the reader's schema matches the selected writer's schema, it is
         // recursively resolved against it. If they do not match, an error is
@@ -135,13 +193,21 @@ bool check_compatible(avro::Node& reader, avro::Node& writer) {
         //
         // Alternatively, reader must match all schema in writer union.
         for (size_t w_idx = 0; w_idx < writer.leaves(); ++w_idx) {
-            if (!check_compatible(reader, *writer.leafAt(int(w_idx)))) {
-                return false;
-            }
+            compat_result.merge(
+              check_compatible(reader, *writer.leafAt(int(w_idx)), p));
         }
-        return true;
+    } else if (writer.resolve(reader) == avro::RESOLVE_NO_MATCH) {
+        // NOTE(oren): this may be too general. always a type mismatch?
+        compat_result.emplace<avro_incompatibility>(
+          std::move(p),
+          avro_incompatibility::Type::type_mismatch,
+          fmt::format(
+            "reader type: {} not compatible with writer type: {}",
+            type_to_upper(reader.type()),
+            type_to_upper(writer.type())));
     }
-    return writer.resolve(reader) != avro::RESOLVE_NO_MATCH;
+
+    return compat_result;
 }
 
 enum class object_type { complex, field };
@@ -534,7 +600,9 @@ sanitize_avro_schema_definition(unparsed_schema_definition def) {
 
 bool check_compatible(
   const avro_schema_definition& reader, const avro_schema_definition& writer) {
-    return check_compatible(*reader().root(), *writer().root());
+    return check_compatible(
+             *reader().root(), *writer().root(), "/")(verbose::no)
+      .is_compat;
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/avro.cc
+++ b/src/v/pandaproxy/schema_registry/avro.cc
@@ -598,11 +598,12 @@ sanitize_avro_schema_definition(unparsed_schema_definition def) {
       def.refs()};
 }
 
-bool check_compatible(
-  const avro_schema_definition& reader, const avro_schema_definition& writer) {
+compatibility_result check_compatible(
+  const avro_schema_definition& reader,
+  const avro_schema_definition& writer,
+  verbose is_verbose) {
     return check_compatible(
-             *reader().root(), *writer().root(), "/")(verbose::no)
-      .is_compat;
+      *reader().root(), *writer().root(), "/")(is_verbose);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/avro.h
+++ b/src/v/pandaproxy/schema_registry/avro.h
@@ -23,7 +23,9 @@ make_avro_schema_definition(sharded_store& store, canonical_schema schema);
 result<canonical_schema_definition>
 sanitize_avro_schema_definition(unparsed_schema_definition def);
 
-bool check_compatible(
-  const avro_schema_definition& reader, const avro_schema_definition& writer);
+compatibility_result check_compatible(
+  const avro_schema_definition& reader,
+  const avro_schema_definition& writer,
+  verbose is_verbose = verbose::no);
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/compatibility.cc
+++ b/src/v/pandaproxy/schema_registry/compatibility.cc
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "pandaproxy/schema_registry/compatibility.h"
+
+namespace pandaproxy::schema_registry {
+
+std::ostream& operator<<(std::ostream& os, const avro_incompatibility_type& t) {
+    switch (t) {
+    case avro_incompatibility_type::name_mismatch:
+        return os << "NAME_MISMATCH";
+    case avro_incompatibility_type::fixed_size_mismatch:
+        return os << "FIXED_SIZE_MISMATCH";
+    case avro_incompatibility_type::missing_enum_symbols:
+        return os << "MISSING_ENUM_SYMBOLS";
+    case avro_incompatibility_type::reader_field_missing_default_value:
+        return os << "READER_FIELD_MISSING_DEFAULT_VALUE";
+    case avro_incompatibility_type::type_mismatch:
+        return os << "TYPE_MISMATCH";
+    case avro_incompatibility_type::missing_union_branch:
+        return os << "MISSING_UNION_BRANCH";
+    case avro_incompatibility_type::unknown:
+        return os << "UNKNOWN";
+    };
+    __builtin_unreachable();
+}
+
+std::string_view description_for_type(avro_incompatibility_type t) {
+    switch (t) {
+    case avro_incompatibility_type::name_mismatch:
+        return "The name of the schema has changed (path '{path}')";
+    case avro_incompatibility_type::fixed_size_mismatch:
+        return "The size of FIXED type field at path '{path}' in the "
+               "{{reader}} schema does not match with the {{writer}} schema";
+    case avro_incompatibility_type::missing_enum_symbols:
+        return "The {{reader}} schema is missing enum symbols '{additional}' "
+               "at path '{path}' in the {{writer}} schema";
+    case avro_incompatibility_type::reader_field_missing_default_value:
+        return "The field '{additional}' at path '{path}' in the {{reader}} "
+               "schema has "
+               "no default value and is missing in the {{writer}}";
+    case avro_incompatibility_type::type_mismatch:
+        return "The type (path '{path}') of a field in the {{reader}} schema "
+               "does not match with the {{writer}} schema";
+    case avro_incompatibility_type::missing_union_branch:
+        return "The {{reader}} schema is missing a type inside a union field "
+               "at path '{path}' in the {{writer}} schema";
+    case avro_incompatibility_type::unknown:
+        return "{{reader}} schema is not compatible with {{writer}} schema: "
+               "check '{path}'";
+    };
+    __builtin_unreachable();
+}
+
+std::ostream& operator<<(std::ostream& os, const avro_incompatibility& v) {
+    return os << fmt::format(
+             "{{errorType:'{}', description:'{}', additionalInfo:'{}'}}",
+             v._type,
+             v.describe(),
+             v._additional_info);
+}
+
+ss::sstring avro_incompatibility::describe() const {
+    return fmt::format(
+      fmt::runtime(description_for_type(_type)),
+      fmt::arg("path", _path.string()),
+      fmt::arg("additional", _additional_info));
+}
+
+std::ostream&
+operator<<(std::ostream& os, const proto_incompatibility_type& t) {
+    switch (t) {
+    case proto_incompatibility_type::message_removed:
+        return os << "MESSAGE_REMOVED";
+    case proto_incompatibility_type::field_kind_changed:
+        return os << "FIELD_KIND_CHANGED";
+    case proto_incompatibility_type::field_scalar_kind_changed:
+        return os << "FIELD_SCALAR_KIND_CHANGED";
+    case proto_incompatibility_type::field_named_type_changed:
+        return os << "FIELD_NAMED_TYPE_CHANGED";
+    case proto_incompatibility_type::required_field_added:
+        return os << "REQUIRED_FIELD_ADDED";
+    case proto_incompatibility_type::required_field_removed:
+        return os << "REQUIRED_FIELD_REMOVED";
+    case proto_incompatibility_type::oneof_field_removed:
+        return os << "ONEOF_FIELD_REMOVED";
+    case proto_incompatibility_type::multiple_fields_moved_to_oneof:
+        return os << "MULTIPLE_FIELDS_MOVED_TO_ONEOF";
+    case proto_incompatibility_type::unknown:
+        return os << "UNKNOWN";
+    }
+    __builtin_unreachable();
+}
+
+std::string_view description_for_type(proto_incompatibility_type t) {
+    switch (t) {
+    case proto_incompatibility_type::message_removed:
+        return "The {{reader}} schema is missing a field of type MESSAGE at "
+               "path '{path}' in the {{writer}} schema";
+    case proto_incompatibility_type::field_kind_changed:
+        return "The type of a field at path '{path}' in the {{reader}} "
+               "schema does  not match the {{writer}} schema";
+    case proto_incompatibility_type::field_scalar_kind_changed:
+        return "The kind of a SCALAR field at path '{path}' in the {{reader}} "
+               "schema does not match its kind in the {{writer}} schema";
+    case proto_incompatibility_type::field_named_type_changed:
+        return "The type of a MESSAGE field at path '{path}' in the {{reader}} "
+               "schema does not match its type in the {{writer}} schema ";
+    case proto_incompatibility_type::required_field_added:
+        return "A required field  at path '{path}' in the {{reader}} schema "
+               "is missing in the {{writer}} schema";
+    case proto_incompatibility_type::required_field_removed:
+        return "The {{reader}} schema is missing a required field at path: "
+               "'{path}' in the {{writer}} schema";
+    case proto_incompatibility_type::oneof_field_removed:
+        return "The {{reader}} schema is missing a oneof field at path "
+               "'{path}' in the {{writer}} schema";
+    case proto_incompatibility_type::multiple_fields_moved_to_oneof:
+        return "Multiple fields in the oneof at path '{path}' in the "
+               "{{reader}} schema are outside a oneof in the {{writer}} "
+               "schema ";
+    case proto_incompatibility_type::unknown:
+        return "{{reader}} schema is not compatible with {{writer}} schema: "
+               "check '{path}'";
+    }
+    __builtin_unreachable();
+}
+
+std::ostream& operator<<(std::ostream& os, const proto_incompatibility& v) {
+    return os << fmt::format(
+             "{{errorType:'{}', description:'{}'}}", v._type, v.describe());
+}
+
+ss::sstring proto_incompatibility::describe() const {
+    return fmt::format(
+      fmt::runtime(description_for_type(_type)),
+      fmt::arg("path", _path.string()));
+}
+
+compatibility_result
+raw_compatibility_result::operator()(verbose is_verbose) && {
+    compatibility_result result = {.is_compat = !has_error()};
+    if (is_verbose) {
+        result.messages.reserve(_errors.size());
+        std::transform(
+          std::make_move_iterator(_errors.begin()),
+          std::make_move_iterator(_errors.end()),
+          std::back_inserter(result.messages),
+          [](auto e) {
+              return std::visit(
+                [](auto&& e) { return fmt::format("{{{}}}", e); }, e);
+          });
+    }
+    return result;
+}
+
+void raw_compatibility_result::merge(raw_compatibility_result&& other) {
+    _errors.reserve(_errors.size() + other._errors.size());
+    std::move(
+      other._errors.begin(), other._errors.end(), std::back_inserter(_errors));
+}
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/compatibility.h
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/vassert.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <fmt/format.h>
+
+#include <filesystem>
+#include <string_view>
+#include <vector>
+
+/**
+ * compatibility.h
+ *
+ * Support classes for tracking, accumulating, and emitting formatted error
+ * messages while checking compatibility of avro & protobuf schemas.
+ *
+ * See avro.cc and protobuf.cc for usage.
+ *
+ */
+
+namespace pandaproxy::schema_registry {
+
+enum class avro_incompatibility_type {
+    name_mismatch = 0,
+    fixed_size_mismatch,
+    missing_enum_symbols,
+    reader_field_missing_default_value,
+    type_mismatch,
+    missing_union_branch,
+    unknown,
+};
+
+/**
+ * avro_incompatibility - A single incompatibility between Avro schemas.
+ *
+ * Encapsulates:
+ *   - the path to the location of the incompatibility in the _writer_ schema
+ *   - the type of incompatibility
+ *   - any additional context for the incompatibility (e.g. a field name)
+ *
+ * Primary interface is `describe`, which combines the contained info into
+ * a format string which can then be interpolated with identifying info for
+ * the reader and writer schema in the request handler.
+ */
+class avro_incompatibility {
+public:
+    using Type = avro_incompatibility_type;
+    avro_incompatibility(
+      std::filesystem::path path, Type type, std::string_view info)
+      : _path(std::move(path))
+      , _type(type)
+      , _additional_info(info) {}
+
+    avro_incompatibility(std::filesystem::path path, Type type)
+      : avro_incompatibility(std::move(path), type, "") {}
+
+    ss::sstring describe() const;
+
+private:
+    friend std::ostream&
+    operator<<(std::ostream& os, const avro_incompatibility& v);
+
+    friend bool
+    operator==(const avro_incompatibility&, const avro_incompatibility&)
+      = default;
+
+    // Useful for unit testing
+    template<typename H>
+    friend H AbslHashValue(H h, const avro_incompatibility& e) {
+        return H::combine(
+          std::move(h), e._path.string(), e._type, e._additional_info);
+    }
+
+    std::filesystem::path _path;
+    Type _type;
+    ss::sstring _additional_info;
+};
+
+enum class proto_incompatibility_type {
+    message_removed = 0,
+    field_kind_changed,
+    field_scalar_kind_changed,
+    field_named_type_changed,
+    required_field_added,
+    required_field_removed,
+    oneof_field_removed,
+    multiple_fields_moved_to_oneof,
+    unknown,
+};
+
+/**
+ * proto_incompatibility - A single incompatibility between Protobuf schemas.
+ *
+ * Encapsulates:
+ *   - the path to the location of the incompatibility in the _writer_ schema
+ *   - the type of incompatibility
+ *
+ * Primary interface is `describe`, which combines the contained info into
+ * a format string which can then be interpolated with identifying info for
+ * the reader and writer schemas in the request handler.
+ */
+class proto_incompatibility {
+public:
+    using Type = proto_incompatibility_type;
+    proto_incompatibility(std::filesystem::path path, Type type)
+      : _path(std::move(path))
+      , _type(type) {}
+
+    ss::sstring describe() const;
+    Type type() const { return _type; }
+
+private:
+    friend std::ostream&
+    operator<<(std::ostream& os, const proto_incompatibility& v);
+
+    friend bool
+    operator==(const proto_incompatibility&, const proto_incompatibility&)
+      = default;
+
+    // Helpful for unit testing
+    template<typename H>
+    friend H AbslHashValue(H h, const proto_incompatibility& e) {
+        return H::combine(std::move(h), e._path.string(), e._type);
+    }
+
+    std::filesystem::path _path;
+    Type _type;
+};
+
+/**
+ * raw_compatibility_result - A collection of unformatted proto or avro
+ * incompatibilities. Its purpose is twofold:
+ *   - Provide an abstracted way to accumulate incompatibilities across
+ *     a recursive call chain. The `merge` function makes this simple
+ *     and seeks to avoid excessive copying.
+ *   - Provide a (type-constrained) generic means to process raw
+ *     incompatibilities into formatted error messages.
+ *
+ */
+class raw_compatibility_result {
+    using schema_incompatibility
+      = std::variant<avro_incompatibility, proto_incompatibility>;
+
+public:
+    raw_compatibility_result() = default;
+
+    template<typename T, typename... Args>
+    requires requires(schema_incompatibility si, Args&&... args) {
+        { std::get<T>(si) } -> std::convertible_to<T>;
+        { T{std::forward<Args>(args)...} } -> std::convertible_to<T>;
+    }
+    auto emplace(Args&&... args) {
+        return _errors.emplace_back(T{std::forward<Args>(args)...});
+    }
+
+    compatibility_result operator()(verbose is_verbose) &&;
+
+    // Move the contents of other into the errors vec of this
+    void merge(raw_compatibility_result&& other);
+
+    bool has_error() const { return !_errors.empty(); }
+
+    operator bool() const { return !has_error(); }
+
+private:
+    std::vector<schema_incompatibility> _errors{};
+};
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -542,14 +542,22 @@ struct compatibility_checker {
                                     == pb::FieldDescriptor::Type::TYPE_MESSAGE
                                   || reader->type()
                                        == pb::FieldDescriptor::Type::TYPE_GROUP;
-            if (type_is_compat) {
+
+            if (!type_is_compat) {
+                compat_result.emplace<proto_incompatibility>(
+                  std::move(p),
+                  proto_incompatibility::Type::field_kind_changed);
+            } else if (
+              reader->message_type()->name()
+              != writer->message_type()->name()) {
+                compat_result.emplace<proto_incompatibility>(
+                  std::move(p),
+                  proto_incompatibility::Type::field_named_type_changed);
+            } else {
                 compat_result.merge(check_compatible(
                   reader->message_type(),
                   writer->message_type(),
                   std::move(p)));
-            } else {
-                compat_result.emplace_error(
-                  p, proto_incompatibility::Type::field_kind_changed);
             }
             break;
         }

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -693,11 +693,12 @@ struct compatibility_checker {
 
 } // namespace
 
-bool check_compatible(
+compatibility_result check_compatible(
   const protobuf_schema_definition& reader,
-  const protobuf_schema_definition& writer) {
+  const protobuf_schema_definition& writer,
+  verbose is_verbose) {
     compatibility_checker checker{reader(), writer()};
-    return checker.check_compatible("#/")(verbose::no).is_compat;
+    return checker.check_compatible("#/")(is_verbose);
 }
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/protobuf.cc
+++ b/src/v/pandaproxy/schema_registry/protobuf.cc
@@ -502,6 +502,17 @@ struct compatibility_checker {
             return compat_result;
         }
 
+        for (int i = 0; i < writer->nested_type_count(); ++i) {
+            auto w = writer->nested_type(i);
+            auto r = reader->FindNestedTypeByName(w->full_name());
+            if (!r) {
+                compat_result.emplace<proto_incompatibility>(
+                  p / w->name(), proto_incompatibility::Type::message_removed);
+            } else {
+                compat_result.merge(check_compatible(r, w, p / w->name()));
+            }
+        }
+
         for (int i = 0; i < writer->field_count(); ++i) {
             if (reader->IsReservedNumber(i) || writer->IsReservedNumber(i)) {
                 continue;

--- a/src/v/pandaproxy/schema_registry/protobuf.h
+++ b/src/v/pandaproxy/schema_registry/protobuf.h
@@ -25,8 +25,9 @@ validate_protobuf_schema(sharded_store& store, canonical_schema schema);
 ss::future<canonical_schema>
 make_canonical_protobuf_schema(sharded_store& store, unparsed_schema schema);
 
-bool check_compatible(
+compatibility_result check_compatible(
   const protobuf_schema_definition& reader,
-  const protobuf_schema_definition& writer);
+  const protobuf_schema_definition& writer,
+  verbose is_verbose = verbose::no);
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/requests/compatibility.h
+++ b/src/v/pandaproxy/schema_registry/requests/compatibility.h
@@ -18,6 +18,7 @@ namespace pandaproxy::schema_registry {
 
 struct post_compatibility_res {
     bool is_compat{false};
+    std::vector<ss::sstring> messages;
 };
 
 inline void rjson_serialize(
@@ -26,6 +27,8 @@ inline void rjson_serialize(
     w.StartObject();
     w.Key("is_compatible");
     ::json::rjson_serialize(w, res.is_compat);
+    w.Key("messages");
+    ::json::rjson_serialize(w, res.messages);
     w.EndObject();
 }
 

--- a/src/v/pandaproxy/schema_registry/sharded_store.cc
+++ b/src/v/pandaproxy/schema_registry/sharded_store.cc
@@ -47,13 +47,14 @@ ss::shard_id shard_for(schema_id id) {
     return jump_consistent_hash(id(), ss::smp::count);
 }
 
-bool check_compatible(const valid_schema& reader, const valid_schema& writer) {
-    return reader.visit([&](const auto& reader) {
-        return writer.visit([&](const auto& writer) {
+compatibility_result check_compatible(
+  const valid_schema& reader, const valid_schema& writer, verbose is_verbose) {
+    return reader.visit([&](const auto& reader) -> compatibility_result {
+        return writer.visit([&](const auto& writer) -> compatibility_result {
             if constexpr (std::is_same_v<decltype(reader), decltype(writer)>) {
-                return check_compatible(reader, writer);
+                return check_compatible(reader, writer, is_verbose);
             }
-            return false;
+            return {.is_compat = false};
         });
     });
 }
@@ -647,6 +648,18 @@ ss::future<> sharded_store::maybe_update_max_schema_id(schema_id id) {
 
 ss::future<bool> sharded_store::is_compatible(
   schema_version version, canonical_schema new_schema) {
+    auto rslt = co_await do_is_compatible(
+      version, std::move(new_schema), verbose::no);
+    co_return rslt.is_compat;
+}
+
+ss::future<compatibility_result> sharded_store::is_compatible(
+  schema_version version, canonical_schema new_schema, verbose is_verbose) {
+    return do_is_compatible(version, std::move(new_schema), is_verbose);
+}
+
+ss::future<compatibility_result> sharded_store::do_is_compatible(
+  schema_version version, canonical_schema new_schema, verbose is_verbose) {
     // Lookup the version_ids
     const auto& sub = new_schema.sub();
     const auto versions = co_await _store.invoke_on(
@@ -672,16 +685,22 @@ ss::future<bool> sharded_store::is_compatible(
     auto old_schema = co_await get_subject_schema(
       sub, version, include_deleted::no);
 
-    // Types must always match
-    if (old_schema.schema.type() != new_schema.type()) {
-        co_return false;
-    }
-
     // Lookup the compatibility level
     auto compat = co_await get_compatibility(sub, default_to_global::yes);
 
+    // Types must always match
+    if (old_schema.schema.type() != new_schema.type()) {
+        compatibility_result result{.is_compat = false};
+        if (is_verbose) {
+            result.messages = {
+              "Incompatible because of different schema type",
+              fmt::format("{{compatibility: {}}}", compat)};
+        }
+        co_return result;
+    }
+
     if (compat == compatibility_level::none) {
-        co_return true;
+        co_return compatibility_result{.is_compat = true};
     }
 
     // Currently support PROTOBUF, AVRO
@@ -701,8 +720,18 @@ ss::future<bool> sharded_store::is_compatible(
 
     auto new_valid = co_await make_valid_schema(new_schema);
 
-    auto is_compat = true;
-    for (; is_compat && ver_it != versions.end(); ++ver_it) {
+    compatibility_result result{.is_compat = true};
+
+    auto formatter = [](std::string_view rdr, std::string_view wrtr) {
+        return [rdr, wrtr](std::string_view msg) {
+            return fmt::format(
+              fmt::runtime(msg),
+              fmt::arg("reader", rdr),
+              fmt::arg("writer", wrtr));
+        };
+    };
+
+    for (; result.is_compat && ver_it != versions.end(); ++ver_it) {
         if (ver_it->deleted) {
             continue;
         }
@@ -711,22 +740,56 @@ ss::future<bool> sharded_store::is_compatible(
           sub, ver_it->version, include_deleted::no);
         auto old_valid = co_await make_valid_schema(old_schema.schema);
 
+        std::vector<ss::sstring> version_messages;
+
         if (
           compat == compatibility_level::backward
           || compat == compatibility_level::backward_transitive
           || compat == compatibility_level::full
           || compat == compatibility_level::full_transitive) {
-            is_compat = is_compat && check_compatible(new_valid, old_valid);
+            auto r = check_compatible(new_valid, old_valid, is_verbose);
+            result.is_compat = result.is_compat && r.is_compat;
+            version_messages.reserve(
+              version_messages.size() + r.messages.size());
+            std::transform(
+              std::make_move_iterator(r.messages.begin()),
+              std::make_move_iterator(r.messages.end()),
+              std::back_inserter(version_messages),
+              formatter("new", "old"));
         }
         if (
           compat == compatibility_level::forward
           || compat == compatibility_level::forward_transitive
           || compat == compatibility_level::full
           || compat == compatibility_level::full_transitive) {
-            is_compat = is_compat && check_compatible(old_valid, new_valid);
+            auto r = check_compatible(old_valid, new_valid, is_verbose);
+            result.is_compat = result.is_compat && r.is_compat;
+            version_messages.reserve(
+              version_messages.size() + r.messages.size());
+            std::transform(
+              std::make_move_iterator(r.messages.begin()),
+              std::make_move_iterator(r.messages.end()),
+              std::back_inserter(version_messages),
+              formatter("old", "new"));
         }
+
+        if (!version_messages.empty()) {
+            version_messages.emplace_back(
+              fmt::format("{{oldSchemaVersion: {}}}", old_schema.version));
+            version_messages.emplace_back(
+              fmt::format("{{oldSchema: '{}'}}", old_valid.raw()));
+            version_messages.emplace_back(
+              fmt::format("{{compatibility: {}}}", compat));
+        }
+
+        result.messages.reserve(
+          result.messages.size() + version_messages.size());
+        std::move(
+          version_messages.begin(),
+          version_messages.end(),
+          std::back_inserter(result.messages));
     }
-    co_return is_compat;
+    co_return result;
 }
 
 void sharded_store::check_mode_mutability(force f) const {

--- a/src/v/pandaproxy/schema_registry/sharded_store.h
+++ b/src/v/pandaproxy/schema_registry/sharded_store.h
@@ -175,12 +175,24 @@ public:
     ss::future<bool>
     is_compatible(schema_version version, canonical_schema new_schema);
 
+    ///\brief Check if the provided schema is compatible with the subject and
+    /// version, according the the current compatibility, with the result
+    /// optionally accompanied by a vector of detailed error messages.
+    ///
+    /// If the compatibility level is transitive, then all versions are checked,
+    /// otherwise checks are against the version provided and newer.
+    ss::future<compatibility_result> is_compatible(
+      schema_version version, canonical_schema new_schema, verbose is_verbose);
+
     ss::future<bool> has_version(const subject&, schema_id, include_deleted);
 
     //// \brief Throw if the store is not mutable
     void check_mode_mutability(force f) const;
 
 private:
+    ss::future<compatibility_result> do_is_compatible(
+      schema_version version, canonical_schema new_schema, verbose is_verbose);
+
     ss::future<bool>
     upsert_schema(schema_id id, canonical_schema_definition def);
 

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -18,6 +18,7 @@ rp_test(
   SOURCES
     sharded_store.cc
     consume_to_store.cc
+    compatibility_common.cc
     compatibility_store.cc
     compatibility_3rdparty.cc
     compatibility_avro.cc

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.cc
@@ -23,12 +23,13 @@ bool check_compatible(
   const pps::canonical_schema_definition& w) {
     pps::sharded_store s;
     return check_compatible(
-      pps::make_avro_schema_definition(
-        s, {pps::subject("r"), {r.raw(), pps::schema_type::avro}})
-        .get(),
-      pps::make_avro_schema_definition(
-        s, {pps::subject("w"), {w.raw(), pps::schema_type::avro}})
-        .get());
+             pps::make_avro_schema_definition(
+               s, {pps::subject("r"), {r.raw(), pps::schema_type::avro}})
+               .get(),
+             pps::make_avro_schema_definition(
+               s, {pps::subject("w"), {w.raw(), pps::schema_type::avro}})
+               .get())
+      .is_compat;
 }
 
 SEASTAR_THREAD_TEST_CASE(test_avro_type_promotion) {

--- a/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_avro.h
@@ -137,6 +137,8 @@ const auto union2 = pps::sanitize_avro_schema_definition(
                        pps::schema_type::avro})
                       .value();
 
+// NOTE(oren): arrays shouldn't have names...is this intentional? sanitizer
+// seems to filter it out?
 const auto int_array = pps::sanitize_avro_schema_definition(
                          {R"({
   "name": "test2",

--- a/src/v/pandaproxy/schema_registry/test/compatibility_common.cc
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_common.cc
@@ -1,0 +1,28 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <absl/container/flat_hash_set.h>
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include <iostream>
+
+namespace std {
+
+std::ostream&
+operator<<(std::ostream& os, const absl::flat_hash_set<ss::sstring>& d) {
+    fmt::print(os, "{}", fmt::join(d, "\n"));
+    return os;
+}
+
+} // namespace std

--- a/src/v/pandaproxy/schema_registry/test/compatibility_common.h
+++ b/src/v/pandaproxy/schema_registry/test/compatibility_common.h
@@ -1,0 +1,53 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/compatibility.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <absl/container/flat_hash_set.h>
+
+namespace pps = pandaproxy::schema_registry;
+
+enum class test_schema_type {
+    AVRO = 1,
+    PROTO2 = 2,
+    PROTO3 = 3,
+};
+
+template<typename incompatibility>
+struct compat_test_data {
+    compat_test_data(
+      pps::canonical_schema_definition reader,
+      pps::canonical_schema_definition writer,
+      test_schema_type schema_type,
+      absl::flat_hash_set<incompatibility> exp)
+      : reader(std::move(reader))
+      , writer(std::move(writer)) {
+        if constexpr (std::is_same_v<
+                        incompatibility,
+                        pps::proto_incompatibility>) {
+            absl::erase_if(exp, [schema_type](const auto& e) {
+                return schema_type == test_schema_type::PROTO3
+                  && (e.type() == incompatibility::Type::required_field_removed || //
+                      e.type() == incompatibility::Type::required_field_added);
+            });
+        }
+        expected = [&exp]() {
+            pps::raw_compatibility_result raw;
+            absl::c_for_each(std::move(exp), [&raw](auto e) {
+                raw.emplace<incompatibility>(std::move(e));
+            });
+            return std::move(raw)(pps::verbose::yes);
+        }();
+    }
+
+    pps::canonical_schema_definition reader;
+    pps::canonical_schema_definition writer;
+    pps::compatibility_result expected;
+};

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -34,6 +34,7 @@ using include_deleted = ss::bool_class<struct include_deleted_tag>;
 using is_deleted = ss::bool_class<struct is_deleted_tag>;
 using default_to_global = ss::bool_class<struct default_to_global_tag>;
 using force = ss::bool_class<struct force_tag>;
+using verbose = ss::bool_class<struct verbose_tag>;
 
 template<typename E>
 std::enable_if_t<std::is_enum_v<E>, std::optional<E>>
@@ -449,5 +450,10 @@ from_string_view<compatibility_level>(std::string_view sv) {
         compatibility_level::full_transitive)
       .default_match(std::nullopt);
 }
+
+struct compatibility_result {
+    bool is_compat;
+    std::vector<ss::sstring> messages;
+};
 
 } // namespace pandaproxy::schema_registry

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -13,6 +13,7 @@ import json
 from typing import Optional
 import uuid
 import re
+import urllib.parse
 import requests
 import time
 import random
@@ -80,6 +81,7 @@ schema1_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":
 schema2_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":["null","string"]},{"name":"f2","type":"string","default":"foo"}]}'
 # Schema 3 is not backwards compatible
 schema3_def = '{"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"},{"name":"f2","type":"string"}]}'
+
 invalid_avro = '{"type":"notatype","name":"myrecord","fields":[{"name":"f1","type":"string"}]}'
 
 simple_proto_def = """
@@ -97,6 +99,95 @@ import "simple";
 message Test2 {
   Simple id =  1;
 }"""
+
+validation_schemas = dict(
+    proto3="""
+syntax = "proto3";
+
+message myrecord {
+  message Msg1 {
+    int32 f1 = 1; 
+  }
+  Msg1 m1 = 1;
+  Msg1 m2 = 2;
+}
+""",
+    proto3_incompat="""
+syntax = "proto3";
+
+message myrecord {
+  // MESSAGE_REMOVED
+  message Msg1d {
+    int32 f1 = 1;
+  }
+  // FIELD_NAMED_TYPE_CHANGED
+  Msg1d m1 = 1;
+}
+""",
+    proto2="""
+syntax = "proto2";
+
+message myrecord {
+  message Msg1 {
+    required int32 f1 = 1; 
+  }
+  required Msg1 m1 = 1;
+  required Msg1 m2 = 2;
+}
+""",
+    proto2_incompat="""
+syntax = "proto2";
+
+message myrecord {
+  // MESSAGE_REMOVED
+  message Msg1d {
+    required int32 f1 = 1;
+  }
+  // FIELD_NAMED_TYPE_CHANGED
+  required Msg1d m1 = 1;
+}
+""",
+    avro="""
+{
+    "type": "record",
+    "name": "myrecord",
+    "fields": [
+        {
+            "name": "f1",
+            "type": "string"
+        },
+        {
+            "name": "enumF",
+            "type": {
+                "name": "ABorC",
+                "type": "enum",
+                "symbols": ["a", "b", "c"]
+            }           
+        }
+    ]
+}
+""",
+    avro_incompat="""
+{
+    "type": "record",
+    "name": "myrecord",
+    "fields": [
+        {
+            "name": "f1",
+            "type": "int"
+        },
+        {
+            "name": "enumF",
+            "type": {
+                "name": "ABorC",
+                "type": "enum",
+                "symbols": ["a"]
+            }           
+        }
+    ]
+}
+""",
+)
 
 log_config = LoggingConfig('info',
                            logger_levels={
@@ -484,10 +575,15 @@ class SchemaRegistryEndpoints(RedpandaTest):
                                             version,
                                             data,
                                             headers=HTTP_POST_HEADERS,
+                                            verbose: bool | None = None,
                                             **kwargs):
+        params = ''
+        if verbose is not None:
+            params = f"?{urllib.parse.urlencode({'verbose': str(verbose).lower()})}"
+
         return self._request(
             "POST",
-            f"compatibility/subjects/{subject}/versions/{version}",
+            f"compatibility/subjects/{subject}/versions/{version}{params}",
             headers=headers,
             data=data,
             **kwargs)
@@ -1060,6 +1156,7 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             subject=f"{topic}-key", version=1, data=schema_2_data)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["is_compatible"] == True
+        assert len(result_raw.json()["messages"]) == 0
 
         self.logger.debug("Set subject config - BACKWARD")
         result_raw = self._set_config_subject(
@@ -1072,14 +1169,32 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             subject=f"{topic}-key", version=1, data=schema_2_data)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["is_compatible"] == True
+        assert len(result_raw.json()["messages"]) == 0
 
-        self.logger.debug("Check compatibility backward, no default")
+        self.logger.debug("Check compatibility backward, no default, verbose")
         result_raw = self._post_compatibility_subject_version(
-            subject=f"{topic}-key", version=1, data=schema_3_data)
+            subject=f"{topic}-key",
+            version=1,
+            data=schema_3_data,
+            verbose=True)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["is_compatible"] == False
 
+        self.logger.debug(
+            "Check compatibility backward, no default, not verbose")
+        result_raw = self._post_compatibility_subject_version(
+            subject=f"{topic}-key",
+            version=1,
+            data=schema_3_data,
+            verbose=False)
+        assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json()["is_compatible"] == False
+        assert not result_raw.json().get(
+            "messages",
+            None), f"Expected no messages, got {result_raw.json()['messages']}"
+
         self.logger.debug("Posting incompatible schema 3 as a subject key")
+
         result_raw = self._post_subjects_subject_versions(
             subject=f"{topic}-key", data=schema_3_data)
         assert result_raw.status_code == requests.codes.conflict
@@ -1108,6 +1223,79 @@ class SchemaRegistryTestMethods(SchemaRegistryEndpoints):
             subject=f"{topic}-key", data=schema_1_data)
         assert result_raw.status_code == requests.codes.ok
         assert result_raw.json()["id"] == v1_id
+
+    p3_errs: list[tuple] = [
+        ("MESSAGE_REMOVED", "#/myrecord/Msg1"),
+        ("FIELD_NAMED_TYPE_CHANGED", "#/myrecord/1"),
+    ]
+    p2_errs: list[tuple] = p3_errs + [
+        ("REQUIRED_FIELD_REMOVED", "#/myrecord/2"),
+    ]
+    av_errs: list[tuple] = [
+        ("TYPE_MISMATCH", "/fields/0/type"),
+        ("MISSING_ENUM_SYMBOLS", "/fields/1/type/symbols"),
+    ]
+    EXPECTED_INCOMPATIBILITIES: dict[str, list[tuple]] = {
+        "proto3_incompat": p3_errs,
+        "proto2_incompat": p2_errs,
+        "avro_incompat": av_errs,
+    }
+
+    @cluster(num_nodes=3)
+    @parametrize(schemas=("avro", "avro_incompat", "AVRO"))
+    @parametrize(schemas=("proto3", "proto3_incompat", "PROTOBUF"))
+    @parametrize(schemas=("proto2", "proto2_incompat", "PROTOBUF"))
+    def test_compatibility_messages(self, schemas):
+        """
+        Verify compatibility messages
+        """
+
+        topic = create_topic_names(1)[0]
+
+        self.logger.debug(f"Register a schema against a subject")
+        schema_data = json.dumps({
+            "schema": validation_schemas[schemas[0]],
+            "schemaType": schemas[2],
+        })
+        incompatible_data = json.dumps({
+            "schema": validation_schemas[schemas[1]],
+            "schemaType": schemas[2],
+        })
+
+        super_username, super_password, _ = self.redpanda.SUPERUSER_CREDENTIALS
+
+        self.logger.debug("Posting schema as a subject key")
+        result_raw = self._post_subjects_subject_versions(
+            subject=f"{topic}-key", data=schema_data)
+        self.logger.debug(result_raw)
+        assert result_raw.status_code == requests.codes.ok
+        v1_id = result_raw.json()["id"]
+
+        self.logger.debug("Set subject config - BACKWARD")
+        result_raw = self._set_config_subject(
+            subject=f"{topic}-key",
+            data=json.dumps({"compatibility": "BACKWARD"}))
+        assert result_raw.status_code == requests.codes.ok
+
+        self.logger.debug("Check compatibility full")
+        result_raw = self._post_compatibility_subject_version(
+            subject=f"{topic}-key",
+            version=1,
+            data=incompatible_data,
+            verbose=True)
+
+        assert result_raw.status_code == requests.codes.ok
+        assert result_raw.json()["is_compatible"] == False
+        msgs = result_raw.json()["messages"]
+        for message in ["oldSchemaVersion", "oldSchema", "compatibility"]:
+            assert any(
+                message in m for m in msgs
+            ), f"Expected to find an instance of '{message}', got {msgs}"
+
+        expected_errs = self.EXPECTED_INCOMPATIBILITIES[schemas[1]]
+        for e in expected_errs:
+            assert any(e[0] in m and e[1] in m
+                       for m in msgs), f"Expected {e} in messages, got {msgs}"
 
     @cluster(num_nodes=3)
     def test_delete_subject(self):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Some side effects of this:
- In general, this PR keeps existing checks in place but adds reference-compatible error codes and messages to provide human-readable detail.
- On the protobuf side, this PR introduces a handful of checks that are _functionally_ new (i.e. schemas which were previously considered compatible are no longer so):
   - ONEOF_FIELD_REMOVED
   - MULTIPLE_FIELDS_MOVED_TO_ONEOF
   - REQUIRED_FIELD_{ADDED,REMOVED}
   - FIELD_NAMED_TYPE_CHANGED
   - MESSAGE_REMOVED 
      - We already detect some of these (file level) but this PR adds additional checks for nested message definitions
- Previously our compatibility checks would short circuit, returning a 👍 / 👎 as soon as a determination is made. Now we want to build up a collection of errors so that users can make all the required changes and avoid repeated checks. To do this, we need to rejigger the structure of the recursion a bit and introduce some new types for collecting errors.
- We also want to report "path" information about errors (i.e. where in the schema the error occurred), so we need to carry that information through the recursion. I used `std::filesystem::path` for this as a first pass, but in the end it looks fit for purpose. We could implement something similar if the cost is a concern, but I suspect most of the cost is in storing the path elements themselves, so it may be a wash. It might be nice to just _not_ do this if verbose error tracking is not enabled.
- 

Fixes CORE-1507

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* SchemaRegistry: Adds support for the `?verbose` parameter on `POST /compatibility/subjects/{subject}/versions/{version}`

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
