### PR TITLE
CORE-2708 - chore: fix open source CI build

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -38,6 +38,11 @@ fetch_dep(fmt
 set(Seastar_TESTING ON CACHE BOOL "" FORCE)
 set(Seastar_API_LEVEL 6 CACHE STRING "" FORCE)
 set(Seastar_CXX_FLAGS -Wno-error)
+set(CMAKE_CXX_STANDARD
+  "${CMAKE_CXX_STANDARD}"
+  CACHE
+  STRING
+  "C++ standard to build with.")
 fetch_dep(seastar
   REPO https://github.com/redpanda-data/seastar.git
   TAG v24.2.x

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -40,7 +40,7 @@ set(Seastar_API_LEVEL 6 CACHE STRING "" FORCE)
 set(Seastar_CXX_FLAGS -Wno-error)
 fetch_dep(seastar
   REPO https://github.com/redpanda-data/seastar.git
-  TAG v24.1.x
+  TAG v24.2.x
   PATCH_COMMAND sed -i "s/add_subdirectory (tests/# add_subdirectory (tests/g" CMakeLists.txt)
 
 fetch_dep(avro

--- a/src/go/kreq-gen/go.mod
+++ b/src/go/kreq-gen/go.mod
@@ -1,5 +1,9 @@
 module kafka-request-generator
 
-go 1.22
+// TODO: ubuntu:mantic and fedora:38 only have go version v1.21, so we are
+// stuck with 1.21. This is until we upgrade the OS used for the open
+// source CI build. (hopefully soon, once we can also build redpanda with
+// clang-18)
+go 1.21
 
 require github.com/twmb/franz-go/pkg/kmsg v1.7.0

--- a/src/v/net/probes.cc
+++ b/src/v/net/probes.cc
@@ -292,7 +292,7 @@ void tls_certificate_probe::loaded(
         return;
     }
 
-    auto to_tls_serial = [](bytes_view b) {
+    auto to_tls_serial = [](const auto& b) {
         using T = tls_serial_number::type;
         T result = 0;
         const auto end = std::min(b.size(), sizeof(T));


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

The open source build is currently failing because of various errors.
1. We need to upgrade the seastar version used by the open source build to match what we use in the vtools-based build.
2. We need to downgrade the golang version used by kreq-gen to 1.21
3. We need to prevent seastar from upgrading the C++ version used by the build.

The open source build is that it tries to use golang version 1.21 to build kreq-gen because that is what is available on `ubuntu:mantic` and `fedora:38`. Unfortunately, we can't upgrade to the newer OS yet because that would upgrade clang to clang-18 as well, which we are not ready for. So for the meantime, I have reverted to using go v1.21 for kreq-gen.

Fixes https://redpandadata.atlassian.net/browse/CORE-2708

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
