### PR TITLE
Do not request votes if term changed in prevote phase

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -919,6 +919,12 @@ consensus::dispatch_prevote(bool leadership_transfer) {
 
     election_success success = election_success::no;
     try {
+        vlog(
+          _ctxlog.info,
+          "starting pre-vote leader election, current term: {}, leadership "
+          "transfer: {}",
+          _term,
+          leadership_transfer);
         success = co_await pv_stm->vote(leadership_transfer);
     } catch (...) {
         vlog(
@@ -994,6 +1000,13 @@ void consensus::dispatch_vote(bool leadership_transfer) {
             return dispatch_prevote(leadership_transfer)
               .then([this, leadership_transfer](
                       election_success prevote_success) mutable {
+                  vlog(
+                    _ctxlog.debug,
+                    "pre-vote phase success: {}, current term: {}, "
+                    "leadership transfer: {}",
+                    prevote_success,
+                    _term,
+                    leadership_transfer);
                   // if a current node is not longer candidate we should skip
                   // proceeding to actual vote phase
                   if (!prevote_success || _vstate != vote_state::candidate) {

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -994,7 +994,9 @@ void consensus::dispatch_vote(bool leadership_transfer) {
             return dispatch_prevote(leadership_transfer)
               .then([this, leadership_transfer](
                       election_success prevote_success) mutable {
-                  if (!prevote_success) {
+                  // if a current node is not longer candidate we should skip
+                  // proceeding to actual vote phase
+                  if (!prevote_success || _vstate != vote_state::candidate) {
                       return ss::make_ready_future<>();
                   }
                   auto vstm = std::make_unique<vote_stm>(this);

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -915,9 +915,6 @@ bool consensus::should_skip_vote(bool ignore_heartbeat) {
 
 ss::future<election_success>
 consensus::dispatch_prevote(bool leadership_transfer) {
-    if (leadership_transfer) {
-        co_return true;
-    }
     auto pv_stm = std::make_unique<vote_stm>(this, is_prevote::yes);
 
     election_success success = election_success::no;


### PR DESCRIPTION
In vote stm we didn't mark the vote replies with greater term as not granted votes. This may lead to unnecessary leader elections and longer recovery after failures. Change the logic in `vote_stm` to explicitly mark vote responses with greater term as failed. Additional check was added in consensus to recognise if a candidate state changed in between the pre-vote and vote phase.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- Made electing a leader faster