### PR TITLE
[CORE-96]: admin/server fix set_log_level handling of overlapping expirations

### DIFF
--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -1422,17 +1422,20 @@ void admin_server::register_config_routes() {
 
           ss::global_logger_registry().set_logger_level(name, new_level);
 
-          // expires=0 is same as not specifying it at all
-          if (expires_v / 1s > 0) {
-              auto when = ss::timer<>::clock::now() + expires_v;
-              auto res = _log_level_resets.try_emplace(name, cur_level, when);
-              if (!res.second) {
-                  res.first->second.expires = when;
+          auto when = [&]() -> std::optional<level_reset::time_point> {
+              // expires=0 is same as not specifying it at all
+              if (expires_v / 1s > 0) {
+                  return ss::timer<>::clock::now() + expires_v;
+              } else {
+                  // new log level never expires, but we still want an entry in
+                  // the resets map as a record of the default
+                  return std::nullopt;
               }
-          } else {
-              // new log level never expires, but we still want an entry in the
-              // resets map as a record of the default
-              _log_level_resets.try_emplace(name, cur_level, std::nullopt);
+          }();
+
+          auto res = _log_level_resets.try_emplace(name, cur_level, when);
+          if (!res.second) {
+              res.first->second.expires = when;
           }
 
           rsp.expiration = expires_v / 1s;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -661,11 +661,17 @@ void admin_server::log_exception(
 void admin_server::rearm_log_level_timer() {
     _log_level_timer.cancel();
 
-    auto next = std::min_element(
-      _log_level_resets.begin(), _log_level_resets.end());
+    if (_log_level_resets.empty()) {
+        return;
+    }
 
-    if (next != _log_level_resets.end() && next->second.expires.has_value()) {
-        _log_level_timer.arm(next->second.expires.value());
+    auto reset_values = _log_level_resets | std::views::values;
+    auto& lvl_rst = *std::ranges::min_element(
+      reset_values, std::less<>{}, [](level_reset const& l) {
+          return l.expires.value_or(ss::timer<>::clock::time_point::max());
+      });
+    if (lvl_rst.expires.has_value()) {
+        _log_level_timer.arm(lvl_rst.expires.value());
     }
 }
 

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -655,16 +655,6 @@ private:
           : level(level)
           , expires(expires) {}
 
-        friend bool operator<(const level_reset& l, const level_reset& r) {
-            if (!l.expires.has_value()) {
-                return false;
-            } else if (!r.expires.has_value()) {
-                return true;
-            } else {
-                return l.expires.value() < r.expires.value();
-            }
-        }
-
         ss::log_level level;
         std::optional<time_point> expires;
     };


### PR DESCRIPTION
This PR fixes this two behaviors

### overlapping expiration of different loggers
#### before

one logger expiration could shadow another logger expiration

`log-level set kafka -l trace -e 30`
`log-level set raft -l trace -e 30`
.. 30+ secs later
`log-level get kafka -> info`
`log-level get raft -> trace` <- not being reset

#### with this pr

both loggers are reset correctly

`log-level set kafka -l trace -e 30`
`log-level set raft -l trace -e 30`
.. 30+ secs later
`log-level get kafka -> info`
`log-level get raft -> info` <- correctly reset

### expire-never request not being honored, if overlapping a previous request

a logger expiration could influence a subsequent request to set a level without expiration 
note: this case in practice is probably never triggered, since the only level that shows anomalous behavior is `error` and `warn`, and they are not levels that are normally used

#### before

`log-level set raft -l trace -e 30`
`log-level set raft -l error -e 0` <- 0 is for expire-never
... 30+ secs later
`log-level get raft -> info`  <- reset to a default level

#### with this pr

`log-level set raft -l trace -e 30`
`log-level set raft -l error -e 0` <- 0 is for expire-never
... 30+ secs later
`log-level get raft -> error` <- keeps its value


Fixes [CORE-96]

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Bug Fixes

* concurrent requests of set_log_level + expiration now work as expected

[CORE-96]: https://redpandadata.atlassian.net/browse/CORE-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ