### PR TITLE
storage/tests: Adjust step size deviation used in test

### DIFF
--- a/src/v/storage/segment_index.h
+++ b/src/v/storage/segment_index.h
@@ -258,6 +258,7 @@ private:
 
     friend class offset_index_utils_fixture;
     friend class log_replayer_fixture;
+    friend class segment_index_observer;
 
     friend std::ostream& operator<<(std::ostream&, const segment_index&);
 };


### PR DESCRIPTION
In the e2e storage test the index step size of 32KiB is used as possible deviation from expected results. An allowance of 50KiB is used to prevent the test failing because of index step size.

The change computes max step size across all segment indices and uses that as the deviation.

FIXES #18396

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
