### PR TITLE
tests: wait for messages before adding a node to cluster

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -616,6 +616,13 @@ class NodesDecommissioningTest(PreallocNodesTest):
         self.start_producer()
         self.start_consumer()
 
+        # wait for more data to be produced, so that the cluster re-balancing will not finish immediately
+        wait_until(lambda: self.producer.produce_status.acked >
+                   (self.msg_count / 2),
+                   timeout_sec=240,
+                   backoff_sec=1)
+        # set recovery rate to small value but allow the controller to recover
+        self._set_recovery_rate(10 * 1024)
         # throttle recovery
         self.redpanda.clean_node(self.redpanda.nodes[-1],
                                  preserve_current_install=True)


### PR DESCRIPTION
In the `test_decommissioning_rebalancing_node` test case we check if a node that joined the cluster and have some partitions assigned to it in the process of data rebalancing can be successfully decommissioned.

The test was flaky as sometimes all the partition rebalance actions were finished before we validated if rebalance started.

Added a condition to make sure that we wait for more data before adding the node to cluster to make sure rebalance will last long enough for the decommission to interrupt it.

Fixes: #13522

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none
