### PR TITLE
[v24.1.x] http: Fix double call to stop() in http::client

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -190,6 +190,13 @@ ss::future<reconnect_result_t> client::get_connected(
 }
 
 ss::future<> client::stop() {
+    if (_stopped) {
+        // Prevent double call to stop() as constructs such as with_client()
+        // will unconditionally call stop(), while exception handlers in this
+        // file may also call stop()
+        co_return;
+    }
+    _stopped = true;
     co_await _connect_gate.close();
     // Can safely stop base_transport
     co_return co_await base_transport::stop();

--- a/src/v/http/include/http/client.h
+++ b/src/v/http/include/http/client.h
@@ -255,6 +255,7 @@ private:
     /// Throw exception if _as is aborted
     void check() const;
 
+    bool _stopped{false};
     std::string _host_with_port;
     ss::gate _connect_gate;
     const ss::abort_source* _as;


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18304
