### PR TITLE
[v23.2.x] [CORE-96]: admin/server fix set_log_level handling of overlapping expirations

### DIFF
--- a/tests/rptest/tests/log_level_test.py
+++ b/tests/rptest/tests/log_level_test.py
@@ -7,10 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import time
 import ducktape.errors
 import requests.exceptions
 import urllib.parse
 
+from ducktape.mark import parametrize
 from ducktape.utils.util import wait_until
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
@@ -93,6 +95,32 @@ class LogLevelTest(RedpandaTest):
                 timeout_sec=10,
                 backoff_sec=1,
                 err_msg="Never saw message")
+
+    @cluster(num_nodes=1)
+    @parametrize(loggers=("admin_api_server", "raft"))
+    @parametrize(loggers=("raft", "admin_api_server"))
+    def test_log_level_multiple_expiry(self, loggers=tuple[str, str]):
+        """
+        Check that more than one logger can be in a modified level and be expired correctly
+        see https://redpandadata.atlassian.net/browse/CORE-96
+        """
+        admin = Admin(self.redpanda)
+        node = self.redpanda.nodes[0]
+
+        first_logger, second_logger = loggers
+        # set two loggers to trace, expect that both of them expires in a timely fashion
+        with self.redpanda.monitor_log(node) as mon:
+            admin.set_log_level(first_logger, "trace", expires=10)
+            time.sleep(1)
+            admin.set_log_level(second_logger, "trace", expires=10)
+            mon.wait_until(f"Expiring log level for {{{first_logger}}}",
+                           timeout_sec=15,
+                           backoff_sec=1,
+                           err_msg=f"Never saw Expiring for {first_logger}")
+            mon.wait_until(f"Expiring log level for {{{second_logger}}}",
+                           timeout_sec=15,
+                           backoff_sec=1,
+                           err_msg=f"Never saw Expiring for {second_logger}")
 
     @cluster(num_nodes=3)
     def test_invalid_logger_name(self):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18397

first commit adapted for v23.2

Fixes #18436