### PR TITLE
Made client id parsing vcluster aware

### DIFF
--- a/src/v/kafka/server/connection_context.h
+++ b/src/v/kafka/server/connection_context.h
@@ -11,6 +11,7 @@
 #pragma once
 #include "base/seastarx.h"
 #include "config/property.h"
+#include "container/chunked_hash_map.h"
 #include "kafka/server/fwd.h"
 #include "kafka/server/handlers/handler_probe.h"
 #include "kafka/server/logger.h"
@@ -437,7 +438,7 @@ private:
      * A map keeping virtual connection states, during default operation the map
      * is empty
      */
-    absl::node_hash_map<
+    chunked_hash_map<
       virtual_connection_id,
       ss::lw_shared_ptr<virtual_connection_state>>
       _virtual_states;

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -106,6 +106,12 @@ public:
 
     const request_header& header() const { return _header; }
 
+    // override the client id. This method is used when handling virtual
+    // connections and an actual client id is part of the client id buffer.
+    void override_client_id(std::optional<std::string_view> new_client_id) {
+        _header.client_id = new_client_id;
+    }
+
     ss::lw_shared_ptr<connection_context> connection() { return _conn; }
 
     ssx::sharded_abort_source& abort_source() { return _conn->abort_source(); }

--- a/src/v/utils/xid.cc
+++ b/src/v/utils/xid.cc
@@ -39,10 +39,10 @@ constexpr decoder_t build_decoder_table() {
 static constexpr decoder_t decoder = build_decoder_table();
 } // namespace
 
-invalid_xid::invalid_xid(const ss::sstring& current_string)
+invalid_xid::invalid_xid(std::string_view current_string)
   : _msg(ssx::sformat("String '{}' is not a valid xid", current_string)) {}
 
-xid xid::from_string(const ss::sstring& str) {
+xid xid::from_string(std::string_view str) {
     if (str.size() != str_size) {
         throw invalid_xid(str);
     }

--- a/src/v/utils/xid.h
+++ b/src/v/utils/xid.h
@@ -28,7 +28,7 @@
  */
 class invalid_xid final : public std::exception {
 public:
-    explicit invalid_xid(const ss::sstring&);
+    explicit invalid_xid(std::string_view);
     const char* what() const noexcept final { return _msg.c_str(); }
 
 private:
@@ -72,7 +72,7 @@ public:
      *
      * @return an xid decoded from the string provided
      */
-    static xid from_string(const ss::sstring&);
+    static xid from_string(std::string_view);
 
     friend bool operator==(const xid&, const xid&) = default;
 

--- a/tests/rptest/tests/vcluster_topic_property_test.py
+++ b/tests/rptest/tests/vcluster_topic_property_test.py
@@ -14,7 +14,7 @@ from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 from random import randbytes
 
-BASE32_ALPHABET = "0123456789abcdefghijklmnopqrstuv"
+from rptest.utils.xid_utils import random_xid_string
 
 
 def get_vcluster_id(topic_properties: dict):
@@ -28,17 +28,12 @@ class VirtualClusterTopicPropertyTest(RedpandaTest):
         super(VirtualClusterTopicPropertyTest,
               self).__init__(test_context=test_context, num_brokers=3)
 
-    def _random_xid_string(self):
-        xid = ''.join([random.choice(BASE32_ALPHABET) for _ in range(19)])
-
-        return xid + random.choice(['0', 'g'])
-
     @cluster(num_nodes=3)
     def test_basic_virtual_cluster_property(self):
         rpk = RpkTool(self.redpanda)
         # try creating vcluster enabled topic with extensions disabled
         topic = TopicSpec()
-        vcluster_id = self._random_xid_string()
+        vcluster_id = random_xid_string()
         rpk.create_topic(
             topic=topic.name,
             partitions=1,
@@ -72,7 +67,7 @@ class VirtualClusterTopicPropertyTest(RedpandaTest):
         try:
             rpk.alter_topic_config(topic.name,
                                    TopicSpec.PROPERTY_VIRTUAL_CLUSTER_ID,
-                                   self._random_xid_string())
+                                   random_xid_string())
             assert False, "Altering topic virtual cluster property should not be supported"
         except RpkException as e:
             assert "INVALID_CONFIG" in e.msg

--- a/tests/rptest/utils/xid_utils.py
+++ b/tests/rptest/utils/xid_utils.py
@@ -1,0 +1,18 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import random
+
+BASE32_ALPHABET = "0123456789abcdefghijklmnopqrstuv"
+
+
+def random_xid_string():
+    xid = ''.join([random.choice(BASE32_ALPHABET) for _ in range(19)])
+
+    return xid + random.choice(['0', 'g'])


### PR DESCRIPTION
Previously Redpanda virtualized Kafka connections based on the full
client_id string and the string was used as a client id in all
downstream processing.

Change the parsing logic to add context to the parsed client id.
The client id format expected by Redpanda has the following structure:

```
[vcluster_id][connection_id][actual client id]
```
where:

`vcluster_id` - string encoded XID representing virtual cluster
	        (20 characters)

`connection_id` - hex encoded 32 bit integer representing virtual
                  connection id (8 characters)

`client_id` - standard protocol defined client id

If Redpanda fails to parse the client id while working with virtualized
connections the whole connection is closed.


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none