### PR TITLE
PESDLC-1362 Update type hints and change char type to str

### DIFF
--- a/tests/rptest/clients/kubectl.py
+++ b/tests/rptest/clients/kubectl.py
@@ -11,7 +11,7 @@ import json
 from logging import Logger
 import os
 import subprocess
-from typing import Any
+from typing import Any, Union, Generator
 
 SUPPORTED_PROVIDERS = ['aws', 'gcp']
 
@@ -223,7 +223,10 @@ class KubectlTool:
         # return that instead.
         return s_out if len(s_out) > 0 else s_err
 
-    def _ssh_cmd(self, cmd: list[str], capture: bool = False):
+    def _ssh_cmd(
+            self,
+            cmd: list[str],
+            capture: bool = False) -> Union[str, Generator[bytes, Any, None]]:
         """Execute a command on a the remote node using ssh/tsh as appropriate."""
         local_cmd = self._ssh_prefix() + cmd
         if capture:
@@ -255,7 +258,7 @@ class KubectlTool:
         cmd = _kubectl + _kcmd
         return self._ssh_cmd(cmd, capture=capture)
 
-    def exec(self, remote_cmd, pod_name=None):
+    def exec(self, remote_cmd, pod_name=None) -> str:
         """Execute a command inside of a redpanda pod container.
 
         :param remote_cmd: string of bash command to run inside of pod container
@@ -269,7 +272,7 @@ class KubectlTool:
             'kubectl', 'exec', pod_name, f'-n={self._namespace}',
             '-c=redpanda', '--', 'bash', '-c'
         ] + ['"' + remote_cmd + '"']
-        return self._ssh_cmd(cmd)
+        return self._ssh_cmd(cmd)  # type: ignore
 
     def exists(self, remote_path):
         self._install()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1510,7 +1510,7 @@ class KubeServiceMixin:
             # If dir doesn't exist yet, use the parent.
             df_path = os.path.dirname(RedpandaServiceBase.PERSISTENT_ROOT)
         df_out = self.kubectl.exec(f"df --output=avail {df_path}")
-        avail_kb = int(df_out.strip().split(b"\n")[1].strip())
+        avail_kb = int(df_out.strip().split("\n")[1].strip())
         return avail_kb * 1024
 
 


### PR DESCRIPTION
    Since _local_cmd now returns str instead of bytes,
    update get_node_disk_free with proper symbol types.

    Also update type hints for exec function

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none