### PR TITLE
[CORE-2952] Add docs as CODEOWNERS for Swagger

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,7 +50,9 @@ licenses           @emaxerrno @dswang
 /src/v/config/node_config.h                         @redpanda-data/documentation
 /src/v/kafka/client/configuration.cc                @redpanda-data/documentation
 /src/v/kafka/client/configuration.h                 @redpanda-data/documentation
+/src/v/pandaproxy/api/api-doc                       @redpanda-data/documentation
 /src/v/pandaproxy/rest/configuration.cc             @redpanda-data/documentation
 /src/v/pandaproxy/rest/configuration.h              @redpanda-data/documentation
 /src/v/pandaproxy/schema_registry/configuration.cc  @redpanda-data/documentation
 /src/v/pandaproxy/schema_registry/configuration.h   @redpanda-data/documentation
+/src/v/redpanda/admin/api-doc                       @redpanda-data/documentation


### PR DESCRIPTION
Add documentation team as CODEOWNERS of Swagger.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
