### PR TITLE
rpk: rename cluster metadata to info

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/info.go
+++ b/src/go/rpk/pkg/cli/cluster/info.go
@@ -34,10 +34,10 @@ func newMetadataCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		detailed bool
 	)
 	cmd := &cobra.Command{
-		Use:     "metadata",
-		Aliases: []string{"status", "info"},
+		Use:     "info",
+		Aliases: []string{"status", "metadata"},
 		Short:   "Request broker metadata",
-		Long: `Request broker metadata.
+		Long: `Request broker metadata information.
 
 The Kafka protocol's metadata contains information about brokers, topics, and
 the cluster as a whole.


### PR DESCRIPTION
Related https://github.com/redpanda-data/docs/pull/493

This PR renames the file from `metadata` to `info`. 
Change the main command from metadata to info, so it appears in the available commands list.
Add metadata as an alias.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
