### PR TITLE
storage: change map type for `_db` in `kvstore`

### DIFF
--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -11,7 +11,9 @@
 
 #pragma once
 #include "base/seastarx.h"
+#include "bytes/bytes.h"
 #include "bytes/iobuf.h"
+#include "container/chunked_hash_map.h"
 #include "metrics/metrics.h"
 #include "storage/fwd.h"
 #include "storage/ntp_config.h"
@@ -25,8 +27,6 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/timer.hh>
-
-#include <absl/container/btree_map.h>
 
 namespace storage {
 
@@ -91,6 +91,8 @@ struct kvstore_config {
 
 class kvstore {
 public:
+    using map_t = chunked_hash_map<bytes, iobuf>;
+
     enum class key_space : int8_t {
         testing = 0,
         consensus = 1,
@@ -164,7 +166,7 @@ private:
     // Protect _db and _next_offset across asynchronous mutations.
     mutex _db_mut{"kvstore::db_mut"};
     model::offset _next_offset;
-    absl::btree_map<bytes, iobuf, bytes_type_cmp> _db;
+    map_t _db;
     std::optional<ntp_sanitizer_config> _ntp_sanitizer_config;
 
     ss::future<> put(key_space ks, bytes key, std::optional<iobuf> value);


### PR DESCRIPTION
In an effort to move to fragmented data structures, the `absl::btree_map` type used in the `kvstore` is now replaced by a `chunked_hash_map`.

We do not rely on the ordering or any sort of pointer/reference/iterator stability provided by `absl::btree_map` in our current uses of `_db`, so this is a painless swap.

Fixes #15906
Fixes #10744 

## Backports Required


- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none