### PR TITLE
register `/rp-unit-test` github slash command

### DIFF
--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -8,11 +8,11 @@ on:
       - dt-command
       - microbench-command
       - publish-to-install-pack-command
+      - rp-unit-test-command
       - test-arm64-command
       - test-codecov-command
       - test-rc-pipeline-command
       - test-release-pipeline-command
-
 jobs:
   run-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildkite-slash-commands.yml
+++ b/.github/workflows/buildkite-slash-commands.yml
@@ -3,15 +3,15 @@ name: BK slash-command
 on:
   repository_dispatch:
     types: 
-      - ci-repeat-command
-      - test-codecov-command
       - cdt-command
-      - test-release-pipeline-command
-      - test-arm64-command
+      - ci-repeat-command
       - dt-command
       - microbench-command
       - publish-to-install-pack-command
+      - test-arm64-command
+      - test-codecov-command
       - test-rc-pipeline-command
+      - test-release-pipeline-command
 
 jobs:
   run-build:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -14,15 +14,15 @@ jobs:
           issue-type: both
           commands: |
             backport
-            ci-repeat
-            test-codecov
             cdt
-            test-release-pipeline
-            test-arm64
+            ci-repeat
             dt
             microbench
             publish-to-install-pack
+            test-arm64
+            test-codecov
             test-rc-pipeline
+            test-release-pipeline
           static-args: |
             org=redpanda-data
             repo=redpanda

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -19,6 +19,7 @@ jobs:
             dt
             microbench
             publish-to-install-pack
+            rp-unit-test
             test-arm64
             test-codecov
             test-rc-pipeline


### PR DESCRIPTION
registers the `/rp-unit-test` slash command so it can trigger the steps as implemented in PR https://github.com/redpanda-data/vtools/pull/2753

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
