### PR TITLE
cmake: FIxup for OpenSSL command on Fedora

### DIFF
--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -160,7 +160,7 @@ if (RP_ENABLE_TESTS)
     message(FATAL_ERROR "openssl is required for performing tests!")
   endif()
 
-  set(OVERRIDE_LD_PATH)
+  set(OPENSSL_ENV)
 
   if(VECTORIZED_CMAKE_DIR)
     if (CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^arm|aarch64")
@@ -168,7 +168,7 @@ if (RP_ENABLE_TESTS)
     else()
       set(OSSL_LIB_DIR "lib64")
     endif()
-    set(OVERRIDE_LD_PATH "${REDPANDA_DEPS_INSTALL_DIR}/${OSSL_LIB_DIR}")
+    set(OPENSSL_ENV "LD_LIBRARY_PATH=${REDPANDA_DEPS_INSTALL_DIR}/${OSSL_LIB_DIR};OPENSSL_CONF=${REDPANDA_DEPS_INSTALL_DIR}/etc/ssl/openssl.cnf")
   endif()
 
   # The following function can be used to setup a simple CA
@@ -195,7 +195,7 @@ if (RP_ENABLE_TESTS)
 
     # The following command generates an ECDSA key pair using the prime256v1 curve
     add_custom_command(OUTPUT ${privkey}
-      COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${OVERRIDE_LD_PATH}"
+      COMMAND ${CMAKE_COMMAND} -E env ${OPENSSL_ENV}
         ${OPENSSL} ecparam
         -name prime256v1 -genkey -noout
         -out ${privkey}
@@ -206,7 +206,7 @@ if (RP_ENABLE_TESTS)
         # This will generate a certificate signing request (CSR) using the generated
         # private key
         add_custom_command(OUTPUT ${req}
-          COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${OVERRIDE_LD_PATH}"
+          COMMAND ${CMAKE_COMMAND} -E env ${OPENSSL_ENV}
             ${OPENSSL} req
             -new -sha256
             -key ${privkey}
@@ -219,7 +219,7 @@ if (RP_ENABLE_TESTS)
         set(ca_privkey ${CERT_CA}.key)
         # This function will sign the generated CSR (above) with the specified CA
         add_custom_command(OUTPUT ${cert}
-          COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${OVERRIDE_LD_PATH}"
+          COMMAND ${CMAKE_COMMAND} -E env ${OPENSSL_ENV}
             ${OPENSSL} x509
             -req -days 1000 -sha256
             -set_serial ${CERT_SERIAL_NUM}
@@ -232,7 +232,7 @@ if (RP_ENABLE_TESTS)
       else()
         # This will generate a self-signed certificate to use as the root CA
         add_custom_command(OUTPUT ${cert}
-          COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=${OVERRIDE_LD_PATH}"
+          COMMAND ${CMAKE_COMMAND} -E env ${OPENSSL_ENV}
             ${OPENSSL} req
             -new -x509 -sha256
             -key ${privkey}

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -50,6 +50,7 @@ deb_deps=(
   libzstd-dev
   lld
   ninja-build
+  openssl
   protobuf-compiler
   python3
   python3-jinja2
@@ -83,6 +84,7 @@ fedora_deps=(
   lz4-static
   ninja-build
   numactl-devel
+  openssl
   openssl-devel
   procps
   protobuf-devel


### PR DESCRIPTION
Fedora's default OpenSSL config file has some weird stuff in there that conflicts with OpenSSL 3.  For now, just set OPENSSL_CONF to /dev/null

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None