### PR TITLE
config/datalake: add options for datalake topics

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -1150,6 +1150,27 @@ ss::future<cloud_storage::upload_result> ntp_archiver::do_upload_segment(
 
     vlog(ctxlog.debug, "Uploading segment {} to {}", candidate, path);
 
+    if (config::shard_local_cfg().enable_datalake) {
+        vlog(ctxlog.debug, "Cluster datalake support enabled");
+        auto topic_config = _parent.get_topic_config();
+        bool datalake_topic
+          = topic_config.has_value()
+            && topic_config->get().properties.datalake_topic.value_or(false);
+
+        auto topic_name = model::topic_view(
+          _parent.get_ntp_config().ntp().tp.topic);
+
+        if (datalake_topic) {
+            vlog(ctxlog.debug, "{} is a datalake topic", topic_name);
+        } else {
+            vlog(ctxlog.trace, "{} is not a datalake topic", topic_name);
+        }
+    } else {
+        vlog(ctxlog.trace, "Cluster datalake support disabled");
+    }
+
+    //, _parent);
+
     auto lazy_abort_source = cloud_storage::lazy_abort_source{
       [this]() { return upload_should_abort(); },
     };

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -462,6 +462,7 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
       std::nullopt,
       std::nullopt,
       std::nullopt,
+      std::nullopt,
     };
 
     auto random_initial_revision_id

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -903,6 +903,7 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
     incremental_update(properties.write_caching, overrides.write_caching);
     incremental_update(properties.flush_ms, overrides.flush_ms);
     incremental_update(properties.flush_bytes, overrides.flush_bytes);
+    incremental_update(properties.datalake_topic, overrides.datalake_topic);
     // no configuration change, no need to generate delta
     if (properties == properties_snapshot) {
         co_return errc::success;

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -1469,7 +1469,7 @@ struct remote_topic_properties
  */
 struct topic_properties
   : serde::
-      envelope<topic_properties, serde::version<8>, serde::compat_version<0>> {
+      envelope<topic_properties, serde::version<9>, serde::compat_version<0>> {
     topic_properties() noexcept = default;
     topic_properties(
       std::optional<model::compression> compression,
@@ -1506,7 +1506,8 @@ struct topic_properties
       std::optional<model::vcluster_id> mpx_virtual_cluster_id,
       std::optional<model::write_caching_mode> write_caching,
       std::optional<std::chrono::milliseconds> flush_ms,
-      std::optional<size_t> flush_bytes)
+      std::optional<size_t> flush_bytes,
+      std::optional<bool> datalake_topic)
       : compression(compression)
       , cleanup_policy_bitflags(cleanup_policy_bitflags)
       , compaction_strategy(compaction_strategy)
@@ -1542,7 +1543,8 @@ struct topic_properties
       , mpx_virtual_cluster_id(mpx_virtual_cluster_id)
       , write_caching(write_caching)
       , flush_ms(flush_ms)
-      , flush_bytes(flush_bytes) {}
+      , flush_bytes(flush_bytes)
+      , datalake_topic(datalake_topic) {}
 
     std::optional<model::compression> compression;
     std::optional<model::cleanup_policy_bitflags> cleanup_policy_bitflags;
@@ -1588,6 +1590,7 @@ struct topic_properties
     std::optional<model::write_caching_mode> write_caching;
     std::optional<std::chrono::milliseconds> flush_ms;
     std::optional<size_t> flush_bytes;
+    std::optional<bool> datalake_topic;
 
     bool is_compacted() const;
     bool has_overrides() const;
@@ -1628,7 +1631,8 @@ struct topic_properties
           mpx_virtual_cluster_id,
           write_caching,
           flush_ms,
-          flush_bytes);
+          flush_bytes,
+          datalake_topic);
     }
 
     friend bool operator==(const topic_properties&, const topic_properties&)
@@ -1726,6 +1730,7 @@ struct incremental_topic_updates
     static constexpr int8_t version_with_schema_id_validation = -6;
     static constexpr int8_t version_with_initial_retention = -7;
     static constexpr int8_t version_with_write_caching = -8;
+    static constexpr int8_t version_with_datalake = -9;
     // negative version indicating different format:
     // -1 - topic_updates with data_policy
     // -2 - topic_updates without data_policy
@@ -1734,7 +1739,7 @@ struct incremental_topic_updates
     // -6 - topic updates with schema id validation
     // -7 - topic updates with initial retention
     // -8 - write caching properties
-    static constexpr int8_t version = version_with_write_caching;
+    static constexpr int8_t version = version_with_datalake;
     property_update<std::optional<model::compression>> compression;
     property_update<std::optional<model::cleanup_policy_bitflags>>
       cleanup_policy_bitflags;
@@ -1775,6 +1780,7 @@ struct incremental_topic_updates
     property_update<std::optional<model::write_caching_mode>> write_caching;
     property_update<std::optional<std::chrono::milliseconds>> flush_ms;
     property_update<std::optional<size_t>> flush_bytes;
+    property_update<std::optional<bool>> datalake_topic;
 
     auto serde_fields() {
         return std::tie(
@@ -1803,7 +1809,8 @@ struct incremental_topic_updates
           initial_retention_local_target_ms,
           write_caching,
           flush_ms,
-          flush_bytes);
+          flush_bytes,
+          datalake_topic);
     }
 
     friend std::ostream&

--- a/src/v/compat/cluster_generator.h
+++ b/src/v/compat/cluster_generator.h
@@ -648,7 +648,8 @@ struct instance_generator<cluster::topic_properties> {
           }),
           tests::random_optional([] { return tests::random_duration_ms(); }),
           tests::random_optional(
-            [] { return random_generators::get_int<size_t>(); })};
+            [] { return random_generators::get_int<size_t>(); }),
+          std::nullopt};
     }
 
     static std::vector<cluster::topic_properties> limits() { return {}; }

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -3194,6 +3194,12 @@ configuration::configuration()
       "internal-only configuration and should be enabled only after consulting "
       "with Redpanda Support or engineers.",
       {.needs_restart = needs_restart::yes, .visibility = visibility::user},
+      false)
+  , enable_datalake(
+      *this,
+      "experimental_enable_datalake",
+      "EXPERIMENTAL - DO NOT ENABLE",
+      {.needs_restart = needs_restart::no, .visibility = visibility::user},
       false) {}
 
 configuration::error_map_t configuration::load(const YAML::Node& root_node) {

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -592,6 +592,8 @@ struct configuration final : public config_store {
     // temporary - to be deprecated
     property<bool> unsafe_enable_consumer_offsets_delete_retention;
 
+    property<bool> enable_datalake;
+
     configuration();
 
     error_map_t load(const YAML::Node& root_node);

--- a/src/v/kafka/server/handlers/alter_configs.cc
+++ b/src/v/kafka/server/handlers/alter_configs.cc
@@ -291,6 +291,13 @@ create_topic_properties_update(
                   flush_bytes_validator{});
                 continue;
             }
+            if (cfg.name == topic_property_datalake_topic) {
+                parse_and_set_optional(
+                  update.properties.datalake_topic,
+                  cfg.value,
+                  kafka::config_resource_operation::set);
+                continue;
+            }
 
         } catch (const validation_error& e) {
             return make_error_alter_config_resource_response<

--- a/src/v/kafka/server/handlers/create_topics.cc
+++ b/src/v/kafka/server/handlers/create_topics.cc
@@ -68,7 +68,8 @@ static constexpr auto supported_configs = std::to_array(
    topic_property_initial_retention_local_target_ms,
    topic_property_write_caching,
    topic_property_flush_ms,
-   topic_property_flush_bytes});
+   topic_property_flush_bytes,
+   topic_property_datalake_topic});
 
 bool is_supported(std::string_view name) {
     return std::any_of(

--- a/src/v/kafka/server/handlers/incremental_alter_configs.cc
+++ b/src/v/kafka/server/handlers/incremental_alter_configs.cc
@@ -300,6 +300,11 @@ create_topic_properties_update(
                   flush_bytes_validator{});
                 continue;
             }
+            if (cfg.name == topic_property_datalake_topic) {
+                parse_and_set_optional(
+                  update.properties.datalake_topic, cfg.value, op);
+                continue;
+            }
 
         } catch (const validation_error& e) {
             vlog(

--- a/src/v/kafka/server/handlers/topics/types.cc
+++ b/src/v/kafka/server/handlers/topics/types.cc
@@ -251,6 +251,9 @@ to_cluster_type(const creatable_topic& t) {
     cfg.properties.flush_bytes = get_config_value<size_t>(
       config_entries, topic_property_flush_bytes);
 
+    cfg.properties.datalake_topic = get_config_value<bool>(
+      config_entries, topic_property_datalake_topic);
+
     schema_id_validation_config_parser schema_id_validation_config_parser{
       cfg.properties};
 

--- a/src/v/kafka/server/handlers/topics/types.h
+++ b/src/v/kafka/server/handlers/topics/types.h
@@ -74,6 +74,9 @@ static constexpr std::string_view topic_property_write_caching
 static constexpr std::string_view topic_property_flush_ms = "flush.ms";
 static constexpr std::string_view topic_property_flush_bytes = "flush.bytes";
 
+static constexpr std::string_view topic_property_datalake_topic
+  = "experimental_datalake_topic";
+
 // Server side schema id validation
 static constexpr std::string_view topic_property_record_key_schema_id_validation
   = "redpanda.key.schema.id.validation";

--- a/src/v/storage/ntp_config.h
+++ b/src/v/storage/ntp_config.h
@@ -77,6 +77,8 @@ public:
         std::optional<std::chrono::milliseconds> flush_ms;
         std::optional<size_t> flush_bytes;
 
+        std::optional<bool> datalake_topic;
+
         friend std::ostream&
         operator<<(std::ostream&, const default_overrides&);
     };


### PR DESCRIPTION
This change adds two new configuration options for controlling datalake support as part of the Iceberg project. One option, at the cluster level, can be used to globally enable or disable datalake support. The topic option turns on datalake support for a specific topic. A topic is considered "datalake-enabled" when both options are set.

This change also adds logging in ntp_archiver_service to indicate the state of topics as they are uploaded.

These new config options are experimental, and should not be enabled outside of development experiments.

- Cluster-level config: `experimental_enable_datalake`
- Topic-level config: `experimental_datalake_topic`

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
