### PR TITLE
mvlog: log basics for segment rolls

### DIFF
--- a/src/v/storage/mvlog/CMakeLists.txt
+++ b/src/v/storage/mvlog/CMakeLists.txt
@@ -14,6 +14,7 @@ v_cc_library(
     segment_appender.cc
     segment_reader.cc
     skipping_data_source.cc
+    versioned_log.cc
   DEPS
     Seastar::seastar
     v::base

--- a/src/v/storage/mvlog/segment_identifier.h
+++ b/src/v/storage/mvlog/segment_identifier.h
@@ -1,0 +1,16 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "utils/named_type.h"
+
+namespace storage::experimental::mvlog {
+// Uniquely identifies segments written with the versioned log.
+using segment_id = named_type<int64_t, struct segment_id_tag>;
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/tests/CMakeLists.txt
+++ b/src/v/storage/mvlog/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ rp_test(
   USE_CWD
   BINARY_NAME mvlog
   SOURCES
+    active_segment_test.cc
     batch_collecting_stream_utils_test.cc
     batch_collector_test.cc
     entry_stream_utils_test.cc
@@ -19,6 +20,7 @@ rp_test(
     v::model_test_utils
     v::mvlog
     v::random
+    v::storage
   ARGS "-- -c1"
 )
 

--- a/src/v/storage/mvlog/tests/active_segment_test.cc
+++ b/src/v/storage/mvlog/tests/active_segment_test.cc
@@ -1,0 +1,188 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/units.h"
+#include "model/tests/random_batch.h"
+#include "model/tests/randoms.h"
+#include "random/generators.h"
+#include "storage/directories.h"
+#include "storage/mvlog/versioned_log.h"
+#include "storage/ntp_config.h"
+#include "test_utils/gtest_utils.h"
+
+#include <seastar/core/seastar.hh>
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+
+using namespace storage::experimental::mvlog;
+using namespace std::literals::chrono_literals;
+
+class ActiveSegmentTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        ntp_ = model::random_ntp();
+        base_dir_ = get_test_directory();
+        storage::directories::initialize(base_dir_).get();
+    }
+
+    void TearDown() override {
+        log_->close().get();
+        log_.reset();
+        std::filesystem::remove_all(std::filesystem::path(base_dir_));
+    }
+    versioned_log* make_log(
+      std::optional<size_t> segment_bytes,
+      tristate<std::chrono::milliseconds> segment_ms) {
+        auto overrides
+          = std::make_unique<storage::ntp_config::default_overrides>();
+        overrides->segment_size = segment_bytes;
+        overrides->segment_ms = segment_ms;
+        const auto ntp = model::random_ntp();
+        storage::ntp_config cfg(ntp, base_dir_, std::move(overrides));
+        storage::directories::initialize(cfg.work_directory()).get();
+        log_ = std::make_unique<versioned_log>(std::move(cfg));
+        return log_.get();
+    }
+
+    ss::future<ss::circular_buffer<model::record_batch>>
+    write_random_batches(versioned_log* log, int num_batches) {
+        auto in_batches = model::test::make_random_batches(
+                            next_offset_, num_batches, true)
+                            .get();
+        for (const auto& b : in_batches) {
+            co_await log->append(b.copy());
+        }
+        next_offset_ = model::next_offset(in_batches.back().last_offset());
+        co_return in_batches;
+    }
+
+private:
+    model::ntp ntp_;
+    ss::sstring base_dir_;
+    model::offset next_offset_{0};
+    std::unique_ptr<versioned_log> log_;
+};
+
+ss::future<> apply_segment_ms_loop(versioned_log* log, bool* stop) {
+    while (!(*stop)) {
+        co_await log->apply_segment_ms();
+    }
+}
+
+TEST_F(ActiveSegmentTest, TestConcurrentAppendsAndApplyMs) {
+    // Make segment rolling very frequent in time so we can race segment.ms
+    // rolls with appends.
+    auto* log = make_log(128_MiB, tristate<std::chrono::milliseconds>{1ms});
+    bool stop{false};
+    auto seg_ms_loop = apply_segment_ms_loop(log, &stop);
+    auto stop_loop = ss::defer([&] {
+        stop = true;
+        seg_ms_loop.get();
+    });
+    while (log->segment_count() < 5) {
+        write_random_batches(log, 10).get();
+        auto sleep_us = random_generators::get_int(1000);
+        ss::sleep(sleep_us * 1us).get();
+    }
+}
+
+TEST_F(ActiveSegmentTest, TestAppend) {
+    auto* log = make_log(128_MiB, tristate<std::chrono::milliseconds>{});
+    ASSERT_EQ(0, log->segment_count());
+
+    write_random_batches(log, 10).get();
+    ASSERT_EQ(1, log->segment_count());
+}
+
+TEST_F(ActiveSegmentTest, TestAppendPastLimit) {
+    auto* log = make_log(128, tristate<std::chrono::milliseconds>{});
+
+    // Each append should write to its own segment because of how small the
+    // segment size is.
+    write_random_batches(log, 10).get();
+    ASSERT_EQ(10, log->segment_count());
+}
+
+TEST_F(ActiveSegmentTest, TestSegmentMs) {
+    auto* log = make_log(128_MiB, tristate<std::chrono::milliseconds>{10ms});
+    log->apply_segment_ms().get();
+    ASSERT_EQ(0, log->segment_count());
+
+    // Once we write, the countdown for rolling begins.
+    write_random_batches(log, 1).get();
+    ASSERT_EQ(1, log->segment_count());
+
+    // Until we roll we should continue to have one segment.
+    ss::sleep(20ms).get();
+    ASSERT_EQ(1, log->segment_count());
+
+    // Rolling will close the active segment.
+    log->apply_segment_ms().get();
+    ASSERT_FALSE(log->has_active_segment());
+    ASSERT_EQ(1, log->segment_count());
+
+    // Writing will always create a new segment.
+    write_random_batches(log, 1).get();
+    ASSERT_TRUE(log->has_active_segment());
+    ASSERT_EQ(2, log->segment_count());
+}
+
+TEST_F(ActiveSegmentTest, TestAppendWithSegmentMs) {
+    auto* log = make_log(128_MiB, tristate<std::chrono::milliseconds>{10ms});
+    log->apply_segment_ms().get();
+    ASSERT_EQ(0, log->segment_count());
+
+    // Once we write, the countdown for rolling begins.
+    write_random_batches(log, 1).get();
+    ASSERT_EQ(1, log->segment_count());
+
+    // Until we roll though, we should continue to have one segment.
+    ss::sleep(20ms).get();
+    ASSERT_EQ(1, log->segment_count());
+    ASSERT_TRUE(log->has_active_segment());
+
+    // An append past the rolling deadline shouldn't create a new segment.
+    write_random_batches(log, 1).get();
+    ASSERT_TRUE(log->has_active_segment());
+    ASSERT_EQ(1, log->segment_count());
+
+    // An explicit call to segment.ms will roll though.
+    log->apply_segment_ms().get();
+    ASSERT_FALSE(log->has_active_segment());
+    ASSERT_EQ(1, log->segment_count());
+
+    write_random_batches(log, 1).get();
+    ASSERT_TRUE(log->has_active_segment());
+    ASSERT_EQ(2, log->segment_count());
+}
+
+TEST_F(ActiveSegmentTest, TestApplySegmentMsEmpty) {
+    auto* log = make_log(128_MiB, tristate<std::chrono::milliseconds>{10ms});
+    log->apply_segment_ms().get();
+    ASSERT_EQ(0, log->segment_count());
+
+    // Even if we wait, there should be no rolls when applying segment.ms
+    // because nothing has been written.
+    ss::sleep(20ms).get();
+    log->apply_segment_ms().get();
+    log->apply_segment_ms().get();
+    log->apply_segment_ms().get();
+    ASSERT_EQ(0, log->segment_count());
+
+    // The next write should create a single segment though (and shouldn't e.g.
+    // process the previous attempts to apply segment.ms).
+    write_random_batches(log, 1).get();
+    ASSERT_EQ(1, log->segment_count());
+    write_random_batches(log, 1).get();
+    ASSERT_EQ(1, log->segment_count());
+    write_random_batches(log, 1).get();
+    ASSERT_EQ(1, log->segment_count());
+}

--- a/src/v/storage/mvlog/versioned_log.cc
+++ b/src/v/storage/mvlog/versioned_log.cc
@@ -1,0 +1,175 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "storage/mvlog/versioned_log.h"
+
+#include "container/fragmented_vector.h"
+#include "model/offset_interval.h"
+#include "storage/mvlog/file.h"
+#include "storage/mvlog/logger.h"
+#include "storage/mvlog/readable_segment.h"
+#include "storage/mvlog/segment_appender.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/lowres_clock.hh>
+
+#include <chrono>
+
+using namespace std::literals::chrono_literals;
+
+namespace storage::experimental::mvlog {
+
+active_segment::active_segment(
+  std::unique_ptr<file> f, model::offset o, segment_id id, size_t target_size)
+  : segment_file(std::move(f))
+  , appender(std::make_unique<segment_appender>(segment_file.get()))
+  , readable_seg(std::make_unique<readable_segment>(segment_file.get()))
+  , construct_time(ss::lowres_clock::now())
+  , target_max_size(target_size)
+  , id(id)
+  , base_offset(o)
+  , next_offset(o) {}
+
+active_segment::~active_segment() = default;
+
+readonly_segment::~readonly_segment() = default;
+readonly_segment::readonly_segment(std::unique_ptr<active_segment> active_seg)
+  : segment_file(std::move(active_seg->segment_file))
+  , readable_seg(std::move(active_seg->readable_seg))
+  , id(active_seg->id)
+  , offsets(model::bounded_offset_interval::checked(
+      active_seg->base_offset, model::prev_offset(active_seg->next_offset))) {}
+
+versioned_log::versioned_log(storage::ntp_config cfg)
+  : ntp_cfg_(std::move(cfg)) {}
+
+ss::future<> versioned_log::roll_unlocked() {
+    vassert(
+      !active_segment_lock_.ready(),
+      "roll_unlocked() must be called with active segment lock held");
+    vassert(has_active_segment(), "Expected an active segment");
+    vlog(
+      log.info,
+      "Rolling segment file {}",
+      active_seg_->segment_file->filepath().c_str());
+    co_await active_seg_->segment_file->flush();
+    auto ro_seg = std::make_unique<readonly_segment>(std::move(active_seg_));
+    segs_.push_back(std::move(ro_seg));
+}
+
+ss::future<> versioned_log::create_unlocked(model::offset base) {
+    vassert(
+      !active_segment_lock_.ready(),
+      "create_unlocked() must be called with active segment lock held");
+    vassert(!has_active_segment(), "Expected no active segment");
+    const auto new_path = fmt::format(
+      "{}/{}.log", ntp_cfg_.work_directory(), next_segment_id_());
+    vlog(log.info, "Creating new segment file {}", new_path);
+    auto f = co_await file_mgr_.create_file(std::filesystem::path{new_path});
+    auto active_seg = std::make_unique<active_segment>(
+      std::move(f), base, next_segment_id_, compute_max_segment_size());
+    active_seg_ = std::move(active_seg);
+    ++next_segment_id_;
+}
+
+ss::future<> versioned_log::apply_segment_ms() {
+    auto lock = co_await active_segment_lock_.get_units();
+    if (!has_active_segment()) {
+        vlog(log.trace, "No active segment to roll");
+        co_return;
+    }
+    const auto target_roll_deadline = compute_roll_deadline();
+    if (!target_roll_deadline.has_value()) {
+        vlog(log.trace, "No segment rolling deadline");
+        co_return;
+    }
+    const auto now = ss::lowres_clock::now();
+    if (now >= target_roll_deadline.value()) {
+        vlog(
+          log.debug,
+          "Starting to roll {}, now vs deadline: {} vs {}",
+          ss::sstring(active_seg_->segment_file->filepath()),
+          now.time_since_epoch(),
+          target_roll_deadline->time_since_epoch());
+        co_await roll_unlocked();
+    }
+}
+
+ss::future<> versioned_log::close() {
+    // TODO(awong): handle concurrency. Should also prevent further appends,
+    // readers, etc.
+    if (active_seg_) {
+        co_await active_seg_->segment_file->close();
+    }
+    for (auto& seg : segs_) {
+        co_await seg->segment_file->close();
+    }
+}
+
+ss::future<> versioned_log::append(model::record_batch b) {
+    auto lock = co_await active_segment_lock_.get_units();
+    if (has_active_segment()) {
+        const auto cur_size = active_seg_->segment_file->size();
+        const auto target_max_size = active_seg_->target_max_size;
+        if (cur_size >= target_max_size) {
+            vlog(
+              log.debug,
+              "Starting to roll {}, cur bytes vs target bytes: {} vs {}",
+              active_seg_->segment_file->filepath().c_str(),
+              cur_size,
+              target_max_size);
+            // The active segment needs to be rolled.
+            co_await roll_unlocked();
+        }
+    }
+    if (!has_active_segment()) {
+        co_await create_unlocked(b.base_offset());
+    }
+    vassert(has_active_segment(), "Expected active segment");
+    // TODO(awong): it's probably worth handling this more gracefully with an
+    // error code. We shouldn't rely on storage-external callers to uphold this
+    // invariant, even if it is true.
+    vassert(
+      b.base_offset() == active_seg_->next_offset,
+      "Appending {} when {} was expected",
+      b.base_offset(),
+      active_seg_->next_offset);
+    auto next = model::next_offset(b.last_offset());
+    co_await active_seg_->appender->append(std::move(b));
+    active_seg_->next_offset = next;
+}
+
+size_t versioned_log::segment_count() const {
+    return segs_.size() + (active_seg_ ? 1 : 0);
+}
+bool versioned_log::has_active_segment() const {
+    return active_seg_ != nullptr;
+}
+
+size_t versioned_log::compute_max_segment_size() const {
+    if (
+      ntp_cfg_.has_overrides()
+      && ntp_cfg_.get_overrides().segment_size.has_value()) {
+        return ntp_cfg_.get_overrides().segment_size.value();
+    }
+    // TODO(awong): get defaults from log_manager
+    // TODO(awong): clamp by min/max configs
+    vassert(false, "Not implemented");
+}
+
+std::optional<ss::lowres_clock::time_point>
+versioned_log::compute_roll_deadline() const {
+    if (!has_active_segment() || !ntp_cfg_.segment_ms().has_value()) {
+        return std::nullopt;
+    }
+    return active_seg_->construct_time + ntp_cfg_.segment_ms().value();
+}
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/versioned_log.h
+++ b/src/v/storage/mvlog/versioned_log.h
@@ -1,0 +1,142 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "container/fragmented_vector.h"
+#include "model/offset_interval.h"
+#include "model/record.h"
+#include "storage/mvlog/file.h"
+#include "storage/mvlog/segment_identifier.h"
+#include "storage/ntp_config.h"
+#include "utils/mutex.h"
+
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/future.hh>
+#include <seastar/core/io_priority_class.hh>
+#include <seastar/core/lowres_clock.hh>
+
+namespace storage::experimental::mvlog {
+
+class readable_segment;
+class segment_appender;
+
+struct active_segment {
+    active_segment(active_segment&) = delete;
+    active_segment(active_segment&&) = delete;
+    active_segment& operator=(active_segment&) = delete;
+    active_segment& operator=(active_segment&&) = delete;
+
+    active_segment(
+      std::unique_ptr<file>, model::offset, segment_id, size_t target_size);
+    ~active_segment();
+
+    std::unique_ptr<file> segment_file;
+    std::unique_ptr<segment_appender> appender;
+    std::unique_ptr<readable_segment> readable_seg;
+
+    // Time this segment was created, used to determine the age of the segment
+    // when applying segment.ms.
+    const ss::lowres_clock::time_point construct_time;
+
+    // Target max size of the segment.
+    const size_t target_max_size;
+
+    const segment_id id;
+    model::offset base_offset;
+    model::offset next_offset;
+};
+
+struct readonly_segment {
+    readonly_segment(readonly_segment&) = delete;
+    readonly_segment(readonly_segment&&) = delete;
+    readonly_segment& operator=(readonly_segment&) = delete;
+    readonly_segment& operator=(readonly_segment&&) = delete;
+
+    explicit readonly_segment(std::unique_ptr<active_segment>);
+    ~readonly_segment();
+
+    std::unique_ptr<file> segment_file;
+    std::unique_ptr<readable_segment> readable_seg;
+    const segment_id id;
+    model::bounded_offset_interval offsets;
+};
+
+class versioned_log {
+public:
+    versioned_log& operator=(versioned_log&) = delete;
+    versioned_log& operator=(versioned_log&&) = delete;
+    versioned_log(versioned_log&) = delete;
+    versioned_log(versioned_log&&) = delete;
+    ~versioned_log() = default;
+
+    explicit versioned_log(storage::ntp_config cfg);
+
+    // Closes the segments in the log.
+    ss::future<> close();
+
+    // Appends the record batch to the active segment, creating a new one if it
+    // doesn't exist or if past the configured segment size. Upon returning,
+    // the record batch will be visible to new readers, though may not be
+    // persisted to disk.
+    // TODO(awong): implement flushing.
+    ss::future<> append(model::record_batch);
+
+    // Checks whether the segment rolling deadline has passed for the active
+    // segment, e.g. as specified by the segment.ms property. If so, rolls the
+    // segment, leaving the log without an active segment.
+    ss::future<> apply_segment_ms();
+
+    // Returns the total of segments in the log.
+    size_t segment_count() const;
+
+    // Returns whether or not the log has an active segment.
+    bool has_active_segment() const;
+
+private:
+    using segments_t = ss::circular_buffer<std::unique_ptr<readonly_segment>>;
+
+    // Returns the appropriate target segment size for the log.
+    size_t compute_max_segment_size() const;
+
+    // Returns the point in time after which a segment should be rolled.
+    std::optional<ss::lowres_clock::time_point> compute_roll_deadline() const;
+
+    // Rolls the active segment, leaving the log without an active segment.
+    // Must be called while the active segment lock is held and while there is
+    // already an active segment.
+    ss::future<> roll_unlocked();
+
+    // Creates a new active segment.
+    // Must be called while the active segment lock is held and while there is
+    // no active segment.
+    ss::future<> create_unlocked(model::offset base);
+
+    // NTP config with which to get segment properties.
+    const ntp_config ntp_cfg_;
+
+    // File manager to manage creation and removal of files.
+    file_manager file_mgr_;
+
+    // The id of the next segment to create.
+    segment_id next_segment_id_{0};
+
+    // Lock protecting mutations that involve the active segment.
+    mutex active_segment_lock_{"active_segment_lock"};
+
+    // The segment containing the most recent data, that will be written to to
+    // if an operation requires appending to the log.
+    // May be null, e.g. if we haven't written for longer than segment.ms.
+    std::unique_ptr<active_segment> active_seg_;
+
+    // The segments with offsets lower than that in the active segment.
+    // Ordered by offsets.
+    segments_t segs_;
+};
+
+} // namespace storage::experimental::mvlog


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Introduces the beginnings of a log implementation that is able to roll
new segments with segment.bytes or segment.ms.

The log, similar to the disk_log_impl, is backed by a circular buffer of
segments, with the noteable difference that the active segment is
managed explicitly and separately from the others.

I'm not fully sold on this approach (e.g. vs only managing the segment
appender separately but keeping the underlying readable segment with the
rest of the segments), but for now it makes reasoning about segment
rolling concurrency a bit more straightforward, and down the line it
will make it easier to reason about segment removals (e.g. the active
segment cannot be removed).

This implementation is still missing quite a bit (e.g. it doesn't flush,
doesn't implement the exact log interface), but at least begins to
introduce some ideas that can back the new log implementation.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
