### PR TITLE
Adjust Rust ABI stubs to match wasmtime expectations in runtime.

### DIFF
--- a/src/transform-sdk/rust/sr-sys/src/abi.rs
+++ b/src/transform-sdk/rust/sr-sys/src/abi.rs
@@ -23,16 +23,16 @@ extern "C" {
     #[link_name = "get_schema_definition"]
     pub(crate) fn get_schema_definition(schema_id: i32, buf: *mut u8, len: i32) -> i32;
 
-    #[link_name = "get_schema_subject_len"]
-    pub(crate) fn get_schema_subject_len(
+    #[link_name = "get_subject_schema_len"]
+    pub(crate) fn get_subject_schema_len(
         subject: *const u8,
         subject_len: i32,
         version: i32,
         len: *mut i32,
     ) -> i32;
 
-    #[link_name = "get_schema_subject"]
-    pub(crate) fn get_schema_subject(
+    #[link_name = "get_subject_schema"]
+    pub(crate) fn get_subject_schema(
         subject: *const u8,
         subject_len: i32,
         version: i32,

--- a/src/transform-sdk/rust/sr-sys/src/lib.rs
+++ b/src/transform-sdk/rust/sr-sys/src/lib.rs
@@ -22,7 +22,7 @@
 mod abi;
 #[cfg(not(target_os = "wasi"))]
 mod stub_abi;
-use abi::{get_schema_definition, get_schema_subject};
+use abi::{get_schema_definition, get_subject_schema};
 #[cfg(not(target_os = "wasi"))]
 use stub_abi as abi;
 mod serde;
@@ -65,7 +65,7 @@ impl SchemaRegistryClientImpl for AbiSchemaRegistryClient {
     ) -> Result<SubjectSchema> {
         let mut length: i32 = 0;
         let errno = unsafe {
-            abi::get_schema_subject_len(
+            abi::get_subject_schema_len(
                 subject.as_ptr(),
                 subject.len() as i32,
                 version.0,
@@ -77,7 +77,7 @@ impl SchemaRegistryClientImpl for AbiSchemaRegistryClient {
         }
         let mut buf = vec![0; length as usize];
         let errno_or_amt = unsafe {
-            get_schema_subject(
+            get_subject_schema(
                 subject.as_ptr(),
                 subject.len() as i32,
                 version.0,

--- a/src/transform-sdk/rust/sr-sys/src/stub_abi.rs
+++ b/src/transform-sdk/rust/sr-sys/src/stub_abi.rs
@@ -24,7 +24,7 @@ pub(crate) unsafe fn get_schema_definition(_schema_id: i32, _buf: *mut u8, _len:
     panic!();
 }
 
-pub(crate) unsafe fn get_schema_subject_len(
+pub(crate) unsafe fn get_subject_schema_len(
     _subject: *const u8,
     _subject_len: i32,
     _version: i32,
@@ -33,7 +33,7 @@ pub(crate) unsafe fn get_schema_subject_len(
     panic!();
 }
 
-pub(crate) unsafe fn get_schema_subject(
+pub(crate) unsafe fn get_subject_schema(
     _subject: *const u8,
     _subject_len: i32,
     _version: i32,


### PR DESCRIPTION
Fixes #18528

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

### Bug Fixes

* Adjust Rust Schema Registry ABI stubs to match expected symbols names.

