### PR TITLE
Prevent Rust transform death spiral by not panicking on transform Err.

### DIFF
--- a/src/transform-sdk/rust/core-sys/src/lib.rs
+++ b/src/transform-sdk/rust/core-sys/src/lib.rs
@@ -179,6 +179,7 @@ where
             },
             writer,
         )
-        .expect("transforming record failed");
+        .inspect_err(|e| eprintln!("transforming record failed with error: {:?}", e))
+        .unwrap_or(())
     }
 }


### PR DESCRIPTION
If a Rust transform returns Err, the runtime panics because it currently calls expect on the Result. This makes any Err returned by a users transform put the wasm runtime into a death spiral of panic and restart loops. Until the runtime has a concept of handling "bad" records that cause errors (e.g. DLQ, drop, etc.) the transform should be responsible for this. Returning Err should just result in a log message, at worst.

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [x] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* Don't panic if a Rust transform returns `Err` when processing a message.

### Bug Fixes

* Stop panic-loops in the Rust runtime when a transform returns `Err`.
