### PR TITLE
base tests on raft_fixture

### DIFF
--- a/src/v/cluster/tests/CMakeLists.txt
+++ b/src/v/cluster/tests/CMakeLists.txt
@@ -28,7 +28,6 @@ set(srcs
     topic_table_partition_generator_test.cc
     idempotency_tests.cc
     feature_barrier_test.cc
-    tm_stm_tests.cc
     tm_coordinator_mapper_tests.cc
     tx_hash_ranges_tests.cc
     rm_stm_tests.cc
@@ -52,6 +51,7 @@ endforeach()
 set(srcs
     distributed_kv_stm_tests.cc
     id_allocator_stm_test.cc
+    tm_stm_tests.cc
     )
 
 foreach(cluster_test_src ${srcs})

--- a/src/v/cluster/tests/distributed_kv_stm_tests.cc
+++ b/src/v/cluster/tests/distributed_kv_stm_tests.cc
@@ -30,7 +30,7 @@ using test_value = int;
 using stm_t = cluster::distributed_kv_stm<test_key, test_value>;
 using stm_cssshptrr_t = const ss::shared_ptr<stm_t>&;
 
-struct kv_stm_fixture : stm_raft_fixture<kv_stm_fixture, stm_t> {
+struct kv_stm_fixture : stm_raft_fixture<stm_t> {
     static constexpr auto TIMEOUT = 30s;
     //
     stm_shptrs_t create_stms(

--- a/src/v/cluster/tests/id_allocator_stm_test.cc
+++ b/src/v/cluster/tests/id_allocator_stm_test.cc
@@ -41,8 +41,7 @@ namespace {
 ss::logger idstmlog{"idstm-test"};
 using stm_ssshptr_t = const ss::shared_ptr<cluster::id_allocator_stm>&;
 
-struct id_allocator_stm_fixture
-  : stm_raft_fixture<id_allocator_stm_fixture, cluster::id_allocator_stm> {
+struct id_allocator_stm_fixture : stm_raft_fixture<cluster::id_allocator_stm> {
     //
     id_allocator_stm_fixture() {
         test_local_cfg.get("id_allocator_batch_size").set_value(int16_t(1));

--- a/src/v/cluster/tests/tm_stm_tests.cc
+++ b/src/v/cluster/tests/tm_stm_tests.cc
@@ -19,19 +19,25 @@
 #include "model/timestamp.h"
 #include "raft/consensus_utils.h"
 #include "raft/tests/raft_group_fixture.h"
-#include "raft/tests/simple_raft_fixture.h"
 #include "random/generators.h"
 #include "storage/record_batch_builder.h"
 #include "storage/tests/utils/disk_log_builder.h"
-#include "test_utils/async.h"
+#include "test_utils/test.h"
+#include "tests/raft_fixture.h"
 
+#include <seastar/core/future.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/util/defer.hh>
+
+#include <gtest/gtest.h>
 
 #include <cstdint>
 #include <system_error>
 
-static ss::logger tm_logger{"tm_stm-test"};
+namespace {
+using namespace raft;
+
+ss::logger tm_logger{"tm_stm-test"};
 
 struct tm_cache_struct {
     tm_cache_struct() { cache = ss::make_lw_shared<cluster::tm_stm_cache>(); }
@@ -39,162 +45,210 @@ struct tm_cache_struct {
     ss::lw_shared_ptr<cluster::tm_stm_cache> cache;
 };
 
-using op_status = cluster::tm_stm::op_status;
+using stm_t = cluster::tm_stm;
+using stm_cssshptrr_t = const ss::shared_ptr<stm_t>&;
+using op_status = stm_t::op_status;
 using tm_transaction = cluster::tm_transaction;
 using tx_status = cluster::tm_transaction::tx_status;
+using partitions_t = std::vector<tm_transaction::tx_partition>;
 
-static tm_transaction expect_tx(checked<tm_transaction, op_status> maybe_tx) {
-    BOOST_REQUIRE(maybe_tx.has_value());
-    return maybe_tx.value();
+ss::future<> check_tx(
+  const checked<tm_transaction, op_status>& res,
+  kafka::transactional_id tx_id) {
+    ASSERT_TRUE_CORO(res);
+    ASSERT_EQ_CORO(res.assume_value().id, tx_id);
 }
-struct tm_stm_test_fixture : simple_raft_fixture {
-    void create_stm_and_start_raft() {
-        create_raft();
-        raft::state_machine_manager_builder stm_m_builder;
 
-        _stm = stm_m_builder.create_stm<cluster::tm_stm>(
+ss::future<> assert_success(op_status status) {
+    ASSERT_EQ_CORO(status, op_status::success);
+}
+
+ss::future<tm_transaction> expect_tx(
+  checked<tm_transaction, op_status>&& res, kafka::transactional_id tx_id) {
+    auto res_mv = std::move(res);
+    co_await check_tx(res_mv, tx_id);
+    auto ret = std::move(res_mv).value();
+    co_return ret;
+}
+
+auto expect_tx(kafka::transactional_id tx_id) {
+    return [tx_id](checked<tm_transaction, op_status>&& res)
+             -> ss::future<tm_transaction> {
+        return expect_tx(std::move(res), tx_id);
+    };
+}
+
+struct tm_stm_test_fixture : stm_raft_fixture<stm_t> {
+    static constexpr std::chrono::milliseconds TIMEOUT = 30s;
+
+    stm_shptrs_t create_stms(
+      state_machine_manager_builder& builder, raft_node_instance& node) {
+        return builder.create_stm<stm_t>(
           tm_logger,
-          _raft.get(),
-          std::ref(_feature_table),
-          std::ref(tm_cache.cache));
+          node.raft().get(),
+          node.get_feature_table(),
+          tm_cache.cache);
+    }
 
-        _raft->start(std::move(stm_m_builder)).get();
-        _started = true;
+    template<class Func>
+    auto retry_with_term(Func&& func) {
+        return retry_with_leader(
+          model::timeout_clock::now() + TIMEOUT,
+          [this,
+           func = std::forward<Func>(func)](raft_node_instance& leader_node) {
+              auto stm = get_stm<0>(leader_node);
+              auto term = leader_node.raft()->term();
+              return func(stm, term);
+          });
+    }
+
+    ss::future<> register_new_producer(
+      kafka::transactional_id tx_id, model::producer_identity pid //
+    ) {
+        return retry_with_term(
+                 [tx_id, pid](stm_cssshptrr_t stm, model::term_id term) {
+                     return stm->register_new_producer(term, tx_id, 0s, pid);
+                 })
+          .then(assert_success);
+    }
+
+    ss::future<> add_partitions(
+      kafka::transactional_id tx_id, const partitions_t& partitions //
+    ) {
+        return retry_with_term([tx_id, &partitions](
+                                 stm_cssshptrr_t stm, model::term_id term) {
+                   return stm->add_partitions(term, tx_id, partitions);
+               })
+          .then(assert_success);
+    }
+
+    ss::future<tm_transaction> get_tx(kafka::transactional_id tx_id) {
+        return stm_retry_with_leader<0>(
+                 TIMEOUT,
+                 [tx_id](stm_cssshptrr_t stm) { return stm->get_tx(tx_id); })
+          .then(expect_tx(tx_id));
+    }
+
+    ss::future<tm_transaction> mark_tx_ongoing(kafka::transactional_id tx_id) {
+        return retry_with_term(
+                 [tx_id](stm_cssshptrr_t stm, model::term_id term)
+                   -> ss::future<checked<tm_transaction, op_status>> {
+                     return stm->mark_tx_ongoing(term, tx_id);
+                 })
+          .then(expect_tx(tx_id));
+    }
+
+    ss::future<tm_transaction> mark_tx_prepared(kafka::transactional_id tx_id) {
+        return retry_with_term(
+                 [tx_id](stm_cssshptrr_t stm, model::term_id term)
+                   -> ss::future<checked<tm_transaction, op_status>> {
+                     return stm->mark_tx_prepared(term, tx_id);
+                 })
+          .then(expect_tx(tx_id));
     }
 
     ss::shared_ptr<cluster::tm_stm> _stm;
     tm_cache_struct tm_cache;
 };
 
-FIXTURE_TEST(test_tm_stm_new_tx, tm_stm_test_fixture) {
-    create_stm_and_start_raft();
-    auto& stm = *_stm;
+TEST_F_CORO(tm_stm_test_fixture, test_tm_stm_new_tx) {
+    co_await initialize_state_machines();
 
-    wait_for_confirmed_leader();
-    wait_for_meta_initialized();
+    kafka::transactional_id tx_id("app-id-1");
+    model::producer_identity pid{1, 0};
 
-    auto tx_id = kafka::transactional_id("app-id-1");
-    auto pid = model::producer_identity{1, 0};
+    co_await register_new_producer(tx_id, pid);
 
-    auto op_code = stm
-                     .register_new_producer(
-                       _raft->term(), tx_id, std::chrono::milliseconds(0), pid)
-                     .get0();
-    BOOST_REQUIRE_EQUAL(op_code, op_status::success);
-    auto tx1 = expect_tx(stm.get_tx(tx_id).get0());
-    BOOST_REQUIRE_EQUAL(tx1.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx1.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx1.status, tx_status::ready);
-    BOOST_REQUIRE_EQUAL(tx1.partitions.size(), 0);
-    expect_tx(stm.mark_tx_ongoing(_raft->term(), tx_id).get0());
+    auto tx1 = co_await get_tx(tx_id);
+    ASSERT_EQ_CORO(tx1.pid, pid);
+    ASSERT_EQ_CORO(tx1.status, tx_status::ready);
+    ASSERT_EQ_CORO(tx1.partitions.size(), 0);
+    co_await mark_tx_ongoing(tx_id);
+
     std::vector<tm_transaction::tx_partition> partitions = {
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    BOOST_REQUIRE_EQUAL(
-      stm.add_partitions(_raft->term(), tx_id, partitions).get0(),
-      cluster::tm_stm::op_status::success);
-    BOOST_REQUIRE_EQUAL(tx1.partitions.size(), 0);
-    auto tx2 = expect_tx(stm.get_tx(tx_id).get0());
-    BOOST_REQUIRE_EQUAL(tx2.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx2.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx2.status, tx_status::ongoing);
-    BOOST_REQUIRE_GT(tx2.tx_seq, tx1.tx_seq);
-    BOOST_REQUIRE_EQUAL(tx2.partitions.size(), 2);
-    auto tx4 = expect_tx(stm.mark_tx_prepared(_raft->term(), tx_id).get());
-    BOOST_REQUIRE_EQUAL(tx4.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx4.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx4.status, tx_status::prepared);
-    BOOST_REQUIRE_EQUAL(tx4.tx_seq, tx2.tx_seq);
-    BOOST_REQUIRE_EQUAL(tx4.partitions.size(), 2);
-    auto tx5 = expect_tx(stm.mark_tx_ongoing(_raft->term(), tx_id).get0());
-    BOOST_REQUIRE_EQUAL(tx5.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx5.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx5.status, tx_status::ongoing);
-    BOOST_REQUIRE_GT(tx5.tx_seq, tx2.tx_seq);
-    BOOST_REQUIRE_EQUAL(tx5.partitions.size(), 0);
+    co_await add_partitions(tx_id, partitions);
+
+    ASSERT_EQ_CORO(tx1.partitions.size(), 0);
+
+    auto tx2 = co_await get_tx(tx_id);
+    ASSERT_EQ_CORO(tx2.pid, pid);
+    ASSERT_EQ_CORO(tx2.status, tx_status::ongoing);
+    ASSERT_GT_CORO(tx2.tx_seq, tx1.tx_seq);
+    ASSERT_EQ_CORO(tx2.partitions.size(), 2);
+
+    auto tx4 = co_await mark_tx_prepared(tx_id);
+    ASSERT_EQ_CORO(tx4.pid, pid);
+    ASSERT_EQ_CORO(tx4.status, tx_status::prepared);
+    ASSERT_EQ_CORO(tx4.tx_seq, tx4.tx_seq);
+    ASSERT_EQ_CORO(tx4.partitions.size(), 2);
+
+    auto tx5 = co_await mark_tx_ongoing(tx_id);
+    ASSERT_EQ_CORO(tx5.pid, pid);
+    ASSERT_EQ_CORO(tx5.status, tx_status::ongoing);
+    ASSERT_GT_CORO(tx5.tx_seq, tx4.tx_seq);
+    ASSERT_EQ_CORO(tx5.partitions.size(), 0);
 }
 
-FIXTURE_TEST(test_tm_stm_seq_tx, tm_stm_test_fixture) {
-    create_stm_and_start_raft();
-    auto& stm = *_stm;
+TEST_F_CORO(tm_stm_test_fixture, test_tm_stm_seq_tx) {
+    co_await initialize_state_machines();
 
-    wait_for_confirmed_leader();
-    wait_for_meta_initialized();
+    kafka::transactional_id tx_id("app-id-1");
+    model::producer_identity pid{1, 0};
 
-    auto tx_id = kafka::transactional_id("app-id-1");
-    auto pid = model::producer_identity{1, 0};
+    co_await register_new_producer(tx_id, pid);
 
-    auto op_code = stm
-                     .register_new_producer(
-                       _raft->term(), tx_id, std::chrono::milliseconds(0), pid)
-                     .get0();
-    BOOST_REQUIRE_EQUAL(op_code, op_status::success);
-    auto tx1 = expect_tx(stm.get_tx(tx_id).get0());
-    auto tx2 = stm.mark_tx_ongoing(_raft->term(), tx_id).get0();
-    std::vector<tm_transaction::tx_partition> partitions = {
+    auto tx1 = co_await get_tx(tx_id);
+    co_await mark_tx_ongoing(tx_id);
+
+    partitions_t partitions = {
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    BOOST_REQUIRE_EQUAL(
-      stm.add_partitions(_raft->term(), tx_id, partitions).get0(),
-      cluster::tm_stm::op_status::success);
-    auto tx3 = expect_tx(stm.get_tx(tx_id).get0());
-    auto tx5 = expect_tx(stm.mark_tx_prepared(_raft->term(), tx_id).get());
-    auto tx6 = expect_tx(stm.mark_tx_ongoing(_raft->term(), tx_id).get0());
-    BOOST_REQUIRE_EQUAL(tx6.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx6.pid, pid);
-    BOOST_REQUIRE_EQUAL(tx6.status, tx_status::ongoing);
-    BOOST_REQUIRE_EQUAL(tx6.partitions.size(), 0);
-    BOOST_REQUIRE_NE(tx6.tx_seq, tx1.tx_seq);
+    co_await add_partitions(tx_id, partitions);
+    co_await get_tx(tx_id);
+    co_await mark_tx_prepared(tx_id);
+    auto tx6 = co_await mark_tx_ongoing(tx_id);
+    ASSERT_EQ_CORO(tx6.pid, pid);
+    ASSERT_EQ_CORO(tx6.status, tx_status::ongoing);
+    ASSERT_EQ_CORO(tx6.partitions.size(), 0);
+    ASSERT_NE_CORO(tx6.tx_seq, tx1.tx_seq);
 }
 
-FIXTURE_TEST(test_tm_stm_re_tx, tm_stm_test_fixture) {
-    create_stm_and_start_raft();
-    auto& stm = *_stm;
+TEST_F_CORO(tm_stm_test_fixture, test_tm_stm_re_tx) {
+    co_await initialize_state_machines();
 
-    wait_for_confirmed_leader();
-    wait_for_meta_initialized();
+    kafka::transactional_id tx_id("app-id-1");
+    model::producer_identity pid1{1, 0};
 
-    auto tx_id = kafka::transactional_id("app-id-1");
-    auto pid1 = model::producer_identity{1, 0};
+    co_await register_new_producer(tx_id, pid1);
+    co_await get_tx(tx_id);
 
-    auto op_code = stm
-                     .register_new_producer(
-                       _raft->term(), tx_id, std::chrono::milliseconds(0), pid1)
-                     .get0();
-    BOOST_REQUIRE(op_code == op_status::success);
-    auto tx1 = expect_tx(stm.get_tx(tx_id).get0());
-    std::vector<tm_transaction::tx_partition> partitions = {
+    partitions_t partitions = {
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 0), .etag = model::term_id(0)},
       tm_transaction::tx_partition{
         .ntp = model::ntp("kafka", "topic", 1), .etag = model::term_id(0)}};
-    auto tx2 = stm.mark_tx_ongoing(_raft->term(), tx_id).get0();
-    BOOST_REQUIRE_EQUAL(
-      stm.add_partitions(_raft->term(), tx_id, partitions).get0(),
-      cluster::tm_stm::op_status::success);
-    auto tx3 = expect_tx(stm.get_tx(tx_id).get0());
-    auto tx5 = expect_tx(stm.mark_tx_prepared(_raft->term(), tx_id).get());
-    auto tx6 = expect_tx(stm.mark_tx_ongoing(_raft->term(), tx_id).get0());
+    co_await mark_tx_ongoing(tx_id);
+    co_await add_partitions(tx_id, partitions);
+    co_await get_tx(tx_id);
+    co_await mark_tx_prepared(tx_id);
+    co_await mark_tx_ongoing(tx_id);
 
-    auto pid2 = model::producer_identity{1, 1};
-    auto expected_pid = model::producer_identity(3, 5);
-    op_code = stm
-                .re_register_producer(
-                  _raft->term(),
-                  tx_id,
-                  std::chrono::milliseconds(0),
-                  pid2,
-                  expected_pid,
-                  pid1)
-                .get0();
-    BOOST_REQUIRE_EQUAL(op_code, op_status::success);
-    auto tx7 = expect_tx(stm.get_tx(tx_id).get0());
-    BOOST_REQUIRE_EQUAL(tx7.id, tx_id);
-    BOOST_REQUIRE_EQUAL(tx7.pid, pid2);
-    BOOST_REQUIRE_EQUAL(tx7.status, tx_status::ready);
-    BOOST_REQUIRE_EQUAL(tx7.partitions.size(), 0);
+    model::producer_identity pid2{1, 1};
+    model::producer_identity expected_pid(3, 5);
+    co_await retry_with_term([tx_id, pid1, expected_pid, pid2](
+                               stm_cssshptrr_t stm, model::term_id term) {
+        return stm->re_register_producer(
+          term, tx_id, 0s, pid2, expected_pid, pid1);
+    }).then(assert_success);
+    auto tx7 = co_await get_tx(tx_id);
+    ASSERT_EQ_CORO(tx7.pid, pid2);
+    ASSERT_EQ_CORO(tx7.status, tx_status::ready);
+    ASSERT_EQ_CORO(tx7.partitions.size(), 0);
 }
+} // namespace

--- a/src/v/raft/tests/CMakeLists.txt
+++ b/src/v/raft/tests/CMakeLists.txt
@@ -30,7 +30,6 @@ set(srcs
     leadership_test.cc
     append_entries_test.cc
     offset_monitor_test.cc
-    mux_state_machine_test.cc
     mutex_buffer_test.cc
     state_removal_test.cc
     configuration_manager_test.cc
@@ -54,6 +53,7 @@ set(gsrcs
     raft_reconfiguration_test.cc
     persisted_stm_test.cc
     replication_monitor_tests.cc
+    mux_state_machine_test.cc
 )
 
 rp_test(

--- a/src/v/raft/tests/mux_state_machine_test.cc
+++ b/src/v/raft/tests/mux_state_machine_test.cc
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "base/vassert.h"
+#include "group_configuration.h"
 #include "model/fundamental.h"
 #include "model/record.h"
 #include "model/record_batch_types.h"
@@ -14,20 +16,38 @@
 #include "raft/mux_state_machine.h"
 #include "raft/tests/simple_raft_fixture.h"
 #include "reflection/adl.h"
+#include "state_machine_base.h"
 #include "storage/record_batch_builder.h"
 #include "storage/tests/utils/disk_log_builder.h"
 #include "test_utils/fixture.h"
+#include "test_utils/test.h"
+#include "tests/raft_fixture.h"
 
 #include <seastar/core/abort_source.hh>
 #include <seastar/core/future.hh>
+#include <seastar/core/loop.hh>
+#include <seastar/core/shared_ptr.hh>
 #include <seastar/core/sleep.hh>
-#include <seastar/util/defer.hh>
 #include <seastar/util/log.hh>
 
 #include <boost/range/irange.hpp>
 #include <boost/test/tools/old/interface.hpp>
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <exception>
+#include <memory>
+#include <numeric>
+#include <system_error>
 
 using namespace std::chrono_literals;
+using namespace raft;
+
+namespace mux_state_machine_test {
+
+ss::logger kvlog{"kv-test"};
 
 struct set_cmd {
     static constexpr uint8_t record_key = 0;
@@ -85,18 +105,20 @@ inline const std::error_category& error_category() noexcept {
 inline std::error_code make_error_code(errc e) noexcept {
     return std::error_code(static_cast<int>(e), error_category());
 }
-
+} // namespace mux_state_machine_test
 namespace std {
 template<>
-struct is_error_code_enum<::errc> : true_type {};
+struct is_error_code_enum<mux_state_machine_test::errc> : true_type {};
 } // namespace std
 
+namespace mux_state_machine_test {
 static constexpr int8_t batch_type_1{10};
 static constexpr int8_t batch_type_2{11};
 
 template<int8_t bt>
 struct simple_kv {
-    absl::flat_hash_map<ss::sstring, int> kv_map;
+    using map_t = absl::flat_hash_map<ss::sstring, int>;
+    map_t kv_map;
     ss::abort_source as;
 
     ss::future<std::error_code> apply_update(model::record_batch&& b) {
@@ -167,7 +189,6 @@ struct simple_kv_stm final : public raft::mux_state_machine<simple_kv<bt>...> {
     template<typename... Args>
     simple_kv_stm(Args&&... stm_args)
       : base_t(std::forward<Args>(stm_args)...) {}
-
     ss::future<std::optional<iobuf>>
     maybe_make_snapshot(ssx::semaphore_units) final {
         iobuf buf;
@@ -182,8 +203,7 @@ struct simple_kv_stm final : public raft::mux_state_machine<simple_kv<bt>...> {
         auto snap_buf_parser = iobuf_parser{
           co_await read_iobuf_exactly(reader.input(), size)};
         auto read_single = [&](auto& state) {
-            state.kv_map = serde::read<absl::flat_hash_map<ss::sstring, int>>(
-              snap_buf_parser);
+            state.kv_map = serde::read<simple_kv<0>::map_t>(snap_buf_parser);
         };
         std::apply(
           [&](auto&&... states) { (read_single(states), ...); },
@@ -193,8 +213,6 @@ struct simple_kv_stm final : public raft::mux_state_machine<simple_kv<bt>...> {
 
 static absl::flat_hash_set<model::record_batch_type> not_handled_batch_types{
   model::record_batch_type::raft_configuration};
-
-ss::logger kvlog{"kv-test"};
 
 template<typename T>
 model::record_batch
@@ -208,203 +226,220 @@ serialize_cmd(T t, int8_t type, model::offset o = model::offset(0)) {
     return std::move(b).build();
 }
 
-FIXTURE_TEST(test_mux_state_machine_simple_scenarios, simple_raft_fixture) {
-    start_raft();
-    simple_kv<batch_type_1> state;
-    simple_kv_stm<batch_type_1> stm(
-      kvlog,
-      _raft.get(),
-      raft::persistent_last_applied::yes,
-      not_handled_batch_types,
-      state);
-    stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
-    wait_for_becoming_leader();
+template<class STM>
+struct kv_stm_fixture : raft::stm_raft_fixture<STM> {
+    static constexpr auto TIMEOUT = 5s;
+
+    using base = raft::stm_raft_fixture<STM>;
+    using stm_shptr_t = ss::shared_ptr<STM>;
+
+    ss::future<> start_stms() {
+        return base::parallel_for_each_node([this](raft_node_instance& node) {
+            return std::get<0>(this->node_stms[node.get_vnode()])->start();
+        });
+    };
+
+    ss::future<> TearDownAsync() override {
+        co_await base::parallel_for_each_node([this](raft_node_instance& node) {
+            return std::get<0>(this->node_stms[node.get_vnode()])->stop();
+        });
+        co_await base::TearDownAsync();
+    };
+
+    ss::future<std::error_code> replicate_and_wait(
+      model::record_batch b, std::chrono::milliseconds timeout = 1s) {
+        return base::template stm_retry_with_leader<0>(
+          TIMEOUT, [b = std::move(b), timeout, this](const stm_shptr_t& stm) {
+              return stm->replicate_and_wait(
+                b.copy(), model::timeout_clock::now() + timeout, as);
+          });
+    }
     ss::abort_source as;
+};
 
+using kv1_stm_t = simple_kv_stm<batch_type_1>;
+struct kv1_stm_fixture : kv_stm_fixture<kv1_stm_t> {
+    using kv_t = simple_kv<batch_type_1>;
+    using map_t = kv_t::map_t;
+    std::tuple<ss::shared_ptr<kv1_stm_t>> create_stms(
+      raft::state_machine_manager_builder& builder,
+      raft_node_instance& node) override {
+        auto [it, inserted] = kvs.emplace(
+          std::piecewise_construct,
+          std::tuple{node.get_vnode()},
+          std::tuple{new kv_t()});
+        vassert(inserted, "attempted to initialize multiple stms per node");
+        return ss::make_shared<kv1_stm_t>(
+          kvlog,
+          node.raft().get(),
+          raft::persistent_last_applied::yes,
+          not_handled_batch_types,
+          *it->second);
+    }
+
+    template<class Func>
+    ss::future<bool> with_leaders_kv(Func&& f) {
+        return with_leader(
+          30s,
+          [this, f = std::forward<Func>(f)](raft_node_instance& node) mutable {
+              return f(kvs[node.get_vnode()]->kv_map);
+          });
+    }
+
+    absl::flat_hash_map<raft::vnode, std::unique_ptr<kv_t>> kvs;
+};
+
+TEST_F_CORO(kv1_stm_fixture, test_mux_state_machine_simple_scenarios) {
+    co_await initialize_state_machines(1);
+    co_await start_stms();
     // success set
-    info("Test case: success set");
-    auto res = stm
-                 .replicate_and_wait(
-                   serialize_cmd(set_cmd{"test", 10}, batch_type_1),
-                   model::timeout_clock::now() + 2s,
-                   as)
-                 .get0();
-
-    BOOST_REQUIRE_EQUAL(res, errc::success);
-    BOOST_CHECK(state.kv_map.find("test")->second == 10);
+    vlog(kvlog.info, "Test case: success set");
+    auto res = co_await replicate_and_wait(
+      serialize_cmd(set_cmd{"test", 10}, batch_type_1));
+    vlog(kvlog.info, "long afterwards");
+    ASSERT_EQ_CORO(res, errc::success);
+    ASSERT_TRUE_CORO(co_await with_leaders_kv(
+      [](const map_t& map) { return map.find("test")->second == 10; }));
 
     // error
-    info("Test case: error set");
-    res = stm
-            .replicate_and_wait(
-              serialize_cmd(set_cmd{"test", 11}, batch_type_1),
-              model::timeout_clock::now() + 2s,
-              as)
-            .get0();
+    vlog(kvlog.info, "Test case: error set");
+    res = co_await replicate_and_wait(
+      serialize_cmd(set_cmd{"test", 11}, batch_type_1));
 
-    BOOST_REQUIRE_EQUAL(res, errc::key_already_exists);
-    BOOST_CHECK(state.kv_map.find("test")->second == 10);
+    ASSERT_EQ_CORO(res, errc::key_already_exists);
+    ASSERT_TRUE_CORO(co_await with_leaders_kv(
+      [](const map_t& map) { return map.find("test")->second == 10; }));
 
     // success cas
-    info("Test case: success cas");
-    res = stm
-            .replicate_and_wait(
-              serialize_cmd(cas_cmd{"test", 10, 20}, batch_type_1),
-              model::timeout_clock::now() + 2s,
-              as)
-            .get0();
-
-    BOOST_REQUIRE_EQUAL(res, errc::success);
-    BOOST_CHECK(state.kv_map.find("test")->second == 20);
+    vlog(kvlog.info, "Test case: success cas");
+    res = co_await replicate_and_wait(
+      serialize_cmd(cas_cmd{"test", 10, 20}, batch_type_1));
+    ASSERT_EQ_CORO(res, errc::success);
+    ASSERT_TRUE_CORO(co_await with_leaders_kv(
+      [](const map_t& map) { return map.find("test")->second == 20; }));
 
     // error cas
-    info("Test case: error cas");
-    res = stm
-            .replicate_and_wait(
-              serialize_cmd(cas_cmd{"test", 11, 20}, batch_type_1),
-              model::timeout_clock::now() + 2s,
-              as)
-            .get0();
-
-    BOOST_REQUIRE_EQUAL(res, errc::cas_error);
-    BOOST_CHECK(state.kv_map.find("test")->second == 20);
+    vlog(kvlog.info, "Test case: error cas");
+    res = co_await replicate_and_wait(
+      serialize_cmd(cas_cmd{"test", 11, 20}, batch_type_1));
+    ASSERT_EQ_CORO(res, errc::cas_error);
+    ASSERT_TRUE_CORO(co_await with_leaders_kv(
+      [](const map_t& map) { return map.find("test")->second == 20; }));
 
     // success delete
-    info("Test case: success delete");
-    res = stm
-            .replicate_and_wait(
-              serialize_cmd(delete_cmd{"test"}, batch_type_1),
-              model::timeout_clock::now() + 2s,
-              as)
-            .get0();
+    vlog(kvlog.info, "Test case: success delete");
+    res = co_await replicate_and_wait(
+      serialize_cmd(delete_cmd{"test"}, batch_type_1));
 
-    BOOST_REQUIRE_EQUAL(res, errc::success);
-    BOOST_CHECK(state.kv_map.empty());
+    ASSERT_EQ_CORO(res, errc::success);
+    ASSERT_TRUE_CORO(
+      co_await with_leaders_kv([](const map_t& map) { return map.empty(); }));
 }
 
-FIXTURE_TEST(test_concurrent_sets, simple_raft_fixture) {
-    start_raft();
-    simple_kv<batch_type_1> state;
-    simple_kv_stm<batch_type_1> stm(
-      kvlog,
-      _raft.get(),
-      raft::persistent_last_applied::yes,
-      not_handled_batch_types,
-      state);
-    stm.start().get0();
-    wait_for_becoming_leader();
-    ss::abort_source as;
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
+TEST_F_CORO(kv1_stm_fixture, test_concurrent_sets) {
+    co_await initialize_state_machines(1);
+    co_await start_stms();
     auto range = boost::irange(0, 50);
+
     std::vector<ss::future<std::error_code>> futures;
     futures.reserve(range.size());
     std::transform(
-      range.begin(),
-      range.end(),
-      std::back_inserter(futures),
-      [&stm, &as](int i) {
+      range.begin(), range.end(), std::back_inserter(futures), [this](int i) {
           return ss::sleep(
                    std::chrono::milliseconds(random_generators::get_int(10)))
-            .then([&stm, &as, i] {
-                return stm.replicate_and_wait(
-                  serialize_cmd(set_cmd{"test", i}, batch_type_1),
-                  model::timeout_clock::now() + 2s,
-                  as);
+            .then([this, i] {
+                return replicate_and_wait(
+                  serialize_cmd(set_cmd{"test", i}, batch_type_1));
             });
       });
 
-    auto results = ss::when_all_succeed(futures.begin(), futures.end()).get0();
+    auto results = co_await ss::when_all_succeed(
+      futures.begin(), futures.end());
 
     auto success_count = 0;
     for (int i = 0; i < results.size(); ++i) {
         if (results[i] == errc::success) {
-            info("Applied value: {}", i);
+            vlog(kvlog.info, "Applied value: {}", i);
             ++success_count;
-            BOOST_REQUIRE_EQUAL(state.kv_map.find("test")->second, i);
+            ASSERT_TRUE_CORO(co_await with_leaders_kv(
+              [i](const map_t& map) { return map.find("test")->second == i; }));
         }
     }
-
-    BOOST_REQUIRE_EQUAL(success_count, 1);
+    ASSERT_EQ_CORO(success_count, 1);
 }
 
-FIXTURE_TEST(test_stm_recovery, simple_raft_fixture) {
+TEST_F_CORO(raft_fixture, test_stm_recovery) {
+    add_node(model::node_id(1), model::revision_id(0));
+    raft_node_instance& node = *(nodes().begin()->second);
     {
+        auto ntp = node.ntp();
         auto cfg = storage::log_builder_config();
-        cfg.base_dir = _data_dir;
+        cfg.base_dir = node.base_directory();
         storage::disk_log_builder builder(cfg);
         model::offset offset(0);
         std::vector<model::record_batch> batches;
 
-        builder | storage::start(_ntp) | storage::add_segment(0);
-
-        builder
-          .add_batch(serialize_cmd(set_cmd{"test", 1}, batch_type_1, offset++))
-          .get0(); // -> test = 1
-        builder
-          .add_batch(serialize_cmd(set_cmd{"test", 2}, batch_type_1, offset++))
-          .get0(); // -> failed
-        builder
-          .add_batch(serialize_cmd(set_cmd{"test", 3}, batch_type_1, offset++))
-          .get0(); // -> failed
-        builder
-          .add_batch(
-            serialize_cmd(cas_cmd{"test", 1, 10}, batch_type_1, offset++))
-          .get0(); // -> test =10
-        builder
-          .add_batch(
-            serialize_cmd(set_cmd{"test-1", 2}, batch_type_1, offset++))
-          .get0(); // -> failed
-        builder
-          .add_batch(
-            serialize_cmd(set_cmd{"test-2", 15}, batch_type_1, offset++))
-          .get0(); // -> test-2 = 15
-        builder
-          .add_batch(
-            serialize_cmd(cas_cmd{"test-2", 15, 1}, batch_type_1, offset++))
-          .get0(); // -> test-2 = 1
-        builder
-          .add_batch(
-            serialize_cmd(cas_cmd{"test-2", 15, 2}, batch_type_1, offset++))
-          .get0(); // -> failed
-        builder
-          .add_batch(
-            serialize_cmd(delete_cmd{"test-1"}, batch_type_1, offset++))
-          .get0(); // -> test-1 deleted
-        builder.stop().get0();
+        co_await builder.start(ntp);
+        co_await builder.add_segment(model::offset(0));
+        co_await builder.add_batch(serialize_cmd(
+          set_cmd{"test", 1}, batch_type_1, offset++)); // -> test = 1
+        co_await builder.add_batch(serialize_cmd(
+          set_cmd{"test", 2}, batch_type_1, offset++)); // -> failed
+        co_await builder.add_batch(serialize_cmd(
+          set_cmd{"test", 3}, batch_type_1, offset++)); // -> failed
+        co_await builder.add_batch(serialize_cmd(
+          cas_cmd{"test", 1, 10}, batch_type_1, offset++)); // -> test =10
+        co_await builder.add_batch(serialize_cmd(
+          set_cmd{"test-1", 2}, batch_type_1, offset++)); // -> failed
+        co_await builder.add_batch(serialize_cmd(
+          set_cmd{"test-2", 15}, batch_type_1, offset++)); // -> test-2 = 15
+        co_await builder.add_batch(serialize_cmd(
+          cas_cmd{"test-2", 15, 1}, batch_type_1, offset++)); // -> test-2 = 1
+        co_await builder.add_batch(serialize_cmd(
+          cas_cmd{"test-2", 15, 2}, batch_type_1, offset++)); // -> failed
+        co_await builder.add_batch(serialize_cmd(
+          delete_cmd{"test-1"}, batch_type_1, offset++)); // -> test-1 deleted
+        co_await builder.stop();
     }
-    start_raft();
-    wait_for_confirmed_leader();
-
-    auto last_offset = _raft->dirty_offset();
+    co_await node.initialise(all_vnodes());
+    co_await node.start(std::nullopt);
+    co_await wait_for_leader(30s);
+    auto last_offset = node.raft()->dirty_offset();
 
     // Correct state:
     // test = 10
     // test-2 = 1
-
     {
         simple_kv<batch_type_1> state;
         simple_kv_stm<batch_type_1> stm(
           kvlog,
-          _raft.get(),
+          node.raft().get(),
           raft::persistent_last_applied::yes,
           not_handled_batch_types,
           state);
-        stm.start().get();
-        auto stop = ss::defer([&stm] { stm.stop().get(); });
+        std::exception_ptr ex = nullptr;
+        try {
+            co_await stm.start();
 
-        stm.wait(last_offset, model::timeout_clock::now() + 1s).get();
-        BOOST_REQUIRE_EQUAL(stm.get_last_applied_offset(), last_offset);
-        BOOST_REQUIRE_EQUAL(state.kv_map.size(), 2);
-        BOOST_REQUIRE_EQUAL(state.kv_map.find("test")->second, 10);
-        BOOST_REQUIRE_EQUAL(state.kv_map.contains("test-1"), false);
-        BOOST_REQUIRE_EQUAL(state.kv_map.contains("test-2"), 1);
+            co_await stm.wait(last_offset, model::timeout_clock::now() + 1s);
+            ASSERT_EQ_CORO(stm.get_last_applied_offset(), last_offset);
+            ASSERT_EQ_CORO(state.kv_map.size(), 2);
+            ASSERT_EQ_CORO(state.kv_map.find("test")->second, 10);
+            ASSERT_EQ_CORO(state.kv_map.contains("test-1"), false);
+            ASSERT_EQ_CORO(state.kv_map.contains("test-2"), 1);
 
-        // create a snapshot
-        BOOST_REQUIRE(stm.maybe_write_snapshot().get());
-        BOOST_REQUIRE_EQUAL(
-          _raft->start_offset(),
-          model::next_offset(stm.get_last_applied_offset()));
+            // create a snapshot
+            ASSERT_TRUE_CORO(co_await stm.maybe_write_snapshot());
+            ASSERT_EQ_CORO(
+              node.raft()->start_offset(),
+              model::next_offset(stm.get_last_applied_offset()));
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        co_await stm.stop();
+        if (ex) {
+            std::rethrow_exception(ex);
+        }
     }
 
     {
@@ -412,120 +447,131 @@ FIXTURE_TEST(test_stm_recovery, simple_raft_fixture) {
         simple_kv<batch_type_1> state;
         simple_kv_stm<batch_type_1> stm(
           kvlog,
-          _raft.get(),
+          node.raft().get(),
           raft::persistent_last_applied::yes,
           not_handled_batch_types,
           state);
-        stm.start().get();
-        auto stop = ss::defer([&stm] { stm.stop().get(); });
+        std::exception_ptr ex = nullptr;
+        try {
+            co_await stm.start();
 
-        stm.wait(last_offset, model::timeout_clock::now() + 1s).get();
-        BOOST_REQUIRE_EQUAL(state.kv_map.size(), 2);
-        BOOST_REQUIRE_EQUAL(state.kv_map.find("test")->second, 10);
-        BOOST_REQUIRE_EQUAL(state.kv_map.contains("test-1"), false);
-        BOOST_REQUIRE_EQUAL(state.kv_map.contains("test-2"), 1);
+            co_await stm.wait(last_offset, model::timeout_clock::now() + 1s);
+            ASSERT_EQ_CORO(state.kv_map.size(), 2);
+            ASSERT_EQ_CORO(state.kv_map.find("test")->second, 10);
+            ASSERT_EQ_CORO(state.kv_map.contains("test-1"), false);
+            ASSERT_EQ_CORO(state.kv_map.contains("test-2"), 1);
+        } catch (...) {
+            ex = std::current_exception();
+        }
+        co_await stm.stop();
+        if (ex) {
+            std::rethrow_exception(ex);
+        }
     }
 }
 
-FIXTURE_TEST(test_mulitple_states, simple_raft_fixture) {
-    start_raft();
-    simple_kv<batch_type_1> state_1;
-    simple_kv<batch_type_2> state_2;
-    simple_kv_stm<batch_type_1, batch_type_2> stm(
-      kvlog,
-      _raft.get(),
-      raft::persistent_last_applied::yes,
-      not_handled_batch_types,
-      state_1,
-      state_2);
-    stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
-    wait_for_becoming_leader();
-    ss::abort_source as;
+using kv2_stm_t = simple_kv_stm<batch_type_1, batch_type_2>;
+struct kv2_stm_fixture : kv_stm_fixture<kv2_stm_t> {
+    using kv1_t = simple_kv<batch_type_1>;
+    using kv2_t = simple_kv<batch_type_2>;
+    using kv_t = std::tuple<kv1_t, kv2_t>;
+    using map1_t = kv1_t::map_t;
+    using map2_t = kv2_t::map_t;
+    std::tuple<ss::shared_ptr<kv2_stm_t>> create_stms(
+      raft::state_machine_manager_builder& builder,
+      raft_node_instance& node) override {
+        auto [it, inserted] = kvs.emplace(
+          std::piecewise_construct,
+          std::tuple{node.get_vnode()},
+          std::tuple{new kv_t()});
+        vassert(inserted, "attempted to initialize multiple stms per node");
+        return ss::make_shared<kv2_stm_t>(
+          kvlog,
+          node.raft().get(),
+          raft::persistent_last_applied::yes,
+          not_handled_batch_types,
+          std::get<0>(*it->second),
+          std::get<1>(*it->second));
+    }
+
+    template<class Func>
+    ss::future<bool> with_leaders_kv(Func&& f) {
+        return with_leader(
+          30s,
+          [this, f = std::forward<Func>(f)](raft_node_instance& node) mutable {
+              kv_t& pair = *kvs[node.get_vnode()];
+              return f(std::get<0>(pair).kv_map, std::get<1>(pair).kv_map);
+          });
+    }
+    absl::flat_hash_map<raft::vnode, std::unique_ptr<kv_t>> kvs;
+};
+
+TEST_F_CORO(kv2_stm_fixture, test_mulitple_states) {
+    co_await initialize_state_machines(3);
+    co_await start_stms();
 
     // set in state 1
-    auto res = stm
-                 .replicate_and_wait(
-                   serialize_cmd(set_cmd{"test", 10}, batch_type_1),
-                   model::timeout_clock::now() + 2s,
-                   as)
-                 .get0();
-
-    BOOST_REQUIRE_EQUAL(res, errc::success);
-    BOOST_REQUIRE_EQUAL(state_1.kv_map.find("test")->second, 10);
-    BOOST_CHECK(state_2.kv_map.empty());
+    auto res = co_await replicate_and_wait(
+      serialize_cmd(set_cmd{"test", 10}, batch_type_1));
+    ASSERT_EQ_CORO(res, errc::success);
+    ASSERT_TRUE_CORO(
+      co_await with_leaders_kv([](const map1_t& map1, const map2_t& map2) {
+          return map1.find("test")->second == 10 && map2.empty();
+      }));
 
     // set in state 2
-    res = stm
-            .replicate_and_wait(
-              serialize_cmd(set_cmd{"test", 11}, batch_type_2),
-              model::timeout_clock::now() + 2s,
-              as)
-            .get0();
+    res = co_await replicate_and_wait(
+      serialize_cmd(set_cmd{"test", 11}, batch_type_2));
 
-    BOOST_REQUIRE_EQUAL(res, errc::success);
-    BOOST_REQUIRE_EQUAL(state_1.kv_map.find("test")->second, 10);
-    BOOST_REQUIRE_EQUAL(state_2.kv_map.find("test")->second, 11);
+    ASSERT_EQ_CORO(res, errc::success);
+    ASSERT_TRUE_CORO(
+      co_await with_leaders_kv([](const map1_t& map1, const map2_t& map2) {
+          return map1.find("test")->second == 10
+                 && map2.find("test")->second == 11;
+      }));
 
     // cas in state 2
-    res = stm
-            .replicate_and_wait(
-              serialize_cmd(cas_cmd{"test", 11, 20}, batch_type_2),
-              model::timeout_clock::now() + 2s,
-              as)
-            .get0();
-
-    BOOST_REQUIRE_EQUAL(res, errc::success);
-    BOOST_REQUIRE_EQUAL(state_1.kv_map.find("test")->second, 10);
-    BOOST_REQUIRE_EQUAL(state_2.kv_map.find("test")->second, 20);
+    res = co_await replicate_and_wait(
+      serialize_cmd(cas_cmd{"test", 11, 20}, batch_type_2));
+    ASSERT_EQ_CORO(res, errc::success);
+    ASSERT_TRUE_CORO(
+      co_await with_leaders_kv([](const map1_t& map1, const map2_t& map2) {
+          return map1.find("test")->second == 10
+                 && map2.find("test")->second == 20;
+      }));
 
     // failed delete in state 1
-    res = stm
-            .replicate_and_wait(
-              serialize_cmd(delete_cmd{"other"}, batch_type_1),
-              model::timeout_clock::now() + 2s,
-              as)
-            .get0();
-
-    BOOST_REQUIRE_EQUAL(res, errc::key_not_exist);
-    BOOST_REQUIRE_EQUAL(state_1.kv_map.find("test")->second, 10);
-    BOOST_REQUIRE_EQUAL(state_2.kv_map.find("test")->second, 20);
+    res = co_await replicate_and_wait(
+      serialize_cmd(delete_cmd{"other"}, batch_type_1));
+    ASSERT_EQ_CORO(res, errc::key_not_exist);
+    ASSERT_TRUE_CORO(
+      co_await with_leaders_kv([](const map1_t& map1, const map2_t& map2) {
+          return map1.find("test")->second == 10
+                 && map2.find("test")->second == 20;
+      }));
 
     // success delete in state 1
-    info("Test case: success delete");
-    res = stm
-            .replicate_and_wait(
-              serialize_cmd(delete_cmd{"test"}, batch_type_1),
-              model::timeout_clock::now() + 2s,
-              as)
-            .get0();
-
-    BOOST_REQUIRE_EQUAL(res, errc::success);
-    BOOST_REQUIRE_EQUAL(state_1.kv_map.empty(), true);
-    BOOST_REQUIRE_EQUAL(state_2.kv_map.find("test")->second, 20);
+    vlog(kvlog.info, "Test case: success delete");
+    res = co_await replicate_and_wait(
+      serialize_cmd(delete_cmd{"test"}, batch_type_1));
+    ASSERT_EQ_CORO(res, errc::success);
+    ASSERT_TRUE_CORO(
+      co_await with_leaders_kv([](const map1_t& map1, const map2_t& map2) {
+          return map1.empty() && map2.find("test")->second == 20;
+      }));
 }
 
-FIXTURE_TEST(timeout_test, simple_raft_fixture) {
-    start_raft();
-    simple_kv<batch_type_1> state_1;
-    simple_kv_stm<batch_type_1> stm(
-      kvlog,
-      _raft.get(),
-      raft::persistent_last_applied::yes,
-      not_handled_batch_types,
-      state_1);
-    stm.start().get0();
-    auto stop = ss::defer([&stm] { stm.stop().get0(); });
-    wait_for_becoming_leader();
-    ss::abort_source as;
-
-    // timeout
-    auto res = stm
-                 .replicate_and_wait(
-                   serialize_cmd(timeout_cmd{"test"}, batch_type_1),
-                   model::timeout_clock::now() + 40ms,
-                   as)
-                 .get0();
-    state_1.as.request_abort();
-    BOOST_REQUIRE_EQUAL(res, raft::errc::timeout);
+TEST_F_CORO(kv1_stm_fixture, timeout_test) {
+    co_await initialize_state_machines(1);
+    co_await start_stms();
+    auto res = co_await replicate_and_wait(
+      serialize_cmd(timeout_cmd{"test"}, batch_type_1), 40ms);
+    ASSERT_EQ_CORO(res, raft::errc::timeout);
+    vlog(kvlog.info, "1234");
+    co_await with_leader(10s, [this](raft_node_instance& node) {
+        vlog(kvlog.info, "leader={}", node.get_vnode());
+        vlog(kvlog.info, "calling as {}", (void*)(&kvs[node.get_vnode()]));
+        kvs[node.get_vnode()]->as.request_abort();
+    });
 }
+} // namespace mux_state_machine_test


### PR DESCRIPTION
Improve raft_fixture and stm_raft_fixture, base mux_state_machine_test and  tm_stm_tests on them.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
