### PR TITLE
mvlog: add gaps to the segment reader

### DIFF
--- a/src/v/storage/mvlog/file_gap.h
+++ b/src/v/storage/mvlog/file_gap.h
@@ -1,0 +1,35 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "container/fragmented_vector.h"
+#include "serde/envelope.h"
+
+#include <cstddef>
+
+namespace storage::experimental::mvlog {
+
+// Serializable representation of a region in a file that is meant to be
+// skipped over by readers, e.g. because the file was truncated.
+struct file_gap
+  : public serde::
+      envelope<file_gap, serde::version<0>, serde::compat_version<0>> {
+    file_gap(size_t start, size_t len)
+      : start_pos(start)
+      , length(len) {}
+
+    // The position in the file at which the gap begins.
+    size_t start_pos{0};
+
+    // The size of the gap in bytes.
+    size_t length{0};
+};
+using gap_list_t = chunked_vector<file_gap>;
+
+} // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/readable_segment.cc
+++ b/src/v/storage/mvlog/readable_segment.cc
@@ -9,12 +9,34 @@
 
 #include "storage/mvlog/readable_segment.h"
 
+#include "base/vlog.h"
+#include "container/interval_set.h"
+#include "storage/mvlog/logger.h"
 #include "storage/mvlog/segment_reader.h"
 
 namespace storage::experimental::mvlog {
 
+readable_segment::readable_segment(file* f)
+  : file_(f) {}
+readable_segment::~readable_segment() = default;
+
 std::unique_ptr<segment_reader> readable_segment::make_reader() {
-    return std::make_unique<segment_reader>(this);
+    return std::make_unique<segment_reader>(
+      gaps_ ? *gaps_ : interval_set<size_t>{}, this);
+}
+
+void readable_segment::add_gap(file_gap gap) {
+    vassert(gap.length > 0, "Expected non-empty gap at pos {}", gap.start_pos);
+    vlog(
+      log.trace,
+      "Adding gap [{}, {})",
+      gap.start_pos,
+      gap.start_pos + gap.length);
+    if (!gaps_) {
+        gaps_ = std::make_unique<interval_set<size_t>>();
+    }
+    auto [_, inserted] = gaps_->insert({gap.start_pos, gap.length});
+    vassert(inserted, "Failed to insert gap");
 }
 
 } // namespace storage::experimental::mvlog

--- a/src/v/storage/mvlog/readable_segment.h
+++ b/src/v/storage/mvlog/readable_segment.h
@@ -8,7 +8,12 @@
 // by the Apache License, Version 2.0
 #pragma once
 
+#include "storage/mvlog/file_gap.h"
+
 #include <memory>
+
+template<std::integral>
+class interval_set;
 
 namespace storage::experimental::mvlog {
 
@@ -19,16 +24,35 @@ class segment_reader;
 // passing out short-lived readers.
 class readable_segment {
 public:
-    explicit readable_segment(file* f)
-      : file_(f) {}
+    readable_segment(readable_segment&) = delete;
+    readable_segment(readable_segment&&) = delete;
+    readable_segment& operator=(readable_segment&) = delete;
+    readable_segment& operator=(readable_segment&&) = delete;
 
+    explicit readable_segment(file* f);
+    ~readable_segment();
+
+    // Returns a segment reader that reads data as of the time of calling. I.e.
+    // honors only gaps that were added before calling, and only reads up to the
+    // segment's end as of calling.
     std::unique_ptr<segment_reader> make_reader();
+
+    // Adds the given gap, such that subsequent readers of the file skip the
+    // specified range and all those previously added.
+    void add_gap(file_gap gap);
+
+    // Returns the number of readers returned created by this segment that have
+    // yet to be destructed.
     size_t num_readers() const { return num_readers_; }
 
 private:
     friend class segment_reader;
 
     file* file_;
+
+    // Set of gaps that have been added to the file. May be null if no gaps
+    // have been added yet.
+    std::unique_ptr<interval_set<size_t>> gaps_{nullptr};
 
     size_t num_readers_{0};
 };

--- a/src/v/storage/mvlog/segment_reader.cc
+++ b/src/v/storage/mvlog/segment_reader.cc
@@ -16,23 +16,72 @@
 #include "storage/mvlog/skipping_data_source.h"
 
 namespace storage::experimental::mvlog {
-segment_reader::segment_reader(readable_segment* segment)
-  : segment_(segment) {
+
+segment_reader::segment_reader(
+  interval_set<size_t> gaps, readable_segment* segment)
+  : gaps_(std::move(gaps))
+  , file_size_(segment->file_->size())
+  , segment_(segment) {
     ++segment_->num_readers_;
 }
 segment_reader::~segment_reader() { --segment_->num_readers_; }
 
 skipping_data_source::read_list_t
 segment_reader::make_read_intervals(size_t start_pos, size_t length) const {
-    // TODO(awong): a future commit will build appropriate intervals for this
-    // reader's truncation id.
+    auto gap_it = gaps_.begin();
+    const size_t max_pos = start_pos + length - 1;
+    auto cur_iter_pos = start_pos;
     skipping_data_source::read_list_t read_intervals;
-    read_intervals.emplace_back(start_pos, length);
+
+    // Iterate through the gaps associated with the version_id, collecting the
+    // intervals to read, and skipping any that are entirely below the start
+    // position.
+    while (gap_it != gaps_.end() && cur_iter_pos <= max_pos) {
+        const auto next_gap_max = gap_it->end - 1;
+        if (cur_iter_pos > next_gap_max) {
+            // We are ahead of the next gap. Drop it from the list to consider.
+            ++gap_it;
+            continue;
+        }
+        if (cur_iter_pos >= gap_it->start) {
+            // We are in the middle of a gap. Skip to just past the end.
+            // NOTE: the gap end is exclusive.
+            cur_iter_pos = gap_it->end;
+            ++gap_it;
+            continue;
+        }
+        // The next gap is ahead of us. Read up to the start of it and skip
+        // over the gap.
+        const auto read_max_pos = std::min(max_pos, gap_it->start - 1);
+        const auto read_length = read_max_pos - cur_iter_pos + 1;
+        read_intervals.emplace_back(cur_iter_pos, read_length);
+        vlog(
+          log.trace,
+          "Adding read interval [{}, {}) within [{}, {})",
+          cur_iter_pos,
+          read_max_pos + 1,
+          start_pos,
+          max_pos + 1);
+        cur_iter_pos = gap_it->end;
+        ++gap_it;
+    }
+    // No more gaps, read the rest of the range.
+    if (cur_iter_pos <= max_pos) {
+        const auto remaining_length = max_pos - cur_iter_pos + 1;
+        read_intervals.emplace_back(cur_iter_pos, remaining_length);
+        vlog(
+          log.trace,
+          "Adding read interval [{}, {}) within [{}, {})",
+          cur_iter_pos,
+          cur_iter_pos + remaining_length,
+          start_pos,
+          max_pos + 1);
+    }
     return read_intervals;
 }
 
 ss::input_stream<char> segment_reader::make_stream(size_t start_pos) const {
-    return make_stream(start_pos, segment_->file_->size() - start_pos);
+    return make_stream(start_pos, file_size_ - start_pos);
 }
 
 ss::input_stream<char>

--- a/src/v/storage/mvlog/tests/segment_reader_test.cc
+++ b/src/v/storage/mvlog/tests/segment_reader_test.cc
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0
 
+#include "random/generators.h"
 #include "storage/mvlog/file.h"
 #include "storage/mvlog/readable_segment.h"
 #include "storage/mvlog/segment_reader.h"
@@ -16,8 +17,9 @@
 
 #include <gtest/gtest.h>
 
-using namespace storage::experimental::mvlog;
 using namespace experimental;
+
+namespace storage::experimental::mvlog {
 
 class SegmentReaderTest : public ::testing::Test {
 public:
@@ -89,3 +91,263 @@ TEST_F(SegmentReaderTest, TestBasicReads) {
         ASSERT_EQ(buf, expected_buf);
     }
 }
+
+namespace {
+// Checks that a given reader starting at the given position reads exactly the
+// expected string.
+void validate_reader_exactly(
+  segment_reader& reader, size_t start_pos, const ss::sstring& expected_str) {
+    // The stream should match exactly. Try to read more the expected length to
+    // ensure the stream stops where it should.
+    auto stream = reader.make_stream(start_pos);
+    auto buf = stream.read_exactly(expected_str.size() + 1).get();
+    ss::temporary_buffer<char> expected_buf{
+      expected_str.begin(), expected_str.size()};
+    ASSERT_EQ(buf, expected_buf) << fmt::format(
+      "{} vs {}", ss::sstring(buf.get(), buf.size()), expected_str);
+}
+
+using expectations_map_t
+  = chunked_vector<std::pair<std::unique_ptr<segment_reader>, ss::sstring>>;
+// Checks that a read as of a specific version matches what is expected of that
+// version.
+void validate_all_versions_exactly(
+  const expectations_map_t& expected_per_version) {
+    for (const auto& [reader, expected_str] : expected_per_version) {
+        ASSERT_NO_FATAL_FAILURE(
+          validate_reader_exactly(*reader, 0, expected_str));
+    }
+}
+} // anonymous namespace
+
+TEST_F(SegmentReaderTest, TestReadIntervals) {
+    const ss::sstring data = "0123456789";
+    iobuf buf;
+    buf.append(data.data(), data.size());
+    paging_file_->append(std::move(buf)).get();
+
+    readable_segment readable_seg(paging_file_.get());
+    // Gap over "234".
+    readable_seg.add_gap(file_gap(2, 3));
+    auto reader = readable_seg.make_reader();
+
+    // Reading ranges [0, 1]..[0, 4] should result in exactly one read
+    // interval, spanning at most [0, 1].
+    for (int len = 1; len <= 5; len++) {
+        auto read_intervals = reader->make_read_intervals(0, len);
+        ASSERT_EQ(1, read_intervals.size());
+        ASSERT_EQ(read_intervals.begin()->offset, 0);
+        ASSERT_EQ(read_intervals.begin()->length, std::min(2, len));
+    }
+    // Reading ranges [0, 5]..[0, 10] should result in exactly two read
+    // intervals, [0, 1] and at most, [5, 9].
+    for (int len = 6; len <= 10; len++) {
+        auto read_intervals = reader->make_read_intervals(0, len);
+        ASSERT_EQ(2, read_intervals.size());
+        ASSERT_EQ(read_intervals.begin()->offset, 0);
+        ASSERT_EQ(read_intervals.begin()->length, 2);
+        ASSERT_EQ(read_intervals.back().offset, 5);
+        ASSERT_EQ(read_intervals.back().length, std::min(5, len - 5));
+    }
+    // Now read after the gap. There should be exactly one read interval
+    // spanning at most [5, 9]
+    for (int len = 1; len <= 5; len++) {
+        auto read_intervals = reader->make_read_intervals(5, len);
+        ASSERT_EQ(1, read_intervals.size());
+        ASSERT_EQ(read_intervals.begin()->offset, 5);
+        ASSERT_EQ(read_intervals.begin()->length, std::min(5, len));
+    }
+}
+
+// Test reading across gaps.
+TEST_F(SegmentReaderTest, TestBasicReadsWithGaps) {
+    const ss::sstring data = "0123456789";
+    iobuf buf;
+    buf.append(data.data(), data.size());
+    paging_file_->append(std::move(buf)).get();
+    readable_segment readable_seg(paging_file_.get());
+
+    expectations_map_t expected_per_version;
+    readable_seg.add_gap(file_gap(1, 3));
+    expected_per_version.emplace_back(readable_seg.make_reader(), "0456789");
+    ASSERT_NO_FATAL_FAILURE(
+      validate_all_versions_exactly(expected_per_version));
+
+    readable_seg.add_gap(file_gap(6, 2));
+    expected_per_version.emplace_back(readable_seg.make_reader(), "04589");
+    ASSERT_NO_FATAL_FAILURE(
+      validate_all_versions_exactly(expected_per_version));
+
+    readable_seg.add_gap(file_gap(0, 10));
+    expected_per_version.emplace_back(readable_seg.make_reader(), "");
+    ASSERT_NO_FATAL_FAILURE(
+      validate_all_versions_exactly(expected_per_version));
+}
+
+TEST_F(SegmentReaderTest, TestReadVersionBeforeGaps) {
+    const ss::sstring data = "0123456789";
+    iobuf buf;
+    buf.append(data.data(), data.size());
+    paging_file_->append(std::move(buf)).get();
+    readable_segment readable_seg(paging_file_.get());
+
+    expectations_map_t expected_per_version;
+    auto reader = readable_seg.make_reader();
+    readable_seg.add_gap(file_gap(1, 3));
+    for (int i = 0; i < data.size(); i++) {
+        // Reading below the gapped version should ignore the gap entirely.
+        ASSERT_NO_FATAL_FAILURE(
+          validate_reader_exactly(*reader, i, data.substr(i)));
+    }
+}
+
+TEST_F(SegmentReaderTest, TestReadersSnapshot) {
+    readable_segment readable_seg(paging_file_.get());
+    const ss::sstring data1 = "01234";
+    iobuf buf1;
+    buf1.append(data1.data(), data1.size());
+    paging_file_->append(std::move(buf1)).get();
+
+    expectations_map_t expected_per_version;
+    expected_per_version.emplace_back(readable_seg.make_reader(), "01234");
+    readable_seg.add_gap(file_gap(0, 2));
+    expected_per_version.emplace_back(readable_seg.make_reader(), "234");
+
+    const ss::sstring data2 = "56789";
+    iobuf buf2;
+    buf2.append(data2.data(), data2.size());
+    paging_file_->append(std::move(buf2)).get();
+
+    expected_per_version.emplace_back(readable_seg.make_reader(), "23456789");
+    readable_seg.add_gap(file_gap(5, 2));
+    expected_per_version.emplace_back(readable_seg.make_reader(), "234789");
+
+    // The readers should keep see the state of the file as of time of
+    // construction.
+    ASSERT_NO_FATAL_FAILURE(
+      validate_all_versions_exactly(expected_per_version));
+}
+
+// Test reading in and around a gap.
+TEST_F(SegmentReaderTest, TestReadInsideGap) {
+    const ss::sstring data = "0123456789";
+    iobuf buf;
+    buf.append(data.data(), data.size());
+    paging_file_->append(std::move(buf)).get();
+    readable_segment readable_seg(paging_file_.get());
+
+    // Remove [2, 4].
+    readable_seg.add_gap(file_gap(2, 3));
+    for (int i = 2; i <= 4; i++) {
+        auto reader = readable_seg.make_reader();
+        // If the start of the read is inside a gap, it should skip to the end
+        // of the gap. Attempt reading in the gap [1, 3].
+        ASSERT_NO_FATAL_FAILURE(validate_reader_exactly(*reader, i, "56789"));
+    }
+    // Also read around the gap. Starting below the gap, we should skip it.
+    {
+        auto reader = readable_seg.make_reader();
+        ASSERT_NO_FATAL_FAILURE(validate_reader_exactly(*reader, 0, "0156789"));
+    }
+    {
+        auto reader = readable_seg.make_reader();
+        ASSERT_NO_FATAL_FAILURE(validate_reader_exactly(*reader, 1, "156789"));
+    }
+    // Starting past the gap, it shouldn't appear either.
+    {
+        auto reader = readable_seg.make_reader();
+        ASSERT_NO_FATAL_FAILURE(validate_reader_exactly(*reader, 5, "56789"));
+    }
+    {
+        auto reader = readable_seg.make_reader();
+        ASSERT_NO_FATAL_FAILURE(validate_reader_exactly(*reader, 6, "6789"));
+    }
+}
+
+// Test applying random gaps and reading from from the beginning of the file.
+TEST_F(SegmentReaderTest, TestReadsWithRandomGaps) {
+    const auto size = 100;
+    const ss::sstring data = random_generators::gen_alphanum_string(size);
+    iobuf buf;
+    buf.append(data.data(), data.size());
+    paging_file_->append(std::move(buf)).get();
+    readable_segment readable_seg(paging_file_.get());
+
+    absl::btree_set<int> removed_pos;
+    expectations_map_t expected_per_version;
+    for (int i = 0; i < 10; i++) {
+        // Generate a random gap and build the cumulative expected string, with
+        // all gaps so far if we were to read from the beginning.
+        auto gap_start = random_generators::get_int(size);
+        auto gap_len = random_generators::get_int(1, size);
+        for (int l = 0; l < gap_len; l++) {
+            removed_pos.emplace(gap_start + l);
+        }
+        // Rebuild the expected string, removing all gaps.
+        ss::sstring expected;
+        for (int d = 0; d < data.size(); d++) {
+            if (removed_pos.contains(d)) {
+                continue;
+            }
+            expected.append(&data[d], 1);
+        }
+        // Now validate all the versions against their expected reads.
+        readable_seg.add_gap(file_gap(gap_start, gap_len));
+        expected_per_version.emplace_back(readable_seg.make_reader(), expected);
+        ASSERT_NO_FATAL_FAILURE(
+          validate_all_versions_exactly(expected_per_version));
+
+        if (expected == "") {
+            break;
+        }
+    }
+}
+
+// Test applying random gaps and reading from different positions in the file.
+TEST_F(SegmentReaderTest, TestRandomReadsWithGaps) {
+    const ss::sstring data = "abcdefghijklmnopqrstuvwxyz";
+    const auto size = data.size();
+    iobuf buf;
+    buf.append(data.data(), data.size());
+    paging_file_->append(std::move(buf)).get();
+    readable_segment readable_seg(paging_file_.get());
+
+    absl::btree_set<int> removed_pos;
+    expectations_map_t expected_per_version;
+    for (int i = 0; i < 10; i++) {
+        auto gap_start = random_generators::get_int(size);
+        auto gap_len = random_generators::get_int(size_t{1}, size);
+        for (int l = 0; l < gap_len; l++) {
+            removed_pos.emplace(gap_start + l);
+        }
+        // Rebuild the expected string, removing all gaps.
+        ss::sstring expected;
+        for (int d = 0; d < data.size(); d++) {
+            if (removed_pos.contains(d)) {
+                continue;
+            }
+            expected.append(&data[d], 1);
+        }
+        // Now validate all the versions so far.
+        readable_seg.add_gap(file_gap(gap_start, gap_len));
+        expected_per_version.emplace_back(readable_seg.make_reader(), expected);
+        for (const auto& [reader, full_expected_str] : expected_per_version) {
+            // Read starting at every position, and ensure nothing funny.
+            for (int i = 0; i < size; i++) {
+                auto stream = reader->make_stream(i);
+                auto buf = stream.read_exactly(size).get();
+
+                // If there is anything to read, it should be the tail of the
+                // expected with-gaps string.
+                const ss::sstring actual{buf.get(), buf.size()};
+                ASSERT_TRUE(full_expected_str.ends_with(actual)) << fmt::format(
+                  "{} not tail of {}", actual, full_expected_str);
+            }
+        }
+
+        if (expected == "") {
+            break;
+        }
+    }
+}
+} // namespace storage::experimental::mvlog


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
Adds a gap set to the readable segment so that readers can iterate as
of a specific version.

The full set of gaps in the segment is long-lived, so this is owned by
the readable segment. Segment readers make of copy of this set (expected
to be small) when constructed, before iterating.

Longer term, multiple segments may have gaps added to them at a time,
but this commit focuses only on introducing the per-segment gaps.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none