### PR TITLE
[CORE-2069]:  Changes to support using S3 FIPS Endpoints 

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -31,7 +31,7 @@ using segment_meta = cloud_storage::partition_manifest::segment_meta;
 namespace {
 ss::logger fixture_logger{"archival_stm_fixture"};
 
-constexpr const char* httpd_host_name = "127.0.0.1";
+constexpr const char* httpd_host_name = "localhost";
 constexpr uint16_t httpd_port_number = 4442;
 
 cloud_storage_clients::s3_configuration get_configuration() {

--- a/src/v/cloud_storage/configuration.h
+++ b/src/v/cloud_storage/configuration.h
@@ -29,7 +29,9 @@ struct configuration {
     friend std::ostream& operator<<(std::ostream& o, const configuration& cfg);
 
     static ss::future<configuration> get_config();
-    static ss::future<configuration> get_s3_config();
+    static ss::future<configuration> get_s3_config(
+      std::optional<cloud_storage_clients::s3_url_style> url_style_override
+      = std::nullopt);
     static ss::future<configuration> get_abs_config();
     static const config::property<std::optional<ss::sstring>>&
     get_bucket_config();

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ rp_test(
   FIXTURE_TEST
   BINARY_NAME cloud_storage
   SOURCES
+    cloud_storage_fixture.cc
     util.cc
     s3_imposter.cc
     remote_test.cc
@@ -77,6 +78,7 @@ rp_test(
   FIXTURE_TEST
   BINARY_NAME cloud_storage_fuzzy
   SOURCES
+    cloud_storage_fixture.cc
     util.cc
     s3_imposter.cc
     remote_partition_fuzz_test.cc

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -223,7 +223,7 @@ ss::sstring iobuf_to_string(iobuf buf) {
 
 class bucket_view_fixture : http_imposter_fixture {
 public:
-    static constexpr auto host_name = "127.0.0.1";
+    static constexpr auto host_name = "localhost";
     static constexpr auto port = 4447;
 
     bucket_view_fixture()

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -67,7 +67,6 @@ public:
     async_manifest_view_fixture()
       : cloud_storage_fixture()
       , stm_manifest(manifest_ntp, manifest_rev)
-      , bucket("test-bucket")
       , rtc(as)
       , ctxlog(test_log, rtc)
       , probe(manifest_ntp)
@@ -324,7 +323,6 @@ public:
     }
 
     partition_manifest stm_manifest;
-    cloud_storage_clients::bucket_name bucket;
     ss::abort_source as;
     retry_chain_node rtc;
     retry_chain_logger ctxlog;

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+
+#include "cloud_storage_fixture.h"
+
+#include "cloud_storage/tests/s3_imposter.h"
+
+cloud_storage_fixture::cloud_storage_fixture() {
+    config::shard_local_cfg()
+      .cloud_storage_max_segment_readers_per_shard.reset();
+    config::shard_local_cfg()
+      .cloud_storage_max_partition_readers_per_shard.reset();
+    config::shard_local_cfg()
+      .cloud_storage_max_materialized_segments_per_shard.reset();
+
+    tmp_directory.create().get();
+    cache
+      .start(
+        tmp_directory.get_path(),
+        30_GiB, // disk size
+        config::mock_binding<double>(0.0),
+        config::mock_binding<uint64_t>(1024 * 1024 * 1024),
+        config::mock_binding<std::optional<double>>(std::nullopt),
+        config::mock_binding<uint32_t>(100000))
+      .get();
+
+    cache.invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
+      .get();
+
+    // Supply some phony disk stats so that the cache doesn't panic and
+    // think it has zero bytes of space
+    cache
+      .invoke_on(
+        ss::shard_id{0},
+        [](cloud_storage::cache& c) {
+            c.notify_disk_status(
+              100ULL * 1024 * 1024 * 1024,
+              50ULL * 1024 * 1024 * 1024,
+              storage::disk_space_alert::ok);
+        })
+      .get();
+
+    auto conf = get_configuration();
+    pool
+      .start(10, ss::sharded_parameter([this] { return get_configuration(); }))
+      .get();
+    api
+      .start(
+        std::ref(pool),
+        ss::sharded_parameter([this] { return get_configuration(); }),
+        ss::sharded_parameter([] { return config_file; }))
+      .get();
+    api.invoke_on_all([](cloud_storage::remote& api) { return api.start(); })
+      .get();
+}
+
+cloud_storage_fixture::~cloud_storage_fixture() {
+    if (!pool.local().shutdown_initiated()) {
+        pool.local().shutdown_connections();
+    }
+    api.stop().get();
+    pool.stop().get();
+    cache.stop().get();
+    tmp_directory.remove().get();
+}

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.cc
@@ -12,7 +12,11 @@
 
 #include "cloud_storage/tests/s3_imposter.h"
 
-cloud_storage_fixture::cloud_storage_fixture() {
+const cloud_storage_clients::bucket_name cloud_storage_fixture::bucket{
+  "bucket"};
+
+cloud_storage_fixture::cloud_storage_fixture()
+  : s3_imposter_fixture(bucket) {
     config::shard_local_cfg()
       .cloud_storage_max_segment_readers_per_shard.reset();
     config::shard_local_cfg()

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.cc
@@ -47,7 +47,6 @@ cloud_storage_fixture::cloud_storage_fixture() {
         })
       .get();
 
-    auto conf = get_configuration();
     pool
       .start(10, ss::sharded_parameter([this] { return get_configuration(); }))
       .get();

--- a/src/v/cloud_storage/tests/cloud_storage_fixture.h
+++ b/src/v/cloud_storage/tests/cloud_storage_fixture.h
@@ -16,6 +16,7 @@
 #include "cloud_storage/tests/common_def.h"
 #include "cloud_storage/tests/s3_imposter.h"
 #include "cloud_storage/types.h"
+#include "model/fundamental.h"
 #include "test_utils/fixture.h"
 
 #include <seastar/core/future.hh>
@@ -33,66 +34,10 @@ static constexpr model::cloud_credentials_source config_file{
   model::cloud_credentials_source::config_file};
 
 struct cloud_storage_fixture : s3_imposter_fixture {
-    cloud_storage_fixture() {
-        config::shard_local_cfg()
-          .cloud_storage_max_segment_readers_per_shard.reset();
-        config::shard_local_cfg()
-          .cloud_storage_max_partition_readers_per_shard.reset();
-        config::shard_local_cfg()
-          .cloud_storage_max_materialized_segments_per_shard.reset();
+    static const cloud_storage_clients::bucket_name bucket;
+    cloud_storage_fixture();
 
-        tmp_directory.create().get();
-        cache
-          .start(
-            tmp_directory.get_path(),
-            30_GiB, // disk size
-            config::mock_binding<double>(0.0),
-            config::mock_binding<uint64_t>(1024 * 1024 * 1024),
-            config::mock_binding<std::optional<double>>(std::nullopt),
-            config::mock_binding<uint32_t>(100000))
-          .get();
-
-        cache.invoke_on_all([](cloud_storage::cache& c) { return c.start(); })
-          .get();
-
-        // Supply some phony disk stats so that the cache doesn't panic and
-        // think it has zero bytes of space
-        cache
-          .invoke_on(
-            ss::shard_id{0},
-            [](cloud_storage::cache& c) {
-                c.notify_disk_status(
-                  100ULL * 1024 * 1024 * 1024,
-                  50ULL * 1024 * 1024 * 1024,
-                  storage::disk_space_alert::ok);
-            })
-          .get();
-
-        auto conf = get_configuration();
-        pool
-          .start(
-            10, ss::sharded_parameter([this] { return get_configuration(); }))
-          .get();
-        api
-          .start(
-            std::ref(pool),
-            ss::sharded_parameter([this] { return get_configuration(); }),
-            ss::sharded_parameter([] { return config_file; }))
-          .get();
-        api
-          .invoke_on_all([](cloud_storage::remote& api) { return api.start(); })
-          .get();
-    }
-
-    ~cloud_storage_fixture() {
-        if (!pool.local().shutdown_initiated()) {
-            pool.local().shutdown_connections();
-        }
-        api.stop().get();
-        pool.stop().get();
-        cache.stop().get();
-        tmp_directory.remove().get();
-    }
+    ~cloud_storage_fixture();
 
     cloud_storage_fixture(const cloud_storage_fixture&) = delete;
     cloud_storage_fixture operator=(const cloud_storage_fixture&) = delete;

--- a/src/v/cloud_storage/tests/delete_records_e2e_test.cc
+++ b/src/v/cloud_storage/tests/delete_records_e2e_test.cc
@@ -78,9 +78,10 @@ class delete_records_e2e_fixture
 public:
     static constexpr auto segs_per_spill = 10;
     delete_records_e2e_fixture()
-      : redpanda_thread_fixture(
-        redpanda_thread_fixture::init_cloud_storage_tag{},
-        httpd_port_number()) {
+      : s3_imposter_fixture(cloud_storage_clients::bucket_name("test-bucket"))
+      , redpanda_thread_fixture(
+          redpanda_thread_fixture::init_cloud_storage_tag{},
+          httpd_port_number()) {
         // No expectations: tests will PUT and GET organically.
         set_expectations_and_listen({});
         wait_for_controller_leadership().get();

--- a/src/v/cloud_storage/tests/manual_fixture.h
+++ b/src/v/cloud_storage/tests/manual_fixture.h
@@ -50,7 +50,7 @@ public:
           8082 + 10,
           8081 + 10,
           std::vector<config::seed_server>{
-            {.addr = net::unresolved_address("127.0.0.1", 33145)}},
+            {.addr = net::unresolved_address("localhost", 33145)}},
           ssx::sformat("test.second_dir{}", time(0)),
           app.sched_groups,
           true,

--- a/src/v/cloud_storage/tests/manual_fixture.h
+++ b/src/v/cloud_storage/tests/manual_fixture.h
@@ -25,10 +25,12 @@ class cloud_storage_manual_multinode_test_base
   , public redpanda_thread_fixture
   , public enable_cloud_storage_fixture {
 public:
-    cloud_storage_manual_multinode_test_base()
-      : redpanda_thread_fixture(
-        redpanda_thread_fixture::init_cloud_storage_tag{},
-        httpd_port_number()) {
+    cloud_storage_manual_multinode_test_base(
+      cloud_storage_clients::bucket_name bucket)
+      : s3_imposter_fixture(bucket)
+      , redpanda_thread_fixture(
+          redpanda_thread_fixture::init_cloud_storage_tag{},
+          httpd_port_number()) {
         // No expectations: tests will PUT and GET organically.
         set_expectations_and_listen({});
 

--- a/src/v/cloud_storage/tests/read_replica_test.cc
+++ b/src/v/cloud_storage/tests/read_replica_test.cc
@@ -32,9 +32,10 @@ class read_replica_e2e_fixture
   , public enable_cloud_storage_fixture {
 public:
     read_replica_e2e_fixture()
-      : redpanda_thread_fixture(
-        redpanda_thread_fixture::init_cloud_storage_tag{},
-        httpd_port_number()) {
+      : s3_imposter_fixture(cloud_storage_clients::bucket_name("test-bucket"))
+      , redpanda_thread_fixture(
+          redpanda_thread_fixture::init_cloud_storage_tag{},
+          httpd_port_number()) {
         // No expectations: tests will PUT and GET organically.
         set_expectations_and_listen({});
         wait_for_controller_leadership().get();

--- a/src/v/cloud_storage/tests/remote_file_test.cc
+++ b/src/v/cloud_storage/tests/remote_file_test.cc
@@ -45,7 +45,8 @@ class remote_file_fixture
   , public cache_test_fixture {
 public:
     remote_file_fixture()
-      : data_dir("data_dir") {
+      : s3_imposter_fixture(bucket)
+      , data_dir("data_dir") {
         ss::recursive_touch_directory(data_dir.get_path().string()).get();
         auto conf = get_configuration();
         pool

--- a/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_fuzz_test.cc
@@ -36,7 +36,7 @@ scan_remote_partition_incrementally_with_reuploads(
   size_t maybe_max_readers = 0) {
     ss::lowres_clock::update();
     auto conf = fixt.get_configuration();
-    static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    static auto bucket = fixt.bucket;
     if (maybe_max_segments) {
         config::shard_local_cfg()
           .cloud_storage_max_materialized_segments_per_shard.set_value(
@@ -456,8 +456,6 @@ FIXTURE_TEST(test_scan_while_shutting_down, cloud_storage_fixture) {
 
     auto m = ss::make_lw_shared<cloud_storage::partition_manifest>(
       manifest_ntp, manifest_revision);
-
-    static auto bucket = cloud_storage_clients::bucket_name("bucket");
 
     auto manifest = hydrate_manifest(api.local(), bucket);
     partition_probe probe(manifest.get_ntp());

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -372,7 +372,8 @@ cloud_storage_clients::s3_configuration
 s3_imposter_fixture::get_configuration() {
     net::unresolved_address server_addr(httpd_host_name, httpd_port_number());
     cloud_storage_clients::s3_configuration conf;
-    conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);
+    conf.uri = cloud_storage_clients::access_point_uri(
+      ssx::sformat("{}.{}", _bucket_name(), httpd_host_name));
     conf.access_key = cloud_roles::public_key_str("acess-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
@@ -386,10 +387,12 @@ s3_imposter_fixture::get_configuration() {
     return conf;
 }
 
-s3_imposter_fixture::s3_imposter_fixture() {
+s3_imposter_fixture::s3_imposter_fixture(
+  cloud_storage_clients::bucket_name bucket)
+  : _bucket_name(std::move(bucket)) {
     _server = ss::make_shared<ss::httpd::http_server_control>();
     _server->start().get();
-    ss::ipv4_addr ip_addr = {httpd_host_name, httpd_port_number()};
+    ss::ipv4_addr ip_addr = {httpd_ip_addr, httpd_port_number()};
     _server_addr = ss::socket_address(ip_addr);
 }
 

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -14,6 +14,7 @@
 #include "cloud_storage_clients/client.h"
 #include "config/configuration.h"
 #include "http/tests/registered_urls.h"
+#include "model/fundamental.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/shared_ptr.hh>
@@ -40,9 +41,10 @@ class s3_imposter_fixture {
 public:
     static constexpr size_t default_max_keys = 100;
     uint16_t httpd_port_number();
-    static constexpr const char* httpd_host_name = "127.0.0.1";
+    static constexpr const char* httpd_host_name = "localhost";
+    static constexpr const char* httpd_ip_addr = "127.0.0.1";
 
-    s3_imposter_fixture();
+    explicit s3_imposter_fixture(cloud_storage_clients::bucket_name bucket);
     ~s3_imposter_fixture();
 
     s3_imposter_fixture(const s3_imposter_fixture&) = delete;
@@ -95,6 +97,9 @@ public:
     cloud_storage_clients::s3_configuration get_configuration();
 
     void set_search_on_get_list(bool should) { _search_on_get_list = should; }
+
+protected:
+    cloud_storage_clients::bucket_name _bucket_name;
 
 private:
     void set_routes(

--- a/src/v/cloud_storage/tests/topic_recovery_service_test.cc
+++ b/src/v/cloud_storage/tests/topic_recovery_service_test.cc
@@ -12,6 +12,7 @@
 #include "cloud_storage/tests/s3_imposter.h"
 #include "cluster/cloud_metadata/tests/manual_mixin.h"
 #include "cluster/topic_recovery_service.h"
+#include "model/fundamental.h"
 #include "redpanda/tests/fixture.h"
 #include "test_utils/fixture.h"
 #include "utils/memory_data_source.h"
@@ -132,9 +133,10 @@ class fixture
   , public enable_cloud_storage_fixture {
 public:
     fixture()
-      : redpanda_thread_fixture(
-        redpanda_thread_fixture::init_cloud_storage_tag{},
-        httpd_port_number()) {
+      : s3_imposter_fixture(cloud_storage_clients::bucket_name("test-bucket"))
+      , redpanda_thread_fixture(
+          redpanda_thread_fixture::init_cloud_storage_tag{},
+          httpd_port_number()) {
         // This test will manually set expectations for list requests.
         set_search_on_get_list(false);
     }

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -644,7 +644,7 @@ std::vector<model::record_batch_header> scan_remote_partition_incrementally(
     // incorrectly.
     ss::lowres_clock::update();
     auto conf = imposter.get_configuration();
-    static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    static auto bucket = imposter.bucket;
     if (maybe_max_segments) {
         config::shard_local_cfg()
           .cloud_storage_max_materialized_segments_per_shard.set_value(
@@ -725,7 +725,7 @@ std::vector<model::record_batch_header> scan_remote_partition(
     // incorrectly.
     ss::lowres_clock::update();
     auto conf = imposter.get_configuration();
-    static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    static auto bucket = imposter.bucket;
     if (maybe_max_segments) {
         config::shard_local_cfg()
           .cloud_storage_max_materialized_segments_per_shard.set_value(
@@ -776,7 +776,7 @@ scan_result scan_remote_partition(
     // incorrectly.
     ss::lowres_clock::update();
     auto conf = imposter.get_configuration();
-    static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    static auto bucket = imposter.bucket;
     if (maybe_max_segments) {
         config::shard_local_cfg()
           .cloud_storage_max_materialized_segments_per_shard.set_value(
@@ -834,7 +834,7 @@ scan_remote_partition_incrementally_with_closest_lso(
   size_t maybe_max_readers) {
     ss::lowres_clock::update();
     auto conf = imposter.get_configuration();
-    static auto bucket = cloud_storage_clients::bucket_name("bucket");
+    static auto bucket = imposter.bucket;
     if (maybe_max_segments) {
         config::shard_local_cfg()
           .cloud_storage_max_materialized_segments_per_shard.set_value(
@@ -958,7 +958,7 @@ void reupload_compacted_segments(
             };
             auto result = fixture.api.local()
                             .upload_segment(
-                              cloud_storage_clients::bucket_name("bucket"),
+                              fixture.bucket,
                               url,
                               meta.size_bytes,
                               std::move(reset_stream),

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -417,12 +417,15 @@ ss::future<configuration> configuration::get_s3_config() {
       config::shard_local_cfg().disable_metrics());
     auto disable_public_metrics = net::public_metrics_disabled(
       config::shard_local_cfg().disable_public_metrics());
+    auto bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
+      config::shard_local_cfg().cloud_storage_bucket, "cloud_storage_bucket"));
 
     auto s3_conf
       = co_await cloud_storage_clients::s3_configuration::make_configuration(
         access_key,
         secret_key,
         region,
+        bucket_name,
         url_style,
         get_default_overrides(),
         disable_metrics,
@@ -434,9 +437,7 @@ ss::future<configuration> configuration::get_s3_config() {
         config::shard_local_cfg().cloud_storage_max_connections.value()),
       .metrics_disabled = remote_metrics_disabled(
         static_cast<bool>(disable_metrics)),
-      .bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
-        config::shard_local_cfg().cloud_storage_bucket,
-        "cloud_storage_bucket")),
+      .bucket_name = bucket_name,
       .cloud_credentials_source = cloud_credentials_source,
     };
 

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -417,6 +417,7 @@ ss::future<configuration> configuration::get_s3_config() {
       config::shard_local_cfg().disable_metrics());
     auto disable_public_metrics = net::public_metrics_disabled(
       config::shard_local_cfg().disable_public_metrics());
+
     auto bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
       config::shard_local_cfg().cloud_storage_bucket, "cloud_storage_bucket"));
 

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "cloud_storage/configuration.h"
 #include "cloud_storage/logger.h"
+#include "config/node_config.h"
 
 #include <absl/container/node_hash_set.h>
 
@@ -428,6 +429,7 @@ ss::future<configuration> configuration::get_s3_config() {
         region,
         bucket_name,
         url_style,
+        config::node().fips_mode.value(),
         get_default_overrides(),
         disable_metrics,
         disable_public_metrics);

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -385,7 +385,8 @@ ss::future<configuration> configuration::get_config() {
     }
 }
 
-ss::future<configuration> configuration::get_s3_config() {
+ss::future<configuration> configuration::get_s3_config(
+  std::optional<cloud_storage_clients::s3_url_style> url_style_override) {
     vlog(cst_log.debug, "Generating S3 cloud storage configuration");
 
     auto cloud_credentials_source
@@ -412,7 +413,10 @@ ss::future<configuration> configuration::get_s3_config() {
 
     auto region = cloud_roles::aws_region_name(get_value_or_throw(
       config::shard_local_cfg().cloud_storage_region, "cloud_storage_region"));
-    auto url_style = config::shard_local_cfg().cloud_storage_url_style.value();
+    auto url_style = url_style_override;
+    if (!url_style.has_value()) {
+        url_style = config::shard_local_cfg().cloud_storage_url_style.value();
+    }
 
     auto disable_metrics = net::metrics_disabled(
       config::shard_local_cfg().disable_metrics());

--- a/src/v/cloud_storage_clients/client_pool.cc
+++ b/src/v/cloud_storage_clients/client_pool.cc
@@ -155,7 +155,7 @@ ss::future<> client_pool::accept_self_configure_result(
     }
 
     if (result) {
-        cloud_storage_clients::apply_self_configuration_result(
+        co_await cloud_storage_clients::apply_self_configuration_result(
           _config, *result);
     }
 

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -12,6 +12,7 @@
 
 #include "cloud_storage_clients/logger.h"
 #include "config/configuration.h"
+#include "config/node_config.h"
 #include "net/tls.h"
 #include "net/tls_certificate_probe.h"
 
@@ -74,11 +75,37 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
   const std::optional<cloud_roles::public_key_str>& pkey,
   const std::optional<cloud_roles::private_key_str>& skey,
   const cloud_roles::aws_region_name& region,
-  const std::optional<cloud_storage_clients::s3_url_style>& url_style,
+  std::optional<cloud_storage_clients::s3_url_style> url_style,
   const default_overrides& overrides,
   net::metrics_disabled disable_metrics,
   net::public_metrics_disabled disable_public_metrics) {
     s3_configuration client_cfg;
+
+    auto in_fips_mode = config::node().fips_mode.value();
+
+    // fips mode in s3 can only be used with url_style==virtual_host
+    if (!url_style.has_value() && in_fips_mode) {
+        vlog(
+          client_config_log.info,
+          "in fips mode, url_style set to {}",
+          s3_url_style::virtual_host);
+        url_style = s3_url_style::virtual_host;
+    }
+
+    if (url_style.has_value()) {
+        vassert(
+          !in_fips_mode || url_style.value() == s3_url_style::virtual_host,
+          "node is in fips mode, but url_style is not set to virtual_host");
+        client_cfg.url_style = url_style.value();
+    } else {
+        // If the url style in not specified, it will be determined with
+        // self configuration.
+        vassert(
+          !in_fips_mode,
+          "node is in fips mode, url_style to has be set or overridden");
+        client_cfg.requires_self_configuration = true;
+    }
+
     const auto endpoint_uri = [&]() -> ss::sstring {
         if (overrides.endpoint) {
             return overrides.endpoint.value();
@@ -92,14 +119,6 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
     client_cfg.secret_key = skey;
     client_cfg.region = region;
     client_cfg.uri = access_point_uri(endpoint_uri);
-
-    if (url_style.has_value()) {
-        client_cfg.url_style = url_style.value();
-    } else {
-        // If the url style is not specified, it will be determined with
-        // self configuration.
-        client_cfg.requires_self_configuration = true;
-    }
 
     if (overrides.disable_tls == false) {
         client_cfg.credentials = co_await build_tls_credentials(

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -366,6 +366,7 @@ model::cloud_storage_backend infer_backend_from_configuration(
       = string_switch<model::cloud_storage_backend>(uri())
           .match_expr("google", model::cloud_storage_backend::google_s3_compat)
           .match_expr(R"(127\.0\.0\.1)", model::cloud_storage_backend::aws)
+          .match_expr("localhost", model::cloud_storage_backend::aws)
           .match_expr("minio", model::cloud_storage_backend::minio)
           .match_expr("amazon", model::cloud_storage_backend::aws)
           .default_match(model::cloud_storage_backend::unknown);

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -75,6 +75,7 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
   const std::optional<cloud_roles::public_key_str>& pkey,
   const std::optional<cloud_roles::private_key_str>& skey,
   const cloud_roles::aws_region_name& region,
+  const bucket_name& bucket,
   std::optional<cloud_storage_clients::s3_url_style> url_style,
   const default_overrides& overrides,
   net::metrics_disabled disable_metrics,
@@ -106,27 +107,38 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
         client_cfg.requires_self_configuration = true;
     }
 
-    const auto endpoint_uri = [&]() -> ss::sstring {
-        if (overrides.endpoint) {
-            return overrides.endpoint.value();
-        }
-        return ssx::sformat("s3.{}.amazonaws.com", region());
-    }();
-    client_cfg.tls_sni_hostname = endpoint_uri;
+    const auto base_endpoint_uri = overrides.endpoint.value_or(
+      endpoint_url{ssx::sformat("s3.{}.amazonaws.com", region())});
+
+    // if url_style is virtual_host, the complete url for s3 is
+    // [bucket].[s3hostname]. s3client will form the complete_endpoint
+    // independently, to allow for self_configuration.
+    const auto complete_endpoint_uri
+      = url_style == s3_url_style::virtual_host
+          ? ssx::sformat("{}.{}", bucket(), base_endpoint_uri())
+          : base_endpoint_uri();
+
+    client_cfg.tls_sni_hostname = complete_endpoint_uri;
 
     // Setup credentials for TLS
     client_cfg.access_key = pkey;
     client_cfg.secret_key = skey;
     client_cfg.region = region;
-    client_cfg.uri = access_point_uri(endpoint_uri);
+    // defer host creation to client, after it has performed self_configure to
+    // discover if the backend is in `virtual_host` or `path mode`
+    client_cfg.uri = access_point_uri(base_endpoint_uri);
 
     if (overrides.disable_tls == false) {
         client_cfg.credentials = co_await build_tls_credentials(
           "s3", overrides.trust_file, s3_log);
     }
 
+    // When using virtual host addressing, the client must connect to
+    // the s3 endpoint with the bucket name, e.g.
+    // <bucket>.s3.<region>.amazonaws.com.  This is especially required
+    // for S3 FIPS endpoints: <bucket>.s3-fips.<region>.amazonaws.com
     client_cfg.server_addr = net::unresolved_address(
-      client_cfg.uri(),
+      complete_endpoint_uri,
       overrides.port ? *overrides.port : default_port,
       ss::net::inet_address::family::INET);
     client_cfg.disable_metrics = disable_metrics;
@@ -135,7 +147,7 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
       disable_metrics,
       disable_public_metrics,
       region,
-      endpoint_url{endpoint_uri});
+      endpoint_url{complete_endpoint_uri});
     client_cfg.max_idle_time = overrides.max_idle_time
                                  ? *overrides.max_idle_time
                                  : default_max_idle_time;

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -11,6 +11,7 @@
 #include "cloud_storage_clients/configuration.h"
 
 #include "cloud_storage_clients/logger.h"
+#include "cloud_storage_clients/types.h"
 #include "config/configuration.h"
 #include "config/node_config.h"
 #include "net/tls.h"

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -70,6 +70,7 @@ struct s3_configuration : common_configuration {
       const cloud_roles::aws_region_name& region,
       const bucket_name& bucket,
       std::optional<cloud_storage_clients::s3_url_style> url_style,
+      bool node_is_in_fips_mode,
       const default_overrides& overrides = {},
       net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
       net::public_metrics_disabled disable_public_metrics

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -29,7 +29,7 @@ struct default_overrides {
     bool disable_tls = false;
 };
 
-/// Configuration options common accross cloud storage clients
+/// Configuration options common across cloud storage clients
 struct common_configuration : net::base_transport::configuration {
     /// URI of the access point
     access_point_uri uri;
@@ -51,13 +51,15 @@ struct s3_configuration : common_configuration {
     /// AWS URL style, either virtual-hosted-style or path-style.
     s3_url_style url_style = s3_url_style::virtual_host;
 
-    /// \brief opinionated configuraiton initialization
+    /// \brief opinionated configuration initialization
     /// Generates uri field from region, initializes credentials for the
     /// transport, resolves the uri to get the server_addr.
     ///
     /// \param pkey is an AWS access key
     /// \param skey is an AWS secret key
     /// \param region is an AWS region code
+    /// \param bucket is an AWS bucket name. it's needed to form the endpoints
+    /// in fips mode
     /// \param overrides contains a bunch of property overrides like
     ///        non-standard SSL port and alternative location of the
     ///        truststore
@@ -66,6 +68,7 @@ struct s3_configuration : common_configuration {
       const std::optional<cloud_roles::public_key_str>& pkey,
       const std::optional<cloud_roles::private_key_str>& skey,
       const cloud_roles::aws_region_name& region,
+      const bucket_name& bucket,
       std::optional<cloud_storage_clients::s3_url_style> url_style,
       const default_overrides& overrides = {},
       net::metrics_disabled disable_metrics = net::metrics_disabled::yes,

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -120,8 +120,8 @@ struct s3_self_configuration_result {
 using client_self_configuration_output
   = std::variant<abs_self_configuration_result, s3_self_configuration_result>;
 
-void apply_self_configuration_result(
-  client_configuration&, const client_self_configuration_output&);
+ss::future<> apply_self_configuration_result(
+  client_configuration&, client_self_configuration_output);
 
 std::ostream& operator<<(std::ostream&, const abs_self_configuration_result&);
 std::ostream& operator<<(std::ostream&, const s3_self_configuration_result&);

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -66,7 +66,7 @@ struct s3_configuration : common_configuration {
       const std::optional<cloud_roles::public_key_str>& pkey,
       const std::optional<cloud_roles::private_key_str>& skey,
       const cloud_roles::aws_region_name& region,
-      const std::optional<cloud_storage_clients::s3_url_style>& url_style,
+      std::optional<cloud_storage_clients::s3_url_style> url_style,
       const default_overrides& overrides = {},
       net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
       net::public_metrics_disabled disable_public_metrics

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -95,7 +95,7 @@ result<http::client::request_header> request_creator::make_get_object_request(
     // x-amz-date:{req-datetime}
     // Authorization:{signature}
     // x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-    auto host = make_host(name);
+    std::string host = _ap();
     auto target = make_target(name, key);
     header.method(boost::beast::http::verb::get);
     header.target(target);
@@ -131,7 +131,7 @@ result<http::client::request_header> request_creator::make_head_object_request(
     // x-amz-date:{req-datetime}
     // Authorization:{signature}
     // x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-    auto host = make_host(name);
+    std::string host = _ap();
     auto target = make_target(name, key);
     header.method(boost::beast::http::verb::head);
     header.target(target);
@@ -164,7 +164,7 @@ request_creator::make_unsigned_put_object_request(
     // Expect: 100-continue
     // [11434 bytes of object data]
     http::client::request_header header{};
-    auto host = make_host(name);
+    std::string host = _ap();
     auto target = make_target(name, key);
     header.method(boost::beast::http::verb::put);
     header.target(target);
@@ -202,7 +202,7 @@ request_creator::make_list_objects_v2_request(
     // x-amz-date: 20160501T000433Z
     // Authorization: authorization string
     http::client::request_header header{};
-    auto host = make_host(name);
+    std::string host = _ap();
     auto key = fmt::format("?list-type=2");
     if (prefix.has_value()) {
         key = fmt::format("{}&prefix={}", key, (*prefix)().string());
@@ -251,7 +251,7 @@ request_creator::make_delete_object_request(
     // x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
     //
     // NOTE: x-amz-mfa, x-amz-bypass-governance-retention are not used for now
-    auto host = make_host(name);
+    std::string host = _ap();
     auto target = make_target(name, key);
     header.method(boost::beast::http::verb::delete_);
     header.target(target);
@@ -344,7 +344,7 @@ request_creator::make_delete_objects_request(
 
     http::client::request_header header{};
     header.method(boost::beast::http::verb::post);
-    auto host = make_host(name);
+    std::string host = _ap();
     auto target = make_target(name, object_key{"?delete"});
     header.target(target);
     header.insert(boost::beast::http::field::host, host);
@@ -367,17 +367,6 @@ request_creator::make_delete_objects_request(
       std::move(header),
       ss::input_stream<char>{ss::data_source{
         std::make_unique<delete_objects_body>(std::move(body))}}};
-}
-
-std::string request_creator::make_host(const bucket_name& name) const {
-    switch (_ap_style) {
-    case s3_url_style::virtual_host:
-        // Host: bucket-name.s3.region-code.amazonaws.com
-        return fmt::format("{}.{}", name(), _ap());
-    case s3_url_style::path:
-        // Host: s3.region-code.amazonaws.com
-        return fmt::format("{}", _ap());
-    }
 }
 
 std::string request_creator::make_target(

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -18,6 +18,7 @@
 #include "cloud_storage_clients/util.h"
 #include "cloud_storage_clients/xml_sax_parser.h"
 #include "config/configuration.h"
+#include "config/node_config.h"
 #include "hashing/secure.h"
 #include "http/client.h"
 #include "net/types.h"
@@ -559,6 +560,15 @@ s3_client::self_configure() {
     // If both addressing methods fail, return an error.
     auto result = s3_self_configuration_result{
       .url_style = s3_url_style::virtual_host};
+
+    // in fips mode this code path should not be reached, because after
+    // s3_configuration::make_configuration() url_style should already have a
+    // definitive value of s3_url_style::virtual_host
+    auto in_fips_mode = config::node().fips_mode.value();
+    vassert(
+      !in_fips_mode,
+      "node is in fips mode, s3_client::self_configure() should not be called");
+
     const auto remote_read
       = config::shard_local_cfg().cloud_storage_enable_remote_read();
     const auto remote_write

--- a/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
@@ -162,11 +162,14 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
         }
     }();
 
+    auto bucket_name = cloud_storage_clients::bucket_name(
+      m["bucket"].as<std::string>());
     cloud_storage_clients::s3_configuration client_cfg
       = cloud_storage_clients::s3_configuration::make_configuration(
           access_key,
           secret_key,
           region,
+          bucket_name,
           url_style,
           cloud_storage_clients::default_overrides{
             .endpoint =
@@ -188,8 +191,7 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
           .get0();
     vlog(test_log.info, "connecting to {}", client_cfg.server_addr);
     return test_conf{
-      .bucket = cloud_storage_clients::bucket_name(
-        m["bucket"].as<std::string>()),
+      .bucket = bucket_name,
       .objects =
         [&] {
             auto keys = m["object"].as<std::vector<std::string>>();

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -35,7 +35,7 @@ using namespace std::chrono_literals;
 
 ss::logger test_log("test-log");
 static const uint16_t httpd_port_number = 4434;
-static constexpr const char* httpd_host_name = "127.0.0.1";
+static constexpr const char* httpd_host_name = "localhost";
 
 static cloud_storage_clients::s3_configuration transport_configuration() {
     net::unresolved_address server_addr(httpd_host_name, httpd_port_number);

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -29,7 +29,7 @@ using namespace std::chrono_literals;
 
 ss::logger test_log("test-log");
 static const uint16_t httpd_port_number = 4434;
-static constexpr const char* httpd_host_name = "127.0.0.1";
+static constexpr const char* httpd_host_name = "localhost";
 
 static cloud_storage_clients::s3_configuration transport_configuration() {
     net::unresolved_address server_addr(httpd_host_name, httpd_port_number);

--- a/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/controller_snapshot_reconciliation_test.cc
@@ -38,12 +38,13 @@ class controller_snapshot_reconciliation_fixture
   , public enable_cloud_storage_fixture {
 public:
     controller_snapshot_reconciliation_fixture()
-      : redpanda_thread_fixture(
-        redpanda_thread_fixture::init_cloud_storage_tag{}, httpd_port_number())
+      : s3_imposter_fixture(cloud_storage_clients::bucket_name("test-bucket"))
+      , redpanda_thread_fixture(
+          redpanda_thread_fixture::init_cloud_storage_tag{},
+          httpd_port_number())
       , raft0(app.partition_manager.local().get(model::controller_ntp)->raft())
       , controller_stm(app.controller->get_controller_stm().local())
       , remote(app.cloud_storage_api.local())
-      , bucket(cloud_storage_clients::bucket_name("test-bucket"))
       , reconciler(
           app.controller->get_cluster_recovery_table().local(),
           app.feature_table.local(),
@@ -61,7 +62,6 @@ protected:
     cluster::consensus_ptr raft0;
     cluster::controller_stm& controller_stm;
     cloud_storage::remote& remote;
-    const cloud_storage_clients::bucket_name bucket;
     model::cluster_uuid cluster_uuid;
 
     controller_snapshot_reconciler reconciler;

--- a/src/v/cluster/cloud_metadata/tests/offsets_lookup_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/offsets_lookup_test.cc
@@ -34,9 +34,10 @@ class offsets_lookup_fixture
   , public enable_cloud_storage_fixture {
 public:
     offsets_lookup_fixture()
-      : redpanda_thread_fixture(
-        redpanda_thread_fixture::init_cloud_storage_tag{},
-        httpd_port_number()) {
+      : s3_imposter_fixture(cloud_storage_clients::bucket_name("test-bucket"))
+      , redpanda_thread_fixture(
+          redpanda_thread_fixture::init_cloud_storage_tag{},
+          httpd_port_number()) {
         set_expectations_and_listen({});
         wait_for_controller_leadership().get();
         RPTEST_REQUIRE_EVENTUALLY(5s, [this] {

--- a/src/v/cluster/cloud_metadata/tests/producer_id_recovery_test.cc
+++ b/src/v/cluster/cloud_metadata/tests/producer_id_recovery_test.cc
@@ -28,6 +28,9 @@ class ProducerIdRecoveryTest
   : public cloud_storage_manual_multinode_test_base
   , public seastar_test {
 public:
+    ProducerIdRecoveryTest()
+      : cloud_storage_manual_multinode_test_base(
+        cloud_storage_clients::bucket_name("test-bucket")) {}
     ss::future<> SetUpAsync() override {
         cluster::topic_properties props;
         props.cleanup_policy_bitflags

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -168,7 +168,7 @@ public:
         std::vector<config::seed_server> seeds = {};
         if (!empty_seed_starts_cluster_val || node_id != 0) {
             seeds.push_back(
-              {.addr = net::unresolved_address("127.0.0.1", 11000)});
+              {.addr = net::unresolved_address("localhost", 11000)});
         }
         add_node(
           node_id,

--- a/src/v/http/include/http/tests/http_imposter.h
+++ b/src/v/http/include/http/tests/http_imposter.h
@@ -20,7 +20,8 @@
 
 class http_imposter_fixture {
 public:
-    static constexpr std::string_view httpd_host_name = "127.0.0.1";
+    static constexpr std::string_view httpd_host_name = "localhost";
+    static constexpr std::string_view httpd_ip_addr = "127.0.0.1";
 
     uint16_t httpd_port_number();
 

--- a/src/v/http/tests/http_client_test.cc
+++ b/src/v/http/tests/http_client_test.cc
@@ -49,7 +49,7 @@
 using namespace std::chrono_literals;
 
 static const uint16_t httpd_port_number = 8128;
-static const char* httpd_host_name = "127.0.0.1";
+static const char* httpd_host_name = "localhost";
 static const char* httpd_server_reply
   = "The Hypertext Transfer Protocol (HTTP) is an "
     "application-level protocol "

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -21,7 +21,7 @@ static ss::logger http_imposter_log("http_imposter"); // NOLINT
 
 http_imposter_fixture::http_imposter_fixture(uint16_t port)
   : _port(port)
-  , _server_addr{ss::ipv4_addr{httpd_host_name.data(), httpd_port_number()}}
+  , _server_addr{ss::ipv4_addr{httpd_ip_addr.data(), httpd_port_number()}}
   , _address{
       {httpd_host_name.data(), httpd_host_name.size()}, httpd_port_number()} {
     _id = fmt::format("{}", uuid_t::create());

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -276,9 +276,9 @@ public:
 
     static cloud_storage_clients::s3_configuration
     get_s3_config(std::optional<uint16_t> port = std::nullopt) {
-        net::unresolved_address server_addr("127.0.0.1", port.value_or(4430));
+        net::unresolved_address server_addr("localhost", port.value_or(4430));
         cloud_storage_clients::s3_configuration s3conf;
-        s3conf.uri = cloud_storage_clients::access_point_uri("127.0.0.1");
+        s3conf.uri = cloud_storage_clients::access_point_uri("localhost");
         s3conf.access_key = cloud_roles::public_key_str("acess-key");
         s3conf.secret_key = cloud_roles::private_key_str("secret-key");
         s3conf.region = cloud_roles::aws_region_name("us-east-1");

--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -58,17 +58,18 @@ def retry_on_slowdown(tries=4, delay=1.0, backoff=2.0):
 
 class S3Client:
     """Simple S3 client"""
-    def __init__(self,
-                 region,
-                 access_key,
-                 secret_key,
-                 logger,
-                 endpoint=None,
-                 disable_ssl=True,
-                 signature_version='s3v4',
-                 before_call_headers=None,
-                 use_fips_endpoint=False,
-                 addressing_style: S3AddressingStyle = S3AddressingStyle.PATH):
+    def __init__(
+            self,
+            region,
+            access_key,
+            secret_key,
+            logger,
+            endpoint=None,
+            disable_ssl=True,
+            signature_version='s3v4',
+            before_call_headers=None,
+            use_fips_endpoint=False,
+            addressing_style: S3AddressingStyle = S3AddressingStyle.VIRTUAL):
 
         logger.debug(
             f"Constructed S3Client in region {region}, endpoint {endpoint}, key is set = {access_key is not None}, fips mode {use_fips_endpoint}, addressing style {addressing_style}"
@@ -98,7 +99,7 @@ class S3Client:
                 'max_attempts': 10,
                 'mode': 'adaptive'
             },
-            s3={'addressing_style': f'{self._addressing_style}'},
+            s3={'addressing_style': 'auto'},
             use_fips_endpoint=True if self._use_fips_endpoint else None)
         cl = boto3.client('s3',
                           config=cfg,

--- a/tests/rptest/archival/s3_client.py
+++ b/tests/rptest/archival/s3_client.py
@@ -11,6 +11,7 @@ from google.cloud import storage as gcs
 
 from concurrent.futures import ThreadPoolExecutor
 import datetime
+from enum import Enum
 from functools import wraps
 from itertools import islice
 from time import sleep
@@ -27,6 +28,11 @@ class ObjectMetadata(NamedTuple):
     bucket: str
     etag: str
     content_length: int
+
+
+class S3AddressingStyle(str, Enum):
+    VIRTUAL = 'virtual'
+    PATH = 'path'
 
 
 def retry_on_slowdown(tries=4, delay=1.0, backoff=2.0):
@@ -60,33 +66,40 @@ class S3Client:
                  endpoint=None,
                  disable_ssl=True,
                  signature_version='s3v4',
-                 before_call_headers=None):
+                 before_call_headers=None,
+                 use_fips_endpoint=False,
+                 addressing_style: S3AddressingStyle = S3AddressingStyle.PATH):
 
         logger.debug(
-            f"Constructed S3Client in region {region}, endpoint {endpoint}, key is set = {access_key is not None}"
+            f"Constructed S3Client in region {region}, endpoint {endpoint}, key is set = {access_key is not None}, fips mode {use_fips_endpoint}, addressing style {addressing_style}"
         )
 
+        self._use_fips_endpoint = use_fips_endpoint
         self._region = region
         self._access_key = access_key
         self._secret_key = secret_key
         self._endpoint = endpoint
-        self._disable_ssl = disable_ssl
+        self._disable_ssl = False if self._use_fips_endpoint else disable_ssl
         if signature_version.lower() == "unsigned":
             self._signature_version = UNSIGNED
         else:
             self._signature_version = signature_version
         self._before_call_headers = before_call_headers
+        self._addressing_style = addressing_style
         self._cli = self.make_client()
         self.register_custom_events()
         self.logger = logger
 
     def make_client(self):
-        cfg = Config(region_name=self._region,
-                     signature_version=self._signature_version,
-                     retries={
-                         'max_attempts': 10,
-                         'mode': 'adaptive'
-                     })
+        cfg = Config(
+            region_name=self._region,
+            signature_version=self._signature_version,
+            retries={
+                'max_attempts': 10,
+                'mode': 'adaptive'
+            },
+            s3={'addressing_style': f'{self._addressing_style}'},
+            use_fips_endpoint=True if self._use_fips_endpoint else None)
         cl = boto3.client('s3',
                           config=cfg,
                           aws_access_key_id=self._access_key,

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -447,42 +447,43 @@ class SISettings:
     ABS_AZURITE_ACCOUNT = "devstoreaccount1"
     ABS_AZURITE_KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
 
-    def __init__(self,
-                 test_context,
-                 *,
-                 log_segment_size: int = 16 * 1000000,
-                 cloud_storage_cache_chunk_size: Optional[int] = None,
-                 cloud_storage_credentials_source: str = 'config_file',
-                 cloud_storage_access_key: str = 'panda-user',
-                 cloud_storage_secret_key: str = 'panda-secret',
-                 cloud_storage_region: str = 'panda-region',
-                 cloud_storage_api_endpoint: str = 'minio-s3',
-                 cloud_storage_api_endpoint_port: int = 9000,
-                 cloud_storage_url_style: str = 'virtual_host',
-                 cloud_storage_cache_size: Optional[int] = None,
-                 cloud_storage_cache_max_objects: Optional[int] = None,
-                 cloud_storage_enable_remote_read: bool = True,
-                 cloud_storage_enable_remote_write: bool = True,
-                 cloud_storage_max_connections: Optional[int] = None,
-                 cloud_storage_disable_tls: bool = True,
-                 cloud_storage_segment_max_upload_interval_sec: Optional[
-                     int] = None,
-                 cloud_storage_manifest_max_upload_interval_sec: Optional[
-                     int] = None,
-                 cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
-                     int] = None,
-                 bypass_bucket_creation: bool = False,
-                 use_bucket_cleanup_policy: bool = True,
-                 cloud_storage_housekeeping_interval_ms: Optional[int] = None,
-                 cloud_storage_spillover_manifest_max_segments: Optional[
-                     int] = None,
-                 fast_uploads=False,
-                 retention_local_strict=True,
-                 cloud_storage_max_throughput_per_shard: Optional[int] = None,
-                 cloud_storage_signature_version: str = "s3v4",
-                 before_call_headers: Optional[dict[str, Any]] = None,
-                 skip_end_of_test_scrubbing: bool = False,
-                 addressing_style: S3AddressingStyle = S3AddressingStyle.PATH):
+    def __init__(
+            self,
+            test_context,
+            *,
+            log_segment_size: int = 16 * 1000000,
+            cloud_storage_cache_chunk_size: Optional[int] = None,
+            cloud_storage_credentials_source: str = 'config_file',
+            cloud_storage_access_key: str = 'panda-user',
+            cloud_storage_secret_key: str = 'panda-secret',
+            cloud_storage_region: str = 'panda-region',
+            cloud_storage_api_endpoint: str = 'minio-s3',
+            cloud_storage_api_endpoint_port: int = 9000,
+            cloud_storage_url_style: str = 'virtual_host',
+            cloud_storage_cache_size: Optional[int] = None,
+            cloud_storage_cache_max_objects: Optional[int] = None,
+            cloud_storage_enable_remote_read: bool = True,
+            cloud_storage_enable_remote_write: bool = True,
+            cloud_storage_max_connections: Optional[int] = None,
+            cloud_storage_disable_tls: bool = True,
+            cloud_storage_segment_max_upload_interval_sec: Optional[
+                int] = None,
+            cloud_storage_manifest_max_upload_interval_sec: Optional[
+                int] = None,
+            cloud_storage_readreplica_manifest_sync_timeout_ms: Optional[
+                int] = None,
+            bypass_bucket_creation: bool = False,
+            use_bucket_cleanup_policy: bool = True,
+            cloud_storage_housekeeping_interval_ms: Optional[int] = None,
+            cloud_storage_spillover_manifest_max_segments: Optional[
+                int] = None,
+            fast_uploads=False,
+            retention_local_strict=True,
+            cloud_storage_max_throughput_per_shard: Optional[int] = None,
+            cloud_storage_signature_version: str = "s3v4",
+            before_call_headers: Optional[dict[str, Any]] = None,
+            skip_end_of_test_scrubbing: bool = False,
+            addressing_style: S3AddressingStyle = S3AddressingStyle.VIRTUAL):
         """
         :param fast_uploads: if true, set low upload intervals to help tests run
                              quickly when they wait for uploads to complete.

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -36,7 +36,7 @@ from ducktape.services.service import Service
 from ducktape.tests.test import TestContext
 from requests.adapters import HTTPAdapter
 from requests.exceptions import HTTPError
-from rptest.archival.s3_client import S3Client
+from rptest.archival.s3_client import S3Client, S3AddressingStyle
 from rptest.archival.abs_client import ABSClient
 from ducktape.cluster.remoteaccount import RemoteCommandError
 from ducktape.utils.local_filesystem_utils import mkdir_p
@@ -247,6 +247,13 @@ def one_or_many(value):
         return value
 
 
+def get_cloud_provider() -> str:
+    """
+    Returns the cloud provider in use.  If one is not set then return 'docker'
+    """
+    return os.getenv("CLOUD_PROVIDER", "docker")
+
+
 def get_cloud_storage_type(applies_only_on: list[CloudStorageType]
                            | None = None,
                            docker_use_arbitrary=False):
@@ -271,7 +278,7 @@ def get_cloud_storage_type(applies_only_on: list[CloudStorageType]
     if applies_only_on is None:
         applies_only_on = []
 
-    cloud_provider = os.getenv("CLOUD_PROVIDER", "docker")
+    cloud_provider = get_cloud_provider()
     if cloud_provider == "docker":
         if docker_use_arbitrary:
             cloud_storage_type = [CloudStorageType.S3]
@@ -427,6 +434,8 @@ class SISettings:
     GLOBAL_S3_SECRET_KEY = "s3_secret_key"
     GLOBAL_S3_REGION_KEY = "s3_region"
     GLOBAL_GCP_PROJECT_ID_KEY = "gcp_project_id"
+    GLOBAL_USE_FIPS_S3_ENDPOINT = "use_fips_s3_endpoint"
+    DEFAULT_USE_FIPS_S3_ENDPOINT = "OFF"
 
     GLOBAL_ABS_STORAGE_ACCOUNT = "abs_storage_account"
     GLOBAL_ABS_SHARED_KEY = "abs_shared_key"
@@ -472,12 +481,14 @@ class SISettings:
                  cloud_storage_max_throughput_per_shard: Optional[int] = None,
                  cloud_storage_signature_version: str = "s3v4",
                  before_call_headers: Optional[dict[str, Any]] = None,
-                 skip_end_of_test_scrubbing: bool = False):
+                 skip_end_of_test_scrubbing: bool = False,
+                 addressing_style: S3AddressingStyle = S3AddressingStyle.PATH):
         """
         :param fast_uploads: if true, set low upload intervals to help tests run
                              quickly when they wait for uploads to complete.
         """
 
+        self._context = test_context
         self.cloud_storage_type = get_cloud_storage_type()[0]
         if hasattr(test_context, 'injected_args') \
         and test_context.injected_args is not None \
@@ -536,6 +547,7 @@ class SISettings:
         self.cloud_storage_max_throughput_per_shard = cloud_storage_max_throughput_per_shard
         self.cloud_storage_signature_version = cloud_storage_signature_version
         self.before_call_headers = before_call_headers
+        self.addressing_style = addressing_style
 
         # Allow disabling end of test scrubbing.
         # It takes a long time with lots of segments i.e. as created in scale
@@ -548,6 +560,32 @@ class SISettings:
             self.cloud_storage_manifest_max_upload_interval_sec = 1
 
         self._expected_damage_types = set()
+
+    def get_use_fips_s3_endpoint(self) -> bool:
+        use_fips_option = self._context.globals.get(
+            self.GLOBAL_USE_FIPS_S3_ENDPOINT,
+            self.DEFAULT_USE_FIPS_S3_ENDPOINT)
+        if use_fips_option == "ON":
+            return True
+        elif use_fips_option == "OFF":
+            return False
+
+        self.logger.warn(
+            f"{self.GLOBAL_USE_FIPS_S3_ENDPOINT} should be 'ON', or 'OFF'")
+        return False
+
+    def use_fips_endpoint(self) -> bool:
+        """
+        Returns whether or not to use the FIPS S3 endpoints.  Only true if:
+        * Cloud provider is AWS, and
+        * Cloud storage type is S3, and
+        * Either
+          * we are in a FIPS environment or,
+          * the global variable 'use_fips_s3_endpoint' is 'ON'
+        """
+        return get_cloud_provider() == "aws" and \
+            self.cloud_storage_type == CloudStorageType.S3 and \
+                True if self.get_use_fips_s3_endpoint() else in_fips_environment()
 
     def load_context(self, logger, test_context):
         if self.cloud_storage_type == CloudStorageType.S3:
@@ -606,6 +644,9 @@ class SISettings:
             self.cloud_storage_disable_tls = False  # SI will fail to create archivers if tls is disabled
             self.cloud_storage_region = cloud_storage_region
             self.cloud_storage_api_endpoint_port = 443
+            self.cloud_storage_api_endpoint = f's3-fips.{cloud_storage_region}.amazonaws.com' if self.use_fips_endpoint(
+            ) else self.cloud_storage_api_endpoint
+            self.addressing_style = S3AddressingStyle.VIRTUAL
         elif cloud_storage_credentials_source == 'config_file' and cloud_storage_access_key and cloud_storage_secret_key:
             # `config_file`` source allows developers to run ducktape tests from
             # non-AWS hardware but targeting a real S3 backend.
@@ -619,6 +660,9 @@ class SISettings:
             self.cloud_storage_disable_tls = False  # SI will fail to create archivers if tls is disabled
             self.cloud_storage_region = cloud_storage_region
             self.cloud_storage_api_endpoint_port = 443
+            self.cloud_storage_api_endpoint = f's3-fips.{cloud_storage_region}.amazonaws.com' if self.use_fips_endpoint(
+            ) else self.cloud_storage_api_endpoint
+            self.addressing_style = S3AddressingStyle.VIRTUAL
         else:
             logger.info('No AWS credentials supplied, assuming minio defaults')
 
@@ -684,11 +728,16 @@ class SISettings:
         conf[
             'cloud_storage_enable_remote_write'] = self.cloud_storage_enable_remote_write
 
-        if self.endpoint_url is not None:
+        if self.endpoint_url is not None or self.use_fips_endpoint():
             conf[
                 "cloud_storage_api_endpoint"] = self.cloud_storage_api_endpoint
             conf[
                 "cloud_storage_api_endpoint_port"] = self.cloud_storage_api_endpoint_port
+
+        if self.addressing_style == S3AddressingStyle.VIRTUAL:
+            conf["cloud_storage_url_style"] = "virtual_host"
+        elif self.addressing_style == S3AddressingStyle.PATH:
+            conf["cloud_storage_url_style"] = "path"
 
         if self.cloud_storage_disable_tls:
             conf['cloud_storage_disable_tls'] = self.cloud_storage_disable_tls
@@ -3043,7 +3092,9 @@ class RedpandaService(RedpandaServiceBase):
                 logger=self.logger,
                 signature_version=self.si_settings.
                 cloud_storage_signature_version,
-                before_call_headers=self.si_settings.before_call_headers)
+                before_call_headers=self.si_settings.before_call_headers,
+                use_fips_endpoint=self.si_settings.use_fips_endpoint(),
+                addressing_style=self.si_settings.addressing_style)
 
             self.logger.debug(
                 f"Creating S3 bucket: {self.si_settings.cloud_storage_bucket}")


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Changes to testing and cloud storage infrastructure in order to be able to point Redpanda at [FIPS compliant S3 endpoints in AWS](https://aws.amazon.com/compliance/fips/) (go to "Amazon Simple Storage Service (S3)" row on table in linked page).

waiting for this https://github.com/redpanda-data/redpanda/pull/18106 to merge

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None
