### PR TITLE
cst: Change acceptable query miss condition

### DIFF
--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -574,17 +574,49 @@ private:
                     // Special case queries below the start offset of the log.
                     // The start offset may have advanced while the request was
                     // in progress. This is expected, so log at debug level.
-                    const auto log_start_offset
-                      = _partition->_manifest_view->stm_manifest()
-                          .full_log_start_kafka_offset();
+                    const auto& manifest
+                      = _partition->_manifest_view->stm_manifest();
 
-                    if (log_start_offset && query_offset < *log_start_offset) {
+                    const auto log_start_offset
+                      = manifest.full_log_start_kafka_offset();
+
+                    // The log has been truncated fully due to retention, IE
+                    // start offset is ahead of all segments in the log. The log
+                    // start offset computes to nullopt.
+                    const auto is_log_fully_truncated
+                      = manifest.get_start_offset().has_value()
+                        && manifest.get_start_offset()
+                             > manifest.get_last_offset()
+                        && !log_start_offset.has_value();
+
+                    // The query is within the manifest segments, we cannot
+                    // translate the current start offset to kafka offset, as we
+                    // do not have its delta. So we combine two different
+                    // checks: the query is within manifest segments, and the
+                    // manifest segments are all below the start offset. We also
+                    // can not check that query is greater than the start kafka
+                    // offset because the start kafka offset is not computable
+                    // if the start offset is outside the range of current
+                    // segments.
+                    const auto query_within_truncated_range
+                      = is_log_fully_truncated
+                        && manifest.get_last_kafka_offset().has_value()
+                        && query_offset
+                             <= manifest.get_last_kafka_offset().value();
+
+                    const auto query_below_log_start
+                      = log_start_offset.has_value()
+                        && query_offset < log_start_offset.value();
+
+                    if (query_below_log_start || query_within_truncated_range) {
                         vlog(
                           _ctxlog.debug,
                           "Manifest query below the log's start Kafka offset: "
-                          "{} < {}",
+                          "{} < {}, log start offset: {}, log end offset: {}",
                           query_offset(),
-                          log_start_offset.value()());
+                          log_start_offset.value()(),
+                          manifest.get_start_offset(),
+                          manifest.get_last_offset());
                         return true;
                     }
                     return false;


### PR DESCRIPTION
When a query for an offset misses, it is possible that this happens because the manifest was entirely truncated. Truncation usually happens in two steps, first the start offset is advanced and later on the manifest segments are removed.

If the query falls between these two steps, the current condition to accept a query miss as a non-error may fail, because it uses the kafka log start offset. If the manifest start offset has been advanced beyond the entire manifest span, the kafka offset is now not calculatable, which results in nullopt kafka start, which does not match the condtion and the query miss is recorded as an error.

The change detects the condition where the manifest is fully truncated and the query offset lies within truncated range, if so the query is considered not to have failed.

FIXES https://github.com/redpanda-data/redpanda/issues/18454

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
