### PR TITLE
tests: support n2 32 machine types

### DIFF
--- a/tests/rptest/services/machinetype.py
+++ b/tests/rptest/services/machinetype.py
@@ -22,6 +22,7 @@ class MachineTypeName(str, Enum):
     N2_STANDARD_4 = 'n2-standard-4'
     N2_STANDARD_8 = 'n2-standard-8'
     N2_STANDARD_16 = 'n2-standard-16'
+    N2_STANDARD_32 = 'n2-standard-32'
     N2D_STANDARD_2 = 'n2d-standard-2'
     N2D_STANDARD_4 = 'n2d-standard-4'
     N2D_STANDARD_16 = 'n2d-standard-16'
@@ -75,6 +76,8 @@ MachineTypeConfigs = {
     MachineTypeConfig(num_shards=7, memory=32 * GiB),
     MachineTypeName.N2_STANDARD_16:
     MachineTypeConfig(num_shards=15, memory=64 * GiB),
+    MachineTypeName.N2_STANDARD_32:
+    MachineTypeConfig(num_shards=31, memory=128 * GiB),
     MachineTypeName.N2D_STANDARD_2:
     MachineTypeConfig(num_shards=1, memory=8 * GiB),
     MachineTypeName.N2D_STANDARD_4:


### PR DESCRIPTION
This is required for perf/HT testing the recently added gcp v2-N2 tiers

## Backports Required


- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
