### PR TITLE
Node-local shard assignments for created/moved partitions

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -141,6 +141,7 @@ ss::future<> controller::wire_up() {
       .then([this] {
           return _partition_allocator.start_single(
             std::ref(_members_table),
+            std::ref(_feature_table),
             config::shard_local_cfg().topic_memory_per_partition.bind(),
             config::shard_local_cfg().topic_fds_per_partition.bind(),
             config::shard_local_cfg().topic_partitions_per_shard.bind(),

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -378,6 +378,7 @@ ss::future<> controller::start(
             std::ref(_members_table),
             std::ref(_partition_manager),
             std::ref(_shard_table),
+            std::ref(_shard_balancer),
             ss::sharded_parameter(
               [this] { return std::ref(_plugin_table.local()); }),
             ss::sharded_parameter(

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -131,6 +131,10 @@ public:
         return _partition_balancer;
     }
 
+    ss::sharded<shard_balancer>& get_shard_balancer() {
+        return _shard_balancer;
+    }
+
     ss::sharded<ss::abort_source>& get_abort_source() { return _as; }
 
     ss::sharded<storage::api>& get_storage() { return _storage; }

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -160,6 +160,11 @@
             "name": "delete_topics",
             "input_type": "delete_topics_request",
             "output_type": "delete_topics_reply"
+        },
+        {
+            "name": "set_partition_shard",
+            "input_type": "set_partition_shard_request",
+            "output_type": "set_partition_shard_reply"
         }
     ]
 }

--- a/src/v/cluster/errc.h
+++ b/src/v/cluster/errc.h
@@ -89,6 +89,7 @@ enum class errc : int16_t {
     topic_invalid_partitions_decreased,
     producer_ids_vcluster_limit_exceeded,
     validation_of_recovery_topic_failed,
+    replica_does_not_exist,
 };
 struct errc_category final : public std::error_category {
     const char* name() const noexcept final { return "cluster::errc"; }
@@ -259,6 +260,8 @@ struct errc_category final : public std::error_category {
             return "To many vclusters registered in producer state cache";
         case errc::validation_of_recovery_topic_failed:
             return "Validation of recovery topic failed";
+        case errc::replica_does_not_exist:
+            return "Partition replica does not exist";
         }
         return "cluster::errc::unknown";
     }

--- a/src/v/cluster/scheduling/allocation_node.cc
+++ b/src/v/cluster/scheduling/allocation_node.cc
@@ -76,14 +76,9 @@ bool allocation_node::is_full(
     return !is_internal_topic && count > _max_capacity;
 }
 
-ss::shard_id
-allocation_node::allocate(const partition_allocation_domain domain) {
+ss::shard_id allocation_node::allocate_shard() {
     auto it = std::min_element(_weights.begin(), _weights.end());
     (*it)++; // increment the weights
-    _allocated_partitions++;
-    ++_allocated_domain_partitions[domain];
-    _final_partitions++;
-    ++_final_domain_partitions[domain];
     const ss::shard_id core = std::distance(_weights.begin(), it);
     vlog(
       clusterlog.trace,
@@ -94,17 +89,24 @@ allocation_node::allocate(const partition_allocation_domain domain) {
     return core;
 }
 
-void allocation_node::deallocate_on(
-  ss::shard_id core, const partition_allocation_domain domain) {
+void allocation_node::add_allocation(partition_allocation_domain domain) {
+    _allocated_partitions++;
+    ++_allocated_domain_partitions[domain];
+}
+
+void allocation_node::add_allocation(ss::shard_id core) {
     vassert(
       core < _weights.size(),
-      "Tried to deallocate a non-existing core:{} - {}",
+      "Tried to allocate a non-existing core:{} - {}",
       core,
       *this);
+    _weights[core]++;
+}
+
+void allocation_node::remove_allocation(partition_allocation_domain domain) {
     vassert(
-      _allocated_partitions > allocation_capacity{0} && _weights[core] > 0,
-      "unable to deallocate partition from core {} at node {}",
-      core,
+      _allocated_partitions > allocation_capacity{0},
+      "unable to deallocate partition at node {}",
       *this);
 
     allocation_capacity& domain_partitions
@@ -112,39 +114,31 @@ void allocation_node::deallocate_on(
     vassert(
       domain_partitions > allocation_capacity{0}
         && domain_partitions <= _allocated_partitions,
-      "Unable to deallocate partition from core {} in domain {} at node {}",
-      core,
+      "Unable to deallocate partition in domain {} at node {}",
       domain,
       *this);
-    --domain_partitions;
 
     _allocated_partitions--;
-    _weights[core]--;
-    vlog(
-      clusterlog.trace,
-      "deallocation [node: {}, core: {}], total allocated: {}",
-      _id,
-      core,
-      _allocated_partitions);
+    --domain_partitions;
 }
 
-void allocation_node::allocate_on(
-  ss::shard_id core, const partition_allocation_domain domain) {
+void allocation_node::remove_allocation(ss::shard_id core) {
     vassert(
-      core < _weights.size(),
-      "Tried to allocate a non-existing core:{} - {}",
+      core < _weights.size() && _weights[core] > 0,
+      "unable to deallocate partition from core {} at node {}",
       core,
       *this);
+    _weights[core]--;
+}
 
-    _weights[core]++;
-    _allocated_partitions++;
-    ++_allocated_domain_partitions[domain];
-    vlog(
-      clusterlog.trace,
-      "allocation [node: {}, core: {}], total allocated: {}",
-      _id,
-      core,
-      _allocated_partitions);
+void allocation_node::add_final_count(partition_allocation_domain domain) {
+    ++_final_partitions;
+    ++_final_domain_partitions[domain];
+}
+
+void allocation_node::remove_final_count(partition_allocation_domain domain) {
+    --_final_partitions;
+    --_final_domain_partitions[domain];
 }
 
 void allocation_node::update_core_count(uint32_t core_count) {

--- a/src/v/cluster/scheduling/allocation_node.h
+++ b/src/v/cluster/scheduling/allocation_node.h
@@ -125,13 +125,18 @@ public:
         return _allocated_partitions == allocation_capacity{0};
     }
     bool is_full(const model::ntp&, bool will_add_allocation) const;
-    ss::shard_id allocate(partition_allocation_domain);
 
 private:
     friend allocation_state;
 
-    void deallocate_on(ss::shard_id core, partition_allocation_domain);
-    void allocate_on(ss::shard_id core, partition_allocation_domain);
+    ss::shard_id allocate_shard();
+
+    void add_allocation(partition_allocation_domain);
+    void add_allocation(ss::shard_id core);
+    void remove_allocation(partition_allocation_domain);
+    void remove_allocation(ss::shard_id core);
+    void add_final_count(partition_allocation_domain);
+    void remove_final_count(partition_allocation_domain);
 
     model::node_id _id;
     /// each index is a CPU. A weight is roughly the number of assignments

--- a/src/v/cluster/scheduling/allocation_state.cc
+++ b/src/v/cluster/scheduling/allocation_state.cc
@@ -11,6 +11,7 @@
 
 #include "base/oncore.h"
 #include "cluster/logger.h"
+#include "features/feature_table.h"
 #include "ssx/sformat.h"
 
 namespace cluster {
@@ -153,13 +154,20 @@ bool allocation_state::is_empty(model::node_id id) const {
     return it->second->empty();
 }
 
+bool allocation_state::node_local_core_assignment_enabled() const {
+    return _feature_table.is_active(
+      features::feature::node_local_core_assignment);
+}
+
 void allocation_state::add_allocation(
   const model::broker_shard& replica,
   const partition_allocation_domain domain) {
     verify_shard();
     if (auto it = _nodes.find(replica.node_id); it != _nodes.end()) {
         it->second->add_allocation(domain);
-        it->second->add_allocation(replica.shard);
+        if (!node_local_core_assignment_enabled()) {
+            it->second->add_allocation(replica.shard);
+        }
         vlog(
           clusterlog.trace,
           "add allocation [node: {}, core: {}], total allocated: {}",
@@ -175,7 +183,9 @@ void allocation_state::remove_allocation(
     verify_shard();
     if (auto it = _nodes.find(replica.node_id); it != _nodes.end()) {
         it->second->remove_allocation(domain);
-        it->second->remove_allocation(replica.shard);
+        if (!node_local_core_assignment_enabled()) {
+            it->second->remove_allocation(replica.shard);
+        }
         vlog(
           clusterlog.trace,
           "remove allocation [node: {}, core: {}], total allocated: {}",
@@ -194,7 +204,17 @@ uint32_t allocation_state::allocate(
 
     it->second->add_allocation(domain);
     it->second->add_final_count(domain);
-    return it->second->allocate_shard();
+    if (node_local_core_assignment_enabled()) {
+#ifndef NDEBUG
+        // return invalid shard in debug mode so that we can spot places where
+        // we are still using it.
+        return 12312312;
+#else
+        return 0;
+#endif
+    } else {
+        return it->second->allocate_shard();
+    }
 }
 
 void allocation_state::add_final_count(

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -13,6 +13,7 @@
 
 #include "base/oncore.h"
 #include "cluster/scheduling/allocation_node.h"
+#include "features/fwd.h"
 #include "model/metadata.h"
 
 #include <seastar/core/weak_ptr.hh>
@@ -29,10 +30,12 @@ public:
     using underlying_t = absl::btree_map<model::node_id, node_ptr>;
 
     allocation_state(
+      features::feature_table& feature_table,
       config::binding<uint32_t> partitions_per_shard,
       config::binding<uint32_t> partitions_reserve_shard0,
       config::binding<std::vector<ss::sstring>> internal_kafka_topics)
-      : _partitions_per_shard(std::move(partitions_per_shard))
+      : _feature_table(feature_table)
+      , _partitions_per_shard(std::move(partitions_per_shard))
       , _partitions_reserve_shard0(std::move(partitions_reserve_shard0))
       , _internal_kafka_topics(std::move(internal_kafka_topics)) {}
 
@@ -80,6 +83,7 @@ private:
      */
     void verify_shard() const;
 
+    features::feature_table& _feature_table;
     config::binding<uint32_t> _partitions_per_shard;
     config::binding<uint32_t> _partitions_reserve_shard0;
     config::binding<std::vector<ss::sstring>> _internal_kafka_topics;

--- a/src/v/cluster/scheduling/allocation_state.h
+++ b/src/v/cluster/scheduling/allocation_state.h
@@ -53,6 +53,8 @@ public:
     const underlying_t& allocation_nodes() const { return _nodes; }
     int16_t available_nodes() const;
 
+    bool node_local_core_assignment_enabled() const;
+
     // Choose a shard for a replica and add the corresponding allocation.
     // node_id is required to belong to an existing node.
     uint32_t allocate(model::node_id id, partition_allocation_domain);

--- a/src/v/cluster/scheduling/partition_allocator.h
+++ b/src/v/cluster/scheduling/partition_allocator.h
@@ -17,6 +17,7 @@
 #include "cluster/scheduling/allocation_strategy.h"
 #include "cluster/scheduling/types.h"
 #include "config/property.h"
+#include "features/fwd.h"
 
 namespace cluster {
 
@@ -31,6 +32,7 @@ public:
     static constexpr ss::shard_id shard = 0;
     partition_allocator(
       ss::sharded<members_table>&,
+      ss::sharded<features::feature_table>&,
       config::binding<std::optional<size_t>> memory_per_partition,
       config::binding<std::optional<int32_t>> fds_per_partition,
       config::binding<uint32_t> partitions_per_shard,
@@ -148,6 +150,7 @@ private:
     std::unique_ptr<allocation_state> _state;
     allocation_strategy _allocation_strategy;
     ss::sharded<members_table>& _members;
+    features::feature_table& _feature_table;
 
     config::binding<std::optional<size_t>> _memory_per_partition;
     config::binding<std::optional<int32_t>> _fds_per_partition;

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -816,4 +816,12 @@ service::delete_topics(delete_topics_request req, rpc::streaming_context&) {
     co_return delete_topics_reply{.results = std::move(result)};
 }
 
+ss::future<set_partition_shard_reply> service::set_partition_shard(
+  set_partition_shard_request req, rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
+    auto ec = co_await _topics_frontend.local().set_local_partition_shard(
+      req.ntp, req.shard);
+    co_return set_partition_shard_reply{.ec = ec};
+}
+
 } // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -136,6 +136,9 @@ public:
     ss::future<delete_topics_reply>
     delete_topics(delete_topics_request, rpc::streaming_context&) final;
 
+    ss::future<set_partition_shard_reply> set_partition_shard(
+      set_partition_shard_request, rpc::streaming_context&) final;
+
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
     std::pair<std::vector<model::topic_metadata>, topic_configuration_vector>

--- a/src/v/cluster/shard_balancer.cc
+++ b/src/v/cluster/shard_balancer.cc
@@ -98,7 +98,7 @@ ss::future<> shard_balancer::start() {
         co_await _shard_placement.initialize_from_topic_table(_topics, _self);
 
         if (_features.is_active(
-              features::feature::shard_placement_persistence)) {
+              features::feature::node_local_core_assignment)) {
             co_await _shard_placement.enable_persistence();
         }
     }
@@ -154,7 +154,7 @@ ss::future<> shard_balancer::assign_fiber() {
         }
 
         if (
-          _features.is_active(features::feature::shard_placement_persistence)
+          _features.is_active(features::feature::node_local_core_assignment)
           && !_shard_placement.is_persistence_enabled()) {
             co_await _shard_placement.enable_persistence();
         }

--- a/src/v/cluster/shard_balancer.h
+++ b/src/v/cluster/shard_balancer.h
@@ -23,8 +23,10 @@ namespace cluster {
 /// shard_placement_table and notifying controller_backend of these modification
 /// so that it can perform necessary reconciling actions.
 ///
-/// Currently shard_balancer simply uses assignments from topic_table, but in
-/// the future it will calculate them on its own.
+/// If node-local core assignment is enabled, shard_balancer is responsible for
+/// assigning partitions to shards and it will do it using topic-aware counts
+/// balancing heuristic. In legacy mode it will use shard assignments from
+/// topic_table.
 class shard_balancer {
 public:
     // single instance
@@ -65,6 +67,11 @@ private:
         int32_t total_count = 0;
         shard2count_t shard2count;
     };
+
+    ss::shard_id choose_shard(
+      const model::ntp&,
+      const topic_data_t&,
+      std::optional<ss::shard_id> prev) const;
 
     void update_counts(
       const model::ntp&,

--- a/src/v/cluster/shard_balancer.h
+++ b/src/v/cluster/shard_balancer.h
@@ -39,6 +39,11 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    /// Persist current shard_placement_table contents to kvstore. Executed once
+    /// when enabling the node_local_core_assignment feature (assumes that it is
+    /// in the "preparing" state).
+    ss::future<> enable_persistence();
+
 private:
     void process_delta(const topic_table::delta&);
 

--- a/src/v/cluster/tests/allocation_bench.cc
+++ b/src/v/cluster/tests/allocation_bench.cc
@@ -30,7 +30,7 @@ PERF_TEST_F(partition_allocator_fixture, allocation_3) {
     auto req = make_allocation_request(1, 3);
 
     perf_tests::start_measuring_time();
-    return allocator.allocate(std::move(req)).then([](auto vals) {
+    return allocator().allocate(std::move(req)).then([](auto vals) {
         perf_tests::do_not_optimize(vals);
         perf_tests::stop_measuring_time();
     });
@@ -48,19 +48,19 @@ PERF_TEST_F(partition_allocator_fixture, deallocation_3) {
 
     std::vector<model::broker_shard> replicas;
 
-    return allocator.allocate(std::move(req)).then([this](auto r) {
+    return allocator().allocate(std::move(req)).then([this](auto r) {
         std::vector<model::broker_shard> replicas;
         {
             auto units = std::move(r.value());
             replicas = units->get_assignments().front().replicas;
-            allocator.add_allocations_for_new_partition(
+            allocator().add_allocations_for_new_partition(
               units->get_assignments().front().replicas,
               units->get_assignments().front().group,
               cluster::partition_allocation_domains::common);
         }
         perf_tests::do_not_optimize(replicas);
         perf_tests::start_measuring_time();
-        allocator.remove_allocations(
+        allocator().remove_allocations(
           replicas, cluster::partition_allocation_domains::common);
         perf_tests::stop_measuring_time();
     });
@@ -84,7 +84,7 @@ PERF_TEST_F(partition_allocator_fixture, recovery) {
     }
 
     perf_tests::start_measuring_time();
-    allocator.add_allocations_for_new_partition(
+    allocator().add_allocations_for_new_partition(
       replicas,
       raft::group_id(replicas.size() / 3),
       cluster::partition_allocation_domains::common);

--- a/src/v/cluster/tests/partition_allocator_fixture.h
+++ b/src/v/cluster/tests/partition_allocator_fixture.h
@@ -19,6 +19,7 @@
 #include "cluster/scheduling/partition_allocator.h"
 #include "config/configuration.h"
 #include "config/mock_property.h"
+#include "features/feature_table.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 #include "random/fast_prng.h"
@@ -36,7 +37,11 @@ struct partition_allocator_fixture {
     partition_allocator_fixture()
       : partition_allocator_fixture(std::nullopt, std::nullopt) {}
 
-    ~partition_allocator_fixture() { members.stop().get0(); }
+    ~partition_allocator_fixture() {
+        _allocator.stop().get();
+        features.stop().get();
+        members.stop().get();
+    }
 
     void register_node(
       int id,
@@ -59,7 +64,7 @@ struct partition_allocator_fixture {
               ss::format("unable to apply add node cmd: {}", ec.message()));
         }
 
-        allocator.register_node(std::make_unique<cluster::allocation_node>(
+        allocator().register_node(std::make_unique<cluster::allocation_node>(
           broker.id(),
           broker.properties().cores,
           config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
@@ -68,12 +73,12 @@ struct partition_allocator_fixture {
     }
 
     void saturate_all_machines() {
-        auto units = allocator
+        auto units = allocator()
                        .allocate(make_allocation_request(max_capacity(), 1))
                        .get();
 
         for (auto& pas : units.value()->get_assignments()) {
-            allocator.add_allocations_for_new_partition(
+            allocator().add_allocations_for_new_partition(
               pas.replicas,
               pas.group,
               cluster::partition_allocation_domains::common);
@@ -93,15 +98,15 @@ struct partition_allocator_fixture {
 
     bool all_nodes_empty() {
         return std::all_of(
-          allocator.state().allocation_nodes().begin(),
-          allocator.state().allocation_nodes().end(),
+          allocator().state().allocation_nodes().begin(),
+          allocator().state().allocation_nodes().end(),
           [](const auto& n) { return n.second->empty(); });
     }
 
     int32_t max_capacity() {
         return std::accumulate(
-          allocator.state().allocation_nodes().begin(),
-          allocator.state().allocation_nodes().end(),
+          allocator().state().allocation_nodes().begin(),
+          allocator().state().allocation_nodes().end(),
           0,
           [](int acc, auto& n) {
               return acc + n.second->partition_capacity();
@@ -125,26 +130,33 @@ struct partition_allocator_fixture {
         return req;
     }
 
+    cluster::partition_allocator& allocator() { return _allocator.local(); }
+
     config::mock_property<std::vector<ss::sstring>> kafka_internal_topics{{}};
     model::topic_namespace tn{model::kafka_namespace, model::topic{"test"}};
     ss::sharded<cluster::members_table> members;
-    cluster::partition_allocator allocator;
+    ss::sharded<features::feature_table> features;
+    ss::sharded<cluster::partition_allocator> _allocator;
 
     fast_prng prng;
 
 protected:
     explicit partition_allocator_fixture(
       std::optional<size_t> memory_per_partition,
-      std::optional<int32_t> fds_per_partition)
-      : allocator(
-        std::ref(members),
-        config::mock_binding<std::optional<size_t>>(memory_per_partition),
-        config::mock_binding<std::optional<int32_t>>(fds_per_partition),
-        config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
-        config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
-        kafka_internal_topics.bind(),
-        config::mock_binding<bool>(true)) {
+      std::optional<int32_t> fds_per_partition) {
         members.start().get0();
+        features.start().get();
+        _allocator
+          .start_single(
+            std::ref(members),
+            std::ref(features),
+            config::mock_binding<std::optional<size_t>>(memory_per_partition),
+            config::mock_binding<std::optional<int32_t>>(fds_per_partition),
+            config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
+            config::mock_binding<uint32_t>(uint32_t{partitions_reserve_shard0}),
+            kafka_internal_topics.bind(),
+            config::mock_binding<bool>(true))
+          .get();
         ss::smp::invoke_on_all([] {
             config::shard_local_cfg()
               .get("partition_autobalancing_mode")

--- a/src/v/cluster/tests/partition_allocator_tests.cc
+++ b/src/v/cluster/tests/partition_allocator_tests.cc
@@ -49,10 +49,10 @@ FIXTURE_TEST(register_node, partition_allocator_fixture) {
     register_node(0, 32);
     register_node(1, 64);
     register_node(2, 12);
-    BOOST_REQUIRE(allocator.contains_node(model::node_id(0)));
-    BOOST_REQUIRE(allocator.contains_node(model::node_id(1)));
-    BOOST_REQUIRE(allocator.contains_node(model::node_id(2)));
-    BOOST_REQUIRE_EQUAL(allocator.state().available_nodes(), 3);
+    BOOST_REQUIRE(allocator().contains_node(model::node_id(0)));
+    BOOST_REQUIRE(allocator().contains_node(model::node_id(1)));
+    BOOST_REQUIRE(allocator().contains_node(model::node_id(2)));
+    BOOST_REQUIRE_EQUAL(allocator().state().available_nodes(), 3);
 }
 
 model::broker create_broker(
@@ -72,17 +72,18 @@ FIXTURE_TEST(unregister_node, partition_allocator_fixture) {
     register_node(1, 64);
     register_node(2, 12);
 
-    allocator.update_allocation_nodes(
+    allocator().update_allocation_nodes(
       std::vector<model::broker>{create_broker(0, 32), create_broker(2, 12)});
-    BOOST_REQUIRE(allocator.contains_node(model::node_id(0)));
+    BOOST_REQUIRE(allocator().contains_node(model::node_id(0)));
     // allocator MUST still contain the node. it has to be marked as removed
-    BOOST_REQUIRE(allocator.contains_node(model::node_id(1)));
-    BOOST_REQUIRE(allocator.state()
+    BOOST_REQUIRE(allocator().contains_node(model::node_id(1)));
+    BOOST_REQUIRE(allocator()
+                    .state()
                     .allocation_nodes()
                     .find(model::node_id(1))
                     ->second->is_removed());
-    BOOST_REQUIRE(allocator.contains_node(model::node_id(2)));
-    BOOST_REQUIRE_EQUAL(allocator.state().available_nodes(), 2);
+    BOOST_REQUIRE(allocator().contains_node(model::node_id(2)));
+    BOOST_REQUIRE_EQUAL(allocator().state().available_nodes(), 2);
 }
 
 FIXTURE_TEST(allocation_over_core_capacity, partition_allocator_fixture) {
@@ -90,7 +91,7 @@ FIXTURE_TEST(allocation_over_core_capacity, partition_allocator_fixture) {
       = partition_allocator_fixture::partitions_per_shard + 1;
     register_node(0, 1);
     auto result
-      = allocator.allocate(make_allocation_request(partition_count, 1)).get();
+      = allocator().allocate(make_allocation_request(partition_count, 1)).get();
     BOOST_REQUIRE(result.has_error());
     BOOST_REQUIRE_EQUAL(
       result.assume_error(),
@@ -101,7 +102,7 @@ FIXTURE_TEST(allocation_over_core_capacity, partition_allocator_fixture) {
 FIXTURE_TEST(
   allocation_over_memory_capacity, partition_allocator_memory_limited_fixture) {
     register_node(0, 1);
-    auto result = allocator.allocate(make_allocation_request(1, 1)).get();
+    auto result = allocator().allocate(make_allocation_request(1, 1)).get();
     BOOST_REQUIRE(result.has_error());
     BOOST_REQUIRE_EQUAL(
       result.assume_error(),
@@ -112,7 +113,7 @@ FIXTURE_TEST(
 FIXTURE_TEST(
   allocation_over_fds_capacity, partition_allocator_fd_limited_fixture) {
     register_node(0, 1);
-    auto result = allocator.allocate(make_allocation_request(1, 1)).get();
+    auto result = allocator().allocate(make_allocation_request(1, 1)).get();
     BOOST_REQUIRE(result.has_error());
     BOOST_REQUIRE_EQUAL(
       result.assume_error(),
@@ -126,21 +127,21 @@ FIXTURE_TEST(allocation_over_capacity, partition_allocator_fixture) {
     register_node(2, 6);
 
     saturate_all_machines();
-    auto gr = allocator.state().last_group_id();
+    auto gr = allocator().state().last_group_id();
     BOOST_REQUIRE(
-      allocator.allocate(make_allocation_request(1, 1)).get().has_error());
+      allocator().allocate(make_allocation_request(1, 1)).get().has_error());
     // group id hasn't changed
-    BOOST_REQUIRE_EQUAL(allocator.state().last_group_id(), gr);
+    BOOST_REQUIRE_EQUAL(allocator().state().last_group_id(), gr);
 
     // Make the topic internal and retry, should work.
     kafka_internal_topics.update({tn.tp()});
-    BOOST_REQUIRE(allocator.allocate(make_allocation_request(1, 1)).get());
-    BOOST_REQUIRE_GT(allocator.state().last_group_id(), gr);
+    BOOST_REQUIRE(allocator().allocate(make_allocation_request(1, 1)).get());
+    BOOST_REQUIRE_GT(allocator().state().last_group_id(), gr);
 
     // Undo the configuration, should fail again.
     kafka_internal_topics.update({});
     BOOST_REQUIRE(
-      allocator.allocate(make_allocation_request(1, 1)).get().has_error());
+      allocator().allocate(make_allocation_request(1, 1)).get().has_error());
 
     auto int_1 = model::topic_namespace{
       model::ns{"redpanda"}, model::topic{"controller"}};
@@ -148,9 +149,9 @@ FIXTURE_TEST(allocation_over_capacity, partition_allocator_fixture) {
       model::ns{"kafka_internal"}, model::topic{"controller"}};
     // Internal namespaces should work too.
     BOOST_REQUIRE(
-      allocator.allocate(make_allocation_request(int_1, 1, 1)).get());
+      allocator().allocate(make_allocation_request(int_1, 1, 1)).get());
     BOOST_REQUIRE(
-      allocator.allocate(make_allocation_request(int_2, 1, 1)).get());
+      allocator().allocate(make_allocation_request(int_2, 1, 1)).get());
 }
 
 FIXTURE_TEST(max_allocation, partition_allocator_fixture) {
@@ -162,16 +163,16 @@ FIXTURE_TEST(max_allocation, partition_allocator_fixture) {
 
     auto req = make_allocation_request(max_capacity() / 3, 3);
 
-    auto units = allocator.allocate(std::move(req)).get().value();
+    auto units = allocator().allocate(std::move(req)).get().value();
 
     BOOST_REQUIRE_EQUAL(units->get_assignments().size(), 1998);
     BOOST_REQUIRE_EQUAL(allocated_nodes_count(units->get_assignments()), 5994);
-    BOOST_REQUIRE_EQUAL(allocator.state().last_group_id()(), 1998);
+    BOOST_REQUIRE_EQUAL(allocator().state().last_group_id()(), 1998);
     validate_replica_set_diversity(units->get_assignments());
 
     // make sure there is no room left after
     auto single_partition_req = make_allocation_request(1, 1);
-    auto result = allocator.allocate(std::move(single_partition_req)).get();
+    auto result = allocator().allocate(std::move(single_partition_req)).get();
     BOOST_REQUIRE(result.has_error());
 }
 
@@ -181,7 +182,7 @@ FIXTURE_TEST(unsatisfyable_diversity_assignment, partition_allocator_fixture) {
     register_node(2, 6);
 
     auto req = make_allocation_request(1, 5);
-    auto allocs = allocator.allocate(std::move(req)).get();
+    auto allocs = allocator().allocate(std::move(req)).get();
     BOOST_TEST_REQUIRE(allocs.has_error());
     BOOST_REQUIRE_EQUAL(
       cluster::errc(allocs.error().value()),
@@ -190,7 +191,7 @@ FIXTURE_TEST(unsatisfyable_diversity_assignment, partition_allocator_fixture) {
     // ensure rollback happened
     BOOST_REQUIRE(all_nodes_empty());
 
-    BOOST_REQUIRE_EQUAL(allocator.state().last_group_id()(), 0);
+    BOOST_REQUIRE_EQUAL(allocator().state().last_group_id()(), 0);
 }
 
 FIXTURE_TEST(diverse_replica_sets, partition_allocator_fixture) {
@@ -212,7 +213,7 @@ FIXTURE_TEST(diverse_replica_sets, partition_allocator_fixture) {
     absl::flat_hash_set<std::vector<model::broker_shard>> seen_replicas;
     for (int i = 0; i < 1000; i++) {
         auto req = make_allocation_request(1, r);
-        auto result = allocator.allocate(std::move(req)).get();
+        auto result = allocator().allocate(std::move(req)).get();
         BOOST_REQUIRE(result);
         auto assignments = result.value()->copy_assignments();
         BOOST_REQUIRE(assignments.size() == 1);
@@ -231,7 +232,7 @@ FIXTURE_TEST(partial_assignment, partition_allocator_fixture) {
     register_node(2, 2);
     auto max_partitions_in_cluster = max_capacity() / 3;
 
-    auto units_1 = allocator
+    auto units_1 = allocator()
                      .allocate(make_allocation_request(
                        max_partitions_in_cluster - 1, 3))
                      .get()
@@ -242,12 +243,12 @@ FIXTURE_TEST(partial_assignment, partition_allocator_fixture) {
     // allocate 2 partitions - one should fail, returning null & deallocating
 
     auto req_2 = make_allocation_request(2, 3);
-    auto units_2 = allocator.allocate(std::move(req_2)).get();
+    auto units_2 = allocator().allocate(std::move(req_2)).get();
     BOOST_REQUIRE(units_2.has_error());
 
     BOOST_REQUIRE_EQUAL(3, max_capacity());
     BOOST_REQUIRE_EQUAL(
-      allocator.state().last_group_id()(), max_partitions_in_cluster - 1);
+      allocator().state().last_group_id()(), max_partitions_in_cluster - 1);
 }
 FIXTURE_TEST(max_deallocation, partition_allocator_fixture) {
     register_node(0, 3);
@@ -257,16 +258,17 @@ FIXTURE_TEST(max_deallocation, partition_allocator_fixture) {
     const auto max = max_capacity();
 
     {
-        auto allocs = allocator.allocate(make_allocation_request(max / 3, 3))
+        auto allocs = allocator()
+                        .allocate(make_allocation_request(max / 3, 3))
                         .get()
                         .value();
 
         BOOST_REQUIRE_EQUAL(allocs->get_assignments().size() * 3, max);
 
-        BOOST_REQUIRE_EQUAL(allocator.state().last_group_id()(), max / 3);
+        BOOST_REQUIRE_EQUAL(allocator().state().last_group_id()(), max / 3);
     }
 
-    BOOST_REQUIRE_EQUAL(allocator.state().last_group_id()(), max / 3);
+    BOOST_REQUIRE_EQUAL(allocator().state().last_group_id()(), max / 3);
     BOOST_REQUIRE_EQUAL(max_capacity(), max);
 }
 
@@ -290,28 +292,31 @@ FIXTURE_TEST(recovery_test, partition_allocator_fixture) {
     };
     // 100 topics with 12 partitions each replicated on 3 nodes each
     auto replicas = create_replicas(100, 12);
-    allocator.add_allocations(
+    allocator().add_allocations(
       replicas, cluster::partition_allocation_domains::common);
     // each node in the cluster holds one replica for each partition,
     // so it has to have topics * partitions shards allocated
     cluster::allocation_node::allocation_capacity allocated_shards{100 * 12};
     // Remaining capacity on node 0
     BOOST_REQUIRE_EQUAL(
-      allocator.state()
+      allocator()
+        .state()
         .allocation_nodes()
         .find(model::node_id(0))
         ->second->allocated_partitions(),
       allocated_shards);
     // Remaining capacity on node 1
     BOOST_REQUIRE_EQUAL(
-      allocator.state()
+      allocator()
+        .state()
         .allocation_nodes()
         .find(model::node_id(1))
         ->second->allocated_partitions(),
       allocated_shards);
     // Remaining capacity on node 2
     BOOST_REQUIRE_EQUAL(
-      allocator.state()
+      allocator()
+        .state()
         .allocation_nodes()
         .find(model::node_id(2))
         ->second->allocated_partitions(),
@@ -326,7 +331,7 @@ FIXTURE_TEST(allocation_units_test, partition_allocator_fixture) {
 
     {
         auto allocs
-          = allocator.allocate(make_allocation_request(10, 3)).get().value();
+          = allocator().allocate(make_allocation_request(10, 3)).get().value();
         BOOST_REQUIRE_EQUAL(allocs->get_assignments().size(), 10);
         BOOST_REQUIRE_EQUAL(
           allocated_nodes_count(allocs->get_assignments()), 3 * 10);
@@ -335,16 +340,16 @@ FIXTURE_TEST(allocation_units_test, partition_allocator_fixture) {
     BOOST_REQUIRE(all_nodes_empty());
 
     // we do not decrement the highest raft group
-    BOOST_REQUIRE_EQUAL(allocator.state().last_group_id()(), 10);
+    BOOST_REQUIRE_EQUAL(allocator().state().last_group_id()(), 10);
 }
 FIXTURE_TEST(decommission_node, partition_allocator_fixture) {
     register_node(0, 32);
     register_node(1, 64);
     register_node(2, 12);
-    allocator.decommission_node(model::node_id(1));
+    allocator().decommission_node(model::node_id(1));
 
     // only two of machines are available as one of them is decommissioned
-    BOOST_REQUIRE_EQUAL(allocator.state().available_nodes(), 2);
+    BOOST_REQUIRE_EQUAL(allocator().state().available_nodes(), 2);
 }
 
 cluster::hard_constraint make_throwing_hard_evaluator() {
@@ -415,11 +420,11 @@ FIXTURE_TEST(allocator_exception_safety_test, partition_allocator_fixture) {
         req.partitions.front().constraints.hard_constraints.push_back(
           ss::make_lw_shared<cluster::hard_constraint>(random_evaluator()));
         try {
-            auto res = allocator.allocate(std::move(req)).get();
+            auto res = allocator().allocate(std::move(req)).get();
             if (res) {
                 capacity--;
                 for (auto& as : res.value()->get_assignments()) {
-                    allocator.add_allocations_for_new_partition(
+                    allocator().add_allocations_for_new_partition(
                       as.replicas,
                       as.group,
                       cluster::partition_allocation_domains::common);
@@ -441,20 +446,20 @@ FIXTURE_TEST(updating_nodes_properties, partition_allocator_fixture) {
     for (int i = 0; i < 50; ++i) {
         // try to allocate single partition
         auto req = make_allocation_request(1, 1);
-        auto res = allocator.allocate(std::move(req)).get();
+        auto res = allocator().allocate(std::move(req)).get();
         if (res) {
             for (auto& as : res.value()->get_assignments()) {
-                allocator.add_allocations_for_new_partition(
+                allocator().add_allocations_for_new_partition(
                   as.replicas,
                   as.group,
                   cluster::partition_allocation_domains::common);
             }
         }
     }
-    auto it = allocator.state().allocation_nodes().find(model::node_id(1));
+    auto it = allocator().state().allocation_nodes().find(model::node_id(1));
     auto allocated = it->second->allocated_partitions();
     auto new_rack = model::rack_id{"rack_A"};
-    allocator.update_allocation_nodes(std::vector<model::broker>{
+    allocator().update_allocation_nodes(std::vector<model::broker>{
       create_broker(0, 2),
       create_broker(1, 10, new_rack),
       create_broker(2, 7)});
@@ -471,7 +476,7 @@ FIXTURE_TEST(change_replication_factor, partition_allocator_fixture) {
     register_node(0, 4);
     register_node(1, 4);
     auto req = make_allocation_request(2, 1);
-    auto res = allocator.allocate(std::move(req)).get();
+    auto res = allocator().allocate(std::move(req)).get();
 
     BOOST_CHECK_EQUAL(res.has_value(), true);
     const auto& orig_assignments = res.value()->get_assignments();
@@ -487,14 +492,14 @@ FIXTURE_TEST(change_replication_factor, partition_allocator_fixture) {
     };
 
     // try to allocate 3 replicas on 2 nodes - should fail
-    auto expected_failure = allocator.allocate(make_reallocate_req()).get();
+    auto expected_failure = allocator().allocate(make_reallocate_req()).get();
 
     BOOST_CHECK_EQUAL(expected_failure.has_error(), true);
 
     // add new node and allocate again
     register_node(2, 4);
 
-    auto expected_success = allocator.allocate(make_reallocate_req()).get();
+    auto expected_success = allocator().allocate(make_reallocate_req()).get();
 
     BOOST_CHECK_EQUAL(expected_success.has_value(), true);
     BOOST_REQUIRE_EQUAL(
@@ -527,7 +532,7 @@ FIXTURE_TEST(rack_aware_assignment_1, partition_allocator_fixture) {
     }
 
     auto units
-      = allocator.allocate(make_allocation_request(1, 3)).get().value();
+      = allocator().allocate(make_allocation_request(1, 3)).get().value();
 
     BOOST_REQUIRE(!units->get_assignments().empty());
     auto group = units->get_assignments().front();
@@ -559,7 +564,7 @@ FIXTURE_TEST(rack_aware_assignment_2, partition_allocator_fixture) {
     }
 
     auto units
-      = allocator.allocate(make_allocation_request(1, 3)).get().value();
+      = allocator().allocate(make_allocation_request(1, 3)).get().value();
 
     BOOST_REQUIRE(!units->get_assignments().empty());
     auto group = units->get_assignments().front();
@@ -585,7 +590,7 @@ FIXTURE_TEST(even_distribution_pri_allocation, partition_allocator_fixture) {
     register_node(1, 2);
     register_node(2, 2);
     auto req_reg = make_allocation_request(max_capacity() / 4, 3);
-    auto units_reg = allocator.allocate(std::move(req_reg)).get().value();
+    auto units_reg = allocator().allocate(std::move(req_reg)).get().value();
     // add empty nodes
     register_node(3, 2);
     register_node(4, 2);
@@ -599,14 +604,14 @@ FIXTURE_TEST(even_distribution_pri_allocation, partition_allocator_fixture) {
           = cluster::partition_allocation_domains::consumer_offsets;
         req.domain = prio_domain;
         units.push_back(
-          std::move(allocator.allocate(std::move(req)).get().value()));
+          std::move(allocator().allocate(std::move(req)).get().value()));
 
         // invariant: number of partitions allocated in the priority domain
         // across all nodes must be even, i.e. must not vary by more than one
         // partition
         const auto priority_part_capacity_minmax = std::minmax_element(
-          allocator.state().allocation_nodes().cbegin(),
-          allocator.state().allocation_nodes().cend(),
+          allocator().state().allocation_nodes().cbegin(),
+          allocator().state().allocation_nodes().cend(),
           [](const auto& lhs, const auto& rhs) {
               return lhs.second->domain_partition_capacity(prio_domain)
                      < rhs.second->domain_partition_capacity(prio_domain);
@@ -622,8 +627,8 @@ FIXTURE_TEST(even_distribution_pri_allocation, partition_allocator_fixture) {
         // all_domains == max_capacity()-partition_capacity()
         // as long as node is not overallocated
         BOOST_CHECK(std::all_of(
-          allocator.state().allocation_nodes().cbegin(),
-          allocator.state().allocation_nodes().cend(),
+          allocator().state().allocation_nodes().cbegin(),
+          allocator().state().allocation_nodes().cend(),
           [](const auto& allocation_nodes_v) {
               const cluster::allocation_node& n = *allocation_nodes_v.second;
               return n.domain_partition_capacity(
@@ -693,27 +698,27 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
     // allocate a partition with 3 replicas on 3 nodes
     auto domain = cluster::partition_allocation_domains::common;
     auto req = make_allocation_request(1, 3);
-    auto res = allocator.allocate(std::move(req)).get();
+    auto res = allocator().allocate(std::move(req)).get();
     auto original_replicas = res.value()->get_assignments().front().replicas;
 
     // add another node to move replicas to and from
     register_node(3, 1);
 
-    check_allocated_counts(allocator, {1, 1, 1, 0});
-    check_final_counts(allocator, {1, 1, 1, 0});
+    check_allocated_counts(allocator(), {1, 1, 1, 0});
+    check_final_counts(allocator(), {1, 1, 1, 0});
 
     {
         auto partition_id = res.value()->get_assignments().front().id;
         auto ntp = model::ntp{tn.ns, tn.tp, partition_id};
         cluster::allocated_partition reallocated
-          = allocator.make_allocated_partition(
+          = allocator().make_allocated_partition(
             std::move(ntp), original_replicas, domain);
 
         cluster::allocation_constraints not_on_old_nodes;
         not_on_old_nodes.add(cluster::distinct_from(original_replicas));
 
         // move to node 3
-        auto moved = allocator.reallocate_replica(
+        auto moved = allocator().reallocate_replica(
           reallocated, model::node_id{0}, not_on_old_nodes);
         BOOST_REQUIRE(moved.has_value());
         BOOST_REQUIRE_EQUAL(moved.value().current().node_id, model::node_id{3});
@@ -721,11 +726,11 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{3});
 
-        check_allocated_counts(allocator, {1, 1, 1, 1});
-        check_final_counts(allocator, {0, 1, 1, 1});
+        check_allocated_counts(allocator(), {1, 1, 1, 1});
+        check_final_counts(allocator(), {0, 1, 1, 1});
 
         // there is no replica on node 0 any more
-        auto moved2 = allocator.reallocate_replica(
+        auto moved2 = allocator().reallocate_replica(
           reallocated, model::node_id{0}, not_on_old_nodes);
         BOOST_REQUIRE(moved2.has_error());
         BOOST_REQUIRE_EQUAL(
@@ -733,17 +738,17 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
 
         // node 3 already has a replica so the replica on node 1 has nowhere to
         // move
-        auto moved3 = allocator.reallocate_replica(
+        auto moved3 = allocator().reallocate_replica(
           reallocated, model::node_id{1}, not_on_old_nodes);
         BOOST_REQUIRE(moved3.has_error());
         BOOST_REQUIRE_EQUAL(
           moved3.error(), cluster::errc::no_eligible_allocation_nodes);
 
-        check_allocated_counts(allocator, {1, 1, 1, 1});
-        check_final_counts(allocator, {0, 1, 1, 1});
+        check_allocated_counts(allocator(), {1, 1, 1, 1});
+        check_final_counts(allocator(), {0, 1, 1, 1});
 
         // replicas can move to the same place
-        auto moved4 = allocator.reallocate_replica(
+        auto moved4 = allocator().reallocate_replica(
           reallocated, model::node_id{3}, not_on_old_nodes);
         BOOST_REQUIRE(moved4.has_value());
         BOOST_REQUIRE_EQUAL(
@@ -751,15 +756,15 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{3});
 
-        check_allocated_counts(allocator, {1, 1, 1, 1});
-        check_final_counts(allocator, {0, 1, 1, 1});
+        check_allocated_counts(allocator(), {1, 1, 1, 1});
+        check_final_counts(allocator(), {0, 1, 1, 1});
 
         std::vector node_0(
           {model::broker_shard{.node_id = model::node_id{0}, .shard = 0}});
         cluster::allocation_constraints not_on_node0;
         not_on_node0.add(cluster::distinct_from(node_0));
 
-        auto moved5 = allocator.reallocate_replica(
+        auto moved5 = allocator().reallocate_replica(
           reallocated, model::node_id{2}, not_on_node0);
         BOOST_REQUIRE(moved5.has_value());
         BOOST_REQUIRE_EQUAL(
@@ -767,15 +772,15 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{2});
 
-        check_allocated_counts(allocator, {1, 1, 1, 1});
-        check_final_counts(allocator, {0, 1, 1, 1});
+        check_allocated_counts(allocator(), {1, 1, 1, 1});
+        check_final_counts(allocator(), {0, 1, 1, 1});
 
         std::vector new_replicas(reallocated.replicas());
         cluster::allocation_constraints not_on_new_nodes;
         not_on_new_nodes.add(cluster::distinct_from(new_replicas));
 
         // move reallocated replica back to node 0
-        auto moved6 = allocator.reallocate_replica(
+        auto moved6 = allocator().reallocate_replica(
           reallocated, model::node_id{3}, not_on_new_nodes);
         BOOST_REQUIRE(moved6.has_value());
         BOOST_REQUIRE_EQUAL(
@@ -784,11 +789,11 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{0});
 
-        check_allocated_counts(allocator, {1, 1, 1, 0});
-        check_final_counts(allocator, {1, 1, 1, 0});
+        check_allocated_counts(allocator(), {1, 1, 1, 0});
+        check_final_counts(allocator(), {1, 1, 1, 0});
 
         // do another move so that we have something to revert
-        auto moved7 = allocator.reallocate_replica(
+        auto moved7 = allocator().reallocate_replica(
           reallocated, model::node_id{1}, not_on_old_nodes);
         BOOST_REQUIRE(moved7.has_value());
         BOOST_REQUIRE_EQUAL(
@@ -797,12 +802,12 @@ FIXTURE_TEST(incrementally_reallocate_replicas, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(
           reallocated.replicas().at(2).node_id, model::node_id{3});
 
-        check_allocated_counts(allocator, {1, 1, 1, 1});
-        check_final_counts(allocator, {1, 0, 1, 1});
+        check_allocated_counts(allocator(), {1, 1, 1, 1});
+        check_final_counts(allocator(), {1, 0, 1, 1});
     }
 
-    check_allocated_counts(allocator, {1, 1, 1, 0});
-    check_final_counts(allocator, {1, 1, 1, 0});
+    check_allocated_counts(allocator(), {1, 1, 1, 0});
+    check_final_counts(allocator(), {1, 1, 1, 0});
 }
 
 FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
@@ -812,7 +817,7 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
 
     // allocate a partition with 3 replicas on 3 nodes
     auto req = make_allocation_request(1, 3);
-    auto res = allocator.allocate(std::move(req)).get();
+    auto res = allocator().allocate(std::move(req)).get();
     auto original_assignment = res.value()->get_assignments().front();
     model::ntp ntp(tn.ns, tn.tp, original_assignment.id);
 
@@ -820,14 +825,14 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
     register_node(3, 1);
     register_node(4, 1);
 
-    check_allocated_counts(allocator, {1, 1, 1, 0, 0});
-    check_final_counts(allocator, {1, 1, 1, 0, 0});
+    check_allocated_counts(allocator(), {1, 1, 1, 0, 0});
+    check_final_counts(allocator(), {1, 1, 1, 0, 0});
 
     cluster::allocation_constraints not_on_old_nodes;
     not_on_old_nodes.add(cluster::distinct_from(original_assignment.replicas));
 
     {
-        auto res = allocator.reallocate_partition(
+        auto res = allocator().reallocate_partition(
           ntp,
           original_assignment.replicas,
           {model::node_id{0}, model::node_id{1}},
@@ -844,12 +849,12 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
         BOOST_REQUIRE(!replicas_set.contains(model::node_id{0}));
         BOOST_REQUIRE(!replicas_set.contains(model::node_id{1}));
 
-        check_allocated_counts(allocator, {1, 1, 1, 1, 1});
-        check_final_counts(allocator, {0, 0, 1, 1, 1});
+        check_allocated_counts(allocator(), {1, 1, 1, 1, 1});
+        check_final_counts(allocator(), {0, 0, 1, 1, 1});
     }
 
     {
-        auto res = allocator.reallocate_partition(
+        auto res = allocator().reallocate_partition(
           ntp,
           original_assignment.replicas,
           {model::node_id{0}, model::node_id{1}, model::node_id{2}},
@@ -861,7 +866,7 @@ FIXTURE_TEST(reallocate_partition_with_move, partition_allocator_fixture) {
     }
 
     {
-        auto res = allocator.reallocate_partition(
+        auto res = allocator().reallocate_partition(
           ntp,
           original_assignment.replicas,
           {model::node_id{3}},
@@ -889,7 +894,7 @@ FIXTURE_TEST(
 
     cluster::allocation_units::pointer partition_1;
     {
-        auto res = allocator.allocate(make_allocation_request(1, 4)).get();
+        auto res = allocator().allocate(make_allocation_request(1, 4)).get();
         BOOST_REQUIRE(res);
         partition_1 = std::move(res.value());
     }
@@ -901,7 +906,7 @@ FIXTURE_TEST(
     {
         auto req = make_allocation_request(1, 3);
         req.partitions.front().constraints.add(cluster::distinct_from(node_3));
-        auto res = allocator.allocate(std::move(req)).get();
+        auto res = allocator().allocate(std::move(req)).get();
         BOOST_REQUIRE(res);
         partition_2 = std::move(res.value());
     }
@@ -912,18 +917,18 @@ FIXTURE_TEST(
         replica2shard.emplace(bs.node_id, bs.shard);
     }
 
-    check_allocated_counts(allocator, {2, 2, 2, 1});
-    check_final_counts(allocator, {2, 2, 2, 1});
+    check_allocated_counts(allocator(), {2, 2, 2, 1});
+    check_final_counts(allocator(), {2, 2, 2, 1});
 
     auto id = partition_2->get_assignments().front().id;
     auto ntp = model::ntp{tn.ns, tn.tp, id};
     cluster::allocated_partition reallocated
-      = allocator.make_allocated_partition(
+      = allocator().make_allocated_partition(
         std::move(ntp),
         original_replicas,
         cluster::partition_allocation_domains::common);
 
-    auto moved = allocator.reallocate_replica(
+    auto moved = allocator().reallocate_replica(
       reallocated, model::node_id{0}, not_on_0);
     BOOST_REQUIRE(moved);
     BOOST_REQUIRE_EQUAL(moved.value().current().node_id, model::node_id{3});
@@ -934,11 +939,11 @@ FIXTURE_TEST(
     // more attractive. But replicas on nodes 0, 1, and 2 should still end up on
     // shard 2
     partition_1.reset();
-    check_allocated_counts(allocator, {1, 1, 1, 1});
-    check_final_counts(allocator, {0, 1, 1, 1});
+    check_allocated_counts(allocator(), {1, 1, 1, 1});
+    check_final_counts(allocator(), {0, 1, 1, 1});
 
     // Reallocate replica on node 1 to itself.
-    moved = allocator.reallocate_replica(
+    moved = allocator().reallocate_replica(
       reallocated, model::node_id{1}, not_on_0);
     BOOST_REQUIRE(moved);
     BOOST_REQUIRE_EQUAL(moved.value().current().node_id, model::node_id{1});
@@ -947,7 +952,7 @@ FIXTURE_TEST(
       replica2shard.at(moved.value().current().node_id));
 
     // Reallocate replica on node 3 to itself.
-    moved = allocator.reallocate_replica(
+    moved = allocator().reallocate_replica(
       reallocated, model::node_id{3}, not_on_0);
     BOOST_REQUIRE(moved);
     BOOST_REQUIRE_EQUAL(moved.value().current().node_id, model::node_id{3});
@@ -958,7 +963,7 @@ FIXTURE_TEST(
       replica2shard.at(moved.value().current().node_id));
 
     // Reallocate replica on node 3 back to the original node 0.
-    moved = allocator.reallocate_replica(
+    moved = allocator().reallocate_replica(
       reallocated, model::node_id{3}, not_on_3);
     BOOST_REQUIRE(moved);
     BOOST_REQUIRE_EQUAL(moved.value().current().node_id, model::node_id{0});
@@ -1005,7 +1010,7 @@ FIXTURE_TEST(revert_allocation_step, partition_allocator_fixture) {
     // allocate a partition with 3 replicas on 3 nodes
     auto domain = cluster::partition_allocation_domains::common;
     auto req = make_allocation_request(1, 3);
-    auto res = allocator.allocate(std::move(req)).get();
+    auto res = allocator().allocate(std::move(req)).get();
     auto original_replicas = res.value()->get_assignments().front().replicas;
 
     // add a couple more nodes
@@ -1018,16 +1023,16 @@ FIXTURE_TEST(revert_allocation_step, partition_allocator_fixture) {
         auto partition_id = res.value()->get_assignments().front().id;
         auto ntp = model::ntp{tn.ns, tn.tp, partition_id};
         cluster::allocated_partition reallocated
-          = allocator.make_allocated_partition(
+          = allocator().make_allocated_partition(
             std::move(ntp), original_replicas, domain);
-        auto step1 = allocator.reallocate_replica(
+        auto step1 = allocator().reallocate_replica(
           reallocated, n(0), on_node(n(3)));
         BOOST_REQUIRE(step1);
         BOOST_REQUIRE_EQUAL(step1.value().current().node_id, n(3));
         BOOST_REQUIRE(step1.value().previous());
         BOOST_REQUIRE_EQUAL(step1.value().previous()->node_id, n(0));
 
-        auto step2 = allocator.reallocate_replica(
+        auto step2 = allocator().reallocate_replica(
           reallocated, n(3), on_node(n(4)));
         BOOST_REQUIRE(step2);
 
@@ -1038,8 +1043,8 @@ FIXTURE_TEST(revert_allocation_step, partition_allocator_fixture) {
         BOOST_REQUIRE_EQUAL(ec, cluster::errc::success);
         BOOST_REQUIRE_EQUAL(
           to_node_ids(reallocated.replicas()), std::vector({n(1), n(2), n(3)}));
-        check_allocated_counts(allocator, {1, 1, 1, 1, 0});
-        check_final_counts(allocator, {0, 1, 1, 1, 0});
+        check_allocated_counts(allocator(), {1, 1, 1, 1, 0});
+        check_final_counts(allocator(), {0, 1, 1, 1, 0});
     }
 }
 
@@ -1048,10 +1053,10 @@ FIXTURE_TEST(topic_aware_reallocate_partition, partition_allocator_fixture) {
 
     cluster::allocation_units::pointer topic1;
     {
-        auto res = allocator.allocate(make_allocation_request(10, 1)).get();
+        auto res = allocator().allocate(make_allocation_request(10, 1)).get();
         topic1 = std::move(res.value());
     }
-    check_allocated_counts(allocator, {10});
+    check_allocated_counts(allocator(), {10});
 
     register_node(1, 4);
     register_node(2, 4);
@@ -1059,11 +1064,11 @@ FIXTURE_TEST(topic_aware_reallocate_partition, partition_allocator_fixture) {
 
     cluster::allocation_units::pointer topic2;
     {
-        auto res = allocator.allocate(make_allocation_request(3, 1)).get();
+        auto res = allocator().allocate(make_allocation_request(3, 1)).get();
         topic2 = std::move(res.value());
     }
     // 1-replica partitions of topic2 should end up on empty nodes
-    check_allocated_counts(allocator, {10, 1, 1, 1});
+    check_allocated_counts(allocator(), {10, 1, 1, 1});
 
     cluster::node2count_t topic2_counts;
     for (const auto& p_as : topic2->get_assignments()) {
@@ -1080,7 +1085,7 @@ FIXTURE_TEST(topic_aware_reallocate_partition, partition_allocator_fixture) {
     cluster::allocation_constraints constraints;
     constraints.add(cluster::distinct_from(p0_replicas));
 
-    auto reallocated = allocator.reallocate_partition(
+    auto reallocated = allocator().reallocate_partition(
       model::ntp(tn.ns, tn.tp, model::partition_id(0)),
       {original},
       {original.node_id},

--- a/src/v/cluster/tests/topic_table_fixture.h
+++ b/src/v/cluster/tests/topic_table_fixture.h
@@ -20,6 +20,7 @@
 #include "cluster/tests/utils.h"
 #include "cluster/topic_table.h"
 #include "config/property.h"
+#include "features/feature_table.h"
 #include "model/metadata.h"
 #include "random/generators.h"
 #include "test_utils/fixture.h"
@@ -47,9 +48,11 @@ struct topic_table_fixture {
     topic_table_fixture() {
         table.start().get0();
         members.start_single().get0();
+        features.start().get();
         allocator
           .start_single(
             std::ref(members),
+            std::ref(features),
             config::mock_binding<std::optional<size_t>>(std::nullopt),
             config::mock_binding<std::optional<int32_t>>(std::nullopt),
             config::mock_binding<uint32_t>(uint32_t{partitions_per_shard}),
@@ -79,6 +82,7 @@ struct topic_table_fixture {
         node_status.stop().get();
         table.stop().get0();
         allocator.stop().get0();
+        features.stop().get();
         members.stop().get0();
         as.request_abort();
     }
@@ -169,6 +173,7 @@ struct topic_table_fixture {
     }
 
     ss::sharded<cluster::members_table> members;
+    ss::sharded<features::feature_table> features;
     ss::sharded<cluster::partition_allocator> allocator;
     ss::sharded<cluster::topic_table> table;
     ss::sharded<cluster::partition_leaders_table> leaders;

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -207,6 +207,15 @@ public:
     /// less than the minimum specified in minimum_topic_replication
     void print_rf_warning_message();
 
+    bool node_local_core_assignment_enabled() const;
+
+    /// Assign a partition replica to a shard on that node.
+    ss::future<std::error_code> set_partition_replica_shard(
+      model::ntp,
+      model::node_id replica,
+      ss::shard_id,
+      model::timeout_clock::time_point deadline);
+
     /// Assign a partition that is expected to be present on this node to a
     /// shard.
     ss::future<errc> set_local_partition_shard(model::ntp, ss::shard_id);

--- a/src/v/cluster/topics_frontend.h
+++ b/src/v/cluster/topics_frontend.h
@@ -66,6 +66,7 @@ public:
       ss::sharded<cluster::members_table>&,
       ss::sharded<partition_manager>&,
       ss::sharded<shard_table>&,
+      ss::sharded<shard_balancer>&,
       plugin_table&,
       metadata_cache&,
       config::binding<unsigned> hard_max_disk_usage_ratio,
@@ -206,6 +207,10 @@ public:
     /// less than the minimum specified in minimum_topic_replication
     void print_rf_warning_message();
 
+    /// Assign a partition that is expected to be present on this node to a
+    /// shard.
+    ss::future<errc> set_local_partition_shard(model::ntp, ss::shard_id);
+
 private:
     using ntp_leader = std::pair<model::ntp, model::node_id>;
 
@@ -283,6 +288,7 @@ private:
     ss::sharded<ss::abort_source>& _as;
     ss::sharded<cloud_storage::remote>& _cloud_storage_api;
     ss::sharded<features::feature_table>& _features;
+    ss::sharded<shard_balancer>& _shard_balancer;
     plugin_table& _plugin_table;
     metadata_cache& _metadata_cache;
 

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -4653,6 +4653,39 @@ struct delete_topics_reply
     auto serde_fields() { return std::tie(results); }
 };
 
+struct set_partition_shard_request
+  : serde::envelope<
+      set_partition_shard_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    model::ntp ntp;
+    uint32_t shard = -1;
+
+    friend bool operator==(
+      const set_partition_shard_request&, const set_partition_shard_request&)
+      = default;
+
+    auto serde_fields() { return std::tie(ntp, shard); }
+};
+
+struct set_partition_shard_reply
+  : serde::envelope<
+      set_partition_shard_reply,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    errc ec;
+
+    friend bool operator==(
+      const set_partition_shard_reply&, const set_partition_shard_reply&)
+      = default;
+
+    auto serde_fields() { return std::tie(ec); }
+};
+
 } // namespace cluster
 namespace std {
 template<>

--- a/src/v/features/feature_table.cc
+++ b/src/v/features/feature_table.cc
@@ -101,8 +101,8 @@ std::string_view to_string_view(feature f) {
         return "role_based_access_control";
     case feature::cluster_topic_manifest_format_v2:
         return "cluster_topic_manifest_format_v2";
-    case feature::shard_placement_persistence:
-        return "shard_placement_persistence";
+    case feature::node_local_core_assignment:
+        return "node_local_core_assignment";
 
     /*
      * testing features

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -75,7 +75,7 @@ enum class feature : std::uint64_t {
     partition_shard_in_health_report = 1ULL << 43U,
     role_based_access_control = 1ULL << 44U,
     cluster_topic_manifest_format_v2 = 1ULL << 45U,
-    shard_placement_persistence = 1ULL << 46U,
+    node_local_core_assignment = 1ULL << 46U,
 
     // Dummy features for testing only
     test_alpha = 1ULL << 61U,
@@ -383,10 +383,10 @@ constexpr static std::array feature_schema{
     feature_spec::prepare_policy::always},
   feature_spec{
     cluster::cluster_version{13},
-    "shard_placement_persistence",
-    feature::shard_placement_persistence,
-    feature_spec::available_policy::always,
-    feature_spec::prepare_policy::always},
+    "node_local_core_assignment",
+    feature::node_local_core_assignment,
+    feature_spec::available_policy::explicit_only,
+    feature_spec::prepare_policy::requires_migration},
 };
 
 std::string_view to_string_view(feature);

--- a/src/v/features/feature_table.h
+++ b/src/v/features/feature_table.h
@@ -385,7 +385,7 @@ constexpr static std::array feature_schema{
     cluster::cluster_version{13},
     "node_local_core_assignment",
     feature::node_local_core_assignment,
-    feature_spec::available_policy::explicit_only,
+    feature_spec::available_policy::new_clusters_only,
     feature_spec::prepare_policy::requires_migration},
 };
 

--- a/src/v/kafka/server/errors.h
+++ b/src/v/kafka/server/errors.h
@@ -107,6 +107,7 @@ constexpr error_code map_topic_error_code(cluster::errc code) {
     case cluster::errc::waiting_for_shard_placement_update:
     case cluster::errc::producer_ids_vcluster_limit_exceeded:
     case cluster::errc::validation_of_recovery_topic_failed:
+    case cluster::errc::replica_does_not_exist:
         break;
     }
     return error_code::unknown_server_error;

--- a/src/v/migrations/CMakeLists.txt
+++ b/src/v/migrations/CMakeLists.txt
@@ -4,6 +4,7 @@ v_cc_library(
     cloud_storage_config.cc
     feature_migrator.cc
     rbac_migrator.cc
+    shard_placement_migrator.cc
   DEPS
     Seastar::seastar
     v::model

--- a/src/v/migrations/feature_migrator.cc
+++ b/src/v/migrations/feature_migrator.cc
@@ -35,15 +35,6 @@ ss::future<> feature_migrator::stop() {
 
 void feature_migrator::start(ss::abort_source& as) {
     _as = as;
-    features::feature_table& ft = _controller.get_feature_table().local();
-    if (ft.is_active(get_feature())) {
-        vlog(
-          featureslog.trace,
-          "Feature {} already active, no migration required.",
-          get_feature());
-        return;
-    }
-
     ssx::spawn_with_gate(_gate, [this]() { return do_migrate(); });
 }
 

--- a/src/v/migrations/feature_migrator.h
+++ b/src/v/migrations/feature_migrator.h
@@ -19,13 +19,12 @@ namespace features {
 
 /**
  * A feature migrator is responsible for waiting til a feature is in
- * 'preparing' state, then executing a certain action at least once
- * on the controller leader.
+ * 'preparing' state, then executing certain actions to get it to 'active'
+ * state.
  *
- * This is not the general case of all migrations: some of them may require
- * running in parallel across all nodes (e.g. `group_metadata_migration`): this
- * class is for the relatively simple cases where we just want to update
- * some controller state on an upgrade.
+ * This base class provides support for both simple cases (when some action has
+ * to be executed at least once on the controller leader), as well as more
+ * general migrations requiring coordinating actions executed on several nodes.
  */
 class feature_migrator {
 public:
@@ -33,22 +32,22 @@ public:
       : _controller(c) {}
     virtual ~feature_migrator() = default;
 
-    virtual void start(ss::abort_source&);
-    virtual ss::future<> stop();
+    void start(ss::abort_source&);
+    ss::future<> stop();
 
 protected:
     virtual features::feature get_feature() = 0;
 
     /**
-     * If not overriding `start` and `do_migrate`, then implement
-     * `do_mutate` to express the change that should be made to
-     * the system during upgrade.
+     * Subclasses should override either `do_migrate` (for migrations that need
+     * to be executed on all nodes) or `do_mutate` (for simpler migrations that
+     * can be executed just on the controller leader).
      *
      * `do_mutate` should be idempotent as it may be executed multiple times if
      * there is a leader reelection while do_mutate is being executed.
      */
+    virtual ss::future<> do_migrate();
     virtual ss::future<> do_mutate() { return ss::now(); }
-    ss::future<> do_migrate();
 
     ss::abort_source& abort_source() { return _as->get(); }
 

--- a/src/v/migrations/migrators.h
+++ b/src/v/migrations/migrators.h
@@ -12,3 +12,4 @@
 #pragma once
 
 #include "migrations/cloud_storage_config.h"
+#include "migrations/shard_placement_migrator.h"

--- a/src/v/migrations/shard_placement_migrator.cc
+++ b/src/v/migrations/shard_placement_migrator.cc
@@ -1,0 +1,77 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "migrations/shard_placement_migrator.h"
+
+#include "base/vlog.h"
+#include "cluster/controller.h"
+#include "cluster/feature_manager.h"
+#include "cluster/shard_balancer.h"
+#include "features/feature_table.h"
+#include "features/logger.h"
+
+namespace features::migrators {
+
+ss::future<> shard_placement_migrator::do_migrate() {
+    features::feature_table& ft = _controller.get_feature_table().local();
+    cluster::feature_manager& fm = _controller.get_feature_manager().local();
+    ss::abort_source& as = _as.value();
+    const auto barrier_tag = cluster::feature_barrier_tag{
+      "node_local_core_assignment"};
+
+    if (ft.is_active(_feature)) {
+        fm.exit_barrier(barrier_tag);
+        co_return;
+    }
+
+    co_await ft.await_feature_preparing(_feature, as);
+    if (!ft.is_preparing(_feature)) {
+        co_return;
+    }
+
+    // persist shard_placement_table and wait for everybody to persist theirs.
+    co_await _controller.get_shard_balancer().invoke_on(
+      cluster::shard_balancer::shard_id,
+      [](cluster::shard_balancer& sb) { return sb.enable_persistence(); });
+    vlog(featureslog.info, "entering the barrier...");
+    co_await fm.barrier(barrier_tag);
+    vlog(featureslog.info, "exited the barrier, all nodes ready");
+
+    // activate the feature
+    while (!as.abort_requested() && ft.is_preparing(_feature)) {
+        if (_controller.is_raft0_leader()) {
+            try {
+                auto ec = co_await fm.write_action(
+                  cluster::feature_update_action{
+                    .feature_name = ss::sstring(to_string_view(_feature)),
+                    .action = cluster::feature_update_action::action_t::
+                      complete_preparing,
+                  });
+
+                if (!ec) {
+                    vlog(featureslog.info, "migration finished");
+                    break;
+                } else {
+                    vlog(featureslog.warn, "activating feature failed: {}", ec);
+                }
+            } catch (...) {
+                auto ex = std::current_exception();
+                if (ssx::is_shutdown_exception(ex)) {
+                    break;
+                } else {
+                    vlog(featureslog.warn, "activating feature failed: {}", ex);
+                }
+            }
+        }
+
+        co_await ss::sleep_abortable(5s, as);
+    }
+}
+
+} // namespace features::migrators

--- a/src/v/migrations/shard_placement_migrator.h
+++ b/src/v/migrations/shard_placement_migrator.h
@@ -1,0 +1,29 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "cluster/fwd.h"
+#include "migrations/feature_migrator.h"
+
+namespace features::migrators {
+
+class shard_placement_migrator : public feature_migrator {
+public:
+    shard_placement_migrator(cluster::controller& c)
+      : feature_migrator(c) {}
+
+private:
+    features::feature get_feature() override { return _feature; }
+    ss::future<> do_migrate() override;
+
+    features::feature _feature{features::feature::node_local_core_assignment};
+};
+
+} // namespace features::migrators

--- a/src/v/redpanda/admin/api-doc/partition.json
+++ b/src/v/redpanda/admin/api-doc/partition.json
@@ -140,6 +140,62 @@
             ]
         },
         {
+            "path": "/v1/partitions/{namespace}/{topic}/{partition}/replicas/{node}",
+            "operations": [
+                {
+                    "method": "POST",
+                    "summary": "Update partition replica core",
+                    "type": "void",
+                    "nickname": "set_partition_replica_core",
+                    "produces": [
+                        "application/json"
+                    ],
+                    "parameters": [
+                        {
+                            "name": "namespace",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "topic",
+                            "in": "path",
+                            "required": true,
+                            "type": "string"
+                        },
+                        {
+                            "name": "partition",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "node",
+                            "in": "path",
+                            "required": true,
+                            "type": "integer"
+                        },
+                        {
+                            "name": "core",
+                            "in": "body",
+                            "required": "true",
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "core": {
+                                        "type": "number"
+                                    }
+                                },
+                                "required": [
+                                    "core"
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        {
             "path": "/v1/partitions/{namespace}/{topic}/{partition}/transfer_leadership",
             "operations": [
                 {
@@ -719,7 +775,7 @@
                     },
                     "description": "Replica assignments"
                 },
-                "dead_nodes" : {
+                "dead_nodes": {
                     "type": "array",
                     "items": {
                         "type": "int"

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -574,6 +574,73 @@ admin_server::set_partition_replicas_handler(
     co_return ss::json::json_void();
 }
 
+namespace {
+
+json::validator make_set_replica_core_validator() {
+    const std::string schema = R"(
+{
+    "type": "object",
+    "properties": {
+        "core": {
+            "type": "number"
+        }
+    },
+    "required": [
+        "core"
+    ],
+    "additionalProperties": false
+}
+)";
+    return json::validator(schema);
+}
+
+uint32_t parse_replica_core_from_json(const json::Document& doc) {
+    static thread_local json::validator json_validator(
+      make_set_replica_core_validator());
+    apply_validator(json_validator, doc);
+
+    if (!doc.IsObject()) {
+        throw ss::httpd::bad_request_exception("Expected array");
+    }
+    const auto& core_field = doc["core"];
+    if (!core_field.IsInt()) {
+        throw ss::httpd::bad_request_exception("`core` must be integer");
+    }
+    return uint32_t(core_field.GetInt());
+}
+
+} // namespace
+
+ss::future<ss::json::json_return_type>
+admin_server::set_partition_replica_core_handler(
+  std::unique_ptr<ss::http::request> req) {
+    auto ntp = parse_ntp_from_request(req->param);
+
+    auto node_str = req->param.get_decoded_param("node");
+    model::node_id node_id;
+    try {
+        node_id = model::node_id(std::stoi(node_str));
+    } catch (...) {
+        throw ss::httpd::bad_param_exception(
+          fmt::format("node parameter must be an integer: `{}'", node_str));
+    }
+
+    auto doc = co_await parse_json_body(req.get());
+    uint32_t core = parse_replica_core_from_json(doc);
+
+    if (ntp == model::controller_ntp) {
+        throw ss::httpd::bad_request_exception(
+          fmt::format("Can't modify controller partition core"));
+    }
+
+    auto ec = co_await _controller->get_topics_frontend()
+                .local()
+                .set_partition_replica_shard(
+                  ntp, node_id, core, model::timeout_clock::now() + 5s);
+    co_await throw_on_error(*req, ec, ntp);
+    co_return ss::json::json_void();
+}
+
 void admin_server::register_partition_routes() {
     /*
      * Get a list of partition summaries.
@@ -743,6 +810,12 @@ void admin_server::register_partition_routes() {
       ss::httpd::partition_json::force_recover_from_nodes,
       [this](std::unique_ptr<ss::http::request> req) {
           return force_recover_partitions_from_nodes(std::move(req));
+      });
+
+    register_route<superuser>(
+      ss::httpd::partition_json::set_partition_replica_core,
+      [this](std::unique_ptr<ss::http::request> req) {
+          return set_partition_replica_core_handler(std::move(req));
       });
 }
 namespace {

--- a/src/v/redpanda/admin/server.h
+++ b/src/v/redpanda/admin/server.h
@@ -528,6 +528,9 @@ private:
     ss::future<ss::json::json_return_type>
       force_set_partition_replicas_handler(std::unique_ptr<ss::http::request>);
     ss::future<ss::json::json_return_type>
+      set_partition_replica_core_handler(std::unique_ptr<ss::http::request>);
+
+    ss::future<ss::json::json_return_type>
       trigger_on_demand_rebalance_handler(std::unique_ptr<ss::http::request>);
 
     ss::future<ss::json::json_return_type>

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2520,6 +2520,9 @@ void application::wire_up_and_start(::stop_signal& app_signal, bool test_mode) {
             *controller));
         _migrators.push_back(
           std::make_unique<features::migrators::rbac_migrator>(*controller));
+        _migrators.push_back(
+          std::make_unique<features::migrators::shard_placement_migrator>(
+            *controller));
     }
 
     if (cd.is_cluster_founder().get()) {

--- a/tests/rptest/services/admin.py
+++ b/tests/rptest/services/admin.py
@@ -1004,6 +1004,16 @@ class Admin:
         path = "partitions/force_recover_from_nodes"
         return self._request('post', path, node, json=payload)
 
+    def set_partition_replica_core(self,
+                                   topic: str,
+                                   partition: int,
+                                   replica: int,
+                                   core: int,
+                                   namespace: str = "kafka",
+                                   node=None):
+        path = f"partitions/{namespace}/{topic}/{partition}/replicas/{replica}"
+        return self._request('post', path, node=node, json={"core": core})
+
     def create_user(self,
                     username,
                     password="12345678",

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3315,20 +3315,25 @@ class RedpandaService(RedpandaServiceBase):
 
     def set_feature_active(self, feature_name: str, active: bool, *,
                            timeout_sec: int):
-        self._admin.put_feature(feature_name,
-                                {"state": "active" if active else "disabled"})
-        self.await_feature(feature_name, active, timeout_sec=timeout_sec)
+        state = 'active' if active else 'disabled'
+        self._admin.put_feature(feature_name, {"state": state})
+        self.await_feature(feature_name, state, timeout_sec=timeout_sec)
 
-    def await_feature(self, feature_name: str, active: bool, *,
-                      timeout_sec: int):
+    def await_feature(self,
+                      feature_name: str,
+                      await_state: str,
+                      *,
+                      timeout_sec: int,
+                      nodes: list[ClusterNode] | None = None):
         """
         For use during upgrade tests, when after upgrade yo uwould like to block
         until a particular feature's active status updates (e.g. if it does migrations)
         """
-        await_state = 'active' if active else 'disabled'
+        if nodes is None:
+            nodes = self.nodes
 
         def is_awaited_state():
-            for n in self.nodes:
+            for n in nodes:
                 f = self._admin.get_features(node=n)
                 by_name = dict((f['name'], f) for f in f['features'])
                 try:

--- a/tests/rptest/tests/controller_log_limiting_test.py
+++ b/tests/rptest/tests/controller_log_limiting_test.py
@@ -246,13 +246,13 @@ class ControllerPartitionMovementLimitTest(PartitionMovementMixin,
     def perform_move(self, topic, partition):
         old_assignments, new_assignment = self._dispatch_random_partition_move(
             topic=topic.name, partition=partition)
-        return old_assignments == new_assignment
+        return self._equal_assignments(old_assignments, new_assignment)
 
     @cluster(num_nodes=3)
     def test_move_partition_limit(self):
         self.start_redpanda(num_nodes=3)
 
-        topic = TopicSpec(partition_count=3)
+        topic = TopicSpec(partition_count=3, replication_factor=1)
         self.client().create_topic(topic)
         try:
             while (self.perform_move(topic, 0)):

--- a/tests/rptest/tests/partition_move_interruption_test.py
+++ b/tests/rptest/tests/partition_move_interruption_test.py
@@ -354,7 +354,8 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         wait_until(new_controller, 10, 1)
 
         # update replica set
-        admin.set_partition_replicas(self.topic, partition, new_assignment)
+        self._set_partition_assignments(self.topic, partition, new_assignment,
+                                        admin)
 
         self._wait_for_move_in_progress(self.topic, partition)
 
@@ -549,7 +550,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
             id = self.redpanda.node_id(n)
             if id not in replica_ids:
                 previous = assignments.pop()
-                assignments.append({"node_id": id, "core": 0})
+                assignments.append({"node_id": id})
                 # stop a node that is going to be removed from current partition assignment
                 to_stop = self.get_node_by_id(previous['node_id'])
                 self.redpanda.stop_node(to_stop)
@@ -567,7 +568,7 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
         self.logger.info(
             f"moving {topic}/{partition}: {prev_assignments} -> {assignments}")
 
-        admin.set_partition_replicas(topic, partition, assignments)
+        self._set_partition_assignments(topic, partition, assignments, admin)
 
         self._wait_for_move_in_progress(topic, partition)
 
@@ -639,13 +640,14 @@ class PartitionMoveInterruption(PartitionMovementMixin, EndToEndTest):
             for id in available_ids:
                 if id not in replica_ids:
                     assignments.pop()
-                    assignments.append({"node_id": id, "core": 0})
+                    assignments.append({"node_id": id})
 
             self.logger.info(
                 f"[{i}] moving {topic}/{partition}: {prev_assignments} -> {assignments}"
             )
 
-            admin.set_partition_replicas(topic, partition, assignments)
+            self._set_partition_assignments(topic, partition, assignments,
+                                            admin)
 
             self._wait_for_move_in_progress(topic, partition)
 

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0
 
+import copy
 import random
 import time
 import signal
@@ -91,12 +92,12 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         admin = Admin(self.redpanda)
 
         # choose a random topic-partition
-        self.logger.info(f"selected topic-partition: {topic}-{partition}")
+        self.logger.info(f"selected topic-partition: {topic}/{partition}")
 
         # get the partition's replica set, including core assignments. the kafka
         # api doesn't expose core information, so we use the redpanda admin api.
         assignments = self._get_assignments(admin, topic, partition)
-        self.logger.info(f"assignments for {topic}-{partition}: {assignments}")
+        self.logger.info(f"assignments for {topic}/{partition}: {assignments}")
 
         brokers = admin.get_brokers()
         # replace all node cores in assignment
@@ -105,31 +106,38 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                 if broker['node_id'] == assignment['node_id']:
                     assignment['core'] = random.randint(
                         0, broker["num_cores"] - 1)
-        self.logger.info(
-            f"new assignments for {topic}-{partition}: {assignments}")
 
-        r = admin.set_partition_replicas(topic, partition, assignments)
+        self._set_partition_assignments(
+            topic,
+            partition,
+            assignments,
+            admin=admin,
+            node_local_core_assignment=not test_mixed_versions)
 
-        def status_done():
+        def node_assignments_converged():
             info = admin.get_partitions(topic, partition)
+            node_assignments = [{
+                "node_id": r["node_id"]
+            } for r in info["replicas"]]
             self.logger.info(
-                f"current assignments for {topic}-{partition}: {info}")
-            converged = self._equal_assignments(info["replicas"], assignments)
+                f"node assignments for {topic}/{partition}: {node_assignments}, "
+                f"partition status: {info['status']}")
+            converged = self._equal_assignments(node_assignments, assignments)
             return converged and info["status"] == "done"
 
         # unset failures
         for n in self.redpanda.nodes:
             hb.unset_failures(n, 'raftgen_service::failure_probes', 'vote')
         # wait until redpanda reports complete
-        wait_until(status_done, timeout_sec=60, backoff_sec=2)
+        wait_until(node_assignments_converged, timeout_sec=60, backoff_sec=2)
 
-        def derived_done():
-            info = self._get_current_partitions(admin, topic, partition)
+        def cores_converged():
+            info = self._get_current_node_cores(admin, topic, partition)
             self.logger.info(
-                f"derived assignments for {topic}-{partition}: {info}")
+                f"derived assignments for {topic}/{partition}: {info}")
             return self._equal_assignments(info, assignments)
 
-        wait_until(derived_done, timeout_sec=60, backoff_sec=2)
+        wait_until(cores_converged, timeout_sec=60, backoff_sec=2)
 
     @cluster(num_nodes=3, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(num_to_upgrade=[0, 2])
@@ -156,7 +164,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             self.client().create_topic(spec)
 
         for _ in range(25):
-            self._move_and_verify()
+            self._move_and_verify(
+                node_local_core_assignment=not test_mixed_versions)
 
     @cluster(num_nodes=4,
              log_allow_list=PARTITION_MOVEMENT_LOG_ERRORS +
@@ -202,7 +211,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             self.logger.info(f"Producer stop complete.")
 
         for _ in range(25):
-            self._move_and_verify()
+            self._move_and_verify(
+                node_local_core_assignment=not test_mixed_versions)
 
         for spec in topics:
             self.logger.info(f"Verifying records in {spec}")
@@ -280,7 +290,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         self.start_consumer(1)
         self.await_startup()
         for _ in range(moves):
-            self._move_and_verify()
+            self._move_and_verify(
+                node_local_core_assignment=not test_mixed_versions)
         self.run_validation(enable_idempotence=False,
                             consumer_timeout_sec=45,
                             min_records=records)
@@ -319,11 +330,16 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         partition = 0
 
         for _ in range(moves):
-            assignments = self._get_assignments(admin, topic, partition)
+            assignments = self._get_current_node_cores(admin, topic, partition)
             for a in assignments:
                 # Bounce between core 0 and 1
                 a['core'] = (a['core'] + 1) % 2
-            admin.set_partition_replicas(topic, partition, assignments)
+            self._set_partition_assignments(
+                topic,
+                partition,
+                assignments,
+                admin=admin,
+                node_local_core_assignment=not test_mixed_versions)
             self._wait_post_move(topic, partition, assignments, 360)
 
         self.run_validation(enable_idempotence=False,
@@ -350,7 +366,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         self.start_consumer(1)
         self.await_startup()
         # execute single move
-        self._move_and_verify()
+        self._move_and_verify(
+            node_local_core_assignment=not test_mixed_versions)
         self.run_validation(enable_idempotence=False, consumer_timeout_sec=45)
 
         # snapshot offsets
@@ -414,41 +431,34 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         invalid_shard = 1000
         invalid_dest = 30
 
+        def dispatch_and_assert_status_code(assignments, expected_sc):
+            try:
+                r = admin.set_partition_replicas(topic, partition, assignments)
+                status_code = r.status_code
+            except requests.exceptions.HTTPError as e:
+                status_code = e.response.status_code
+            assert status_code == expected_sc, \
+                f"Expected {expected_sc} but got {status_code}"
+
+        node_local_core_assignment = not test_mixed_versions
+
         # A valid node but an invalid core
         assignments = [{"node_id": valid_dest, "core": invalid_shard}]
-        try:
-            r = admin.set_partition_replicas(topic, partition, assignments)
-        except requests.exceptions.HTTPError as e:
-            assert e.response.status_code == 400
-        else:
-            raise RuntimeError(f"Expected 400 but got {r.status_code}")
+        dispatch_and_assert_status_code(
+            assignments,
+            expected_sc=200 if node_local_core_assignment else 400)
 
         # An invalid node but a valid core
         assignments = [{"node_id": invalid_dest, "core": 0}]
-        try:
-            r = admin.set_partition_replicas(topic, partition, assignments)
-        except requests.exceptions.HTTPError as e:
-            assert e.response.status_code == 400
-        else:
-            raise RuntimeError(f"Expected 400 but got {r.status_code}")
+        dispatch_and_assert_status_code(assignments, expected_sc=400)
 
         # An syntactically invalid destination (float instead of int)
         # Reproducer for https://github.com/redpanda-data/redpanda/issues/2286
         assignments = [{"node_id": valid_dest, "core": 3.14}]
-        try:
-            r = admin.set_partition_replicas(topic, partition, assignments)
-        except requests.exceptions.HTTPError as e:
-            assert e.response.status_code == 400
-        else:
-            raise RuntimeError(f"Expected 400 but got {r.status_code}")
+        dispatch_and_assert_status_code(assignments, expected_sc=400)
 
         assignments = [{"node_id": 3.14, "core": 0}]
-        try:
-            r = admin.set_partition_replicas(topic, partition, assignments)
-        except requests.exceptions.HTTPError as e:
-            assert e.response.status_code == 400
-        else:
-            raise RuntimeError(f"Expected 400 but got {r.status_code}")
+        dispatch_and_assert_status_code(assignments, expected_sc=400)
 
         # Not unique replicas in replica set
         assignments = [{
@@ -458,17 +468,11 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             "node_id": valid_dest,
             "core": 0
         }]
-        try:
-            r = admin.set_partition_replicas(topic, partition, assignments)
-        except requests.exceptions.HTTPError as e:
-            assert e.response.status_code == 400
-        else:
-            raise RuntimeError(f"Expected 400 but got {r.status_code}")
+        dispatch_and_assert_status_code(assignments, expected_sc=400)
 
         # Finally a valid move
         assignments = [{"node_id": valid_dest, "core": 0}]
-        r = admin.set_partition_replicas(topic, partition, assignments)
-        assert r.status_code == 200
+        dispatch_and_assert_status_code(assignments, expected_sc=200)
 
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(num_to_upgrade=[0, 2])
@@ -538,7 +542,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         # Start an inter-node move, which should take some time
         # to complete because of recovery network traffic
-        assignments = self._get_assignments(admin, name, 0)
+        assignments = self._get_assignments(admin, name, 0, with_cores=True)
         new_node = list(node_ids - set([a['node_id'] for a in assignments]))[0]
         self.logger.info(f"old assignments: {assignments}")
         old_assignments = assignments
@@ -603,7 +607,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         # get current assignments
         assignments = self._get_assignments(admin, topic, partition)
         assert len(assignments) == 1
-        self.logger.info(f"assignments for {topic}-{partition}: {assignments}")
+        self.logger.info(f"assignments for {topic}/{partition}: {assignments}")
         brokers = admin.get_brokers()
         self.logger.info(f"available brokers: {brokers}")
         candidates = list(
@@ -612,7 +616,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         replacement = random.choice(candidates)
         target_assignment = [{'node_id': replacement['node_id'], 'core': 0}]
         self.logger.info(
-            f"target assignments for {topic}-{partition}: {target_assignment}")
+            f"target assignments for {topic}/{partition}: {target_assignment}")
         # shutdown target node to make sure that move will never complete
         node = self.redpanda.get_node(replacement['node_id'])
         self.redpanda.stop_node(node)
@@ -649,7 +653,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
                 else:
                     raise e
             self.logger.info(
-                f"current assignments for {topic}-{partition}: {partition_info}"
+                f"current assignments for {topic}/{partition}: {partition_info}"
             )
             return partition_info["status"]
 
@@ -683,7 +687,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         for partition in range(0, partition_count):
             assignments = self._get_assignments(admin, self.topic, partition)
             new_assignment = [assignments[0]]
-            admin.set_partition_replicas(self.topic, partition, new_assignment)
+            self._set_partition_assignments(self.topic, partition,
+                                            new_assignment, admin)
             self._wait_post_move(self.topic, partition, new_assignment, 60)
 
         self.run_validation(enable_idempotence=False,
@@ -725,7 +730,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         ]
         selected = random.choice(to_select)
         # replace one of the assignments
-        assignments[0] = {'node_id': selected['node_id'], 'core': 0}
+        assignments[0] = {'node_id': selected['node_id']}
         self.logger.info(
             f"new assignment for {self.topic}/{partition_id}: {assignments}")
 
@@ -745,7 +750,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
 
         wait_until(new_controller_available, 30, 1)
         # ask partition to move
-        admin.set_partition_replicas(self.topic, partition_id, assignments)
+        self._set_partition_assignments(self.topic, partition_id, assignments,
+                                        admin)
 
         def status_done():
             info = admin.get_partitions(self.topic, partition_id)
@@ -798,7 +804,7 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         selected = random.choice(to_select)
         # replace one of the assignments
         replaced = assignments[0]['node_id']
-        assignments[0] = {'node_id': selected['node_id'], 'core': 0}
+        assignments[0] = {'node_id': selected['node_id']}
         self.logger.info(
             f"target assignment for {self.topic}/{partition_id}: {assignments}"
         )
@@ -820,7 +826,8 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         wait_until(new_controller_available, 30, 1)
 
         # ask partition to move
-        admin.set_partition_replicas(self.topic, partition_id, assignments)
+        self._set_partition_assignments(self.topic, partition_id, assignments,
+                                        admin)
 
         def status_done():
             info = admin.get_partitions(self.topic, partition_id)
@@ -836,8 +843,9 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             "first movement done, scheduling second movement back")
 
         # bring replaced node back
-        assignments[0] = {'node_id': replaced, 'core': 0}
-        admin.set_partition_replicas(self.topic, partition_id, assignments)
+        assignments[0] = {'node_id': replaced}
+        self._set_partition_assignments(self.topic, partition_id, assignments,
+                                        admin)
 
         time.sleep(5)
         self.logger.info(f"unfreezing node: {replaced} again")
@@ -866,17 +874,18 @@ class PartitionMovementTest(PartitionMovementMixin, EndToEndTest):
         brokers = admin.get_brokers()
         for partition in range(0, partition_count):
             assignments = self._get_assignments(admin, self.topic, partition)
-            prev_assignments = assignments.copy()
+            prev_assignments = copy.deepcopy(assignments)
             replicas = set([r['node_id'] for r in prev_assignments])
             for b in brokers:
                 if b['node_id'] not in replicas:
-                    assignments[0]['node_id'] = b['node_id']
+                    assignments[0] = {"node_id": b['node_id']}
                     break
 
             self.logger.info(
                 f"initial assignments for {self.topic}/{partition}: {prev_assignments}, new assignment: {assignments}"
             )
-            admin.set_partition_replicas(self.topic, partition, assignments)
+            self._set_partition_assignments(self.topic, partition, assignments,
+                                            admin)
 
         wait_until(
             lambda: len(admin.list_reconfigurations()) == partition_count, 30)
@@ -991,7 +1000,8 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             if i == upgrade_at_step and test_mixed_versions:
                 self._partial_upgrade(num_to_upgrade)
 
-            self._move_and_verify()
+            self._move_and_verify(
+                node_local_core_assignment=not test_mixed_versions)
 
         self.run_validation(enable_idempotence=False,
                             consumer_timeout_sec=45,
@@ -1039,11 +1049,16 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
             if i == upgrade_at_step and test_mixed_versions:
                 self._partial_upgrade(num_to_upgrade)
 
-            assignments = self._get_assignments(admin, topic, partition)
+            assignments = self._get_current_node_cores(admin, topic, partition)
             for a in assignments:
                 # Bounce between core 0 and 1
                 a['core'] = (a['core'] + 1) % 2
-            admin.set_partition_replicas(topic, partition, assignments)
+            self._set_partition_assignments(
+                topic,
+                partition,
+                assignments,
+                admin=admin,
+                node_local_core_assignment=not test_mixed_versions)
             self._wait_post_move(topic, partition, assignments, 360)
 
         self.run_validation(enable_idempotence=False,

--- a/tests/rptest/tests/shard_placement_test.py
+++ b/tests/rptest/tests/shard_placement_test.py
@@ -1,0 +1,231 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from ducktape.utils.util import wait_until
+
+from rptest.services.cluster import cluster
+from rptest.services.admin import Admin
+from rptest.clients.rpk import RpkTool
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.redpanda_installer import RedpandaInstaller
+
+
+class ShardPlacementTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, num_brokers=5, **kwargs)
+
+    def setUp(self):
+        # start the nodes manually
+        pass
+
+    def get_replica_shard_map(self, nodes, admin=None):
+        """Return map of topic -> partition -> [(node_id, core)]"""
+
+        if admin is None:
+            admin = Admin(self.redpanda)
+
+        topic2partition2shard = dict()
+        for node in nodes:
+            partitions = admin.get_partitions(node=node)
+            for p in partitions:
+                topic2partition2shard.setdefault(
+                    p["topic"],
+                    dict()).setdefault(p["partition_id"], list()).append(
+                        (self.redpanda.node_id(node), p["core"]))
+
+        for partitions in topic2partition2shard.values():
+            for replicas in partitions.values():
+                # sort replicas for the ease of comparison
+                replicas.sort()
+
+        return topic2partition2shard
+
+    def get_shard_counts_by_topic(self, shard_map, node_id):
+        core_count = self.redpanda.get_node_cpu_count()
+        topic2shard2count = dict()
+        for topic, partitions in shard_map.items():
+            for replicas in partitions.values():
+                for replica_id, core in replicas:
+                    if replica_id == node_id:
+                        topic2shard2count.setdefault(
+                            topic,
+                            list(0 for _ in range(core_count)))[core] += 1
+        return topic2shard2count
+
+    def debug_print_shard_map(self, shard_map, with_counts=True):
+        node_ids = set()
+        for topic, partitions in sorted(shard_map.items()):
+            for p, replicas in sorted(partitions.items()):
+                self.logger.debug(f"ntp: {topic}/{p} replicas: {replicas}")
+                for n_id, _ in replicas:
+                    node_ids.add(n_id)
+
+        if not with_counts:
+            return
+
+        core_count = self.redpanda.get_node_cpu_count()
+        for node_id in sorted(node_ids):
+            shard_counts = self.get_shard_counts_by_topic(shard_map, node_id)
+            total_counts = list(0 for _ in range(core_count))
+            self.logger.debug(f"shard replica counts on node {node_id}:")
+            for t, counts in sorted(shard_counts.items()):
+                self.logger.debug(f"topic {t}: {counts}")
+                for i, c in enumerate(counts):
+                    total_counts[i] += c
+            self.logger.debug(f"total: {total_counts}")
+
+    def wait_shard_map_stationary(self,
+                                  nodes,
+                                  admin=None,
+                                  timeout_sec=10,
+                                  backoff_sec=1):
+        shard_map = None
+
+        def is_stationary():
+            nonlocal shard_map
+            new_map = self.get_replica_shard_map(nodes, admin)
+            self.debug_print_shard_map(new_map, with_counts=False)
+            if new_map == shard_map:
+                return True
+            else:
+                shard_map = new_map
+
+        wait_until(is_stationary,
+                   timeout_sec=timeout_sec,
+                   backoff_sec=backoff_sec)
+        return shard_map
+
+    @cluster(num_nodes=5)
+    def test_upgrade(self):
+        # Disable partition balancer in this test, as we need partitions
+        # to remain stationary.
+        self.redpanda.add_extra_rp_conf(
+            {'partition_autobalancing_mode': 'off'})
+
+        seed_nodes = self.redpanda.nodes[0:3]
+        joiner_nodes = self.redpanda.nodes[3:]
+
+        # Create a cluster that doesn't support node-local core assignment yet
+        # and add some topics.
+
+        installer = self.redpanda._installer
+        installer.install(seed_nodes, (24, 1))
+        self.redpanda.start(nodes=seed_nodes)
+
+        admin = Admin(self.redpanda, default_node=seed_nodes[0])
+        rpk = RpkTool(self.redpanda)
+
+        n_partitions = 10
+
+        for topic in ["foo", "bar"]:
+            rpk.create_topic(topic, partitions=n_partitions, replicas=3)
+
+        self.logger.info("created cluster and topics.")
+        initial_map = self.get_replica_shard_map(seed_nodes, admin)
+        self.debug_print_shard_map(initial_map)
+
+        # Upgrade the cluster and enable the feature.
+
+        installer.install(seed_nodes, RedpandaInstaller.HEAD)
+        self.redpanda.restart_nodes(seed_nodes)
+        self.redpanda.wait_for_membership(first_start=False)
+
+        self.redpanda.await_feature("node_local_core_assignment",
+                                    "available",
+                                    timeout_sec=15,
+                                    nodes=seed_nodes)
+        admin.put_feature("node_local_core_assignment", {"state": "active"})
+        self.redpanda.await_feature("node_local_core_assignment",
+                                    "active",
+                                    timeout_sec=15,
+                                    nodes=seed_nodes)
+
+        self.logger.info(
+            "feature enabled, checking that shard map is stable...")
+        map_after_upgrade = self.get_replica_shard_map(seed_nodes, admin)
+        self.debug_print_shard_map(map_after_upgrade)
+        assert map_after_upgrade == initial_map
+
+        # Manually move replicas of one topic on one node to shard 0
+
+        moved_replica_id = self.redpanda.node_id(seed_nodes[-1])
+        for p in range(n_partitions):
+            admin.set_partition_replica_core(topic="foo",
+                                             partition=p,
+                                             replica=moved_replica_id,
+                                             core=0,
+                                             node=seed_nodes[p % 3])
+
+        # check that they indeed moved
+        self.logger.info(
+            f"manually moved some replicas on node {moved_replica_id}, "
+            "checking shard map...")
+        map_after_manual_move = self.wait_shard_map_stationary(
+            seed_nodes, admin)
+        self.debug_print_shard_map(map_after_manual_move)
+        foo_shard_counts = self.get_shard_counts_by_topic(
+            map_after_manual_move, moved_replica_id)["foo"]
+        assert foo_shard_counts[0] == n_partitions
+        assert sum(foo_shard_counts) == n_partitions
+
+        # Add more nodes to the cluster and create another topic
+
+        self.redpanda.start(nodes=joiner_nodes)
+        self.redpanda.wait_for_membership(first_start=True)
+
+        rpk.create_topic("quux", partitions=n_partitions, replicas=3)
+
+        # check that shard counts are balanced
+        self.logger.info(f"added 2 nodes and a topic, checking shard map...")
+        map_after_join = self.get_replica_shard_map(joiner_nodes, admin)
+        self.debug_print_shard_map(map_after_join)
+        for joiner in joiner_nodes:
+            joiner_id = self.redpanda.node_id(joiner)
+            shard_counts = self.get_shard_counts_by_topic(
+                map_after_join, joiner_id)["quux"]
+            assert max(shard_counts) - min(shard_counts) <= 1
+
+        # Check that joiner nodes support manual partition moves as well
+
+        joiner_id = self.redpanda.node_id(joiner_nodes[0])
+        quux_partitions_on_joiner = [
+            p for p, rs in map_after_join["quux"].items()
+            if any(n == joiner_id for n, _ in rs)
+        ]
+        for p in quux_partitions_on_joiner:
+            admin.set_partition_replica_core(topic="quux",
+                                             partition=p,
+                                             replica=joiner_id,
+                                             core=0,
+                                             node=self.redpanda.nodes[p % 5])
+
+        # check that they indeed moved
+        self.logger.info(f"manually moved some replicas on node {joiner_id}, "
+                         "checking shard map...")
+        map_after_manual_move2 = self.wait_shard_map_stationary(
+            joiner_nodes, admin)
+        self.debug_print_shard_map(map_after_manual_move2)
+        quux_shard_counts = self.get_shard_counts_by_topic(
+            map_after_manual_move2, joiner_id)["quux"]
+        assert quux_shard_counts[0] > 0
+        assert sum(quux_shard_counts) == quux_shard_counts[0]
+
+        # Restart and check that the shard map remains stable
+
+        map_before_restart = self.get_replica_shard_map(
+            self.redpanda.nodes, admin)
+
+        self.redpanda.restart_nodes(self.redpanda.nodes)
+        self.redpanda.wait_for_membership(first_start=False)
+
+        self.logger.info("restarted cluster, checking shard map...")
+        map_after_restart = self.get_replica_shard_map(self.redpanda.nodes,
+                                                       admin)
+        self.debug_print_shard_map(map_after_restart)
+        assert map_after_restart == map_before_restart

--- a/tests/rptest/tests/topic_delete_test.py
+++ b/tests/rptest/tests/topic_delete_test.py
@@ -267,7 +267,8 @@ class TopicDeleteAfterMovementTest(RedpandaTest):
 
         self.kafka_tools = KafkaCliTools(self.redpanda)
 
-    def movement_done(self, partition, assignments):
+    def movement_done(self, partition, to_nodes):
+        assignments = [dict(node_id=n) for n in to_nodes]
         results = []
         for n in self.redpanda._started:
             info = self.admin.get_partitions(self.topic, partition, node=n)
@@ -278,7 +279,7 @@ class TopicDeleteAfterMovementTest(RedpandaTest):
             results.append(converged and info["status"] == "done")
         return all(results)
 
-    def move_topic(self, assignments):
+    def move_topic(self, to_nodes):
         for partition in range(3):
 
             def get_nodes(partition):
@@ -286,13 +287,17 @@ class TopicDeleteAfterMovementTest(RedpandaTest):
 
             nodes_before = set(
                 get_nodes(self.admin.get_partitions(self.topic, partition)))
-            nodes_after = {r['node_id'] for r in assignments}
+            nodes_after = set(to_nodes)
             if nodes_before == nodes_after:
                 continue
+            assignments = [
+                dict(node_id=n, core=PartitionMovementMixin.INVALID_CORE)
+                for n in to_nodes
+            ]
             self.admin.set_partition_replicas(self.topic, partition,
                                               assignments)
 
-            wait_until(lambda: self.movement_done(partition, assignments),
+            wait_until(lambda: self.movement_done(partition, to_nodes),
                        timeout_sec=60,
                        backoff_sec=2)
 
@@ -307,8 +312,7 @@ class TopicDeleteAfterMovementTest(RedpandaTest):
         self.admin = Admin(self.redpanda)
 
         # Move every partition to nodes 1,2,3
-        assignments = [dict(node_id=n, core=0) for n in [1, 2, 3]]
-        self.move_topic(assignments)
+        self.move_topic([1, 2, 3])
 
         down_node = self.redpanda.nodes[0]
         try:
@@ -317,8 +321,7 @@ class TopicDeleteAfterMovementTest(RedpandaTest):
                 f"chattr +i {self.redpanda.DATA_DIR}/kafka/{self.topic}")
 
             # Move every partition from node 1 to node 4
-            new_assignments = [dict(node_id=n, core=0) for n in [2, 3, 4]]
-            self.move_topic(new_assignments)
+            self.move_topic([2, 3, 4])
 
             def topic_exist_on_every_node(redpanda, topic_name):
                 storage = redpanda.storage()
@@ -852,7 +855,10 @@ class TopicDeleteCloudStorageTest(RedpandaTest):
         nodes_after = nodes_before[1:] + [
             replacement_node,
         ]
-        new_assignments = list({'core': 0, 'node_id': n} for n in nodes_after)
+        new_assignments = list({
+            'node_id': n,
+            'core': PartitionMovementMixin.INVALID_CORE
+        } for n in nodes_after)
         admin.set_partition_replicas(self.topic, 0, new_assignments)
 
         def move_complete():


### PR DESCRIPTION
This PR implements node-local core assignment - nodes decide themselves on which core to put partitions instead of using global assignments. Partitions are placed so that topic-aware core counts are balanced. No online balancing is preformed yet (i.e. cores only for newly appearing partitions are chosen).

More detailed changes rundown:
* Implemented migrator for the feature flag, so that we will switch to node-local assignment only after *all* nodes in the cluster successfully persist their shard placement tables
* Implemented topic-aware partition placement in `shard_balancer`. For this it needs to maintain per-topic core counts.
* Added admin API to manually change replica core on a node
* Modified `partition_allocator` to stop tracking and assigning cores
* Modified partition admin APIs to ignore core values passed by the client
* Modified tests to accommodate both new and old way (for upgraded clusters) of assigning cores.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Improvements
* Implemented _node-local core assignment_ - nodes decide themselves on which core to put partitions instead of using global assignments. This feature is enabled by default for new clusters.

