### PR TITLE
segment_appender: truncate in addition to allocate

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -163,7 +163,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	f.StringVar(&logsSince, "logs-since", "", "Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD")
 	f.StringVar(&logsUntil, "logs-until", "", "Include log entries on or older than the specified date (journalctl date format, e.g. YYYY-MM-DD")
 	f.StringVar(&logsSizeLimit, "logs-size-limit", "100MiB", "Read the logs until the given size is reached (e.g. 3MB, 1GiB)")
-	f.StringVar(&controllerLogsSizeLimit, "controller-logs-size-limit", "20MB", "The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB)")
+	f.StringVar(&controllerLogsSizeLimit, "controller-logs-size-limit", "132MB", "The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB)")
 	f.StringVar(&uploadURL, "upload-url", "", "If provided, where to upload the bundle in addition to creating a copy on disk")
 	f.StringVarP(&namespace, "namespace", "n", "redpanda", "The namespace to use to collect the resources from (k8s only)")
 	f.StringArrayVarP(&labelSelector, "label-selector", "l", []string{"app.kubernetes.io/name=redpanda"}, "Comma-separated label selectors to filter your resources. e.g: <label>=<value>,<label>=<value> (k8s only)")

--- a/src/v/storage/tests/log_retention_tests.cc
+++ b/src/v/storage/tests/log_retention_tests.cc
@@ -133,14 +133,16 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
         offset += model::offset(num_records);
     }
 
-    BOOST_CHECK_LT(
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
        - 2_MiB),
-      20_KiB);
-    BOOST_CHECK_LT(
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 2_MiB),
-      20_KiB);
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
 
     // second segment
     builder | storage::add_segment(offset);
@@ -159,14 +161,16 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     }
 
     // the first segment is now eligible for reclaim
-    BOOST_CHECK_LT(
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
        - 3_MiB),
-      20_KiB);
-    BOOST_CHECK_LT(
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 3_MiB),
-      20_KiB);
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
 
     // third segment
     builder | storage::add_segment(offset);
@@ -185,14 +189,16 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     }
 
     // the first,second segment is now eligible for reclaim
-    BOOST_CHECK_LT(
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
        - 4_MiB),
-      20_KiB);
-    BOOST_CHECK_LT(
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 4_MiB),
-      20_KiB);
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
 
     // active segment
     builder | storage::add_segment(offset);
@@ -211,14 +217,16 @@ FIXTURE_TEST(retention_test_size_time, gc_fixture) {
     }
 
     // the first,second segment is now eligible for reclaim
-    BOOST_CHECK_LT(
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention
        - 5_MiB),
-      20_KiB);
-    BOOST_CHECK_LT(
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 5_MiB),
-      20_KiB);
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
 
     builder | storage::garbage_collect(model::timestamp::now(), 4_MiB);
 
@@ -436,10 +444,11 @@ FIXTURE_TEST(non_collectible_disk_usage_test, gc_fixture) {
     BOOST_CHECK_EQUAL(
       builder.disk_usage(model::timestamp::now(), 0).get().reclaim.retention,
       0);
-    BOOST_CHECK_LT(
+    BOOST_CHECK_LE(
       (builder.disk_usage(model::timestamp::now(), 0).get().usage.total()
        - 3_MiB),
-      20_KiB);
+      builder.storage().resources().get_falloc_step({})
+        * builder.get_disk_log_impl().segments().size());
 
     builder | storage::stop();
 }

--- a/tests/rptest/remote_scripts/compute_storage.py
+++ b/tests/rptest/remote_scripts/compute_storage.py
@@ -7,6 +7,49 @@ Useful in tests if you want to know what files exist on a node or if they are a 
 from pathlib import Path
 import sys
 import json
+import io
+import struct
+import collections
+import hashlib
+import subprocess
+from typing import Iterator
+
+
+# NB: SegmentReader is duplicated in si_utils.py for deployment reasons. If
+# making changes please adapt both.
+class SegmentReader:
+    HDR_FMT_RP = "<IiqbIhiqqqhii"
+    HEADER_SIZE = struct.calcsize(HDR_FMT_RP)
+    Header = collections.namedtuple(
+        'Header', ('header_crc', 'batch_size', 'base_offset', 'type', 'crc',
+                   'attrs', 'delta', 'first_ts', 'max_ts', 'producer_id',
+                   'producer_epoch', 'base_seq', 'record_count'))
+
+    def __init__(self, stream):
+        self.stream = stream
+
+    def read_batch(self):
+        data = self.stream.read(self.HEADER_SIZE)
+        if len(data) == self.HEADER_SIZE:
+            header = self.Header(*struct.unpack(self.HDR_FMT_RP, data))
+            if all(map(lambda v: v == 0, header)):
+                return None
+            records_size = header.batch_size - self.HEADER_SIZE
+            data = self.stream.read(records_size)
+            if len(data) < records_size:
+                return None
+            assert len(
+                data
+            ) == records_size, f"data len is {len(data)} but the expected records size is {records_size}"
+            return header
+        return None
+
+    def __iter__(self) -> Iterator[Header]:
+        while True:
+            it = self.read_batch()
+            if it is None:
+                return
+            yield it
 
 
 def safe_isdir(p: Path) -> bool:
@@ -33,7 +76,48 @@ def safe_listdir(p: Path) -> list[Path]:
         return []
 
 
-def compute_size(data_dir: Path, sizes: bool):
+def md5_for_bytes(calculate_md5: bool, data: bytes) -> str:
+    return hashlib.md5(data).hexdigest() if calculate_md5 else ''
+
+
+def md5_for_filename(calculate_md5: bool, file: Path) -> str:
+    return subprocess.check_output([
+        'md5sum', file.absolute()
+    ]).decode('utf-8').split(' ')[0] if calculate_md5 else ''
+
+
+def compute_size_for_file(file: Path, calc_md5: bool):
+    file_size = file.stat().st_size
+    if file.suffix == '.log':
+        page_size = 4096
+
+        # just read segments for small files
+        if file_size < 4 * page_size:
+            data = file.read_bytes()
+            reader = SegmentReader(io.BytesIO(data))
+            return md5_for_bytes(calc_md5,
+                                 data), sum(h.batch_size for h in reader)
+        else:
+            # if the large page is not a null page this is a properly closed and
+            # truncated segment and hence we can just use filesize otherwise
+            # compute the size of the segment
+            with file.open('rb') as f:
+                f.seek(-page_size, io.SEEK_END)
+                end_page = f.read(page_size)
+                if end_page != b'\x00' * page_size:
+                    return md5_for_filename(calc_md5, file), file_size
+
+                f.seek(0)
+                data = f.read()
+                reader = SegmentReader(io.BytesIO(data))
+                return md5_for_bytes(calc_md5,
+                                     data), sum(h.batch_size for h in reader)
+    else:
+        return md5_for_filename(calc_md5, file), file_size
+
+
+def compute_size(data_dir: Path, sizes: bool, calculate_md5: bool,
+                 print_flat: bool):
     output = {}
     for ns in safe_listdir(data_dir):
         if not safe_isdir(ns):
@@ -49,7 +133,13 @@ def compute_size(data_dir: Path, sizes: bool):
                     seg_output = {}
                     if sizes:
                         try:
-                            seg_output["size"] = segment.stat().st_size
+                            md5, size = compute_size_for_file(
+                                segment, calculate_md5)
+                            seg_output["size"] = size
+                            if calculate_md5:
+                                seg_output["md5"] = md5
+                            if print_flat:
+                                print(f"{segment.absolute()} {size} {md5}")
                         except FileNotFoundError:
                             # It's valid to have a segment deleted
                             # at anytime
@@ -71,8 +161,17 @@ if __name__ == "__main__":
     parser.add_argument('--sizes',
                         action="store_true",
                         help='Also compute sizes of files')
+    parser.add_argument('--md5',
+                        action="store_true",
+                        help='Also compute md5 checksums')
+    parser.add_argument(
+        '--print-flat',
+        action="store_true",
+        help='Print output for each file instead of returning as json')
     args = parser.parse_args()
+
     data_dir = Path(args.data_dir)
     assert data_dir.exists(), f"{data_dir} must exist"
-    output = compute_size(data_dir, args.sizes)
-    json.dump(output, sys.stdout)
+    output = compute_size(data_dir, args.sizes, args.md5, args.print_flat)
+    if not args.print_flat:
+        json.dump(output, sys.stdout)

--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -283,7 +283,8 @@ class FullDiskReclaimTest(RedpandaTest):
 
         def observed_data_size(pred):
             observed = self.redpanda.data_stat(node)
-            observed_total = sum(s for _, s in observed)
+            observed_total = sum(s for path, s in observed
+                                 if path.parts[0] == 'kafka')
             return pred(observed_total)
 
         # write around 30 megabytes into the topic

--- a/tests/rptest/utils/si_utils.py
+++ b/tests/rptest/utils/si_utils.py
@@ -176,6 +176,8 @@ class SegmentSummary(NamedTuple):
     size_bytes: int
 
 
+# NB: SegmentReader is duplicated compute_storage.py for deployment reasons. If
+# making changes please adapt both.
 class SegmentReader:
     HDR_FMT_RP = "<IiqbIhiqqqhii"
     HEADER_SIZE = struct.calcsize(HDR_FMT_RP)


### PR DESCRIPTION
In the segment_appender we adaptively increase the file size of log
segments using `ss::file::allocate`.

This however doesn't immediately do what's intended. Internally it calls
`fallocate` with the `FALLOC_FL_KEEP_SIZE|FALLOC_FL_ZERO_RANGE` flags.
The former leads to the logical file size not being extended.

Extending the logical file size however seems to have been the intention
of https://github.com/redpanda-data/redpanda/commit/7d7706778918772336dda3a5cc7f63b665f106bf. We do already handle zero
bytes at the end fine either way as we are writing zero appended 4k
chunks anyway.

Besides this side effect there is other reasons why we want to update
the logical file size immediately.

First, this means that on every write we will need to update the file
size which makes both the write and the fsync more expensive: as updating
the file size is a metadata operation which needs to be journaled to the XFS
in-memory log ("CIL") and then flushed out to disk when the inevitable fsync
occurs immediately after. So adjusting the size costs CPU on the write
and the fsync and potentially also causes some additional IO on the fsync
(shows up as write amplification), though this latter effect wasn't noticeable
in testing.

Second, seastar considers XFS an append-challenged file system. This
means that seastar will avoid having size changing and non-size changing
operations outstanding at the same time. They will be queued internally
in the ioqueue. Because of how `allocate` works above all our writes
will always be considered as "appending" as we never updated the logical
file size.

To optimize the queued operations seastar employs certain
"optimizations" in `append_challenged_posix_file_impl::optimize_queue`,
including issuing `ftruncate` calls when it observes the application
issuing writes that will extend the logical file size.
Because nearly all our writes are appending this causes a continuous stream
of implicit `ftruncate` syscalls of about 100/s per shard.

```
root:/tmp# perf trace -t 11990 -s -e ftruncate -- sleep 5

 Summary of events:

 redpanda (11990), 1122 events, 100.0%

   syscall            calls  errors  total       min       avg       max       stddev
                                     (msec)    (msec)    (msec)    (msec)        (%)
   --------------- --------  ------ -------- --------- --------- ---------     ------
   ftruncate            561      0    32.056     0.013     0.057     0.265      1.85%
```

To avoid the two aforementioned issues this patch adds an explicit
`truncate` after our `allocate` call. Note that we still need both as
`ftruncate` alone doesn't preallocate blocks so it's a lot less
performant on its own.

In a medium IOPS OMB workload we see a drop in p99 producer latency from
~14ms to ~10ms. Threaded fallbacks and hence steal time are down by
about 5 and 10% respectively.

Further we can also see the `fsync` times distribution slightly
improved:

Before:

```
root:/tmp# xfsdist-bpfcc 5 1
Tracing XFS operation latency... Hit Ctrl-C to end.

14:07:37:

operation = b'fsync'
     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 55       |                                        |
         4 -> 7          : 11872    |*****                                   |
         8 -> 15         : 38206    |*****************                       |
        16 -> 31         : 18405    |********                                |
        32 -> 63         : 11474    |*****                                   |
        64 -> 127        : 29074    |*************                           |
       128 -> 255        : 88607    |****************************************|
       256 -> 511        : 27403    |************                            |
       512 -> 1023       : 557      |                                        |
      1024 -> 2047       : 28       |                                        |
      2048 -> 4095       : 23       |
```

After:

```
root:/tmp# xfsdist-bpfcc 5 1
Tracing XFS operation latency... Hit Ctrl-C to end.

13:57:45:

operation = b'fsync'
     usecs               : count     distribution
         0 -> 1          : 0        |                                        |
         2 -> 3          : 56       |                                        |
         4 -> 7          : 15472    |*******                                 |
         8 -> 15         : 45440    |***********************                 |
        16 -> 31         : 22825    |***********                             |
        32 -> 63         : 13378    |******                                  |
        64 -> 127        : 31979    |****************                        |
       128 -> 255        : 77529    |****************************************|
       256 -> 511        : 18116    |*********                               |
       512 -> 1023       : 250      |                                        |
      1024 -> 2047       : 1        |
```

Further we can also observe the logial file size adapting during a run:

Before:

```
root:/tmp# for i in {0..5} ; do ll /var/lib/redpanda/data/kafka/test-topic-zUv2_Hs-0000/0_32/ | grep log ; sleep 1 ; done
-rw-r--r--   1 redpanda redpanda 37502976 May 21 10:10 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 39337984 May 21 10:10 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 41267200 May 21 10:10 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 43479040 May 21 10:10 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 45416448 May 21 10:10 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 47005696 May 21 10:10 0-1-v1.log
```

After:

```
root:/tmp# for i in {0..5} ; do ll /var/lib/redpanda/data/kafka/test-topic-Yk-n3mY-0000/0_35/ | grep log ; sleep 1 ; done
-rw-r--r--   1 redpanda redpanda 67108864 May 21 10:22 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 67108864 May 21 10:22 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 67108864 May 21 10:22 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 67108864 May 21 10:22 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 67108864 May 21 10:22 0-1-v1.log
-rw-r--r--   1 redpanda redpanda 67108864 May 21 10:22 0-1-v1.log
```

Note that longterm we will want to improve/change seastar to allow doing
a "full" fallocate but just adding the truncate is the easier change for
now.

Fixes https://github.com/redpanda-data/core-internal/issues/1293

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none


