### PR TITLE
Backport timequery bugfixes to 23.3.x

### DIFF
--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -510,7 +510,7 @@ ss::future<> ntp_archiver::upload_topic_manifest() {
 
     try {
         retry_chain_node fib(
-          _conf->manifest_upload_timeout,
+          _conf->manifest_upload_timeout(),
           _conf->cloud_storage_initial_backoff,
           &_rtcnode);
         retry_chain_logger ctxlog(archival_log, fib);
@@ -922,7 +922,7 @@ ss::future<
 ntp_archiver::download_manifest() {
     auto guard = _gate.hold();
     retry_chain_node fib(
-      _conf->manifest_upload_timeout,
+      _conf->manifest_upload_timeout(),
       _conf->cloud_storage_initial_backoff,
       &_rtcnode);
     cloud_storage::partition_manifest tmp(_ntp, _rev);
@@ -1076,7 +1076,7 @@ ss::future<cloud_storage::upload_result> ntp_archiver::upload_manifest(
     auto guard = _gate.hold();
     auto rtc = source_rtc.value_or(std::ref(_rtcnode));
     retry_chain_node fib(
-      _conf->manifest_upload_timeout,
+      _conf->manifest_upload_timeout(),
       _conf->cloud_storage_initial_backoff,
       &rtc.get());
     retry_chain_logger ctxlog(archival_log, fib, _ntp.path());
@@ -1907,7 +1907,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
           _ntp.path());
 
         auto deadline = ss::lowres_clock::now()
-                        + _conf->manifest_upload_timeout;
+                        + _conf->manifest_upload_timeout();
 
         std::optional<model::offset> manifest_clean_offset;
         if (
@@ -2096,7 +2096,7 @@ ntp_archiver::maybe_truncate_manifest() {
     const auto& m = manifest();
     for (const auto& meta : m) {
         retry_chain_node fib(
-          _conf->manifest_upload_timeout,
+          _conf->manifest_upload_timeout(),
           _conf->upload_loop_initial_backoff,
           &rtc);
         auto sname = cloud_storage::generate_local_segment_name(
@@ -2125,12 +2125,12 @@ ntp_archiver::maybe_truncate_manifest() {
           "manifest, start offset before cleanup: {}",
           manifest().get_start_offset());
         retry_chain_node rc_node(
-          _conf->manifest_upload_timeout,
+          _conf->manifest_upload_timeout(),
           _conf->upload_loop_initial_backoff,
           &rtc);
         auto error = co_await _parent.archival_meta_stm()->truncate(
           adjusted_start_offset,
-          ss::lowres_clock::now() + _conf->manifest_upload_timeout,
+          ss::lowres_clock::now() + _conf->manifest_upload_timeout(),
           _as);
         if (error != cluster::errc::success) {
             vlog(
@@ -3029,7 +3029,7 @@ ss::future<bool> ntp_archiver::do_upload_local(
           features::feature::cloud_metadata_cluster_recovery)
           ? _parent.highest_producer_id()
           : model::producer_id{};
-    auto deadline = ss::lowres_clock::now() + _conf->manifest_upload_timeout;
+    auto deadline = ss::lowres_clock::now() + _conf->manifest_upload_timeout();
     auto error = co_await _parent.archival_meta_stm()->add_segments(
       {meta},
       std::nullopt,

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -186,13 +186,14 @@ archiver_fixture::get_configurations() {
       cloud_storage_clients::endpoint_url{});
     s3conf.server_addr = server_addr;
 
-    archival::configuration aconf;
+    archival::configuration aconf{
+      .manifest_upload_timeout = config::mock_binding(1000ms),
+    };
     aconf.bucket_name = cloud_storage_clients::bucket_name("test-bucket");
     aconf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
     aconf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
     aconf.cloud_storage_initial_backoff = 100ms;
     aconf.segment_upload_timeout = 1s;
-    aconf.manifest_upload_timeout = 1s;
     aconf.garbage_collect_timeout = 1s;
     aconf.upload_loop_initial_backoff = 100ms;
     aconf.upload_loop_max_backoff = 5s;

--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -45,7 +45,7 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
       std::chrono::duration_cast<std::chrono::milliseconds>(
         cfg.segment_upload_timeout),
       std::chrono::duration_cast<std::chrono::milliseconds>(
-        cfg.manifest_upload_timeout),
+        cfg.manifest_upload_timeout()),
       cfg.time_limit);
     return o;
 }
@@ -97,7 +97,7 @@ get_archival_service_config(ss::scheduling_group sg, ss::io_priority_class p) {
           .cloud_storage_segment_upload_timeout_ms.value(),
       .manifest_upload_timeout
       = config::shard_local_cfg()
-          .cloud_storage_manifest_upload_timeout_ms.value(),
+          .cloud_storage_manifest_upload_timeout_ms.bind(),
       .garbage_collect_timeout
       = config::shard_local_cfg()
           .cloud_storage_garbage_collect_timeout_ms.value(),

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -48,7 +48,7 @@ struct configuration {
     /// Long upload timeout
     ss::lowres_clock::duration segment_upload_timeout;
     /// Shor upload timeout
-    ss::lowres_clock::duration manifest_upload_timeout;
+    config::binding<std::chrono::milliseconds> manifest_upload_timeout;
     /// Timeout for running delete operations during the GC phase
     ss::lowres_clock::duration garbage_collect_timeout;
     /// Initial backoff for upload loop in case there is nothing to upload

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -865,6 +865,22 @@ bool async_manifest_view::in_archive(async_view_search_query_t o) {
                       kafka::offset::min());
       },
       [this](async_view_timestamp_query ts_query) {
+          // For a query to be satisfiable by the archive the min offset must be
+          // in the archive. The same condition can be stated as: min offset
+          // must be before the start of the STM manifest.
+          //
+          // Otherwise, even though the last timestamp in the archive could
+          // satisfy the query, it can't be used because offset-wise it is
+          // outside of the queried range.
+          kafka::offset archive_end_offset = kafka::prev_offset(
+            _stm_manifest.get_start_kafka_offset().value_or(
+              kafka::offset::min()));
+
+          bool range_overlaps
+            = ts_query.min_offset <= archive_end_offset
+              && ts_query.max_offset
+                   >= _stm_manifest.get_archive_start_kafka_offset();
+
           // The condition for timequery is tricky. With offsets there is a
           // clear pivot point. The start_offset of the STM manifest separates
           // the STM region from the archive. With timestamps it's not as
@@ -872,13 +888,6 @@ bool async_manifest_view::in_archive(async_view_search_query_t o) {
           // and the first segment in the STM manifest. We need in_stm and
           // in_archive to be consistent with each other. To do this we can use
           // last timestamp in the archive as a pivot point.
-          bool range_overlaps
-            = ts_query.min_offset
-                < _stm_manifest.get_start_kafka_offset().value_or(
-                  kafka::offset::min())
-              && ts_query.max_offset
-                   >= _stm_manifest.get_archive_start_kafka_offset();
-
           return range_overlaps
                  && _stm_manifest.get_spillover_map()
                         .last_segment()
@@ -910,8 +919,7 @@ bool async_manifest_view::in_stm(async_view_search_query_t o) {
               // STM manifest with spillover segments is never empty.
               return true;
           }
-          // The last timestamp in the archive is used as a pivot point. See
-          // description in in_archive.
+
           bool range_overlaps
             = ts_query.min_offset
                 <= _stm_manifest.get_last_kafka_offset().value_or(
@@ -920,6 +928,8 @@ bool async_manifest_view::in_stm(async_view_search_query_t o) {
                    >= _stm_manifest.get_start_kafka_offset().value_or(
                      kafka::offset::max());
 
+          // The last timestamp in the archive is used as a pivot point. See
+          // description in in_archive.
           return range_overlaps
                  && _stm_manifest.get_spillover_map()
                         .last_segment()

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -63,7 +63,9 @@ static ss::sstring to_string(const async_view_search_query_t& t) {
       t,
       [&](model::offset ro) { return ssx::sformat("[offset: {}]", ro); },
       [&](kafka::offset ko) { return ssx::sformat("[kafka offset: {}]", ko); },
-      [&](model::timestamp ts) { return ssx::sformat("[timestamp: {}]", ts); });
+      [&](const async_view_timestamp_query& ts) {
+          return ssx::sformat("{}", ts);
+      });
 }
 
 std::ostream& operator<<(std::ostream& s, const async_view_search_query_t& q) {
@@ -83,9 +85,27 @@ contains(const partition_manifest& m, const async_view_search_query_t& query) {
           return k >= m.get_start_kafka_offset()
                  && k < m.get_next_kafka_offset();
       },
-      [&](model::timestamp t) {
-          return m.size() > 0 && t >= m.begin()->base_timestamp
-                 && t <= m.last_segment()->max_timestamp;
+      [&](const async_view_timestamp_query& ts_query) {
+          if (m.size() == 0) {
+              return false;
+          }
+
+          auto kafka_start_offset = m.get_start_kafka_offset();
+          if (!kafka_start_offset.has_value()) {
+              return false;
+          }
+
+          auto kafka_last_offset = m.get_last_kafka_offset();
+          if (!kafka_last_offset.has_value()) {
+              return false;
+          }
+
+          auto range_overlaps = ts_query.min_offset <= kafka_last_offset.value()
+                                && ts_query.max_offset
+                                     >= kafka_start_offset.value();
+
+          return range_overlaps && ts_query.ts >= m.begin()->base_timestamp
+                 && ts_query.ts <= m.last_segment()->max_timestamp;
       });
 }
 
@@ -565,15 +585,7 @@ async_manifest_view::get_cursor(
   cursor_base_t cursor_base) noexcept {
     try {
         ss::gate::holder h(_gate);
-        if (
-          !in_archive(query) && !in_stm(query)
-          && !std::holds_alternative<model::timestamp>(query)) {
-            // The view should contain manifest below archive start in
-            // order to be able to perform retention and advance metadata.
-            vlog(
-              _ctxlog.debug,
-              "query {} is out of valid range",
-              to_string(query));
+        if (!in_archive(query) && !in_stm(query)) {
             co_return error_outcome::out_of_range;
         }
         model::offset begin;
@@ -852,7 +864,7 @@ bool async_manifest_view::in_archive(async_view_search_query_t o) {
                  && ko < _stm_manifest.get_start_kafka_offset().value_or(
                       kafka::offset::min());
       },
-      [this](model::timestamp ts) {
+      [this](async_view_timestamp_query ts_query) {
           // The condition for timequery is tricky. With offsets there is a
           // clear pivot point. The start_offset of the STM manifest separates
           // the STM region from the archive. With timestamps it's not as
@@ -860,8 +872,18 @@ bool async_manifest_view::in_archive(async_view_search_query_t o) {
           // and the first segment in the STM manifest. We need in_stm and
           // in_archive to be consistent with each other. To do this we can use
           // last timestamp in the archive as a pivot point.
-          return _stm_manifest.get_spillover_map().last_segment()->max_timestamp
-                 >= ts;
+          bool range_overlaps
+            = ts_query.min_offset
+                < _stm_manifest.get_start_kafka_offset().value_or(
+                  kafka::offset::min())
+              && ts_query.max_offset
+                   >= _stm_manifest.get_archive_start_kafka_offset();
+
+          return range_overlaps
+                 && _stm_manifest.get_spillover_map()
+                        .last_segment()
+                        ->max_timestamp
+                      >= ts_query.ts;
       });
 }
 
@@ -878,8 +900,9 @@ bool async_manifest_view::in_stm(async_view_search_query_t o) {
             kafka::offset::max());
           return ko >= sko;
       },
-      [this](model::timestamp ts) {
-          vlog(_ctxlog.debug, "Checking timestamp {} using timequery", ts);
+      [this](async_view_timestamp_query ts_query) {
+          vlog(
+            _ctxlog.debug, "Checking timestamp {} using timequery", ts_query);
           if (_stm_manifest.get_spillover_map().empty()) {
               // The STM manifest is empty, so the timestamp has to be directed
               // to the STM manifest.
@@ -890,8 +913,19 @@ bool async_manifest_view::in_stm(async_view_search_query_t o) {
           }
           // The last timestamp in the archive is used as a pivot point. See
           // description in in_archive.
-          return _stm_manifest.get_spillover_map().last_segment()->max_timestamp
-                 < ts;
+          bool range_overlaps
+            = ts_query.min_offset
+                <= _stm_manifest.get_last_kafka_offset().value_or(
+                  kafka::offset::min())
+              && ts_query.max_offset
+                   >= _stm_manifest.get_start_kafka_offset().value_or(
+                     kafka::offset::max());
+
+          return range_overlaps
+                 && _stm_manifest.get_spillover_map()
+                        .last_segment()
+                        ->max_timestamp
+                      < ts_query.ts;
       });
 }
 
@@ -1311,7 +1345,7 @@ async_manifest_view::get_materialized_manifest(
         }
         // query in not in the stm region
         if (
-          std::holds_alternative<model::timestamp>(q)
+          std::holds_alternative<async_view_timestamp_query>(q)
           && _stm_manifest.get_archive_start_offset() == model::offset{}) {
             vlog(_ctxlog.debug, "Using STM manifest for timequery {}", q);
             co_return std::ref(_stm_manifest);
@@ -1471,7 +1505,7 @@ std::optional<segment_meta> async_manifest_view::search_spillover_manifests(
           }
           return -1;
       },
-      [&](model::timestamp t) {
+      [&](const async_view_timestamp_query& ts_query) {
           if (manifests.empty()) {
               return -1;
           }
@@ -1481,35 +1515,56 @@ std::optional<segment_meta> async_manifest_view::search_spillover_manifests(
             "{}, last: {}",
             query,
             manifests.size(),
-            manifests.begin()->base_timestamp,
-            manifests.last_segment()->max_timestamp);
+            *manifests.begin(),
+            *manifests.last_segment());
 
-          auto first_manifest = manifests.begin();
-          auto base_t = first_manifest->base_timestamp;
           auto max_t = manifests.last_segment()->max_timestamp;
 
           // Edge cases
-          if (t < base_t || max_t == base_t) {
-              return 0;
-          } else if (t > max_t) {
+          if (ts_query.ts > max_t) {
               return -1;
           }
 
+          const auto& bo_col = manifests.get_base_offset_column();
+          const auto& co_col = manifests.get_committed_offset_column();
+          const auto& do_col = manifests.get_delta_offset_column();
+          const auto& de_col = manifests.get_delta_offset_end_column();
           const auto& bt_col = manifests.get_base_timestamp_column();
           const auto& mt_col = manifests.get_max_timestamp_column();
-          auto mt_it = mt_col.begin();
-          auto bt_it = bt_col.begin();
+
+          auto bo_it = bo_col.begin();
+          auto co_it = co_col.begin();
+          auto do_it = do_col.begin();
+          auto de_it = de_col.begin();
+          auto max_ts_it = mt_col.begin();
+          auto base_ts_it = bt_col.begin();
+
           int target_ix = -1;
-          while (!bt_it.is_end()) {
-              if (*mt_it >= t.value() || *bt_it > t.value()) {
+          while (!base_ts_it.is_end()) {
+              static constexpr int64_t min_delta = model::offset::min()();
+              auto d_begin = *do_it == min_delta ? 0 : *do_it;
+              auto d_end = *de_it == min_delta ? d_begin : *de_it;
+              auto bko = kafka::offset(*bo_it - d_begin);
+              auto cko = kafka::offset(*co_it - d_end);
+
+              auto range_overlaps = ts_query.min_offset <= cko
+                                    && ts_query.max_offset >= bko;
+
+              if (
+                range_overlaps
+                && (*max_ts_it >= ts_query.ts() || *base_ts_it > ts_query.ts())) {
                   // Handle case when we're overshooting the target
                   // (base_timestamp > t) or the case when the target is in the
                   // middle of the manifest (max_timestamp >= t)
-                  target_ix = static_cast<int>(bt_it.index());
+                  target_ix = static_cast<int>(base_ts_it.index());
                   break;
               }
-              ++bt_it;
-              ++mt_it;
+              ++bo_it;
+              ++co_it;
+              ++do_it;
+              ++de_it;
+              ++base_ts_it;
+              ++max_ts_it;
           }
           return target_ix;
       });

--- a/src/v/cloud_storage/async_manifest_view.cc
+++ b/src/v/cloud_storage/async_manifest_view.cc
@@ -904,11 +904,10 @@ bool async_manifest_view::in_stm(async_view_search_query_t o) {
           vlog(
             _ctxlog.debug, "Checking timestamp {} using timequery", ts_query);
           if (_stm_manifest.get_spillover_map().empty()) {
-              // The STM manifest is empty, so the timestamp has to be directed
-              // to the STM manifest.
-              // Implicitly, this case also handles the empty manifest case
-              // because the STM manifest with spillover segments is never
-              // empty.
+              // The spillover manifest is empty, so the timestamp query has to
+              // be directed to the STM manifest. Otherwise, we can safely
+              // direct the query either to spillover or stm because the
+              // STM manifest with spillover segments is never empty.
               return true;
           }
           // The last timestamp in the archive is used as a pivot point. See

--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -80,6 +80,17 @@ public:
     ss::future<> start();
     ss::future<> stop();
 
+    enum class cursor_base_t {
+        archive_start_offset,
+
+        /// Special case that is used when computing retention.
+        ///
+        /// For details, see:
+        /// GitHub: https://github.com/redpanda-data/redpanda/pull/12177
+        /// Commit: 1b6ab7be8818e3878a32f9037694ae5c4cf4fea2
+        archive_clean_offset,
+    };
+
     /// Get active spillover manifests asynchronously
     ///
     /// \note the method may hydrate manifests in the cache or
@@ -89,7 +100,8 @@ public:
       result<std::unique_ptr<async_manifest_view_cursor>, error_outcome>>
     get_cursor(
       async_view_search_query_t q,
-      std::optional<model::offset> end_inclusive = std::nullopt) noexcept;
+      std::optional<model::offset> end_inclusive = std::nullopt,
+      cursor_base_t cursor_base = cursor_base_t::archive_start_offset) noexcept;
 
     /// Get inactive spillover manifests which are waiting for
     /// retention

--- a/src/v/cloud_storage/async_manifest_view.h
+++ b/src/v/cloud_storage/async_manifest_view.h
@@ -37,9 +37,32 @@
 
 namespace cloud_storage {
 
+struct async_view_timestamp_query {
+    async_view_timestamp_query(
+      kafka::offset min_offset, model::timestamp ts, kafka::offset max_offset)
+      : min_offset(min_offset)
+      , ts(ts)
+      , max_offset(max_offset) {}
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const async_view_timestamp_query& q) {
+        fmt::print(
+          o,
+          "async_view_timestamp_query{{min_offset:{}, ts:{}, max_offset:{}}}",
+          q.min_offset,
+          q.ts,
+          q.max_offset);
+        return o;
+    }
+
+    kafka::offset min_offset;
+    model::timestamp ts;
+    kafka::offset max_offset;
+};
+
 /// Search query type
 using async_view_search_query_t
-  = std::variant<model::offset, kafka::offset, model::timestamp>;
+  = std::variant<model::offset, kafka::offset, async_view_timestamp_query>;
 
 std::ostream& operator<<(std::ostream&, const async_view_search_query_t&);
 

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1228,7 +1228,8 @@ remote_partition::timequery(storage::timequery_config cfg) {
     vlog(_ctxlog.debug, "timequery: {} batches", batches.size());
 
     if (batches.size()) {
-        co_return storage::batch_timequery(*(batches.begin()), cfg.time);
+        co_return storage::batch_timequery(
+          *(batches.begin()), cfg.min_offset, cfg.time, cfg.max_offset);
     } else {
         co_return std::nullopt;
     }

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -513,7 +513,10 @@ private:
 
         async_view_search_query_t query;
         if (config.first_timestamp.has_value()) {
-            query = config.first_timestamp.value();
+            query = async_view_timestamp_query(
+              model::offset_cast(config.start_offset),
+              config.first_timestamp.value(),
+              model::offset_cast(config.max_offset));
         } else {
             // NOTE: config.start_offset actually contains kafka offset
             // stored using model::offset type.
@@ -563,7 +566,7 @@ private:
                             log_start_offset.value()());
                       }
                   },
-                  [&](model::timestamp query_ts) {
+                  [&](const async_view_timestamp_query& query_ts) {
                       // Special case, it can happen when a timequery falls
                       // below the clean offset. Caused when the query races
                       // with retention/gc.
@@ -572,9 +575,10 @@ private:
                                                  .get_spillover_map();
 
                       bool timestamp_inside_spillover
-                        = query_ts() <= spillovers.get_max_timestamp_column()
-                                          .last_value()
-                                          .value_or(model::timestamp::min()());
+                        = query_ts.ts()
+                          <= spillovers.get_max_timestamp_column()
+                               .last_value()
+                               .value_or(model::timestamp::min()());
 
                       if (timestamp_inside_spillover) {
                           vlog(

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -1201,11 +1201,13 @@ remote_partition::timequery(storage::timequery_config cfg) {
         co_return std::nullopt;
     }
 
-    auto start_offset = stm_manifest.full_log_start_kafka_offset().value();
+    auto start_offset = std::max(
+      cfg.min_offset,
+      kafka::offset_cast(stm_manifest.full_log_start_kafka_offset().value()));
 
     // Synthesize a log_reader_config from our timequery_config
     storage::log_reader_config config(
-      kafka::offset_cast(start_offset),
+      start_offset,
       cfg.max_offset,
       0,
       2048, // We just need one record batch

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -524,27 +524,40 @@ private:
                 co_return;
             }
 
+            // Out of range queries are unexpected. The caller must take care
+            // to send only valid queries to remote_partition. I.e. the fetch
+            // handler does such validation. Similar validation is done inside
+            // remote partition.
+            //
+            // Out of range at this point is due to a race condition or due to
+            // a bug. In both cases the only valid action is to throw an
+            // exception and let the caller deal with it. If the caller doesn't
+            // handle it it leads to a closed kafka connection which the
+            // end clients retry.
             if (
               cur.error() == error_outcome::out_of_range
               && ss::visit(
                 query,
-                [&](model::offset) { return false; },
+                [&](model::offset) {
+                    vassert(
+                      false,
+                      "Unreachable code. Remote partition doesn't know how to "
+                      "handle model::offset queries.");
+                    return false;
+                },
                 [&](kafka::offset query_offset) {
-                    // Special case queries below the start offset of the log.
-                    // The start offset may have advanced while the request was
-                    // in progress. This is expected, so log at debug level.
+                    // Bug or retention racing with the query.
                     const auto log_start_offset
                       = _partition->_manifest_view->stm_manifest()
                           .full_log_start_kafka_offset();
 
                     if (log_start_offset && query_offset < *log_start_offset) {
                         vlog(
-                          _ctxlog.debug,
+                          _ctxlog.warn,
                           "Manifest query below the log's start Kafka offset: "
                           "{} < {}",
                           query_offset(),
                           log_start_offset.value()());
-                        return true;
                     }
                     return false;
                 },

--- a/src/v/cloud_storage/remote_partition.cc
+++ b/src/v/cloud_storage/remote_partition.cc
@@ -578,12 +578,10 @@ private:
                 co_return;
             }
 
-            vlog(
-              _ctxlog.error,
+            throw std::runtime_error(fmt::format(
               "Failed to query spillover manifests: {}, query: {}",
               cur.error(),
-              query);
-            co_return;
+              query));
         }
         _view_cursor = std::move(cur.value());
         co_await _view_cursor->with_manifest(

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -1117,7 +1117,8 @@ FIXTURE_TEST(test_async_manifest_view_timequery, async_manifest_view_fixture) {
 
     // Find exact matches for all segments
     for (const auto& meta : expected) {
-        auto target = meta.base_timestamp;
+        auto target = async_view_timestamp_query(
+          kafka::offset(0), meta.base_timestamp, kafka::offset::max());
         auto maybe_cursor = view.get_cursor(target).get();
         BOOST_REQUIRE(!maybe_cursor.has_failure());
         auto cursor = std::move(maybe_cursor.value());
@@ -1130,9 +1131,9 @@ FIXTURE_TEST(test_async_manifest_view_timequery, async_manifest_view_fixture) {
                 m.last_segment()->max_timestamp,
                 stm_manifest.begin()->base_timestamp,
                 stm_manifest.last_segment()->max_timestamp);
-              auto res = m.timequery(target);
+              auto res = m.timequery(target.ts);
               BOOST_REQUIRE(res.has_value());
-              BOOST_REQUIRE(res.value().base_timestamp == target);
+              BOOST_REQUIRE(res.value().base_timestamp == target.ts);
           })
           .get();
     }
@@ -1159,7 +1160,10 @@ FIXTURE_TEST(
     // that there is a gap between any two segments.
 
     for (const auto& meta : expected) {
-        auto target = model::timestamp(meta.base_timestamp.value() - 1);
+        auto target = async_view_timestamp_query(
+          kafka::offset(0),
+          model::timestamp(meta.base_timestamp() - 1),
+          kafka::offset::max());
         auto maybe_cursor = view.get_cursor(target).get();
         BOOST_REQUIRE(!maybe_cursor.has_failure());
         auto cursor = std::move(maybe_cursor.value());
@@ -1173,11 +1177,11 @@ FIXTURE_TEST(
                 m.last_segment()->max_timestamp,
                 stm_manifest.begin()->base_timestamp,
                 stm_manifest.last_segment()->max_timestamp);
-              auto res = m.timequery(target);
+              auto res = m.timequery(target.ts);
               BOOST_REQUIRE(res.has_value());
               BOOST_REQUIRE(
                 model::timestamp(res.value().base_timestamp.value() - 1)
-                == target);
+                == target.ts);
           })
           .get();
     }

--- a/src/v/cloud_storage/tests/async_manifest_view_test.cc
+++ b/src/v/cloud_storage/tests/async_manifest_view_test.cc
@@ -455,8 +455,19 @@ FIXTURE_TEST(test_async_manifest_view_truncate, async_manifest_view_fixture) {
 
     model::offset so = model::offset{0};
     auto maybe_cursor = view.get_cursor(so).get();
+    BOOST_REQUIRE(
+      maybe_cursor.has_error()
+      && maybe_cursor.error() == cloud_storage::error_outcome::out_of_range);
+
     // The clean offset should still be accesible such that retention
     // can operate above it.
+    maybe_cursor = view
+                     .get_cursor(
+                       so,
+                       std::nullopt,
+                       cloud_storage::async_manifest_view::cursor_base_t::
+                         archive_clean_offset)
+                     .get();
     BOOST_REQUIRE(!maybe_cursor.has_failure());
 
     maybe_cursor = view.get_cursor(new_so).get();

--- a/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
+++ b/src/v/cloud_storage/tests/cloud_storage_e2e_test.cc
@@ -710,7 +710,7 @@ FIXTURE_TEST(test_local_timequery, e2e_fixture) {
         bool expect_value = false,
         std::optional<model::offset> expected_o = std::nullopt) {
           auto timequery_conf = storage::timequery_config(
-            t, o, ss::default_priority_class(), std::nullopt);
+            model::offset(0), t, o, ss::default_priority_class(), std::nullopt);
 
           auto result = partition->timequery(timequery_conf).get();
 
@@ -797,7 +797,7 @@ FIXTURE_TEST(test_cloud_storage_timequery, e2e_fixture) {
         bool expect_value = false,
         std::optional<model::offset> expected_o = std::nullopt) {
           auto timequery_conf = storage::timequery_config(
-            t, o, ss::default_priority_class(), std::nullopt);
+            model::offset(0), t, o, ss::default_priority_class(), std::nullopt);
 
           auto result = partition->timequery(timequery_conf).get();
 
@@ -903,7 +903,7 @@ FIXTURE_TEST(test_mixed_timequery, e2e_fixture) {
         bool expect_value = false,
         std::optional<model::offset> expected_o = std::nullopt) {
           auto timequery_conf = storage::timequery_config(
-            t, o, ss::default_priority_class(), std::nullopt);
+            model::offset(0), t, o, ss::default_priority_class(), std::nullopt);
 
           auto result = partition->timequery(timequery_conf).get();
 

--- a/src/v/cloud_storage/tests/remote_partition_test.cc
+++ b/src/v/cloud_storage/tests/remote_partition_test.cc
@@ -18,6 +18,7 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_partition.h"
 #include "cloud_storage/remote_segment.h"
+#include "cloud_storage/spillover_manifest.h"
 #include "cloud_storage/tests/cloud_storage_fixture.h"
 #include "cloud_storage/tests/common_def.h"
 #include "cloud_storage/tests/s3_imposter.h"
@@ -2281,4 +2282,134 @@ FIXTURE_TEST(test_out_of_range_query, cloud_storage_fixture) {
 
     test_log.debug("Timestamp withing segment");
     BOOST_TEST_REQUIRE(timequery(*this, model::timestamp(1014), 5));
+}
+
+FIXTURE_TEST(test_out_of_range_spillover_query, cloud_storage_fixture) {
+    auto data = [&](size_t t) {
+        return batch_t{
+          .num_records = 1,
+          .type = model::record_batch_type::raft_data,
+          .timestamp = model::timestamp(t)};
+    };
+
+    const std::vector<std::vector<batch_t>> batches = {
+      {data(1000), data(1002), data(1004), data(1006), data(1008), data(1010)},
+      {data(1012), data(1014), data(1016), data(1018), data(1020), data(1022)},
+      {data(1024), data(1026), data(1028), data(1030), data(1032), data(1034)},
+      {data(1036), data(1038), data(1040), data(1042), data(1044), data(1046)},
+      {data(1048), data(1050), data(1052), data(1054), data(1056), data(1058)},
+      {data(1060), data(1062), data(1064), data(1066), data(1068), data(1070)},
+    };
+
+    auto segments = make_segments(batches, false, false);
+    cloud_storage::partition_manifest manifest(manifest_ntp, manifest_revision);
+
+    auto expectations = make_imposter_expectations(manifest, segments);
+    set_expectations_and_listen(expectations);
+
+    for (int i = 0; i < 2; i++) {
+        spillover_manifest spm(manifest_ntp, manifest_revision);
+
+        for (int j = 0; auto s : manifest) {
+            spm.add(s);
+            if (++j == 2) {
+                break;
+            }
+        }
+        manifest.spillover(spm.make_manifest_metadata());
+
+        std::ostringstream ostr;
+        spm.serialize_json(ostr);
+
+        vlog(
+          test_util_log.info,
+          "Uploading spillover manifest at {}:\n{}",
+          spm.get_manifest_path(),
+          ostr.str());
+
+        auto s_data = spm.serialize().get();
+        auto buf = s_data.stream.read_exactly(s_data.size_bytes).get();
+        add_expectations({cloud_storage_fixture::expectation{
+          .url = "/" + spm.get_manifest_path()().string(),
+          .body = ss::sstring(buf.begin(), buf.end()),
+        }});
+    }
+
+    // Advance start offset as-if archiver did apply retention but didn't
+    // run GC yet (the clean offset is not updated).
+    //
+    // We set it to the second segment of the second spillover manifest in an
+    // attempt to cover more potential edge cases.
+    auto archive_start = segments[3].base_offset;
+    manifest.set_archive_start_offset(archive_start, model::offset_delta(0));
+
+    // Upload latest manifest version.
+    auto serialize_manifest = [](const cloud_storage::partition_manifest& m) {
+        auto s_data = m.serialize().get();
+        auto buf = s_data.stream.read_exactly(s_data.size_bytes).get();
+        return ss::sstring(buf.begin(), buf.end());
+    };
+    std::ostringstream ostr;
+    manifest.serialize_json(ostr);
+
+    vlog(
+      test_util_log.info,
+      "Rewriting manifest at {}:\n{}",
+      manifest.get_manifest_path(),
+      ostr.str());
+
+    auto manifest_url = "/" + manifest.get_manifest_path()().string();
+    remove_expectations({manifest_url});
+    add_expectations({
+      cloud_storage_fixture::expectation{
+        .url = manifest_url, .body = serialize_manifest(manifest)},
+    });
+
+    auto base = segments[0].base_offset;
+    auto max = segments[segments.size() - 1].max_offset;
+
+    vlog(test_log.debug, "offset range: {}-{}", base, max);
+
+    // Can query from start of the archive.
+    BOOST_REQUIRE(
+      scan_remote_partition(*this, archive_start, max).size() == 3 * 6);
+
+    // Can't query from the start of partition.
+    BOOST_REQUIRE_EXCEPTION(
+      scan_remote_partition(*this, base, max),
+      std::runtime_error,
+      [](const auto& ex) {
+          ss::sstring what{ex.what()};
+          return what.find("Failed to query spillover manifests") != what.npos;
+      });
+
+    // Can't query from start of the still valid spillover manifest.
+    // Since we don't rewrite spillover manifests we want to be sure that
+    // we don't allow querying stale segments (below the start offset).
+    BOOST_REQUIRE_EXCEPTION(
+      scan_remote_partition(*this, segments[2].base_offset, max),
+      std::runtime_error,
+      [](const auto& ex) {
+          ss::sstring what{ex.what()};
+          return what.find("Failed to query spillover manifests") != what.npos;
+      });
+
+    // BUG: This assertion is disabled because it currently fails.
+    // test_log.debug("Timestamp undershoots the partition");
+    // BOOST_TEST_REQUIRE(timequery(*this, model::timestamp(100), 3 * 6));
+
+    test_log.debug("Timestamp within valid spillover but below archive start");
+    BOOST_TEST_REQUIRE(
+      timequery(*this, segments[2].base_timestamp.value(), 3 * 6));
+
+    test_log.debug("Valid timestamp start of retention");
+    BOOST_TEST_REQUIRE(
+      timequery(*this, batches[3][0].timestamp.value(), 3 * 6));
+
+    test_log.debug("Valid timestamp within retention");
+    BOOST_TEST_REQUIRE(
+      timequery(*this, batches[3][1].timestamp.value(), 3 * 6 - 1));
+
+    test_log.debug("Timestamp overshoots the partition");
+    BOOST_TEST_REQUIRE(timequery(*this, model::timestamp::max(), 0));
 }

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -742,6 +742,10 @@ std::vector<model::record_batch_header> scan_remote_partition(
     partition_probe probe(manifest.get_ntp());
     auto manifest_view = ss::make_shared<async_manifest_view>(
       imposter.api, imposter.cache, manifest, bucket);
+    auto manifest_view_stop = ss::defer(
+      [&manifest_view] { manifest_view->stop().get(); });
+    manifest_view->start().get();
+
     auto partition = ss::make_shared<remote_partition>(
       manifest_view,
       imposter.api.local(),
@@ -794,6 +798,10 @@ scan_result scan_remote_partition(
     partition_probe probe(manifest.get_ntp());
     auto manifest_view = ss::make_shared<async_manifest_view>(
       imposter.api, imposter.cache, manifest, bucket);
+    auto manifest_view_stop = ss::defer(
+      [&manifest_view] { manifest_view->stop().get(); });
+
+    manifest_view->start().get();
     auto partition = ss::make_shared<remote_partition>(
       manifest_view,
       imposter.api.local(),

--- a/src/v/cloud_storage/tests/util.cc
+++ b/src/v/cloud_storage/tests/util.cc
@@ -768,6 +768,7 @@ std::vector<model::record_batch_header> scan_remote_partition(
 /// Similar to previous function but uses timequery to start the scan
 scan_result scan_remote_partition(
   cloud_storage_fixture& imposter,
+  model::offset min,
   model::timestamp timestamp,
   model::offset max,
   size_t maybe_max_segments,
@@ -792,7 +793,7 @@ scan_result scan_remote_partition(
     }
     auto manifest = hydrate_manifest(imposter.api.local(), bucket);
     storage::log_reader_config reader_config(
-      model::offset(0), max, ss::default_priority_class());
+      min, max, ss::default_priority_class());
     reader_config.first_timestamp = timestamp;
 
     partition_probe probe(manifest.get_ntp());

--- a/src/v/cloud_storage/tests/util.h
+++ b/src/v/cloud_storage/tests/util.h
@@ -200,6 +200,7 @@ struct scan_result {
 /// Similar to prev function but uses timequery
 scan_result scan_remote_partition(
   cloud_storage_fixture& imposter,
+  model::offset min,
   model::timestamp timestamp,
   model::offset max = model::offset::max(),
   size_t maybe_max_segments = 0,

--- a/src/v/cluster/partition.cc
+++ b/src/v/cluster/partition.cc
@@ -623,7 +623,15 @@ partition::timequery(storage::timequery_config cfg) {
         // means it _might_ hit on local data: start_timestamp is not
         // precise, so once we query we might still fall back to cloud
         // storage
-        auto result = co_await local_timequery(cfg);
+        //
+        // We also need to adjust the lower bound for the local query as the
+        // min_offset corresponds to the full log (including tiered storage).
+        auto local_query_cfg = cfg;
+        local_query_cfg.min_offset = std::max(
+          _raft->get_offset_translator_state()->from_log_offset(
+            _raft->start_offset()),
+          local_query_cfg.min_offset);
+        auto result = co_await local_timequery(local_query_cfg);
         if (result.has_value()) {
             co_return result;
         } else {
@@ -636,9 +644,17 @@ partition::timequery(storage::timequery_config cfg) {
             // Timestamp is before local storage but within cloud storage
             co_return co_await cloud_storage_timequery(cfg);
         } else {
-            // No cloud data: queries earlier than the start of the log
-            // will hit on the start of the log.
-            co_return co_await local_timequery(cfg);
+            // No cloud data OR not allowed to read from cloud: queries earlier
+            // than the start of the log will hit on the start of the log.
+            //
+            // Adjust the lower bound for the local query as the min_offset
+            // corresponds to the full log (including tiered storage).
+            auto local_query_cfg = cfg;
+            local_query_cfg.min_offset = std::max(
+              _raft->get_offset_translator_state()->from_log_offset(
+                _raft->start_offset()),
+              local_query_cfg.min_offset);
+            co_return co_await local_timequery(local_query_cfg);
         }
     }
 }
@@ -658,12 +674,7 @@ partition::cloud_storage_timequery(storage::timequery_config cfg) {
     // raft log is ahead of the query timestamp or the topic is a read
     // replica, so proceed to query the remote partition to try and
     // find the earliest data that has timestamp >= the query time.
-    vlog(
-      clusterlog.debug,
-      "timequery (cloud) {} t={} max_offset(k)={}",
-      _raft->ntp(),
-      cfg.time,
-      cfg.max_offset);
+    vlog(clusterlog.debug, "timequery (cloud) {} cfg(k)={}", _raft->ntp(), cfg);
 
     // remote_partition pre-translates offsets for us, so no call into
     // the offset translator here
@@ -671,10 +682,9 @@ partition::cloud_storage_timequery(storage::timequery_config cfg) {
     if (result.has_value()) {
         vlog(
           clusterlog.debug,
-          "timequery (cloud) {} t={} max_offset(r)={} result(r)={}",
+          "timequery (cloud) {} cfg(k)={} result(k)={}",
           _raft->ntp(),
-          cfg.time,
-          cfg.max_offset,
+          cfg,
           result->offset);
     }
 
@@ -683,13 +693,10 @@ partition::cloud_storage_timequery(storage::timequery_config cfg) {
 
 ss::future<std::optional<storage::timequery_result>>
 partition::local_timequery(storage::timequery_config cfg) {
-    vlog(
-      clusterlog.debug,
-      "timequery (raft) {} t={} max_offset(k)={}",
-      _raft->ntp(),
-      cfg.time,
-      cfg.max_offset);
+    vlog(clusterlog.debug, "timequery (raft) {} cfg(k)={}", _raft->ntp(), cfg);
 
+    cfg.min_offset = _raft->get_offset_translator_state()->to_log_offset(
+      cfg.min_offset);
     cfg.max_offset = _raft->get_offset_translator_state()->to_log_offset(
       cfg.max_offset);
 
@@ -707,10 +714,10 @@ partition::local_timequery(storage::timequery_config cfg) {
                 // Query raced with prefix truncation
                 vlog(
                   clusterlog.debug,
-                  "timequery (raft) {} ts={} raced with truncation "
+                  "timequery (raft) {} cfg(r)={} raced with truncation "
                   "(start_timestamp {}, result {})",
                   _raft->ntp(),
-                  cfg.time,
+                  cfg,
                   _raft->log()->start_timestamp(),
                   result->time);
                 co_return std::nullopt;
@@ -729,11 +736,11 @@ partition::local_timequery(storage::timequery_config cfg) {
                 // https://github.com/redpanda-data/redpanda/issues/9669
                 vlog(
                   clusterlog.debug,
-                  "Timequery (raft) {} ts={} miss on local log "
+                  "Timequery (raft) {} cfg(r)={} miss on local log "
                   "(start_timestamp "
                   "{}, result {})",
                   _raft->ntp(),
-                  cfg.time,
+                  cfg,
                   _raft->log()->start_timestamp(),
                   result->time);
                 co_return std::nullopt;
@@ -746,11 +753,11 @@ partition::local_timequery(storage::timequery_config cfg) {
             // have the same timestamp and are present in cloud storage.
             vlog(
               clusterlog.debug,
-              "Timequery (raft) {} ts={} hit start_offset in local log "
+              "Timequery (raft) {} cfg(r)={} hit start_offset in local log "
               "(start_offset {} start_timestamp {}, result {})",
               _raft->ntp(),
+              cfg,
               _raft->log()->offsets().start_offset,
-              cfg.time,
               _raft->log()->start_timestamp(),
               cfg.time);
 
@@ -765,10 +772,9 @@ partition::local_timequery(storage::timequery_config cfg) {
 
         vlog(
           clusterlog.debug,
-          "timequery (raft) {} t={} max_offset(r)={} result(r)={}",
+          "timequery (raft) {} cfg(r)={} result(r)={}",
           _raft->ntp(),
-          cfg.time,
-          cfg.max_offset,
+          cfg,
           result->offset);
         result->offset = _raft->get_offset_translator_state()->from_log_offset(
           result->offset);

--- a/src/v/cluster/partition.h
+++ b/src/v/cluster/partition.h
@@ -504,7 +504,7 @@ private:
     bool may_read_from_cloud() const;
 
     ss::future<std::optional<storage::timequery_result>>
-      local_timequery(storage::timequery_config);
+    local_timequery(storage::timequery_config, bool allow_cloud_fallback);
 
     consensus_ptr _raft;
     ss::shared_ptr<util::mem_tracker> _partition_mem_tracker;

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -130,6 +130,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           kafka_partition->leader_epoch());
     }
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
+      kafka_partition->start_offset(),
       timestamp,
       offset,
       kafka_read_priority(),

--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -132,7 +132,7 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
       kafka_partition->start_offset(),
       timestamp,
-      offset,
+      model::prev_offset(offset),
       kafka_read_priority(),
       {model::record_batch_type::raft_data},
       octx.rctx.abort_source().local()});

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -283,7 +283,8 @@ replicated_partition::timequery(storage::timequery_config cfg) {
     if (batches.empty()) {
         co_return std::nullopt;
     }
-    co_return storage::batch_timequery(*(batches.begin()), cfg.time);
+    co_return storage::batch_timequery(
+      *(batches.begin()), cfg.min_offset, cfg.time, cfg.max_offset);
 }
 
 ss::future<result<model::offset>> replicated_partition::replicate(

--- a/src/v/kafka/server/replicated_partition.cc
+++ b/src/v/kafka/server/replicated_partition.cc
@@ -247,44 +247,7 @@ ss::future<std::optional<storage::timequery_result>>
 replicated_partition::timequery(storage::timequery_config cfg) {
     // cluster::partition::timequery returns a result in Kafka offsets,
     // no further offset translation is required here.
-    auto res = co_await _partition->timequery(cfg);
-    if (!res.has_value()) {
-        co_return std::nullopt;
-    }
-    const auto kafka_start_override = _partition->kafka_start_offset_override();
-    if (
-      !kafka_start_override.has_value()
-      || kafka_start_override.value() <= res.value().offset) {
-        // The start override doesn't affect the result of the timequery.
-        co_return res;
-    }
-    vlog(
-      klog.debug,
-      "{} timequery result {} clamped by start override, fetching result at "
-      "start {}",
-      ntp(),
-      res->offset,
-      kafka_start_override.value());
-    storage::log_reader_config config(
-      kafka_start_override.value(),
-      cfg.max_offset,
-      0,
-      2048, // We just need one record batch
-      cfg.prio,
-      cfg.type_filter,
-      std::nullopt, // No timestamp, just use the offset
-      cfg.abort_source);
-    auto translating_reader = co_await make_reader(config, std::nullopt);
-    auto ot_state = std::move(translating_reader.ot_state);
-    model::record_batch_reader::storage_t data
-      = co_await model::consume_reader_to_memory(
-        std::move(translating_reader.reader), model::no_timeout);
-    auto& batches = std::get<model::record_batch_reader::data_t>(data);
-    if (batches.empty()) {
-        co_return std::nullopt;
-    }
-    co_return storage::batch_timequery(
-      *(batches.begin()), cfg.min_offset, cfg.time, cfg.max_offset);
+    return _partition->timequery(cfg);
 }
 
 ss::future<result<model::offset>> replicated_partition::replicate(

--- a/src/v/model/offset_interval.h
+++ b/src/v/model/offset_interval.h
@@ -1,0 +1,80 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#pragma once
+
+#include "base/vassert.h"
+#include "model/fundamental.h"
+
+namespace model {
+/// A non-empty, bounded, closed interval of offsets [min offset, max offset].
+///
+/// This property helps to simplify the logic and the instructions required to
+/// check for overlaps, containment, etc. It is the responsibility of the caller
+/// to ensure these properties hold before constructing an instance of this
+/// class.
+///
+/// To represent a potentially empty range, wrap it in an optional.
+class bounded_offset_interval {
+public:
+    static bounded_offset_interval
+    unchecked(model::offset min, model::offset max) noexcept {
+        return {min, max};
+    }
+
+    static bounded_offset_interval
+    checked(model::offset min, model::offset max) {
+        if (min < model::offset(0) || max < model::offset(0) || min > max) {
+            throw std::invalid_argument(fmt::format(
+              "Invalid arguments for constructing a non-empty bounded offset "
+              "interval: min({}) <= max({})",
+              min,
+              max));
+        }
+
+        return {min, max};
+    }
+
+    inline bool overlaps(const bounded_offset_interval& other) const noexcept {
+        return _min <= other._max && _max >= other._min;
+    }
+
+    inline bool contains(model::offset o) const noexcept {
+        return _min <= o && o <= _max;
+    }
+
+    friend std::ostream&
+    operator<<(std::ostream& o, const bounded_offset_interval& r) {
+        fmt::print(o, "{{min: {}, max: {}}}", r._min, r._max);
+        return o;
+    }
+
+    inline model::offset min() const noexcept { return _min; }
+    inline model::offset max() const noexcept { return _max; }
+
+private:
+    bounded_offset_interval(model::offset min, model::offset max) noexcept
+      : _min(min)
+      , _max(max) {
+#ifndef NDEBUG
+        vassert(
+          min >= model::offset(0), "Offset interval min({}) must be >= 0", min);
+        vassert(
+          min <= max,
+          "Offset interval invariant not satisfied: min({}) <= max({})",
+          min,
+          max);
+#endif
+    }
+
+    model::offset _min;
+    model::offset _max;
+};
+
+} // namespace model

--- a/src/v/model/offset_interval.h
+++ b/src/v/model/offset_interval.h
@@ -9,8 +9,8 @@
 
 #pragma once
 
-#include "base/vassert.h"
 #include "model/fundamental.h"
+#include "vassert.h"
 
 namespace model {
 /// A non-empty, bounded, closed interval of offsets [min offset, max offset].

--- a/src/v/model/tests/random_batch.cc
+++ b/src/v/model/tests/random_batch.cc
@@ -118,7 +118,10 @@ make_random_batch(model::offset o, int num_records, bool allow_compression) {
 
 model::record_batch make_random_batch(record_batch_spec spec) {
     auto ts = spec.timestamp.value_or(model::timestamp::now());
-    auto max_ts = model::timestamp(ts() + spec.count - 1);
+    auto max_ts = ts;
+    if (!spec.all_records_have_same_timestamp) {
+        max_ts = model::timestamp(ts() + spec.count - 1);
+    }
     auto header = model::record_batch_header{
       .size_bytes = 0, // computed later
       .base_offset = spec.offset,
@@ -234,7 +237,9 @@ make_random_batches(record_batch_spec spec) {
         auto num_records = spec.records ? *spec.records : get_int(2, 30);
         auto batch_spec = spec;
         batch_spec.timestamp = ts;
-        ts = model::timestamp(ts() + num_records);
+        if (!batch_spec.all_records_have_same_timestamp) {
+            ts = model::timestamp(ts() + num_records);
+        }
         batch_spec.offset = o;
         batch_spec.count = num_records;
         if (spec.enable_idempotence) {

--- a/src/v/model/tests/random_batch.h
+++ b/src/v/model/tests/random_batch.h
@@ -34,6 +34,7 @@ struct record_batch_spec {
     bool is_transactional{false};
     std::optional<std::vector<size_t>> record_sizes;
     std::optional<model::timestamp> timestamp;
+    bool all_records_have_same_timestamp{false};
 };
 
 model::record make_random_record(int, iobuf);

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -284,13 +284,14 @@ public:
     }
 
     static archival::configuration get_archival_config() {
-        archival::configuration aconf;
+        archival::configuration aconf{
+          .manifest_upload_timeout = config::mock_binding(1000ms),
+        };
         aconf.bucket_name = cloud_storage_clients::bucket_name("test-bucket");
         aconf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
         aconf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
         aconf.cloud_storage_initial_backoff = 100ms;
         aconf.segment_upload_timeout = 1s;
-        aconf.manifest_upload_timeout = 1s;
         aconf.garbage_collect_timeout = 1s;
         aconf.time_limit = std::nullopt;
         return aconf;
@@ -322,18 +323,7 @@ public:
       std::optional<uint32_t> kafka_admin_topic_api_rate = std::nullopt,
       bool data_transforms_enabled = false) {
         auto base_path = std::filesystem::path(data_dir);
-        ss::smp::invoke_on_all([node_id,
-                                kafka_port,
-                                rpc_port,
-                                seed_servers = std::move(seed_servers),
-                                base_path,
-                                s3_config,
-                                archival_cfg,
-                                cloud_cfg,
-                                use_node_id,
-                                empty_seed_starts_cluster_val,
-                                kafka_admin_topic_api_rate,
-                                data_transforms_enabled]() mutable {
+        ss::smp::invoke_on_all([=]() {
             auto& config = config::shard_local_cfg();
 
             config.get("enable_pid_file").set_value(false);
@@ -378,25 +368,29 @@ public:
                     static_cast<int16_t>(s3_config->server_addr.port()));
             }
             if (archival_cfg) {
+                // Copy archival config to this shard to avoid `config::binding`
+                // asserting on cross-shard access.
+                auto local_cfg = archival_cfg;
+
                 config.get("cloud_storage_disable_tls").set_value(true);
                 config.get("cloud_storage_bucket")
-                  .set_value(std::make_optional(archival_cfg->bucket_name()));
+                  .set_value(std::make_optional(local_cfg->bucket_name()));
                 config.get("cloud_storage_initial_backoff_ms")
                   .set_value(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
-                      archival_cfg->cloud_storage_initial_backoff));
+                      local_cfg->cloud_storage_initial_backoff));
                 config.get("cloud_storage_manifest_upload_timeout_ms")
                   .set_value(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
-                      archival_cfg->manifest_upload_timeout));
+                      local_cfg->manifest_upload_timeout()));
                 config.get("cloud_storage_segment_upload_timeout_ms")
                   .set_value(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
-                      archival_cfg->segment_upload_timeout));
+                      local_cfg->segment_upload_timeout));
                 config.get("cloud_storage_garbage_collect_timeout_ms")
                   .set_value(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
-                      archival_cfg->garbage_collect_timeout));
+                      local_cfg->garbage_collect_timeout));
             }
             if (cloud_cfg) {
                 config.get("cloud_storage_enable_remote_read").set_value(true);

--- a/src/v/storage/lock_manager.cc
+++ b/src/v/storage/lock_manager.cc
@@ -9,6 +9,7 @@
 
 #include "storage/lock_manager.h"
 
+#include "model/offset_interval.h"
 #include "storage/segment.h"
 
 #include <seastar/core/future-util.hh>
@@ -38,14 +39,27 @@ range(segment_set::underlying_t segs) {
 
 ss::future<std::unique_ptr<lock_manager::lease>>
 lock_manager::range_lock(const timequery_config& cfg) {
+    auto query_interval = model::bounded_offset_interval::checked(
+      cfg.min_offset, cfg.max_offset);
+
     segment_set::underlying_t tmp;
+    // Copy segments that have timestamps >= cfg.time and overlap with the
+    // offset range [min_offset, max_offset].
     std::copy_if(
       _set.lower_bound(cfg.time),
       _set.end(),
       std::back_inserter(tmp),
-      [&cfg](ss::lw_shared_ptr<segment>& s) {
-          // must be base offset
-          return s->offsets().base_offset <= cfg.max_offset;
+      [&query_interval](ss::lw_shared_ptr<segment>& s) {
+          if (s->empty()) {
+              return false;
+          }
+
+          // Safety: unchecked is safe here because we did already check
+          // `!s->empty()` above to ensure that the segment has data.
+          auto segment_interval = model::bounded_offset_interval::unchecked(
+            s->offsets().base_offset, s->offsets().dirty_offset);
+
+          return segment_interval.overlaps(query_interval);
       });
     return range(std::move(tmp));
 }

--- a/src/v/storage/log_reader.cc
+++ b/src/v/storage/log_reader.cc
@@ -10,6 +10,8 @@
 #include "storage/log_reader.h"
 
 #include "bytes/iobuf.h"
+#include "model/fundamental.h"
+#include "model/offset_interval.h"
 #include "model/record.h"
 #include "storage/logger.h"
 #include "storage/parser_errc.h"
@@ -391,23 +393,28 @@ bool log_reader::is_done() {
            || is_finished_offset(_lease->range, _config.start_offset);
 }
 
-timequery_result
-batch_timequery(const model::record_batch& b, model::timestamp t) {
+timequery_result batch_timequery(
+  const model::record_batch& b,
+  model::offset min_offset,
+  model::timestamp t,
+  model::offset max_offset) {
+    auto query_interval = model::bounded_offset_interval::checked(
+      min_offset, max_offset);
+
     // If the timestamp matches something mid-batch, then
     // parse into the batch far enough to find it: this
     // happens when we had CreateTime input, such that
     // records in the batch have different timestamps.
     model::offset result_o = b.base_offset();
     model::timestamp result_t = b.header().first_timestamp;
-    if (b.header().first_timestamp < t && !b.compressed()) {
+    if (!b.compressed()) {
         b.for_each_record(
-          [&result_o, &result_t, t, &b](
+          [&result_o, &result_t, &b, query_interval, t](
             const model::record& r) -> ss::stop_iteration {
+              auto record_o = model::offset{r.offset_delta()} + b.base_offset();
               auto record_t = model::timestamp(
                 b.header().first_timestamp() + r.timestamp_delta());
-              if (record_t >= t) {
-                  auto record_o = model::offset{r.offset_delta()}
-                                  + b.base_offset();
+              if (record_t >= t && query_interval.contains(record_o)) {
                   result_o = record_o;
                   result_t = record_t;
                   return ss::stop_iteration::yes;

--- a/src/v/storage/log_reader.h
+++ b/src/v/storage/log_reader.h
@@ -238,14 +238,33 @@ private:
 
 /**
  * Assuming caller has already determined that this batch contains
- * the record that should be the result to the timequery, traverse
- * the batch to find which record matches.
+ * the record that should be the result to the timequery (critical!),
+ * traverse the batch to find the record with with timestamp >= \ref t.
+ *
+ * The min and max offsets are used to limit the search to a specific
+ * range inside the batch. This is necessary to support the case where
+ * log was requested to be prefix-truncated (trim-prefix) to an offset
+ * which lies in the middle of a batch.
+ *
+ * If the preconditions aren't met, the result is the timestamp of the first
+ * record in the batch.
  *
  * This is used by both storage's disk_log_impl and by cloud_storage's
  * remote_partition, to seek to their final result after finding
  * the batch.
+ *
+ * To read more about trim-prefix:
+ * https://docs.redpanda.com/current/reference/rpk/rpk-topic/rpk-topic-trim-prefix/
+ *
+ * \param b The batch to search in.
+ * \param min_offset The minimum offset to consider
+ * \param t The timestamp to search for
+ * \param max_offset The maximum offset to consider
  */
-timequery_result
-batch_timequery(const model::record_batch& b, model::timestamp t);
+timequery_result batch_timequery(
+  const model::record_batch& b,
+  model::offset min_offset,
+  model::timestamp t,
+  model::offset max_offset);
 
 } // namespace storage

--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -283,10 +283,20 @@ FIXTURE_TEST(test_reading_range_from_a_log, storage_test_fixture) {
     BOOST_REQUIRE_EQUAL(range.size(), 5);
     BOOST_REQUIRE_EQUAL(range.front().header().crc, batches[3].header().crc);
     BOOST_REQUIRE_EQUAL(range.back().header().crc, batches[7].header().crc);
-    // range from base of beging to the middle of end
+
+    // Range that starts and ends in the middle of the same batch.
     range = read_range_to_vector(
       log,
-      batches[3].base_offset(),
+      batches[3].base_offset() + model::offset(batches[3].record_count() / 3),
+      batches[3].base_offset()
+        + model::offset(batches[3].record_count() / 3 * 2LL));
+    BOOST_REQUIRE_EQUAL(range.size(), 1);
+    BOOST_REQUIRE_EQUAL(range.front().header().crc, batches[3].header().crc);
+
+    // Range that starts and ends in the middle of batches.
+    range = read_range_to_vector(
+      log,
+      batches[3].base_offset() + model::offset(batches[3].record_count() / 2),
       batches[7].base_offset() + model::offset(batches[7].record_count() / 2));
     BOOST_REQUIRE_EQUAL(range.size(), 5);
     BOOST_REQUIRE_EQUAL(range.front().header().crc, batches[3].header().crc);

--- a/src/v/storage/types.cc
+++ b/src/v/storage/types.cc
@@ -87,8 +87,8 @@ std::ostream& operator<<(std::ostream& o, const timequery_result& a) {
     return o << "{offset:" << a.offset << ", time:" << a.time << "}";
 }
 std::ostream& operator<<(std::ostream& o, const timequery_config& a) {
-    o << "{max_offset:" << a.max_offset << ", time:" << a.time
-      << ", type_filter:";
+    o << "{min_offset: " << a.min_offset << ", max_offset: " << a.max_offset
+      << ", time:" << a.time << ", type_filter:";
     if (a.type_filter) {
         o << *a.type_filter;
     } else {

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -289,6 +289,8 @@ struct truncate_prefix_config {
     operator<<(std::ostream&, const truncate_prefix_config&);
 };
 
+using translate_offsets = ss::bool_class<struct translate_tag>;
+
 /**
  * Log reader configuration.
  *
@@ -300,7 +302,21 @@ struct truncate_prefix_config {
  * search when the size of the filter set is small (e.g. < 5). If you need to
  * use a larger filter then this design should be revisited.
  *
- * Start and max offset are inclusive.
+ * Start and max offset are inclusive. Because the reader only looks at batch
+ * headers the first batch may start before the start offset and the last batch
+ * may end after the max offset.
+ *
+ * Consider the following case:
+ *
+ *         cfg = {start offset = 14, max offset = 17}
+ *                    +                      +
+ *                    v                      v
+ *  //-------+-------------+------------+-------------+-------//
+ *  \\...9   |   10...14   |   15..15   |  16.....22  |  23...\\
+ *  //-------+-------------+------------+-------------+-------//
+ *           ^                                        ^
+ *           |                                        |
+ * The reader will actually return whole batches: [10, 14], [15, 15], [16, 22].
  */
 struct log_reader_config {
     model::offset start_offset;

--- a/src/v/storage/types.h
+++ b/src/v/storage/types.h
@@ -226,20 +226,25 @@ using opt_abort_source_t
 
 using opt_client_address_t = std::optional<model::client_address_t>;
 
+/// A timequery configuration specifies the range of offsets to search for a
+/// record with a timestamp equal to or greater than the specified time.
 struct timequery_config {
     timequery_config(
+      model::offset min_offset,
       model::timestamp t,
-      model::offset o,
+      model::offset max_offset,
       ss::io_priority_class iop,
       std::optional<model::record_batch_type> type_filter,
       opt_abort_source_t as = std::nullopt,
       opt_client_address_t client_addr = std::nullopt) noexcept
-      : time(t)
-      , max_offset(o)
+      : min_offset(min_offset)
+      , time(t)
+      , max_offset(max_offset)
       , prio(iop)
       , type_filter(type_filter)
       , abort_source(as)
       , client_address(std::move(client_addr)) {}
+    model::offset min_offset;
     model::timestamp time;
     model::offset max_offset;
     ss::io_priority_class prio;

--- a/tests/rptest/services/cluster.py
+++ b/tests/rptest/services/cluster.py
@@ -154,7 +154,7 @@ def cluster(log_allow_list=None,
 
                 self.redpanda.validate_controller_log()
 
-                if self.redpanda.si_settings is not None:
+                if self.redpanda.si_settings is not None and not self.redpanda.si_settings.skip_end_of_test_scrubbing:
                     try:
                         self.redpanda.maybe_do_internal_scrub()
                         self.redpanda.stop_and_scrub_object_storage()

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -411,7 +411,8 @@ class SISettings:
                  retention_local_strict=True,
                  cloud_storage_max_throughput_per_shard: Optional[int] = None,
                  cloud_storage_signature_version: str = "s3v4",
-                 before_call_headers: Optional[dict[str, Any]] = None):
+                 before_call_headers: Optional[dict[str, Any]] = None,
+                 skip_end_of_test_scrubbing: bool = False):
         """
         :param fast_uploads: if true, set low upload intervals to help tests run
                              quickly when they wait for uploads to complete.
@@ -465,6 +466,12 @@ class SISettings:
         self.cloud_storage_max_throughput_per_shard = cloud_storage_max_throughput_per_shard
         self.cloud_storage_signature_version = cloud_storage_signature_version
         self.before_call_headers = before_call_headers
+
+        # Allow disabling end of test scrubbing.
+        # It takes a long time with lots of segments i.e. as created in scale
+        # tests. Should figure out how to re-enable it, or consider using
+        # redpanda's built-in scrubbing capabilities.
+        self.skip_end_of_test_scrubbing = skip_end_of_test_scrubbing
 
         if fast_uploads:
             self.cloud_storage_segment_max_upload_interval_sec = 10

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -9,7 +9,6 @@
 
 import concurrent.futures
 import re
-import time
 import threading
 from logging import Logger
 from typing import Callable
@@ -22,9 +21,8 @@ from rptest.services.metrics_check import MetricCheck
 from rptest.clients.types import TopicSpec
 from rptest.clients.rpk import RpkTool
 from rptest.clients.kafka_cat import KafkaCat
-from rptest.clients.rpk_remote import RpkRemoteTool
-from rptest.util import (wait_until, segments_count,
-                         wait_for_local_storage_truncate)
+from rptest.util import (wait_until, wait_for_local_storage_truncate,
+                         wait_until_result)
 
 from rptest.services.kgo_verifier_services import KgoVerifierProducer
 from rptest.utils.si_utils import BucketView, NTP
@@ -38,7 +36,6 @@ from ducktape.mark.resource import cluster as ducktape_cluster
 from kafkatest.version import V_3_0_0
 from ducktape.tests.test import Test
 from rptest.clients.default import DefaultClient
-from rptest.utils.mode_checks import skip_debug_mode
 
 
 class BaseTimeQuery:
@@ -517,6 +514,97 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         kcat = KafkaCat(self.redpanda)
         offset = kcat.query_offset(topic.name, 0, timestamps[0] - 1000)
         assert offset == msg_count - 1, f"Expected {msg_count - 1}, got {offset}"
+
+    @cluster(
+        num_nodes=4,
+        log_allow_list=["Failed to upload spillover manifest {timed_out}"])
+    def test_timequery_with_spillover_gc_delayed(self):
+        self.set_up_cluster(cloud_storage=True,
+                            batch_cache=False,
+                            spillover=True)
+        total_segments = 16
+        record_size = 1024
+        base_ts = 1664453149000
+        msg_count = (self.log_segment_size * total_segments) // record_size
+        local_retention = self.log_segment_size * 4
+        topic_retention = self.log_segment_size * 8
+        topic, timestamps = self._create_and_produce(self.redpanda, True,
+                                                     local_retention, base_ts,
+                                                     record_size, msg_count)
+
+        # Confirm messages written
+        rpk = RpkTool(self.redpanda)
+        p = next(rpk.describe_topic(topic.name))
+        assert p.high_watermark == msg_count
+
+        # If using cloud storage, we must wait for some segments
+        # to fall out of local storage, to ensure we are really
+        # hitting the cloud storage read path when querying.
+        wait_for_local_storage_truncate(redpanda=self.redpanda,
+                                        topic=topic.name,
+                                        target_bytes=local_retention)
+
+        # Set timeout to 0 to prevent the cloud storage housekeeping from
+        # running, triggering gc, and advancing clean offset.
+        self.redpanda.set_cluster_config(
+            {"cloud_storage_manifest_upload_timeout_ms": 0})
+        # Disable internal scrubbing as it won't be able to make progress.
+        self.redpanda.si_settings.skip_end_of_test_scrubbing = True
+
+        self.client().alter_topic_config(topic.name, 'retention.bytes',
+                                         topic_retention)
+        self.logger.info("Waiting for start offset to advance...")
+        start_offset = wait_until_result(
+            lambda: next(rpk.describe_topic(topic.name)).start_offset > 0,
+            timeout_sec=120,
+            backoff_sec=5,
+            err_msg="Start offset did not advance")
+
+        start_offset = next(rpk.describe_topic(topic.name)).start_offset
+
+        # Query below valid timestamps the offset of the first message.
+        kcat = KafkaCat(self.redpanda)
+
+        test_cases = [
+            (timestamps[0] - 1000, start_offset, "before start of log"),
+            (timestamps[0], start_offset,
+             "first message but out of retention now"),
+            (timestamps[start_offset - 1], start_offset,
+             "before new HWM, out of retention"),
+            (timestamps[start_offset], start_offset, "new HWM"),
+            (timestamps[start_offset + 10], start_offset + 10,
+             "few messages after new HWM"),
+            (timestamps[msg_count - 1] + 1000, -1, "after last message"),
+        ]
+
+        # Basic time query cases.
+        for ts, expected_offset, desc in test_cases:
+            self.logger.info(f"Querying ts={ts} ({desc})")
+            offset = kcat.query_offset(topic.name, 0, ts)
+            self.logger.info(f"Time query returned offset {offset}")
+            assert offset == expected_offset, f"Expected {expected_offset}, got {offset}"
+
+        # Now check every single one of them to make sure there are no
+        # off-by-one errors, iterators aren't getting stuck on segment and
+        # spillover boundaries, etc. The segment boundaries are not exact
+        # due to internal messages, segment roll logic, etc. but the tolerance
+        # should cover that.
+        boundary_ranges = []
+        for i in range(1, total_segments):
+            boundary_ranges.append(
+                (int(i * self.log_segment_size / record_size - 100),
+                 int(i * self.log_segment_size / record_size + 100)))
+
+        for r in boundary_ranges:
+            self.logger.debug(f"Checking range {r}")
+            for o in range(int(r[0]), int(r[1])):
+                ts = timestamps[o]
+                self.logger.debug(f"  Querying ts={ts}")
+                offset = kcat.query_offset(topic.name, 0, ts)
+                if o < start_offset:
+                    assert offset == start_offset, f"Expected {start_offset}, got {offset}"
+                else:
+                    assert offset == o, f"Expected {o}, got {offset}"
 
 
 class TimeQueryKafkaTest(Test, BaseTimeQuery):

--- a/tests/rptest/util.py
+++ b/tests/rptest/util.py
@@ -371,7 +371,8 @@ class firewall_blocked:
         """Isolate certain ips from the nodes using firewall rules"""
         cmd = [
             f"iptables -A INPUT -p tcp --{self.mode_for_input} {self._port} -j DROP",
-            f"iptables -A OUTPUT -p tcp --dport {self._port} -j DROP"
+            f"iptables -A OUTPUT -p tcp --dport {self._port} -j DROP",
+            f"ss -K dport {self._port}",
         ]
         cmd = " && ".join(cmd)
         for node in self._nodes:


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/18097
Backport of https://github.com/redpanda-data/redpanda/pull/18112

Closes https://github.com/redpanda-data/redpanda/issues/18282
Closes https://github.com/redpanda-data/redpanda/issues/18566

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Bug Fixes
* Fix a scenario where list_offset with a timestamp could return a lower offset than partition start after a trim-prefix command. This could lead to consumers being stuck with an out-of-range-offset exception if they began consuming from an offset below the one which was used in the trim-prefix command.
* Fix an edge case where a timequery returns no results if it races with tiered storage retention and garbage collection. This is important at least for consumers that fall behind retention. They interpret such response as the partition is empty and jump to the HWM instead of resuming consuming from the first available message.
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
