### PR TITLE
deps: change name of regel package on RPM distros

### DIFF
--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -91,7 +91,7 @@ fedora_deps=(
   python3
   python3-jinja2
   python3-jsonschema
-  ragel-devel
+  ragel
   re2-devel
   rust
   snappy-devel


### PR DESCRIPTION
Minor tweak to make dependencies work on fedora 40.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
