### PR TITLE
cst/ducktape: Add query failure log to allow list

### DIFF
--- a/tests/rptest/tests/e2e_shadow_indexing_test.py
+++ b/tests/rptest/tests/e2e_shadow_indexing_test.py
@@ -1126,11 +1126,13 @@ class ShadowIndexingWhileBusyTest(PreallocNodesTest):
         # Topic creation happens here
         super().setUp()
 
-    @cluster(num_nodes=8,
-             log_allow_list=[
-                 r"failed to hydrate chunk.*Connection reset by peer",
-                 r"failed to hydrate chunk.*NotFound"
-             ])
+    @cluster(
+        num_nodes=8,
+        log_allow_list=[
+            r"failed to hydrate chunk.*Connection reset by peer",
+            r"failed to hydrate chunk.*NotFound",
+            r"Failed to query spillover manifests: cloud_storage::error_outcome:10",
+        ])
     @matrix(short_retention=[False, True],
             cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode


### PR DESCRIPTION
cst/ducktape: Add query failure log to allow list

When querying for spillover manifests, it is possible that the segment being queried for has been truncated from the cloud storage, usually due to retention setting a start offset that is ahead of all segments in manifest.

This error is added to the allow list for the test.

FIXES https://github.com/redpanda-data/redpanda/issues/18116
FIXES https://github.com/redpanda-data/redpanda/issues/17513
FIXES https://github.com/redpanda-data/redpanda/issues/11735

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
