### PR TITLE
rpk: small fixes.

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/login.go
+++ b/src/go/rpk/pkg/cli/cloud/login.go
@@ -156,7 +156,7 @@ rpk will talk to a localhost:9092 cluster until you swap to a different profile.
 			}
 
 			if p.Name == common.ContainerProfileName {
-				fmt.Printf("You are talking to a localhost 'rpk container' cluster (rpk profile name: %q)", p.Name)
+				fmt.Printf("You are talking to a localhost 'rpk container' cluster (rpk profile name: %q)\n", p.Name)
 			} else {
 				fmt.Printf("You are talking to a self hosted cluster (rpk profile name: %q)\n", p.Name)
 			}

--- a/src/go/rpk/pkg/cli/profile/create.go
+++ b/src/go/rpk/pkg/cli/profile/create.go
@@ -198,7 +198,7 @@ func CreateFlow(
 		var err error
 		o, err = createCloudProfile(ctx, yAuthVir, cfg, fromCloud)
 		if err != nil {
-			if err == ErrNoCloudClusters {
+			if errors.Is(err, ErrNoCloudClusters) {
 				fmt.Println("Your cloud account has no clusters available to select, avoiding creating a cloud profile.")
 				return nil
 			}

--- a/src/go/rpk/pkg/cli/topic/consume.go
+++ b/src/go/rpk/pkg/cli/topic/consume.go
@@ -89,13 +89,15 @@ func newConsumeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			out.MaybeDie(err, "unable to initialize admin kafka client: %v", err)
 
 			// We fail if the topic does not exist.
-			listed, err := adm.ListTopics(cmd.Context(), topics...)
-			out.MaybeDie(err, "unable to check topic existence: %v", err)
-			listed.EachError(func(d kadm.TopicDetail) {
-				if errors.Is(d.Err, kerr.UnknownTopicOrPartition) {
-					out.Die("unable to consume topic %q: %v", d.Topic, d.Err.Error())
-				}
-			})
+			if !c.regex {
+				listed, err := adm.ListTopics(cmd.Context(), topics...)
+				out.MaybeDie(err, "unable to check topic existence: %v", err)
+				listed.EachError(func(d kadm.TopicDetail) {
+					if errors.Is(d.Err, kerr.UnknownTopicOrPartition) {
+						out.Die("unable to consume topic %q: %v", d.Topic, d.Err.Error())
+					}
+				})
+			}
 
 			err = c.parseOffset(offset, topics, adm)
 			out.MaybeDie(err, "invalid --offset %q: %v", offset, err)

--- a/src/go/rpk/pkg/cli/transform/deploy.go
+++ b/src/go/rpk/pkg/cli/transform/deploy.go
@@ -37,7 +37,7 @@ func newDeployCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	var file string
 
 	cmd := &cobra.Command{
-		Use:   "deploy [WASM]",
+		Use:   "deploy",
 		Short: "Deploy a transform",
 		Long: `Deploy a transform.
 


### PR DESCRIPTION
This PR addresses a couple of small fixes:

- Missing new line for `rpk cloud login` when you attempted to log in and had an `rpk-container` profile.
- Change the error checking for empty organizations in the login flow
- Removes unnecessary `[WASM]` input help text in `rpk transform deploy`
- Fixes a regression in the `--regex` flag in `rpk topic consume`

Fixes #18602 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.1.x
- [X] v23.3.x
- [ ] v23.2.x

## Release Notes
### Bug Fixes

* rpk: fixes an error in `rpk topic consume` that prevented the usage of the `--regex` flag.

