### PR TITLE
schema_registry: Make mode_mutability: true by default

### DIFF
--- a/src/v/pandaproxy/schema_registry/configuration.cc
+++ b/src/v/pandaproxy/schema_registry/configuration.cc
@@ -32,7 +32,7 @@ configuration::configuration()
       {},
       {},
       config::endpoint_tls_config::validate_many)
-  , mode_mutability(*this, "mode_mutability", "Allow modifying mode", {}, false)
+  , mode_mutability(*this, "mode_mutability", "Allow modifying mode", {}, true)
   , schema_registry_replication_factor(
       *this,
       "schema_registry_replication_factor",


### PR DESCRIPTION
schema_registry: Make mode_mutability: true by default

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
