### PR TITLE
config: break dependency on cloud_storage_clients

### DIFF
--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -423,7 +423,7 @@ ss::future<configuration> configuration::get_s3_config() {
         access_key,
         secret_key,
         region,
-        url_style,
+        cloud_storage_clients::from_config(url_style),
         get_default_overrides(),
         disable_metrics,
         disable_public_metrics);

--- a/src/v/cloud_storage_clients/tests/CMakeLists.txt
+++ b/src/v/cloud_storage_clients/tests/CMakeLists.txt
@@ -26,3 +26,11 @@ rp_test(
   LABELS s3
 )
 
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gtest_cloud_storage_clients
+  SOURCES types_test.cc
+  LIBRARIES v::gtest_main v::config v::cloud_storage_clients
+  LABELS utils
+)

--- a/src/v/cloud_storage_clients/tests/types_test.cc
+++ b/src/v/cloud_storage_clients/tests/types_test.cc
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "cloud_storage_clients/types.h"
+#include "config/types.h"
+#include "test_utils/test.h"
+
+TEST(FromConfig, S3UrlStyle) {
+    ASSERT_EQ(cloud_storage_clients::from_config(std::nullopt), std::nullopt);
+
+    ASSERT_EQ(
+      cloud_storage_clients::from_config(config::s3_url_style::path),
+      cloud_storage_clients::s3_url_style::path);
+
+    ASSERT_EQ(
+      cloud_storage_clients::from_config(config::s3_url_style::virtual_host),
+      cloud_storage_clients::s3_url_style::virtual_host);
+}

--- a/src/v/cloud_storage_clients/types.h
+++ b/src/v/cloud_storage_clients/types.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "config/types.h"
 #include "utils/named_type.h"
 
 #include <seastar/core/sstring.hh>
@@ -72,6 +73,19 @@ inline std::ostream& operator<<(std::ostream& os, const s3_url_style& us) {
     case s3_url_style::path:
         return os << "path";
     }
+}
+
+inline std::optional<s3_url_style>
+from_config(std::optional<config::s3_url_style> us) {
+    if (us.has_value()) {
+        switch (us.value()) {
+        case config::s3_url_style::virtual_host:
+            return s3_url_style::virtual_host;
+        case config::s3_url_style::path:
+            return s3_url_style::path;
+        }
+    }
+    return std::nullopt;
 }
 
 } // namespace cloud_storage_clients

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1699,9 +1699,7 @@ configuration::configuration()
        .example = "virtual_host",
        .visibility = visibility::user},
       std::nullopt,
-      {cloud_storage_clients::s3_url_style::virtual_host,
-       cloud_storage_clients::s3_url_style::path,
-       std::nullopt})
+      {s3_url_style::virtual_host, s3_url_style::path, std::nullopt})
   , cloud_storage_credentials_source(
       *this,
       "cloud_storage_credentials_source",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "cloud_storage_clients/types.h"
 #include "config/bounded_property.h"
 #include "config/broker_endpoint.h"
 #include "config/client_group_byte_rate_quota.h"
@@ -22,6 +21,7 @@
 #include "config/property.h"
 #include "config/throughput_control_group.h"
 #include "config/tls_config.h"
+#include "config/types.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -309,8 +309,7 @@ struct configuration final : public config_store {
     property<std::optional<ss::sstring>> cloud_storage_region;
     property<std::optional<ss::sstring>> cloud_storage_bucket;
     property<std::optional<ss::sstring>> cloud_storage_api_endpoint;
-    enum_property<std::optional<cloud_storage_clients::s3_url_style>>
-      cloud_storage_url_style;
+    enum_property<std::optional<s3_url_style>> cloud_storage_url_style;
     enum_property<model::cloud_credentials_source>
       cloud_storage_credentials_source;
     property<std::optional<ss::sstring>>

--- a/src/v/config/convert.h
+++ b/src/v/config/convert.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include "cloud_storage_clients/types.h"
+#include "config/types.h"
 #include "model/compression.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -226,8 +226,8 @@ struct convert<model::timestamp_type> {
 };
 
 template<>
-struct convert<cloud_storage_clients::s3_url_style> {
-    using type = cloud_storage_clients::s3_url_style;
+struct convert<config::s3_url_style> {
+    using type = config::s3_url_style;
     static Node encode(const type& rhs) {
         Node node;
         return node = fmt::format("{}", rhs);

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -11,7 +11,6 @@
 
 #pragma once
 #include "base/oncore.h"
-#include "cloud_storage_clients/types.h"
 #include "config/base_property.h"
 #include "config/rjson_serialization.h"
 #include "container/intrusive_list_helpers.h"
@@ -629,9 +628,7 @@ consteval std::string_view property_type_name() {
     } else if constexpr (std::
                            is_same_v<type, model::cloud_credentials_source>) {
         return "string";
-    } else if constexpr (std::is_same_v<
-                           type,
-                           cloud_storage_clients::s3_url_style>) {
+    } else if constexpr (std::is_same_v<type, s3_url_style>) {
         return "string";
     } else if constexpr (std::is_same_v<type, model::cloud_storage_backend>) {
         return "string";

--- a/src/v/config/rjson_serialization.cc
+++ b/src/v/config/rjson_serialization.cc
@@ -139,8 +139,7 @@ void rjson_serialize(
 }
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
-  const cloud_storage_clients::s3_url_style& v) {
+  json::Writer<json::StringBuffer>& w, const config::s3_url_style& v) {
     stringize(w, v);
 }
 

--- a/src/v/config/rjson_serialization.h
+++ b/src/v/config/rjson_serialization.h
@@ -63,8 +63,7 @@ void rjson_serialize(
   json::Writer<json::StringBuffer>& w, const model::cleanup_policy_bitflags& v);
 
 void rjson_serialize(
-  json::Writer<json::StringBuffer>& w,
-  const cloud_storage_clients::s3_url_style& v);
+  json::Writer<json::StringBuffer>& w, const config::s3_url_style& v);
 
 void rjson_serialize(
   json::Writer<json::StringBuffer>& w,

--- a/src/v/config/types.h
+++ b/src/v/config/types.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include <ostream>
+
+/*
+ * Because `config::` is used across every part of Redpanda, it's easy to create
+ * accidental circular dependencies by including sub-system specific types in
+ * the configuration.
+ *
+ * This file is expected to contain dependency-free types that mirror sub-system
+ * specific types. It is then expected that each sub-system convert as needed.
+ *
+ * Example:
+ *
+ *    config/types.h
+ *    ==============
+ *
+ *      - defines config::s3_url_style enumeration and uses this in a
+ *      configuration option.
+ *
+ *    cloud_storage_clients/types.h
+ *    =============================
+ *
+ *      - defines its own type T, such as a s3_url_style enumeration, or
+ *        whatever representation it wants to use that is independent from
+ *        the config type.
+ *
+ *      - defines a `T from_config(config::s3_url_style)` conversion type used
+ *      to convert from the configuration option type to the sub-system type.
+ */
+namespace config {
+
+enum class s3_url_style { virtual_host = 0, path };
+
+inline std::ostream& operator<<(std::ostream& os, const s3_url_style& us) {
+    switch (us) {
+    case s3_url_style::virtual_host:
+        return os << "virtual_host";
+    case s3_url_style::path:
+        return os << "path";
+    }
+}
+
+} // namespace config

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -29,6 +29,7 @@
 #include "config/broker_authn_endpoint.h"
 #include "config/mock_property.h"
 #include "config/node_config.h"
+#include "config/types.h"
 #include "kafka/client/transport.h"
 #include "kafka/protocol/fetch.h"
 #include "kafka/protocol/schemata/fetch_request.h"
@@ -374,7 +375,14 @@ public:
                 config.get("cloud_storage_api_endpoint")
                   .set_value(std::make_optional(s3_config->server_addr.host()));
                 config.get("cloud_storage_url_style")
-                  .set_value(std::make_optional(s3_config->url_style));
+                  .set_value(std::make_optional([&] {
+                      switch (s3_config->url_style) {
+                      case cloud_storage_clients::s3_url_style::virtual_host:
+                          return config::s3_url_style::virtual_host;
+                      case cloud_storage_clients::s3_url_style::path:
+                          return config::s3_url_style::path;
+                      }
+                  }()));
                 config.get("cloud_storage_api_endpoint_port")
                   .set_value(
                     static_cast<int16_t>(s3_config->server_addr.port()));

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -371,8 +371,6 @@ public:
                   .set_value(std::make_optional((*s3_config->access_key)()));
                 config.get("cloud_storage_secret_key")
                   .set_value(std::make_optional((*s3_config->secret_key)()));
-                config.get("cloud_storage_url_style")
-                  .set_value(std::make_optional((s3_config->url_style)));
                 config.get("cloud_storage_api_endpoint")
                   .set_value(std::make_optional(s3_config->server_addr.host()));
                 config.get("cloud_storage_url_style")


### PR DESCRIPTION
Defines a new config::s3_url_style type and converts between this type and the cloud_storage_clients sub-system specific type.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

