### PR TITLE
rpk: add error for unknown command execution

### DIFF
--- a/src/go/rpk/pkg/cli/cloud/auth/create.go
+++ b/src/go/rpk/pkg/cli/cloud/auth/create.go
@@ -21,6 +21,7 @@ func newCreateCommand(_ afero.Fs, _ *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:    "create [NAME]",
 		Short:  "Create an rpk cloud auth",
+		Args:   cobra.ExactArgs(1),
 		Hidden: true,
 		Run: func(*cobra.Command, []string) {
 			fmt.Println("'rpk cloud auth create' is deprecated as a no-op; use 'rpk cloud login' instead.")

--- a/src/go/rpk/pkg/cli/cloud/auth/rename.go
+++ b/src/go/rpk/pkg/cli/cloud/auth/rename.go
@@ -22,6 +22,7 @@ func newRenameToCommand(_ afero.Fs, _ *config.Params) *cobra.Command {
 		Use:     "rename-to [NAME]",
 		Short:   "Rename the current rpk auth",
 		Aliases: []string{"rename"},
+		Args:    cobra.ExactArgs(1),
 		Hidden:  true,
 		Run: func(*cobra.Command, []string) {
 			fmt.Println("rename-to is deprecated, rpk now fully manages auth names.")

--- a/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
+++ b/src/go/rpk/pkg/cli/cloud/byoc/byoc.go
@@ -123,6 +123,7 @@ func NewCommand(fs afero.Fs, p *config.Params, execFn func(string, []string) err
 	cmd := &cobra.Command{
 		Use:   "byoc",
 		Short: "Manage a Redpanda cloud BYOC agent",
+		Args:  cobra.MinimumNArgs(0), // This allows us to run "unknown" commands that live in the plugin.
 		Long: `Manage a Redpanda cloud BYOC agent
 
 For BYOC, Redpanda installs an agent service in your owned cluster. The agent

--- a/src/go/rpk/pkg/cli/cluster/config/export.go
+++ b/src/go/rpk/pkg/cli/cluster/config/export.go
@@ -142,6 +142,7 @@ command.
 By default, low level tunables are excluded: use the '--all' flag
 to include all properties including these low level tunables.
 `,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/cluster/config/import.go
+++ b/src/go/rpk/pkg/cli/cluster/config/import.go
@@ -299,6 +299,7 @@ corresponding 'export' command.  This downloads the current cluster
 configuration, calculates the difference with the YAML file, and
 updates any properties that were changed.  If a property is removed
 from the YAML file, it is reset to its default value.  `,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/cluster/config/lint.go
+++ b/src/go/rpk/pkg/cli/cluster/config/lint.go
@@ -51,6 +51,7 @@ Deprecated content includes properties which were set via redpanda.yaml
 in earlier versions of redpanda, but are now managed via Redpanda's
 central configuration store (and via 'rpk cluster config edit').
 `,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, propertyNames []string) {
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/cluster/config/status.go
+++ b/src/go/rpk/pkg/cli/cluster/config/status.go
@@ -31,7 +31,8 @@ Additionally show the version of cluster configuration that each node
 has applied: under normal circumstances these should all be equal,
 a lower number shows that a node is out of sync, perhaps because it
 is offline.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)

--- a/src/go/rpk/pkg/cli/cluster/partitions/unsafe_recover.go
+++ b/src/go/rpk/pkg/cli/cluster/partitions/unsafe_recover.go
@@ -38,6 +38,7 @@ nodes are gone and irrecoverable; this may result in data loss.
 You can perform a dry run and verify the partitions that will be recovered by 
 using the '--dry' flag.
 `,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			f := p.Formatter
 			if f.Kind != "text" && f.Kind != "help" && !dry {

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/start.go
@@ -35,7 +35,8 @@ func newStartCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 This command starts the process of restoring topics from the archival bucket.
 If the wait flag (--wait/-w) is set, the command will poll the status of the
 recovery process until it's finished.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)

--- a/src/go/rpk/pkg/cli/cluster/storage/recovery/status.go
+++ b/src/go/rpk/pkg/cli/cluster/storage/recovery/status.go
@@ -27,7 +27,8 @@ func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		
 This command fetches the status of the process of restoring topics from the 
 archival bucket.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			config.CheckExitCloudAdmin(p)

--- a/src/go/rpk/pkg/cli/cluster/txn/describe.go
+++ b/src/go/rpk/pkg/cli/cluster/txn/describe.go
@@ -57,7 +57,6 @@ format with print partitions included.
 
 If no transactional IDs are requested, all transactional IDs are printed.
 `,
-
 		Run: func(cmd *cobra.Command, txnIDs []string) {
 			f := p.Formatter
 			if h, ok := f.Help([]describeResponse{}); ok {

--- a/src/go/rpk/pkg/cli/cluster/txn/describe_producers.go
+++ b/src/go/rpk/pkg/cli/cluster/txn/describe_producers.go
@@ -64,8 +64,8 @@ You can query all topics and partitions that have active producers with --all.
 To filter for specific topics, use --topics. You can additionally filter by
 partitions with --partitions.
 `,
-
-		Run: func(cmd *cobra.Command, txnIDs []string) {
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			f := p.Formatter
 			if h, ok := f.Help([]describeProducersResponse{}); ok {
 				out.Exit(h)

--- a/src/go/rpk/pkg/cli/container/purge.go
+++ b/src/go/rpk/pkg/cli/container/purge.go
@@ -30,6 +30,7 @@ func newPurgeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "purge",
 		Short: "Stop and remove an existing local container cluster's data",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			c, err := common.NewDockerClient(cmd.Context())
 			out.MaybeDie(err, "unable to create docker client: %v", err)

--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -127,6 +127,7 @@ Start a 3-broker cluster, selecting every admin API port:
 			// (POSIX standard)
 			UnknownFlags: true,
 		},
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			if nodes < 1 {
 				out.Die("--nodes should be 1 or greater")

--- a/src/go/rpk/pkg/cli/container/status.go
+++ b/src/go/rpk/pkg/cli/container/status.go
@@ -21,6 +21,7 @@ func newStatusCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "status",
 		Short: "Get status",
+		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			c, err := common.NewDockerClient(cmd.Context())
 			out.MaybeDieErr(err)

--- a/src/go/rpk/pkg/cli/container/stop.go
+++ b/src/go/rpk/pkg/cli/container/stop.go
@@ -23,6 +23,7 @@ func newStopCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop an existing local container cluster",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			c, err := common.NewDockerClient(cmd.Context())
 			if err != nil {

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -76,7 +76,8 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "bundle",
 		Short: "Collect environment data and create a bundle file for the Redpanda Data support team to inspect",
 		Long:  bundleHelpText,
-		Run: func(cmd *cobra.Command, args []string) {
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			//  Redpanda queries for samples from Seastar every ~13 seconds by
 			//  default. Setting wait_ms to anything less than 13 seconds will
 			//  result in no samples being returned.

--- a/src/go/rpk/pkg/cli/generate/app.go
+++ b/src/go/rpk/pkg/cli/generate/app.go
@@ -86,7 +86,8 @@ func newAppCmd(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "app",
 		Short: "Generate a sample application to connect with Redpanda",
 		Long:  appHelpText,
-		Run: func(cmd *cobra.Command, args []string) {
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			p, err := p.LoadVirtualProfile(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 

--- a/src/go/rpk/pkg/cli/generate/grafana.go
+++ b/src/go/rpk/pkg/cli/generate/grafana.go
@@ -125,7 +125,8 @@ metrics endpoint used.
 
 To see a list of all available dashboards, use the '--dashboard help' flag.
 `,
-		Run: func(cmd *cobra.Command, args []string) {
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			switch {
 			case dashboard == "legacy":
 				if datasource == "" {

--- a/src/go/rpk/pkg/cli/generate/prometheus.go
+++ b/src/go/rpk/pkg/cli/generate/prometheus.go
@@ -73,7 +73,8 @@ func newPrometheusConfigCmd(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:   "prometheus-config",
 		Short: "Generate the Prometheus configuration to scrape Redpanda nodes",
 		Long:  prometheusHelpText,
-		Run: func(cmd *cobra.Command, args []string) {
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			y, err := p.LoadVirtualRedpandaYaml(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 

--- a/src/go/rpk/pkg/cli/iotune/iotune.go
+++ b/src/go/rpk/pkg/cli/iotune/iotune.go
@@ -34,7 +34,8 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "iotune",
 		Short: "Measure filesystem performance and create IO configuration file",
-		Run: func(cmd *cobra.Command, args []string) {
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, _ []string) {
 			timeout += duration
 			y, err := p.LoadVirtualRedpandaYaml(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)

--- a/src/go/rpk/pkg/cli/redpanda/check.go
+++ b/src/go/rpk/pkg/cli/redpanda/check.go
@@ -29,7 +29,8 @@ func NewCheckCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Check if system meets redpanda requirements",
-		Run: func(_ *cobra.Command, args []string) {
+		Args:  cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
 			y, err := p.LoadVirtualRedpandaYaml(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 			err = executeCheck(fs, y, timeout)

--- a/src/go/rpk/pkg/cli/redpanda/stop.go
+++ b/src/go/rpk/pkg/cli/redpanda/stop.go
@@ -36,7 +36,8 @@ func NewStopCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 first sends SIGINT, and waits for the specified timeout. Then, if redpanda
 hasn't stopped, it sends SIGTERM. Lastly, it sends SIGKILL if it's still
 running.`,
-		Run: func(_ *cobra.Command, args []string) {
+		Args: cobra.NoArgs,
+		Run: func(_ *cobra.Command, _ []string) {
 			y, err := p.LoadVirtualRedpandaYaml(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
 

--- a/src/go/rpk/pkg/cli/root.go
+++ b/src/go/rpk/pkg/cli/root.go
@@ -165,6 +165,15 @@ func Execute() {
 		}
 	})
 
+	// Cobra does not return an 'unknown command' error unless cobra.NoArgs is
+	// specified.
+	// See: https://github.com/spf13/cobra/issues/706
+	cobraext.Walk(root, func(c *cobra.Command) {
+		if c.Args == nil && c.HasSubCommands() {
+			c.Args = cobra.NoArgs
+		}
+	})
+
 	cobra.AddTemplateFunc("wrappedLocalFlagUsages", wrappedLocalFlagUsages)
 	cobra.AddTemplateFunc("wrappedGlobalFlagUsages", wrappedGlobalFlagUsages)
 	root.SetUsageTemplate(usageTemplate)

--- a/src/go/rpk/pkg/cli/security/role/describe.go
+++ b/src/go/rpk/pkg/cli/security/role/describe.go
@@ -63,6 +63,7 @@ Print only the members of role 'red'
 Print only the ACL associated to the role 'red'
   rpk security role describe red --print-permissions
 `,
+		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			f := p.Formatter
 			if h, ok := f.Help(describeResponse{}); ok {

--- a/src/go/rpk/pkg/cli/security/user/list.go
+++ b/src/go/rpk/pkg/cli/security/user/list.go
@@ -22,6 +22,7 @@ func newListUsersCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List SASL users",
+		Args:    cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			f := p.Formatter
 			if h, ok := f.Help([]string{}); ok {

--- a/src/go/rpk/pkg/cli/version/version.go
+++ b/src/go/rpk/pkg/cli/version/version.go
@@ -59,6 +59,7 @@ version running on each node in your cluster.
 
 To list the Redpanda version of each node in your cluster you may pass the
 Admin API hosts via flags, profile, or environment variables.`,
+		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, _ []string) {
 			rv := rpkVersion{
 				Version:   version,


### PR DESCRIPTION
Cobra won't recognize unknown commands unless
cobra.NoArg is set as an Arg validation parameter
in the command definition.

This means that running 'rpk cluster unknowncommand'
won't return an 'unknown command' error, therefore,
exit as a successful command execution.

See: https://github.com/spf13/cobra/issues/706

Now, cobra will return an 'unknown error' and exit
with code 1.


Fixes #18627 

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* rpk now will exit (1) when running rpk with unknown commands
