### PR TITLE
[CORE-2069]:  Changes to support using S3 FIPS Endpoints 

### DIFF
--- a/src/v/archival/tests/archival_metadata_stm_gtest.cc
+++ b/src/v/archival/tests/archival_metadata_stm_gtest.cc
@@ -31,14 +31,14 @@ using segment_meta = cloud_storage::partition_manifest::segment_meta;
 namespace {
 ss::logger fixture_logger{"archival_stm_fixture"};
 
-constexpr const char* httpd_host_name = "127.0.0.1";
+constexpr const char* httpd_host_name = "localhost";
 constexpr uint16_t httpd_port_number = 4442;
 
 cloud_storage_clients::s3_configuration get_configuration() {
     net::unresolved_address server_addr(httpd_host_name, httpd_port_number);
     cloud_storage_clients::s3_configuration conf;
     conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);
-    conf.access_key = cloud_roles::public_key_str("acess-key");
+    conf.access_key = cloud_roles::public_key_str("access-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
     conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -182,7 +182,7 @@ archiver_fixture::get_configurations() {
       ss::sstring(httpd_host_name), httpd_port_number());
     cloud_storage_clients::s3_configuration s3conf;
     s3conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);
-    s3conf.access_key = cloud_roles::public_key_str("acess-key");
+    s3conf.access_key = cloud_roles::public_key_str("access-key");
     s3conf.secret_key = cloud_roles::private_key_str("secret-key");
     s3conf.region = cloud_roles::aws_region_name("us-east-1");
     s3conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;

--- a/src/v/cloud_storage/tests/anomalies_detector_test.cc
+++ b/src/v/cloud_storage/tests/anomalies_detector_test.cc
@@ -223,7 +223,7 @@ ss::sstring iobuf_to_string(iobuf buf) {
 
 class bucket_view_fixture : http_imposter_fixture {
 public:
-    static constexpr auto host_name = "127.0.0.1";
+    static constexpr auto host_name = "localhost";
     static constexpr auto port = 4447;
 
     bucket_view_fixture()
@@ -471,7 +471,7 @@ private:
 
         cloud_storage_clients::s3_configuration conf;
         conf.uri = cloud_storage_clients::access_point_uri(host_name);
-        conf.access_key = cloud_roles::public_key_str("acess-key");
+        conf.access_key = cloud_roles::public_key_str("access-key");
         conf.secret_key = cloud_roles::private_key_str("secret-key");
         conf.region = cloud_roles::aws_region_name("us-east-1");
         conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -393,7 +393,7 @@ s3_imposter_fixture::s3_imposter_fixture(
   , conf(get_configuration()) {
     _server = ss::make_shared<ss::httpd::http_server_control>();
     _server->start().get();
-    ss::ipv4_addr ip_addr = {httpd_host_name, httpd_port_number()};
+    ss::ipv4_addr ip_addr = {httpd_ip_addr, httpd_port_number()};
     _server_addr = ss::socket_address(ip_addr);
 }
 

--- a/src/v/cloud_storage/tests/s3_imposter.h
+++ b/src/v/cloud_storage/tests/s3_imposter.h
@@ -49,7 +49,8 @@ class s3_imposter_fixture {
 public:
     static constexpr size_t default_max_keys = 100;
     uint16_t httpd_port_number();
-    static constexpr const char* httpd_host_name = "127.0.0.1";
+    static constexpr const char* httpd_host_name = "localhost";
+    static constexpr const char* httpd_ip_addr = "127.0.0.1";
 
     s3_imposter_fixture(
       cloud_storage_clients::s3_url_style url_style = default_url_style);

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -13,6 +13,7 @@
 #include "base/vlog.h"
 #include "cloud_storage/configuration.h"
 #include "cloud_storage/logger.h"
+#include "config/node_config.h"
 
 #include <absl/container/node_hash_set.h>
 
@@ -424,6 +425,7 @@ ss::future<configuration> configuration::get_s3_config() {
         secret_key,
         region,
         cloud_storage_clients::from_config(url_style),
+        config::node().fips_mode.value(),
         get_default_overrides(),
         disable_metrics,
         disable_public_metrics);

--- a/src/v/cloud_storage/types.cc
+++ b/src/v/cloud_storage/types.cc
@@ -418,12 +418,15 @@ ss::future<configuration> configuration::get_s3_config() {
       config::shard_local_cfg().disable_metrics());
     auto disable_public_metrics = net::public_metrics_disabled(
       config::shard_local_cfg().disable_public_metrics());
+    auto bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
+      config::shard_local_cfg().cloud_storage_bucket, "cloud_storage_bucket"));
 
     auto s3_conf
       = co_await cloud_storage_clients::s3_configuration::make_configuration(
         access_key,
         secret_key,
         region,
+        bucket_name,
         cloud_storage_clients::from_config(url_style),
         config::node().fips_mode.value(),
         get_default_overrides(),
@@ -436,9 +439,7 @@ ss::future<configuration> configuration::get_s3_config() {
         config::shard_local_cfg().cloud_storage_max_connections.value()),
       .metrics_disabled = remote_metrics_disabled(
         static_cast<bool>(disable_metrics)),
-      .bucket_name = cloud_storage_clients::bucket_name(get_value_or_throw(
-        config::shard_local_cfg().cloud_storage_bucket,
-        "cloud_storage_bucket")),
+      .bucket_name = bucket_name,
       .cloud_credentials_source = cloud_credentials_source,
     };
 

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -363,6 +363,7 @@ model::cloud_storage_backend infer_backend_from_configuration(
       = string_switch<model::cloud_storage_backend>(uri())
           .match_expr("google", model::cloud_storage_backend::google_s3_compat)
           .match_expr(R"(127\.0\.0\.1)", model::cloud_storage_backend::aws)
+          .match_expr("localhost", model::cloud_storage_backend::aws)
           .match_expr("minio", model::cloud_storage_backend::minio)
           .match_expr("amazon", model::cloud_storage_backend::aws)
           .default_match(model::cloud_storage_backend::unknown);

--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -74,6 +74,7 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
   const std::optional<cloud_roles::public_key_str>& pkey,
   const std::optional<cloud_roles::private_key_str>& skey,
   const cloud_roles::aws_region_name& region,
+  const bucket_name& bucket,
   std::optional<cloud_storage_clients::s3_url_style> url_style,
   bool node_is_in_fips_mode,
   const default_overrides& overrides,
@@ -104,27 +105,38 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
         }
     }
 
-    const auto endpoint_uri = [&]() -> ss::sstring {
-        if (overrides.endpoint) {
-            return overrides.endpoint.value();
-        }
-        return ssx::sformat("s3.{}.amazonaws.com", region());
-    }();
-    client_cfg.tls_sni_hostname = endpoint_uri;
+    const auto base_endpoint_uri = overrides.endpoint.value_or(
+      endpoint_url{ssx::sformat("s3.{}.amazonaws.com", region())});
+
+    // if url_style is virtual_host, the complete url for s3 is
+    // [bucket].[s3hostname]. s3client will form the complete_endpoint
+    // independently, to allow for self_configuration.
+    const auto complete_endpoint_uri
+      = url_style == s3_url_style::virtual_host
+          ? ssx::sformat("{}.{}", bucket(), base_endpoint_uri())
+          : base_endpoint_uri();
+
+    client_cfg.tls_sni_hostname = complete_endpoint_uri;
 
     // Setup credentials for TLS
     client_cfg.access_key = pkey;
     client_cfg.secret_key = skey;
     client_cfg.region = region;
-    client_cfg.uri = access_point_uri(endpoint_uri);
+    // defer host creation to client, after it has performed self_configure to
+    // discover if the backend is in `virtual_host` or `path mode`
+    client_cfg.uri = access_point_uri(base_endpoint_uri);
 
     if (overrides.disable_tls == false) {
         client_cfg.credentials = co_await build_tls_credentials(
           "s3", overrides.trust_file, s3_log);
     }
 
+    // When using virtual host addressing, the client must connect to
+    // the s3 endpoint with the bucket name, e.g.
+    // <bucket>.s3.<region>.amazonaws.com.  This is especially required
+    // for S3 FIPS endpoints: <bucket>.s3-fips.<region>.amazonaws.com
     client_cfg.server_addr = net::unresolved_address(
-      client_cfg.uri(),
+      complete_endpoint_uri,
       overrides.port ? *overrides.port : default_port,
       ss::net::inet_address::family::INET);
     client_cfg.disable_metrics = disable_metrics;
@@ -133,7 +145,7 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
       disable_metrics,
       disable_public_metrics,
       region,
-      endpoint_url{endpoint_uri});
+      endpoint_url{complete_endpoint_uri});
     client_cfg.max_idle_time = overrides.max_idle_time
                                  ? *overrides.max_idle_time
                                  : default_max_idle_time;

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -67,7 +67,8 @@ struct s3_configuration : common_configuration {
       const std::optional<cloud_roles::public_key_str>& pkey,
       const std::optional<cloud_roles::private_key_str>& skey,
       const cloud_roles::aws_region_name& region,
-      const std::optional<cloud_storage_clients::s3_url_style>& url_style,
+      std::optional<cloud_storage_clients::s3_url_style> url_style,
+      bool node_is_in_fips_mode,
       const default_overrides& overrides = {},
       net::metrics_disabled disable_metrics = net::metrics_disabled::yes,
       net::public_metrics_disabled disable_public_metrics

--- a/src/v/cloud_storage_clients/configuration.h
+++ b/src/v/cloud_storage_clients/configuration.h
@@ -30,7 +30,7 @@ struct default_overrides {
     bool disable_tls = false;
 };
 
-/// Configuration options common accross cloud storage clients
+/// Configuration options common across cloud storage clients
 struct common_configuration : net::base_transport::configuration {
     /// URI of the access point
     access_point_uri uri;
@@ -52,13 +52,15 @@ struct s3_configuration : common_configuration {
     /// AWS URL style, either virtual-hosted-style or path-style.
     s3_url_style url_style = s3_url_style::virtual_host;
 
-    /// \brief opinionated configuraiton initialization
+    /// \brief opinionated configuration initialization
     /// Generates uri field from region, initializes credentials for the
     /// transport, resolves the uri to get the server_addr.
     ///
     /// \param pkey is an AWS access key
     /// \param skey is an AWS secret key
     /// \param region is an AWS region code
+    /// \param bucket is an AWS bucket name. it's needed to form the endpoints
+    /// in fips mode
     /// \param overrides contains a bunch of property overrides like
     ///        non-standard SSL port and alternative location of the
     ///        truststore
@@ -67,6 +69,7 @@ struct s3_configuration : common_configuration {
       const std::optional<cloud_roles::public_key_str>& pkey,
       const std::optional<cloud_roles::private_key_str>& skey,
       const cloud_roles::aws_region_name& region,
+      const bucket_name& bucket,
       std::optional<cloud_storage_clients::s3_url_style> url_style,
       bool node_is_in_fips_mode,
       const default_overrides& overrides = {},

--- a/src/v/cloud_storage_clients/s3_client.cc
+++ b/src/v/cloud_storage_clients/s3_client.cc
@@ -18,6 +18,7 @@
 #include "cloud_storage_clients/util.h"
 #include "cloud_storage_clients/xml_sax_parser.h"
 #include "config/configuration.h"
+#include "config/node_config.h"
 #include "hashing/secure.h"
 #include "http/client.h"
 #include "net/types.h"
@@ -597,6 +598,13 @@ s3_client::self_configure() {
         // Virtual-host style request succeeded.
         co_return result;
     }
+
+    // fips mode can only work in virtual_host mode, so if the above test failed
+    // the TS service is likely misconfigured
+    vassert(
+      !config::node().fips_mode.value(),
+      "fips_mode requires the bucket to configured in virtual_host mode, but "
+      "the connectivity test failed");
 
     // Test path style.
     _requestor._ap_style = s3_url_style::path;

--- a/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
+++ b/src/v/cloud_storage_clients/test_client/s3_test_client_main.cc
@@ -162,12 +162,16 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
         }
     }();
 
+    auto bucket_name = cloud_storage_clients::bucket_name(
+      m["bucket"].as<std::string>());
     cloud_storage_clients::s3_configuration client_cfg
       = cloud_storage_clients::s3_configuration::make_configuration(
           access_key,
           secret_key,
           region,
+          bucket_name,
           url_style,
+          false,
           cloud_storage_clients::default_overrides{
             .endpoint =
               [&]() -> std::optional<cloud_storage_clients::endpoint_url> {
@@ -188,8 +192,7 @@ test_conf cfg_from(boost::program_options::variables_map& m) {
           .get0();
     vlog(test_log.info, "connecting to {}", client_cfg.server_addr);
     return test_conf{
-      .bucket = cloud_storage_clients::bucket_name(
-        m["bucket"].as<std::string>()),
+      .bucket = bucket_name,
       .objects =
         [&] {
             auto keys = m["object"].as<std::vector<std::string>>();

--- a/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_mt_test.cc
@@ -35,13 +35,13 @@ using namespace std::chrono_literals;
 
 ss::logger test_log("test-log");
 static const uint16_t httpd_port_number = 4434;
-static constexpr const char* httpd_host_name = "127.0.0.1";
+static constexpr const char* httpd_host_name = "localhost";
 
 static cloud_storage_clients::s3_configuration transport_configuration() {
     net::unresolved_address server_addr(httpd_host_name, httpd_port_number);
     cloud_storage_clients::s3_configuration conf;
     conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);
-    conf.access_key = cloud_roles::public_key_str("acess-key");
+    conf.access_key = cloud_roles::public_key_str("access-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
     conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;

--- a/src/v/cloud_storage_clients/tests/client_pool_test.cc
+++ b/src/v/cloud_storage_clients/tests/client_pool_test.cc
@@ -29,13 +29,13 @@ using namespace std::chrono_literals;
 
 ss::logger test_log("test-log");
 static const uint16_t httpd_port_number = 4434;
-static constexpr const char* httpd_host_name = "127.0.0.1";
+static constexpr const char* httpd_host_name = "localhost";
 
 static cloud_storage_clients::s3_configuration transport_configuration() {
     net::unresolved_address server_addr(httpd_host_name, httpd_port_number);
     cloud_storage_clients::s3_configuration conf;
     conf.uri = cloud_storage_clients::access_point_uri(httpd_host_name);
-    conf.access_key = cloud_roles::public_key_str("acess-key");
+    conf.access_key = cloud_roles::public_key_str("access-key");
     conf.secret_key = cloud_roles::private_key_str("secret-key");
     conf.region = cloud_roles::aws_region_name("us-east-1");
     conf.url_style = cloud_storage_clients::s3_url_style::virtual_host;

--- a/src/v/cloud_storage_clients/tests/s3_client_test.cc
+++ b/src/v/cloud_storage_clients/tests/s3_client_test.cc
@@ -52,7 +52,7 @@
 using namespace std::chrono_literals;
 
 static const uint16_t httpd_port_number = 4434;
-static constexpr const char* httpd_host_name = "127.0.0.1";
+static constexpr const char* httpd_host_name = "localhost";
 static constexpr const char* expected_payload
   = "Amazon Simple Storage Service (Amazon S3) is storage for the internet. "
     "You can use Amazon S3 to store and retrieve any amount of data at any "

--- a/src/v/http/include/http/tests/http_imposter.h
+++ b/src/v/http/include/http/tests/http_imposter.h
@@ -20,7 +20,8 @@
 
 class http_imposter_fixture {
 public:
-    static constexpr std::string_view httpd_host_name = "127.0.0.1";
+    static constexpr std::string_view httpd_host_name = "localhost";
+    static constexpr std::string_view httpd_host_ip = "127.0.0.1";
 
     uint16_t httpd_port_number();
 

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -21,7 +21,7 @@ static ss::logger http_imposter_log("http_imposter"); // NOLINT
 
 http_imposter_fixture::http_imposter_fixture(uint16_t port)
   : _port(port)
-  , _server_addr{ss::ipv4_addr{httpd_host_name.data(), httpd_port_number()}}
+  , _server_addr{ss::ipv4_addr{httpd_host_ip.data(), httpd_port_number()}}
   , _address{
       {httpd_host_name.data(), httpd_host_name.size()}, httpd_port_number()} {
     _id = fmt::format("{}", uuid_t::create());

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -281,9 +281,9 @@ public:
     static cloud_storage_clients::s3_configuration get_s3_config(
       std::optional<uint16_t> port = std::nullopt,
       cloud_storage_clients::s3_url_style url_style = default_url_style) {
-        net::unresolved_address server_addr("127.0.0.1", port.value_or(4430));
+        net::unresolved_address server_addr("localhost", port.value_or(4430));
         cloud_storage_clients::s3_configuration s3conf;
-        s3conf.uri = cloud_storage_clients::access_point_uri("127.0.0.1");
+        s3conf.uri = cloud_storage_clients::access_point_uri("localhost");
         s3conf.access_key = cloud_roles::public_key_str("access-key");
         s3conf.secret_key = cloud_roles::private_key_str("secret-key");
         s3conf.region = cloud_roles::aws_region_name("us-east-1");

--- a/tests/docker/dns/Dockerfile
+++ b/tests/docker/dns/Dockerfile
@@ -1,0 +1,9 @@
+FROM public.ecr.aws/docker/library/ubuntu:jammy-20230816 as base
+
+RUN apt update && \
+    apt install -y dnsmasq && \
+    rm -rf /var/lib/apt/lists/*
+
+EXPOSE 53/udp
+
+ENTRYPOINT ["dnsmasq", "-k", "-q"]

--- a/tests/docker/dns/dnsmasq.conf
+++ b/tests/docker/dns/dnsmasq.conf
@@ -3,3 +3,6 @@ log-queries
 #use cloudflare as default nameservers
 server=1.1.1.1
 server=1.0.0.1
+
+#point *.minio-s3 to its static address
+address=/minio-s3/192.168.215.125

--- a/tests/docker/dns/dnsmasq.conf
+++ b/tests/docker/dns/dnsmasq.conf
@@ -1,0 +1,5 @@
+#log all dns queries
+log-queries
+#use cloudflare as default nameservers
+server=1.1.1.1
+server=1.0.0.1

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -4,8 +4,21 @@ networks:
   redpanda-test:
     name: redpanda-test
     driver: bridge
+    ipam:
+      config:
+        - subnet: 192.168.215.0/24
 
 services:
+  dns:
+    restart: always
+    build: ./dns
+    volumes:
+      - ./dns/dnsmasq.conf:/etc/dnsmasq.conf
+    cap_add:
+      - NET_ADMIN
+    networks:
+      redpanda-test:
+        ipv4_address: 192.168.215.126
   minio:
     command: server /data
     container_name: minio-s3
@@ -28,7 +41,8 @@ services:
       timeout: 20s
     image: minio/minio:RELEASE.2023-01-25T00-19-54Z
     networks:
-    - redpanda-test
+      redpanda-test:
+        ipv4_address: 192.168.215.125
   azurite:
     container_name: azurite
     restart: always
@@ -54,3 +68,5 @@ services:
     - '${BUILD_ROOT}/redpanda_installs:/opt/redpanda_installs'
     networks:
     - redpanda-test
+    dns:
+      - 192.168.215.126

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -251,6 +251,13 @@ def one_or_many(value):
         return value
 
 
+def get_cloud_provider() -> str:
+    """
+    Returns the cloud provider in use.  If one is not set then return 'docker'
+    """
+    return os.getenv("CLOUD_PROVIDER", "docker")
+
+
 def get_cloud_storage_type(applies_only_on: list[CloudStorageType]
                            | None = None,
                            docker_use_arbitrary=False):
@@ -275,7 +282,7 @@ def get_cloud_storage_type(applies_only_on: list[CloudStorageType]
     if applies_only_on is None:
         applies_only_on = []
 
-    cloud_provider = os.getenv("CLOUD_PROVIDER", "docker")
+    cloud_provider = get_cloud_provider()
     if cloud_provider == "docker":
         if docker_use_arbitrary:
             cloud_storage_type = [CloudStorageType.S3]

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -29,7 +29,7 @@ import zipfile
 import pathlib
 import shlex
 from enum import Enum, IntEnum
-from typing import Callable, List, Generator, Mapping, Optional, Protocol, Set, Tuple, Any, Type, cast
+from typing import Callable, List, Generator, Literal, Mapping, Optional, Protocol, Set, Tuple, Any, Type, cast
 
 import yaml
 from ducktape.services.service import Service
@@ -222,7 +222,8 @@ class CloudStorageType(IntEnum):
     ABS = 2
 
 
-CloudStorageTypeAndUrlStyle = Tuple[CloudStorageType, str]
+CloudStorageTypeAndUrlStyle = Tuple[CloudStorageType, Literal['virtual_host',
+                                                              'path']]
 
 
 def prepare_allow_list(allow_list):
@@ -293,8 +294,10 @@ def get_cloud_storage_type(applies_only_on: list[CloudStorageType]
     return cloud_storage_type
 
 
-def get_cloud_storage_url_style(cloud_storage_type: CloudStorageType
-                                | None = None) -> str:
+def get_cloud_storage_url_style(
+    cloud_storage_type: CloudStorageType
+    | None = None
+) -> list[Literal['virtual_host', 'path']]:
     if cloud_storage_type is None:
         return ['virtual_host', 'path']
 

--- a/tests/rptest/tests/archival_test.py
+++ b/tests/rptest/tests/archival_test.py
@@ -15,7 +15,7 @@ import traceback
 from collections import namedtuple, defaultdict
 from typing import DefaultDict, List
 
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ok_to_fail_fips
 
 from rptest.clients.kafka_cat import KafkaCat
 from rptest.clients.kafka_cli_tools import KafkaCliTools
@@ -233,6 +233,8 @@ class ArchivalTest(RedpandaTest):
     @matrix(
         cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(
         ))
+    # fips on S3 is not compatible with path-style urls. TODO remove this once get_cloud_storage_type_and_url_style is fips aware
+    @ok_to_fail_fips
     def test_write(
             self,
             cloud_storage_type_and_url_style: List[CloudStorageTypeAndUrlStyle]

--- a/tests/rptest/tests/control_character_flag_test.py
+++ b/tests/rptest/tests/control_character_flag_test.py
@@ -9,7 +9,7 @@
 import time
 
 import requests.exceptions
-from ducktape.mark import parametrize
+from ducktape.mark import parametrize, ok_to_fail_fips
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
 from rptest.services.cluster import cluster
@@ -138,6 +138,8 @@ class ControlCharacterNag(ControlCharacterPermittedBase):
     @parametrize(initial_version=(22, 2, 9))
     @parametrize(initial_version=(22, 3, 11))
     @parametrize(initial_version=(23, 1, 1))
+    # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
+    @ok_to_fail_fips
     def test_validate_nag_message(self, initial_version):
         """
         Validates that the nag message is present after upgrading a cluster

--- a/tests/rptest/tests/partition_movement_test.py
+++ b/tests/rptest/tests/partition_movement_test.py
@@ -15,7 +15,7 @@ import requests
 from rptest.services.cluster import cluster
 from ducktape.utils.util import wait_until
 from rptest.clients.kafka_cat import KafkaCat
-from ducktape.mark import ignore, matrix
+from ducktape.mark import ignore, matrix, ok_to_fail_fips
 
 from rptest.utils.mode_checks import skip_debug_mode
 from rptest.clients.types import TopicSpec
@@ -956,6 +956,8 @@ class SIPartitionMovementTest(PartitionMovementMixin, EndToEndTest):
     @cluster(num_nodes=5, log_allow_list=PREV_VERSION_LOG_ALLOW_LIST)
     @matrix(num_to_upgrade=[0, 2], cloud_storage_type=get_cloud_storage_type())
     @skip_debug_mode  # rolling restarts require more reliable recovery that a slow debug mode cluster can provide
+    # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
+    @ok_to_fail_fips
     def test_shadow_indexing(self, num_to_upgrade, cloud_storage_type):
         """
         Test interaction between the shadow indexing and the partition movement.

--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -14,7 +14,7 @@ from rptest.clients.rpk import RpkTool
 from rptest.services.admin import Admin
 from rptest.tests.prealloc_nodes import PreallocNodesTest
 
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ok_to_fail_fips
 from ducktape.utils.util import wait_until
 from rptest.services.admin_ops_fuzzer import AdminOperationsFuzzer
 from rptest.services.cluster import cluster
@@ -272,6 +272,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
     @matrix(enable_failures=[True, False],
             num_to_upgrade=[0, 3],
             with_tiered_storage=[True, False])
+    # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
+    @ok_to_fail_fips
     def test_node_operations(self, enable_failures, num_to_upgrade,
                              with_tiered_storage):
         # In order to reduce the number of parameters and at the same time cover

--- a/tests/rptest/tests/read_replica_e2e_test.py
+++ b/tests/rptest/tests/read_replica_e2e_test.py
@@ -16,7 +16,7 @@ from rptest.clients.rpk import RpkTool, RpkException
 from rptest.clients.types import TopicSpec
 from rptest.util import expect_exception
 
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ok_to_fail_fips
 from ducktape.tests.test import TestContext
 
 from rptest.services.redpanda import CloudStorageType, CloudStorageTypeAndUrlStyle, MetricsEndpoint, RedpandaService, get_cloud_storage_type, get_cloud_storage_url_style, get_cloud_storage_type_and_url_style, make_redpanda_service
@@ -412,6 +412,8 @@ class TestReadReplicaService(EndToEndTest):
         partition_count=[10],
         cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(
         ))
+    # fips on S3 is not compatible with path-style urls. TODO remove this once get_cloud_storage_type_and_url_style is fips aware
+    @ok_to_fail_fips
     def test_simple_end_to_end(
         self, partition_count: int,
         cloud_storage_type_and_url_style: List[CloudStorageTypeAndUrlStyle]
@@ -486,6 +488,8 @@ class ReadReplicasUpgradeTest(EndToEndTest):
     @cluster(num_nodes=8)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))
+    # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
+    @ok_to_fail_fips
     def test_upgrades(self, cloud_storage_type):
         partition_count = 1
         install_opts = InstallOptions(install_previous_version=True)

--- a/tests/rptest/tests/tiered_storage_model_test.py
+++ b/tests/rptest/tests/tiered_storage_model_test.py
@@ -16,7 +16,7 @@ from threading import Condition
 from collections import defaultdict
 from typing import List
 
-from ducktape.mark import matrix
+from ducktape.mark import matrix, ok_to_fail_fips
 from ducktape.tests.test import TestContext
 from ducktape.utils.util import wait_until
 
@@ -551,6 +551,8 @@ class TieredStorageTest(TieredStorageEndToEndTest, RedpandaTest):
         cloud_storage_type_and_url_style=get_cloud_storage_type_and_url_style(
         ),
         test_case=get_tiered_storage_test_cases(fast_run=True))
+    # fips on S3 is not compatible with path-style urls. TODO remove this once get_cloud_storage_type_and_url_style is fips aware
+    @ok_to_fail_fips
     def test_tiered_storage(self, cloud_storage_type_and_url_style: List[
         CloudStorageTypeAndUrlStyle], test_case: TestCase):
         """This is a main entry point of the test.

--- a/tests/rptest/tests/upgrade_test.py
+++ b/tests/rptest/tests/upgrade_test.py
@@ -12,7 +12,7 @@ import time
 from collections import defaultdict
 from packaging.version import Version
 
-from ducktape.mark import parametrize, matrix, ok_to_fail
+from ducktape.mark import parametrize, matrix, ok_to_fail_fips
 from ducktape.utils.util import wait_until
 from rptest.services.admin import Admin
 from rptest.clients.rpk import RpkTool
@@ -384,6 +384,8 @@ class UpgradeFromPriorFeatureVersionCloudStorageTest(RedpandaTest):
     @cluster(num_nodes=4, log_allow_list=RESTART_LOG_ALLOW_LIST)
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))
+    # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
+    @ok_to_fail_fips
     def test_rolling_upgrade(self, cloud_storage_type):
         """
         Verify that when tiered storage writes happen during a rolling upgrade,

--- a/tests/rptest/tests/workload_upgrade_runner_test.py
+++ b/tests/rptest/tests/workload_upgrade_runner_test.py
@@ -23,7 +23,7 @@ from rptest.tests.redpanda_test import RedpandaTest
 from rptest.tests.workload_license import LicenseWorkload
 from rptest.tests.workload_upgrade_config_defaults import SetLogSegmentMsMinConfig
 from rptest.utils.mode_checks import skip_debug_mode
-from ducktape.mark import matrix, ok_to_fail
+from ducktape.mark import matrix, ok_to_fail_fips
 
 
 def expand_version(
@@ -256,6 +256,8 @@ class RedpandaUpgradeTest(PreallocNodesTest):
     # of Redpanda that support Azure Hierarchical Namespaces.
     @matrix(cloud_storage_type=get_cloud_storage_type(
         applies_only_on=[CloudStorageType.S3]))
+    # before v24.2, dns query to s3 endpoint do not include the bucketname, which is required for AWS S3 fips endpoints
+    @ok_to_fail_fips
     def test_workloads_through_releases(self, cloud_storage_type):
         # this callback will be called between each upgrade, in a mixed version state
         def mid_upgrade_check(raw_versions: dict[Any, RedpandaVersion]):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Changes to testing and cloud storage infrastructure in order to be able to point Redpanda at [FIPS compliant S3 endpoints in AWS](https://aws.amazon.com/compliance/fips/) (go to "Amazon Simple Storage Service (S3)" row on the table in the linked page).

Changes in redpanda:
When constructing s3_config
- `url_style=virtual_host`, server_addr will be set to `[bucket].[endpoint_url]`. Before, it was `[endpoint_url]`. This is a requirement for fips mode
- `url_style=path`, `fips_mode=true`, and `client=s3` are incompatible for now and will stop the process. This is because the current implementation of fips mode is meant to work with AWS, and that requires virtual host URLs
- `url_style=nullopt` (self configure) and `fips_mode=true` will force `url_style=virtual`, and at startup s3_client will validate that it can use virtual host style urls

Changes in fixture tests:
- in tests using cloud storage, `127.0.0.1` is replaced with `localhost`. this is to support resolving `test_bucket.localhost` to `127.0.0.1`. Trying to resolve `test_bucket.127.0.0.1` would hang until timeout
- `server_addr = *.localhost` will infer `cloud_storage_backend::aws`, like it's done for `127.0.0.1`

Changes in dockerized ducktape:
- to support resolving `test_bucket.minio-s3`, `docker-compose.yaml` has a new DNS service (provided by `dnsmasq`) with the only rule `*.minio-s3 -> minio-s3`. This is accomplished with a combination of static IPs that need to be available on the machine running the compose cluster.
- `redpanda.py` and `s3_client.py` gains support for explicitly using fips mode and virtual_host urls. Note that in a docker environment, s3_client can only use Path-style urls, until a relevant change is implemented in vtools

Changes in CDT:
- ok_to_fail_fips on upgrade tests + tiered storage. before v24.2 redpanda does not include the bucket name in the DNS query, making it incompatible with s3 fips endpoints
- ok_to_fail_fips on TS tests that try to set url_style=path. only virtual_host is supported with s3 fips endpoints

Fixes [CORE-2069](https://redpandadata.atlassian.net/browse/CORE-2069)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* None


[CORE-2069]: https://redpandadata.atlassian.net/browse/CORE-2069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ