### PR TITLE
[v24.1.x] ignore benthos local repo dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,7 @@ vbuild/
 
 /.vtools.yml
 /vtools
+/benthos
 /Taskfile.yml
 /.dockerignore
 /.task/


### PR DESCRIPTION
This is part of the "rpk connect" / "benthos" integration effort.  Benthos aka `rpk connect` plugin will be built and bundled with Redpanda.  During build workflows, we will checkout benthos code and build it.  We will follow a similar pattern to vtools, where the cloned vtools repo is saved as redpanda/vtools.

Therefore `benthos/` also needs to be .gitignore'd, just like `vtools/`.  Otherwise goreleaser may complain that the local git repo is dirty and fail rpk build.

Companion vtools PR [here](https://github.com/redpanda-data/vtools/pull/2787) (private).

## Forward-ports required

TBD: needed if we decide to persist with the "bundle plugin with redpanda" model for `rpk connect`.  This one is trivial to port (unlike the [vtools change](https://github.com/redpanda-data/vtools/pull/2787)).

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x


## Release Notes

* none