### PR TITLE
r/recovery_stm: log taking on demand snapshot at info level

### DIFF
--- a/src/v/raft/recovery_stm.cc
+++ b/src/v/raft/recovery_stm.cc
@@ -20,6 +20,7 @@
 #include "raft/raftgen_service.h"
 #include "ssx/sformat.h"
 #include "storage/snapshot.h"
+#include "utils/human.h"
 
 #include <seastar/core/condition-variable.hh>
 #include <seastar/core/coroutine.hh>
@@ -454,9 +455,14 @@ ss::future<> recovery_stm::install_snapshot(required_snapshot_type s_type) {
 ss::future<>
 recovery_stm::take_on_demand_snapshot(model::offset last_included_offset) {
     vlog(
-      _ctxlog.debug,
-      "creating on demand snapshot with last included offset: {}",
-      last_included_offset);
+      _ctxlog.info,
+      "creating on demand snapshot with last included offset: {}, current "
+      "leader start offset: {}. Total partition size on leader {}, expected to "
+      "transfer to learner: {}",
+      last_included_offset,
+      _ptr->start_offset(),
+      human::bytes(_ptr->log()->size_bytes()),
+      human::bytes(_ptr->log()->size_bytes_after_offset(last_included_offset)));
 
     _inflight_snapshot_last_included_index = last_included_offset;
     // if there is no stm_manager available for the raft group use empty


### PR DESCRIPTION
When on demand snapshot is taken it may be helpful to check the difference between configured learner start offset and current leader start offset.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- made fast partition movements easier to debug.