### PR TITLE
[v24.1.x] CDT- remove /var/lib/redpanda/.cache before proceeding to clean regular entries

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3580,6 +3580,14 @@ class RedpandaService(RedpandaServiceBase):
                                   clean_shutdown=False,
                                   allow_fail=True)
         if node.account.exists(RedpandaService.PERSISTENT_ROOT):
+            hidden_cache_folder = f'{RedpandaService.PERSISTENT_ROOT}/.cache'
+            self.logger.debug(
+                f"Checking for presence of {hidden_cache_folder}")
+            if node.account.exists(hidden_cache_folder):
+                self.logger.debug(
+                    f"Seeing {hidden_cache_folder}, removing that specifically first"
+                )
+                node.account.remove(hidden_cache_folder)
             if node.account.sftp_client.listdir(
                     RedpandaService.PERSISTENT_ROOT):
                 if not preserve_logs:


### PR DESCRIPTION
CDT fails during RC testing.  Suspicion is that `/var/lib/redpanda/.cache` exists.  It causes us to want to do `rm -r /var/lib/redpanda/*`, but the glob does not expand to hidden name like `.cache`.  rm explodes.  Not clear why this is happening now, but not before.

About 1400 failures during RC1 CDT:

https://buildkite.com/redpanda/redpanda/builds/49610#018fc0ea-2aab-4846-a112-67c1676793f3

```
[DEBUG - 2024-05-29 00:11:51,468 - remoteaccount - _log - lineno:183]: root@ip-172-31-9-170: Running ssh command: rm -r /var/lib/redpanda/*
[ERROR - 2024-05-29 00:11:51,515 - redpanda - clean_one - lineno:2488]: Error cleaning node ip-172-31-9-170:
Traceback (most recent call last):
  File "/home/ubuntu/redpanda/tests/rptest/services/redpanda.py", line 2483, in clean_one
    self.clean_node(node, preserve_current_install=True)
  File "/home/ubuntu/redpanda/tests/rptest/services/redpanda.py", line 3586, in clean_node
    node.account.remove(f"{RedpandaService.PERSISTENT_ROOT}/*")
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/cluster/remoteaccount.py", line 643, in remove
    self.ssh(cmd, allow_fail=allow_fail)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/cluster/remoteaccount.py", line 41, in wrapper
    return method(self, *args, **kwargs)
  File "/opt/.ducktape-venv/lib/python3.10/site-packages/ducktape/cluster/remoteaccount.py", line 300, in ssh
    raise RemoteCommandError(self, cmd, exit_status, stderr.read())
```

It would be good to be able to try this out for 24.1.4 release (as RC1 CDT shows about 1400 failures right now with the "rm" error.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
