### PR TITLE
[CORE-2503] Fix for CI failure: `ControlCharacterPermittedAfterUpgrade.test_upgrade_from_pre_v23_2`

### DIFF
--- a/tests/rptest/tests/control_character_flag_test.py
+++ b/tests/rptest/tests/control_character_flag_test.py
@@ -45,12 +45,11 @@ class ControlCharacterPermittedBase(RedpandaTest):
         assert config.keys().isdisjoint(
             {self.feature_legacy_permit_control_char})
 
-    def _perform_update(self, initial_version, version):
-        for v in self.load_version_range(initial_version):
-            self._installer.install(self.redpanda.nodes, v)
-            self.redpanda.restart_nodes(self.redpanda.nodes)
-            unique_versions = wait_for_num_versions(self.redpanda, 1)
-            assert ver_string(initial_version) not in unique_versions
+    def _perform_update(self, initial_version):
+        versions = self.load_version_range(initial_version)[1:]
+        for version in self.upgrade_through_versions(versions,
+                                                     already_running=True):
+            self.logger.info(f"Updated to {version}")
 
         config = self._admin.get_cluster_config()
         assert config.keys() > {self.feature_legacy_permit_control_char}
@@ -84,7 +83,7 @@ class ControlCharacterPermittedAfterUpgrade(ControlCharacterPermittedBase):
         # Creates a user with invalid control characters
 
         self._admin.create_user("my\nuser", "password", "SCRAM-SHA-256")
-        self._perform_update(initial_version, RedpandaInstaller.HEAD)
+        self._perform_update(initial_version)
         # Should still be able to create a user
         self._admin.create_user("my\notheruser", "password", "SCRAM-SHA-256")
         self._admin.patch_cluster_config(
@@ -147,7 +146,7 @@ class ControlCharacterNag(ControlCharacterPermittedBase):
         # Nag shouldn't be in logs
         assert not self._has_flag_nag()
 
-        self._perform_update(initial_version, RedpandaInstaller.HEAD)
+        self._perform_update(initial_version)
 
         assert self._has_flag_nag()
 


### PR DESCRIPTION
- This upgrade test failed because the iterative upgrade through rp version loop wasn't waiting until the cluster active version had changed, between each install and upgrade of a new version.

- It therefore isn't enough to wait until all binaries report the desired version, but for the cluster logical version to also have been bumped.

- The solution is to use the already existing method `upgrade_through_versions` which properly waits between installs of the next redpanda version before starting another install and restart.

Fixes: https://redpandadata.atlassian.net/browse/CORE-2503
Fixes: https://redpandadata.atlassian.net/browse/CORE-2631

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
