### PR TITLE
[v23.3.x] http: Fix double call to stop() in http::client

### DIFF
--- a/src/v/http/client.cc
+++ b/src/v/http/client.cc
@@ -172,6 +172,13 @@ ss::future<reconnect_result_t> client::get_connected(
 }
 
 ss::future<> client::stop() {
+    if (_stopped) {
+        // Prevent double call to stop() as constructs such as with_client()
+        // will unconditionally call stop(), while exception handlers in this
+        // file may also call stop()
+        co_return;
+    }
+    _stopped = true;
     co_await _connect_gate.close();
     // Can safely stop base_transport
     co_return co_await base_transport::stop();

--- a/src/v/http/client.h
+++ b/src/v/http/client.h
@@ -227,6 +227,7 @@ private:
     /// Throw exception if _as is aborted
     void check() const;
 
+    bool _stopped{false};
     ss::gate _connect_gate;
     const ss::abort_source* _as;
     ss::shared_ptr<http::client_probe> _probe;


### PR DESCRIPTION
Backport of https://github.com/redpanda-data/redpanda/pull/18304

- http::client::stop() can be called twice in the event the client is used via the `with_client` method.

- The method had unconditionally called stop() in a finally clause with the intention to have users not have to manually do this and forget to call stop.

- However stop() can also be called within certain exception handlers within methods invoked by http::client, ones that handle tls::verification_error exceptions.

- This patch adds a boolean to our http client so that stop() can early exit if it has already been called.

Fixes: https://redpandadata.atlassian.net/browse/CORE-2932

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fixes a bug where crashes within the redpanda http client could occur when encountering tls exceptions 
