### PR TITLE
[CORE-2845]: Ensure create_acls requests return an error when resources as topics are non valid kafka topic names 

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -410,22 +410,22 @@ class RpkTool:
         return self._run(cmd)
 
     def sasl_allow_principal(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args, **kwargs, deny=False)
+        return self._sasl_set_principal_access(*args, **kwargs, deny=False)
 
     def sasl_deny_principal(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args, **kwargs, deny=True)
+        return self._sasl_set_principal_access(*args, **kwargs, deny=True)
 
     def sasl_allow_role(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args,
-                                        **kwargs,
-                                        deny=False,
-                                        ptype="role")
+        return self._sasl_set_principal_access(*args,
+                                               **kwargs,
+                                               deny=False,
+                                               ptype="role")
 
     def sasl_deny_role(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args,
-                                        **kwargs,
-                                        deny=True,
-                                        ptype="role")
+        return self._sasl_set_principal_access(*args,
+                                               **kwargs,
+                                               deny=True,
+                                               ptype="role")
 
     def allow_principal(self, principal, operations, resource, resource_name):
         if resource == "topic":


### PR DESCRIPTION
Within create_acls requests, requests to create acls for resources that are topics would succeed even when the resource name was not a valid kafka topic name. This patch adds validation that makes the request fail with the appropriate error code. 

Fixes: https://redpandadata.atlassian.net/browse/CORE-2845

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

### Bug Fixes

* Fixes a bug that would allow requests to complete that created acls for topics with invalid kafka topic names

