### PR TITLE
[rpk connect] add /benthos to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,6 +246,7 @@ vbuild/
 
 /.vtools.yml
 /vtools
+/benthos
 /Taskfile.yml
 /.dockerignore
 /.task/


### PR DESCRIPTION
This is a forward port of https://github.com/redpanda-data/redpanda/pull/18663, which is needed for vtools build pipelines to function without complaints from goreleaser that the repo is dirty.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none