### PR TITLE
[rpk connect / CDT] CDT - remove /var/lib/redpanda/.cache before proceeding to clean regular entries

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -3723,6 +3723,14 @@ class RedpandaService(RedpandaServiceBase):
                                   clean_shutdown=False,
                                   allow_fail=True)
         if node.account.exists(RedpandaService.PERSISTENT_ROOT):
+            hidden_cache_folder = f'{RedpandaService.PERSISTENT_ROOT}/.cache'
+            self.logger.debug(
+                f"Checking for presence of {hidden_cache_folder}")
+            if node.account.exists(hidden_cache_folder):
+                self.logger.debug(
+                    f"Seeing {hidden_cache_folder}, removing that specifically first"
+                )
+                node.account.remove(hidden_cache_folder)
             if node.account.sftp_client.listdir(
                     RedpandaService.PERSISTENT_ROOT):
                 if not preserve_logs:


### PR DESCRIPTION
`rpk connect` implementation as a preinstalled plugin `.rpk.ac-connect` was shipped as part of `v24.1.2`.  In this setup, when `rpk` is invoked (say with `--help-autocomplete`, or `start`), `$HOME/.cache/snowflake/oscp_response_cache.json` is written.

This trips up CDT node cleanup (because `.cache` is a hidden file, exposing a gap in the logic for "only `rm *` if there is something there)".  I.e.
* `sftp_client.listdir()` sees the hidden entry
* But `rm -r *` does not... CDT blows up.

This PR allows CDT to handle `.cache` gracefully.  This is a forward port of https://github.com/redpanda-data/redpanda/pull/18687

It is currently considered acceptable (ala v24.1.4) to have this `.cache` exist for now - work may be prioritized on connect / rpk side to improve this logic (like not create the cache if no snowflake work is being done!) at some point.  cc @Jeffail @twmb 

While work is planned to implement `rpk connect` more tightly (to `rpk`), the default trajectory for now is that the preinstall method will continue for next minor release (`24.2`).

This PR just covers us until either of the above work item gets completed.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none