### PR TITLE
rpk: add client quotas support to rpk

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/cluster.go
+++ b/src/go/rpk/pkg/cli/cluster/cluster.go
@@ -14,6 +14,7 @@ import (
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/license"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/maintenance"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/partitions"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/quotas"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/selftest"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/storage"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/cluster/txn"
@@ -47,6 +48,7 @@ func NewCommand(fs afero.Fs, p *pkgconfig.Params) *cobra.Command {
 		selftest.NewSelfTestCommand(fs, p),
 		storage.NewCommand(fs, p),
 		txn.NewCommand(fs, p),
+		quotas.NewCommand(fs, p),
 		offsets,
 	)
 

--- a/src/go/rpk/pkg/cli/cluster/quotas/alter.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/alter.go
@@ -1,0 +1,194 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package quotas
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"go.uber.org/zap"
+)
+
+type createResponse struct {
+	Entity []entityData `json:"entity" yaml:"entity"`
+	Status string       `json:"status" yaml:"status"`
+
+	entityStr string
+}
+
+func alterCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		dry      bool
+		names    []string
+		defaults []string
+		adds     []string
+		deletes  []string
+	)
+	cmd := &cobra.Command{
+		Use:   "alter",
+		Args:  cobra.NoArgs,
+		Short: "Add or delete a client quota",
+		Long: `Add or delete a client quota
+
+This command allows you to add or delete a client quota.
+
+A client quota consists of an entity (to whom the quota is applied) and a quota 
+type (what is being applied).
+
+There are two entity types supported by Redpanda: client ID and client ID 
+prefix.
+
+Assigning quotas to default entity types is possible using the '--default' flag.
+
+You can perform a dry run using the '--dry' flag.
+`,
+		Example: `
+Add quota (consumer_byte_rate) to client ID 'foo':
+  rpk cluster quotas alter --add consumer_byte_rate=200000 \
+    --name client-id=foo
+
+Add quota (consumer_byte_rate) to client ID starting with 'bar-':
+  rpk cluster quotas alter --add consumer_byte_rate=200000 \
+    --name client-id-prefix=bar-
+
+Add quota (producer_byte_rate) to default client ID:
+  rpk cluster quotas alter --add producer_byte_rate=180000 \
+    --default client-id=foo
+
+Remove quota (producer_byte_rate) from client ID 'foo':
+  rpk cluster quotas alter --delete producer_byte_rate \
+    --name client-id=foo
+`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			f := p.Formatter
+			if h, ok := f.Help(createResponse{}); ok {
+				out.Exit(h)
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			var (
+				entity  []kadm.ClientQuotaEntityComponent
+				nameMap = make(map[string]bool)
+			)
+			for _, name := range names {
+				split := strings.SplitN(name, "=", 2)
+				if len(split) != 2 {
+					out.Die("name %q missing value", split[0])
+				}
+				k, v := split[0], split[1]
+				k = strings.ToLower(k)
+				if !validTypes[k] {
+					out.Die("name type %q is invalid (allowed: client-id, client-id-prefix)", split[0])
+				}
+				nameMap[k] = true
+				entity = append(entity, kadm.ClientQuotaEntityComponent{
+					Type: k,
+					Name: &v,
+				})
+			}
+			for _, def := range defaults {
+				if !validTypes[def] {
+					out.Die("default type %q is invalid (allowed: client-id, client-id-prefix)", def)
+				}
+				if nameMap[def] {
+					out.Die("default type %q was previously defined in --name, you can only set it once", def)
+				}
+				entity = append(entity, kadm.ClientQuotaEntityComponent{
+					Type: def,
+				})
+			}
+
+			var operations []kadm.AlterClientQuotaOp
+			for _, add := range adds {
+				split := strings.SplitN(add, "=", 2)
+				if len(split) != 2 {
+					out.Die("missing value in flag --add: %q", add)
+				}
+				k, v := split[0], split[1]
+				f, err := strconv.ParseFloat(v, 64)
+				out.MaybeDie(err, "unable to parse add %q: %v", add, err)
+
+				operations = append(operations, kadm.AlterClientQuotaOp{
+					Key:   k,
+					Value: f,
+				})
+			}
+			for _, del := range deletes {
+				operations = append(operations, kadm.AlterClientQuotaOp{
+					Key:    del,
+					Remove: true,
+				})
+			}
+
+			request := []kadm.AlterClientQuotaEntry{{entity, operations}}
+			var altered kadm.AlteredClientQuotas
+			if dry {
+				zap.L().Sugar().Debug("dry run: this result will not alter the client quotas")
+				altered, err = adm.ValidateAlterClientQuotas(cmd.Context(), request)
+			} else {
+				altered, err = adm.AlterClientQuotas(cmd.Context(), request)
+			}
+			out.MaybeDie(err, "unable to run alter client quotas: %v", err)
+			err = printAlteredQuotas(f, altered)
+			out.MaybeDie(err, "unable to print altered quotas: %v", err)
+		},
+	}
+	cmd.Flags().StringSliceVar(&names, "name", nil, "Entity for exact matching. Format type=name where type is client-id or client-id-prefix (repeatable)")
+	cmd.Flags().StringSliceVar(&defaults, "default", nil, "Entity type for default matching, where type is client-id or client-id-prefix (repeatable)")
+	cmd.Flags().StringSliceVar(&adds, "add", nil, "Key=value quota to add, where the value is a float number (repeatable)")
+	cmd.Flags().StringSliceVar(&deletes, "delete", nil, "Key of the quota to delete (repeatable)")
+	cmd.Flags().BoolVar(&dry, "dry", false, "Key of the quota to delete (repeatable)")
+
+	cmd.MarkFlagsOneRequired("name", "default")
+	cmd.MarkFlagsOneRequired("add", "delete")
+	return cmd
+}
+
+func printAlteredQuotas(f config.OutFormatter, altered kadm.AlteredClientQuotas) error {
+	// We only alter a single entity/quota.
+	var resp createResponse
+	for _, entry := range altered {
+		entity, entityStr := parseEntityData(entry.Entity)
+		status := "OK"
+		if entry.Err != nil {
+			status = fmt.Sprintf("Error: %v", entry.ErrMessage)
+		}
+		resp = createResponse{
+			Entity:    entity,
+			Status:    status,
+			entityStr: entityStr,
+		}
+	}
+	if isText, _, s, err := f.Format(resp); !isText {
+		if err != nil {
+			return fmt.Errorf("unable to print in the required format %q: %v", f.Kind, err)
+		}
+		fmt.Println(s)
+		return nil
+	}
+
+	tw := out.NewTable("entity", "status")
+	defer tw.Flush()
+	tw.Print(resp.entityStr, resp.Status)
+
+	return nil
+}

--- a/src/go/rpk/pkg/cli/cluster/quotas/alter.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/alter.go
@@ -96,7 +96,7 @@ Remove quota (producer_byte_rate) from client ID 'foo':
 				}
 				k, v := split[0], split[1]
 				k = strings.ToLower(k)
-				if !validTypes[k] {
+				if !anyValidTypes[k] {
 					out.Die("name type %q is invalid (allowed: client-id, client-id-prefix)", split[0])
 				}
 				nameMap[k] = true
@@ -106,8 +106,8 @@ Remove quota (producer_byte_rate) from client ID 'foo':
 				})
 			}
 			for _, def := range defaults {
-				if !validTypes[def] {
-					out.Die("default type %q is invalid (allowed: client-id, client-id-prefix)", def)
+				if !defaultValidTypes[def] {
+					out.Die("default type %q is invalid (allowed: client-id)", def)
 				}
 				if nameMap[def] {
 					out.Die("default type %q was previously defined in --name, you can only set it once", def)

--- a/src/go/rpk/pkg/cli/cluster/quotas/describe.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/describe.go
@@ -88,7 +88,7 @@ Describe client quotas for a given client ID prefix 'bar.':
 				}
 				k, v := split[0], split[1]
 				k = strings.ToLower(k)
-				if !validTypes[k] {
+				if !anyValidTypes[k] {
 					out.Die("name type %q is invalid (allowed: client-id, client-id-prefix)", split[0])
 				}
 				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{
@@ -99,8 +99,8 @@ Describe client quotas for a given client ID prefix 'bar.':
 			}
 			for _, def := range defaults {
 				k := strings.ToLower(def)
-				if !validTypes[k] {
-					out.Die("default type %q is invalid (allowed: client-id, client-id-prefix)", def)
+				if !defaultValidTypes[k] {
+					out.Die("default type %q is invalid (allowed: client-id)", def)
 				}
 				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{
 					Type:      k,
@@ -109,7 +109,7 @@ Describe client quotas for a given client ID prefix 'bar.':
 			}
 			for _, a := range anyFlag {
 				k := strings.ToLower(a)
-				if !validTypes[k] {
+				if !anyValidTypes[k] {
 					out.Die("'any' type %q is invalid (allowed: client-id, client-id-prefix)", a)
 				}
 				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{

--- a/src/go/rpk/pkg/cli/cluster/quotas/describe.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/describe.go
@@ -1,0 +1,174 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package quotas
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/kafka"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/out"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+)
+
+type quotaValues struct {
+	Key   string `json:"key" yaml:"key"`
+	Value string `json:"values" yaml:"values"`
+}
+type describedQuota struct {
+	Entity []entityData  `json:"entity" yaml:"entity"`
+	Values []quotaValues `json:"values" yaml:"values"`
+
+	entityStr string
+}
+
+type describeResponse struct {
+	DescribedQuotas []describedQuota `json:"quotas,omitempty" yaml:"quotas,omitempty"`
+}
+
+func describeCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	var (
+		names    []string
+		defaults []string
+		anyFlag  []string
+		strict   bool
+	)
+	cmd := &cobra.Command{
+		Use:   "describe",
+		Args:  cobra.NoArgs,
+		Short: "Describe client quotas",
+		Long: `Describe client quotas.
+
+This command describes client quotas that match the provided filtering criteria.
+Running the command without filters returns all client quotas. Use the 
+'--strict' flag for strict matching, which means that the only quotas returned 
+exactly match the filters.
+
+Filters can be provided in terms of entities. An entity consists of either a 
+client ID or a client ID prefix.
+`,
+		Example: `
+Describe all client quotas:
+  rpk cluster quotas describe
+
+Describe all client quota with client ID foo:
+  rpk cluster quotas describe --name client-id=foo
+
+Describe client quotas for a given client ID prefix 'bar.':
+  rpk cluster quotas describe --name client-id=bar.
+`,
+		Run: func(cmd *cobra.Command, _ []string) {
+			f := p.Formatter
+			if h, ok := f.Help(describeResponse{}); ok {
+				out.Exit(h)
+			}
+			p, err := p.LoadVirtualProfile(fs)
+			out.MaybeDie(err, "rpk unable to load config: %v", err)
+
+			adm, err := kafka.NewAdmin(fs, p)
+			out.MaybeDie(err, "unable to initialize kafka client: %v", err)
+			defer adm.Close()
+
+			var reqQuotas []kadm.DescribeClientQuotaComponent
+			for _, name := range names {
+				split := strings.SplitN(name, "=", 2)
+				if len(split) != 2 {
+					out.Die("--name flag %q missing value", split[0])
+				}
+				k, v := split[0], split[1]
+				k = strings.ToLower(k)
+				if !validTypes[k] {
+					out.Die("name type %q is invalid (allowed: client-id, client-id-prefix)", split[0])
+				}
+				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{
+					Type:      k,
+					MatchName: &v,
+					MatchType: 0,
+				})
+			}
+			for _, def := range defaults {
+				k := strings.ToLower(def)
+				if !validTypes[k] {
+					out.Die("default type %q is invalid (allowed: client-id, client-id-prefix)", def)
+				}
+				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{
+					Type:      k,
+					MatchType: 1,
+				})
+			}
+			for _, a := range anyFlag {
+				k := strings.ToLower(a)
+				if !validTypes[k] {
+					out.Die("'any' type %q is invalid (allowed: client-id, client-id-prefix)", a)
+				}
+				reqQuotas = append(reqQuotas, kadm.DescribeClientQuotaComponent{
+					Type:      k,
+					MatchType: 2,
+				})
+			}
+			quotas, err := adm.DescribeClientQuotas(cmd.Context(), strict, reqQuotas)
+			out.MaybeDie(err, "unable to describe client quotas: %v", err)
+
+			err = printDescribedQuotas(f, quotas)
+			out.MaybeDie(err, "unable to print described quotas: %v", err)
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&names, "name", nil, "type=name pair for exact name matching, where type is client-id or client-id-prefix (repeatable)")
+	cmd.Flags().StringSliceVar(&defaults, "default", nil, "type for default matching, where type is client-id or client-id-prefix (repeatable)")
+	cmd.Flags().StringSliceVar(&anyFlag, "any", nil, "type for any matching (names or default), where type is client-id or client-id-prefix (repeatable)")
+	cmd.Flags().BoolVar(&strict, "strict", false, "whether matches are strict, if true, entities with unspecified entity types are excluded")
+
+	return cmd
+}
+
+func printDescribedQuotas(f config.OutFormatter, quotas []kadm.DescribedClientQuota) error {
+	var described []describedQuota
+	for _, q := range quotas {
+		entity, entityStr := parseEntityData(q.Entity)
+		var qv []quotaValues
+		for _, v := range q.Values {
+			qv = append(qv, quotaValues{
+				Key:   v.Key,
+				Value: strconv.FormatFloat(v.Value, 'f', -1, 64),
+			})
+		}
+		described = append(described, describedQuota{
+			Entity:    entity,
+			Values:    qv,
+			entityStr: entityStr,
+		})
+	}
+	if isText, _, s, err := f.Format(describeResponse{described}); !isText {
+		if err != nil {
+			return fmt.Errorf("unable to print in the required format %q: %v", f.Kind, err)
+		}
+		fmt.Println(s)
+		return nil
+	}
+	if len(described) == 0 {
+		fmt.Println("no quotas matched to describe")
+		return nil
+	}
+	for i, d := range described {
+		fmt.Println(d.entityStr)
+		for _, qv := range d.Values {
+			fmt.Printf("\t%v=%v\n", qv.Key, qv.Value)
+		}
+		if i < len(described)-1 {
+			fmt.Println()
+		}
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/cli/cluster/quotas/quotas.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/quotas.go
@@ -36,10 +36,20 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	return cmd
 }
 
-var validTypes = map[string]bool{
+// anyValidTypes are the types allowed in --name and --any flags.
+var anyValidTypes = map[string]bool{
 	// Supported by Redpanda.
 	"client-id":        true,
 	"client-id-prefix": true,
+	// Not supported by Redpanda yet.
+	"user": true,
+	"ip":   true,
+}
+
+// defaultValidTypes are the types allowed in --default flag.
+var defaultValidTypes = map[string]bool{
+	// Supported by Redpanda.
+	"client-id": true,
 	// Not supported by Redpanda yet.
 	"user": true,
 	"ip":   true,

--- a/src/go/rpk/pkg/cli/cluster/quotas/quotas.go
+++ b/src/go/rpk/pkg/cli/cluster/quotas/quotas.go
@@ -1,0 +1,73 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package quotas
+
+import (
+	"strings"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/twmb/franz-go/pkg/kadm"
+	"github.com/twmb/types"
+)
+
+func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "quotas",
+		Aliases: []string{"quota"},
+		Args:    cobra.NoArgs,
+		Short:   "Manage Redpanda client quotas",
+	}
+	cmd.AddCommand(
+		alterCommand(fs, p),
+		describeCommand(fs, p),
+	)
+	p.InstallKafkaFlags(cmd)
+	p.InstallFormatFlag(cmd)
+
+	return cmd
+}
+
+var validTypes = map[string]bool{
+	// Supported by Redpanda.
+	"client-id":        true,
+	"client-id-prefix": true,
+	// Not supported by Redpanda yet.
+	"user": true,
+	"ip":   true,
+}
+
+type entityData struct {
+	Name string `json:"name" yaml:"name"`
+	Type string `json:"type" yaml:"type"`
+}
+
+func parseEntityData(entity kadm.ClientQuotaEntity) ([]entityData, string) {
+	var sb strings.Builder
+	var ed []entityData
+	types.Sort(entity)
+	for i, e := range entity {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(e.Type)
+		sb.WriteString("=")
+		name := "<default>"
+		if e.Name != nil {
+			name = *e.Name
+		}
+		sb.WriteString(name)
+		ed = append(ed, entityData{
+			name, e.Type,
+		})
+	}
+	return ed, sb.String()
+}

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1849,3 +1849,57 @@ class RpkTool:
         out = self._execute(cmd)
 
         return json.loads(out) if output_format == "json" else out
+
+    def describe_cluster_quotas(self,
+                                any=[],
+                                default=[],
+                                name=[],
+                                strict=False,
+                                output_format="json"):
+        cmd = ["describe"]
+
+        if strict:
+            cmd += ["--strict"]
+        if len(any) > 0:
+            cmd += ["--any", ",".join(any)]
+        if len(default) > 0:
+            cmd += ["--default", ",".join(default)]
+        if len(name) > 0:
+            cmd += ["--name", ",".join(name)]
+
+        return self._run_cluster_quotas(cmd, output_format=output_format)
+
+    def alter_cluster_quotas(self,
+                             add=[],
+                             delete=[],
+                             default=[],
+                             name=[],
+                             dry=False,
+                             output_format="json"):
+        cmd = ["describe"]
+
+        if dry:
+            cmd += ["--dry"]
+        if len(add) > 0:
+            cmd += ["--add", ",".join(add)]
+        if len(delete) > 0:
+            cmd += ["--delete", ",".join(delete)]
+        if len(default) > 0:
+            cmd += ["--default", ",".join(default)]
+        if len(name) > 0:
+            cmd += ["--name", ",".join(name)]
+
+        return self._run_cluster_quotas(cmd, output_format=output_format)
+
+    def _run_cluster_quotas(self, cmd, output_format="json"):
+        cmd = [
+            self._rpk_binary(),
+            "cluster",
+            "quotas",
+            "--format",
+            output_format,
+        ] + self._kafka_conn_settings() + cmd
+
+        out = self._execute(cmd)
+
+        return json.loads(out) if output_format == "json" else out


### PR DESCRIPTION
This PR adds rpk support to DescribeClientQuotas and AlterClientQuotas under the `rpk cluster quotas` command.

### Examples:

**Creating a Quota**
```
$ rpk cluster quotas alter --add consumer_byte_rate=12000 --name client-id=foo --default user
ENTITY                        STATUS
client-id=foo,user=<default>  OK
```

**Describing Quotas**
```
$ rpk cluster quotas describe --name client-id=testclient                                    
ENTITY                               QUOTA-TYPE          QUOTA-VALUE
client-id=testclient,user=user2      producer_byte_rate  130000
client-id=testclient,user=<default>  producer_byte_rate  140000
```
All new commands now include support for `--format` json|yaml flag.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* rpk: now you can manage client quotas using `rpk cluster quotas`.
