### PR TITLE
Test changes to support increased connection counts

### DIFF
--- a/tests/docker/ducktape-deps/client-swarm
+++ b/tests/docker/ducktape-deps/client-swarm
@@ -6,7 +6,7 @@ pushd /tmp
 git clone https://github.com/redpanda-data/client-swarm.git
 
 pushd client-swarm
-git reset --hard 54031af964203da02949eefa406d615049bd00c1
+git reset --hard 7ba96b8a78717c03392a3959a31e3c5a36cda472
 cargo build --release
 cp target/release/client-swarm /usr/local/bin
 popd

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -296,8 +296,13 @@ class OMBValidationTest(RedpandaCloudTest):
                                  warmup_duration) + warm_up_time_s
         records_per_producer = messages_per_sec_per_producer * target_runtime_s
 
-        self._ctx.logger.warn(
-            f"Producers per node: {_conn_per_node} Messages per producer: {records_per_producer} Message rate: {messages_per_sec_per_producer} msg/s"
+        self.logger.warn(
+            f"OMB nodes: {OMB_WORKERS}, omb producers: {total_producers}, omb consumers: "
+            f"{total_consumers}, producer rate: {producer_rate / 10**6} MB/s")
+
+        self.logger.warn(
+            f"Swarm nodes: {SWARM_WORKERS}, producers per node: {_conn_per_node}, messages per producer: "
+            f"{records_per_producer} Message rate: {messages_per_sec_per_producer} msg/s"
         )
 
         producer_kwargs[
@@ -338,8 +343,8 @@ class OMBValidationTest(RedpandaCloudTest):
             s.start()
 
         # Allow time for the producers in the swarm to authenticate and start
-        self._ctx.logger.info(
-            f"waiting {warm_up_time_s} seconds to producer swarm to start")
+        self.logger.info(
+            f"waiting {warm_up_time_s} seconds for producer swarm to start")
         sleep(warm_up_time_s)
 
         benchmark.start()

--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -8,21 +8,22 @@
 # by the Apache License, Version 2.0
 
 import math
-from time import sleep
+from time import time
 from typing import Any, TypeVar
 
 from rptest.services.cluster import cluster
 from rptest.tests.redpanda_cloud_test import RedpandaCloudTest
-from rptest.tests.redpanda_test import RedpandaTest
 from ducktape.tests.test import TestContext
 from rptest.services.producer_swarm import ProducerSwarm
 from rptest.clients.rpk import RpkTool
-from rptest.services.redpanda_cloud import CloudTierName, ProductInfo, get_config_profile_name
-from rptest.services.redpanda import (SISettings, RedpandaServiceCloud)
+from rptest.services.redpanda_cloud import ProductInfo
 from rptest.services.openmessaging_benchmark import OpenMessagingBenchmark
 from rptest.services.openmessaging_benchmark_configs import \
     OMBSampleConfigurations
 from rptest.services.machinetype import get_machine_info
+from rptest.utils.type_utils import rcast
+
+# pyright: strict
 
 KiB = 1024
 MiB = KiB * KiB
@@ -34,6 +35,9 @@ minutes = 60
 hours = 60 * minutes
 
 T = TypeVar('T')
+
+REJECTED_METRIC = "vectorized_kafka_rpc_connections_rejected_total"
+ACTIVE_METRIC = "vectorized_kafka_rpc_active_connections"
 
 
 def not_none(value: T | None) -> T:
@@ -146,7 +150,7 @@ class OMBValidationTest(RedpandaCloudTest):
             OMBValidationTest.LATENCY_SERIES_AND_MAX.items()
         }
 
-    def __init__(self, test_ctx: TestContext, *args, **kwargs):
+    def __init__(self, test_ctx: TestContext, *args: Any, **kwargs: Any):
         self._ctx = test_ctx
 
         super().__init__(test_ctx, *args, **kwargs)
@@ -166,7 +170,7 @@ class OMBValidationTest(RedpandaCloudTest):
         config_profile = install_pack['config_profiles'][
             self.config_profile_name]
 
-        self.num_brokers = config_profile['nodes_count']
+        self.num_brokers: int = config_profile['nodes_count']
         self.tier_limits: ProductInfo = not_none(self.redpanda.get_product())
         self.tier_machine_info = get_machine_info(
             config_profile['machine_type'])
@@ -199,17 +203,17 @@ class OMBValidationTest(RedpandaCloudTest):
         machine_config = self.tier_machine_info
         return 5 * self.num_brokers * machine_config.num_shards
 
-    def _producer_count(self, ingress_rate) -> int:
-        """Determine the number of producers based on the ingress rate.
+    def _producer_count(self, ingress_rate: int) -> int:
+        """Determine the number of producers based on the ingress rate (in bytes).
         We assume that each producer is capable of 5 MB/s."""
         return max(ingress_rate // (5 * MB), 1)
 
-    def _consumer_count(self, egress_rate) -> int:
-        """Determine the number of consumers based on the egress rate.
+    def _consumer_count(self, egress_rate: int) -> int:
+        """Determine the number of consumers based on the egress rate (in bytes).
         We assume that each consumer is capable of 5 MB/s."""
         return max(egress_rate // (5 * MB), 1)
 
-    def _mb_to_mib(self, mb):
+    def _mb_to_mib(self, mb: float | int):
         return math.floor(0.9537 * mb)
 
     @cluster(num_nodes=CLUSTER_NODES)
@@ -229,20 +233,26 @@ class OMBValidationTest(RedpandaCloudTest):
         producer_rate = tier_limits.max_ingress // 5
         subscriptions = max(tier_limits.max_egress // tier_limits.max_ingress,
                             1)
-        total_producers = self._producer_count(producer_rate)
-        total_consumers = self._consumer_count(producer_rate * subscriptions)
-        warmup_duration = self.WORKLOAD_DEFAULTS["warmup_duration_minutes"]
-        test_duration = self.WORKLOAD_DEFAULTS["test_duration_minutes"]
-
+        omb_producer_count = self._producer_count(producer_rate)
+        omb_consumer_count = self._consumer_count(producer_rate *
+                                                  subscriptions)
         workload = self.WORKLOAD_DEFAULTS | {
-            "name": "MaxConnectionsTestWorkload",
-            "partitions_per_topic": self._partition_count(),
-            "subscriptions_per_topic": subscriptions,
-            "consumer_per_subscription": max(total_consumers // subscriptions,
-                                             1),
-            "producers_per_topic": total_producers,
-            "producer_rate": producer_rate // (1 * KiB),
+            "name":
+            "MaxConnectionsTestWorkload",
+            "partitions_per_topic":
+            self._partition_count(),
+            "subscriptions_per_topic":
+            subscriptions,
+            "consumer_per_subscription":
+            max(omb_consumer_count // subscriptions, 1),
+            "producers_per_topic":
+            omb_producer_count,
+            "producer_rate":
+            producer_rate // (1 * KiB),
         }
+
+        warmup_duration = rcast(int, workload["warmup_duration_minutes"])
+        omb_test_duration = rcast(int, workload["test_duration_minutes"])
 
         driver = {
             "name": "MaxConnectionsTestDriver",
@@ -267,46 +277,91 @@ class OMBValidationTest(RedpandaCloudTest):
             ],
         }
 
+        rejected_start = self._rejected_count()
+
+        def assert_no_rejected():
+            """Assert that there have been no rejected connections since the
+            start of the test."""
+            rejected_now = self._rejected_count()
+            assert rejected_now == rejected_start, f"Rejected connections detected, start={rejected_start}, now={rejected_now}"
+
         # ProducerSwarm parameters
         #
 
-        producer_kwargs = {}
-        producer_kwargs['min_record_size'] = 64
-        producer_kwargs['max_record_size'] = 64
+        record_size = 64
 
-        effective_msg_size = producer_kwargs['min_record_size'] + (
-            producer_kwargs['max_record_size'] -
-            producer_kwargs['min_record_size']) // 2
+        # very rough estimated number of connections for OMB
+        omb_connections = 3 * (omb_producer_count + omb_consumer_count)
 
-        conn_limit = tier_limits.max_connection_count - 3 * (total_producers +
-                                                             total_consumers)
-        _target_per_node = conn_limit // SWARM_WORKERS
-        _conn_per_node = int(_target_per_node * 0.7)
+        # We have a certain advertised connection count (ACC) figure, and this way this works
+        # in practice is that we set the per-broker limit to 1.2 ACC/N where N is the number of brokers
+        # and 1.2 is a fudge factor that makes it more likely that particular workload can actually get
+        # to the ACC figure globally even when connection counts aren't exactly balanced across brokers.
 
-        msg_rate_per_node = (1 * KiB) // effective_msg_size
-        messages_per_sec_per_producer = max(
-            msg_rate_per_node // _conn_per_node, 1)
+        # The remainder of our connection budget after OMB connections are accounted for we will
+        # fill with swarm connections: we add 10% to the nominal amount to ensure we test the
+        # advertised limit and this uses up ~half the slack we have in the enforcement (we currently
+        # set the per broker limit to 1.2x of what it would be if enforced exactly).
+        swarm_target_connections = int(
+            (tier_limits.max_connection_count - omb_connections) * 1.1)
+
+        # we expect each swarm producer to create 1 connection per broker, plus 1 additional connection
+        # for metadata
+        conn_per_swarm_producer = self.num_brokers + 1
+
+        producer_per_swarm_node: int = swarm_target_connections // conn_per_swarm_producer // SWARM_WORKERS
+
+        messages_per_sec_per_producer = 1
+        msg_rate_per_node = messages_per_sec_per_producer * producer_per_swarm_node
 
         # single producer runtime
-        # Roughly every 500 connection needs 60 seconds to ramp up
-        time_per_500_s = 60
-        warm_up_time_s = max(
-            time_per_500_s * math.ceil(_target_per_node / 500), time_per_500_s)
-        target_runtime_s = 60 * (test_duration +
+        # Each swarm will throttle the client creation rate to about 30 connections/second
+        warm_up_time_s = (producer_per_swarm_node *
+                          ProducerSwarm.CLIENT_SPAWN_WAIT_MS // 1000) + 60
+        target_runtime_s = 60 * (omb_test_duration +
                                  warmup_duration) + warm_up_time_s
-        records_per_producer = messages_per_sec_per_producer * target_runtime_s
+        # We want the swarm to run "past" the end of the test, so we give a good buffer
+        # of 1.5 the total expected runtime. We don't use infinite because DT cleanup is
+        # often not reliable (e.g., there may be an exception during cleanup which prevents
+        # swarm cleanup from running, or the test may be abruptly halted, skipping cleanup),
+        # so having some time limit is helpful to avoid runaway swarm processes (though if
+        # cleanup does fail it is likely to affect subsequent tests).
+        records_per_producer = math.ceil(messages_per_sec_per_producer *
+                                         target_runtime_s * 1.5)
+
+        total_target = omb_connections + swarm_target_connections
 
         self.logger.warn(
-            f"OMB nodes: {OMB_WORKERS}, omb producers: {total_producers}, omb consumers: "
-            f"{total_consumers}, producer rate: {producer_rate / 10**6} MB/s")
+            f"Connections (before start): {self._connection_count()}, target conn: {total_target} "
+            f"(OMB: {omb_connections}, swarm: {swarm_target_connections}), per-broker: {total_target / self.num_brokers:.0f}"
+        )
 
         self.logger.warn(
-            f"Swarm nodes: {SWARM_WORKERS}, producers per node: {_conn_per_node}, messages per producer: "
+            f"OMB nodes: {OMB_WORKERS}, omb producers: {omb_producer_count}, omb consumers: "
+            f"{omb_consumer_count}, producer rate: {producer_rate / 10**6} MB/s"
+        )
+
+        self.logger.warn(
+            f"target_runtime: {target_runtime_s / 60:.2f}m, omb test_duration: {omb_test_duration}m, "
+            f"warmup_duration: {warmup_duration}m, {warm_up_time_s / 60:.2f}m")
+
+        self.logger.warn(
+            f"Swarm nodes: {SWARM_WORKERS}, producers per node: {producer_per_swarm_node}, messages per producer: "
             f"{records_per_producer} Message rate: {messages_per_sec_per_producer} msg/s"
         )
 
-        producer_kwargs[
-            'messages_per_second_per_producer'] = messages_per_sec_per_producer
+        # Before the test even starts, assert that there are a "small" number of connections.
+        # This number is not zero because various things maintain or make occasional connections
+        # to cloud clusters like kminion, so I observe typically ~45 connections on an idle T1 and 450
+        # on an idle T7 cluster. So we just use a SWAG of 100 + 1% of the connection target as the
+        # threshold above which we complain.
+        # If this fails it is probably because some other test left services running
+        # against the cluster.
+        count_before = self._connection_count()
+        maximum_allowed = int(tier_limits.max_connection_count * 0.01 + 100)
+        assert count_before <= maximum_allowed, (
+            f"Wanted less than {maximum_allowed}"
+            f"connections to start but got {count_before}")
 
         benchmark = OpenMessagingBenchmark(self._ctx,
                                            self.redpanda,
@@ -326,50 +381,135 @@ class OMBValidationTest(RedpandaCloudTest):
                               self._partition_count(),
                               replicas=3)
 
-        swarm = []
-        for _ in range(SWARM_WORKERS):
-            _swarm_node = ProducerSwarm(
+        def make_swarm():
+            return ProducerSwarm(
                 self._ctx,
                 self.redpanda,
                 topic=swarm_topic_name,
-                producers=_conn_per_node,
+                producers=producer_per_swarm_node,
                 records_per_producer=records_per_producer,
                 timeout_ms=PRODUCER_TIMEOUT_MS,
-                **producer_kwargs)
+                min_record_size=record_size,
+                max_record_size=record_size,
+                messages_per_second_per_producer=messages_per_sec_per_producer)
 
-            swarm.append(_swarm_node)
+        swarm = [make_swarm() for _ in range(SWARM_WORKERS)]
 
         for s in swarm:
             s.start()
 
-        # Allow time for the producers in the swarm to authenticate and start
-        self.logger.info(
-            f"waiting {warm_up_time_s} seconds for producer swarm to start")
-        sleep(warm_up_time_s)
+        for s in swarm:
+            # wait for the swarm to report that all producers have started (sent at least 1 message)
+            s.wait_for_all_started()
 
+        assert_no_rejected()
+
+        # Now wait for up to five minutes to hit our target connection count: even though all producers
+        # have started, it's possible that the connections haven't hit their target yet because some
+        # brokers haven't been produced to by some clients: at 1 message/sec it can take some time
+        # for all brokers to be connected to by all producers. If we assume a maximum of 30 brokers,
+        # and well-distributed partitions and random keys, after 5 minutes each broker will have
+        # received one message with probability 1 - (1 - 1/30)^300 = ~0.99996.
+        # In practice the cloud there will be some additional external connections on top of those
+        # created by the test because of connections from kminion, etc.
+        def target_connections_reached():
+            ccount = self._connection_count()
+            self.logger.debug(
+                'Waiting for connections to reach target, current:'
+                f'{ccount}, target: {swarm_target_connections}')
+            return self._connection_count() >= swarm_target_connections
+
+        def not_reached():
+            return f"Failed to reach target connections, actual: {self._connection_count()}, target: {swarm_target_connections}"
+
+        self.redpanda.wait_until(target_connections_reached,
+                                 timeout_sec=5 * 60,
+                                 backoff_sec=10,
+                                 err_msg=not_reached)
+
+        time_before_body = time()
+
+        assert_no_rejected()
+
+        # run the OMB portion of the benchmark and ensure it succeeded
         benchmark.start()
-        benchmark_time_min = benchmark.benchmark_time() + 5
+        omb_seconds = benchmark.benchmark_time() * 60
+        benchmark.wait(timeout_sec=omb_seconds + 300)
 
-        try:
-            benchmark.wait(timeout_sec=benchmark_time_min * 60)
+        assert_no_rejected()
 
-            benchmark.check_succeed()
+        body_runtime = time() - time_before_body
 
-            for s in swarm:
-                s.wait(timeout_sec=30 * 60)
+        assert body_runtime >= benchmark.benchmark_time(), \
+            f"unexpectedly short runtime: {body_runtime} vs {benchmark.benchmark_time()}"
 
-        finally:
-            self.rpk.delete_topic(swarm_topic_name)
+        # Get and print all the swarm metrics now so if we fail in check_succeed()
+        # we have this info in the log. Specify the lookback window to be the time
+        # of the OMB run so we exclude the initialization part of swarm which is
+        # going to have unstable metrics
+        swarm_metrics = [(s, s.get_metrics_summary(seconds=omb_seconds))
+                         for s in swarm]
+
+        # print all metrics first
+        for i, metrics in enumerate(swarm_metrics):
+            self.logger.debug(f"Metrics for swarm {i}: {metrics}")
+
+        benchmark.check_succeed()
+
+        # now check that the swarm producers were also reasonably successful
+        # they may not be _completely_ successful because of:
+        # https://github.com/redpanda-data/redpanda/issues/15475
+        # which means that some swarm producers appear to get into a state
+        # where some significant fraction of messages time out, which will keep
+        # the overall throughput of those producers much below average
+        for s, metrics in swarm_metrics:
+            sname = str(s)
+            assert metrics.clients_alive == producer_per_swarm_node, \
+                f"On {sname} bad clients_alive: {metrics.clients_alive} != {producer_per_swarm_node}"
+            assert metrics.clients_stopped == 0, f"clients unexpectedly stopped"
+
+            def in_range(name: str, value: float, nominal: float,
+                         max_range: float):
+                lb = nominal * (1 - max_range)
+                ub = nominal * (1 + max_range)
+                assert lb <= value <= ub, f"On {sname} for {name} value {value} is outside allowed range [{lb}, {ub}]"
+
+            in_range("msg/s p50", metrics.p50, messages_per_sec_per_producer,
+                     0.01)
+
+            # no more than 1% error rate
+            error_rate = metrics.total_error / (metrics.total_attempts)
+            assert error_rate < 0.01, f"On {s} error rate {error_rate:.2} is too high: {metrics}"
+
+            # we should have at least 95% of the expected success messages
+            expected_messages = msg_rate_per_node * body_runtime
+            assert metrics.total_success >= 0.95 * expected_messages, \
+                f"On {s} expected {expected_messages} but only got {metrics.total_success}"
+
+            if (metrics.p0 < messages_per_sec_per_producer / 2):
+                # This probably means that the slowest producer was running at less that half the expected
+                # rate. Normally this does not occur (except perhaps transiently when the swarm)
+                # is first starting up, and probably indicates that redpanda-data/redpanda#15475
+                # has occurred, so just log it and move on
+                self.logger.warn(
+                    f"On {sname} p0 rate was very slow, probably redpanda-data/redpanda#15475 : "
+                    f"p0={metrics.p0}")
+
+        for s in swarm:
+            s.stop()
 
         self.redpanda.assert_cluster_is_reusable()
 
-    def _warn_metrics(self, metrics, validator):
+    def _warn_metrics(self, metrics: dict[str, Any], validator: dict[str,
+                                                                     Any]):
         """Validates metrics and just warn if any fail."""
 
         assert len(validator) > 0, "At least one metric should be validated"
 
-        results = []
-        kv_str = lambda k, v: f"Metric {k}, value {v}, "
+        results: list[str] = []
+
+        def kv_str(k: str, v: Any):
+            return f"Metric {k}, value {v}, "
 
         for key in validator.keys():
             assert key in metrics, f"Missing requested validator key {key} in metrics"
@@ -587,3 +727,9 @@ class OMBValidationTest(RedpandaCloudTest):
         max_retries = 2
         self.run_benchmark_with_retries(benchmark, max_retries)
         self.redpanda.assert_cluster_is_reusable()
+
+    def _connection_count(self):
+        return self.redpanda.metric_sum(ACTIVE_METRIC)
+
+    def _rejected_count(self):
+        return self.redpanda.metric_sum(REJECTED_METRIC)

--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -107,6 +107,9 @@ class ProducerSwarm(Service):
 
         if self._keys is not None:
             cmd += f" --keys={self._keys}"
+        else:
+            # by default use a very large key space so all partitions are written to
+            cmd += " --keys=18446744073709551557"
 
         if self._unique_topics:
             cmd += " --unique-topics"

--- a/tests/rptest/services/producer_swarm.py
+++ b/tests/rptest/services/producer_swarm.py
@@ -10,7 +10,7 @@
 from dataclasses import dataclass
 from ducktape.tests.test import TestContext
 from ducktape.services.service import Service
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import requests
 
@@ -20,6 +20,10 @@ from rptest.services.redpanda import AnyRedpandaService
 class ProducerSwarm(Service):
     EXE = "client-swarm"
     LOG_PATH = "/opt/remote/var/client-swarm.log"
+
+    # client swarm throttles producer startups to one every 33 ms by default,
+    # see client_spawn_wait_ms in client-swarm
+    CLIENT_SPAWN_WAIT_MS = 33
 
     logs = {"repeater_log": {"path": LOG_PATH, "collect_default": True}}
 
@@ -76,6 +80,9 @@ class ProducerSwarm(Service):
             node.account.remove(self.LOG_PATH)
 
     def start_node(self, node, clean=None):
+        assert self._node is None or self._node == node, f'started on more than one node? {self._node} {node}'
+        self._node = node
+
         cmd = f"{self.EXE}"
         cmd += f" --brokers {self._redpanda.brokers()}"
         cmd += f" --metrics-address {self._remote_addr}"
@@ -107,10 +114,12 @@ class ProducerSwarm(Service):
         if self._messages_per_second_per_producer is not None:
             cmd += f" --messages-per-second {self._messages_per_second_per_producer}"
 
+        cmd += f" --client-spawn-wait-ms={self.CLIENT_SPAWN_WAIT_MS}"
+
         cmd = f"RUST_LOG={self._log_level} bash /opt/remote/control/start.sh {self.EXE} \"{cmd}\""
         node.account.ssh(cmd)
         self._redpanda.wait_until(
-            lambda: self.is_alive(node),
+            self.is_alive,
             timeout_sec=600,
             backoff_sec=1,
             err_msg=
@@ -124,7 +133,30 @@ class ProducerSwarm(Service):
             f"producer_swarm metrics endpoint at {self._remote_url(node, 'metrics/summary')} failed to answer after {30} sec",
         )
 
-        self._node = node
+    def wait_for_all_started(self):
+        """Wait until the requested number of producers have started. Note that if the expected
+        swarm runtime (messages / rate) is short, this may fail as all producers and start and
+        finish before we are able to see this via the metrics endpoint and an exception is thrown."""
+
+        # calculate the theoretical start time based on the spawn rate and then
+        # use 1.5x that + 10 seconds as the timeout
+        timeout_s = 10 + 1.5 * (self._producers * self.CLIENT_SPAWN_WAIT_MS /
+                                1000)
+
+        def started_count():
+            started = self.get_metrics_summary().clients_started
+            self.logger.debug(f'{started} producers started so far')
+            return started
+
+        self.logger.info(
+            f'Waiting up to {timeout_s}s for all {self._producers} to start')
+
+        self._redpanda.wait_until(
+            lambda: started_count() == self._producers,
+            timeout_sec=timeout_s,
+            backoff_sec=1,
+            err_msg=lambda: f"Producers did not start in time: "
+            "{started_count()} started, expected {self._producers}")
 
     def is_metrics_available(self, node):
         path = f"metrics/summary"
@@ -135,16 +167,19 @@ class ProducerSwarm(Service):
         except:
             return False
 
-    def is_alive(self, node):
-        result = node.account.ssh_output(
+    def is_alive(self) -> bool:
+        result = self._node.account.ssh_output(
             f"bash /opt/remote/control/alive.sh {self.EXE}")
         result = result.decode("utf-8")
         return "YES" in result
 
-    def wait_node(self, node, timeout_sec=600):
-        self._redpanda.wait_until(lambda: not self.is_alive(node),
-                                  timeout_sec=timeout_sec,
-                                  backoff_sec=5)
+    def wait_node(self, node, timeout_sec=600) -> bool:
+        try:
+            self._redpanda.wait_until(lambda: not self.is_alive(),
+                                      timeout_sec=timeout_sec,
+                                      backoff_sec=5)
+        except TimeoutError:
+            return False
         return True
 
     def stop_node(self, node):
@@ -167,18 +202,51 @@ class ProducerSwarm(Service):
     @dataclass
     class MetricsSummary:
         p0: int
+        """The p0 (minimum value) for single-interval message rate (msg/s)."""
         p50: int
+        """The p50 (median value) for single-interval message rate (msg/s)."""
         p100: int
+        """The p100 (maximum value) for single-interval message rate (msg/s)."""
+        total_success: int
+        """Number of messages delivered successfully during the entire lifetime of the swarm process."""
+        total_error: int
+        """Number of failed deliveries during the entire lifetime of the swarm process."""
+        clients_started: int
+        """The number of clients that have ever been started (includes ones that have subsequently stopped).
+        To get the number of _currently_ active clients, use clients_alive."""
+        clients_stopped: int
+        """The number of clients that have stopped as they reached their target message count."""
+        @property
+        def clients_alive(self):
+            """The number of clients running as of this snapshot."""
+            return self.clients_started - self.clients_stopped
 
-    def get_metrics_summary(self, seconds=None) -> MetricsSummary:
+        @property
+        def total_attempts(self):
+            """The total number of messages we attempted to send, whether successful or not."""
+            return self.total_success + self.total_error
+
+    def get_metrics_summary(self,
+                            seconds: int | None = None) -> MetricsSummary:
         path = f"metrics/summary"
         if seconds:
             path = f"{path}?seconds={seconds}"
 
         res = self._get(self._node, path)
 
-        return self.MetricsSummary(int(res["min"]), int(res["median"]),
-                                   int(res["max"]))
+        def i(name: str, input: dict[str, Any] = res, type: Any = int):
+            """Get the value with the given key, casted to type"""
+            return type(input[name])
+
+        # response looks like:
+        # {'min': 0, 'max': 10, 'median': 0, 'counts_from_start': {'success_count': 1078, 'error_count': 0}, 'clients_started': 10, 'clients_stopped': 0}
+        cfs = res['counts_from_start']
+        return self.MetricsSummary(i("min", type=float), i("median",
+                                                           type=float),
+                                   i("max", type=float),
+                                   i('success_count', cfs),
+                                   i('error_count', cfs), i('clients_started'),
+                                   i('clients_stopped'))
 
     def await_progress(self, target_msg_rate, timeout_sec, err_msg=None):
         def check():

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -657,7 +657,7 @@ class CloudCluster():
                                f"'{self.config.region}'")
 
         # Call Api to create cluster
-        self._logger.info(f'creating cluster name {self.current.name}')
+        self._logger.warning(f'creating cluster name {self.current.name}')
         # Prepare cluster payload block
         _body = self._create_cluster_payload()
         self._logger.debug(f'body: {json.dumps(_body)}')
@@ -681,8 +681,8 @@ class CloudCluster():
             _cluster_id = self._wait_for_cluster_id(r['id'])
             c = self._get_cluster(_cluster_id)
             self.current.last_status = c['state']
-            self._logger.info("Cluster status when id was available: "
-                              f"'{self.current.last_status}'")
+            self._logger.warning(f"Cluster ID is {_cluster_id}, last status: "
+                                 f"'{self.current.last_status}'")
         except Exception as e:
             raise RuntimeError("Failed to get initial cluster spec") from e
 
@@ -725,6 +725,9 @@ class CloudCluster():
         # just save the id to reuse it in next test
         if self.config.use_same_cluster:
             self.save_cluster_id(self.current.cluster_id)
+
+        self._logger.warning(
+            f"Cloud cluster {_cluster_id} created successfully.")
 
         return
 

--- a/tests/rptest/tests/topic_creation_test.py
+++ b/tests/rptest/tests/topic_creation_test.py
@@ -96,7 +96,7 @@ class TopicRecreateTest(RedpandaTest):
         rpk = RpkTool(self.redpanda)
 
         def topic_is_healthy():
-            if not swarm.is_alive(swarm.nodes[0]):
+            if not swarm.is_alive():
                 swarm.stop()
                 swarm.start()
             partitions = rpk.describe_topic(spec.name)
@@ -780,7 +780,7 @@ class CreateTopicReplicaDistributionTest(RedpandaTest):
     @cluster(num_nodes=5)
     def test_topic_aware_distribution(self):
         """
-        Test that replicas for newly created topic are distributed evenly, 
+        Test that replicas for newly created topic are distributed evenly,
         even though there is an imbalance in existing replica distribution.
         """
 


### PR DESCRIPTION
The thrust of these changes is to enhance OMBValidationTest.text_max_connections to be more reliable when testing high connection counts. Specifically to work around redpanda-data/redpanda#15475.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

