### PR TITLE
CORE-2698 `quota_store` controller frontend/backend

### DIFF
--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -94,6 +94,7 @@ v_cc_library(
     logger.cc
     config_frontend.cc
     config_manager.cc
+    client_quota_frontend.cc
     client_quota_serde.cc
     client_quota_store.cc
     cluster_utils.cc

--- a/src/v/cluster/CMakeLists.txt
+++ b/src/v/cluster/CMakeLists.txt
@@ -96,6 +96,7 @@ v_cc_library(
     config_manager.cc
     client_quota_frontend.cc
     client_quota_serde.cc
+    client_quota_backend.cc
     client_quota_store.cc
     cluster_utils.cc
     id_allocator.cc

--- a/src/v/cluster/client_quota_backend.cc
+++ b/src/v/cluster/client_quota_backend.cc
@@ -1,0 +1,43 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/client_quota_backend.h"
+
+#include "cluster/client_quota_store.h"
+#include "cluster/commands.h"
+#include "cluster/controller_snapshot.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/util/variant_utils.hh>
+
+namespace cluster::client_quota {
+
+ss::future<std::error_code> backend::apply_update(model::record_batch batch) {
+    auto cmd = co_await cluster::deserialize(std::move(batch), commands);
+    co_await _quotas.invoke_on_all([&cmd](store& quota_store) {
+        ss::visit(cmd, [&quota_store](const alter_quotas_delta_cmd& cmd) {
+            quota_store.apply_delta(cmd.value);
+        });
+    });
+    co_return errc::success;
+}
+
+ss::future<> backend::fill_snapshot(controller_snapshot& snap) const {
+    snap.client_quotas.quotas = _quotas.local().all_quotas();
+    return ss::now();
+}
+
+ss::future<>
+backend::apply_snapshot(model::offset, const controller_snapshot& snap) {
+    auto new_store = store{snap.client_quotas};
+    co_await _quotas.invoke_on_all(
+      [&new_store](store& quota_store) { quota_store = new_store; });
+}
+
+} // namespace cluster::client_quota

--- a/src/v/cluster/client_quota_backend.h
+++ b/src/v/cluster/client_quota_backend.h
@@ -1,0 +1,40 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "cluster/commands.h"
+#include "cluster/fwd.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/sharded.hh>
+
+namespace cluster::client_quota {
+
+class backend final {
+public:
+    explicit backend(ss::sharded<store>& quotas)
+      : _quotas(quotas){};
+
+    static constexpr auto commands
+      = make_commands_list<alter_quotas_delta_cmd>();
+
+    ss::future<std::error_code> apply_update(model::record_batch);
+
+    bool is_batch_applicable(const model::record_batch& batch) const {
+        return batch.header().type == model::record_batch_type::client_quota;
+    }
+
+    ss::future<> fill_snapshot(controller_snapshot&) const;
+    ss::future<> apply_snapshot(model::offset, const controller_snapshot&);
+
+private:
+    ss::sharded<store>& _quotas;
+};
+
+} // namespace cluster::client_quota

--- a/src/v/cluster/client_quota_frontend.cc
+++ b/src/v/cluster/client_quota_frontend.cc
@@ -1,0 +1,22 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cluster/client_quota_frontend.h"
+
+#include "cluster/cluster_utils.h"
+
+namespace cluster::client_quota {
+
+ss::future<std::error_code> frontend::alter_quotas(
+  alter_delta_cmd_data data, model::timeout_clock::time_point tout) {
+    alter_quotas_delta_cmd cmd(0 /*unused*/, std::move(data));
+    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
+}
+
+} // namespace cluster::client_quota

--- a/src/v/cluster/client_quota_frontend.h
+++ b/src/v/cluster/client_quota_frontend.h
@@ -1,0 +1,43 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "cluster/client_quota_serde.h"
+#include "cluster/fwd.h"
+#include "model/timeout_clock.h"
+
+#include <seastar/core/sharded.hh>
+
+#include <system_error>
+
+namespace cluster::client_quota {
+
+class frontend final {
+public:
+    frontend(
+      ss::sharded<controller_stm>& stm, ss::sharded<ss::abort_source>& as)
+      : _stm(stm)
+      , _as(as) {}
+
+    /// Applies the given delta to the client quota store
+    /// Should be called ONLY on the controller leader node, but may be called
+    /// from any shard
+    /// Returns errc::success on success or cluster errors on failure
+    /// There are no client quota store-specific errors, because the upsert and
+    /// remove operations always succeed regardless of the previous state of the
+    /// given quota (eg. there is no error for removing non-existent quotas).
+    ss::future<std::error_code>
+      alter_quotas(alter_delta_cmd_data, model::timeout_clock::time_point);
+
+private:
+    ss::sharded<controller_stm>& _stm;
+    ss::sharded<ss::abort_source>& _as;
+};
+
+} // namespace cluster::client_quota

--- a/src/v/cluster/client_quota_serde.h
+++ b/src/v/cluster/client_quota_serde.h
@@ -16,6 +16,8 @@
 
 #include <absl/container/flat_hash_set.h>
 
+#include <iosfwd>
+
 namespace cluster::client_quota {
 
 /// entity_key is used to key client quotas. It consists of multiple parts as a
@@ -42,7 +44,9 @@ struct entity_key
               client_id_default_match,
               serde::version<0>,
               serde::compat_version<0>> {
-            bool operator==(const client_id_default_match&) const = default;
+            friend bool operator==(
+              const client_id_default_match&, const client_id_default_match&)
+              = default;
 
             friend std::ostream&
             operator<<(std::ostream&, const client_id_default_match&);
@@ -61,8 +65,9 @@ struct entity_key
               client_id_match,
               serde::version<0>,
               serde::compat_version<0>> {
-            ss::sstring value;
-            bool operator==(const client_id_match&) const = default;
+            friend bool
+            operator==(const client_id_match&, const client_id_match&)
+              = default;
 
             friend std::ostream&
             operator<<(std::ostream&, const client_id_match&);
@@ -72,6 +77,8 @@ struct entity_key
                 return H::combine(
                   std::move(h), typeid(client_id_match).hash_code(), c.value);
             }
+
+            ss::sstring value;
         };
 
         /// client_id_prefix_match is the quota entity type corresponding to the
@@ -82,8 +89,9 @@ struct entity_key
               client_id_prefix_match,
               serde::version<0>,
               serde::compat_version<0>> {
-            ss::sstring value;
-            bool operator==(const client_id_prefix_match&) const = default;
+            friend bool operator==(
+              const client_id_prefix_match&, const client_id_prefix_match&)
+              = default;
 
             friend std::ostream&
             operator<<(std::ostream&, const client_id_prefix_match&);
@@ -95,6 +103,8 @@ struct entity_key
                   typeid(client_id_prefix_match).hash_code(),
                   c.value);
             }
+
+            ss::sstring value;
         };
 
         serde::variant<
@@ -102,8 +112,6 @@ struct entity_key
           client_id_match,
           client_id_prefix_match>
           part;
-
-        auto serde_fields() { return std::tie(part); }
     };
 
     auto serde_fields() { return std::tie(parts); }
@@ -122,11 +130,6 @@ struct entity_key
 /// entity_value describes the quotas applicable to an entity_key
 struct entity_value
   : serde::envelope<entity_value, serde::version<0>, serde::compat_version<0>> {
-    auto serde_fields() {
-        return std::tie(
-          producer_byte_rate, consumer_byte_rate, controller_mutation_rate);
-    }
-
     friend bool operator==(const entity_value&, const entity_value&) = default;
     friend std::ostream& operator<<(std::ostream&, const entity_value&);
 

--- a/src/v/cluster/client_quota_store.cc
+++ b/src/v/cluster/client_quota_store.cc
@@ -44,4 +44,14 @@ void store::clear() { _quotas.clear(); }
 
 const store::container_type& store::all_quotas() const { return _quotas; }
 
+void store::apply_delta(const alter_delta_cmd_data& data) {
+    for (auto& [key, value] : data.upsert) {
+        set_quota(key, value);
+    }
+    for (auto& [key] : data.remove) {
+        remove_quota(key);
+    }
+    _quotas.rehash(0);
+}
+
 } // namespace cluster::client_quota

--- a/src/v/cluster/client_quota_store.h
+++ b/src/v/cluster/client_quota_store.h
@@ -8,7 +8,8 @@
 // by the Apache License, Version 2.0
 #pragma once
 
-#include "client_quota_serde.h"
+#include "cluster/client_quota_serde.h"
+#include "cluster/controller_snapshot.h"
 #include "container/fragmented_vector.h"
 
 #include <absl/algorithm/container.h>
@@ -23,6 +24,13 @@ public:
       = chunked_vector<std::pair<entity_key, entity_value>>;
     using range_callback_type
       = std::function<bool(const std::pair<entity_key, entity_value>&)>;
+
+    /// Constructs an empty store
+    store() = default;
+
+    /// Constructs a store based on a controller snapshot
+    explicit store(const controller_snapshot_parts::client_quotas_t& snap)
+      : _quotas{snap.quotas} {};
 
     /// Upserts the given quota at the given entity key
     /// All quota types are overwritten with the given entity_value, so on alter
@@ -47,6 +55,9 @@ public:
 
     /// Returns a copy of all the client quotas in the store
     const container_type& all_quotas() const;
+
+    /// Applies the given alter controller command to the store
+    void apply_delta(const alter_delta_cmd_data&);
 
     static constexpr auto entity_part_filter =
       [](

--- a/src/v/cluster/client_quota_store.h
+++ b/src/v/cluster/client_quota_store.h
@@ -21,6 +21,8 @@ public:
     using container_type = absl::node_hash_map<entity_key, entity_value>;
     using range_container_type
       = chunked_vector<std::pair<entity_key, entity_value>>;
+    using range_callback_type
+      = std::function<bool(const std::pair<entity_key, entity_value>&)>;
 
     /// Upserts the given quota at the given entity key
     /// All quota types are overwritten with the given entity_value, so on alter
@@ -35,8 +37,7 @@ public:
     std::optional<entity_value> get_quota(const entity_key&) const;
 
     /// Returns a list of quotas that match the given predicate
-    store::range_container_type range(
-      std::function<bool(const std::pair<entity_key, entity_value>&)>&&) const;
+    store::range_container_type range(range_callback_type&&) const;
 
     /// Returns the number of quotas stored in the store
     container_type::size_type size() const;

--- a/src/v/cluster/commands.h
+++ b/src/v/cluster/commands.h
@@ -11,6 +11,7 @@
 
 #pragma once
 #include "bytes/iobuf_parser.h"
+#include "cluster/client_quota_serde.h"
 #include "cluster/simple_batch_builder.h"
 #include "cluster/types.h"
 #include "model/metadata.h"
@@ -142,6 +143,9 @@ static constexpr int8_t transform_remove_cmd_type = 1;
 // cluster recovery commands
 static constexpr int8_t cluster_recovery_init_cmd_type = 0;
 static constexpr int8_t cluster_recovery_update_cmd_type = 1;
+
+// client quota commands
+static constexpr int8_t alter_quotas_delta_cmd_type = 0;
 
 using create_topic_cmd = controller_command<
   model::topic_namespace,
@@ -424,6 +428,12 @@ using cluster_recovery_update_cmd = controller_command<
   cluster_recovery_update_cmd_data,
   cluster_recovery_update_cmd_type,
   model::record_batch_type::cluster_recovery_cmd>;
+
+using alter_quotas_delta_cmd = controller_command<
+  int8_t, // unused
+  client_quota::alter_delta_cmd_data,
+  alter_quotas_delta_cmd_type,
+  model::record_batch_type::client_quota>;
 
 // typelist utils
 template<typename T>

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -155,6 +155,12 @@ public:
         return _recovery_table;
     }
 
+    ss::sharded<client_quota::frontend>& get_quota_frontend() {
+        return _quota_frontend;
+    }
+
+    ss::sharded<client_quota::store>& get_quota_store() { return _quota_store; }
+
     bool is_raft0_leader() const {
         vassert(
           ss::this_shard_id() == ss::shard_id(0),
@@ -294,6 +300,9 @@ private:
     ss::sharded<cluster_recovery_table> _recovery_table; // instance per core
     ss::sharded<cluster_recovery_manager> _recovery_manager; // single instance
     std::unique_ptr<cloud_metadata::cluster_recovery_backend> _recovery_backend;
+    ss::sharded<client_quota::frontend> _quota_frontend; // instance per core
+    ss::sharded<client_quota::store> _quota_store;       // instance per core
+    ss::sharded<client_quota::backend> _quota_backend;   // single instance
 
     ss::gate _gate;
     consensus_ptr _raft0;

--- a/src/v/cluster/controller_snapshot.cc
+++ b/src/v/cluster/controller_snapshot.cc
@@ -192,6 +192,7 @@ ss::future<> controller_snapshot::serde_async_write(iobuf& out) {
     co_await serde::write_async(out, std::move(metrics_reporter));
     co_await serde::write_async(out, std::move(plugins));
     co_await serde::write_async(out, std::move(cluster_recovery));
+    co_await serde::write_async(out, std::move(client_quotas));
 }
 
 ss::future<>
@@ -219,6 +220,11 @@ controller_snapshot::serde_async_read(iobuf_parser& in, serde::header const h) {
     if (h._version >= 2) {
         cluster_recovery
           = co_await serde::read_async_nested<decltype(cluster_recovery)>(
+            in, h._bytes_left_limit);
+    }
+    if (h._version >= 3) {
+        client_quotas
+          = co_await serde::read_async_nested<decltype(client_quotas)>(
             in, h._bytes_left_limit);
     }
 

--- a/src/v/cluster/controller_snapshot.h
+++ b/src/v/cluster/controller_snapshot.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include "cluster/client_quota_serde.h"
 #include "cluster/cluster_recovery_state.h"
 #include "cluster/types.h"
 #include "container/chunked_hash_map.h"
@@ -257,12 +258,24 @@ struct cluster_recovery_t
     auto serde_fields() { return std::tie(recovery_states); }
 };
 
+struct client_quotas_t
+  : public serde::
+      envelope<client_quotas_t, serde::version<0>, serde::compat_version<0>> {
+    absl::node_hash_map<client_quota::entity_key, client_quota::entity_value>
+      quotas;
+
+    friend bool operator==(const client_quotas_t&, const client_quotas_t&)
+      = default;
+
+    auto serde_fields() { return std::tie(quotas); }
+};
+
 } // namespace controller_snapshot_parts
 
 struct controller_snapshot
   : public serde::checksum_envelope<
       controller_snapshot,
-      serde::version<2>,
+      serde::version<3>,
       serde::compat_version<0>> {
     controller_snapshot_parts::bootstrap_t bootstrap;
     controller_snapshot_parts::features_t features;
@@ -273,6 +286,7 @@ struct controller_snapshot
     controller_snapshot_parts::metrics_reporter_t metrics_reporter;
     controller_snapshot_parts::plugins_t plugins;
     controller_snapshot_parts::cluster_recovery_t cluster_recovery;
+    controller_snapshot_parts::client_quotas_t client_quotas;
 
     friend bool
     operator==(const controller_snapshot&, const controller_snapshot&)

--- a/src/v/cluster/controller_stm.cc
+++ b/src/v/cluster/controller_stm.cc
@@ -178,7 +178,9 @@ ss::future<> controller_stm::apply_snapshot(
           std::get<plugin_backend&>(_state).apply_snapshot(offset, snapshot),
           std::get<cluster_recovery_manager&>(_state).apply_snapshot(
             offset, snapshot),
-          std::get<security_manager&>(_state).apply_snapshot(offset, snapshot));
+          std::get<security_manager&>(_state).apply_snapshot(offset, snapshot),
+          std::get<client_quota::backend&>(_state).apply_snapshot(
+            offset, snapshot));
 
     } catch (const seastar::abort_requested_exception&) {
     } catch (const seastar::gate_closed_exception&) {

--- a/src/v/cluster/controller_stm.h
+++ b/src/v/cluster/controller_stm.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "cluster/bootstrap_backend.h"
+#include "cluster/client_quota_backend.h"
 #include "cluster/cluster_recovery_manager.h"
 #include "cluster/config_manager.h"
 #include "cluster/controller_log_limiter.h"
@@ -37,7 +38,8 @@ class controller_stm final
       feature_backend,
       bootstrap_backend,
       plugin_backend,
-      cluster_recovery_manager> {
+      cluster_recovery_manager,
+      client_quota::backend> {
 public:
     template<typename... Args>
     controller_stm(

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -110,6 +110,7 @@ class uploader;
 
 namespace client_quota {
 class frontend;
+class backend;
 class store;
 }; // namespace client_quota
 

--- a/src/v/cluster/fwd.h
+++ b/src/v/cluster/fwd.h
@@ -108,6 +108,11 @@ class producer_id_recovery_manager;
 class uploader;
 } // namespace cloud_metadata
 
+namespace client_quota {
+class frontend;
+class store;
+}; // namespace client_quota
+
 } // namespace cluster
 
 namespace seastar {

--- a/src/v/cluster/tests/client_quota_store_test.cc
+++ b/src/v/cluster/tests/client_quota_store_test.cc
@@ -17,8 +17,6 @@
 #include <boost/test/unit_test.hpp>
 #include <fmt/ostream.h>
 
-#include <vector>
-
 namespace cluster::client_quota {
 
 const entity_key key0{

--- a/src/v/kafka/server/handlers/alter_client_quotas.cc
+++ b/src/v/kafka/server/handlers/alter_client_quotas.cc
@@ -38,6 +38,10 @@ ss::future<response_ptr> alter_client_quotas_handler::handle(
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
 
+    // TODO: implement the AlterClientQuotas API
+    // ctx.quota_store().get_quota(...);
+    // ctx.quota_frontend().alter_quotas(...);
+
     alter_client_quotas_response response;
     make_error_response(request, response);
 

--- a/src/v/kafka/server/handlers/describe_client_quotas.cc
+++ b/src/v/kafka/server/handlers/describe_client_quotas.cc
@@ -32,6 +32,9 @@ ss::future<response_ptr> describe_client_quotas_handler::handle(
     request.decode(ctx.reader(), ctx.header().version);
     log_request(ctx.header(), request);
 
+    // TODO: implement the DescribeClientQuotas API
+    // ctx.quota_store().get_quota(...);
+
     co_return co_await ctx.respond(make_response({
       .error_code = error_code::unsupported_version,
       .error_message = "Unsupported version - not yet implemented",

--- a/src/v/kafka/server/request_context.h
+++ b/src/v/kafka/server/request_context.h
@@ -141,6 +141,14 @@ public:
         return _conn->server().topics_frontend();
     }
 
+    cluster::client_quota::frontend& quota_frontend() {
+        return _conn->server().quota_frontend();
+    }
+
+    cluster::client_quota::store& quota_store() {
+        return _conn->server().quota_store();
+    }
+
     quota_manager& quota_mgr() { return _conn->server().quota_mgr(); }
 
     ss::sharded<cluster::config_frontend>& config_frontend() const {

--- a/src/v/kafka/server/server.cc
+++ b/src/v/kafka/server/server.cc
@@ -70,6 +70,7 @@
 #include <seastar/core/byteorder.hh>
 #include <seastar/core/loop.hh>
 #include <seastar/core/metrics.hh>
+#include <seastar/core/sharded.hh>
 #include <seastar/core/sstring.hh>
 #include <seastar/net/api.hh>
 #include <seastar/net/socket_defs.hh>
@@ -115,6 +116,8 @@ server::server(
   ss::sharded<cluster::topics_frontend>& tf,
   ss::sharded<cluster::config_frontend>& cf,
   ss::sharded<features::feature_table>& ft,
+  ss::sharded<cluster::client_quota::frontend>& quota_frontend,
+  ss::sharded<cluster::client_quota::store>& quota_store,
   ss::sharded<quota_manager>& quota,
   ss::sharded<snc_quota_manager>& snc_quota_mgr,
   ss::sharded<kafka::group_router>& router,
@@ -139,6 +142,8 @@ server::server(
   , _config_frontend(cf)
   , _feature_table(ft)
   , _metadata_cache(meta)
+  , _quota_frontend(quota_frontend)
+  , _quota_store(quota_store)
   , _quota_mgr(quota)
   , _snc_quota_mgr(snc_quota_mgr)
   , _group_router(router)

--- a/src/v/kafka/server/server.h
+++ b/src/v/kafka/server/server.h
@@ -54,6 +54,8 @@ public:
       ss::sharded<cluster::topics_frontend>&,
       ss::sharded<cluster::config_frontend>&,
       ss::sharded<features::feature_table>&,
+      ss::sharded<cluster::client_quota::frontend>&,
+      ss::sharded<cluster::client_quota::store>&,
       ss::sharded<quota_manager>&,
       ss::sharded<snc_quota_manager>&,
       ss::sharded<kafka::group_router>&,
@@ -121,6 +123,10 @@ public:
     coordinator_ntp_mapper& coordinator_mapper();
 
     fetch_session_cache& fetch_sessions_cache() { return _fetch_session_cache; }
+    cluster::client_quota::frontend& quota_frontend() {
+        return _quota_frontend.local();
+    }
+    cluster::client_quota::store& quota_store() { return _quota_store.local(); }
     quota_manager& quota_mgr() { return _quota_mgr.local(); }
     usage_manager& usage_mgr() { return _usage_manager.local(); }
     snc_quota_manager& snc_quota_mgr() { return _snc_quota_mgr.local(); }
@@ -214,6 +220,8 @@ private:
     ss::sharded<cluster::config_frontend>& _config_frontend;
     ss::sharded<features::feature_table>& _feature_table;
     ss::sharded<cluster::metadata_cache>& _metadata_cache;
+    ss::sharded<cluster::client_quota::frontend>& _quota_frontend;
+    ss::sharded<cluster::client_quota::store>& _quota_store;
     ss::sharded<quota_manager>& _quota_mgr;
     ss::sharded<snc_quota_manager>& _snc_quota_mgr;
     ss::sharded<kafka::group_router>& _group_router;

--- a/src/v/model/model.cc
+++ b/src/v/model/model.cc
@@ -370,6 +370,8 @@ std::ostream& operator<<(std::ostream& o, record_batch_type bt) {
         return o << "batch_type::compaction_placeholder";
     case record_batch_type::role_management_cmd:
         return o << "batch_type::role_management_cmd";
+    case record_batch_type::client_quota:
+        return o << "batch_type::client_quota";
     }
 
     return o << "batch_type::unknown{" << static_cast<int>(bt) << "}";

--- a/src/v/model/record_batch_types.h
+++ b/src/v/model/record_batch_types.h
@@ -49,7 +49,8 @@ enum class record_batch_type : int8_t {
     compaction_placeholder
     = 29, // place holder for last batch in a segment that was aborted
     role_management_cmd = 30, // role management command
-    MAX = role_management_cmd,
+    client_quota = 31,        // client quota command
+    MAX = client_quota,
 };
 
 std::ostream& operator<<(std::ostream& o, record_batch_type bt);

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2070,6 +2070,8 @@ void application::wire_up_redpanda_services(
         std::ref(controller->get_topics_frontend()),
         std::ref(controller->get_config_frontend()),
         std::ref(controller->get_feature_table()),
+        std::ref(controller->get_quota_frontend()),
+        std::ref(controller->get_quota_store()),
         std::ref(quota_mgr),
         std::ref(snc_quota_mgr),
         std::ref(group_router),

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -152,6 +152,8 @@ public:
             std::ref(app.controller->get_topics_frontend()),
             std::ref(app.controller->get_config_frontend()),
             std::ref(app.controller->get_feature_table()),
+            std::ref(app.controller->get_quota_frontend()),
+            std::ref(app.controller->get_quota_store()),
             std::ref(app.quota_mgr),
             std::ref(app.snc_quota_mgr),
             std::ref(app.group_router),


### PR DESCRIPTION
This adds a controller frontend/backend for the quota store, introduces the client quota controller commands and integrates the quota store and quota frontend into the controller and kafka server.

It also includes a small fixup cherry-pick of nits from the previous PR https://github.com/redpanda-data/redpanda/pull/18681.

Fixes https://redpandadata.atlassian.net/browse/CORE-2698

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
