### PR TITLE
rpk: explicitly add Arg validation to plugins

### DIFF
--- a/src/go/rpk/pkg/cli/plugin_cmds.go
+++ b/src/go/rpk/pkg/cli/plugin_cmds.go
@@ -88,6 +88,7 @@ func addPluginWithExec(
 			Use:                p0,
 			Short:              p0 + pluginShortSuffix,
 			DisableFlagParsing: true,
+			Args:               cobra.MinimumNArgs(0),
 			Run: func(cmd *cobra.Command, args []string) {
 				keepForPlugin, _ := cobraext.StripFlagset(args, cmd.InheritedFlags()) // strip all rpk specific flags before execing the plugin
 				err := osExec(execPath, keepForPlugin)
@@ -263,6 +264,7 @@ func addPluginSubcommands(
 		childCmd := &cobra.Command{
 			Short:              fmt.Sprintf("%s external plugin", childUse),
 			DisableFlagParsing: true,
+			Args:               cobra.MinimumNArgs(0),
 			Run: func(cmd *cobra.Command, args []string) {
 				keepForPlugin, _ := cobraext.StripFlagset(args, cmd.InheritedFlags()) // strip all rpk specific flags before execing the plugin
 				osExec(execPath, append(append(leadingPieces, cmd.Use), keepForPlugin...))


### PR DESCRIPTION
In #18650 we added Arg validations for every
comman and an automatic "walk" through the command space to add cobra.NoArgs.

Plugins were not taken into account, this commit
explicitly set the cobra.MinimumArg(0) to avoid
adding "NoArgs" on execution.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
