### PR TITLE
[CORE-1562] config: update `archive::configuration` types to `config::binding<>`

### DIFF
--- a/src/v/archival/tests/archival_service_fixture.h
+++ b/src/v/archival/tests/archival_service_fixture.h
@@ -70,16 +70,15 @@ class archiver_cluster_fixture
         s3_conf.server_addr = server_addr;
 
         archival::configuration a_conf{
+          .cloud_storage_initial_backoff = config::mock_binding(100ms),
+          .segment_upload_timeout = config::mock_binding(1000ms),
           .manifest_upload_timeout = config::mock_binding(1000ms),
-        };
+          .garbage_collect_timeout = config::mock_binding(1000ms),
+          .upload_loop_initial_backoff = config::mock_binding(100ms),
+          .upload_loop_max_backoff = config::mock_binding(5000ms)};
         a_conf.bucket_name = cloud_storage_clients::bucket_name("test-bucket");
         a_conf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
         a_conf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
-        a_conf.cloud_storage_initial_backoff = 100ms;
-        a_conf.segment_upload_timeout = 1s;
-        a_conf.garbage_collect_timeout = 1s;
-        a_conf.upload_loop_initial_backoff = 100ms;
-        a_conf.upload_loop_max_backoff = 5s;
         a_conf.time_limit = std::nullopt;
 
         cloud_storage::configuration c_conf;

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -194,16 +194,15 @@ archiver_fixture::get_configurations() {
     s3conf.server_addr = server_addr;
 
     archival::configuration aconf{
+      .cloud_storage_initial_backoff = config::mock_binding(100ms),
+      .segment_upload_timeout = config::mock_binding(1000ms),
       .manifest_upload_timeout = config::mock_binding(1000ms),
-    };
+      .garbage_collect_timeout = config::mock_binding(1000ms),
+      .upload_loop_initial_backoff = config::mock_binding(100ms),
+      .upload_loop_max_backoff = config::mock_binding(5000ms)};
     aconf.bucket_name = cloud_storage_clients::bucket_name("test-bucket");
     aconf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
     aconf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
-    aconf.cloud_storage_initial_backoff = 100ms;
-    aconf.segment_upload_timeout = 1s;
-    aconf.garbage_collect_timeout = 1s;
-    aconf.upload_loop_initial_backoff = 100ms;
-    aconf.upload_loop_max_backoff = 5s;
     aconf.time_limit = std::nullopt;
 
     cloud_storage::configuration cconf;

--- a/src/v/archival/types.cc
+++ b/src/v/archival/types.cc
@@ -46,12 +46,9 @@ std::ostream& operator<<(std::ostream& o, const configuration& cfg) {
       "segment_upload_timeout: {}, "
       "manifest_upload_timeout: {}, time_limit: {}}}",
       cfg.bucket_name,
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-        cfg.cloud_storage_initial_backoff),
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-        cfg.segment_upload_timeout),
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-        cfg.manifest_upload_timeout()),
+      cfg.cloud_storage_initial_backoff(),
+      cfg.segment_upload_timeout(),
+      cfg.manifest_upload_timeout(),
       cfg.time_limit);
     return o;
 }
@@ -97,22 +94,22 @@ get_archival_service_config(ss::scheduling_group sg, ss::io_priority_class p) {
       .bucket_name = cloud_storage_clients::bucket_name(
         get_value_or_throw(bucket_config, bucket_config.name())),
       .cloud_storage_initial_backoff
-      = config::shard_local_cfg().cloud_storage_initial_backoff_ms.value(),
+      = config::shard_local_cfg().cloud_storage_initial_backoff_ms.bind(),
       .segment_upload_timeout
       = config::shard_local_cfg()
-          .cloud_storage_segment_upload_timeout_ms.value(),
+          .cloud_storage_segment_upload_timeout_ms.bind(),
       .manifest_upload_timeout
       = config::shard_local_cfg()
           .cloud_storage_manifest_upload_timeout_ms.bind(),
       .garbage_collect_timeout
       = config::shard_local_cfg()
-          .cloud_storage_garbage_collect_timeout_ms.value(),
+          .cloud_storage_garbage_collect_timeout_ms.bind(),
       .upload_loop_initial_backoff
       = config::shard_local_cfg()
-          .cloud_storage_upload_loop_initial_backoff_ms.value(),
+          .cloud_storage_upload_loop_initial_backoff_ms.bind(),
       .upload_loop_max_backoff
       = config::shard_local_cfg()
-          .cloud_storage_upload_loop_max_backoff_ms.value(),
+          .cloud_storage_upload_loop_max_backoff_ms.bind(),
       .svc_metrics_disabled = service_metrics_disabled(
         static_cast<bool>(disable_metrics)),
       .ntp_metrics_disabled = per_ntp_metrics_disabled(

--- a/src/v/archival/types.h
+++ b/src/v/archival/types.h
@@ -42,17 +42,17 @@ struct configuration {
     /// Bucket used to store all archived data
     cloud_storage_clients::bucket_name bucket_name;
     /// Initial backoff for requests to cloud storage
-    ss::lowres_clock::duration cloud_storage_initial_backoff;
+    config::binding<std::chrono::milliseconds> cloud_storage_initial_backoff;
     /// Long upload timeout
-    ss::lowres_clock::duration segment_upload_timeout;
+    config::binding<std::chrono::milliseconds> segment_upload_timeout;
     /// Shor upload timeout
     config::binding<std::chrono::milliseconds> manifest_upload_timeout;
     /// Timeout for running delete operations during the GC phase
-    ss::lowres_clock::duration garbage_collect_timeout;
+    config::binding<std::chrono::milliseconds> garbage_collect_timeout;
     /// Initial backoff for upload loop in case there is nothing to upload
-    ss::lowres_clock::duration upload_loop_initial_backoff;
+    config::binding<std::chrono::milliseconds> upload_loop_initial_backoff;
     /// Max backoff for upload loop in case there is nothing to upload
-    ss::lowres_clock::duration upload_loop_max_backoff;
+    config::binding<std::chrono::milliseconds> upload_loop_max_backoff;
     /// Flag that indicates that service level metrics are disabled
     service_metrics_disabled svc_metrics_disabled;
     /// Flag that indicates that ntp-archiver level metrics are disabled

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1735,14 +1735,14 @@ configuration::configuration()
       "cloud_storage_upload_loop_initial_backoff_ms",
       "Initial backoff interval when there is nothing to upload for a "
       "partition (ms)",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       100ms)
   , cloud_storage_upload_loop_max_backoff_ms(
       *this,
       "cloud_storage_upload_loop_max_backoff_ms",
       "Max backoff interval when there is nothing to upload for a "
       "partition (ms)",
-      {.visibility = visibility::tunable},
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       10s)
   , cloud_storage_max_connections(
       *this,

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -81,6 +81,8 @@ using configure_node_id = ss::bool_class<struct configure_node_id_tag>;
 using empty_seed_starts_cluster
   = ss::bool_class<struct empty_seed_starts_cluster_tag>;
 
+using namespace std::chrono_literals;
+
 class redpanda_thread_fixture {
 public:
     static constexpr const char* rack_name = "i-am-rack";
@@ -294,14 +296,15 @@ public:
 
     static archival::configuration get_archival_config() {
         archival::configuration aconf{
+          .cloud_storage_initial_backoff = config::mock_binding(100ms),
+          .segment_upload_timeout = config::mock_binding(1000ms),
           .manifest_upload_timeout = config::mock_binding(1000ms),
-        };
+          .garbage_collect_timeout = config::mock_binding(1000ms),
+          .upload_loop_initial_backoff = config::mock_binding(100ms),
+          .upload_loop_max_backoff = config::mock_binding(5000ms)};
         aconf.bucket_name = cloud_storage_clients::bucket_name("test-bucket");
         aconf.ntp_metrics_disabled = archival::per_ntp_metrics_disabled::yes;
         aconf.svc_metrics_disabled = archival::service_metrics_disabled::yes;
-        aconf.cloud_storage_initial_backoff = 100ms;
-        aconf.segment_upload_timeout = 1s;
-        aconf.garbage_collect_timeout = 1s;
         aconf.time_limit = std::nullopt;
         return aconf;
     }
@@ -398,7 +401,7 @@ public:
                 config.get("cloud_storage_initial_backoff_ms")
                   .set_value(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
-                      local_cfg->cloud_storage_initial_backoff));
+                      local_cfg->cloud_storage_initial_backoff()));
                 config.get("cloud_storage_manifest_upload_timeout_ms")
                   .set_value(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -406,11 +409,11 @@ public:
                 config.get("cloud_storage_segment_upload_timeout_ms")
                   .set_value(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
-                      local_cfg->segment_upload_timeout));
+                      local_cfg->segment_upload_timeout()));
                 config.get("cloud_storage_garbage_collect_timeout_ms")
                   .set_value(
                     std::chrono::duration_cast<std::chrono::milliseconds>(
-                      local_cfg->garbage_collect_timeout));
+                      local_cfg->garbage_collect_timeout()));
             }
             if (cloud_cfg) {
                 config.get("cloud_storage_enable_remote_read").set_value(true);


### PR DESCRIPTION
Fixes #14779 

A number of properties in the `archival::configuration` object do not require restarts, and have been updated to `config::binding<>` types in order to reflect updates made to the cluster config during runtime.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
