### PR TITLE
[CORE-1867] config: add `validate_cloud_storage_api_endpoint`

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -1681,7 +1681,7 @@ configuration::configuration()
       "Optional API endpoint",
       {.visibility = visibility::user},
       std::nullopt,
-      &validate_non_empty_string_opt)
+      &validate_cloud_storage_api_endpoint)
   , cloud_storage_url_style(
       *this,
       "cloud_storage_url_style",

--- a/src/v/config/validators.cc
+++ b/src/v/config/validators.cc
@@ -230,4 +230,21 @@ validate_audit_excluded_topics(const std::vector<ss::sstring>& vs) {
 
     return std::nullopt;
 }
+
+std::optional<ss::sstring>
+validate_cloud_storage_api_endpoint(const std::optional<ss::sstring>& os) {
+    if (auto non_empty_string_opt = validate_non_empty_string_opt(os);
+        non_empty_string_opt.has_value()) {
+        return non_empty_string_opt;
+    }
+
+    if (
+      os.has_value()
+      && (os.value().starts_with("http://") || os.value().starts_with("https://"))) {
+        return "String starting with URL protocol is not valid";
+    }
+
+    return std::nullopt;
+}
+
 }; // namespace config

--- a/src/v/config/validators.h
+++ b/src/v/config/validators.h
@@ -53,4 +53,7 @@ validate_audit_event_types(const std::vector<ss::sstring>& vs);
 std::optional<ss::sstring>
 validate_audit_excluded_topics(const std::vector<ss::sstring>&);
 
+std::optional<ss::sstring>
+validate_cloud_storage_api_endpoint(const std::optional<ss::sstring>& os);
+
 }; // namespace config

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1490,6 +1490,22 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
                 if s['node_id'] == self.redpanda.idx(controller_node))
             assert local_status['config_version'] == config_version
 
+    @cluster(num_nodes=3)
+    @parametrize(value="http://pandazone", valid=False)
+    @parametrize(value="https://securepandazone", valid=False)
+    @parametrize(value="pandazone", valid=True)
+    def test_validate_cloud_storage_api_endpoint(self, value, valid):
+        try:
+            self.admin.patch_cluster_config(
+                upsert={"cloud_storage_api_endpoint": value})
+        except requests.exceptions.HTTPError as e:
+            #Invalid api endpoint
+            assert not valid
+            assert e.response.status_code == 400
+        else:
+            #Valid api endpoint
+            assert valid
+
 
 """
 PropertyAliasData:

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1180,7 +1180,7 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
         # but on a non-secret property, thereby validating that our log scanning procedure
         # would have detected the secret if it had been printed
         unsecret_key = "cloud_storage_api_endpoint"
-        unsecret_value = "http://nowhere"
+        unsecret_value = "nowhere"
         set_and_search(unsecret_key, unsecret_value, True)
 
     @cluster(num_nodes=3)


### PR DESCRIPTION
Fixes #17014.

A new validation function is added in order to prevent configuration issues where users set a `cloud_storage_api_endpoint` starting with `http://` or `https://`.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none