### PR TITLE
cpu_profiler: prealloc result buffers

### DIFF
--- a/src/v/redpanda/admin/debug.cc
+++ b/src/v/redpanda/admin/debug.cc
@@ -27,6 +27,7 @@
 #include "redpanda/admin/api-doc/debug.json.hh"
 #include "redpanda/admin/server.h"
 #include "redpanda/admin/util.h"
+#include "resource_mgmt/cpu_profiler.h"
 #include "serde/rw/rw.h"
 #include "storage/kvstore.h"
 
@@ -542,23 +543,23 @@ admin_server::cpu_profile_handler(std::unique_ptr<ss::http::request> req) {
           *wait_ms, shard_id);
     }
 
-    std::vector<ss::httpd::debug_json::cpu_profile_shard_samples> response{
-      profiles.size()};
-    for (size_t i = 0; i < profiles.size(); i++) {
-        response[i].shard_id = profiles[i].shard;
-        response[i].dropped_samples = profiles[i].dropped_samples;
-
-        for (auto& sample : profiles[i].samples) {
-            ss::httpd::debug_json::cpu_profile_sample s;
-            s.occurrences = sample.occurrences;
-            s.user_backtrace = sample.user_backtrace;
-
-            response[i].samples.push(s);
-        }
-    }
-
     co_return co_await ss::make_ready_future<ss::json::json_return_type>(
-      std::move(response));
+      ss::json::stream_range_as_array(
+        lw_shared_container(std::move(profiles)),
+        [](const resources::cpu_profiler::shard_samples& profile) {
+            ss::httpd::debug_json::cpu_profile_shard_samples ret;
+            ret.shard_id = profile.shard;
+            ret.dropped_samples = profile.dropped_samples;
+
+            for (auto& sample : profile.samples) {
+                ss::httpd::debug_json::cpu_profile_sample s;
+                s.occurrences = sample.occurrences;
+                s.user_backtrace = sample.user_backtrace;
+
+                ret.samples.push(s);
+            }
+            return ret;
+        }));
 }
 
 ss::future<ss::json::json_return_type>

--- a/src/v/resource_mgmt/cpu_profiler.cc
+++ b/src/v/resource_mgmt/cpu_profiler.cc
@@ -36,6 +36,14 @@ cpu_profiler::cpu_profiler(
   , _sample_period(std::move(sample_period)) {
     _enabled.watch([this] { on_enabled_change(); });
     _sample_period.watch([this] { on_sample_period_change(); });
+
+    for (size_t i = 0; i < number_of_results_buffers; i++) {
+        _results_buffers.emplace_back(
+          0,
+          std::vector<ss::cpu_profiler_trace>{},
+          ss::lowres_clock::time_point::min());
+        _results_buffers.back().samples.reserve(ss::max_number_of_traces);
+    }
 }
 
 ss::future<> cpu_profiler::start() {


### PR DESCRIPTION
Preallocated result buffers at startup to avoid oversized allocs later
down the line.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none


