### PR TITLE
[v23.3.x] cloud_storage_clients: check for `BlobNotFound` in `abs_client::do_delete_path()`

### DIFF
--- a/src/v/cloud_storage_clients/abs_client.cc
+++ b/src/v/cloud_storage_clients/abs_client.cc
@@ -925,7 +925,9 @@ ss::future<> abs_client::do_delete_path(
         try {
             co_await do_delete_file(name, *iter, timeout);
         } catch (const abs_rest_error_response& abs_error) {
-            if (abs_error.code() == abs_error_code::path_not_found) {
+            if (
+              abs_error.code() == abs_error_code::path_not_found
+              || abs_error.code() == abs_error_code::blob_not_found) {
                 vlog(
                   abs_log.debug,
                   "Object to be deleted was not found in cloud storage: "

--- a/src/v/cloud_storage_clients/abs_error.cc
+++ b/src/v/cloud_storage_clients/abs_error.cc
@@ -32,7 +32,6 @@ std::istream& operator>>(std::istream& i, abs_error_code& code) {
           .match("InternalError", abs_error_code::internal_error)
           .match("OperationTimedOut", abs_error_code::operation_timed_out)
           .match("SystemInUse", abs_error_code::system_in_use)
-          .match("BlobNotFound", abs_error_code::blob_not_found)
           .match("AccountBeingCreated", abs_error_code::account_being_created)
           .match(
             "ResourceAlreadyExists", abs_error_code::resource_already_exists)


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18700
