### PR TITLE
CORE-2699 kafka/quota_mgr: extract keys and limit logic into `client_quota_translator`

### DIFF
--- a/src/v/kafka/CMakeLists.txt
+++ b/src/v/kafka/CMakeLists.txt
@@ -48,6 +48,7 @@ v_cc_library(
     server/server.cc
     server/protocol_utils.cc
     server/quota_manager.cc
+    server/client_quota_translator.cc
     server/snc_quota_manager.cc
     server/fetch_session_cache.cc
     server/replicated_partition.cc

--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "kafka/server/client_quota_translator.h"
+
+#include "config/configuration.h"
+
+#include <optional>
+#include <utility>
+
+namespace kafka {
+
+std::ostream& operator<<(std::ostream& os, const client_quota_limits& l) {
+    fmt::print(
+      os,
+      "limits{{produce_limit: {}, fetch_limit: {}, "
+      "partition_mutation_limit: {}}}",
+      l.produce_limit,
+      l.fetch_limit,
+      l.partition_mutation_limit);
+    return os;
+}
+
+client_quota_translator::client_quota_translator()
+  : _default_target_produce_tp_rate(
+    config::shard_local_cfg().target_quota_byte_rate.bind())
+  , _default_target_fetch_tp_rate(
+      config::shard_local_cfg().target_fetch_quota_byte_rate.bind())
+  , _target_partition_mutation_quota(
+      config::shard_local_cfg().kafka_admin_topic_api_rate.bind())
+  , _target_produce_tp_rate_per_client_group(
+      config::shard_local_cfg().kafka_client_group_byte_rate_quota.bind())
+  , _target_fetch_tp_rate_per_client_group(
+      config::shard_local_cfg()
+        .kafka_client_group_fetch_byte_rate_quota.bind()) {}
+
+uint64_t client_quota_translator::get_client_target_produce_tp_rate(
+  const tracker_key& quota_id) {
+    return ss::visit(
+      quota_id,
+      [this](const k_client_id&) -> uint64_t {
+          return _default_target_produce_tp_rate();
+      },
+      [this](const k_group_name& k) -> uint64_t {
+          auto group = _target_produce_tp_rate_per_client_group().find(k);
+          if (group != _target_produce_tp_rate_per_client_group().end()) {
+              return group->second.quota;
+          }
+          return _default_target_produce_tp_rate();
+      });
+}
+
+std::optional<uint64_t>
+client_quota_translator::get_client_target_fetch_tp_rate(
+  const tracker_key& quota_id) {
+    return ss::visit(
+      quota_id,
+      [this](const k_client_id&) -> std::optional<uint64_t> {
+          return _default_target_fetch_tp_rate();
+      },
+      [this](const k_group_name& k) -> std::optional<uint64_t> {
+          auto group = _target_fetch_tp_rate_per_client_group().find(k);
+          if (group != _target_fetch_tp_rate_per_client_group().end()) {
+              return group->second.quota;
+          }
+          return _default_target_fetch_tp_rate();
+      });
+}
+
+namespace {
+// If client is part of some group then client quota ID is a group
+// else client quota ID is client_id
+tracker_key get_client_quota_id(
+  const std::optional<std::string_view>& client_id,
+  const std::unordered_map<ss::sstring, config::client_group_quota>&
+    group_quota) {
+    if (!client_id) {
+        // requests without a client id are grouped into an anonymous group that
+        // shares a default quota. the anonymous group is keyed on empty string.
+        return tracker_key{std::in_place_type<k_client_id>, ""};
+    }
+    for (const auto& group_and_limit : group_quota) {
+        if (client_id->starts_with(
+              std::string_view(group_and_limit.second.clients_prefix))) {
+            return tracker_key{
+              std::in_place_type<k_group_name>, group_and_limit.first};
+        }
+    }
+    return tracker_key{std::in_place_type<k_client_id>, *client_id};
+}
+
+} // namespace
+
+tracker_key client_quota_translator::get_produce_key(
+  std::optional<std::string_view> client_id) {
+    return get_client_quota_id(
+      client_id, _target_produce_tp_rate_per_client_group());
+}
+
+tracker_key client_quota_translator::get_fetch_key(
+  std::optional<std::string_view> client_id) {
+    return get_client_quota_id(
+      client_id, _target_fetch_tp_rate_per_client_group());
+}
+
+tracker_key client_quota_translator::get_partition_mutation_key(
+  std::optional<std::string_view> client_id) {
+    return get_client_quota_id(client_id, {});
+}
+
+tracker_key
+client_quota_translator::find_quota_key(const client_quota_request_ctx& ctx) {
+    switch (ctx.q_type) {
+    case client_quota_type::produce_quota:
+        return get_produce_key(ctx.client_id);
+    case client_quota_type::fetch_quota:
+        return get_fetch_key(ctx.client_id);
+    case client_quota_type::partition_mutation_quota:
+        return get_partition_mutation_key(ctx.client_id);
+    };
+}
+
+std::pair<tracker_key, client_quota_limits>
+client_quota_translator::find_quota(const client_quota_request_ctx& ctx) {
+    auto key = find_quota_key(ctx);
+    auto value = find_quota_value(key);
+    return {std::move(key), value};
+}
+
+client_quota_limits
+client_quota_translator::find_quota_value(const tracker_key& key) {
+    return client_quota_limits{
+      .produce_limit = get_client_target_produce_tp_rate(key),
+      .fetch_limit = get_client_target_fetch_tp_rate(key),
+      .partition_mutation_limit = _target_partition_mutation_quota(),
+    };
+}
+
+void client_quota_translator::watch(on_change_fn&& fn) {
+    auto watcher = [fn = std::move(fn)]() { fn(); };
+    _target_produce_tp_rate_per_client_group.watch(watcher);
+    _target_fetch_tp_rate_per_client_group.watch(watcher);
+    _target_partition_mutation_quota.watch(watcher);
+    _default_target_produce_tp_rate.watch(watcher);
+    _default_target_fetch_tp_rate.watch(watcher);
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/client_quota_translator.h
+++ b/src/v/kafka/server/client_quota_translator.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "config/client_group_byte_rate_quota.h"
+#include "config/property.h"
+#include "utils/named_type.h"
+
+#include <seastar/core/sstring.hh>
+
+#include <utility>
+
+namespace kafka {
+
+using k_client_id = named_type<ss::sstring, struct k_client_id_tag>;
+using k_group_name = named_type<ss::sstring, struct k_group_name_tag>;
+
+/// tracker_key is the we use to key into the client quotas map
+///
+/// Note: while the limits applicable to a single tracker_key are always going
+/// to be the same, it is not guaranteed that a client id will have the same
+/// tracker_key for different types of kafka requests (produce/fetch/partition
+/// mutations). For examples, refer to the unit tests.
+///
+/// Note: the tracker_key is different from the entity_key used to configure
+/// client quotas. The tracker_key defines the granularity at which we track
+/// quotas, whereas the quota limits might be defined more broadly.
+/// For example, if the default client quota applies to the request, the
+/// tracker_key may be client id specific even though the matching entity_key is
+/// the default client quota. In this case, we may have multiple independent
+/// rate trackers for each unique client with all of these rate tracking having
+/// the same shared quota limit
+using tracker_key = std::variant<k_client_id, k_group_name>;
+
+/// client_quota_limits describes the limits applicable to a tracker_key
+struct client_quota_limits {
+    std::optional<uint64_t> produce_limit;
+    std::optional<uint64_t> fetch_limit;
+    std::optional<uint64_t> partition_mutation_limit;
+
+    friend bool
+    operator==(const client_quota_limits&, const client_quota_limits&)
+      = default;
+    friend std::ostream&
+    operator<<(std::ostream& os, const client_quota_limits& l);
+};
+
+enum class client_quota_type {
+    produce_quota,
+    fetch_quota,
+    partition_mutation_quota
+};
+
+struct client_quota_request_ctx {
+    client_quota_type q_type;
+    std::optional<std::string_view> client_id;
+};
+
+/// client_quota_translator is responsible for providing quota_manager with a
+/// simplified interface to the quota configurations
+///  * It is responsible for translating the quota-specific request context (for
+///  now the client.id header field) into the applicable tracker_key.
+///  * It is also responsible for finding the quota limits of a tracker_key
+class client_quota_translator {
+public:
+    using on_change_fn = std::function<void()>;
+
+    client_quota_translator();
+
+    /// Returns the quota tracker key applicable to the given quota context
+    /// Note: because the client quotas configured for produce/fetch/pm might be
+    /// different, the tracker_key for produce/fetch/pm might be different
+    tracker_key find_quota_key(const client_quota_request_ctx& ctx);
+
+    /// Finds the limits applicable to the given quota tracker key
+    client_quota_limits find_quota_value(const tracker_key&);
+
+    /// Returns the quota tracker key and quota limit applicable to the given
+    /// quota context
+    std::pair<tracker_key, client_quota_limits>
+    find_quota(const client_quota_request_ctx& ctx);
+
+    /// `watch` can be used to register for quota changes
+    void watch(on_change_fn&& fn);
+
+private:
+    using quota_config
+      = std::unordered_map<ss::sstring, config::client_group_quota>;
+
+    tracker_key get_produce_key(std::optional<std::string_view> client_id);
+    tracker_key get_fetch_key(std::optional<std::string_view> client_id);
+    tracker_key
+    get_partition_mutation_key(std::optional<std::string_view> client_id);
+
+    uint64_t get_client_target_produce_tp_rate(const tracker_key& quota_id);
+    std::optional<uint64_t>
+    get_client_target_fetch_tp_rate(const tracker_key& quota_id);
+
+    config::binding<uint32_t> _default_target_produce_tp_rate;
+    config::binding<std::optional<uint32_t>> _default_target_fetch_tp_rate;
+    config::binding<std::optional<uint32_t>> _target_partition_mutation_quota;
+    config::binding<quota_config> _target_produce_tp_rate_per_client_group;
+    config::binding<quota_config> _target_fetch_tp_rate_per_client_group;
+};
+
+} // namespace kafka

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ rp_test(
     fetch_unit_test.cc
     config_utils_test.cc
     config_response_utils_test.cc
+    client_quota_translator_test.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES Boost::unit_test_framework v::kafka
   LABELS kafka

--- a/src/v/kafka/server/tests/client_quota_translator_test.cc
+++ b/src/v/kafka/server/tests/client_quota_translator_test.cc
@@ -1,0 +1,195 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+#include "config/configuration.h"
+#include "kafka/server/client_quota_translator.h"
+
+#include <boost/test/auto_unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <variant>
+
+using namespace kafka;
+
+const ss::sstring client_id = "franz-go";
+const tracker_key client_id_key = k_client_id{client_id};
+
+constexpr std::string_view raw_basic_produce_config = R"([
+  {
+    "group_name": "not-franz-go-produce-group",
+    "clients_prefix": "not-franz-go",
+    "quota": 2048
+  },
+  {
+    "group_name": "franz-go-produce-group",
+    "clients_prefix": "franz-go",
+    "quota": 4096
+  }
+])";
+
+constexpr std::string_view raw_basic_fetch_config = R"([
+  {
+    "group_name": "not-franz-go-fetch-group",
+    "clients_prefix": "not-franz-go",
+    "quota": 2049
+  },
+  {
+    "group_name": "franz-go-fetch-group",
+    "clients_prefix": "franz-go",
+    "quota": 4097
+  }
+])";
+
+// Helper for checking std::variant types for equality
+const auto CHECK_VARIANT_EQ = [](auto expected, auto got) {
+    BOOST_CHECK_EQUAL(expected, get<decltype(expected)>(got));
+};
+
+BOOST_AUTO_TEST_CASE(quota_translator_default_test) {
+    client_quota_translator tr;
+
+    auto default_limits = client_quota_limits{
+      .produce_limit = 2147483648,
+      .fetch_limit = std::nullopt,
+      .partition_mutation_limit = std::nullopt,
+    };
+    auto [key, limits] = tr.find_quota(
+      {client_quota_type::produce_quota, client_id});
+    BOOST_CHECK_EQUAL(client_id_key, key);
+    BOOST_CHECK_EQUAL(default_limits, limits);
+}
+
+BOOST_AUTO_TEST_CASE(quota_translator_modified_default_test) {
+    config::shard_local_cfg().target_quota_byte_rate.set_value(1111);
+    config::shard_local_cfg().target_fetch_quota_byte_rate.set_value(2222);
+    config::shard_local_cfg().kafka_admin_topic_api_rate.set_value(3333);
+
+    client_quota_translator tr;
+
+    auto expected_limits = client_quota_limits{
+      .produce_limit = 1111,
+      .fetch_limit = 2222,
+      .partition_mutation_limit = 3333,
+    };
+    auto [key, limits] = tr.find_quota(
+      {client_quota_type::produce_quota, client_id});
+    BOOST_CHECK_EQUAL(client_id_key, key);
+    BOOST_CHECK_EQUAL(expected_limits, limits);
+}
+
+BOOST_AUTO_TEST_CASE(quota_translator_client_group_test) {
+    constexpr auto P_DEF = 1111;
+    constexpr auto F_DEF = 2222;
+    constexpr auto PM_DEF = 3333;
+
+    config::shard_local_cfg().target_quota_byte_rate.set_value(P_DEF);
+    config::shard_local_cfg().target_fetch_quota_byte_rate.set_value(F_DEF);
+    config::shard_local_cfg().kafka_admin_topic_api_rate.set_value(PM_DEF);
+
+    config::shard_local_cfg().kafka_client_group_byte_rate_quota.set_value(
+      YAML::Load(std::string(raw_basic_produce_config)));
+    config::shard_local_cfg()
+      .kafka_client_group_fetch_byte_rate_quota.set_value(
+        YAML::Load(std::string(raw_basic_fetch_config)));
+
+    client_quota_translator tr;
+
+    // Stage 1 - Start by checking that tracker_key's are correctly detected
+    // for various client ids
+    auto get_produce_key = [&tr](auto client_id) {
+        return tr.find_quota_key({client_quota_type::produce_quota, client_id});
+    };
+    auto get_fetch_key = [&tr](auto client_id) {
+        return tr.find_quota_key({client_quota_type::fetch_quota, client_id});
+    };
+    auto get_mutation_key = [&tr](auto client_id) {
+        return tr.find_quota_key(
+          {client_quota_type::partition_mutation_quota, client_id});
+    };
+
+    // Check keys for produce
+    CHECK_VARIANT_EQ(
+      k_group_name{"franz-go-produce-group"}, get_produce_key("franz-go"));
+    CHECK_VARIANT_EQ(
+      k_group_name{"franz-go-produce-group"}, get_produce_key("franz-go"));
+    CHECK_VARIANT_EQ(
+      k_group_name{"not-franz-go-produce-group"},
+      get_produce_key("not-franz-go"));
+    CHECK_VARIANT_EQ(k_client_id{"unknown"}, get_produce_key("unknown"));
+    CHECK_VARIANT_EQ(k_client_id{""}, get_produce_key(std::nullopt));
+
+    // Check keys for fetch
+    CHECK_VARIANT_EQ(
+      k_group_name{"franz-go-fetch-group"}, get_fetch_key("franz-go"));
+    CHECK_VARIANT_EQ(
+      k_group_name{"not-franz-go-fetch-group"}, get_fetch_key("not-franz-go"));
+    CHECK_VARIANT_EQ(k_client_id{"unknown"}, get_fetch_key("unknown"));
+    CHECK_VARIANT_EQ(k_client_id{""}, get_fetch_key(std::nullopt));
+
+    // Check keys for partition mutations
+    CHECK_VARIANT_EQ(k_client_id{"franz-go"}, get_mutation_key("franz-go"));
+    CHECK_VARIANT_EQ(
+      k_client_id{"not-franz-go"}, get_mutation_key("not-franz-go"));
+    CHECK_VARIANT_EQ(k_client_id{"unknown"}, get_mutation_key("unknown"));
+    CHECK_VARIANT_EQ(k_client_id{""}, get_mutation_key(std::nullopt));
+
+    // Stage 2 - Next verify that the correct quota limits apply to the
+    // various tracker_key's being tested
+    // Check limits for the franz-go groups
+    auto franz_go_produce_limits = client_quota_limits{
+      .produce_limit = 4096,
+      .fetch_limit = F_DEF,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      franz_go_produce_limits,
+      tr.find_quota_value(k_group_name{"franz-go-produce-group"}));
+    auto franz_go_fetch_limits = client_quota_limits{
+      .produce_limit = P_DEF,
+      .fetch_limit = 4097,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      franz_go_fetch_limits,
+      tr.find_quota_value(k_group_name{"franz-go-fetch-group"}));
+
+    // Check limits for the not-franz-go groups
+    auto not_franz_go_produce_limits = client_quota_limits{
+      .produce_limit = 2048,
+      .fetch_limit = F_DEF,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      not_franz_go_produce_limits,
+      tr.find_quota_value(k_group_name{"not-franz-go-produce-group"}));
+    auto not_franz_go_fetch_limits = client_quota_limits{
+      .produce_limit = P_DEF,
+      .fetch_limit = 2049,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      not_franz_go_fetch_limits,
+      tr.find_quota_value(k_group_name{"not-franz-go-fetch-group"}));
+
+    // Check limits for the non-client-group keys
+    auto default_limits = client_quota_limits{
+      .produce_limit = P_DEF,
+      .fetch_limit = F_DEF,
+      .partition_mutation_limit = PM_DEF,
+    };
+    BOOST_CHECK_EQUAL(
+      default_limits, tr.find_quota_value(k_client_id{"unknown"}));
+    BOOST_CHECK_EQUAL(default_limits, tr.find_quota_value(k_client_id{""}));
+    BOOST_CHECK_EQUAL(
+      default_limits, tr.find_quota_value(k_client_id{"franz-go"}));
+    BOOST_CHECK_EQUAL(
+      default_limits, tr.find_quota_value(k_client_id{"not-franz-go"}));
+}

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -173,6 +173,8 @@ constexpr auto basic_config = [](config::configuration& conf) {
 };
 
 SEASTAR_THREAD_TEST_CASE(static_config_test) {
+    using k_client_id = kafka::quota_manager::k_client_id;
+    using k_group_name = kafka::quota_manager::k_group_name;
     fixture f;
     f.start().get();
     auto stop = ss::defer([&] { f.stop().get(); });
@@ -186,7 +188,8 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
         f.sqm.local().record_fetch_tp(client_id, 1).get();
         f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
         f.sqm.local().record_partition_mutations(client_id, 1).get();
-        auto it = f.buckets_map.local()->find(client_id + "-group");
+        auto it = f.buckets_map.local()->find(
+          k_group_name{client_id + "-group"});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_produce_rate->rate(), 4096);
@@ -200,7 +203,8 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
         f.sqm.local().record_fetch_tp(client_id, 1).get();
         f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
         f.sqm.local().record_partition_mutations(client_id, 1).get();
-        auto it = f.buckets_map.local()->find(client_id + "-group");
+        auto it = f.buckets_map.local()->find(
+          k_group_name{client_id + "-group"});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_produce_rate->rate(), 2048);
@@ -214,7 +218,7 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
         f.sqm.local().record_fetch_tp(client_id, 1).get();
         f.sqm.local().record_produce_tp_and_throttle(client_id, 1).get();
         f.sqm.local().record_partition_mutations(client_id, 1).get();
-        auto it = f.buckets_map.local()->find(client_id);
+        auto it = f.buckets_map.local()->find(k_client_id{client_id});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_produce_rate->rate(), 1024);
@@ -227,6 +231,7 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
 
 SEASTAR_THREAD_TEST_CASE(update_test) {
     using clock = kafka::quota_manager::clock;
+    using k_group_name = kafka::quota_manager::k_group_name;
     fixture f;
     f.start().get();
     auto stop = ss::defer([&] { f.stop().get(); });
@@ -252,7 +257,8 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
         }).get();
 
         // Check the rate has been updated
-        auto it = f.buckets_map.local()->find(client_id + "-group");
+        auto it = f.buckets_map.local()->find(
+          k_group_name{client_id + "-group"});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_fetch_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_fetch_rate->rate(), 4098);
@@ -288,7 +294,8 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
         }).get();
 
         // Check the rate has been updated
-        auto it = f.buckets_map.local()->find(client_id + "-group");
+        auto it = f.buckets_map.local()->find(
+          k_group_name{client_id + "-group"});
         BOOST_REQUIRE(it != f.buckets_map.local()->end());
         BOOST_REQUIRE(it->second->tp_produce_rate.has_value());
         BOOST_CHECK_EQUAL(it->second->tp_produce_rate->rate(), 1024);

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -8,6 +8,7 @@
 // by the Apache License, Version 2.0
 
 #include "config/configuration.h"
+#include "kafka/server/client_quota_translator.h"
 #include "kafka/server/quota_manager.h"
 
 #include <seastar/core/coroutine.hh>
@@ -173,8 +174,8 @@ constexpr auto basic_config = [](config::configuration& conf) {
 };
 
 SEASTAR_THREAD_TEST_CASE(static_config_test) {
-    using k_client_id = kafka::quota_manager::k_client_id;
-    using k_group_name = kafka::quota_manager::k_group_name;
+    using k_client_id = kafka::k_client_id;
+    using k_group_name = kafka::k_group_name;
     fixture f;
     f.start().get();
     auto stop = ss::defer([&] { f.stop().get(); });
@@ -231,7 +232,7 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
 
 SEASTAR_THREAD_TEST_CASE(update_test) {
     using clock = kafka::quota_manager::clock;
-    using k_group_name = kafka::quota_manager::k_group_name;
+    using k_group_name = kafka::k_group_name;
     fixture f;
     f.start().get();
     auto stop = ss::defer([&] { f.stop().get(); });


### PR DESCRIPTION
This introduces a new class `quota_translator` that handles two things:
* Translating a client id (or more generally a request context) into the `tracker_key` that should be used.
* Finding the quota limits that apply to a `tracker_key`

This code is extracted because while for now `quota_translator` only reads quota configurations from cluster configs, in follow-up PRs we intend to integrate the new `quota_store` into `quota_translator` as well. `quota_translator` is going to handle the merging of these two source of quota configurations.

Fixes https://redpandadata.atlassian.net/browse/CORE-2699

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
