### PR TITLE
[release process] automate rpk connect plugin bundling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,10 @@ licenses           @emaxerrno @dswang
 # rpk
 #
 /src/go/rpk        @twmb @r-vasquez @gene-redpanda
+# There are now two copies goreleaser.yaml in the interim `rpk connect` arch
+# Adding devprod to code owners to review any changes (e.g. they should stay in sync)
+/src/go/.goreleaser.yaml @twmb @r-vasquez @gene-redpanda @redpanda-data/devprod
+/src/go/.goreleaser_rpk_connect.yaml @twmb @r-vasquez @gene-redpanda @redpanda-data/devprod
 
 #
 # testing

--- a/src/go/.goreleaser_rp_connect.yaml
+++ b/src/go/.goreleaser_rp_connect.yaml
@@ -1,0 +1,171 @@
+project_name: rpk
+builds:
+  # rpk-windows-and-linux is deprecated; will be replaced by rpk-windows, rpk-linux, rpk-linux-microsoft-go
+  - id: rpk-windows-and-linux
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-linux-darwin-connect
+    builder: prebuilt
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    prebuilt:
+      # We expect to see $RP_CONNECT_BUILD_ROOT/go/linux/amd64/.rpk.ac-connect, etc.
+      path: '{{ .Env.RP_CONNECT_BUILD_ROOT }}/go/{{ .Os }}/{{ .Arch }}/bin/.rpk.ac-connect'
+    binary: .rpk.ac-connect
+  - id: rpk-linux-microsoft-go
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - 'CGO_ENABLED={{ if index .Env "CGO_ENABLED" }}{{ .Env.CGO_ENABLED }}{{ else }}0{{ end }}'
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-linux
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-windows
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-darwin
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    hooks:
+      post:
+        # The binary is signed and notarized when running a production release, but for snapshot builds notarization is
+        # skipped and only ad-hoc signing is performed (not cryptographic material is needed).
+        #
+        # note: environment variables required for signing and notarization (set in CI) but are not needed for snapshot builds
+        #    QUILL_SIGN_P12, QUILL_SIGN_PASSWORD, QUILL_NOTARY_KEY, QUILL_NOTARY_KEY_ID, QUILL_NOTARY_ISSUER
+        - cmd: quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }} -vv
+          env:
+            - QUILL_LOG_FILE=dist/quill-{{ .Target }}.log
+archives:
+  - id: rpk-zip
+    builds:
+      - rpk-windows-and-linux
+      - rpk-linux-darwin-connect
+      - rpk-darwin
+    format: zip
+    name_template: "rpk-{{ .Os }}-{{ .Arch }}"
+    allow_different_binary_count: true
+release:
+  github:
+    owner: redpanda-data
+    name: redpanda
+  ids:
+    - rpk-zip
+  draft: true
+  discussion_category_name: Releases
+brews:
+  - name: redpanda
+    homepage: "https://redpanda.com"
+    description: "Redpanda CLI & toolbox"
+    repository:
+      owner: redpanda-data
+      name: homebrew-tap
+    folder: Formula
+    skip_upload: auto
+    ids:
+      - rpk-zip
+    extra_install: |
+      generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
+    caveats: |
+        Redpanda Keeper (rpk) is Redpanda's command line interface (CLI)
+        utility. The rpk commands let you configure, manage, and tune
+        Redpanda clusters. They also let you manage topics, groups,
+        and access control lists (ACLs).
+        Start a three-node docker cluster locally:
+
+            rpk container start -n 3
+
+        Interact with the cluster using commands like:
+
+            rpk topic list
+
+        When done, stop and delete the docker cluster:
+
+            rpk container purge
+
+        For more examples and guides, visit: https://docs.redpanda.com
+    commit_author:
+      name: vbotbuildovich
+      email: vbot@redpanda.com
+announce:
+  skip: "true"


### PR DESCRIPTION
This creates a new `.goreleaser_rpk_connect.yaml` file for releasing `v24.1.x`.  Our internal release pipeline will leverage this file to release using the `prebuilt` feature of Goreleaser, which is [available only in Goreleaser Pro](https://goreleaser.com/customization/builds/#import-pre-built-binaries).

Creating a separate file like this introduces some duplication which is sad.  However it avoids the "Goreleaser Pro" requirement to any OSS developers or Redpanda developers working locally.  Using "Pro" means:
* installing a different goreleaser binary, AND
* having a `GORELEASER_KEY`.

The prevent code drift between the two yaml files, I added @redpanda-data/devprod as joint CODEOWNERS, so devprod can help review changes (which hopefully are not too frequent).

This will need to be ported to `dev` at some point, and likely remain in use until (but *may be* not including) `v24.3.x`.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none