### PR TITLE
Added basic test validating consume group recovery

### DIFF
--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -1662,7 +1662,6 @@ void group::fail_offset_commit(
 
 void group::reset_tx_state(model::term_id term) {
     _term = term;
-    _volatile_txs.clear();
     _prepared_txs.clear();
     _expiration_info.clear();
     _tx_data.clear();
@@ -3051,9 +3050,7 @@ ss::future<> group::do_abort_old_txes() {
     for (auto& [id, _] : _prepared_txs) {
         pids.push_back(id);
     }
-    for (auto& [id, _] : _volatile_txs) {
-        pids.push_back(id);
-    }
+
     for (auto& [id, _] : _tx_data) {
         auto it = _fence_pid_epoch.find(id);
         if (it != _fence_pid_epoch.end()) {
@@ -3413,7 +3410,7 @@ group::get_expired_offsets(std::chrono::seconds retention_period) {
 
 bool group::has_offsets() const {
     return !_offsets.empty() || !_pending_offset_commits.empty()
-           || !_volatile_txs.empty() || !_tx_data.empty();
+           || !_tx_data.empty();
 }
 
 std::vector<model::topic_partition>

--- a/src/v/kafka/server/group.cc
+++ b/src/v/kafka/server/group.cc
@@ -170,9 +170,9 @@ bool group::valid_previous_state(group_state s) const {
 
     __builtin_unreachable();
 }
-
+namespace {
 template<typename T>
-static model::record_batch make_tx_batch(
+model::record_batch make_tx_batch(
   model::record_batch_type type,
   int8_t version,
   const model::producer_identity& pid,
@@ -192,7 +192,7 @@ static model::record_batch make_tx_batch(
     return std::move(builder).build();
 }
 
-static model::record_batch make_tx_fence_batch(
+model::record_batch make_tx_fence_batch(
   const model::producer_identity& pid, group_log_fencing cmd) {
     return make_tx_batch(
       model::record_batch_type::tx_fence,
@@ -200,6 +200,7 @@ static model::record_batch make_tx_fence_batch(
       pid,
       std::move(cmd));
 }
+} // namespace
 
 group_state group::set_state(group_state s) {
     vassert(

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -191,7 +191,7 @@ public:
         }
     };
 
-    struct prepared_tx {
+    struct ongoing_tx_offsets {
         model::producer_identity pid;
         model::tx_seq tx_seq;
         absl::node_hash_map<model::topic_partition, offset_metadata> offsets;
@@ -591,7 +591,7 @@ public:
         }
     }
 
-    void insert_prepared(prepared_tx);
+    void insert_ongoing_tx_offsets(ongoing_tx_offsets);
 
     void try_set_fence(model::producer_id id, model::producer_epoch epoch) {
         auto [fence_it, _] = _fence_pid_epoch.try_emplace(id, epoch);
@@ -828,8 +828,8 @@ private:
         }
 
         if (std::any_of(
-              _prepared_txs.begin(),
-              _prepared_txs.end(),
+              _ongoing_tx_offsets.begin(),
+              _ongoing_tx_offsets.end(),
               [&tp](const auto& tp_info) {
                   return tp_info.second.offsets.contains(tp);
               })) {
@@ -926,7 +926,8 @@ private:
       _pending_offset_commits;
     enable_group_metrics _enable_group_metrics;
 
-    absl::node_hash_map<model::producer_identity, prepared_tx> _prepared_txs;
+    absl::node_hash_map<model::producer_identity, ongoing_tx_offsets>
+      _ongoing_tx_offsets;
 
     struct expiration_info {
         expiration_info(model::timeout_clock::duration timeout)

--- a/src/v/kafka/server/group.h
+++ b/src/v/kafka/server/group.h
@@ -828,15 +828,6 @@ private:
         }
 
         if (std::any_of(
-              _volatile_txs.begin(),
-              _volatile_txs.end(),
-              [&tp](const auto& tp_info) {
-                  return tp_info.second.offsets.contains(tp);
-              })) {
-            return true;
-        }
-
-        if (std::any_of(
               _prepared_txs.begin(),
               _prepared_txs.end(),
               [&tp](const auto& tp_info) {
@@ -934,18 +925,7 @@ private:
     absl::node_hash_map<model::topic_partition, offset_metadata>
       _pending_offset_commits;
     enable_group_metrics _enable_group_metrics;
-    struct volatile_offset {
-        model::offset offset;
-        kafka::leader_epoch leader_epoch;
-        std::optional<ss::sstring> metadata;
-    };
 
-    struct volatile_tx {
-        model::tx_seq tx_seq;
-        absl::node_hash_map<model::topic_partition, volatile_offset> offsets;
-    };
-
-    absl::node_hash_map<model::producer_identity, volatile_tx> _volatile_txs;
     absl::node_hash_map<model::producer_identity, prepared_tx> _prepared_txs;
 
     struct expiration_info {

--- a/src/v/kafka/server/group_manager.cc
+++ b/src/v/kafka/server/group_manager.cc
@@ -973,8 +973,8 @@ ss::future<> group_manager::do_recover_group(
               });
         }
 
-        for (const auto& [_, tx] : group_stm.prepared_txs()) {
-            group->insert_prepared(tx);
+        for (const auto& [_, tx] : group_stm.ongoing_tx_offsets()) {
+            group->insert_ongoing_tx_offsets(tx);
         }
         for (auto& [id, epoch] : group_stm.fences()) {
             group->try_set_fence(id, epoch);

--- a/src/v/kafka/server/group_metadata.cc
+++ b/src/v/kafka/server/group_metadata.cc
@@ -32,6 +32,14 @@
 
 namespace kafka {
 
+group_metadata_kv group_metadata_kv::copy() const {
+    group_metadata_kv cp{.key = key};
+    if (value) {
+        cp.value = value->copy();
+    }
+    return cp;
+}
+
 /**
  * /Kafka
  * Messages stored for the group topic has versions for both the key and value

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -168,6 +168,8 @@ struct offset_metadata_kv {
 struct group_metadata_kv {
     group_metadata_key key;
     std::optional<group_metadata_value> value;
+
+    group_metadata_kv copy() const;
 };
 
 inline group_metadata_version read_metadata_version(protocol::decoder& reader) {

--- a/src/v/kafka/server/group_metadata.h
+++ b/src/v/kafka/server/group_metadata.h
@@ -222,7 +222,59 @@ group_metadata_serializer make_consumer_offsets_serializer();
 
 using group_metadata_serializer_factory
   = ss::noncopyable_function<group_metadata_serializer()>;
+namespace group_tx {
+struct fence_metadata_v0 {
+    kafka::group_id group_id;
+};
 
+struct fence_metadata_v1 {
+    kafka::group_id group_id;
+    model::tx_seq tx_seq;
+    model::timeout_clock::duration transaction_timeout_ms;
+};
+/**
+ * Fence is set by the transaction manager when consumer adds an offset to
+ * transaction.
+ */
+struct fence_metadata {
+    kafka::group_id group_id;
+    model::tx_seq tx_seq;
+    model::timeout_clock::duration transaction_timeout_ms;
+    model::partition_id tm_partition;
+};
+/**
+ * Single partition committed offset
+ */
+struct partition_offset {
+    model::topic_partition tp;
+    model::offset offset;
+    int32_t leader_epoch;
+    std::optional<ss::sstring> metadata;
+};
+/**
+ * Consumer offsets commited as a part of transaction
+ */
+struct offsets_metadata {
+    kafka::group_id group_id;
+    model::producer_identity pid;
+    model::tx_seq tx_seq;
+    std::vector<partition_offset> offsets;
+};
+
+/**
+ * Content of transaction commit batch
+ */
+struct commit_metadata {
+    kafka::group_id group_id;
+};
+/**
+ * Content of transaction abort batch
+ */
+struct abort_metadata {
+    kafka::group_id group_id;
+    model::tx_seq tx_seq;
+};
+} // namespace group_tx
 } // namespace kafka
 
 namespace std {

--- a/src/v/kafka/server/group_stm.cc
+++ b/src/v/kafka/server/group_stm.cc
@@ -1,6 +1,7 @@
 #include "kafka/server/group_stm.h"
 
 #include "cluster/logger.h"
+#include "kafka/server/group_metadata.h"
 #include "kafka/types.h"
 
 namespace kafka {
@@ -23,7 +24,7 @@ void group_stm::update_offset(
 }
 
 void group_stm::update_prepared(
-  model::offset offset, group_log_prepared_tx val) {
+  model::offset offset, group_tx::offsets_metadata val) {
     auto tx = group::prepared_tx{.pid = val.pid, .tx_seq = val.tx_seq};
 
     auto [prepared_it, inserted] = _prepared_txs.try_emplace(

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -72,11 +72,6 @@ public:
     };
 
     void overwrite_metadata(group_metadata_value&&);
-    void remove() {
-        _offsets.clear();
-        _is_loaded = false;
-        _is_removed = true;
-    }
 
     void update_offset(
       const model::topic_partition&, model::offset, offset_metadata_value&&);

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -1,5 +1,13 @@
+// Copyright 2020 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
 #pragma once
-#include "base/seastarx.h"
 #include "kafka/server/group.h"
 #include "kafka/server/group_metadata.h"
 #include "model/fundamental.h"
@@ -13,51 +21,7 @@
 #include <absl/container/node_hash_map.h>
 #include <absl/container/node_hash_set.h>
 
-#include <optional>
-#include <vector>
-
 namespace kafka {
-
-struct group_log_prepared_tx_offset {
-    model::topic_partition tp;
-    model::offset offset;
-    int32_t leader_epoch;
-    std::optional<ss::sstring> metadata;
-};
-
-struct group_log_fencing_v0 {
-    kafka::group_id group_id;
-};
-
-struct group_log_fencing_v1 {
-    kafka::group_id group_id;
-    model::tx_seq tx_seq;
-    model::timeout_clock::duration transaction_timeout_ms;
-};
-
-struct group_log_fencing {
-    kafka::group_id group_id;
-    model::tx_seq tx_seq;
-    model::timeout_clock::duration transaction_timeout_ms;
-    model::partition_id tm_partition;
-};
-
-struct group_log_prepared_tx {
-    kafka::group_id group_id;
-    // TODO: get rid of pid, we have it in the headers
-    model::producer_identity pid;
-    model::tx_seq tx_seq;
-    std::vector<group_log_prepared_tx_offset> offsets;
-};
-
-struct group_log_commit_tx {
-    kafka::group_id group_id;
-};
-
-struct group_log_aborted_tx {
-    kafka::group_id group_id;
-    model::tx_seq tx_seq;
-};
 
 class group_stm {
 public:
@@ -76,7 +40,7 @@ public:
     void update_offset(
       const model::topic_partition&, model::offset, offset_metadata_value&&);
     void remove_offset(const model::topic_partition&);
-    void update_prepared(model::offset, group_log_prepared_tx);
+    void update_prepared(model::offset, group_tx::offsets_metadata);
     void commit(model::producer_identity);
     void abort(model::producer_identity, model::tx_seq);
     void try_set_fence(model::producer_id id, model::producer_epoch epoch) {

--- a/src/v/kafka/server/group_stm.h
+++ b/src/v/kafka/server/group_stm.h
@@ -68,9 +68,9 @@ public:
     }
     bool is_removed() const { return _is_removed; }
 
-    const absl::node_hash_map<model::producer_id, group::prepared_tx>&
-    prepared_txs() const {
-        return _prepared_txs;
+    const absl::node_hash_map<model::producer_id, group::ongoing_tx_offsets>&
+    ongoing_tx_offsets() const {
+        return _ongoing_tx_offsets;
     }
 
     const absl::node_hash_map<model::topic_partition, logged_metadata>&
@@ -100,7 +100,8 @@ public:
 
 private:
     absl::node_hash_map<model::topic_partition, logged_metadata> _offsets;
-    absl::node_hash_map<model::producer_id, group::prepared_tx> _prepared_txs;
+    absl::node_hash_map<model::producer_id, group::ongoing_tx_offsets>
+      _ongoing_tx_offsets;
     absl::node_hash_map<model::producer_id, model::producer_epoch>
       _fence_pid_epoch;
     absl::node_hash_map<model::producer_identity, tx_info> _tx_data;

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -18,6 +18,16 @@ rp_test(
   LABELS kafka
 )
 
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME test_consumer_group_recovery
+  SOURCES
+        consumer_group_recovery_test.cc
+  LIBRARIES v::gtest_main v::kafka
+  LABELS kafka
+)
+
 
 v_cc_library(
   NAME

--- a/src/v/kafka/server/tests/consumer_group_recovery_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_recovery_test.cc
@@ -390,7 +390,7 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_happy_path) {
           make_tx_offset("topic-3", 12, 1)}}));
 
     auto state = co_await recover_from_batches(copy_batches(batches));
-    EXPECT_EQ(state.groups[gr_1].prepared_txs().size(), 1);
+    EXPECT_EQ(state.groups[gr_1].ongoing_tx_offsets().size(), 1);
     EXPECT_EQ(state.groups[gr_1].tx_data().size(), 1);
     EXPECT_EQ(state.groups[gr_1].fences().size(), 1);
     // tx is ongoing offsets included in the transaction should not be
@@ -407,7 +407,7 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_happy_path) {
       group_tx::commit_metadata{.group_id = gr_1}));
 
     state = co_await recover_from_batches(copy_batches(batches));
-    EXPECT_TRUE(state.groups[gr_1].prepared_txs().empty());
+    EXPECT_TRUE(state.groups[gr_1].ongoing_tx_offsets().empty());
     EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
     EXPECT_EQ(state.groups[gr_1].fences().size(), 1);
 
@@ -434,7 +434,7 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_happy_path) {
       "topic-3/12@1");
 
     EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
-    EXPECT_TRUE(state.groups[gr_1].prepared_txs().empty());
+    EXPECT_TRUE(state.groups[gr_1].ongoing_tx_offsets().empty());
     EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
     // EXPECT_TRUE(state.groups[gr_1].fences().empty());
 }
@@ -477,7 +477,7 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_abort) {
       group_tx::abort_metadata{.group_id = gr_1, .tx_seq = tx_seq}));
     auto state = co_await recover_from_batches(copy_batches(batches));
     EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
-    EXPECT_TRUE(state.groups[gr_1].prepared_txs().empty());
+    EXPECT_TRUE(state.groups[gr_1].ongoing_tx_offsets().empty());
     EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
     // EXPECT_TRUE(state.groups[gr_1].fences().empty());
     expect_committed_offsets(
@@ -491,7 +491,7 @@ TEST_F_CORO(cg_recovery_test_fixture, test_tx_abort) {
       group_tx::commit_metadata{.group_id = gr_1}));
 
     EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
-    EXPECT_TRUE(state.groups[gr_1].prepared_txs().empty());
+    EXPECT_TRUE(state.groups[gr_1].ongoing_tx_offsets().empty());
     EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
     // EXPECT_TRUE(state.groups[gr_1].fences().empty());
     expect_committed_offsets(

--- a/src/v/kafka/server/tests/consumer_group_recovery_test.cc
+++ b/src/v/kafka/server/tests/consumer_group_recovery_test.cc
@@ -1,0 +1,499 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "kafka/protocol/types.h"
+#include "kafka/server/group_metadata.h"
+#include "kafka/server/group_recovery_consumer.h"
+#include "kafka/server/group_stm.h"
+#include "model/fundamental.h"
+#include "model/record.h"
+#include "model/record_batch_reader.h"
+#include "model/record_batch_types.h"
+#include "model/timeout_clock.h"
+#include "model/timestamp.h"
+#include "storage/record_batch_builder.h"
+#include "test_utils/test.h"
+
+#include <seastar/core/abort_source.hh>
+#include <seastar/core/circular_buffer.hh>
+#include <seastar/core/sstring.hh>
+
+#include <absl/container/node_hash_map.h>
+#include <absl/strings/str_split.h>
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+
+#include <tuple>
+
+using namespace std::chrono_literals;
+using namespace kafka;
+using namespace std::chrono_literals;
+
+struct cg_recovery_test_fixture : seastar_test {
+    ss::future<group_recovery_consumer_state>
+    recover_from_batches(ss::circular_buffer<model::record_batch> batches) {
+        group_recovery_consumer consumer(
+          make_consumer_offsets_serializer(), as);
+
+        return model::make_memory_record_batch_reader(std::move(batches))
+          .consume(std::move(consumer), model::no_timeout);
+    }
+    template<typename T>
+    model::record_batch serialize(T metadata) {
+        storage::record_batch_builder buider(
+          model::record_batch_type::raft_data, offset++);
+
+        auto kv = serializer.to_kv(std::move(metadata));
+        buider.add_raw_kv(std::move(kv.key), std::move(kv.value));
+
+        return std::move(buider).build();
+    }
+
+    template<typename T>
+    model::record_batch serialize(std::vector<T> metadata) {
+        storage::record_batch_builder buider(
+          model::record_batch_type::raft_data, offset++);
+        for (auto& m : metadata) {
+            auto kv = serializer.to_kv(std::move(m));
+            buider.add_raw_kv(std::move(kv.key), std::move(kv.value));
+        }
+
+        return std::move(buider).build();
+    }
+
+    template<typename... Args>
+    ss::circular_buffer<model::record_batch> serialize_metadata(Args... args) {
+        ss::circular_buffer<model::record_batch> batches;
+
+        (batches.push_back(serialize(std::move(args))), ...);
+        return batches;
+    }
+
+    group_metadata_kv make_group_metadata(
+      std::string_view g_name,
+      generation_id g_id,
+      protocol_type p_type,
+      std::optional<protocol_name> p_name,
+      std::optional<member_id> leader,
+      model::timestamp ts,
+      std::vector<member_state> members) {
+        group_metadata_kv kv;
+        kv.key = group_metadata_key{group_id(g_name)};
+        kv.value = group_metadata_value{
+          .protocol_type = std::move(p_type),
+          .generation = g_id,
+          .protocol = std::move(p_name),
+          .leader = std::move(leader),
+          .state_timestamp = ts,
+          .members = std::move(members),
+        };
+
+        return kv;
+    }
+
+    member_state make_member_state(
+      member_id id,
+      std::optional<group_instance_id> g_inst_id,
+      client_id cid,
+      client_host host,
+      std::chrono::milliseconds rb_tout,
+      std::chrono::milliseconds s_tout) {
+        return member_state{
+          .id = std::move(id),
+          .instance_id = std::move(g_inst_id),
+          .client_id = std::move(cid),
+          .client_host = std::move(host),
+          .rebalance_timeout = rb_tout,
+          .session_timeout = s_tout,
+          .subscription = iobuf{},
+          .assignment = iobuf{},
+        };
+    }
+
+    offset_metadata_kv make_offset_kv(
+      std::string_view group,
+      std::string_view topic,
+      int partition_id,
+      int64_t offset,
+      kafka::leader_epoch epoch,
+      ss::sstring metadata = "") {
+        return offset_metadata_kv{
+          .key
+          = offset_metadata_key{.group_id = group_id(group), .topic = model::topic(topic), .partition = model::partition_id(partition_id),},
+          .value = offset_metadata_value{
+            .offset = model::offset(offset),
+            .leader_epoch = epoch,
+            .metadata = std::move(metadata)}};
+    }
+
+    group_metadata_serializer serializer = make_consumer_offsets_serializer();
+    ss::abort_source as;
+    model::offset offset{0};
+
+    std::pair<model::topic_partition, model::offset>
+    parse_offset(std::string_view str) const {
+        std::vector<std::string_view> splits = absl::StrSplit(str, '/');
+        if (splits.size() != 2) {
+            throw std::runtime_error(
+              ss::format("invalid committed_offset: {}", str));
+        }
+        std::pair<model::topic_partition, model::offset> ret;
+        ret.first.topic = model::topic(splits[0]);
+
+        splits = absl::StrSplit(splits[1], '@');
+        if (splits.size() != 2) {
+            throw std::runtime_error(
+              ss::format("invalid committed_offset: {}", str));
+        }
+        std::string_view partition = splits[0];
+        std::string_view offset = splits[1];
+        bool valid = true;
+        valid &= absl::SimpleAtoi(partition, &ret.first.partition);
+        valid &= absl::SimpleAtoi(offset, &ret.second);
+
+        if (!valid) {
+            throw std::runtime_error(
+              ss::format("invalid committed_offset: {}", str));
+        }
+        return ret;
+    }
+    /**
+     * Simple method to validate if committed offset for particular topic and
+     * and partition has an expected value, the list of expected commit values
+     * is expressed as a strings of format: <topic>/partition@offset
+     */
+    template<typename... Args>
+    void expect_committed_offsets(
+      const absl::node_hash_map<
+        model::topic_partition,
+        group_stm::logged_metadata> metadata,
+      Args... offset_desc) {
+        absl::node_hash_map<model::topic_partition, model::offset> expected_set;
+        (expected_set.emplace(parse_offset(offset_desc)), ...);
+
+        for (auto [tp, offset] : expected_set) {
+            auto it = metadata.find(tp);
+            ASSERT_TRUE(it != metadata.end());
+            EXPECT_EQ(it->second.metadata.offset, offset);
+        }
+    }
+
+    template<typename T>
+    model::record_batch make_tx_batch(
+      model::record_batch_type type,
+      int8_t version,
+      const model::producer_identity& pid,
+      T cmd) {
+        iobuf key;
+        reflection::serialize(key, type, pid.id);
+
+        iobuf value;
+        reflection::serialize(value, version);
+        reflection::serialize(value, std::move(cmd));
+
+        storage::record_batch_builder builder(type, model::offset(0));
+        builder.set_producer_identity(pid.id, pid.epoch);
+        builder.set_control_type();
+        builder.add_raw_kv(std::move(key), std::move(value));
+
+        return std::move(builder).build();
+    }
+
+    model::record_batch make_tx_fence_batch(
+      const model::producer_identity& pid, group_log_fencing cmd) {
+        return make_tx_batch(
+          model::record_batch_type::tx_fence,
+          group::fence_control_record_version,
+          pid,
+          std::move(cmd));
+    }
+
+    group_log_prepared_tx_offset
+    make_tx_offset(std::string_view topic, int partition, int offset) {
+        return group_log_prepared_tx_offset{
+          .tp = model::topic_partition(
+            model::topic(topic), model::partition_id(partition)),
+          .offset = model::offset(offset),
+        };
+    }
+
+    ss::circular_buffer<model::record_batch>
+    copy_batches(const ss::circular_buffer<model::record_batch>& orig) {
+        ss::circular_buffer<model::record_batch> ret;
+        ret.reserve(orig.size());
+        std::transform(
+          orig.begin(),
+          orig.end(),
+          std::back_inserter(ret),
+          [](const model::record_batch& b) { return b.copy(); });
+        return ret;
+    }
+    /**
+     * Returns batches representing metadata of single group with id `g-1` one
+     * member and two committed offsets for test-1/0 at 1024 and for test-2/1 at
+     * 256.
+     */
+    std::tuple<group_metadata_kv, ss::circular_buffer<model::record_batch>>
+    serialize_single_group() {
+        kafka::group_id gr_1("g-1");
+        auto g_1_metadata = make_group_metadata(
+          gr_1(),
+          generation_id(0),
+          protocol_type("proto"),
+          protocol_name("proto-name"),
+          member_id("member-1"),
+          model::timestamp::now(),
+          std::vector<member_state>{});
+
+        g_1_metadata.value->members.push_back(make_member_state(
+          member_id("m-1"),
+          std::nullopt,
+          client_id("cid-m1"),
+          client_host("127.0.0.1"),
+          60s,
+          30s));
+        auto o_md = make_offset_kv(gr_1(), "test-1", 0, 1024, leader_epoch(0));
+        auto o_md_2 = make_offset_kv(
+          gr_1(), "test-2", 10, 256, leader_epoch(0));
+
+        return std::make_tuple(
+          g_1_metadata.copy(),
+          serialize_metadata(
+            g_1_metadata.copy(),
+            std::vector<offset_metadata_kv>{o_md, o_md_2}));
+    }
+};
+
+TEST_F_CORO(cg_recovery_test_fixture, test_single_group_recovery) {
+    auto [meta, batches] = serialize_single_group();
+    auto state = co_await recover_from_batches(std::move(batches));
+    const auto gr = meta.key.group_id;
+    EXPECT_EQ(state.groups.size(), 1);
+    EXPECT_EQ(state.groups[gr].get_metadata(), meta.value);
+    EXPECT_EQ(state.groups[gr].offsets().size(), 2);
+    expect_committed_offsets(
+      state.groups[gr].offsets(), "test-1/0@1024", "test-2/10@256");
+}
+
+TEST_F_CORO(cg_recovery_test_fixture, test_tombstone_recovery) {
+    auto g_1_metadata = make_group_metadata(
+      "g-1",
+      generation_id(0),
+      protocol_type("proto"),
+      protocol_name("proto-name"),
+      member_id("member-1"),
+      model::timestamp::now(),
+      std::vector<member_state>{});
+
+    auto g_2_metadata = make_group_metadata(
+      "g-2",
+      generation_id(10),
+      protocol_type("proto-2"),
+      protocol_name("proto-name-2"),
+      member_id("member-1"),
+      model::timestamp::now(),
+      std::vector<member_state>{});
+
+    g_2_metadata.value->members.push_back(make_member_state(
+      member_id("m-1"),
+      std::nullopt,
+      client_id("cid-m1"),
+      client_host("127.0.0.1"),
+      60s,
+      30s));
+    auto o_md = make_offset_kv("g-1", "test-1", 0, 1024, leader_epoch(0));
+    auto o_md_2 = make_offset_kv("g-1", "test-2", 10, 256, leader_epoch(0));
+    auto o_md_3 = make_offset_kv("g-2", "test-20", 2, 123, leader_epoch(0));
+    auto o_md_4 = make_offset_kv("g-2", "test-123", 10, 45, leader_epoch(0));
+
+    auto batches = serialize_metadata(
+      g_1_metadata.copy(),
+      std::vector<offset_metadata_kv>{o_md, o_md_2},
+      g_2_metadata.copy(),
+      std::vector<offset_metadata_kv>{o_md_3},
+      std::vector<offset_metadata_kv>{o_md_4});
+
+    auto state = co_await recover_from_batches(std::move(batches));
+    const auto gr_1 = g_1_metadata.key.group_id;
+    const auto gr_2 = g_2_metadata.key.group_id;
+    EXPECT_EQ(state.groups.size(), 2);
+    EXPECT_EQ(state.groups[gr_1].get_metadata(), g_1_metadata.value);
+    expect_committed_offsets(
+      state.groups[gr_1].offsets(), "test-1/0@1024", "test-2/10@256");
+
+    expect_committed_offsets(
+      state.groups[gr_2].offsets(), "test-20/2@123", "test-123/10@45");
+
+    // add group 1 tombstone
+    auto g_1_ts_kv = group_metadata_kv{
+      .key = group_metadata_key(kafka::group_id("g-1"))};
+    std::vector<group_metadata_kv> g_1_tombstones;
+    g_1_tombstones.push_back(g_1_ts_kv.copy());
+
+    // add offset tombstone for group 2 topic-20 partition 2
+    auto g_2_o_ts = offset_metadata_kv{
+      .key = offset_metadata_key{
+        .group_id = kafka::group_id("g-2"),
+        .topic = model::topic("t-20"),
+        .partition = model::partition_id(2)}};
+
+    auto batches_with_tombstones = serialize_metadata(
+      g_1_metadata.copy(),
+      std::vector<offset_metadata_kv>{o_md, o_md_2},
+      g_2_metadata.copy(),
+      std::vector<offset_metadata_kv>{o_md_3},
+      std::vector<offset_metadata_kv>{o_md_4},
+      g_1_ts_kv.copy(),
+      g_2_o_ts);
+
+    auto state_new = co_await recover_from_batches(
+      std::move(batches_with_tombstones));
+    EXPECT_EQ(state_new.groups.size(), 1);
+    EXPECT_FALSE(state_new.groups.contains(gr_1));
+    EXPECT_FALSE(state_new.groups[gr_2].offsets().contains(
+      model::topic_partition(model::topic("t-20"), model::partition_id(2))));
+}
+
+TEST_F_CORO(cg_recovery_test_fixture, test_tx_happy_path) {
+    /**
+     * Create a single group
+     */
+    auto [meta, batches] = serialize_single_group();
+    const auto gr_1 = meta.key.group_id;
+    model::producer_identity pid(100, 0);
+    model::tx_seq tx_seq(3);
+    batches.push_back(make_tx_fence_batch(
+      pid,
+      group_log_fencing{
+        .group_id = gr_1,
+        .tx_seq = tx_seq,
+        .transaction_timeout_ms = 10s,
+        .tm_partition = model::partition_id(10),
+      }));
+
+    batches.push_back(make_tx_batch(
+      model::record_batch_type::group_prepare_tx,
+      0,
+      pid,
+      group_log_prepared_tx{
+        .group_id = gr_1,
+        .pid = pid,
+        .tx_seq = tx_seq,
+        .offsets = std::vector<group_log_prepared_tx_offset>{
+          make_tx_offset("test-1", 0, 2048),
+          make_tx_offset("topic-3", 12, 1)}}));
+
+    auto state = co_await recover_from_batches(copy_batches(batches));
+    EXPECT_EQ(state.groups[gr_1].prepared_txs().size(), 1);
+    EXPECT_EQ(state.groups[gr_1].tx_data().size(), 1);
+    EXPECT_EQ(state.groups[gr_1].fences().size(), 1);
+    // tx is ongoing offsets included in the transaction should not be
+    // visible in state machine
+
+    EXPECT_EQ(state.groups.size(), 1);
+    expect_committed_offsets(
+      state.groups[gr_1].offsets(), "test-1/0@1024", "test-2/10@256");
+
+    batches.push_back(make_tx_batch(
+      model::record_batch_type::group_commit_tx,
+      0,
+      pid,
+      group_log_commit_tx{.group_id = gr_1}));
+
+    state = co_await recover_from_batches(copy_batches(batches));
+    EXPECT_TRUE(state.groups[gr_1].prepared_txs().empty());
+    EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
+    EXPECT_EQ(state.groups[gr_1].fences().size(), 1);
+
+    expect_committed_offsets(
+      state.groups[gr_1].offsets(),
+      "test-1/0@2048",
+      "test-2/10@256",
+      "topic-3/12@1");
+
+    /**
+     * try aborting already committed tx, this should fail
+     */
+    batches.push_back(make_tx_batch(
+      model::record_batch_type::group_abort_tx,
+      0,
+      pid,
+      group_log_aborted_tx{.group_id = gr_1, .tx_seq = tx_seq}));
+
+    state = co_await recover_from_batches(copy_batches(batches));
+    expect_committed_offsets(
+      state.groups[gr_1].offsets(),
+      "test-1/0@2048",
+      "test-2/10@256",
+      "topic-3/12@1");
+
+    EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
+    EXPECT_TRUE(state.groups[gr_1].prepared_txs().empty());
+    EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
+    // EXPECT_TRUE(state.groups[gr_1].fences().empty());
+}
+
+TEST_F_CORO(cg_recovery_test_fixture, test_tx_abort) {
+    /**
+     * Create a single group
+     */
+    auto [meta, batches] = serialize_single_group();
+    const auto gr_1 = meta.key.group_id;
+    model::producer_identity pid(100, 0);
+    model::tx_seq tx_seq(3);
+    // set fence
+    batches.push_back(make_tx_fence_batch(
+      pid,
+      group_log_fencing{
+        .group_id = gr_1,
+        .tx_seq = tx_seq,
+        .transaction_timeout_ms = 10s,
+        .tm_partition = model::partition_id(10),
+      }));
+    // begin tx
+    batches.push_back(make_tx_batch(
+      model::record_batch_type::group_prepare_tx,
+      0,
+      pid,
+      group_log_prepared_tx{
+        .group_id = gr_1,
+        .pid = pid,
+        .tx_seq = tx_seq,
+        .offsets = std::vector<group_log_prepared_tx_offset>{
+          make_tx_offset("test-1", 0, 2048),
+          make_tx_offset("topic-3", 12, 1)}}));
+
+    // abort tx
+    batches.push_back(make_tx_batch(
+      model::record_batch_type::group_abort_tx,
+      0,
+      pid,
+      group_log_aborted_tx{.group_id = gr_1, .tx_seq = tx_seq}));
+    auto state = co_await recover_from_batches(copy_batches(batches));
+    EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
+    EXPECT_TRUE(state.groups[gr_1].prepared_txs().empty());
+    EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
+    // EXPECT_TRUE(state.groups[gr_1].fences().empty());
+    expect_committed_offsets(
+      state.groups[gr_1].offsets(), "test-1/0@1024", "test-2/10@256");
+
+    // commit of aborted tx should be ignored
+    batches.push_back(make_tx_batch(
+      model::record_batch_type::group_commit_tx,
+      0,
+      pid,
+      group_log_commit_tx{.group_id = gr_1}));
+
+    EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
+    EXPECT_TRUE(state.groups[gr_1].prepared_txs().empty());
+    EXPECT_TRUE(state.groups[gr_1].tx_data().empty());
+    // EXPECT_TRUE(state.groups[gr_1].fences().empty());
+    expect_committed_offsets(
+      state.groups[gr_1].offsets(), "test-1/0@1024", "test-2/10@256");
+}


### PR DESCRIPTION
Added a test validating recovery of consumer group state from log.
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none