### PR TITLE
[v24.1.x] [CORE-2845]: Ensure create_acls requests return an error when resources as topics are non valid kafka topic names 

### DIFF
--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -410,22 +410,22 @@ class RpkTool:
         return self._run(cmd)
 
     def sasl_allow_principal(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args, **kwargs, deny=False)
+        return self._sasl_set_principal_access(*args, **kwargs, deny=False)
 
     def sasl_deny_principal(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args, **kwargs, deny=True)
+        return self._sasl_set_principal_access(*args, **kwargs, deny=True)
 
     def sasl_allow_role(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args,
-                                        **kwargs,
-                                        deny=False,
-                                        ptype="role")
+        return self._sasl_set_principal_access(*args,
+                                               **kwargs,
+                                               deny=False,
+                                               ptype="role")
 
     def sasl_deny_role(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args,
-                                        **kwargs,
-                                        deny=True,
-                                        ptype="role")
+        return self._sasl_set_principal_access(*args,
+                                               **kwargs,
+                                               deny=True,
+                                               ptype="role")
 
     def allow_principal(self, principal, operations, resource, resource_name):
         if resource == "topic":


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18701
