### PR TITLE
rptest: test_max_connections fixes

### DIFF
--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -479,8 +479,8 @@ class CloudCluster():
         for p in products:
             if p['redpandaConfigProfileName'] == config_profile_name:
                 return p['name']
-        self._logger.warning("CloudV2 API returned empty 'product_name' list "
-                             f"for request: '{params}'")
+        self._logger.warning("Could not find product for install pack, "
+                             f"request: '{params}', response:\n{products}")
         return None
 
     def _create_cluster_payload(self):


### PR DESCRIPTION
Adjust the warmup time buffer to 2.5x the nominal value, in part because the sleep duration is addition to any other delay in the startup loop in producer swarm.

Fix log message (missing f-string). Adjust some logging.

Add additional details when we fail to get the product.


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not backporting cloud DT
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
