### PR TITLE
[CORE-3177] automatic s3 endpoint for fips

### DIFF
--- a/src/v/cloud_storage_clients/configuration.cc
+++ b/src/v/cloud_storage_clients/configuration.cc
@@ -111,8 +111,13 @@ ss::future<s3_configuration> s3_configuration::make_configuration(
         }
     }
 
+    // if overrides.endpoint is not specified, build the default base endpoint.
+    // for fips mode the it uses the `s3-fips` subdomain.
     const auto base_endpoint_uri = overrides.endpoint.value_or(
-      endpoint_url{ssx::sformat("s3.{}.amazonaws.com", region())});
+      endpoint_url{ssx::sformat(
+        "{}.{}.amazonaws.com",
+        node_is_in_fips_mode ? "s3-fips" : "s3",
+        region())});
 
     // if url_style is virtual_host, the complete url for s3 is
     // [bucket].[s3hostname]. s3client will form the complete_endpoint

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -682,8 +682,6 @@ class SISettings:
             self.cloud_storage_disable_tls = False  # SI will fail to create archivers if tls is disabled
             self.cloud_storage_region = cloud_storage_region
             self.cloud_storage_api_endpoint_port = 443
-            self.cloud_storage_api_endpoint = f's3-fips.{cloud_storage_region}.amazonaws.com' if self.use_fips_endpoint(
-            ) else self.cloud_storage_api_endpoint
             self.addressing_style = S3AddressingStyle.VIRTUAL
         elif cloud_storage_credentials_source == 'config_file' and cloud_storage_access_key and cloud_storage_secret_key:
             # `config_file`` source allows developers to run ducktape tests from
@@ -698,8 +696,6 @@ class SISettings:
             self.cloud_storage_disable_tls = False  # SI will fail to create archivers if tls is disabled
             self.cloud_storage_region = cloud_storage_region
             self.cloud_storage_api_endpoint_port = 443
-            self.cloud_storage_api_endpoint = f's3-fips.{cloud_storage_region}.amazonaws.com' if self.use_fips_endpoint(
-            ) else self.cloud_storage_api_endpoint
             self.addressing_style = S3AddressingStyle.VIRTUAL
         else:
             logger.info('No AWS credentials supplied, assuming minio defaults')


### PR DESCRIPTION
cloud_storage_clients/configuration: use `s3-fips` subdomain if in fips mode

Before this change, a fips cluster would have to set
`cloud_storage_api_endpoint` manually to `s3-fips.[zone].amazonaws.com`

This change makes it optional; the default endpoint will be constructed as 
```
s3-fips.[zone].amazonaws.com if in fisp mode and
     s3.[zone].amazonaws.com otherwise
```

Fixes [CORE-3177](https://redpandadata.atlassian.net/browse/CORE-3177)
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none 

[CORE-3177]: https://redpandadata.atlassian.net/browse/CORE-3177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ