### PR TITLE
net: Make connection limit reached log at WARN

### DIFF
--- a/src/v/net/server.cc
+++ b/src/v/net/server.cc
@@ -220,7 +220,7 @@ ss::future<ss::stop_iteration> server::accept_finish(
             // Connection limit hit, drop this connection.
             _probe->connection_rejected();
             vlog(
-              _log.info,
+              _log.warn,
               "Connection limit reached, rejecting {}",
               ar.remote_address.addr());
             co_return ss::stop_iteration::no;


### PR DESCRIPTION
- Fixes: CORE-1771

## Backports Required

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Modify connection limit reached log line at WARN instead of INFO level

