### PR TITLE
raft: fix node_id mismatch log message

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -364,7 +364,7 @@ consensus::success_reply consensus::update_follower_index(
           "Received append entries response node_id doesn't match expected "
           "node_id (received: {}, expected: {})",
           reply.node_id.id(),
-          node);
+          physical_node);
         return success_reply::no;
     }
 


### PR DESCRIPTION
Previously it looked like this:
```
WARN  2024-05-24 12:38:33,690 [shard 0:clus] raft - [group_id:0, {redpanda/controller/0}] consensus.cc:357 - Received append entries response node_id doesn't match expected node_id (received: 8, expected: {id: {8}, revision: {0}})
```
which is very confusing

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes
* none
