### PR TITLE
[v23.3.x] cloud_storage: Rehash segment name prefixes

### DIFF
--- a/src/v/cloud_storage/cache_service.h
+++ b/src/v/cloud_storage/cache_service.h
@@ -216,6 +216,14 @@ private:
         bool trim_missed_tmp_files{false};
     };
 
+    ss::future<std::optional<cache_item>> _get(std::filesystem::path key);
+
+    /// Remove object from cache
+    ss::future<> _invalidate(const std::filesystem::path& key);
+
+    ss::future<cache_element_status>
+    _is_cached(const std::filesystem::path& key);
+
     /// Ordinary trim: prioritze trimming data chunks, only delete indices etc
     /// if all their chunks are dropped.
     ss::future<trim_result> trim_fast(

--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -2386,6 +2386,15 @@ configuration::configuration()
       "Number of chunks to prefetch ahead of every downloaded chunk",
       {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
       0)
+  , cloud_storage_cache_num_buckets(
+      *this,
+      "cloud_storage_cache_num_buckets",
+      "Divide cloud storage cache across specified number of buckets. This "
+      "only works for objects with randomized prefixes. The names will not be "
+      "changed if the value is set to zero.",
+      {.needs_restart = needs_restart::no, .visibility = visibility::tunable},
+      0,
+      {.min = 0, .max = 1024})
   , superusers(
       *this,
       "superusers",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -432,6 +432,7 @@ struct configuration final : public config_store {
     enum_property<model::cloud_storage_chunk_eviction_strategy>
       cloud_storage_chunk_eviction_strategy;
     property<uint16_t> cloud_storage_chunk_prefetch;
+    bounded_property<uint32_t> cloud_storage_cache_num_buckets;
 
     one_or_many_property<ss::sstring> superusers;
 


### PR DESCRIPTION
Backport #18762 

Currently, the cache uses segment object names as file paths. This means that we have series of nested directories to store every file. Also, the first directory is a randomized prefix. This creates very large number of nonsense directories in the root of the cache.

This PR adds new configuration option `cloud_storage_cache_num_buckets`. When this property is set the cache will check if the object name starts with randomized prefix (8-character hex number). If this is the case it will replace it with a different prefix that has much smaller cardinality. Basically, it will put all object names into `cloud_storage_cache_num_buckets` buckets.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Features

* Split cache into buckets using `cloud_storage_cache_num_buckets` configuration parameter.