### PR TITLE
[v23.2.x] raft: fix node_id mismatch log message

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -340,7 +340,7 @@ consensus::success_reply consensus::update_follower_index(
           "Received append entries response node_id doesn't match expected "
           "node_id (received: {}, expected: {})",
           reply.node_id.id(),
-          node);
+          physical_node);
         return success_reply::no;
     }
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18776
