### PR TITLE
cluster: Reduce cloud storage self-test output

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/selftest/status.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/status.go
@@ -164,6 +164,11 @@ func makeReportTable(report adminapi.SelfTestNodeReport) [][]string {
 			table = append(table, []string{""})
 			continue
 		}
+		if sr.TestType == adminapi.CloudcheckTagIdentifier {
+			// Cloudcheck does not have any IOPS, THROUGHPUT, or LATENCY results.
+			table = append(table, []string{""})
+			continue
+		}
 		table = append(table, []string{"IOPS", fmt.Sprintf("%d req/sec", *sr.RequestsPerSec)})
 		var throughput string
 		if sr.TestType == adminapi.NetcheckTagIdentifier {

--- a/src/v/cluster/self_test/cloudcheck.cc
+++ b/src/v/cluster/self_test/cloudcheck.cc
@@ -228,7 +228,7 @@ ss::future<self_test_result> cloudcheck::verify_upload(
   cloud_storage_clients::object_key key,
   const std::optional<iobuf>& payload) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "Put", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "Put", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
@@ -276,7 +276,7 @@ cloudcheck::verify_list(
   std::optional<cloud_storage_clients::object_key> prefix,
   size_t max_keys) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "List", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "List", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
@@ -317,7 +317,7 @@ ss::future<self_test_result> cloudcheck::verify_head(
   cloud_storage_clients::bucket_name bucket,
   std::optional<cloud_storage_clients::object_key> key) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "Head", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "Head", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
@@ -372,7 +372,7 @@ cloudcheck::verify_download(
   cloud_storage_clients::bucket_name bucket,
   std::optional<cloud_storage_clients::object_key> key) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "Get", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "Get", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
@@ -430,7 +430,7 @@ ss::future<self_test_result> cloudcheck::verify_delete(
   cloud_storage_clients::bucket_name bucket,
   cloud_storage_clients::object_key key) {
     auto result = self_test_result{
-      .name = _opts.name, .info = "Delete", .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "Delete", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";
@@ -472,9 +472,7 @@ ss::future<self_test_result> cloudcheck::verify_delete(
 ss::future<self_test_result> cloudcheck::verify_deletes(
   cloud_storage_clients::bucket_name bucket, size_t num_objects) {
     auto result = self_test_result{
-      .name = _opts.name,
-      .info = "Plural Delete",
-      .test_type = "cloud_storage"};
+      .name = _opts.name, .info = "Plural Delete", .test_type = "cloud"};
 
     if (_cancelled) {
         result.warning = "Run was manually cancelled.";

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -77,7 +77,7 @@ class SelfTestTest(EndToEndTest):
             assert node['status'] == 'idle'
             assert node.get('results') is not None
             for report in node['results']:
-                if report['test_type'] == 'cloud_storage':
+                if report['test_type'] == 'cloud':
                     if report['info'] in read_tests:
                         if remote_read:
                             assert_pass(report)
@@ -111,9 +111,7 @@ class SelfTestTest(EndToEndTest):
         # Assert properties of the network results hold true
         network_results = [r for r in reports if r['test_type'] == 'network']
 
-        cloud_results = [
-            r for r in reports if r['test_type'] == 'cloud_storage'
-        ]
+        cloud_results = [r for r in reports if r['test_type'] == 'cloud']
 
         num_expected_cloud_storage_read_tests = num_nodes * len(read_tests)
         num_expected_cloud_storage_write_tests = num_nodes * len(write_tests)


### PR DESCRIPTION
Cloud storage self-test doesn't have `IOPS`, `THROUGHPUT`,or `LATENCY` results, so these fields are skipped in the output of `rpk cluster self-test status`.

Before, the output of `rpk cluster self-test status` would include these fields for the cloud storage self-test.

```
NODE ID: 0 | STATUS: IDLE
=========================
NAME        Cloud Storage Test
INFO        Put
TYPE        cloud_storage
TEST ID     60ff3286-4701-4aea-8c56-9862045d34d1
TIMEOUTS    0
DURATION    18ms
IOPS        0 req/sec
THROUGHPUT  0B/sec
LATENCY     P50   P90   P99   P999  MAX
            0us   0us   0us   0us   0us

NAME        Cloud Storage Test
INFO        List
TYPE        cloud_storage
TEST ID     60ff3286-4701-4aea-8c56-9862045d34d1
TIMEOUTS    0
DURATION    0ms
IOPS        0 req/sec
THROUGHPUT  0B/sec
LATENCY     P50   P90   P99   P999  MAX
            0us   0us   0us   0us   0us
...
```

Now, the output is reduced to remove unfilled rows.

```
NODE ID: 0 | STATUS: IDLE
=========================
NAME      Cloud Storage Test
INFO      Put
TYPE      cloud
TEST ID   26b992ca-27ad-422a-8a97-944fbdbba2b2
TIMEOUTS  0
DURATION  12ms

NAME      Cloud Storage Test
INFO      List
TYPE      cloud
TEST ID   26b992ca-27ad-422a-8a97-944fbdbba2b2
TIMEOUTS  0
DURATION  0ms
...
```

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none