### PR TITLE
CORE-2699 Quotas: act on quotas from `quota_store`

### DIFF
--- a/src/v/cluster/client_quota_store.h
+++ b/src/v/cluster/client_quota_store.h
@@ -69,6 +69,21 @@ public:
             });
       };
 
+    static constexpr auto prefix_group_filter(std::string_view client_id) {
+        return [client_id](const std::pair<entity_key, entity_value>& kv) {
+            return absl::c_any_of(
+              kv.first.parts, [client_id](const entity_key::part& key_part) {
+                  return ss::visit(
+                    key_part.part,
+                    [client_id](const entity_key::part::client_id_prefix_match&
+                                  prefix_match) {
+                        return client_id.starts_with(prefix_match.value);
+                    },
+                    [](const auto&) { return false; });
+              });
+        };
+    }
+
     // TODO: provide an observer mechanism so that quota_manager can listen to
     // quota changes and update its state accordingly
 

--- a/src/v/cluster/tests/client_quota_store_test.cc
+++ b/src/v/cluster/tests/client_quota_store_test.cc
@@ -35,6 +35,12 @@ const entity_key key2{
     .part = entity_key::part::client_id_match{.value = "consumer-app-1"},
   }},
 };
+const entity_key key3{
+  .parts = {entity_key::part{
+    .part
+    = entity_key::part::client_id_prefix_match{.value = "franz-go-prefix"},
+  }},
+};
 
 const entity_value val0{
   .consumer_byte_rate = 10240,
@@ -45,6 +51,9 @@ const entity_value val1{
 const entity_value val2{
   .producer_byte_rate = 25600,
   .consumer_byte_rate = 20480,
+};
+const entity_value val3{
+  .producer_byte_rate = 12345,
 };
 
 BOOST_AUTO_TEST_CASE(quota_store_set_get_remove) {
@@ -91,6 +100,7 @@ BOOST_AUTO_TEST_CASE(quota_store_range) {
 
     st.set_quota(key1, val1);
     st.set_quota(key2, val2);
+    st.set_quota(key3, val3);
 
     auto default_client_quotas = st.range(
       [](const std::pair<entity_key, entity_value>& kv) -> bool {
@@ -110,6 +120,12 @@ BOOST_AUTO_TEST_CASE(quota_store_range) {
     BOOST_CHECK_EQUAL(specific_client_quota.size(), 1);
     BOOST_CHECK_EQUAL(specific_client_quota[0].first, key1);
     BOOST_CHECK_EQUAL(specific_client_quota[0].second, val1);
+
+    auto group_quotas = st.range(
+      store::prefix_group_filter("franz-go-prefix--and-some-more"));
+    BOOST_CHECK_EQUAL(group_quotas.size(), 1);
+    BOOST_CHECK_EQUAL(group_quotas[0].first, key3);
+    BOOST_CHECK_EQUAL(group_quotas[0].second, val3);
 }
 
 BOOST_AUTO_TEST_CASE(quota_store_snapshot_delta) {

--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -11,12 +11,13 @@
 
 #include "kafka/server/client_quota_translator.h"
 
+#include "cluster/client_quota_store.h"
 #include "config/configuration.h"
 
-#include <optional>
-#include <utility>
-
 namespace kafka {
+
+using cluster::client_quota::entity_key;
+using cluster::client_quota::entity_value;
 
 std::ostream& operator<<(std::ostream& os, const client_quota_limits& l) {
     fmt::print(
@@ -44,42 +45,57 @@ client_quota_translator::client_quota_translator(
       config::shard_local_cfg()
         .kafka_client_group_fetch_byte_rate_quota.bind()) {}
 
-std::optional<uint64_t>
-client_quota_translator::get_client_target_produce_tp_rate(
-  const tracker_key& quota_id) {
-    return get_client_quota_value(
-      quota_id,
-      _target_produce_tp_rate_per_client_group(),
-      _default_target_produce_tp_rate());
-}
-
-std::optional<uint64_t>
-client_quota_translator::get_client_target_fetch_tp_rate(
-  const tracker_key& quota_id) {
-    return get_client_quota_value(
-      quota_id,
-      _target_fetch_tp_rate_per_client_group(),
-      _default_target_fetch_tp_rate());
-}
-
-std::optional<uint64_t>
-client_quota_translator::get_client_target_partition_mutation_rate(
-  const tracker_key& quota_id) {
-    return get_client_quota_value(
-      quota_id, {}, _target_partition_mutation_quota());
-}
-
 std::optional<uint64_t> client_quota_translator::get_client_quota_value(
-  const tracker_key& quota_id,
-  const std::unordered_map<ss::sstring, config::client_group_quota>&
-    group_quota_config,
-  std::optional<uint64_t> default_value_config) {
+  const tracker_key& quota_id, client_quota_type qt) const {
+    const auto accessor = [qt](const cluster::client_quota::entity_value& ev) {
+        switch (qt) {
+        case client_quota_type::produce_quota:
+            return ev.producer_byte_rate;
+        case client_quota_type::fetch_quota:
+            return ev.consumer_byte_rate;
+        case client_quota_type::partition_mutation_quota:
+            return ev.controller_mutation_rate;
+        }
+    };
     return ss::visit(
       quota_id,
-      [&default_value_config](const k_client_id&) -> std::optional<uint64_t> {
-          return default_value_config;
+      [this, qt, &accessor](const k_client_id& k) -> std::optional<uint64_t> {
+          auto exact_match_key = entity_key{
+            .parts = {entity_key::part{
+              .part = entity_key::part::client_id_match{.value = k},
+            }},
+          };
+          auto exact_match_quota = _quota_store.local().get_quota(
+            exact_match_key);
+          if (exact_match_quota && accessor(*exact_match_quota)) {
+              return accessor(*exact_match_quota);
+          }
+
+          const static auto default_client_key = entity_key{
+            .parts = {entity_key::part{
+              .part = entity_key::part::client_id_default_match{},
+            }},
+          };
+          auto default_quota = _quota_store.local().get_quota(
+            default_client_key);
+          if (default_quota && accessor(*default_quota)) {
+              return accessor(*default_quota);
+          }
+
+          return get_default_config(qt);
       },
-      [&group_quota_config](const k_group_name& k) -> std::optional<uint64_t> {
+      [this, qt, &accessor](const k_group_name& k) -> std::optional<uint64_t> {
+          const auto& group_quota_config = get_quota_config(qt);
+          auto group_key = entity_key{
+            .parts = {entity_key::part{
+              .part = entity_key::part::client_id_prefix_match{.value = k},
+            }},
+          };
+          auto group_quota = _quota_store.local().get_quota(group_key);
+          if (group_quota && accessor(*group_quota)) {
+              return accessor(*group_quota);
+          }
+
           auto group = group_quota_config.find(k);
           if (group != group_quota_config.end()) {
               return group->second.quota;
@@ -89,18 +105,64 @@ std::optional<uint64_t> client_quota_translator::get_client_quota_value(
       });
 }
 
-namespace {
 // If client is part of some group then client quota ID is a group
 // else client quota ID is client_id
-tracker_key get_client_quota_id(
-  const std::optional<std::string_view>& client_id,
-  const std::unordered_map<ss::sstring, config::client_group_quota>&
-    group_quota) {
+tracker_key client_quota_translator::find_quota_key(
+  const client_quota_request_ctx& ctx) const {
+    auto qt = ctx.q_type;
+    const auto& client_id = ctx.client_id;
+    const auto& group_quota = get_quota_config(qt);
+    const auto& quota_store = _quota_store.local();
+
+    const auto checker = [qt](const entity_value val) {
+        switch (qt) {
+        case kafka::client_quota_type::produce_quota:
+            return val.producer_byte_rate.has_value();
+        case kafka::client_quota_type::fetch_quota:
+            return val.consumer_byte_rate.has_value();
+        case kafka::client_quota_type::partition_mutation_quota:
+            return val.controller_mutation_rate.has_value();
+        }
+    };
+
     if (!client_id) {
         // requests without a client id are grouped into an anonymous group that
         // shares a default quota. the anonymous group is keyed on empty string.
         return tracker_key{std::in_place_type<k_client_id>, ""};
     }
+
+    // Exact match quotas
+    auto exact_match_key = entity_key{
+      .parts = {entity_key::part{
+        .part
+        = entity_key::part::client_id_match{.value = ss::sstring{*client_id}},
+      }},
+    };
+    auto exact_match_quota = quota_store.get_quota(exact_match_key);
+    if (exact_match_quota && checker(*exact_match_quota)) {
+        return tracker_key{std::in_place_type<k_client_id>, *client_id};
+    }
+
+    // Group quotas configured through the Kafka API
+    auto group_quotas = quota_store.range(
+      cluster::client_quota::store::prefix_group_filter(*client_id));
+    for (auto& [gk, gv] : group_quotas) {
+        if (checker(gv)) {
+            for (auto& part : gk.parts) {
+                using client_id_prefix_match
+                  = entity_key::part::client_id_prefix_match;
+
+                if (std::holds_alternative<client_id_prefix_match>(part.part)) {
+                    auto& prefix_key_part = get<client_id_prefix_match>(
+                      part.part);
+                    return tracker_key{
+                      std::in_place_type<k_group_name>, prefix_key_part.value};
+                }
+            }
+        }
+    }
+
+    // Group quotas configured through cluster configs
     for (const auto& group_and_limit : group_quota) {
         if (client_id->starts_with(
               std::string_view(group_and_limit.second.clients_prefix))) {
@@ -108,54 +170,27 @@ tracker_key get_client_quota_id(
               std::in_place_type<k_group_name>, group_and_limit.first};
         }
     }
+
+    // Default quotas configured through either the Kafka API or cluster configs
     return tracker_key{std::in_place_type<k_client_id>, *client_id};
 }
 
-} // namespace
-
-tracker_key client_quota_translator::get_produce_key(
-  std::optional<std::string_view> client_id) {
-    return get_client_quota_id(
-      client_id, _target_produce_tp_rate_per_client_group());
-}
-
-tracker_key client_quota_translator::get_fetch_key(
-  std::optional<std::string_view> client_id) {
-    return get_client_quota_id(
-      client_id, _target_fetch_tp_rate_per_client_group());
-}
-
-tracker_key client_quota_translator::get_partition_mutation_key(
-  std::optional<std::string_view> client_id) {
-    return get_client_quota_id(client_id, {});
-}
-
-tracker_key
-client_quota_translator::find_quota_key(const client_quota_request_ctx& ctx) {
-    switch (ctx.q_type) {
-    case client_quota_type::produce_quota:
-        return get_produce_key(ctx.client_id);
-    case client_quota_type::fetch_quota:
-        return get_fetch_key(ctx.client_id);
-    case client_quota_type::partition_mutation_quota:
-        return get_partition_mutation_key(ctx.client_id);
-    };
-}
-
 std::pair<tracker_key, client_quota_limits>
-client_quota_translator::find_quota(const client_quota_request_ctx& ctx) {
+client_quota_translator::find_quota(const client_quota_request_ctx& ctx) const {
     auto key = find_quota_key(ctx);
     auto value = find_quota_value(key);
     return {std::move(key), value};
 }
 
 client_quota_limits
-client_quota_translator::find_quota_value(const tracker_key& key) {
+client_quota_translator::find_quota_value(const tracker_key& key) const {
     return client_quota_limits{
-      .produce_limit = get_client_target_produce_tp_rate(key),
-      .fetch_limit = get_client_target_fetch_tp_rate(key),
-      .partition_mutation_limit = get_client_target_partition_mutation_rate(
-        key),
+      .produce_limit = get_client_quota_value(
+        key, client_quota_type::produce_quota),
+      .fetch_limit = get_client_quota_value(
+        key, client_quota_type::fetch_quota),
+      .partition_mutation_limit = get_client_quota_value(
+        key, client_quota_type::partition_mutation_quota),
     };
 }
 
@@ -166,6 +201,31 @@ void client_quota_translator::watch(on_change_fn&& fn) {
     _target_partition_mutation_quota.watch(watcher);
     _default_target_produce_tp_rate.watch(watcher);
     _default_target_fetch_tp_rate.watch(watcher);
+}
+
+const client_quota_translator::quota_config&
+client_quota_translator::get_quota_config(client_quota_type qt) const {
+    static const quota_config empty;
+    switch (qt) {
+    case kafka::client_quota_type::produce_quota:
+        return _target_produce_tp_rate_per_client_group();
+    case kafka::client_quota_type::fetch_quota:
+        return _target_fetch_tp_rate_per_client_group();
+    case kafka::client_quota_type::partition_mutation_quota:
+        return empty;
+    }
+}
+
+std::optional<uint64_t>
+client_quota_translator::get_default_config(client_quota_type qt) const {
+    switch (qt) {
+    case kafka::client_quota_type::produce_quota:
+        return _default_target_produce_tp_rate();
+    case kafka::client_quota_type::fetch_quota:
+        return _default_target_fetch_tp_rate();
+    case kafka::client_quota_type::partition_mutation_quota:
+        return _target_partition_mutation_quota();
+    }
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/client_quota_translator.h
+++ b/src/v/kafka/server/client_quota_translator.h
@@ -83,15 +83,15 @@ public:
     /// Returns the quota tracker key applicable to the given quota context
     /// Note: because the client quotas configured for produce/fetch/pm might be
     /// different, the tracker_key for produce/fetch/pm might be different
-    tracker_key find_quota_key(const client_quota_request_ctx& ctx);
+    tracker_key find_quota_key(const client_quota_request_ctx& ctx) const;
 
     /// Finds the limits applicable to the given quota tracker key
-    client_quota_limits find_quota_value(const tracker_key&);
+    client_quota_limits find_quota_value(const tracker_key&) const;
 
     /// Returns the quota tracker key and quota limit applicable to the given
     /// quota context
     std::pair<tracker_key, client_quota_limits>
-    find_quota(const client_quota_request_ctx& ctx);
+    find_quota(const client_quota_request_ctx& ctx) const;
 
     /// `watch` can be used to register for quota changes
     void watch(on_change_fn&& fn);
@@ -100,22 +100,11 @@ private:
     using quota_config
       = std::unordered_map<ss::sstring, config::client_group_quota>;
 
-    tracker_key get_produce_key(std::optional<std::string_view> client_id);
-    tracker_key get_fetch_key(std::optional<std::string_view> client_id);
-    tracker_key
-    get_partition_mutation_key(std::optional<std::string_view> client_id);
+    const quota_config& get_quota_config(client_quota_type qt) const;
+    std::optional<uint64_t> get_default_config(client_quota_type qt) const;
 
-    std::optional<uint64_t>
-    get_client_target_produce_tp_rate(const tracker_key& quota_id);
-    std::optional<uint64_t>
-    get_client_target_fetch_tp_rate(const tracker_key& quota_id);
-    std::optional<uint64_t>
-    get_client_target_partition_mutation_rate(const tracker_key& quota_id);
     std::optional<uint64_t> get_client_quota_value(
-      const tracker_key& quota_id,
-      const std::unordered_map<ss::sstring, config::client_group_quota>&
-        group_quota_config,
-      std::optional<uint64_t> default_value_config);
+      const tracker_key& quota_id, client_quota_type qt) const;
 
     ss::sharded<cluster::client_quota::store>& _quota_store;
 


### PR DESCRIPTION
This follows https://github.com/redpanda-data/redpanda/pull/18777 and is the PR that implements the lookups to the `quota_store` on the request path and handles the merging of the various quotas configured through the quota store and cluster configs at various priority levels.

Fixes https://redpandadata.atlassian.net/browse/CORE-2699

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
