### PR TITLE
CORE-3078 Quotas: scale up cluster configs by core count

### DIFF
--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -82,7 +82,10 @@ std::optional<uint64_t> client_quota_translator::get_client_quota_value(
               return accessor(*default_quota);
           }
 
-          return get_default_config(qt);
+          auto default_config = get_default_config(qt);
+          return default_config ? std::make_optional<uint64_t>(
+                   *default_config * ss::smp::count)
+                                : std::nullopt;
       },
       [this, qt, &accessor](const k_group_name& k) -> std::optional<uint64_t> {
           const auto& group_quota_config = get_quota_config(qt);
@@ -98,7 +101,7 @@ std::optional<uint64_t> client_quota_translator::get_client_quota_value(
 
           auto group = group_quota_config.find(k);
           if (group != group_quota_config.end()) {
-              return group->second.quota;
+              return group->second.quota * ss::smp::count;
           }
 
           return {};

--- a/src/v/kafka/server/tests/client_quota_test_helpers.h
+++ b/src/v/kafka/server/tests/client_quota_test_helpers.h
@@ -1,0 +1,28 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "base/seastarx.h"
+
+#include <seastar/core/smp.hh>
+
+#include <cstdint>
+
+namespace kafka {
+
+// Cluster configs used to be per-shard and for backwards compatibility,
+// when we made them node-wide, we started acting on the cluster configs at
+// the "core count" * "per-shard cluster config" value to be backwards
+// compatible with the existing configurations.
+// Therefore, in the unit tests, we need to scale various values by the core
+// count to keep them passing.
+inline uint64_t scale_to_smp_count(uint64_t val) {
+    return val * ss::smp::count;
+}
+
+} // namespace kafka

--- a/src/v/kafka/server/tests/client_quota_translator_test.cc
+++ b/src/v/kafka/server/tests/client_quota_translator_test.cc
@@ -12,6 +12,7 @@
 #include "cluster/client_quota_store.h"
 #include "config/configuration.h"
 #include "kafka/server/client_quota_translator.h"
+#include "kafka/server/tests/client_quota_test_helpers.h"
 
 #include <seastar/testing/thread_test_case.hh>
 
@@ -86,7 +87,7 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_default_test) {
     fixture f;
 
     auto default_limits = client_quota_limits{
-      .produce_limit = 2147483648,
+      .produce_limit = scale_to_smp_count(2147483648),
       .fetch_limit = std::nullopt,
       .partition_mutation_limit = std::nullopt,
     };
@@ -105,9 +106,9 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_modified_default_test) {
     fixture f;
 
     auto expected_limits = client_quota_limits{
-      .produce_limit = 1111,
-      .fetch_limit = 2222,
-      .partition_mutation_limit = 3333,
+      .produce_limit = scale_to_smp_count(1111),
+      .fetch_limit = scale_to_smp_count(2222),
+      .partition_mutation_limit = scale_to_smp_count(3333),
     };
     auto [key, limits] = f.tr.find_quota(
       {client_quota_type::produce_quota, test_client_id});
@@ -155,8 +156,8 @@ void run_quota_translator_client_group_test(fixture& f) {
     // various tracker_key's being tested
     // Check limits for the franz-go groups
     auto franz_go_limits = client_quota_limits{
-      .produce_limit = 4096,
-      .fetch_limit = 4097,
+      .produce_limit = scale_to_smp_count(4096),
+      .fetch_limit = scale_to_smp_count(4097),
       .partition_mutation_limit = {},
     };
     BOOST_CHECK_EQUAL(
@@ -164,8 +165,8 @@ void run_quota_translator_client_group_test(fixture& f) {
 
     // Check limits for the not-franz-go groups
     auto not_franz_go_limits = client_quota_limits{
-      .produce_limit = 2048,
-      .fetch_limit = 2049,
+      .produce_limit = scale_to_smp_count(2048),
+      .fetch_limit = scale_to_smp_count(2049),
       .partition_mutation_limit = {},
     };
     BOOST_CHECK_EQUAL(
@@ -173,9 +174,9 @@ void run_quota_translator_client_group_test(fixture& f) {
 
     // Check limits for the non-client-group keys
     auto default_limits = client_quota_limits{
-      .produce_limit = P_DEF,
-      .fetch_limit = F_DEF,
-      .partition_mutation_limit = PM_DEF,
+      .produce_limit = scale_to_smp_count(P_DEF),
+      .fetch_limit = scale_to_smp_count(F_DEF),
+      .partition_mutation_limit = scale_to_smp_count(PM_DEF),
     };
     BOOST_CHECK_EQUAL(
       default_limits, f.tr.find_quota_value(k_client_id{"unknown"}));
@@ -215,9 +216,9 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_store_client_group_test) {
       }},
     };
     auto default_values = entity_value{
-      .producer_byte_rate = P_DEF,
-      .consumer_byte_rate = F_DEF,
-      .controller_mutation_rate = PM_DEF,
+      .producer_byte_rate = scale_to_smp_count(P_DEF),
+      .consumer_byte_rate = scale_to_smp_count(F_DEF),
+      .controller_mutation_rate = scale_to_smp_count(PM_DEF),
     };
 
     auto franz_go_key = entity_key{
@@ -226,8 +227,8 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_store_client_group_test) {
       }},
     };
     auto franz_go_values = entity_value{
-      .producer_byte_rate = 4096,
-      .consumer_byte_rate = 4097,
+      .producer_byte_rate = scale_to_smp_count(4096),
+      .consumer_byte_rate = scale_to_smp_count(4097),
     };
 
     auto not_franz_go_key = entity_key{
@@ -237,8 +238,8 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_store_client_group_test) {
       }},
     };
     auto not_franz_go_values = entity_value{
-      .producer_byte_rate = 2048,
-      .consumer_byte_rate = 2049,
+      .producer_byte_rate = scale_to_smp_count(2048),
+      .consumer_byte_rate = scale_to_smp_count(2049),
     };
 
     f.quota_store.local().set_quota(default_key, default_values);
@@ -291,9 +292,9 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_priority_order) {
     config::shard_local_cfg().target_fetch_quota_byte_rate.set_value(12);
     config::shard_local_cfg().kafka_admin_topic_api_rate.set_value(13);
 
-    check_produce("franz-go", k_client_id{"franz-go"}, 11);
-    check_fetch("franz-go", k_client_id{"franz-go"}, 12);
-    check_pm("franz-go", k_client_id{"franz-go"}, 13);
+    check_produce("franz-go", k_client_id{"franz-go"}, scale_to_smp_count(11));
+    check_fetch("franz-go", k_client_id{"franz-go"}, scale_to_smp_count(12));
+    check_pm("franz-go", k_client_id{"franz-go"}, scale_to_smp_count(13));
 
     // 2. Next: default client quota
     auto default_key = entity_key{
@@ -332,8 +333,8 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_priority_order) {
     config::shard_local_cfg()
       .kafka_client_group_fetch_byte_rate_quota.set_value(fetch_prefix_config);
 
-    check_produce("franz-go", k_group_name{"franz-go"}, 31);
-    check_fetch("franz-go", k_group_name{"franz-go"}, 32);
+    check_produce("franz-go", k_group_name{"franz-go"}, scale_to_smp_count(31));
+    check_fetch("franz-go", k_group_name{"franz-go"}, scale_to_smp_count(32));
     // there's no cluster config for partition mutation quotas based on client
     // prefix, so this fall backs to the previous priority level
     check_pm("franz-go", k_client_id{"franz-go"}, 23);

--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -31,28 +31,17 @@ struct fixture {
     ss::sharded<cluster::client_quota::store> quota_store;
     ss::sharded<kafka::quota_manager> sqm;
 
-    ss::future<> start() {
-        co_await quota_store.start();
-        co_await sqm.start(std::ref(buckets_map), std::ref(quota_store));
-        co_await sqm.invoke_on_all(&kafka::quota_manager::start);
+    fixture() {
+        quota_store.start().get();
+        sqm.start(std::ref(buckets_map), std::ref(quota_store)).get();
+        sqm.invoke_on_all(&kafka::quota_manager::start).get();
     }
 
-    ss::future<> stop() {
-        co_await sqm.stop();
-        co_await quota_store.stop();
+    ~fixture() {
+        sqm.stop().get();
+        quota_store.stop().get();
     }
 };
-
-template<typename F>
-ss::future<> run_quota_manager_test(F test_core) {
-    fixture f;
-    co_await f.start();
-
-    // Run the core of the test now that everything's set up
-    co_await ss::futurize_invoke(test_core, f.sqm);
-
-    co_await f.stop();
-}
 
 template<typename F>
 ss::future<> set_config(F update) {
@@ -62,80 +51,93 @@ ss::future<> set_config(F update) {
 }
 
 SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_no_throttling) {
-    set_config([](auto& conf) {
-        conf.target_fetch_quota_byte_rate.set_value(std::nullopt);
-    }).get();
+    fixture f;
 
-    run_quota_manager_test(
-      ss::coroutine::lambda(
-        [](ss::sharded<kafka::quota_manager>& sqm) -> ss::future<> {
-            auto& qm = sqm.local();
+    auto& qm = f.sqm.local();
 
-            // Test that if fetch throttling is disabled, we don't throttle
-            co_await qm.record_fetch_tp(client_id, 10000000000000);
-            auto delay = co_await qm.throttle_fetch_tp(client_id);
+    // Test that if fetch throttling is disabled, we don't throttle
+    qm.record_fetch_tp(client_id, 10000000000000).get();
+    auto delay = qm.throttle_fetch_tp(client_id).get();
 
-            BOOST_CHECK_EQUAL(0ms, delay);
-        }))
-      .get();
+    BOOST_CHECK_EQUAL(0ms, delay);
 }
 
 SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_throttling) {
-    set_config([](auto& conf) {
-        conf.target_fetch_quota_byte_rate.set_value(100);
-        conf.max_kafka_throttle_delay_ms.set_value(
-          std::chrono::milliseconds::max());
-    }).get();
+    fixture f;
 
-    run_quota_manager_test(
-      ss::coroutine::lambda(
-        [](ss::sharded<kafka::quota_manager>& sqm) -> ss::future<> {
-            auto& qm = sqm.local();
+    using cluster::client_quota::entity_key;
+    using cluster::client_quota::entity_value;
 
-            // Test that below the fetch quota we don't throttle
-            co_await qm.record_fetch_tp(client_id, 99);
-            auto delay = co_await qm.throttle_fetch_tp(client_id);
+    auto default_key = entity_key{
+      .parts = {entity_key::part{
+        .part = entity_key::part::client_id_default_match{},
+      }},
+    };
+    auto default_values = entity_value{
+      .consumer_byte_rate = 100,
+    };
+    f.quota_store.local().set_quota(default_key, default_values);
 
-            BOOST_CHECK_EQUAL(delay, 0ms);
+    auto& qm = f.sqm.local();
 
-            // Test that above the fetch quota we throttle
-            co_await qm.record_fetch_tp(client_id, 10);
-            delay = co_await qm.throttle_fetch_tp(client_id);
+    // Test that below the fetch quota we don't throttle
+    qm.record_fetch_tp(client_id, 99).get();
+    auto delay = qm.throttle_fetch_tp(client_id).get();
 
-            BOOST_CHECK_GT(delay, 0ms);
+    BOOST_CHECK_EQUAL(delay, 0ms);
 
-            // Test that once we wait out the throttling delay, we don't
-            // throttle again (as long as we stay under the limit)
-            co_await seastar::sleep_abortable(delay + 1s);
-            co_await qm.record_fetch_tp(client_id, 10);
-            delay = co_await qm.throttle_fetch_tp(client_id);
+    // Test that above the fetch quota we throttle
+    qm.record_fetch_tp(client_id, 10).get();
+    delay = qm.throttle_fetch_tp(client_id).get();
 
-            BOOST_CHECK_EQUAL(delay, 0ms);
-        }))
-      .get();
+    BOOST_CHECK_GT(delay, 0ms);
+
+    // Test that once we wait out the throttling delay, we don't
+    // throttle again (as long as we stay under the limit)
+    seastar::sleep_abortable(delay + 1s).get();
+    qm.record_fetch_tp(client_id, 10).get();
+    delay = qm.throttle_fetch_tp(client_id).get();
+
+    BOOST_CHECK_EQUAL(delay, 0ms);
 }
 
 SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_stress_test) {
+    fixture f;
+
     set_config([](config::configuration& conf) {
-        conf.target_fetch_quota_byte_rate.set_value(100);
         conf.max_kafka_throttle_delay_ms.set_value(
           std::chrono::milliseconds::max());
     }).get();
 
-    run_quota_manager_test(
-      ss::coroutine::lambda(
-        [](ss::sharded<kafka::quota_manager>& sqm) -> ss::future<> {
-            // Exercise the quota manager from multiple cores to attempt to
-            // discover segfaults caused by data races/use-after-free
-            co_await sqm.invoke_on_all(ss::coroutine::lambda(
-              [](kafka::quota_manager& qm) -> ss::future<> {
-                  for (size_t i = 0; i < 1000; ++i) {
-                      co_await qm.record_fetch_tp(client_id, 1);
-                      auto delay [[maybe_unused]]
-                      = co_await qm.throttle_fetch_tp(client_id);
-                      co_await ss::maybe_yield();
-                  }
-              }));
+    using cluster::client_quota::entity_key;
+    using cluster::client_quota::entity_value;
+
+    auto default_key = entity_key{
+      .parts = {entity_key::part{
+        .part = entity_key::part::client_id_default_match{},
+      }},
+    };
+    auto default_values = entity_value{
+      .consumer_byte_rate = 100,
+    };
+    f.quota_store
+      .invoke_on_all(
+        [&default_key, &default_values](cluster::client_quota::store& store) {
+            store.set_quota(default_key, default_values);
+        })
+      .get();
+
+    // Exercise the quota manager from multiple cores to attempt to
+    // discover segfaults caused by data races/use-after-free
+    f.sqm
+      .invoke_on_all(
+        ss::coroutine::lambda([](kafka::quota_manager& qm) -> ss::future<> {
+            for (size_t i = 0; i < 1000; ++i) {
+                co_await qm.record_fetch_tp(client_id, 1);
+                auto delay [[maybe_unused]] = co_await qm.throttle_fetch_tp(
+                  client_id);
+                co_await ss::maybe_yield();
+            }
         }))
       .get();
 }
@@ -183,8 +185,6 @@ SEASTAR_THREAD_TEST_CASE(static_config_test) {
     using k_client_id = kafka::k_client_id;
     using k_group_name = kafka::k_group_name;
     fixture f;
-    f.start().get();
-    auto stop = ss::defer([&] { f.stop().get(); });
 
     set_config(basic_config).get();
 
@@ -239,8 +239,6 @@ SEASTAR_THREAD_TEST_CASE(update_test) {
     using k_group_name = kafka::k_group_name;
     using k_client_id = kafka::k_client_id;
     fixture f;
-    f.start().get();
-    auto stop = ss::defer([&] { f.stop().get(); });
 
     set_config(basic_config).get();
 

--- a/tests/rptest/tests/cluster_quota_test.py
+++ b/tests/rptest/tests/cluster_quota_test.py
@@ -35,6 +35,13 @@ class ClusterQuotaPartitionMutationTest(RedpandaTest):
                          num_brokers=3,
                          extra_rp_conf=additional_options,
                          **kwargs)
+        # Cluster configs used to be per-shard and for backwards compatibility, when we made them node-wide,
+        # we started acting on the cluster configs at the "core count" * "per-shard cluster config" value to
+        # be backwards compatible with the existing configurations.
+        # To keep the tests simple, run the tests with 1 core / broker to have the per-shard cluster configs
+        # be the same as the node-wide limit after upscaling by the core count.
+        self.redpanda.set_resource_settings(ResourceSettings(num_cpus=1))
+
         # Use kcl so the throttle_time_ms value in the response can be examined
         self.kcl = RawKCL(self.redpanda)
 
@@ -143,6 +150,12 @@ class ClusterRateQuotaTest(RedpandaTest):
                              'info', logger_levels={'kafka': 'trace'}),
                          resource_settings=ResourceSettings(num_cpus=1),
                          **kwargs)
+        # Cluster configs used to be per-shard and for backwards compatibility, when we made them node-wide,
+        # we started acting on the cluster configs at the "core count" * "per-shard cluster config" value to
+        # be backwards compatible with the existing configurations.
+        # To keep the tests simple, run the tests with 1 core / broker to have the per-shard cluster configs
+        # be the same as the node-wide limit after upscaling by the core count.
+        self.redpanda.set_resource_settings(ResourceSettings(num_cpus=1))
         self.rpk = RpkTool(self.redpanda)
 
     def init_test_data(self):


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
After the client quotas are made per-node, we need to multiply up the per-shard configs by the core count to keep the intent of what the configs are set to.

Fixes https://redpandadata.atlassian.net/browse/CORE-3078

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
