### PR TITLE
cluster: enable controller log eviction

### DIFF
--- a/src/v/cluster/raft0_utils.h
+++ b/src/v/cluster/raft0_utils.h
@@ -38,7 +38,7 @@ static ss::future<consensus_ptr> create_raft0(
         std::nullopt,
         std::nullopt,
         raft::with_learner_recovery_throttle::no,
-        raft::keep_snapshotted_log::yes)
+        raft::keep_snapshotted_log::no)
       .then([&st](consensus_ptr p) {
           // Add raft 0 to shard table
           return st


### PR DESCRIPTION
Enable eviction of the snapshotted part of the controller log so that it doesn't grow uncontrollably.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Improvements
* Enable controller log eviction - now the snapshotted part of the controller log will be deleted.
