### PR TITLE
Add start/end times to self test results

### DIFF
--- a/src/go/rpk/pkg/adminapi/api_debug.go
+++ b/src/go/rpk/pkg/adminapi/api_debug.go
@@ -43,6 +43,8 @@ type SelfTestNodeResult struct {
 	TestName       string  `json:"name"`
 	TestInfo       string  `json:"info"`
 	TestType       string  `json:"test_type"`
+	StartTime      int64   `json:"start_time"`
+	EndTime        int64   `json:"end_time"`
 	Duration       uint    `json:"duration"`
 	Warning        *string `json:"warning,omitempty"`
 	Error          *string `json:"error,omitempty"`

--- a/src/go/rpk/pkg/cli/cluster/selftest/selftest_test.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/selftest_test.go
@@ -152,6 +152,8 @@ func TestSelfTestResults(t *testing.T) {
                      "name": "unittesting",
                      "info": "golang unit tests",
                      "test_type": "disk",
+                     "start_time": 1717615532,
+                     "end_time": 1717615693,
                      "duration": 50000,
                      "warning": "Mild transient issue detected"
                    }
@@ -167,6 +169,8 @@ func TestSelfTestResults(t *testing.T) {
                      "name": "unittesting",
                      "info": "golang unit tests",
                      "test_type": "disk",
+                     "start_time": 1717615532,
+                     "end_time": 1717615693,
                      "duration": 50000,
                      "error": "Unexpected exception detected"
                    }
@@ -182,6 +186,8 @@ func TestSelfTestResults(t *testing.T) {
                      "name": "unittesting",
                      "info": "golang unit tests",
                      "test_type": "disk",
+                     "start_time": 1717615532,
+                     "end_time": 1717615693,
                      "duration": 50000,
                      "error": "Unexpected exception detected"
                    }
@@ -200,7 +206,9 @@ func TestSelfTestResults(t *testing.T) {
 					{"TYPE", "disk"},
 					{"TEST ID", "8272-3843-38c8-381f"},
 					{"TIMEOUTS", "1"},
-					{"DURATION", "50000ms"},
+					{"START TIME", "Wed Jun  5 19:25:32 UTC 2024"},
+					{"END TIME", "Wed Jun  5 19:28:13 UTC 2024"},
+					{"AVG DURATION", "50000ms"},
 					{"IOPS", "2222 req/sec"},
 					{"THROUGHPUT", "907.5KiB/sec"},
 					{"WARNING", "Mild transient issue detected"},
@@ -214,7 +222,9 @@ func TestSelfTestResults(t *testing.T) {
 					[]string{"TYPE", "disk"},
 					[]string{"TEST ID", "8272-3843-38c8-381f"},
 					[]string{"TIMEOUTS", "55"},
-					[]string{"DURATION", "50000ms"},
+					[]string{"START TIME", "Wed Jun  5 19:25:32 UTC 2024"},
+					[]string{"END TIME", "Wed Jun  5 19:28:13 UTC 2024"},
+					[]string{"AVG DURATION", "50000ms"},
 					[]string{"ERROR", "Unexpected exception detected"},
 					[]string{""},
 				},
@@ -224,7 +234,9 @@ func TestSelfTestResults(t *testing.T) {
 					[]string{"TYPE", "disk"},
 					[]string{"TEST ID", "8272-3843-38c8-381f"},
 					[]string{"TIMEOUTS", "78"},
-					[]string{"DURATION", "50000ms"},
+					[]string{"START TIME", "Wed Jun  5 19:25:32 UTC 2024"},
+					[]string{"END TIME", "Wed Jun  5 19:28:13 UTC 2024"},
+					[]string{"AVG DURATION", "50000ms"},
 					[]string{"ERROR", "Unexpected exception detected"},
 					[]string{""},
 				},

--- a/src/go/rpk/pkg/cli/cluster/selftest/status.go
+++ b/src/go/rpk/pkg/cli/cluster/selftest/status.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -155,7 +156,9 @@ func makeReportTable(report adminapi.SelfTestNodeReport) [][]string {
 		table = append(table, []string{"TYPE", sr.TestType})
 		table = append(table, []string{"TEST ID", sr.TestID})
 		table = append(table, []string{"TIMEOUTS", fmt.Sprintf("%d", sr.Timeouts)})
-		table = append(table, []string{"DURATION", fmt.Sprintf("%dms", sr.Duration)})
+		table = append(table, []string{"START TIME", time.Unix(sr.StartTime, 0).UTC().Format(time.UnixDate)})
+		table = append(table, []string{"END TIME", time.Unix(sr.EndTime, 0).UTC().Format(time.UnixDate)})
+		table = append(table, []string{"AVG DURATION", fmt.Sprintf("%dms", sr.Duration)})
 		if sr.Warning != nil {
 			table = append(table, []string{"WARNING", *sr.Warning})
 		}

--- a/src/v/cluster/self_test/diskcheck.cc
+++ b/src/v/cluster/self_test/diskcheck.cc
@@ -169,6 +169,7 @@ template<diskcheck::read_or_write mode>
 ss::future<metrics> diskcheck::do_run_benchmark(ss::file& file) {
     auto irange = boost::irange<uint16_t>(0, _opts.parallelism);
     auto start = ss::lowres_clock::now();
+    auto start_highres = ss::lowres_system_clock::now();
     static const auto five_seconds_us = 500000;
     metrics m{five_seconds_us};
     ss::timer<ss::lowres_clock> timer;
@@ -184,7 +185,9 @@ ss::future<metrics> diskcheck::do_run_benchmark(ss::file& file) {
         vlog(clusterlog.debug, "Benchmark completed (duration reached)");
     }
     timer.cancel();
-    m.set_total_time(ss::lowres_clock::now() - start);
+    auto end = ss::lowres_system_clock::now();
+    m.set_start_end_time(start_highres, end);
+    m.set_total_time(end - start_highres);
     _last_pos = 0;
     co_return m;
 }

--- a/src/v/cluster/self_test/metrics.h
+++ b/src/v/cluster/self_test/metrics.h
@@ -48,6 +48,13 @@ public:
         }
     }
 
+    void set_start_end_time(
+      ss::lowres_system_clock::time_point start,
+      ss::lowres_system_clock::time_point end) {
+        _start_time = start;
+        _end_time = end;
+    }
+
     void set_total_time(ss::lowres_clock::duration t) { _total_time = t; }
 
     size_t iops() const {
@@ -78,12 +85,28 @@ public:
           .rps = iops(),
           .bps = throughput_bytes_sec(),
           .timeouts = static_cast<uint32_t>(_number_of_timeouts),
+          .start_time = get_start_time_since_epoch(),
+          .end_time = get_end_time_since_epoch(),
           .duration = std::chrono::duration_cast<std::chrono::milliseconds>(
             _total_time)};
     }
 
+    uint64_t get_start_time_since_epoch() const {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+                 _start_time.time_since_epoch())
+          .count();
+    }
+
+    uint64_t get_end_time_since_epoch() const {
+        return std::chrono::duration_cast<std::chrono::seconds>(
+                 _end_time.time_since_epoch())
+          .count();
+    }
+
 private:
     ss::lowres_clock::duration _total_time{};
+    ss::lowres_system_clock::time_point _start_time{};
+    ss::lowres_system_clock::time_point _end_time{};
     size_t _number_of_timeouts{0};
     size_t _bytes_operated{0};
     uint64_t _num_requests{0};

--- a/src/v/cluster/self_test/netcheck.cc
+++ b/src/v/cluster/self_test/netcheck.cc
@@ -114,6 +114,7 @@ netcheck::run_individual_benchmark(model::node_id peer) {
     const auto max_deadline = ss::lowres_clock::now() + _opts.max_duration;
     self_test_result result;
     try {
+        auto begin_t = ss::lowres_system_clock::now();
         auto durations = co_await ssx::parallel_transform(
           irange, [this, max_deadline, peer, &m](auto) {
               return run_benchmark_fiber(
@@ -124,6 +125,7 @@ netcheck::run_individual_benchmark(model::node_id peer) {
         const auto total_duration = std::accumulate(
           durations.begin(), durations.end(), ss::lowres_clock::duration{0});
         m.set_total_time(total_duration / _opts.parallelism);
+        m.set_start_end_time(begin_t, ss::lowres_system_clock::now());
         result = m.to_st_result();
         if (total_duration == 0ms) {
             /// Constant timeouts prevented test from any successful work

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -233,7 +233,7 @@ struct cloudcheck_opts
 
 struct self_test_result
   : serde::
-      envelope<self_test_result, serde::version<0>, serde::compat_version<0>> {
+      envelope<self_test_result, serde::version<1>, serde::compat_version<1>> {
     double p50{0};
     double p90{0};
     double p99{0};
@@ -246,6 +246,9 @@ struct self_test_result
     ss::sstring name;
     ss::sstring info;
     ss::sstring test_type;
+    uint64_t
+      start_time{}; // lowres_clock::time_point is not serializable in serde
+    uint64_t end_time{};
     ss::lowres_clock::duration duration{};
     std::optional<ss::sstring> warning;
     std::optional<ss::sstring> error;
@@ -255,7 +258,8 @@ struct self_test_result
         fmt::print(
           o,
           "{{p50: {} p90: {} p99: {} p999: {} max: {} rps: {} bps: {} "
-          "timeouts: {} test_id: {} name: {} info: {} type: {} duration: {}ms "
+          "timeouts: {} test_id: {} name: {} info: {} type: {} start_time: {} "
+          "end_time: {} duration: {}ms "
           "warning: {} error: {}}}",
           r.p50,
           r.p90,
@@ -269,6 +273,8 @@ struct self_test_result
           r.name,
           r.info,
           r.test_type,
+          r.start_time,
+          r.end_time,
           std::chrono::duration_cast<std::chrono::milliseconds>(r.duration)
             .count(),
           r.warning ? *r.warning : "<no_value>",

--- a/src/v/redpanda/admin/api-doc/debug.json
+++ b/src/v/redpanda/admin/api-doc/debug.json
@@ -831,6 +831,14 @@
                     "type": "string",
                     "description": "Type of self test, one of either disk/network/cloud"
                 },
+                "start_time": {
+                    "type": "long",
+                    "description": "Start time of the test run"
+                },
+                "end_time": {
+                    "type": "long",
+                    "description": "End time of the test run"
+                },
                 "duration": {
                     "type": "long",
                     "description": "Length of time the test took to complete"

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -2862,6 +2862,8 @@ self_test_result_to_json(const cluster::self_test_result& str) {
     r.name = str.name;
     r.info = str.info;
     r.test_type = str.test_type;
+    r.start_time = str.start_time;
+    r.end_time = str.end_time;
     r.duration = std::chrono::duration_cast<std::chrono::milliseconds>(
                    str.duration)
                    .count();


### PR DESCRIPTION
Adding start/end times to self test results. Modifying the `DURATION` field to be `AVG DURATION` since it really represents the average the of all of the runs which may or may not run concurrently depending on the test type. Start and end represent (respectively) the moments the first sub-test started and the last one ended.

JIRA Link: https://redpandadata.atlassian.net/browse/CORE-381

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Self-test results will now also include start and end timestamps of test runs 


