### PR TITLE
[v24.1.x] Added `vectorized_raft_learners_gap_bytes` metric

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -4064,4 +4064,18 @@ void consensus::notify_config_update() {
     }
 }
 
+size_t consensus::bytes_to_deliver_to_learners() const {
+    if (!is_leader()) {
+        return 0;
+    }
+
+    size_t total = 0;
+    for (auto& [f_id, f_meta] : _fstats) {
+        if (f_meta.is_learner) [[unlikely]] {
+            total += _log->size_bytes_after_offset(f_meta.match_index);
+        }
+    }
+    return total;
+}
+
 } // namespace raft

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -522,6 +522,11 @@ public:
     replication_monitor& get_replication_monitor() {
         return _replication_monitor;
     }
+    /**
+     * Returns the number of bytes that are required to deliver to all
+     * learners that are being recovered.
+     */
+    size_t bytes_to_deliver_to_learners() const;
 
     bool has_configuration_override() const {
         return _configuration_manager.has_configuration_override();

--- a/src/v/raft/group_manager.cc
+++ b/src/v/raft/group_manager.cc
@@ -51,6 +51,18 @@ group_manager::group_manager(
       _configuration.recovery_concurrency_per_shard,
       _configuration.heartbeat_interval)
   , _feature_table(feature_table.local())
+  // we use a reasonable default not to bloat the configuration properties
+  , _metric_collection_interval(5s)
+  , _metrics_timer([this] {
+      try {
+          collect_learner_metrics();
+      } catch (...) {
+          vlog(
+            raftlog.error,
+            "failed to collect learner metrics - {}",
+            std::current_exception());
+      }
+  })
   , _is_ready(false) {
     _configuration.write_caching.watch(
       [this]() { trigger_config_update_notification(); });
@@ -64,9 +76,13 @@ group_manager::group_manager(
 ss::future<> group_manager::start() {
     co_await _heartbeats.start();
     co_await _recovery_scheduler.start();
+    _metrics_timer.arm_periodic(_metric_collection_interval);
 }
 
 ss::future<> group_manager::stop() {
+    _metrics.clear();
+    _public_metrics.clear();
+    _metrics_timer.cancel();
     auto f = _gate.close();
 
     f = f.then([this] { return _recovery_scheduler.stop(); });
@@ -219,9 +235,22 @@ void group_manager::setup_metrics() {
     _metrics.add_group(
       prometheus_sanitize::metrics_name("raft"),
       {sm::make_gauge(
-        "group_count",
-        [this] { return _groups.size(); },
-        sm::description("Number of raft groups"))});
+         "group_count",
+         [this] { return _groups.size(); },
+         sm::description("Number of raft groups")),
+       sm::make_gauge(
+         "learners_gap_bytes",
+         [this] { return _learners_gap_bytes; },
+         sm::description(
+           "Total numbers of bytes that must be delivered to learners"))});
+
+    _public_metrics.add_group(
+      prometheus_sanitize::metrics_name("raft"),
+      {sm::make_gauge(
+        "learners_gap_bytes",
+        [this] { return _learners_gap_bytes; },
+        sm::description(
+          "Total numbers of bytes that must be delivered to learners"))});
 }
 
 void group_manager::trigger_config_update_notification() {
@@ -230,6 +259,15 @@ void group_manager::trigger_config_update_notification() {
     }
     for (auto& group : _groups) {
         group->notify_config_update();
+    }
+}
+
+void group_manager::collect_learner_metrics() {
+    // we can use a synchronous loop here as the number of raft groups per core
+    // is limited.
+    _learners_gap_bytes = 0;
+    for (const auto& group : _groups) {
+        _learners_gap_bytes += group->bytes_to_deliver_to_learners();
     }
 }
 

--- a/src/v/raft/group_manager.h
+++ b/src/v/raft/group_manager.h
@@ -100,6 +100,7 @@ private:
     void setup_metrics();
 
     void trigger_config_update_notification();
+    void collect_learner_metrics();
 
     raft::group_configuration create_initial_configuration(
       std::vector<model::broker>, model::revision_id) const;
@@ -114,12 +115,15 @@ private:
     notification_list<leader_cb_t, cluster::notification_id_type>
       _notifications;
     metrics::internal_metric_groups _metrics;
+    metrics::public_metric_groups _public_metrics;
     storage::api& _storage;
     coordinated_recovery_throttle& _recovery_throttle;
     recovery_memory_quota _recovery_mem_quota;
     recovery_scheduler _recovery_scheduler;
     features::feature_table& _feature_table;
-
+    std::chrono::milliseconds _metric_collection_interval;
+    ss::timer<> _metrics_timer;
+    size_t _learners_gap_bytes{0};
     bool _is_ready;
 };
 


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18691
