### PR TITLE
rpk: display float values as float in cluster config get

### DIFF
--- a/src/go/rpk/pkg/cli/cluster/config/get.go
+++ b/src/go/rpk/pkg/cli/cluster/config/get.go
@@ -11,6 +11,7 @@ package config
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -48,10 +49,14 @@ output, use the 'edit' and 'export' commands respectively.`,
 			} else {
 				// currentConfig is the result of json.Unmarshal into a
 				// map[string]interface{}. Due to json rules, all numbers
-				// are float64. We do not want to print floats, especially
-				// for large numbers.
+				// are float64. We do not want to print floats for large
+				// numbers.
 				if f64, ok := val.(float64); ok {
-					val = int64(f64)
+					if math.Mod(f64, 1.0) == 0 {
+						val = int64(f64)
+					} else {
+						val = f64
+					}
 				}
 				// Intentionally bare output, so that the output can be readily
 				// consumed in a script.

--- a/tests/rptest/tests/cluster_config_test.py
+++ b/tests/rptest/tests/cluster_config_test.py
@@ -1089,7 +1089,8 @@ class ClusterConfigTest(RedpandaTest, ClusterConfigHelpersMixin):
             Example("kafka_qdc_enable", "true", True),
             Example("append_chunk_size", "32768", 32768),
             Example("superusers", "['bob','alice']", ["bob", "alice"]),
-            Example("storage_min_free_bytes", "1234567890", 1234567890)
+            Example("storage_min_free_bytes", "1234567890", 1234567890),
+            Example("kafka_memory_share_for_fetch", "0.6", 0.6)
         ]
 
         def yamlize(input) -> str:


### PR DESCRIPTION
In 610e3ad8 we introduced a fix for #6070, to avoid printing large numbers with scientific notation, we treated all numbers as integers.

Now, the API uses float values and they are rounded by rpk, this change introduces a mod check to determine whether the number is an integer or a float.

```
# Before
$ rpk cluster config get kafka_memory_share_for_fetch
0

# Now
$ rpk cluster config get kafka_memory_share_for_fetch
0.5
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.1.x
- [X] v23.3.x
- [X] v23.2.x

## Release Notes

### Bug Fixes

* rpk cluster config get: does not round float numbers anymore.
