### PR TITLE
rptest: increase initial connections threshold

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
+++ b/tests/rptest/redpanda_cloud_tests/omb_validation_test.py
@@ -357,14 +357,14 @@ class OMBValidationTest(RedpandaCloudTest):
         # Before the test even starts, assert that there are a "small" number of connections.
         # This number is not zero because various things maintain or make occasional connections
         # to cloud clusters like kminion, so I observe typically ~45 connections on an idle T1 and 450
-        # on an idle T7 cluster. So we just use a SWAG of 100 + 1% of the connection target as the
+        # on an idle T7 cluster. So we just use a SWAG of 100 + 2% of the connection target as the
         # threshold above which we complain.
         # If this fails it is probably because some other test left services running
         # against the cluster.
         count_before = self._connection_count()
-        maximum_allowed = int(tier_limits.max_connection_count * 0.01 + 100)
+        maximum_allowed = int(tier_limits.max_connection_count * 0.02 + 100)
         assert count_before <= maximum_allowed, (
-            f"Wanted less than {maximum_allowed}"
+            f"Wanted less than {maximum_allowed} "
             f"connections to start but got {count_before}")
 
         benchmark = OpenMessagingBenchmark(self._ctx,


### PR DESCRIPTION
Before test_max_connections starts the main body of the test we assert that there are a "small" number of connections.

This number is not zero because various things maintain or make occasional connections to cloud clusters like kminion, so we need to choose a higher value.

I observed typically ~45 connections on an idle T1 and 450 on an idle T7 cluster. This led to an initial SWAG of 100 + 1% of the connection target as the threshold above which we complain.

However, this check failed on a GCP T4 run with 320 connections, versus 250 allowed. So just double the calculation to 2% + 100. This threshold will automatically become much larger once the connection count increase makes it into the product data.

Ref: Ref: https://redpandadata.slack.com/archives/C06MCRY75U7/p1717697617572749?thread_ts=1717641932.726599&cid=C06MCRY75U7

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
