### PR TITLE
k/fetch: do not return aborted txs for read uncommitted requests

### DIFF
--- a/tests/rptest/services/kgo_verifier_services.py
+++ b/tests/rptest/services/kgo_verifier_services.py
@@ -716,7 +716,8 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
             producer: Optional[KgoVerifierProducer] = None,
             username: Optional[str] = None,
             password: Optional[str] = None,
-            enable_tls: Optional[bool] = False):
+            enable_tls: Optional[bool] = False,
+            use_transactions: Optional[bool] = False):
         super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs,
                          trace_logs, username, password, enable_tls)
         self._max_msgs = max_msgs
@@ -725,6 +726,7 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
         self._continuous = continuous
         self._tolerate_data_loss = tolerate_data_loss
         self._producer = producer
+        self._use_transactions = use_transactions
 
     def start_node(self, node, clean=False):
         if clean:
@@ -746,6 +748,8 @@ class KgoVerifierSeqConsumer(AbstractConsumer):
             cmd += " --continuous"
         if self._tolerate_data_loss:
             cmd += " --tolerate-data-loss"
+        if self._use_transactions:
+            cmd += " --use-transactions"
         self.spawn(cmd, node)
 
         self._status_thread = StatusThread(self, node, ConsumerStatus)
@@ -795,11 +799,13 @@ class KgoVerifierRandomConsumer(AbstractConsumer):
                  trace_logs=False,
                  username=None,
                  password=None,
-                 enable_tls=False):
+                 enable_tls=False,
+                 use_transactions: Optional[bool] = False):
         super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs,
                          trace_logs, username, password, enable_tls)
         self._rand_read_msgs = rand_read_msgs
         self._parallel = parallel
+        self._use_transactions = use_transactions
 
     def start_node(self, node, clean=False):
         if clean:
@@ -812,6 +818,8 @@ class KgoVerifierRandomConsumer(AbstractConsumer):
             cmd = cmd + f' --password {self._password}'
         if self._enable_tls:
             cmd = cmd + f' --enable-tls'
+        if self._use_transactions:
+            cmd += " --use-transactions"
 
         self.spawn(cmd, node)
 
@@ -840,7 +848,8 @@ class KgoVerifierConsumerGroupConsumer(AbstractConsumer):
                  enable_tls=False,
                  continuous=False,
                  tolerate_data_loss=False,
-                 group_name=None):
+                 group_name=None,
+                 use_transactions=False):
         super().__init__(context, redpanda, topic, msg_size, nodes, debug_logs,
                          trace_logs, username, password, enable_tls)
 
@@ -851,6 +860,7 @@ class KgoVerifierConsumerGroupConsumer(AbstractConsumer):
         self._group_name = group_name
         self._continuous = continuous
         self._tolerate_data_loss = tolerate_data_loss
+        self._use_transactions = use_transactions
 
     def start_node(self, node, clean=False):
         if clean:
@@ -875,6 +885,8 @@ class KgoVerifierConsumerGroupConsumer(AbstractConsumer):
             cmd += " --tolerate-data-loss"
         if self._group_name is not None:
             cmd += f" --consumer_group_name {self._group_name}"
+        if self._use_transactions:
+            cmd += " --use-transactions"
         self.spawn(cmd, node)
 
         self._status_thread = StatusThread(self, node, ConsumerStatus)

--- a/tests/rptest/tests/e2e_topic_recovery_test.py
+++ b/tests/rptest/tests/e2e_topic_recovery_test.py
@@ -288,6 +288,7 @@ class EndToEndTopicRecovery(RedpandaTest):
                                               msg_size,
                                               loop=False,
                                               nodes=[traffic_node],
+                                              use_transactions=True,
                                               debug_logs=True,
                                               trace_logs=True)
             consumer.start(clean=False)

--- a/tests/rptest/tests/shadow_indexing_tx_test.py
+++ b/tests/rptest/tests/shadow_indexing_tx_test.py
@@ -94,7 +94,8 @@ class ShadowIndexingTxTest(RedpandaTest):
                                           self.topic,
                                           msg_size,
                                           loop=False,
-                                          nodes=[traffic_node])
+                                          nodes=[traffic_node],
+                                          use_transactions=True)
         consumer.start(clean=False)
         consumer.wait()
         status = consumer.consumer_status


### PR DESCRIPTION
When a consumer issues a fetch request with `read_uncommitted` isolation level it doesn't need the aborted transactions information. Some clients ignore the range if reading uncommitted batches some of them do not. In Kafka aborted transaction ranges are not returned for uncommitted reads. Change Redpanda fetch handler not to return aborted transactions when `read_uncommitted` isolation level is requested by the consumer in `FetchRequest`.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- do not return aborted transaction ranges when reading with `read_uncommitted` isolation level.