### PR TITLE
kafka/quotas: Improve API for entity_key

### DIFF
--- a/src/v/cluster/tests/client_quota_store_test.cc
+++ b/src/v/cluster/tests/client_quota_store_test.cc
@@ -20,27 +20,10 @@
 
 namespace cluster::client_quota {
 
-const entity_key key0{
-  .parts = {entity_key::part{
-    .part = entity_key::part::client_id_default_match{},
-  }},
-};
-const entity_key key1{
-  .parts = {entity_key::part{
-    .part = entity_key::part::client_id_match{.value = "producer-app-1"},
-  }},
-};
-const entity_key key2{
-  .parts = {entity_key::part{
-    .part = entity_key::part::client_id_match{.value = "consumer-app-1"},
-  }},
-};
-const entity_key key3{
-  .parts = {entity_key::part{
-    .part
-    = entity_key::part::client_id_prefix_match{.value = "franz-go-prefix"},
-  }},
-};
+const entity_key key0{entity_key::client_id_default_match{}};
+const entity_key key1{entity_key::client_id_match{"producer-app-1"}};
+const entity_key key2{entity_key::client_id_match{"consumer-app-1"}};
+const entity_key key3{entity_key::client_id_prefix_match{"franz-go-prefix"}};
 
 const entity_value val0{
   .consumer_byte_rate = 10240,

--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -60,11 +60,7 @@ std::optional<uint64_t> client_quota_translator::get_client_quota_value(
     return ss::visit(
       quota_id,
       [this, qt, &accessor](const k_client_id& k) -> std::optional<uint64_t> {
-          auto exact_match_key = entity_key{
-            .parts = {entity_key::part{
-              .part = entity_key::part::client_id_match{.value = k},
-            }},
-          };
+          auto exact_match_key = entity_key{entity_key::client_id_match{k}};
           auto exact_match_quota = _quota_store.local().get_quota(
             exact_match_key);
           if (exact_match_quota && accessor(*exact_match_quota)) {
@@ -72,10 +68,7 @@ std::optional<uint64_t> client_quota_translator::get_client_quota_value(
           }
 
           const static auto default_client_key = entity_key{
-            .parts = {entity_key::part{
-              .part = entity_key::part::client_id_default_match{},
-            }},
-          };
+            entity_key::client_id_default_match{}};
           auto default_quota = _quota_store.local().get_quota(
             default_client_key);
           if (default_quota && accessor(*default_quota)) {
@@ -86,11 +79,7 @@ std::optional<uint64_t> client_quota_translator::get_client_quota_value(
       },
       [this, qt, &accessor](const k_group_name& k) -> std::optional<uint64_t> {
           const auto& group_quota_config = get_quota_config(qt);
-          auto group_key = entity_key{
-            .parts = {entity_key::part{
-              .part = entity_key::part::client_id_prefix_match{.value = k},
-            }},
-          };
+          auto group_key = entity_key{entity_key::client_id_prefix_match{k}};
           auto group_quota = _quota_store.local().get_quota(group_key);
           if (group_quota && accessor(*group_quota)) {
               return accessor(*group_quota);
@@ -132,12 +121,7 @@ tracker_key client_quota_translator::find_quota_key(
     }
 
     // Exact match quotas
-    auto exact_match_key = entity_key{
-      .parts = {entity_key::part{
-        .part
-        = entity_key::part::client_id_match{.value = ss::sstring{*client_id}},
-      }},
-    };
+    auto exact_match_key = entity_key{entity_key::client_id_match{*client_id}};
     auto exact_match_quota = quota_store.get_quota(exact_match_key);
     if (exact_match_quota && checker(*exact_match_quota)) {
         return tracker_key{std::in_place_type<k_client_id>, *client_id};

--- a/src/v/kafka/server/tests/client_quota_translator_test.cc
+++ b/src/v/kafka/server/tests/client_quota_translator_test.cc
@@ -209,11 +209,7 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_store_client_group_test) {
     using cluster::client_quota::entity_key;
     using cluster::client_quota::entity_value;
 
-    auto default_key = entity_key{
-      .parts = {entity_key::part{
-        .part = entity_key::part::client_id_default_match{},
-      }},
-    };
+    auto default_key = entity_key{entity_key::client_id_default_match{}};
     auto default_values = entity_value{
       .producer_byte_rate = P_DEF,
       .consumer_byte_rate = F_DEF,
@@ -221,21 +217,14 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_store_client_group_test) {
     };
 
     auto franz_go_key = entity_key{
-      .parts = {entity_key::part{
-        .part = entity_key::part::client_id_prefix_match{.value = "franz-go"},
-      }},
-    };
+      entity_key::client_id_prefix_match{"franz-go"}};
     auto franz_go_values = entity_value{
       .producer_byte_rate = 4096,
       .consumer_byte_rate = 4097,
     };
 
     auto not_franz_go_key = entity_key{
-      .parts = {entity_key::part{
-        .part
-        = entity_key::part::client_id_prefix_match{.value = "not-franz-go"},
-      }},
-    };
+      entity_key::client_id_prefix_match{"not-franz-go"}};
     auto not_franz_go_values = entity_value{
       .producer_byte_rate = 2048,
       .consumer_byte_rate = 2049,
@@ -296,11 +285,7 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_priority_order) {
     check_pm("franz-go", k_client_id{"franz-go"}, 13);
 
     // 2. Next: default client quota
-    auto default_key = entity_key{
-      .parts = {entity_key::part{
-        .part = entity_key::part::client_id_default_match{},
-      }},
-    };
+    auto default_key = entity_key{entity_key::client_id_default_match{}};
     auto default_values = entity_value{
       .producer_byte_rate = 21,
       .consumer_byte_rate = 22,
@@ -340,10 +325,7 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_priority_order) {
 
     // 4. Next: client id prefix quota store
     auto franz_go_prefix_key = entity_key{
-      .parts = {entity_key::part{
-        .part = entity_key::part::client_id_prefix_match{.value = "franz-go"},
-      }},
-    };
+      entity_key::client_id_prefix_match{"franz-go"}};
     auto franz_go_prefix_values = entity_value{
       .producer_byte_rate = 41,
       .consumer_byte_rate = 42,
@@ -358,10 +340,7 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_priority_order) {
 
     // 5. Finally: client id exact match quota store
     auto franz_go_exact_key = entity_key{
-      .parts = {entity_key::part{
-        .part = entity_key::part::client_id_match{.value = "franz-go"},
-      }},
-    };
+      entity_key::client_id_match{"franz-go"}};
     auto franz_go_exact_values = entity_value{
       .producer_byte_rate = 51,
       .consumer_byte_rate = 52,


### PR DESCRIPTION
Add a small utility to help constructing an `entity_key`.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none
