### PR TITLE
tests: adjusted topic settings to make learner gap test stable

### DIFF
--- a/tests/rptest/tests/nodes_decommissioning_test.py
+++ b/tests/rptest/tests/nodes_decommissioning_test.py
@@ -428,7 +428,8 @@ class NodesDecommissioningTest(PreallocNodesTest):
         self.start_redpanda()
         # set small segment size to calculate the gap correctly
         self.redpanda.set_cluster_config({"log_segment_size": 1024 * 1024})
-        self._create_topics()
+        self._topic = TopicSpec(name="gap-test-topic", partition_count=10)
+        self.client().create_topic(self._topic)
 
         self.start_producer()
         self.start_consumer()
@@ -449,6 +450,7 @@ class NodesDecommissioningTest(PreallocNodesTest):
 
         self.logger.info(f"decommissioning node: {to_decommission_id}", )
         self._decommission(to_decommission_id)
+        self.producer.wait()
 
         def learner_gap_reported(decommissioned_node_id: int):
             total_gap = calculate_total_learners_gap()


### PR DESCRIPTION
The test using decommission operation to validate the correctness of learner gap metrics used random properties for topic partition count and replication. This made the test flaky as in some circumstances the `redpanda/controller/0` was the only partition on the decommissioned node. This partition is removed from the node and not moved anywhere else hence it does not contribute to learner gap but it still contributes to overall data on the decommissioned node.

Fixes: #19067

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none