### PR TITLE
rpk: Improve k8s bundle errors + better admin API fallback 

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"time"
 
+	authorizationv1 "k8s.io/api/authorization/v1"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/adminapi"
 	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
@@ -70,8 +72,6 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveDataDirStructure(ps, bp.y),
 		saveDiskUsage(ctx, ps, bp.y),
 		saveInterrupts(ps),
-		saveK8SLogs(ctx, ps, bp.namespace, bp.logsSince, bp.logsLimitBytes, bp.labelSelector),
-		saveK8SResources(ctx, ps, bp.namespace, bp.labelSelector),
 		saveKafkaMetadata(ctx, ps, bp.cl),
 		saveKernelSymbols(ps),
 		saveMdstat(ps),
@@ -81,9 +81,25 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		saveSlabInfo(ps),
 	}
 
-	adminAddresses, err := adminAddressesFromK8S(ctx, bp.namespace)
-	if err != nil {
-		zap.L().Sugar().Debugf("unable to get admin API addresses from the k8s API: %v", err)
+	// We use the K8S to discover the cluster's admin API addresses and collect
+	// logs and k8s resources. First we check if we have enough permissions
+	// before kicking the steps.
+	var adminAddresses []string
+	if err := checkK8sPermissions(ctx, bp.namespace); err != nil {
+		errs = multierror.Append(
+			errs,
+			fmt.Errorf("skipping log collection and Kubernetes resource collection (such as Pods and Services) in the namespace %q. To enable this, grant additional permissions to your Service Account. For more information, visit https://docs.redpanda.com/current/manage/kubernetes/troubleshooting/k-diagnostics-bundle/", err),
+		)
+	} else {
+		steps = append(steps, []step{
+			saveK8SResources(ctx, ps, bp.namespace, bp.labelSelector),
+			saveK8SLogs(ctx, ps, bp.namespace, bp.logsSince, bp.logsLimitBytes, bp.labelSelector),
+		}...)
+
+		adminAddresses, err = adminAddressesFromK8S(ctx, bp.namespace)
+		if err != nil {
+			zap.L().Sugar().Debugf("unable to get admin API addresses from the k8s API: %v", err)
+		}
 	}
 	if len(adminAddresses) == 0 {
 		if len(bp.p.AdminAPI.Addresses) > 0 {
@@ -143,6 +159,41 @@ func k8sPodList(ctx context.Context, namespace string, labelSelector map[string]
 		return nil, nil, fmt.Errorf("unable to get pods in the %q namespace: %v", namespace, err)
 	}
 	return clientset, pods, nil
+}
+
+// checkK8sPermissions will check for the minimal service account permissions
+// needed to perform the k8s-API-related steps in the debug bundle collection
+// process.
+func checkK8sPermissions(ctx context.Context, namespace string) error {
+	cl, err := k8sClientset()
+	if err != nil {
+		return fmt.Errorf("unable to create kubernetes client: %v", err)
+	}
+
+	// These are the minimal permissions needed for the k8s bundle to function.
+	perMap := map[string]string{
+		"services": "list",
+		"pods":     "list",
+	}
+	for resource, verb := range perMap {
+		sar := &authorizationv1.SelfSubjectAccessReview{
+			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1.ResourceAttributes{
+					Namespace: namespace,
+					Verb:      verb,
+					Resource:  resource,
+				},
+			},
+		}
+		response, err := cl.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+		if err != nil {
+			return fmt.Errorf("unable to check service account permissions: %v", err)
+		}
+		if !response.Status.Allowed {
+			return fmt.Errorf("permission denied to %s %s", verb, resource)
+		}
+	}
+	return nil
 }
 
 // adminAddressesFromK8S returns the admin API host:port list by querying the
@@ -379,7 +430,7 @@ func saveK8SResources(ctx context.Context, ps *stepParams, namespace string, lab
 	return func() error {
 		clientset, pods, err := k8sPodList(ctx, namespace, labelSelector)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to save k8s resources: unable to list k8s pods: %v", err)
 		}
 		// This is a safeguard, so we don't end up saving empty request for
 		// namespace who don't have any pods.
@@ -421,7 +472,7 @@ func saveK8SLogs(ctx context.Context, ps *stepParams, namespace, since string, l
 	return func() error {
 		clientset, pods, err := k8sPodList(ctx, namespace, labelSelector)
 		if err != nil {
-			return err
+			return fmt.Errorf("unable to save logs: unable to list k8s pods: %v", err)
 		}
 		podsInterface := clientset.CoreV1().Pods(namespace)
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_k8s_linux.go
@@ -86,7 +86,14 @@ func executeK8SBundle(ctx context.Context, bp bundleParams) error {
 		zap.L().Sugar().Debugf("unable to get admin API addresses from the k8s API: %v", err)
 	}
 	if len(adminAddresses) == 0 {
-		adminAddresses = []string{fmt.Sprintf("127.0.0.1:%v", config.DefaultAdminPort)}
+		if len(bp.p.AdminAPI.Addresses) > 0 {
+			zap.L().Sugar().Debugf("using admin API addresses from profile: %v", bp.p.AdminAPI.Addresses)
+			adminAddresses = bp.p.AdminAPI.Addresses
+		} else {
+			defaultAddress := fmt.Sprintf("127.0.0.1:%v", config.DefaultAdminPort)
+			zap.L().Sugar().Debugf("profile empty, using %v for the Admin API address", defaultAddress)
+			adminAddresses = []string{defaultAddress}
+		}
 	}
 	steps = append(steps, []step{
 		saveClusterAdminAPICalls(ctx, ps, bp.fs, bp.p, adminAddresses, bp.partitions),

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -557,6 +557,9 @@ func saveSlabInfo(ps *stepParams) step {
 	return func() error {
 		bs, err := afero.ReadFile(ps.fs, "/proc/slabinfo")
 		if err != nil {
+			if errors.Is(err, fs.ErrPermission) {
+				return fmt.Errorf("%v: you may need to run the command as root to read this file", err)
+			}
 			return err
 		}
 		return writeFileToZip(ps, "proc/slabinfo", bs)

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -310,7 +310,7 @@ func writeCommandOutputToZipLimit(
 	err = cmd.Wait()
 	if err != nil {
 		if !strings.Contains(err.Error(), "broken pipe") {
-			return fmt.Errorf("couldn't save '%s': %w", filename, err)
+			return fmt.Errorf("couldn't save '%s': %w; %[1]v contains the full error message", filename, err)
 		}
 		zap.L().Sugar().Debugf(
 			"Got '%v' while running '%s'. This is probably due to the"+


### PR DESCRIPTION
Debug bundles are often collected when things are not working properly, so it is normal that `rpk debug bundle` hits some errors along the collection steps. This PR aims to improve the error messages and provide better hints when errors occur, it focuses on the Kubernetes experience.

Fixes #18057 

### Main Changes:

1. rpk uses the k8s API to 'find' the admin API addresses and collect the logs, this is the first step that leads many other steps, if the service account does not have the authorization to access some resources it will fail. Now we check for the authorization before executing the steps, reducing the clutter and providing a better error message:

```
# Before:
	* unable to get pods in the "redpanda" namespace: pods is forbidden: User "system:serviceaccount:redpanda:default" cannot list resource "pods" in API group "" in the namespace "redpanda"
	* unable to get pods in the "redpanda" namespace: pods is forbidden: User "system:serviceaccount:redpanda:default" cannot list resource "pods" in API group "" in the namespace "redpanda"

# Now:

	* skipping log collection and collecting Kubernetes resources (such as pods, services, etc.) in the namespace "permission denied to list services". To enable this you may need to grant additional permissions to your service account; visit https://docs.redpanda.com/current/manage/kubernetes/troubleshooting/k-diagnostics-bundle/
```

2. Our fallback in the case of (1) was to use localhost:9644 for the admin API addresses, we are now using the loaded profile's addresses as the primary fallback since it includes TLS information as such. This does have a big impact on clusters that were created using our helm chart/operator since we now populate the redpanda.yaml with the cluster admin API addresses:
```
# Before
	* unable to issue request for "admin/disk_stat_cache_127.0.0.1-9644.json": Get "https://127.0.0.1:9644/v1/debug/storage/disk_stat/cache": tls: failed to verify certificate: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs
	* unable to issue request for "metrics/127.0.0.1-9644/t0_public_metrics.txt": Get "https://127.0.0.1:9644/public_metrics": tls: failed to verify certificate: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs
	* unable to issue request for "admin/node_config_127.0.0.1-9644.json": Get "https://127.0.0.1:9644/v1/node_config": tls: failed to verify certificate: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs
	* unable to issue request for "admin/raft_status_127.0.0.1-9644.json": Get "https://127.0.0.1:9644/v1/raft/recovery/status": tls: failed to verify certificate: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs

# Now: use the profile, which would have the TLS configuration in place :smile: 
```

3. `/proc/slabinfo` collection often fails because `rpk debug bundle` is not being executed with root permissions:
```
# Before: 
open /proc/slabinfo: permission denied
# Now:
open /proc/slabinfo: permission denied; you may need to run the command as root to read this file
```

4.  Controller log collection requires the presence of `redpanda.data_directory` in the configuration file (redpanda.yaml), this is also necessary to start Redpanda, so it is often a sign of a corrupted or invalid config file. The error we were printing was not a clear indication of that

```
# Before:
	* lstat redpanda/controller/0_0: no such file or directory
# Now: 
	* failed to save controller logs: 'redpanda.data_directory' is empty on the provided configuration file
```

5. If a command execution failed (du, top, etc...) we would print that the command exited with status 1, and the error (stderr) is saved in the file. Our error did not provide a hint that this was the behavior, this is now clear:

```
# Before:
* couldn't save 'utils/dmidecode.txt': exit status 1

# Now:
* couldn't save 'utils/dmidecode.txt': exit status 1; utils/dmidecode.txt contains the full error message

$ cat utils/dmidecode.txt
# dmidecode 3.3
/sys/firmware/dmi/tables/smbios_entry_point: Permission denied
Scanning /dev/mem for entry point.
/dev/mem: Permission denied
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Improvements

* rpk debug bundle now fallback to loaded profile's admin API URLs if we fail to discover the cluster in the collection steps.

