### PR TITLE
k/tests: fixed use of entity_key constructor

### DIFF
--- a/src/v/kafka/server/tests/quota_manager_test.cc
+++ b/src/v/kafka/server/tests/quota_manager_test.cc
@@ -70,11 +70,7 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_throttling) {
     using cluster::client_quota::entity_key;
     using cluster::client_quota::entity_value;
 
-    auto default_key = entity_key{
-      .parts = {entity_key::part{
-        .part = entity_key::part::client_id_default_match{},
-      }},
-    };
+    auto default_key = entity_key(entity_key::client_id_default_match{});
     auto default_values = entity_value{
       .consumer_byte_rate = 100,
     };
@@ -116,11 +112,7 @@ SEASTAR_THREAD_TEST_CASE(quota_manager_fetch_stress_test) {
     using cluster::client_quota::entity_key;
     using cluster::client_quota::entity_value;
 
-    auto default_key = entity_key{
-      .parts = {entity_key::part{
-        .part = entity_key::part::client_id_default_match{},
-      }},
-    };
+    auto default_key = entity_key(entity_key::client_id_default_match{});
     auto default_values = entity_value{
       .consumer_byte_rate = 100,
     };


### PR DESCRIPTION
Fixed usage of `entity_key` constructor in `quota_manager` fixture test.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none