### PR TITLE
gha/labeler: fix format of yml file for v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,23 +1,27 @@
 area/k8s:
-- src/go/k8s/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/go/k8s/**/*']
 
 k8s/tests:
-- src/go/k8s/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/go/k8s/**/*']
 
 area/build:
-- cmake/**/*
-- .github/**/*
+- changed-files:
+  - any-glob-to-any-file: ['cmake/**/*', '.github/**/*']
 
 area/docs:
-- docs/**/*
+- changed-files:
+  - any-glob-to-any-file: ['docs/**/*']
 
 area/rpk:
-- src/go/rpk/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/go/rpk/**/*']
 
 area/redpanda:
-- src/v/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/v/**/*']
 
 area/wasm:
-- src/transform-sdk/**/*
-- src/v/transform/**/*
-- src/v/wasm/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/transform-sdk/**/*', 'src/v/transform/**/*', 'src/v/wasm/**/*']


### PR DESCRIPTION
The v5 of labeler has breaking change that needs update to the configuration file:
https://github.com/actions/labeler/tree/v5.0.0?tab=readme-ov-file#breaking-changes-in-v5

This fixes it and retains existing behavior. Just syntax differences.

Unfortunately, the gha job `triage` will fail using label v5 until this PR is merged to `dev` branch because of known issue https://github.com/actions/labeler/issues/712#issuecomment-1852440098, so needs a force merge.

I recommend merging this PR to keep the fixes for nodejs that were brought in with labeler v5. But if this PR is merged, then PR #19626 should not be merged.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none