### PR TITLE
Revert "gha: update to actions/labeler@v5"

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -11,6 +11,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v5
+    - uses: actions/labeler@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This reverts commit d7f2c138eece185264557d156da7182610330060.

Because v5 requires config format changes in `.github/labeler.yml` that cannot be verified in a PR.

Just reverts the 1 commit from PR #18857 that updates gha labeler.

Needs a force merge because of known issue with v5: https://github.com/actions/labeler/issues/712#issuecomment-1852440098

If this PR is merged, then PR #19625 should not be merged.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
