### PR TITLE
[v23.3.x] gha/labeler: fix format of yml file for v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,21 +1,27 @@
 area/k8s:
-- src/go/k8s/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/go/k8s/**/*']
 
 k8s/tests:
-- src/go/k8s/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/go/k8s/**/*']
 
 area/build:
-- cmake/**/*
-- .github/**/*
+- changed-files:
+  - any-glob-to-any-file: ['cmake/**/*', '.github/**/*']
 
 area/docs:
-- docs/**/*
+- changed-files:
+  - any-glob-to-any-file: ['docs/**/*']
 
 area/rpk:
-- src/go/rpk/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/go/rpk/**/*']
 
 area/redpanda:
-- src/v/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/v/**/*']
 
 area/wasm:
-- src/transform-sdk/**/*
+- changed-files:
+  - any-glob-to-any-file: ['src/transform-sdk/**/*']


### PR DESCRIPTION
Backport of PR #19625 

conflict resolution in cherry-pick was simple (just for `area/wasm`)

jira: https://redpandadata.atlassian.net/browse/PESDLC-1510

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none