### PR TITLE
producer_state: add request::set_error and make it idempotent 

### DIFF
--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -243,13 +243,18 @@ std::ostream& operator<<(std::ostream& o, const producer_state& state) {
     fmt::print(
       o,
       "{{ id: {}, group: {}, requests: {}, "
-      "ms_since_last_update: {}, transaction_state: {}, evicted: {} }}",
+      "ms_since_last_update: {}, evicted: {}, ",
       state._id,
       state._group,
       state._requests,
       state.ms_since_last_update(),
-      state._transaction_state,
       state._evicted);
+    if (state._transaction_state) {
+        fmt::print(o, "transaction_state: {}", *state._transaction_state);
+    } else {
+        fmt::print(o, "transaction_state: {{ null }}");
+    }
+    fmt::print(o, "}}");
     return o;
 }
 

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -16,6 +16,17 @@
 
 namespace cluster::tx {
 
+std::ostream& operator<<(std::ostream& os, request_state state) {
+    switch (state) {
+    case request_state::initialized:
+        return os << "initialized";
+    case request_state::in_progress:
+        return os << "in_progress";
+    case request_state::completed:
+        return os << "completed";
+    }
+}
+
 result_promise_t::future_type request::result() const {
     return _result.get_shared_future();
 }
@@ -228,6 +239,18 @@ bool producer_state::operator==(const producer_state& other) const {
     return _id == other._id && _group == other._group
            && _requests == other._requests
            && _transaction_state == other._transaction_state;
+}
+
+std::ostream& operator<<(std::ostream& o, const request& request) {
+    fmt::print(
+      o,
+      "{{ first: {}, last: {}, term: {}, result_available: {}, state: {} }}",
+      request._first_sequence,
+      request._last_sequence,
+      request._term,
+      request._result.available(),
+      request._state);
+    return o;
 }
 
 std::ostream& operator<<(std::ostream& o, const requests& requests) {

--- a/src/v/cluster/producer_state.cc
+++ b/src/v/cluster/producer_state.cc
@@ -325,7 +325,7 @@ result<request_ptr> producer_state::try_emplace_request(
 
     if (unlikely(result.has_error())) {
         vlog(
-          _logger.debug,
+          _logger.warn,
           "[{}] error {} processing request {}, term: {}, reset: {}",
           *this,
           result.error(),

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -50,6 +50,8 @@ enum class request_state : uint8_t {
     completed = 2
 };
 
+std::ostream& operator<<(std::ostream&, request_state);
+
 /// A request for a given sequence range, both inclusive.
 /// The sequence numbers are stamped by the client and are a part
 /// of batch header. A request can either be in progress or completed
@@ -71,10 +73,8 @@ public:
     void set_value(ValueType&& value) {
         vassert(
           _state <= request_state::in_progress && !_result.available(),
-          "unexpected request state during set: state: {}, result available: "
-          "{}",
-          static_cast<std::underlying_type_t<request_state>>(_state),
-          _result.available());
+          "unexpected request state during result set: {}",
+          *this);
         _result.set_value(std::forward<ValueType>(value));
         _state = request_state::completed;
     }
@@ -83,6 +83,8 @@ public:
     result_promise_t::future_type result() const;
 
     bool operator==(const request&) const;
+
+    friend std::ostream& operator<<(std::ostream&, const request&);
 
 private:
     request_state _state{request_state::initialized};

--- a/src/v/cluster/producer_state.h
+++ b/src/v/cluster/producer_state.h
@@ -40,7 +40,8 @@ concept AcceptsUnits = requires(Func f, ssx::semaphore_units units) {
 };
 
 using producer_ptr = ss::lw_shared_ptr<producer_state>;
-using result_promise_t = ss::shared_promise<result<kafka_result>>;
+using request_result_t = result<kafka_result>;
+using result_promise_t = ss::shared_promise<request_result_t>;
 using request_ptr = ss::lw_shared_ptr<request>;
 using seq_t = int32_t;
 
@@ -69,15 +70,8 @@ public:
         }
     }
 
-    template<class ValueType>
-    void set_value(ValueType&& value) {
-        vassert(
-          _state <= request_state::in_progress && !_result.available(),
-          "unexpected request state during result set: {}",
-          *this);
-        _result.set_value(std::forward<ValueType>(value));
-        _state = request_state::completed;
-    }
+    void set_value(request_result_t::value_type);
+    void set_error(request_result_t::error_type);
     void mark_request_in_progress() { _state = request_state::in_progress; }
     request_state state() const { return _state; }
     result_promise_t::future_type result() const;


### PR DESCRIPTION
A request can be marked as errored multiple times, consider the example
below.

```
replicate_f : waiting for replication
term change and leadership change
requests from old terms gc-ed: set_err(ec) -- separate fiber
replicate_f: set_err(ec)
```

Current assert assumes that a request can be set only once, which is
true for setting a successful result but not for errors. This commit
splits set_value() into set_value() and set_error() and adjusts
assert conditions accordingly.

This was identified in a chaos build. Also included some logging improvements noticed while debugging, most notably printing the transaction state correctly (currently printing the pointer instead of value).

Also fixes https://github.com/redpanda-data/redpanda/issues/18267


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

* none


<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
