### PR TITLE
[v23.3.x] [CORE-2845]: Ensure create_acls requests return an error when resources as topics are non valid kafka topic names 

### DIFF
--- a/src/v/kafka/server/handlers/details/security.h
+++ b/src/v/kafka/server/handlers/details/security.h
@@ -12,6 +12,7 @@
 #include "kafka/protocol/schemata/delete_acls_request.h"
 #include "kafka/protocol/schemata/describe_acls_request.h"
 #include "kafka/server/request_context.h"
+#include "model/validation.h"
 #include "security/acl.h"
 namespace kafka::details {
 
@@ -146,6 +147,17 @@ inline security::acl_binding to_acl_binding(const creatable_acl& acl) {
       && pattern.name() != security::default_cluster_name) {
         throw acl_conversion_error(
           fmt::format("Invalid cluster name: {}", pattern.name()));
+    }
+
+    if (pattern.resource() == security::resource_type::topic) {
+        auto errc = model::validate_kafka_topic_name(
+          model::topic_view(pattern.name()));
+        if (pattern.name() != "*" && errc) {
+            throw acl_conversion_error(fmt::format(
+              "ACL topic {} does not conform to kafka topic schema: {}",
+              pattern.name(),
+              errc.message()));
+        }
     }
 
     security::acl_entry entry(

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -389,10 +389,10 @@ class RpkTool:
         return self._run(cmd)
 
     def sasl_allow_principal(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args, **kwargs, deny=False)
+        return self._sasl_set_principal_access(*args, **kwargs, deny=False)
 
     def sasl_deny_principal(self, *args, **kwargs):
-        self._sasl_set_principal_access(*args, **kwargs, deny=True)
+        return self._sasl_set_principal_access(*args, **kwargs, deny=True)
 
     def allow_principal(self, principal, operations, resource, resource_name):
         if resource == "topic":


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18701 

Fixes https://github.com/redpanda-data/redpanda/issues/18770