### PR TITLE
gha: fix backport-command type-branch job to retrieve aws sm token

### DIFF
--- a/.github/workflows/backport-command.yml
+++ b/.github/workflows/backport-command.yml
@@ -78,6 +78,20 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_SM_READONLY_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SM_READONLY_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+
+      - name: get secrets from aws sm
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            ,sdlc/prod/github/actions_bot_token
+          parse-json-secrets: true
+
       - name: Get user
         env:
           GITHUB_TOKEN: ${{ env.ACTIONS_BOT_TOKEN }}


### PR DESCRIPTION
follow-on to PR #18857

fixes https://redpandadata.atlassian.net/browse/PESDLC-1511

There are 2 jobs defined in this file and initially access to AWS SM was added to just the first one. This commit adds it to the second job, "type-branch", as well since it also needs access.

backports are not strictly necessary for this PR because the workflow file runs on `repository_dispatch` which only runs on the default branch (`dev`), but doing a backport would be good to verify it works after this is merged.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

* none
