### PR TITLE
c/p_balancer: fixed possible overflow of final used ration

### DIFF
--- a/src/v/cluster/partition_balancer_types.h
+++ b/src/v/cluster/partition_balancer_types.h
@@ -43,6 +43,13 @@ struct node_disk_space {
     double peak_used_ratio() const { return double(used + assigned) / total; }
 
     double final_used_ratio() const {
+        // it sometimes may happen  that the partition replica size on one node
+        // is out of date with the total used size reported by a node space
+        // manager. This may lead to an overflow of final used ratio.
+        if (released >= used + assigned) {
+            return 0.0;
+        }
+
         return double(used + assigned - released) / total;
     }
 


### PR DESCRIPTION
Replicas eviction policy is asynchronously applied to each partition it may happen that the size of individual partitions is not exactly equal to the total usage size reported. In this case the individual partition sizes that are moved out of the node may sum up to a value larger than the total used bytes. Added a code preventing overflowing the final ratio in this case

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [x] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Bug Fixes
- fixed overflow that may lead to unnecessary moves