### PR TITLE
[v24.1.x] s/disk_log_impl: don't prefix-truncate empty segments

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2507,7 +2507,12 @@ ss::future<>
 disk_log_impl::remove_prefix_full_segments(truncate_prefix_config cfg) {
     return ss::do_until(
       [this, cfg] {
+          // base_offset check is for the case of an empty segment
+          // (where dirty = base - 1). We don't want to remove it because
+          // batches may be concurrently appended to it and we should keep them.
           return _segs.empty()
+                 || _segs.front()->offsets().get_base_offset()
+                      >= cfg.start_offset
                  || _segs.front()->offsets().get_dirty_offset()
                       >= cfg.start_offset;
       },


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/19790
Fixes: https://github.com/redpanda-data/redpanda/issues/19800,