### PR TITLE
[v24.1.x] t/fetch_test: wait longer for leadership after stepping down

### DIFF
--- a/src/v/kafka/server/tests/fetch_test.cc
+++ b/src/v/kafka/server/tests/fetch_test.cc
@@ -413,7 +413,7 @@ FIXTURE_TEST(fetch_leader_epoch, redpanda_thread_fixture) {
                   .get0();
             }
             partition->raft()->step_down("trigger epoch change").get0();
-            wait_for_leader(ntp).get0();
+            wait_for_leader(ntp, 10s).get0();
             {
                 auto batches = model::test::make_random_batches(
                   model::offset(0), 5);


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/18468
Fixes: https://github.com/redpanda-data/redpanda/issues/19806, Fixes: https://github.com/redpanda-data/redpanda/issues/19807,

Fixes: CORE-4179
Fixes: CORE-4174