### PR TITLE
storage/tests: fix `max_step_size()` in `test_offset_range_size_incremental`

### DIFF
--- a/src/v/storage/disk_log_impl.cc
+++ b/src/v/storage/disk_log_impl.cc
@@ -2161,7 +2161,7 @@ disk_log_impl::offset_range_size(
     size_t current_size = 0;
     // Last offset included to the result, default value means that we didn't
     // find anything
-    model::offset last_included_offset;
+    model::offset last_included_offset = {};
     size_t num_segments = 0;
     auto it = _segs.lower_bound(first);
     for (; it < _segs.end(); it++) {


### PR DESCRIPTION
Fixes #18396 (again)

When finding the `max_step_size()`, consider the final step between last position index value and segment size.

Also avoids an uninitialized value in `offset_range_size()`, which _might_ fix #18496 - I haven't seen the error appear in `debug` mode since making the change.

## Backports Required

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none