### PR TITLE
[CORE-4180] schema_registry/json: Initial commits for JSON Schema

### DIFF
--- a/src/v/pandaproxy/schema_registry/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/CMakeLists.txt
@@ -20,6 +20,7 @@ v_cc_library(
     sharded_store.cc
     types.cc
     avro.cc
+    json.cc
     protobuf.cc
     validation.cc
     ${schema_registry_file}

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "json/document.h"
+#include "json/stringbuffer.h"
+#include "json/writer.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/coroutine/exception.hh>
+#include <seastar/util/defer.hh>
+
+#include <absl/container/flat_hash_set.h>
+#include <boost/outcome/std_result.hpp>
+#include <boost/outcome/success_failure.hpp>
+#include <fmt/core.h>
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <rapidjson/error/en.h>
+
+#include <string_view>
+
+namespace pandaproxy::schema_registry {
+
+struct json_schema_definition::impl {
+    ss::sstring to_json() const {
+        json::StringBuffer buf;
+        json::Writer<json::StringBuffer> wrt(buf);
+        doc.Accept(wrt);
+        return {buf.GetString(), buf.GetLength()};
+    }
+
+    explicit impl(json::Document doc, std::string_view name)
+      : doc{std::move(doc)}
+      , name{name} {}
+
+    json::Document doc;
+    ss::sstring name;
+};
+
+bool operator==(
+  const json_schema_definition& lhs, const json_schema_definition& rhs) {
+    return lhs.raw() == rhs.raw();
+}
+
+std::ostream& operator<<(std::ostream& os, const json_schema_definition& def) {
+    fmt::print(
+      os,
+      "type: {}, definition: {}",
+      to_string_view(def.type()),
+      def().to_json());
+    return os;
+}
+
+canonical_schema_definition::raw_string json_schema_definition::raw() const {
+    return canonical_schema_definition::raw_string{_impl->to_json()};
+}
+
+ss::sstring json_schema_definition::name() const { return {_impl->name}; };
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -9,9 +9,13 @@
  * by the Apache License, Version 2.0
  */
 
+#include "pandaproxy/schema_registry/json.h"
+
 #include "json/document.h"
 #include "json/stringbuffer.h"
 #include "json/writer.h"
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/errors.h"
 #include "pandaproxy/schema_registry/types.h"
 
 #include <seastar/core/coroutine.hh>
@@ -66,5 +70,41 @@ canonical_schema_definition::raw_string json_schema_definition::raw() const {
 }
 
 ss::sstring json_schema_definition::name() const { return {_impl->name}; };
+
+namespace {
+
+result<json::Document> parse_json(std::string_view v) {
+    json::Document doc;
+    doc.Parse(v.data(), v.size());
+    if (doc.HasParseError()) {
+        return error_info{
+          error_code::schema_invalid,
+          fmt::format(
+            "Invalid schema: {} at offset {}",
+            rapidjson::GetParseError_En(doc.GetParseError()),
+            doc.GetErrorOffset())};
+    }
+    return {std::move(doc)};
+}
+
+} // namespace
+
+ss::future<json_schema_definition>
+make_json_schema_definition(sharded_store&, canonical_schema schema) {
+    auto doc = parse_json(schema.def().raw()()).value(); // throws on error
+    std::string_view name = schema.sub()();
+    auto refs = std::move(schema).def().refs();
+    co_return json_schema_definition{
+      ss::make_shared<json_schema_definition::impl>(std::move(doc), name),
+      std::move(refs)};
+}
+
+ss::future<canonical_schema>
+make_canonical_json_schema(sharded_store&, unparsed_schema def) {
+    // TODO BP: More validation and normalisation
+    parse_json(def.def().raw()()).value(); // throws on error
+    co_return canonical_schema{
+      def.sub(), canonical_schema_definition{def.def().raw(), def.type()}};
+}
 
 } // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/json.h
+++ b/src/v/pandaproxy/schema_registry/json.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "pandaproxy/schema_registry/fwd.h"
+#include "pandaproxy/schema_registry/types.h"
+
+namespace pandaproxy::schema_registry {
+
+ss::future<json_schema_definition>
+make_json_schema_definition(sharded_store& store, canonical_schema schema);
+
+ss::future<canonical_schema>
+make_canonical_json_schema(sharded_store& store, unparsed_schema def);
+
+} // namespace pandaproxy::schema_registry

--- a/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
+++ b/src/v/pandaproxy/schema_registry/test/CMakeLists.txt
@@ -22,6 +22,7 @@ rp_test(
     compatibility_3rdparty.cc
     compatibility_avro.cc
     compatibility_protobuf.cc
+    test_json_schema.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES v::seastar_testing_main v_pandaproxy_schema_registry
   ARGS "-- -c 1"

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -1,0 +1,97 @@
+// Copyright 2021 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "pandaproxy/schema_registry/error.h"
+#include "pandaproxy/schema_registry/errors.h"
+#include "pandaproxy/schema_registry/exceptions.h"
+#include "pandaproxy/schema_registry/json.h"
+#include "pandaproxy/schema_registry/sharded_store.h"
+#include "pandaproxy/schema_registry/types.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/testing/thread_test_case.hh>
+#include <seastar/util/defer.hh>
+
+#include <boost/test/tools/context.hpp>
+#include <fmt/core.h>
+
+namespace pp = pandaproxy;
+namespace pps = pp::schema_registry;
+
+struct store_fixture {
+    store_fixture() {
+        store.start(pps::is_mutable::yes, ss::default_smp_service_group())
+          .get();
+    }
+    ~store_fixture() { store.stop().get(); }
+
+    pps::sharded_store store;
+};
+
+struct error_test_case {
+    ss::sstring def;
+    pps::error_info err;
+    friend std::ostream&
+    operator<<(std::ostream& os, error_test_case const& e) {
+        fmt::print(
+          os,
+          "def: {}, error_code: {}, error_message: {}",
+          e.def,
+          e.err.code(),
+          e.err.message());
+        return os;
+    }
+};
+static const auto error_test_cases = std::to_array({
+  // Test invalid JSON
+  error_test_case{
+    R"({])",
+    pps::error_info{
+      pps::error_code::schema_invalid,
+      "Invalid schema: Missing a name for object member. at offset 1"}},
+});
+SEASTAR_THREAD_TEST_CASE(test_make_invalid_json_schema) {
+    for (const auto& data : error_test_cases) {
+        store_fixture f;
+        BOOST_TEST_CONTEXT(data) {
+            BOOST_REQUIRE_EXCEPTION(
+              pps::make_canonical_json_schema(
+                f.store,
+                {pps::subject{"test"}, {data.def, pps::schema_type::json}})
+                .get(),
+              pps::exception,
+              [&data](pps::exception const& e) {
+                  return e.code() == data.err.code()
+                         && e.message() == data.err.message();
+              });
+        }
+    };
+}
+
+static constexpr auto valid_test_cases = std::to_array<std::string_view>(
+  {// primitives
+   R"({"type": "number"})",
+   R"({"type": "integer"})",
+   R"({"type": "object"})",
+   R"({"type": "array"})",
+   R"({"type": "boolean"})",
+   R"({"type": "null"})"});
+SEASTAR_THREAD_TEST_CASE(test_make_valid_json_schema) {
+    for (const auto& data : valid_test_cases) {
+        store_fixture f;
+        BOOST_TEST_CONTEXT(data) {
+            auto s = pps::make_json_schema_definition(
+              f.store,
+              pps::make_canonical_json_schema(
+                f.store, {pps::subject{"test"}, {data, pps::schema_type::json}})
+                .get());
+            BOOST_REQUIRE_NO_THROW(s.get());
+        }
+    };
+}

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -239,6 +239,42 @@ private:
     canonical_schema_definition::references _refs;
 };
 
+class json_schema_definition {
+public:
+    struct impl;
+    using pimpl = ss::shared_ptr<const impl>;
+
+    explicit json_schema_definition(
+      pimpl p, canonical_schema_definition::references refs)
+      : _impl{std::move(p)}
+      , _refs(std::move(refs)) {}
+
+    canonical_schema_definition::raw_string raw() const;
+    canonical_schema_definition::references const& refs() const {
+        return _refs;
+    };
+
+    const impl& operator()() const { return *_impl; }
+
+    friend bool operator==(
+      const json_schema_definition& lhs, const json_schema_definition& rhs);
+
+    friend std::ostream&
+    operator<<(std::ostream& os, const json_schema_definition& rhs);
+
+    constexpr schema_type type() const { return schema_type::json; }
+
+    explicit operator canonical_schema_definition() const {
+        return {raw(), type(), refs()};
+    }
+
+    ss::sstring name() const;
+
+private:
+    pimpl _impl;
+    canonical_schema_definition::references _refs;
+};
+
 ///\brief A schema that has been validated.
 class valid_schema {
     using impl


### PR DESCRIPTION
Some cleanup from the [initial PoC](https://github.com/redpanda-data/redpanda/compare/dev...BenPope:redpanda:schema_registry/json/PoC), but drops some commits, too.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
