### PR TITLE
tests: Adapt size in LocalDiskReportTimeTest

### DIFF
--- a/tests/rptest/tests/full_disk_test.py
+++ b/tests/rptest/tests/full_disk_test.py
@@ -349,7 +349,7 @@ class LocalDiskReportTimeTest(RedpandaTest):
         # params. the size is about 900k larger than what was written,
         # attributable to per record overheads etc... and determined emperically
         # by looking at trace log stats.
-        size = 32441102
+        size = 32664482
         time = 61
         retention = 3600
         expected = retention * (size / time)


### PR DESCRIPTION
After https://github.com/redpanda-data/redpanda/commit/7d0d283abeacdad8177e4fc4a2cfb95a52654e18 the expected size in
LocalDiskReportTimeTest.test_target_min_capacity_wanted_time_based
changed slightly.

The test is already time based and has some flakiness leeway but the
above change seems to have made it flake more often.

Hence, adapt the size to get a more accurate calculation.

Fixes https://github.com/redpanda-data/redpanda/issues/14320
## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none


