### PR TITLE
Respect target local retention settings when moving cloud enabled partition replicas

### DIFF
--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -448,6 +448,17 @@ ss::future<> controller::start(
                 return config::shard_local_cfg()
                   .initial_retention_local_target_ms_default.bind();
             }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .retention_local_target_bytes_default.bind();
+            }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg()
+                  .retention_local_target_ms_default.bind();
+            }),
+            ss::sharded_parameter([] {
+                return config::shard_local_cfg().retention_local_strict.bind();
+            }),
             std::ref(_as));
       })
       .then([this] {

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -34,6 +34,7 @@
 
 #include <cstdint>
 #include <iosfwd>
+#include <optional>
 
 namespace cluster {
 
@@ -209,6 +210,11 @@ public:
         initial_retention_local_target_bytes,
       config::binding<std::optional<std::chrono::milliseconds>>
         initial_retention_local_target_ms,
+      config::binding<std::optional<size_t>>
+        retention_local_target_bytes_default,
+      config::binding<std::chrono::milliseconds>
+        retention_local_target_ms_default,
+      config::binding<bool> retention_local_strict,
       ss::sharded<seastar::abort_source>&);
     ~controller_backend();
 
@@ -355,6 +361,7 @@ private:
     bool should_skip(const model::ntp&) const;
 
     std::optional<model::offset> calculate_learner_initial_offset(
+      reconfiguration_policy policy,
       const ss::lw_shared_ptr<partition>& partition) const;
 
     ss::sharded<topic_table>& _topics;
@@ -374,6 +381,11 @@ private:
       _initial_retention_local_target_bytes;
     config::binding<std::optional<std::chrono::milliseconds>>
       _initial_retention_local_target_ms;
+    config::binding<std::optional<size_t>>
+      _retention_local_target_bytes_default;
+    config::binding<std::chrono::milliseconds>
+      _retention_local_target_ms_default;
+    config::binding<bool> _retention_local_strict;
     ss::sharded<ss::abort_source>& _as;
 
     absl::btree_map<model::ntp, ss::lw_shared_ptr<ntp_reconciliation_state>>

--- a/tests/rptest/tests/scaling_up_test.py
+++ b/tests/rptest/tests/scaling_up_test.py
@@ -497,3 +497,115 @@ class ScalingUpTest(PreallocNodesTest):
         assert self.consumer.consumer_status.validator.invalid_reads == 0, \
         f"Invalid reads in topic: {topic.name}, invalid reads count: "
         "{self.consumer.consumer_status.validator.invalid_reads}"
+
+    @skip_debug_mode
+    @cluster(num_nodes=7)
+    @matrix(use_topic_property=[True, False])
+    def test_moves_with_local_retention(self, use_topic_property):
+
+        log_segment_size = 2 * 1024 * 1024
+        total_segments_per_partition = 40
+        partition_cnt = 20
+        msg_size = 16 * 1024  # 16 KiB
+        data_size = log_segment_size * total_segments_per_partition * partition_cnt
+        msg_cnt = data_size // msg_size
+
+        # configure and start redpanda
+        extra_rp_conf = {
+            'cloud_storage_segment_max_upload_interval_sec': 10,
+            'cloud_storage_manifest_max_upload_interval_sec': 10,
+        }
+        # shadow indexing is required when we want to leverage fast partition movements
+        si_settings = SISettings(test_context=self.test_context,
+                                 log_segment_size=log_segment_size,
+                                 retention_local_strict=False)
+
+        self.redpanda.set_extra_rp_conf(extra_rp_conf)
+        self.redpanda.set_si_settings(si_settings)
+        self.redpanda.start(nodes=self.redpanda.nodes[0:4])
+        topic = TopicSpec(replication_factor=3,
+                          partition_count=partition_cnt,
+                          redpanda_remote_write=True,
+                          redpanda_remote_read=True)
+
+        total_replicas = 3 * partition_cnt
+
+        self.client().create_topic(topic)
+        requested_local_retention = log_segment_size * 15
+
+        if use_topic_property:
+            self.client().alter_topic_config(
+                topic.name, TopicSpec.PROPERTY_RETENTION_LOCAL_TARGET_BYTES,
+                requested_local_retention)
+        else:
+            self.redpanda.set_cluster_config({
+                "retention_local_target_bytes_default":
+                requested_local_retention
+            })
+
+        self.logger.info(
+            f"Producing {data_size} bytes of data in {msg_cnt} total messages")
+        self.producer = KgoVerifierProducer(
+            self.test_context,
+            self.redpanda,
+            topic.name,
+            msg_size=msg_size,
+            msg_count=msg_cnt,
+            custom_node=self.preallocated_nodes)
+        self.producer.start()
+        self.producer.wait()
+
+        # add fifth node
+        self.redpanda.start_node(self.redpanda.nodes[4])
+        self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
+                                            timeout_sec=self.rebalance_timeout)
+
+        def print_disk_usage(usage):
+            for n, b in usage.items():
+                self.logger.info(
+                    f"node: {n} total partitions size: {b/(1024*1024)} Mb")
+
+        def verify_node_disk_usage(nodes, node_id):
+            usage_per_node = self._kafka_usage(nodes=nodes)
+            print_disk_usage(usage_per_node)
+            replicas_per_node = self._topic_replicas_per_node()
+            node_replicas = replicas_per_node[topic.name][node_id]
+
+            target_size = node_replicas * requested_local_retention
+
+            current_usage = usage_per_node[node_id]
+            tolerance = 0.1
+            max = target_size * (1.0 + tolerance)
+            min = target_size * (1.0 - tolerance)
+            self.logger.info(
+                f"node {node_id} target size: {target_size}, current size: {usage_per_node[node_id]}, expected range ({min}, {max})"
+            )
+            assert current_usage > min and current_usage < max, \
+                f"node {node_id} disk usage should be withing the range ({min}, {max}). Current value: {current_usage} "
+
+        first_new_id = self.redpanda.node_id(self.redpanda.nodes[4])
+
+        verify_node_disk_usage(self.redpanda.nodes[0:5], first_new_id)
+
+        # add sixth node
+        self.redpanda.start_node(self.redpanda.nodes[5])
+        self.wait_for_partitions_rebalanced(total_replicas=total_replicas,
+                                            timeout_sec=self.rebalance_timeout)
+
+        usage = self._kafka_usage(self.redpanda.nodes)
+        print_disk_usage(usage)
+        next_new_id = self.redpanda.node_id(self.redpanda.nodes[5])
+        verify_node_disk_usage(self.redpanda.nodes, next_new_id)
+        # verify that data can be read
+        self.consumer = KgoVerifierSeqConsumer(self.test_context,
+                                               self.redpanda,
+                                               topic.name,
+                                               msg_size,
+                                               nodes=self.preallocated_nodes)
+
+        self.consumer.start(clean=False)
+        self.consumer.wait()
+
+        assert self.consumer.consumer_status.validator.invalid_reads == 0, \
+        f"Invalid reads in topic: {topic.name}, invalid reads count: "
+        "{self.consumer.consumer_status.validator.invalid_reads}"


### PR DESCRIPTION
With non strict local retention the storage manager will not trigger
data eviction immediately when partition is eligible for eviction but
will allow local data to use the whole available disk space. Using
standard partition movement policy would force raft to deliver all local
data over the network which is not necessary and might take long time.

Changed the controller backend to always override the learner start
offset when non strict retention is enabled and deliver over the network
only data that would normally be retained if strict local retention is
turned on.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
 - reduced the amount of data required to transfer over the network 