### PR TITLE
golang SDK: Introduce serde opts for subject auto(ish)-creation

### DIFF
--- a/src/transform-sdk/go/transform/internal/testdata/schema-registry/transform.go
+++ b/src/transform-sdk/go/transform/internal/testdata/schema-registry/transform.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 
 	"github.com/redpanda-data/redpanda/src/transform-sdk/go/transform"
 	"github.com/redpanda-data/redpanda/src/transform-sdk/go/transform/sr"
@@ -30,14 +31,6 @@ var (
 
 func main() {
 	c = sr.NewClient()
-	e := avro.Example{}
-	_, err := c.CreateSchema(topicName+"-value", sr.Schema{
-		Type:   sr.TypeAvro,
-		Schema: e.Schema(),
-	})
-	if err != nil {
-		println("unable to registry schema: ", err)
-	}
 	transform.OnRecordWritten(avroToJsonTransform)
 }
 
@@ -53,9 +46,9 @@ func avroToJsonTransform(e transform.WriteEvent, w transform.RecordWriter) error
 		if err != nil {
 			return err
 		}
-		schema, err := c.LookupSchemaById(id)
-		if err != nil {
-			return err
+		schema := sr.Schema{
+			Type:   sr.TypeAvro,
+			Schema: ex.Schema(),
 		}
 		// Register the new schema
 		s.Register(id, sr.DecodeFn[*avro.Example](func(b []byte, e *avro.Example) error {
@@ -64,6 +57,9 @@ func avroToJsonTransform(e transform.WriteEvent, w transform.RecordWriter) error
 				schema.Schema,
 			)
 			*e = ex
+			return err
+		}), sr.ValueSubjectTopicName[*avro.Example](os.Getenv("REDPANDA_INPUT_TOPIC"), func(sn string) error {
+			_, err = c.CreateSchema(sn, schema)
 			return err
 		}))
 		// Now try and decode the value now that we've looked it up.

--- a/src/transform-sdk/rust/examples/schema_registry/main.rs
+++ b/src/transform-sdk/rust/examples/schema_registry/main.rs
@@ -31,7 +31,7 @@ fn main() {
     let mut client = SchemaRegistryClient::new();
     let s: apache_avro::Schema = Example::get_schema();
     match client.create_schema(
-        "demo-topic-value",
+        "avro-value",
         Schema::new_avro(s.canonical_form(), Vec::new()),
     ) {
         Ok(_) => {}

--- a/src/transform-sdk/tests/integration_test.go
+++ b/src/transform-sdk/tests/integration_test.go
@@ -300,6 +300,13 @@ func TestSchemaRegistry(t *testing.T) {
 	// Make sure the schema was created by the transform
 	schema, err := srClient.SchemaByID(ctx, 1)
 	require.NoError(t, err)
+
+	// Quick check that the transform created an additional subject
+	// by applying topic name strategy to the input topic
+	subj_schema, err := srClient.SchemaByVersion(ctx, "avro-value", -1)
+	require.NoError(t, err)
+	require.Equal(t, schema, subj_schema.Schema, "Schemas should be the same")
+
 	// Ensure the canonicalized schema is what we expect.
 	require.Equal(t, avro.MustParse(schema.Schema).String(), RecordV1Schema.String())
 	v2 := RecordV2{


### PR DESCRIPTION
Includes unit tests.

The primary purpose here is to generate a correct subject name based
on user-provided info:

- output topic name
- subject name strategy
- whether it is a key or a value
- record name (depending on SNS)

Users may include a nameless function, parameterized by the derived
subject name, where they can perform the actual creation of the subject
version in SR. The idea here is to keep Serde[T] more ore less decoupled
from the particular schema it's working on.

Closes CORE-3123

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Golang Transforms SDK (Serde): Adds the ability to specify subject name strategy for output topics. Transforms can also provide a function to be called after the subject name is derived - e.g. to ensure that the subject is created before emitting records.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
