### PR TITLE
rpk: more debug bundle improvements

### DIFF
--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -84,8 +84,6 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			if cpuProfilerWait < 15*time.Second {
 				out.Die("--cpu-profiler-wait must be higher than 15 seconds")
 			}
-			path, err := determineFilepath(fs, outFile, cmd.Flags().Changed(outputFlag))
-			out.MaybeDie(err, "unable to determine filepath %q: %v", outFile, err)
 
 			cfg, err := p.Load(fs)
 			out.MaybeDie(err, "rpk unable to load config: %v", err)
@@ -100,6 +98,9 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 			if !ok {
 				yActual = y
 			}
+
+			path, err := determineFilepath(fs, yActual, outFile, cmd.Flags().Changed(outputFlag))
+			out.MaybeDie(err, "unable to determine filepath %q: %v", outFile, err)
 
 			partitions, err := parsePartitionFlag(partitionFlag)
 			out.MaybeDie(err, "unable to parse partition flag %v: %v", partitionFlag, err)

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -160,7 +160,7 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	f.StringVarP(&outFile, outputFlag, "o", "", "The file path where the debug file will be written (default ./<timestamp>-bundle.zip)")
 	f.DurationVar(&timeout, "timeout", 31*time.Second, "How long to wait for child commands to execute (e.g. 30s, 1.5m)")
 	f.DurationVar(&metricsInterval, "metrics-interval", 10*time.Second, "Interval between metrics snapshots (e.g. 30s, 1.5m)")
-	f.StringVar(&logsSince, "logs-since", "", "Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD")
+	f.StringVar(&logsSince, "logs-since", "yesterday", "Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD")
 	f.StringVar(&logsUntil, "logs-until", "", "Include log entries on or older than the specified date (journalctl date format, e.g. YYYY-MM-DD")
 	f.StringVar(&logsSizeLimit, "logs-size-limit", "100MiB", "Read the logs until the given size is reached (e.g. 3MB, 1GiB)")
 	f.StringVar(&controllerLogsSizeLimit, "controller-logs-size-limit", "132MB", "The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB)")
@@ -268,9 +268,9 @@ BARE-METAL
 
  - Disk usage: The disk usage for the data directory, as output by 'du'.
 
- - redpanda logs: The node's redpanda logs written to journald. If --logs-since 
-   or --logs-until are passed, then only the logs within the resulting time frame
-   will be included.
+ - redpanda logs: The node's redpanda logs written to journald since yesterday. 
+   If --logs-since or --logs-until are passed, then only the logs within the
+   resulting time frame will be included.
 
  - Socket info: The active sockets data output by 'ss'.
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle.go
@@ -161,8 +161,8 @@ func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	f.StringVarP(&outFile, outputFlag, "o", "", "The file path where the debug file will be written (default ./<timestamp>-bundle.zip)")
 	f.DurationVar(&timeout, "timeout", 31*time.Second, "How long to wait for child commands to execute (e.g. 30s, 1.5m)")
 	f.DurationVar(&metricsInterval, "metrics-interval", 10*time.Second, "Interval between metrics snapshots (e.g. 30s, 1.5m)")
-	f.StringVar(&logsSince, "logs-since", "yesterday", "Include log entries on or newer than the specified date (journalctl date format, e.g. YYYY-MM-DD")
-	f.StringVar(&logsUntil, "logs-until", "", "Include log entries on or older than the specified date (journalctl date format, e.g. YYYY-MM-DD")
+	f.StringVar(&logsSince, "logs-since", "yesterday", "Include logs dated from specified date onward; (journalctl date format: YYYY-MM-DD, 'yesterday', or 'today'). Refer to journalctl documentation for more options")
+	f.StringVar(&logsUntil, "logs-until", "", "Include logs older than the specified date; (journalctl date format: YYYY-MM-DD, 'yesterday', or 'today'). Refer to journalctl documentation for more options")
 	f.StringVar(&logsSizeLimit, "logs-size-limit", "100MiB", "Read the logs until the given size is reached (e.g. 3MB, 1GiB)")
 	f.StringVar(&controllerLogsSizeLimit, "controller-logs-size-limit", "132MB", "The size limit of the controller logs that can be stored in the bundle (e.g. 3MB, 1GiB)")
 	f.StringVar(&uploadURL, "upload-url", "", "If provided, where to upload the bundle in addition to creating a copy on disk")
@@ -269,9 +269,10 @@ BARE-METAL
 
  - Disk usage: The disk usage for the data directory, as output by 'du'.
 
- - redpanda logs: The node's redpanda logs written to journald since yesterday. 
-   If --logs-since or --logs-until are passed, then only the logs within the
-   resulting time frame will be included.
+ - Redpanda logs: The node's Redpanda logs written to journald since yesterday
+   (00:00:00 of the previous day based on systemd.time). If '--logs-since' or 
+   '--logs-until' are passed, then only the logs within the resulting time frame
+   are included.
 
  - Socket info: The active sockets data output by 'ss'.
 

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_all.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_all.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
 	"github.com/spf13/afero"
 )
 
@@ -26,6 +27,6 @@ func executeK8SBundle(context.Context, bundleParams) error {
 	return errors.New("rpk debug bundle is unsupported on your operating system")
 }
 
-func determineFilepath(afero.Fs, string, bool) (string, error) {
+func determineFilepath(afero.Fs, *config.RedpandaYaml, string, bool) (string, error) {
 	return "", errors.New("rpk debug bundle is not supported on your operating system")
 }

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -312,12 +312,7 @@ func writeCommandOutputToZipLimit(
 		if !strings.Contains(err.Error(), "broken pipe") {
 			return fmt.Errorf("couldn't save '%s': %w; %[1]v contains the full error message", filename, err)
 		}
-		zap.L().Sugar().Debugf(
-			"Got '%v' while running '%s'. This is probably due to the"+
-				" command's output exceeding its limit in bytes.",
-			err,
-			cmd,
-		)
+		zap.L().Sugar().Warnf("%v: got '%v' while running '%s'. This is probably due to the command's output exceeding its limit in bytes.", filename, err, cmd)
 	}
 	return nil
 }

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -954,8 +954,13 @@ func saveControllerLogDir(ps *stepParams, y *config.RedpandaYaml, logLimitBytes 
 			return fmt.Errorf("unable to save controller logs: %v", err)
 		}
 
+		// Our decoding tools look for the base of the data directory, and it
+		// searches for the expected directory: redpanda/controller/0_0. If we
+		// use this folder structure, we will make the life easier to the users
+		// who wish to decode the controller logs using our tools.
+		baseDestDir := filepath.Join("controller-logs", "redpanda", "controller", "0_0")
 		if int(size) < logLimitBytes {
-			return writeDirToZip(ps, controllerDir, "controller", exclude)
+			return writeDirToZip(ps, controllerDir, baseDestDir, exclude)
 		}
 
 		fmt.Printf("WARNING: controller logs directory size is too big (%v). Saving a slice of the logs; you can adjust the limit by changing --controller-logs-size-limit flag\n", units.HumanSize(float64(size)))
@@ -973,7 +978,7 @@ func saveControllerLogDir(ps *stepParams, y *config.RedpandaYaml, logLimitBytes 
 			if err != nil {
 				return fmt.Errorf("unable to save controller logs: %v", err)
 			}
-			err = writeFileToZip(ps, filepath.Join("controller", filepath.Base(cLog.path)), file)
+			err = writeFileToZip(ps, filepath.Join(baseDestDir, filepath.Base(cLog.path)), file)
 			if err != nil {
 				return fmt.Errorf("unable to save controller logs: %v", err)
 			}

--- a/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
+++ b/src/go/rpk/pkg/cli/debug/bundle/bundle_linux.go
@@ -56,11 +56,15 @@ const linuxUtilsRoot = "utils"
 //   - File Extension: if no extension is provided we default to .zip
 //   - File Location: we check for write permissions in the pwd (for backcompat);
 //     if permission is denied we default to $HOME unless isFlag is true.
-func determineFilepath(fs afero.Fs, path string, isFlag bool) (finalPath string, err error) {
+func determineFilepath(fs afero.Fs, rp *config.RedpandaYaml, path string, isFlag bool) (finalPath string, err error) {
 	// if it's empty, use ./<timestamp>-bundle.zip
 	if path == "" {
 		timestamp := time.Now().Unix()
-		path = fmt.Sprintf("%d-bundle.zip", timestamp)
+		if rp.Redpanda.AdvertisedRPCAPI != nil {
+			path = fmt.Sprintf("%v-%d-bundle.zip", sanitizeName(rp.Redpanda.AdvertisedRPCAPI.Address), timestamp)
+		} else {
+			path = fmt.Sprintf("%d-bundle.zip", timestamp)
+		}
 	} else if isDir, _ := afero.IsDir(fs, path); isDir {
 		return "", fmt.Errorf("output file path is a directory, please specify the name of the file")
 	}

--- a/tests/rptest/tests/rpk_cluster_test.py
+++ b/tests/rptest/tests/rpk_cluster_test.py
@@ -110,7 +110,7 @@ class RpkClusterTest(RedpandaTest):
         assert f'{root_name}/redpanda.log' in files
 
         # At least the first controller log is being saved:
-        assert f'{root_name}/controller/0-1-v1.log' in files
+        assert f'{root_name}/controller-logs/redpanda/controller/0_0/0-1-v1.log' in files
 
         # Cluster admin API calls:
         assert f'{root_name}/admin/brokers.json' in files


### PR DESCRIPTION
- 0c68485875298cfddb6b433abbd1cb3f9291c0e8 Changes the default log collection (in bare metal) to grab the logs since `yesterday`. Fixes #18640 Fixes #15683
- 3b746bbfddf7463d6cffde5c45a1a8a0babf8a5a Moves 'trimming file' DEBUG message to WARN.
- d93ff83cc95ab912fba25095795f4b5f6a8db092 Uses the `redpanda.advertised_rpc_api.address` to mark the file name of the debug bundle. Fixes #11857
- 9ae144f5e76e39d3758fbeac89091d44c94fdce7 Mimics the redpanda data directory structure to our debug bundle so we can easily use our decoding tool w/o any hacks or extra steps. It does not fix #16575 but it's a QOL improvement until we decide the best way to handle the request.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* rpk debug bundle now collects the log since `yesterday` by default, you can still change them with `--logs-since`.
* rpk debug bundle mark the generated bundle file with the node's advertised_rpc address.
