### PR TITLE
storage: use uint64_t for batch type map

### DIFF
--- a/src/v/storage/file_sanitizer.h
+++ b/src/v/storage/file_sanitizer.h
@@ -410,7 +410,7 @@ private:
       model::record_batch_type batch_type) const {
         auto batch_types_for_next_write = _appender_ptr->batch_types_to_write();
         return batch_types_for_next_write
-               & (1U << static_cast<uint8_t>(batch_type));
+               & (1LU << static_cast<uint8_t>(batch_type));
     }
 
     void output_pending_ops() {

--- a/src/v/storage/segment_appender.cc
+++ b/src/v/storage/segment_appender.cc
@@ -110,7 +110,7 @@ segment_appender::segment_appender(segment_appender&& o) noexcept
 }
 
 ss::future<> segment_appender::append(const model::record_batch& batch) {
-    _batch_types_to_write |= 1U << static_cast<uint8_t>(batch.header().type);
+    _batch_types_to_write |= 1LU << static_cast<uint8_t>(batch.header().type);
 
     auto hdrbuf = std::make_unique<iobuf>(
       storage::batch_header_to_disk_iobuf(batch.header()));

--- a/src/v/storage/segment_appender.h
+++ b/src/v/storage/segment_appender.h
@@ -163,7 +163,7 @@ private:
     // Reset the bit-map tracking unwritten batch types in the `_head` chunk.
     void reset_batch_types_to_write() { _batch_types_to_write = 0; }
 
-    uint32_t batch_types_to_write() const { return _batch_types_to_write; }
+    uint64_t batch_types_to_write() const { return _batch_types_to_write; }
 
     // called to assert that no writes are currently in progress, dying if
     // there are
@@ -300,8 +300,8 @@ private:
 
     // Bit-map tracking the types of batches in the `_head` chunk that have
     // not been written to disk yet.
-    static_assert(static_cast<uint8_t>(model::record_batch_type::MAX) <= 32);
-    uint32_t _batch_types_to_write{0};
+    static_assert(static_cast<uint8_t>(model::record_batch_type::MAX) <= 63);
+    uint64_t _batch_types_to_write{0};
 
     friend std::ostream& operator<<(std::ostream&, const segment_appender&);
     friend class file_io_sanitizer;


### PR DESCRIPTION
We are about to run out of ids.
Also, the static assert as it was wouldn't work as it's off by one.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
