### PR TITLE
CORE-2715 Quotas: add trace-level logger

### DIFF
--- a/src/v/kafka/protocol/logger.cc
+++ b/src/v/kafka/protocol/logger.cc
@@ -15,4 +15,5 @@ namespace kafka {
 static constexpr size_t max_log_line_bytes = 128_KiB;
 ss::logger klog("kafka");
 truncating_logger kwire(klog, max_log_line_bytes);
+ss::logger client_quota_log("kafka_quotas");
 } // namespace kafka

--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -30,6 +30,23 @@ std::ostream& operator<<(std::ostream& os, const client_quota_limits& l) {
     return os;
 }
 
+std::ostream& operator<<(std::ostream& os, client_quota_rule r) {
+    switch (r) {
+    case client_quota_rule::not_applicable:
+        return os << "not_applicable";
+    case client_quota_rule::cluster_client_default:
+        return os << "cluster_client_default";
+    case client_quota_rule::kafka_client_default:
+        return os << "kafka_client_default";
+    case client_quota_rule::cluster_client_prefix:
+        return os << "cluster_client_prefix";
+    case client_quota_rule::kafka_client_prefix:
+        return os << "kafka_client_prefix";
+    case client_quota_rule::kafka_client_id:
+        return os << "kafka_client_id";
+    }
+}
+
 client_quota_translator::client_quota_translator(
   ss::sharded<cluster::client_quota::store>& quota_store)
   : _quota_store(quota_store)
@@ -45,7 +62,7 @@ client_quota_translator::client_quota_translator(
       config::shard_local_cfg()
         .kafka_client_group_fetch_byte_rate_quota.bind()) {}
 
-std::optional<uint64_t> client_quota_translator::get_client_quota_value(
+client_quota_value client_quota_translator::get_client_quota_value(
   const tracker_key& quota_id, client_quota_type qt) const {
     const auto accessor = [qt](const cluster::client_quota::entity_value& ev) {
         switch (qt) {
@@ -59,12 +76,14 @@ std::optional<uint64_t> client_quota_translator::get_client_quota_value(
     };
     return ss::visit(
       quota_id,
-      [this, qt, &accessor](const k_client_id& k) -> std::optional<uint64_t> {
+      [this, qt, &accessor](const k_client_id& k) -> client_quota_value {
           auto exact_match_key = entity_key{entity_key::client_id_match{k}};
           auto exact_match_quota = _quota_store.local().get_quota(
             exact_match_key);
           if (exact_match_quota && accessor(*exact_match_quota)) {
-              return accessor(*exact_match_quota);
+              return client_quota_value{
+                accessor(*exact_match_quota),
+                client_quota_rule::kafka_client_id};
           }
 
           const static auto default_client_key = entity_key{
@@ -72,28 +91,38 @@ std::optional<uint64_t> client_quota_translator::get_client_quota_value(
           auto default_quota = _quota_store.local().get_quota(
             default_client_key);
           if (default_quota && accessor(*default_quota)) {
-              return accessor(*default_quota);
+              return client_quota_value{
+                accessor(*default_quota),
+                client_quota_rule::kafka_client_default};
           }
 
           auto default_config = get_default_config(qt);
-          return default_config ? std::make_optional<uint64_t>(
-                   *default_config * ss::smp::count)
-                                : std::nullopt;
+          if (default_config) {
+              return client_quota_value{
+                *default_config * ss::smp::count,
+                client_quota_rule::cluster_client_default};
+          }
+          return client_quota_value{
+            std::nullopt, client_quota_rule::not_applicable};
       },
-      [this, qt, &accessor](const k_group_name& k) -> std::optional<uint64_t> {
+      [this, qt, &accessor](const k_group_name& k) -> client_quota_value {
           const auto& group_quota_config = get_quota_config(qt);
           auto group_key = entity_key{entity_key::client_id_prefix_match{k}};
           auto group_quota = _quota_store.local().get_quota(group_key);
           if (group_quota && accessor(*group_quota)) {
-              return accessor(*group_quota);
+              return client_quota_value{
+                accessor(*group_quota), client_quota_rule::kafka_client_prefix};
           }
 
           auto group = group_quota_config.find(k);
           if (group != group_quota_config.end()) {
-              return group->second.quota * ss::smp::count;
+              return client_quota_value{
+                static_cast<uint64_t>(group->second.quota * ss::smp::count),
+                client_quota_rule::cluster_client_prefix};
           }
 
-          return {};
+          return client_quota_value{
+            std::nullopt, client_quota_rule::not_applicable};
       });
 }
 
@@ -162,22 +191,23 @@ tracker_key client_quota_translator::find_quota_key(
     return tracker_key{std::in_place_type<k_client_id>, *client_id};
 }
 
-std::pair<tracker_key, client_quota_limits>
+std::pair<tracker_key, client_quota_value>
 client_quota_translator::find_quota(const client_quota_request_ctx& ctx) const {
     auto key = find_quota_key(ctx);
-    auto value = find_quota_value(key);
+    auto value = get_client_quota_value(key, ctx.q_type);
     return {std::move(key), value};
 }
 
 client_quota_limits
 client_quota_translator::find_quota_value(const tracker_key& key) const {
     return client_quota_limits{
-      .produce_limit = get_client_quota_value(
-        key, client_quota_type::produce_quota),
-      .fetch_limit = get_client_quota_value(
-        key, client_quota_type::fetch_quota),
-      .partition_mutation_limit = get_client_quota_value(
-        key, client_quota_type::partition_mutation_quota),
+      .produce_limit
+      = get_client_quota_value(key, client_quota_type::produce_quota).limit,
+      .fetch_limit
+      = get_client_quota_value(key, client_quota_type::fetch_quota).limit,
+      .partition_mutation_limit
+      = get_client_quota_value(key, client_quota_type::partition_mutation_quota)
+          .limit,
     };
 }
 

--- a/src/v/kafka/server/client_quota_translator.h
+++ b/src/v/kafka/server/client_quota_translator.h
@@ -68,6 +68,24 @@ struct client_quota_request_ctx {
     std::optional<std::string_view> client_id;
 };
 
+/// client_quota_rule is used for reporting metrics to show which type of rule
+/// is being used for limiting clients
+enum class client_quota_rule {
+    not_applicable,
+    kafka_client_default,
+    cluster_client_default,
+    kafka_client_prefix,
+    cluster_client_prefix,
+    kafka_client_id
+};
+
+std::ostream& operator<<(std::ostream&, client_quota_rule);
+
+struct client_quota_value {
+    std::optional<uint64_t> limit;
+    client_quota_rule rule;
+};
+
 /// client_quota_translator is responsible for providing quota_manager with a
 /// simplified interface to the quota configurations
 ///  * It is responsible for translating the quota-specific request context (for
@@ -88,10 +106,16 @@ public:
     /// Finds the limits applicable to the given quota tracker key
     client_quota_limits find_quota_value(const tracker_key&) const;
 
-    /// Returns the quota tracker key and quota limit applicable to the given
-    /// quota context
-    std::pair<tracker_key, client_quota_limits>
+    /// Returns the quota tracker key and value. If no quota applies to the
+    /// given context, the value may have an empty limit with the rule
+    /// not_applicable
+    std::pair<tracker_key, client_quota_value>
     find_quota(const client_quota_request_ctx& ctx) const;
+
+    /// Returns the quota rule type that applies to the given tracker key and
+    /// quota type
+    client_quota_rule
+    find_quota_rule(const tracker_key&, client_quota_type) const;
 
     /// `watch` can be used to register for quota changes
     void watch(on_change_fn&& fn);
@@ -103,7 +127,7 @@ private:
     const quota_config& get_quota_config(client_quota_type qt) const;
     std::optional<uint64_t> get_default_config(client_quota_type qt) const;
 
-    std::optional<uint64_t> get_client_quota_value(
+    client_quota_value get_client_quota_value(
       const tracker_key& quota_id, client_quota_type qt) const;
 
     ss::sharded<cluster::client_quota::store>& _quota_store;

--- a/src/v/kafka/server/client_quota_translator.h
+++ b/src/v/kafka/server/client_quota_translator.h
@@ -44,6 +44,8 @@ using k_group_name = named_type<ss::sstring, struct k_group_name_tag>;
 /// the same shared quota limit
 using tracker_key = std::variant<k_client_id, k_group_name>;
 
+std::ostream& operator<<(std::ostream&, const tracker_key&);
+
 /// client_quota_limits describes the limits applicable to a tracker_key
 struct client_quota_limits {
     std::optional<uint64_t> produce_limit;
@@ -63,10 +65,14 @@ enum class client_quota_type {
     partition_mutation_quota
 };
 
+std::ostream& operator<<(std::ostream&, client_quota_type);
+
 struct client_quota_request_ctx {
     client_quota_type q_type;
     std::optional<std::string_view> client_id;
 };
+
+std::ostream& operator<<(std::ostream&, const client_quota_request_ctx&);
 
 /// client_quota_rule is used for reporting metrics to show which type of rule
 /// is being used for limiting clients
@@ -85,6 +91,8 @@ struct client_quota_value {
     std::optional<uint64_t> limit;
     client_quota_rule rule;
 };
+
+std::ostream& operator<<(std::ostream&, client_quota_value);
 
 /// client_quota_translator is responsible for providing quota_manager with a
 /// simplified interface to the quota configurations

--- a/src/v/kafka/server/connection_context.cc
+++ b/src/v/kafka/server/connection_context.cc
@@ -592,7 +592,7 @@ connection_context::record_tp_and_calculate_throttle(
       delay_enforce != clock::duration::zero()
       || delay_request != clock::duration::zero()) {
         vlog(
-          klog.trace,
+          client_quota_log.trace,
           "[{}:{}] throttle request:{{snc:{}, client:{}}}, "
           "enforce:{{snc:{}, client:{}}}, key:{}, request_size:{}",
           _client_addr,

--- a/src/v/kafka/server/logger.h
+++ b/src/v/kafka/server/logger.h
@@ -20,4 +20,5 @@
 namespace kafka {
 extern ss::logger klog;
 extern truncating_logger kwire;
+extern ss::logger client_quota_log;
 } // namespace kafka

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -206,8 +206,8 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
       .q_type = client_quota_type::partition_mutation_quota,
       .client_id = client_id,
     };
-    auto [key, limits] = _translator.find_quota(ctx);
-    if (!limits.partition_mutation_limit) {
+    auto [key, value] = _translator.find_quota(ctx);
+    if (!value.limit) {
         co_return 0ms;
     }
 
@@ -254,8 +254,8 @@ ss::future<clock::duration> quota_manager::record_produce_tp_and_throttle(
       .q_type = client_quota_type::produce_quota,
       .client_id = client_id,
     };
-    auto [key, limits] = _translator.find_quota(ctx);
-    if (!limits.produce_limit) {
+    auto [key, value] = _translator.find_quota(ctx);
+    if (!value.limit) {
         co_return clock::duration::zero();
     }
     auto delay = co_await maybe_add_and_retrieve_quota(
@@ -279,8 +279,8 @@ ss::future<> quota_manager::record_fetch_tp(
       .q_type = client_quota_type::fetch_quota,
       .client_id = client_id,
     };
-    auto [key, limits] = _translator.find_quota(ctx);
-    if (!limits.fetch_limit) {
+    auto [key, value] = _translator.find_quota(ctx);
+    if (!value.limit) {
         co_return;
     }
     auto delay [[maybe_unused]] = co_await maybe_add_and_retrieve_quota(
@@ -300,8 +300,8 @@ ss::future<clock::duration> quota_manager::throttle_fetch_tp(
       .q_type = client_quota_type::fetch_quota,
       .client_id = client_id,
     };
-    auto [key, limits] = _translator.find_quota(ctx);
-    if (!limits.fetch_limit) {
+    auto [key, value] = _translator.find_quota(ctx);
+    if (!value.limit) {
         co_return clock::duration::zero();
     }
 


### PR DESCRIPTION
This creates a trace-level logger to enable us and customers to debug client quota behaviour. It introduces the enum type `client_quota_rule` which is used to describe which quota rule was used to configure the quota that applies to the given request, so that we can tell using the logger which quotas are being actively used to throttle requests, what limits apply, what tracking key is being used, how big the requests are, and what delays are being returned to the client.

The log lines generated look like this:
```
TRACE 2024-06-14 15:36:05,240 [shard  2:main] kafka_quotas - quota_manager.cc:361 - request: ctx:{quota_type: produce_quota, client_id: {rpk}}, key:k_client_id{rpk}, value:{limit: {1111}, rule: kafka_client_default}, bytes: 1316, delay:184518451ns, capped_delay:184518451ns
TRACE 2024-06-14 15:36:05,240 [shard  2:main] kafka_quotas - connection_context.cc:605 - [127.0.0.1:51256] throttle request:{snc:0, client:184}, enforce:{snc:-365123762, client:-365123762}, key:0, request_size:1316
TRACE 2024-06-14 15:37:44,835 [shard  2:main] kafka_quotas - quota_manager.cc:361 - request: ctx:{quota_type: produce_quota, client_id: {rpk}}, key:k_client_id{rpk}, value:{limit: {1111}, rule: kafka_client_default}, bytes: 119, delay:0ns, capped_delay:0ns
TRACE 2024-06-14 15:37:59,195 [shard  2:main] kafka_quotas - quota_manager.cc:361 - request: ctx:{quota_type: produce_quota, client_id: {rpk}}, key:k_client_id{rpk}, value:{limit: {1111}, rule: kafka_client_default}, bytes: 1316, delay:184518451ns, capped_delay:184518451ns
TRACE 2024-06-14 15:37:59,195 [shard  2:main] kafka_quotas - connection_context.cc:605 - [127.0.0.1:58636] throttle request:{snc:0, client:184}, enforce:{snc:-14359, client:-14359}, key:0, request_size:1316
```

https://redpandadata.atlassian.net/browse/CORE-2715

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
