### PR TITLE
cmake: tweaks for vtools trunk-based development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Redirect control for internal Redpanda builds
-if(VECTORIZED_CMAKE_DIR)
+if(REDPANDA_CMAKE_DIR)
   cmake_minimum_required(VERSION 3.22)
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-  include(${VECTORIZED_CMAKE_DIR}/main.cmake)
+  include(${REDPANDA_CMAKE_DIR}/main.cmake)
   return()
 endif()
 

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -149,11 +149,11 @@ class BacktraceCapture(threading.Thread):
             return ci_location
 
         # Workstation: find our build directory by searching back from binary
-        vbuild = find_vbuild_path_from_binary(self.binary, 3)
+        vbuild = find_vbuild_path_from_binary(self.binary, 5)
         if vbuild:
             location = os.path.join(
                 vbuild,
-                "v_deps_build/seastar-prefix/src/seastar/scripts/seastar-addr2line"
+                "deps_build/seastar-prefix/src/seastar/scripts/seastar-addr2line"
             )
 
             if not os.path.exists(location):


### PR DESCRIPTION
Needs to be merged after `main` is made the default branch in vtools, so that builds work with the new trunk-based development model in vtools.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
