### PR TITLE
[v23.3.x] cmake: tweaks for vtools trunk-based development

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Redirect control for internal Redpanda builds
-if(VECTORIZED_CMAKE_DIR)
+if(REDPANDA_CMAKE_DIR)
   cmake_minimum_required(VERSION 3.22)
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
-  include(${VECTORIZED_CMAKE_DIR}/main.cmake)
+  include(${REDPANDA_CMAKE_DIR}/main.cmake)
   return()
 endif()
 

--- a/tools/cmake_test.py
+++ b/tools/cmake_test.py
@@ -133,7 +133,7 @@ class BacktraceCapture(threading.Thread):
         # Workstation: find our build directory by searching back from binary
         path_parts = self.binary.split("/")
         try:
-            vbuild = "/".join(path_parts[0:path_parts.index("vbuild") + 3])
+            vbuild = "/".join(path_parts[0:path_parts.index("vbuild") + 5])
         except (ValueError, IndexError):
             sys.stderr.write(
                 f"Could not find vbuild in binary path {self.binary}\n")
@@ -141,7 +141,7 @@ class BacktraceCapture(threading.Thread):
         else:
             location = os.path.join(
                 vbuild,
-                "v_deps_build/seastar-prefix/src/seastar/scripts/seastar-addr2line"
+                "deps_build/seastar-prefix/src/seastar/scripts/seastar-addr2line"
             )
 
             if not os.path.exists(location):


### PR DESCRIPTION
Needs to be merged after `main` is made the default branch in vtools so that builds against the 23.3.x branch work with the new trunk-based development model in vtools.

Manual backport of https://github.com/redpanda-data/redpanda/pull/19853. Done manually to have it ready to be merged right after the switch of vtools default branch

## Backports Required

- [ ] none - not a bug fix
- [x] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
