### PR TITLE
Added basic compatibility test for handling concurrent producers with the same `transactional.id`

### DIFF
--- a/tests/docker/ducktape-deps/kafka-tools
+++ b/tests/docker/ducktape-deps/kafka-tools
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -e
-for ver in "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0"; do
+for ver in "2.3.1" "2.4.1" "2.5.0" "2.7.0" "3.0.0" "3.7.0"; do
   mkdir -p "/opt/kafka-${ver}"
   chmod a+rw "/opt/kafka-${ver}"
   curl "$KAFKA_MIRROR/kafka_2.12-${ver}.tgz" | tar xz --strip-components=1 -C "/opt/kafka-${ver}"

--- a/tests/rptest/services/kafka.py
+++ b/tests/rptest/services/kafka.py
@@ -1,8 +1,8 @@
 from ducktape.utils.util import wait_until
-from rptest.services.redpanda_types import PLAINTEXT_SECURITY, KafkaClientSecurity
+from rptest.services.redpanda_types import PLAINTEXT_SECURITY, KafkaClientSecurity, RedpandaServiceForClients
 
 
-class KafkaServiceAdapter:
+class KafkaServiceAdapter(RedpandaServiceForClients):
     '''
         Simple adapter to match KafkaService interface with
         what is required by Redpanda test clients

--- a/tests/rptest/tests/basic_kafka_compat_tests.py
+++ b/tests/rptest/tests/basic_kafka_compat_tests.py
@@ -1,0 +1,158 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+import time
+from collections.abc import Callable
+from typing import Protocol, TypeVar
+
+import kafkatest.version
+from rptest.clients.default import DefaultClient
+from rptest.services.cluster import cluster
+from rptest.clients.types import TopicSpec
+import confluent_kafka as ck
+from rptest.services.kafka import KafkaServiceAdapter
+from rptest.services.redpanda import RedpandaService
+from rptest.tests.end_to_end import EndToEndTest
+
+from kafkatest.services.kafka import KafkaService
+
+from kafkatest.services.zookeeper import ZookeeperService
+import kafkatest
+from ducktape.mark import parametrize
+
+KAFKA_VERSION = kafkatest.version.KafkaVersion("3.7.0")
+from rptest.services.redpanda_types import RedpandaServiceForClients
+
+T = TypeVar('T')
+
+
+class CompatTestCaseCallable(Protocol[T]):
+    def __call__(self, broker_service: RedpandaServiceForClients) -> T:
+        ...
+
+
+class KafkaCompatTest(EndToEndTest):
+    """Base for test validating Redpanda compatibility with Kafka"""
+    def __init__(self, test_context):
+        super(KafkaCompatTest, self).__init__(test_context)
+
+        self.redpanda: RedpandaService = RedpandaService(self.test_context,
+                                                         num_brokers=3)
+
+        self.kafka = KafkaServiceAdapter(
+            self.test_context,
+            KafkaService(self.test_context,
+                         num_nodes=3,
+                         zk=None,
+                         version=KAFKA_VERSION))
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        self.kafka.stop()
+
+    def start_brokers(self):
+        self.kafka.start()
+        if self.redpanda:
+            self.redpanda.start()
+
+    def _compat_test_case(self, test_callable: CompatTestCaseCallable[T]):
+        self.start_brokers()
+        self.logger.info("executing test callable against Kafka broker")
+        kafka_result = test_callable(self.kafka)
+
+        self.logger.info("executing test callable against Redpanda broker")
+        rp_result = test_callable(self.redpanda)
+
+        self.logger.info(
+            f"Redpanda result: {rp_result}, kafka result: {kafka_result}")
+        assert rp_result == kafka_result, "Kafka and Redpanda results differs"
+
+
+class TxKafkaCompatTest(KafkaCompatTest):
+    @cluster(num_nodes=6)
+    @parametrize(metadata_quorum='COLOCATED_KRAFT')
+    def test_concurrent_producer_ids(self, metadata_quorum):
+        def test_case(broker_service: RedpandaServiceForClients) -> list[str]:
+
+            partition_count = 1
+            topic = TopicSpec(name="test-topic",
+                              replication_factor=3,
+                              partition_count=partition_count)
+
+            DefaultClient(broker_service).create_topic(topic)
+
+            producer_1 = ck.Producer(
+                {
+                    'bootstrap.servers': broker_service.brokers(),
+                    'transactional.id': "tx-id-1",
+                    'client.id': "prod-1"
+                },
+                logger=self.logger,
+                debug='all')
+
+            self.logger.info("Initializing transactions for producer-1")
+            producer_1.init_transactions()
+            producer_1.begin_transaction()
+            for i in range(5):
+                self.logger.info(f"Producing message {i} from producer-1")
+                producer_1.produce(topic.name,
+                                   key="k",
+                                   value=f"producer-1-value-{i}")
+
+            self.logger.info("Producer-1 committing transaction...")
+            producer_1.commit_transaction()
+
+            self.logger.info("Initializing transactions for producer-2")
+            producer_2 = ck.Producer(
+                {
+                    'bootstrap.servers': broker_service.brokers(),
+                    'transactional.id': "tx-id-1",
+                    'client.id': "prod-2"
+                },
+                logger=self.logger,
+                debug='all')
+            producer_2.init_transactions()
+
+            producer_2.begin_transaction()
+            for i in range(5):
+                producer_2.produce(topic.name,
+                                   key="k",
+                                   value=f"producer-2-value-{i}")
+
+            producer_2.commit_transaction()
+
+            consumer = ck.Consumer(
+                {
+                    "bootstrap.servers": broker_service.brokers(),
+                    "group.id": "group-1",
+                    'auto.offset.reset': 'earliest',
+                    'enable.auto.commit': True,
+                    'isolation.level': 'read_committed',
+                },
+                logger=self.logger,
+            )
+            consumer.subscribe([topic.name])
+
+            msgs = []
+            timeout = time.time() + 30
+            while len(msgs) < 10:
+                msg = consumer.poll(timeout=1)
+                if time.time() > timeout:
+                    break
+
+                if msg:
+                    self.logger.info(
+                        f"consumed: {msg.value()} at offset: {msg.offset()}")
+                    msgs.append(msg.value().decode('utf-8'))
+            consumer.close()
+            return msgs
+
+        self._compat_test_case(test_case)


### PR DESCRIPTION
Sometimes it may be hard to find the Kafka protocol specification. In
this cases we treat Kafka implementation as a in code specification.
Added a simple test stub to prove that executing the same set of
commands yield the same result on both Redpanda and Kafka.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none