### PR TITLE
wasm/tests: Fix SR unit test

### DIFF
--- a/src/transform-sdk/go/transform/internal/testdata/schema-registry/transform.go
+++ b/src/transform-sdk/go/transform/internal/testdata/schema-registry/transform.go
@@ -31,6 +31,14 @@ var (
 
 func main() {
 	c = sr.NewClient()
+	e := avro.Example{}
+	_, err := c.CreateSchema(topicName+"-value", sr.Schema{
+		Type:   sr.TypeAvro,
+		Schema: e.Schema(),
+	})
+	if err != nil {
+		println("unable to register schema ", err)
+	}
 	transform.OnRecordWritten(avroToJsonTransform)
 }
 


### PR DESCRIPTION
Recently changed the schema creation logic in the SR example transform
to create the schema on first record receipt, to flex recent subject
autocreation logic. This breaks some assumptions in the Wasm unit tests,
so we'll just restore the original behavior and reassess testing strategy
for the new code.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
