### PR TITLE
Refined leadership changed metrics

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3114,7 +3114,9 @@ void consensus::update_follower_stats(const group_configuration& cfg) {
 }
 
 void consensus::trigger_leadership_notification() {
-    _probe->leadership_changed();
+    if (_leader_id == _self) {
+        _probe->leadership_changed();
+    }
     vlog(
       _ctxlog.debug,
       "triggering leadership notification with term: {}, new leader: {}",

--- a/src/v/raft/probe.cc
+++ b/src/v/raft/probe.cc
@@ -49,8 +49,8 @@ void probe::setup_public_metrics(const model::ntp& ntp) {
       {sm::make_counter(
          "leadership_changes",
          [this] { return _leadership_changes; },
-         sm::description("Number of leadership changes across all partitions "
-                         "of a given topic"),
+         sm::description("Number of won leader elections across all partitions "
+                         "in given topic"),
          labels)
          .aggregate(aggregate_labels)});
 }
@@ -119,7 +119,7 @@ void probe::setup_metrics(const model::ntp& ntp) {
         sm::make_counter(
           "leadership_changes",
           [this] { return _leadership_changes; },
-          sm::description("Number of leadership changes"),
+          sm::description("Number of won leader elections"),
           labels),
         sm::make_counter(
           "replicate_request_errors",


### PR DESCRIPTION
Previously the leadership changed metric was incremented every time a group leader was updated with the new leader or the leader was currently unknown. Technically the change from leader to no leader is a leadership change but it was confusing to users.

Change the metric updates to only account the changes when leader is present. This way after each successful leader election the metric is incremented by one on all partition replicas.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
### Improvements
- refined `vectorized_raft_leadership_changes_total` metric 