### PR TITLE
CORE-4200 quotas: watch quota store changes

### DIFF
--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -255,6 +255,7 @@ void client_quota_translator::watch(on_change_fn&& fn) {
     _target_partition_mutation_quota.watch(watcher);
     _default_target_produce_tp_rate.watch(watcher);
     _default_target_fetch_tp_rate.watch(watcher);
+    _quota_store.local().watch(watcher);
 }
 
 const client_quota_translator::quota_config&

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -50,8 +50,6 @@ quota_manager::quota_manager(
   , _max_delay(config::shard_local_cfg().max_kafka_throttle_delay_ms.bind()) {
     if (seastar::this_shard_id() == _client_quotas.shard_id()) {
         _gc_timer.set_callback([this]() { gc(); });
-        auto update_quotas = [this]() { update_client_quotas(); };
-        _translator.watch(update_quotas);
     }
 }
 
@@ -66,6 +64,9 @@ ss::future<> quota_manager::start() {
     if (ss::this_shard_id() == _client_quotas.shard_id()) {
         co_await _client_quotas.reset(client_quotas_map_t{});
         _gc_timer.arm_periodic(_gc_freq);
+
+        auto update_quotas = [this]() { update_client_quotas(); };
+        _translator.watch(update_quotas);
     }
 }
 


### PR DESCRIPTION
This provides an observer mechanism to `quota_store` to allow updating the trackers in `quota_manager` whenever there are changes in the `quota_store`.

Previously, we only watched for quota changes through cluster configs but not through the quota_store. This meant that if the limit of a quota configured through the Kafka API changed, this limit update would not propagate to existing trackers (and would only update if either the tracker expires or a quota cluster config change triggers a reevaluation of the quotas). This PR fixes that.

Fixes https://redpandadata.atlassian.net/browse/CORE-4200

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
