### PR TITLE
archival: add `ntp_archiver::flush()`

### DIFF
--- a/src/v/archival/archival_policy.h
+++ b/src/v/archival/archival_policy.h
@@ -98,6 +98,7 @@ public:
     ss::future<candidate_creation_result> get_next_candidate(
       model::offset begin_inclusive,
       model::offset end_exclusive,
+      std::optional<model::offset> flush_offset,
       ss::shared_ptr<storage::log>,
       ss::lowres_clock::duration segment_lock_duration);
 
@@ -126,6 +127,7 @@ private:
     lookup_result find_segment(
       model::offset last_offset,
       model::offset adjusted_lso,
+      std::optional<model::offset> flush_offset,
       ss::shared_ptr<storage::log>);
 
     model::ntp _ntp;

--- a/src/v/archival/ntp_archiver_service.cc
+++ b/src/v/archival/ntp_archiver_service.cc
@@ -343,6 +343,17 @@ ss::future<> ntp_archiver::upload_until_abort() {
         }
 
         _start_term = _parent.term();
+
+        // If a flush is in progress from a previous term, reset the flush
+        // uploads offset and signal to the condition variable.
+        if (flush_in_progress()) {
+            vlog(
+              _rtclog.debug,
+              "Flush from previous term was in progress, resetting.");
+            _flush_uploads_offset.reset();
+            _flush_cond.broadcast();
+        }
+
         if (!may_begin_uploads()) {
             continue;
         }
@@ -711,6 +722,31 @@ ss::future<> ntp_archiver::upload_until_term_change() {
             break;
         }
 
+        // If a flush was in progress and the archiver has uploaded past the set
+        // _flush_uploads_offset, there should be a number of actions taken to
+        // fully complete the flush operation.
+        // 1. Upload topic manifest (if we are partition 0).
+        // 2. Upload the partition manifest.
+        // 3. Flush manifest to the clean offset.
+        // 4. Reset flush state.
+        // 5. Broadcast using flush cv to alert all waiters.
+        if (uploaded_data_past_flush_offset()) {
+            if (_parent.ntp().tp.partition == 0) {
+                co_await upload_topic_manifest();
+            }
+
+            // Attempt to upload the manifest. Flush is considered complete upon
+            // success. If unsuccessful, this will be retried on next iteration
+            // of background loop.
+            if (
+              co_await upload_manifest(upload_loop_flush_complete_ctx_label)
+              == cloud_storage::upload_result::success) {
+                co_await flush_manifest_clean_offset();
+                _flush_uploads_offset.reset();
+                _flush_cond.broadcast();
+            }
+        }
+
         // This is the fallback path for uploading manifest if it didn't happen
         // inline with segment uploads: this path will be taken on e.g. restarts
         // or unclean leadership changes.
@@ -893,6 +929,7 @@ ss::future<> ntp_archiver::stop() {
     _as.request_abort();
     _uploads_active.broken();
     _leader_cond.broken();
+    _flush_cond.broken();
     co_await _gate.close();
 }
 
@@ -1559,6 +1596,7 @@ ntp_archiver::schedule_single_upload(const upload_context& upload_ctx) {
         candidate_result = co_await _policy.get_next_candidate(
           start_upload_offset,
           last_stable_offset,
+          _flush_uploads_offset,
           log,
           _conf->segment_upload_timeout());
         break;
@@ -1816,7 +1854,7 @@ ss::future<ntp_archiver::upload_group_result> ntp_archiver::wait_uploads(
     }
 
     absl::flat_hash_map<cloud_storage::upload_result, size_t> upload_results;
-    for (auto result : segment_results) {
+    for (const auto& result : segment_results) {
         ++upload_results[result.result()];
     }
 
@@ -2167,6 +2205,37 @@ std::ostream& operator<<(std::ostream& os, segment_upload_kind upload_kind) {
     case segment_upload_kind::compacted:
         fmt::print(os, "compacted");
         break;
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, flush_response fr) {
+    switch (fr) {
+    case flush_response::accepted:
+        fmt::print(os, "accepted");
+        break;
+    case flush_response::rejected:
+        fmt::print(os, "rejected");
+        break;
+    }
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, flush_result fr) {
+    fmt::print(os, "response: {}, offset: {}", fr.response, fr.offset);
+    return os;
+}
+
+std::ostream& operator<<(std::ostream& os, wait_result fr) {
+    switch (fr) {
+    case wait_result::not_in_progress:
+        return os << "not in progress";
+    case wait_result::complete:
+        return os << "complete";
+    case wait_result::lost_leadership:
+        return os << "lost leadership";
+    case wait_result::failed:
+        return os << "failed";
     }
     return os;
 }
@@ -2606,6 +2675,84 @@ ss::future<> ntp_archiver::apply_spillover() {
               tail.get_manifest_path());
         }
     }
+}
+
+flush_result ntp_archiver::flush() {
+    // Return early if we are not the leader, or if we are a read replica.
+    if (!_parent.is_leader() || _parent.is_read_replica_mode_enabled()) {
+        vlog(
+          _rtclog.debug,
+          "Flush request not accepted, node is not the leader for the "
+          "partition, or the node is a read replica");
+        return flush_result{
+          .response = flush_response::rejected, .offset = std::nullopt};
+    }
+
+    _flush_uploads_offset = model::prev_offset(
+      max_uploadable_offset_exclusive());
+    vlog(
+      _rtclog.debug,
+      "Accepted flush, flush offset is {}",
+      _flush_uploads_offset.value());
+    return flush_result{
+      .response = flush_response::accepted,
+      .offset = _flush_uploads_offset.value()};
+}
+
+ss::future<wait_result> ntp_archiver::wait(model::offset o) {
+    if (_parent.is_read_replica_mode_enabled()) {
+        vlog(
+          _rtclog.debug,
+          "Cannot wait on a flush in ntp_archiver, node is read replica");
+        co_return wait_result::failed;
+    }
+
+    // Currently we tie wait() to flush() state. If there is no flush in
+    // progress, we return.
+    if (!flush_in_progress()) {
+        vlog(
+          _rtclog.debug,
+          "Cannot wait on a flush in ntp_archiver, as no flush in progress");
+        co_return wait_result::not_in_progress;
+    }
+
+    // If o is outside bounds of _flush_uploads_offset, we indicate so.
+    if (o > _flush_uploads_offset.value()) {
+        vlog(
+          _rtclog.debug,
+          "Passed offset {} is outside bounds of current flush offset {}",
+          o,
+          _flush_uploads_offset.value());
+        co_return wait_result::not_in_progress;
+    }
+
+    // Save the _start_term before entering wait loop, where we will suspend on
+    // condition variable.
+    auto wait_issued_term = _start_term;
+
+    while (!uploaded_and_clean_past_offset(o)) {
+        if (!_parent.is_leader() || wait_issued_term != _start_term) {
+            vlog(
+              _rtclog.debug,
+              "Leadership was lost during flush operation in ntp_archiver");
+            co_return wait_result::lost_leadership;
+        }
+
+        try {
+            vlog(_rtclog.trace, "Waiting on _flush_cond in ntp_archiver");
+            co_await _flush_cond.wait();
+        } catch (const ss::broken_condition_variable&) {
+            // We shutdown while waiting for a flush() to finish.
+            // Return a failure result.
+            vlog(
+              _rtclog.debug,
+              "Shutdown was issued during flush operation in ntp_archiver");
+            co_return wait_result::failed;
+        }
+    }
+
+    vlog(_rtclog.debug, "Flush was successfully completed in ntp_archiver.");
+    co_return wait_result::complete;
 }
 
 bool ntp_archiver::stm_retention_needed() const {
@@ -3129,6 +3276,29 @@ bool ntp_archiver::local_storage_pressure() const {
     return eviction_offset.has_value()
            && _parent.archival_meta_stm()->get_last_clean_at()
                 <= eviction_offset.value();
+}
+
+bool ntp_archiver::flush_in_progress() const {
+    return _flush_uploads_offset.has_value();
+}
+
+bool ntp_archiver::uploaded_and_clean_past_offset(model::offset o) const {
+    vlog(
+      _rtclog.trace,
+      "In uploaded_and_clean_past_offset(), manifest last "
+      "offset: {}, last clean offset: {}, query offset: {}.",
+      manifest().get_last_offset(),
+      _parent.archival_meta_stm()->get_last_clean_at(),
+      o);
+    return std::min(
+             manifest().get_last_offset(),
+             _parent.archival_meta_stm()->get_last_clean_at())
+           >= o;
+}
+
+bool ntp_archiver::uploaded_data_past_flush_offset() const {
+    return flush_in_progress()
+           && manifest().get_last_offset() >= _flush_uploads_offset.value();
 }
 
 } // namespace archival

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -556,6 +556,9 @@ private:
     ss::future<cloud_storage::upload_result>
     delete_segment(const remote_segment_path& path);
 
+    // If true, we are not the leader, or are no longer the leader.
+    bool lost_leadership() const;
+
     /// If true, we are holding up trimming of local storage
     bool local_storage_pressure() const;
 
@@ -581,7 +584,7 @@ private:
       model::term_id archiver_term, const upload_candidate& candidate);
 
     /// Method to use with lazy_abort_source
-    std::optional<ss::sstring> upload_should_abort();
+    std::optional<ss::sstring> upload_should_abort() const;
 
     // Adjacent segment merging
 

--- a/src/v/archival/ntp_archiver_service.h
+++ b/src/v/archival/ntp_archiver_service.h
@@ -35,7 +35,7 @@
 namespace archival {
 
 // Forward declaration for test class that we will befriend
-class archival_fixture;
+class archiver_fixture;
 
 using namespace std::chrono_literals;
 
@@ -745,7 +745,7 @@ private:
 
     ss::shared_ptr<cloud_storage::async_manifest_view> _manifest_view;
 
-    friend class archival_fixture;
+    friend class archiver_fixture;
 };
 
 } // namespace archival

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -6,21 +6,21 @@ else()
     rp_test(
       FIXTURE_TEST
       BINARY_NAME test_archival_service
-      SOURCES 
-        service_fixture.cc 
-        ntp_archiver_test.cc 
-        segment_reupload_test.cc 
-        ntp_archiver_reupload_test.cc 
+      SOURCES
+        service_fixture.cc
+        ntp_archiver_test.cc
+        segment_reupload_test.cc
+        ntp_archiver_reupload_test.cc
         retention_strategy_test.cc
         archival_metadata_stm_test.cc
         async_data_uploader_test.cc
       DEFINITIONS BOOST_TEST_DYN_LINK
-      LIBRARIES 
-        v::seastar_testing_main 
-        v::application 
-        Boost::unit_test_framework 
+      LIBRARIES
+        v::seastar_testing_main
+        v::application
+        Boost::unit_test_framework
         v::cluster
-        v::storage_test_utils 
+        v::storage_test_utils
         v::cloud_roles
         v::http_test_utils
         v::kafka_test_utils
@@ -31,15 +31,15 @@ else()
     rp_test(
       FIXTURE_TEST
       BINARY_NAME test_archiver_manager_smp
-      SOURCES 
+      SOURCES
         archiver_manager_test.cc
       DEFINITIONS BOOST_TEST_DYN_LINK
-      LIBRARIES 
-        v::seastar_testing_main 
-        v::application 
-        Boost::unit_test_framework 
+      LIBRARIES
+        v::seastar_testing_main
+        v::application
+        Boost::unit_test_framework
         v::cluster
-        v::storage_test_utils 
+        v::storage_test_utils
         v::cloud_roles
         v::http_test_utils
       ARGS "-- -c 2"
@@ -49,13 +49,13 @@ else()
     rp_test(
       UNIT_TEST
       BINARY_NAME test_archival_service
-      SOURCES 
+      SOURCES
         upload_housekeeping_service_test.cc
         scrubber_scheduler_test.cc
       DEFINITIONS BOOST_TEST_DYN_LINK
-      LIBRARIES 
-        v::seastar_testing_main 
-        Boost::unit_test_framework 
+      LIBRARIES
+        v::seastar_testing_main
+        Boost::unit_test_framework
         v::cluster
       ARGS "-- -c 1"
       LABELS archival

--- a/src/v/archival/tests/CMakeLists.txt
+++ b/src/v/archival/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ else()
       LIBRARIES
         v::seastar_testing_main
         v::application
+        v::s3_imposter
         Boost::unit_test_framework
         v::cluster
         v::storage_test_utils

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -19,6 +19,7 @@
 #include "cloud_storage/fwd.h"
 #include "cloud_storage/read_path_probes.h"
 #include "cloud_storage/remote.h"
+#include "cloud_storage/tests/manual_fixture.h"
 #include "cloud_storage/types.h"
 #include "cloud_storage_clients/client_pool.h"
 #include "config/configuration.h"
@@ -114,6 +115,11 @@ void log_upload_candidate(const archival::upload_candidate& up) {
       up.exposed_name,
       first_source->offsets().get_base_offset(),
       first_source->offsets().get_dirty_offset());
+}
+
+bool is_partition_manifest_upload_req(
+  const http_test_utils::request_info& req) {
+    return req.method == "PUT" && req.url == manifest_url;
 }
 
 // NOLINTNEXTLINE
@@ -1942,4 +1948,453 @@ FIXTURE_TEST(test_upload_with_gap_blocked, archiver_fixture) {
     BOOST_REQUIRE_EQUAL(stm_manifest.size(), 1);
     BOOST_REQUIRE_EQUAL(
       stm_manifest.last_segment()->base_offset, segments[0].base_offset);
+}
+
+FIXTURE_TEST(test_flush_not_leader, cloud_storage_manual_multinode_test_base) {
+    // start a second fixture and wait for stable setup
+    auto fx2 = start_second_fixture();
+    RPTEST_REQUIRE_EVENTUALLY(3s, [&] {
+        return app.controller->get_members_table().local().node_ids().size()
+               == 2;
+    });
+
+    // Create topic
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    props.segment_size = 64_KiB;
+    props.retention_local_target_bytes = tristate<size_t>(1);
+    add_topic({model::kafka_namespace, topic_name}, 1, props, 2).get();
+
+    // Figure out which fixture is the follower
+    redpanda_thread_fixture* fx_follower = nullptr;
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        cluster::partition* prt_a
+          = app.partition_manager.local().get(ntp).get();
+        cluster::partition* prt_b
+          = fx2->app.partition_manager.local().get(ntp).get();
+        if (!prt_a || !prt_b) {
+            return false;
+        }
+        if (!prt_a->is_leader()) {
+            fx_follower = this;
+            return true;
+        }
+        if (!prt_b->is_leader()) {
+            fx_follower = fx2.get();
+            return true;
+        }
+        return false;
+    });
+
+    BOOST_REQUIRE(fx_follower != nullptr);
+
+    // Get the follower partition
+    cluster::partition* prt_follower
+      = fx_follower->app.partition_manager.local().get(ntp).get();
+
+    auto archiver_opt = prt_follower->archiver();
+    BOOST_REQUIRE(archiver_opt.has_value());
+
+    auto& archiver = archiver_opt.value().get();
+
+    // Expect that a flush() call to the follower partition's archiver is
+    // rejected
+    auto flush_res = archiver.flush();
+    BOOST_REQUIRE(!flush_res.offset.has_value());
+    BOOST_REQUIRE_EQUAL(flush_res.response, flush_response::rejected);
+}
+
+FIXTURE_TEST(test_flush_leader, cloud_storage_manual_multinode_test_base) {
+    // start a second fixture and wait for stable setup
+    auto fx2 = start_second_fixture();
+    RPTEST_REQUIRE_EVENTUALLY(3s, [&] {
+        return app.controller->get_members_table().local().node_ids().size()
+               == 2;
+    });
+
+    // Create topic
+    const model::topic topic_name("tapioca");
+    model::ntp ntp(model::kafka_namespace, topic_name, 0);
+    cluster::topic_properties props;
+    props.shadow_indexing = model::shadow_indexing_mode::full;
+    props.cleanup_policy_bitflags = model::cleanup_policy_bitflags::deletion;
+    props.segment_size = 64_KiB;
+    props.retention_local_target_bytes = tristate<size_t>(1);
+    add_topic({model::kafka_namespace, topic_name}, 1, props, 2).get();
+
+    // Figure out which fixture is the leader
+    redpanda_thread_fixture* fx_leader = nullptr;
+    RPTEST_REQUIRE_EVENTUALLY(10s, [&] {
+        cluster::partition* prt_a
+          = app.partition_manager.local().get(ntp).get();
+        cluster::partition* prt_b
+          = fx2->app.partition_manager.local().get(ntp).get();
+        if (!prt_a || !prt_b) {
+            return false;
+        }
+        if (prt_a->is_leader()) {
+            fx_leader = this;
+            return true;
+        }
+        if (prt_b->is_leader()) {
+            fx_leader = fx2.get();
+            return true;
+        }
+        return false;
+    });
+
+    BOOST_REQUIRE(fx_leader != nullptr);
+
+    // Get the leader partition
+    cluster::partition* prt_leader
+      = fx_leader->app.partition_manager.local().get(ntp).get();
+
+    auto archiver_opt = prt_leader->archiver();
+    BOOST_REQUIRE(archiver_opt.has_value());
+
+    auto& archiver = archiver_opt.value().get();
+
+    // Expect that a flush() call to the leader partition's archiver is accepted
+    auto flush_res = archiver.flush();
+    BOOST_REQUIRE_EQUAL(flush_res.response, flush_response::accepted);
+    BOOST_REQUIRE(flush_res.offset.has_value());
+}
+
+FIXTURE_TEST(test_flush_wait_out_of_bounds, archiver_fixture) {
+    const auto num_segments = 2;
+    const auto term_id = 1;
+    const auto num_records = 100;
+    std::vector<segment_desc> segments = {};
+    segments.reserve(num_segments);
+    for (int i = 0; i < num_segments; ++i) {
+        segments.emplace_back(
+          manifest_ntp,
+          model::offset(i * num_records),
+          model::term_id(term_id),
+          num_records);
+    }
+
+    const auto very_clearly_out_of_bounds_offset = model::offset{
+      num_segments * num_records * 100};
+
+    init_storage_api_local(segments);
+    vlog(test_log.info, "Initialized, start waiting for partition leadership");
+
+    wait_for_partition_leadership(manifest_ntp);
+    auto part = app.partition_manager.local().get(manifest_ntp);
+
+    listen();
+    auto [arch_conf, remote_conf] = get_configurations();
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    // Issue a flush request, syncing up with added segments doesn't matter for
+    // this test.
+    auto flush_res = archiver.flush();
+    BOOST_REQUIRE_EQUAL(flush_res.response, flush_response::accepted);
+
+    model::offset flush_offset = very_clearly_out_of_bounds_offset;
+    auto wait_res = archiver.wait(flush_offset).get();
+
+    // Out of bounds wait() request will return not_in_progress.
+    BOOST_REQUIRE_EQUAL(wait_res, wait_result::not_in_progress);
+}
+
+FIXTURE_TEST(test_flush_wait_with_no_flush, archiver_fixture) {
+    const auto num_segments = 2;
+    const auto term_id = 1;
+    const auto num_records = 100;
+    std::vector<segment_desc> segments = {};
+    segments.reserve(num_segments);
+    for (int i = 0; i < num_segments; ++i) {
+        segments.emplace_back(
+          manifest_ntp,
+          model::offset(i * num_records),
+          model::term_id(term_id),
+          num_records);
+    }
+
+    init_storage_api_local(segments);
+    vlog(test_log.info, "Initialized, start waiting for partition leadership");
+
+    wait_for_partition_leadership(manifest_ntp);
+    auto part = app.partition_manager.local().get(manifest_ntp);
+
+    listen();
+    auto [arch_conf, remote_conf] = get_configurations();
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    model::offset flush_offset = model::offset{1};
+    auto wait_res = archiver.wait(flush_offset).get();
+    BOOST_REQUIRE_EQUAL(wait_res, wait_result::not_in_progress);
+}
+
+FIXTURE_TEST(test_flush_wait_with_flush, archiver_fixture) {
+    scoped_config test_local_cfg;
+    test_local_cfg.get("cloud_storage_disable_upload_loop_for_tests")
+      .set_value(true);
+
+    const auto num_segments = 10;
+    const auto term_id = 1;
+    const auto num_records = 100;
+    const auto last_offset = model::offset{num_segments * num_records};
+    std::vector<segment_desc> segments = {};
+    segments.reserve(num_segments);
+    for (int i = 0; i < num_segments; ++i) {
+        segments.emplace_back(
+          manifest_ntp,
+          model::offset(i * num_records),
+          model::term_id(term_id),
+          num_records);
+    }
+    init_storage_api_local(segments);
+    vlog(test_log.info, "Initialized, start waiting for partition leadership");
+
+    wait_for_partition_leadership(manifest_ntp);
+    auto part = app.partition_manager.local().get(manifest_ntp);
+
+    listen();
+    auto [arch_conf, remote_conf] = get_configurations();
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    // Flush once max_uploadable_offset_exclusive() reflects added segments,
+    // and assert the request is accepted.
+    model::offset flush_offset;
+    RPTEST_REQUIRE_EVENTUALLY(3s, [&] {
+        auto max_uploadable_offset = archiver.max_uploadable_offset_exclusive();
+        if (max_uploadable_offset > model::offset{0}) {
+            auto flush_res = archiver.flush();
+            flush_offset = flush_res.offset.value();
+            return flush_res.response == flush_response::accepted
+                   && flush_offset == last_offset;
+        }
+        return false;
+    });
+
+    // Create a waiter.
+    auto wait_res = archiver.wait(flush_offset);
+
+    // Start the upload loop.
+    auto upload_future = upload_until_term_change(archiver);
+
+    // Assert the flush eventually completes.
+    BOOST_REQUIRE(wait_res.get() == wait_result::complete);
+
+    // Check that last offset of the manifest is equal to or past the last
+    // segment offset.
+    const auto& manifest = archiver.manifest();
+    BOOST_REQUIRE(manifest.get_last_offset() >= last_offset);
+
+    // Now we can force a step down to stop upload loop.
+    part->raft()->step_down("forced stepdown").get();
+    upload_future.get();
+
+    auto http_requests = get_requests(is_partition_manifest_upload_req);
+    BOOST_REQUIRE(!http_requests.empty());
+}
+
+FIXTURE_TEST(test_flush_wait_with_flush_multiple_waiters, archiver_fixture) {
+    const auto num_segments = 10;
+    const auto term_id = 1;
+    const auto num_records = 100;
+    const auto last_offset = model::offset{num_segments * num_records};
+    std::vector<segment_desc> segments = {};
+    segments.reserve(num_segments);
+    for (int i = 0; i < num_segments; ++i) {
+        segments.emplace_back(
+          manifest_ntp,
+          model::offset(i * num_records),
+          model::term_id(term_id),
+          num_records);
+    }
+    init_storage_api_local(segments);
+    vlog(test_log.info, "Initialized, start waiting for partition leadership");
+
+    wait_for_partition_leadership(manifest_ntp);
+    auto part = app.partition_manager.local().get(manifest_ntp);
+
+    listen();
+    auto [arch_conf, remote_conf] = get_configurations();
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    // Flush once max_uploadable_offset_exclusive() reflects added segments,
+    // and assert the request is accepted.
+    RPTEST_REQUIRE_EVENTUALLY(3s, [&] {
+        auto max_uploadable_offset = archiver.max_uploadable_offset_exclusive();
+        if (max_uploadable_offset > model::offset{0}) {
+            auto flush_res = archiver.flush();
+            return flush_res.response == flush_response::accepted
+                   && flush_res.offset.value() == last_offset;
+        }
+        return false;
+    });
+
+    const auto num_waiters = 10;
+    std::vector<ss::future<wait_result>> waiters;
+    waiters.reserve(num_waiters);
+    for (int i = 0; i < num_waiters; ++i) {
+        auto wait_offset = model::offset{(i + 1) * last_offset / num_waiters};
+        waiters.push_back(archiver.wait(wait_offset));
+    }
+
+    auto upload_future = upload_until_term_change(archiver);
+
+    // Assert the flush eventually completes.
+    RPTEST_REQUIRE_EVENTUALLY(3s, [&] {
+        return std::all_of(
+          waiters.begin(), waiters.end(), [](auto& wait_future) {
+              return wait_future.get() == wait_result::complete;
+          });
+    });
+
+    // Check that last offset of the manifest is equal to or past the last
+    // segment offset.
+    const auto& manifest = archiver.manifest();
+    BOOST_REQUIRE(manifest.get_last_offset() >= last_offset);
+
+    // Now we can force a step down to stop upload loop.
+    part->raft()->step_down("forced stepdown").get();
+    upload_future.get();
+
+    auto http_requests = get_requests(is_partition_manifest_upload_req);
+    BOOST_REQUIRE(!http_requests.empty());
+}
+
+FIXTURE_TEST(test_flush_with_leadership_change, archiver_fixture) {
+    const auto num_segments = 10;
+    const auto term_id = 1;
+    const auto num_records = 100;
+    const auto last_offset = model::offset{num_segments * num_records};
+    std::vector<segment_desc> segments = {};
+    segments.reserve(num_segments);
+    for (int i = 0; i < num_segments; ++i) {
+        segments.emplace_back(
+          manifest_ntp,
+          model::offset(i * num_records),
+          model::term_id(term_id),
+          num_records);
+    }
+    init_storage_api_local(segments);
+    vlog(test_log.info, "Initialized, start waiting for partition leadership");
+
+    wait_for_partition_leadership(manifest_ntp);
+    auto part = app.partition_manager.local().get(manifest_ntp);
+
+    listen();
+    auto [arch_conf, remote_conf] = get_configurations();
+    auto amv = ss::make_shared<cloud_storage::async_manifest_view>(
+      remote,
+      app.shadow_index_cache,
+      part->archival_meta_stm()->manifest(),
+      arch_conf->bucket_name);
+    archival::ntp_archiver archiver(
+      get_ntp_conf(),
+      arch_conf,
+      remote.local(),
+      app.shadow_index_cache.local(),
+      *part,
+      amv);
+
+    auto action = ss::defer([&archiver, &amv] {
+        archiver.stop().get();
+        amv->stop().get();
+    });
+
+    // Flush once max_uploadable_offset_exclusive() reflects added segments,
+    // and assert the request is accepted.
+    model::offset flush_offset;
+    RPTEST_REQUIRE_EVENTUALLY(3s, [&] {
+        auto max_uploadable_offset = archiver.max_uploadable_offset_exclusive();
+        if (max_uploadable_offset > model::offset{0}) {
+            auto flush_res = archiver.flush();
+            flush_offset = flush_res.offset.value();
+            return flush_res.response == flush_response::accepted
+                   && flush_offset == last_offset;
+        }
+        return false;
+    });
+
+    // Create a waiter.
+    auto wait_res = archiver.wait(flush_offset);
+
+    // Start the upload loop.
+    auto upload_future = upload_until_term_change(archiver);
+
+    // Now we can force a step down
+    part->raft()->step_down("forced stepdown").get();
+
+    // Manually signal to the condition variable, so that waiters can wake up
+    // and notice the loss of leadership.
+    broadcast_flush_condition_variable(archiver);
+
+    // Assert that we lost leadership while waiting for a flush() to complete.
+    BOOST_REQUIRE(wait_res.get() == wait_result::lost_leadership);
+
+    upload_future.get();
 }

--- a/src/v/archival/tests/ntp_archiver_test.cc
+++ b/src/v/archival/tests/ntp_archiver_test.cc
@@ -829,11 +829,14 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
     BOOST_REQUIRE(partition);
 
     // Starting offset is lower than offset1
-    auto upload1 = require_upload_candidate(
-                     policy
-                       .get_next_candidate(
-                         model::offset(0), lso, log, segment_read_lock_timeout)
-                       .get())
+    auto upload1 = require_upload_candidate(policy
+                                              .get_next_candidate(
+                                                model::offset(0),
+                                                lso,
+                                                std::nullopt,
+                                                log,
+                                                segment_read_lock_timeout)
+                                              .get())
                      .candidate;
     log_upload_candidate(upload1);
     BOOST_REQUIRE(!upload1.sources.empty());
@@ -843,12 +846,13 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
 
     start_offset = upload1.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
-    auto upload2 = require_upload_candidate(
-                     policy
-                       .get_next_candidate(
-                         start_offset, lso, log, segment_read_lock_timeout)
-                       .get())
-                     .candidate;
+    auto upload2
+      = require_upload_candidate(
+          policy
+            .get_next_candidate(
+              start_offset, lso, std::nullopt, log, segment_read_lock_timeout)
+            .get())
+          .candidate;
     log_upload_candidate(upload2);
     BOOST_REQUIRE(!upload2.sources.empty());
     BOOST_REQUIRE(upload2.starting_offset() == offset2);
@@ -859,12 +863,13 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
 
     start_offset = upload2.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
-    auto upload3 = require_upload_candidate(
-                     policy
-                       .get_next_candidate(
-                         start_offset, lso, log, segment_read_lock_timeout)
-                       .get())
-                     .candidate;
+    auto upload3
+      = require_upload_candidate(
+          policy
+            .get_next_candidate(
+              start_offset, lso, std::nullopt, log, segment_read_lock_timeout)
+            .get())
+          .candidate;
     log_upload_candidate(upload3);
     BOOST_REQUIRE(!upload3.sources.empty());
     BOOST_REQUIRE(upload3.starting_offset() == offset3);
@@ -877,13 +882,18 @@ FIXTURE_TEST(test_archiver_policy, archiver_fixture) {
                    + model::offset(1);
     require_candidate_creation_error(
       policy
-        .get_next_candidate(start_offset, lso, log, segment_read_lock_timeout)
+        .get_next_candidate(
+          start_offset, lso, std::nullopt, log, segment_read_lock_timeout)
         .get(),
       candidate_creation_error::no_segment_for_begin_offset);
     require_candidate_creation_error(
       policy
         .get_next_candidate(
-          lso + model::offset(1), lso, log, segment_read_lock_timeout)
+          lso + model::offset(1),
+          lso,
+          std::nullopt,
+          log,
+          segment_read_lock_timeout)
         .get(),
       candidate_creation_error::no_segment_for_begin_offset);
 }
@@ -925,13 +935,16 @@ FIXTURE_TEST(
     auto partition = app.partition_manager.local().get(manifest_ntp);
     BOOST_REQUIRE(partition);
 
-    auto candidate
-      = require_upload_candidate(
-          archival::archival_policy{manifest_ntp}
-            .get_next_candidate(
-              model::offset(0), lso, log, segment_read_lock_timeout)
-            .get())
-          .candidate;
+    auto candidate = require_upload_candidate(
+                       archival::archival_policy{manifest_ntp}
+                         .get_next_candidate(
+                           model::offset(0),
+                           lso,
+                           std::nullopt,
+                           log,
+                           segment_read_lock_timeout)
+                         .get())
+                       .candidate;
 
     // The search is expected to find the next segment after the compacted
     // segment, skipping the compacted one.
@@ -966,6 +979,7 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
                                               .get_next_candidate(
                                                 start_offset,
                                                 last_stable_offset,
+                                                std::nullopt,
                                                 log,
                                                 segment_read_lock_timeout)
                                               .get())
@@ -1027,6 +1041,7 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
             .get_next_candidate(
               start_offset,
               log->offsets().dirty_offset + model::offset{1},
+              std::nullopt,
               log,
               segment_read_lock_timeout)
             .get(),
@@ -1062,6 +1077,7 @@ SEASTAR_THREAD_TEST_CASE(test_archival_policy_timeboxed_uploads) {
             .get_next_candidate(
               start_offset,
               log->offsets().dirty_offset + model::offset{1},
+              std::nullopt,
               log,
               segment_read_lock_timeout)
             .get(),
@@ -1551,24 +1567,26 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
     model::offset start_offset{0};
     model::offset lso{9999};
     // Starting offset is lower than offset1
-    auto upload1 = require_upload_candidate(
-                     policy
-                       .get_next_candidate(
-                         start_offset, lso, log, segment_read_lock_timeout)
-                       .get())
-                     .candidate;
+    auto upload1
+      = require_upload_candidate(
+          policy
+            .get_next_candidate(
+              start_offset, lso, std::nullopt, log, segment_read_lock_timeout)
+            .get())
+          .candidate;
     log_upload_candidate(upload1);
     BOOST_REQUIRE(!upload1.sources.empty());
     BOOST_REQUIRE(upload1.starting_offset == offset1);
 
     start_offset = upload1.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
-    auto upload2 = require_upload_candidate(
-                     policy
-                       .get_next_candidate(
-                         start_offset, lso, log, segment_read_lock_timeout)
-                       .get())
-                     .candidate;
+    auto upload2
+      = require_upload_candidate(
+          policy
+            .get_next_candidate(
+              start_offset, lso, std::nullopt, log, segment_read_lock_timeout)
+            .get())
+          .candidate;
     log_upload_candidate(upload2);
     BOOST_REQUIRE(!upload2.sources.empty());
     BOOST_REQUIRE(upload2.starting_offset == offset2);
@@ -1579,12 +1597,13 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
 
     start_offset = upload2.sources.front()->offsets().get_dirty_offset()
                    + model::offset(1);
-    auto upload3 = require_upload_candidate(
-                     policy
-                       .get_next_candidate(
-                         start_offset, lso, log, segment_read_lock_timeout)
-                       .get())
-                     .candidate;
+    auto upload3
+      = require_upload_candidate(
+          policy
+            .get_next_candidate(
+              start_offset, lso, std::nullopt, log, segment_read_lock_timeout)
+            .get())
+          .candidate;
     log_upload_candidate(upload3);
     BOOST_REQUIRE(!upload3.sources.empty());
     BOOST_REQUIRE(upload3.starting_offset == offset3);
@@ -1597,7 +1616,8 @@ FIXTURE_TEST(test_upload_segments_with_overlap, archiver_fixture) {
                    + model::offset(1);
     require_candidate_creation_error(
       policy
-        .get_next_candidate(start_offset, lso, log, segment_read_lock_timeout)
+        .get_next_candidate(
+          start_offset, lso, std::nullopt, log, segment_read_lock_timeout)
         .get(),
       candidate_creation_error::no_segment_for_begin_offset);
 }

--- a/src/v/archival/tests/service_fixture.cc
+++ b/src/v/archival/tests/service_fixture.cc
@@ -49,7 +49,7 @@ namespace archival {
 
 using namespace std::chrono_literals;
 
-inline ss::logger fixt_log("fixture"); // NOLINT
+inline ss::logger fixt_log("archiver_fixture"); // NOLINT
 
 archiver_fixture::archiver_fixture()
   : http_imposter_fixture(4441)

--- a/src/v/cloud_storage/tests/s3_imposter.cc
+++ b/src/v/cloud_storage/tests/s3_imposter.cc
@@ -35,7 +35,7 @@
 
 using namespace std::chrono_literals;
 
-inline ss::logger fixt_log("fixture"); // NOLINT
+inline ss::logger fixt_log("s3_imposter_fixture"); // NOLINT
 
 /// For http_imposter to run this binary with a unique port
 uint16_t unit_test_httpd_port_number() { return 4442; }

--- a/src/v/http/include/http/tests/http_imposter.h
+++ b/src/v/http/include/http/tests/http_imposter.h
@@ -56,6 +56,13 @@ public:
     /// Access all http requests ordered by time
     const std::vector<http_test_utils::request_info>& get_requests() const;
 
+    using req_pred_t
+      = std::function<bool(const http_test_utils::request_info&)>;
+
+    /// Access http requests matching the given predicate
+    std::vector<http_test_utils::request_info>
+    get_requests(req_pred_t predicate) const;
+
     /// Get the latest request to a particular URL
     std::optional<std::reference_wrapper<const http_test_utils::request_info>>
     get_latest_request(

--- a/src/v/http/tests/http_imposter.cc
+++ b/src/v/http/tests/http_imposter.cc
@@ -43,6 +43,18 @@ http_imposter_fixture::get_requests() const {
     return _requests;
 }
 
+std::vector<http_test_utils::request_info> http_imposter_fixture::get_requests(
+  http_imposter_fixture::req_pred_t predicate) const {
+    std::vector<http_test_utils::request_info> matching_requests;
+    matching_requests.reserve(_requests.size());
+    std::copy_if(
+      _requests.cbegin(),
+      _requests.cend(),
+      std::back_inserter(matching_requests),
+      std::move(predicate));
+    return matching_requests;
+}
+
 static ss::sstring remove_query_params(std::string_view url) {
     return ss::sstring{url.substr(0, url.find('?'))};
 }


### PR DESCRIPTION
Adds a flushing mechanism to the `ntp_archiver` to allow for the forceful upload of all local data to cloud storage. Users can call `flush()` and then `wait()` in order to synchronize with the upload of a partition's data to cloud storage.

The uploads still take place in the `ntp_archiver`'s background upload loop, and when a `flush()` is issued, the `archival_policy` forces uploads in the same branch of logic to that of the `archival_configuration::time_limit` being reached.

A `flush()` is considered finished when the `partition_manifest`'s `_insync_offset` is greater or equal to the value of the `max_uploadable_offset_exclusive()` at the time `flush()` was called.

## Backports Required
- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none