### PR TITLE
cst/inv: Add tooling for parsing, writing and reading inventory reports

### DIFF
--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -50,6 +50,7 @@ v_cc_library(
     inventory/aws_ops.cc
     inventory/types.cc
     inventory/report_parser.cc
+    inventory/inv_consumer.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -49,6 +49,7 @@ v_cc_library(
     inventory/inv_ops.cc
     inventory/aws_ops.cc
     inventory/types.cc
+    inventory/report_parser.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -51,6 +51,7 @@ v_cc_library(
     inventory/types.cc
     inventory/report_parser.cc
     inventory/inv_consumer.cc
+    inventory/ntp_hashes.cc
   DEPS
     Seastar::seastar
     v::bytes

--- a/src/v/cloud_storage/inventory/inv_consumer.cc
+++ b/src/v/cloud_storage/inventory/inv_consumer.cc
@@ -1,0 +1,259 @@
+
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/inventory/inv_consumer.h"
+
+#include "bytes/iostream.h"
+#include "cloud_storage/logger.h"
+#include "hashing/xx.h"
+#include "serde/serde.h"
+
+#include <seastar/core/file-types.hh>
+#include <seastar/core/file.hh>
+#include <seastar/core/fstream.hh>
+#include <seastar/core/seastar.hh>
+
+#include <re2/re2.h>
+
+#include <ranges>
+
+namespace ranges = std::ranges;
+namespace views = std::views;
+
+namespace {
+// hash-string/ns/tp/partition_rev/.*
+const RE2 path_expr{"^[[:xdigit:]]+/(.*?)/(.*?)/(\\d+)_\\d+/.*?"};
+struct flush_entry {
+    model::ntp ntp;
+    fragmented_vector<uint64_t> hashes;
+    uint64_t file_name;
+};
+
+// Will remove nested, embedded quotes and spaces. The CSV report format we
+// expect should be resilient to this because we only care about path names,
+// which contain neither spaces nor quotes, but this is not a real CSV parser.
+bool drop_chars(char c) { return c != '"' && !std::isspace(c); }
+
+ss::sstring trim_string(ranges::subrange<char*> r) {
+    auto filtered = r | views::filter(drop_chars);
+    return {filtered.begin(), filtered.end()};
+}
+
+} // namespace
+
+namespace cloud_storage::inventory {
+
+inventory_consumer::inventory_consumer(
+  std::filesystem::path hash_store_path,
+  absl::node_hash_set<model::ntp> ntps,
+  size_t max_paths_in_memory)
+  : _hash_store_path{std::move(hash_store_path)}
+  , _ntps{std::move(ntps)}
+  , _max_hash_size_in_memory{max_paths_in_memory} {}
+
+ss::future<> inventory_consumer::consume(
+  ss::input_stream<char> s, is_gzip_compressed is_report_compressed) {
+    auto h = _gate.hold();
+    report_parser parser{std::move(s), is_report_compressed};
+    co_await parser
+      .consume([this](auto&& paths) { return process_paths(std::move(paths)); })
+      .finally([&parser] { return parser.stop(); });
+    co_await flush(write_all_t::yes);
+}
+
+std::vector<ss::sstring> inventory_consumer::parse_row(ss::sstring row) {
+    std::vector<ss::sstring> pieces;
+    for (auto p : row | views::split(',') | views::transform(trim_string)) {
+        pieces.emplace_back(p);
+    }
+    return pieces;
+}
+
+ss::future<>
+inventory_consumer::process_paths(fragmented_vector<ss::sstring> paths) {
+    for (const auto& path : paths) {
+        // The row is expected to be in the form:
+        // "bucket","path"
+        auto pieces = parse_row(path);
+        // If a row is malformed we skip it and do not abort processing.
+        // This way the rest of the entries are processed, and if there
+        // was a path in this row it will be recorded as missing.
+        if (pieces.size() != 2) {
+            vlog(cst_log.warn, "unexpected row in inventory report: {}", path);
+        }
+        process_path(pieces[1]);
+    }
+
+    if (_total_size >= _max_hash_size_in_memory) {
+        co_await flush();
+    }
+}
+
+void inventory_consumer::process_path(ss::sstring path) {
+    if (auto maybe_ntp = ntp_from_path(path);
+        _ntps.contains(maybe_ntp.value())) {
+        const auto& ntp = maybe_ntp.value();
+        auto hash = xxhash_64(path.data(), path.size());
+
+        if (!_ntp_flush_states.contains(ntp)) {
+            _ntp_flush_states.insert({ntp, flush_state{}});
+        }
+
+        _ntp_flush_states[ntp].hashes.push_back(hash);
+        _total_size += sizeof(hash);
+    }
+}
+
+ss::future<>
+inventory_consumer::flush(inventory_consumer::write_all_t write_all_entries) {
+    auto h = _gate.hold();
+    vlog(
+      cst_log.trace,
+      "Flushing to disk, write_all_entries: {}",
+      write_all_entries);
+
+    _num_flushes += 1;
+    if (write_all_entries) {
+        for (auto& [ntp, flush_state] : _ntp_flush_states) {
+            if (!flush_state.hashes.empty()) {
+                co_await flush_ntp_hashes(
+                  ntp,
+                  std::move(flush_state.hashes),
+                  flush_state.next_file_name);
+            }
+        }
+        co_return;
+    }
+
+    // Set up a vector to sort entries. The ntp and next filename are not moved
+    // out of the map, only the hashes are moved out.
+    fragmented_vector<flush_entry> entries;
+    ranges::transform(
+      _ntp_flush_states, std::back_inserter(entries), [](auto& e) {
+          return flush_entry{
+            e.first, std::move(e.second.hashes), e.second.next_file_name};
+      });
+
+    ranges::sort(entries, ranges::greater(), [](const auto& e) {
+        return e.hashes.size();
+    });
+
+    const auto target_size = _max_hash_size_in_memory / 3;
+    vlog(
+      cst_log.trace,
+      "Before flush, size in memory {}, target {}",
+      _total_size,
+      target_size);
+
+    size_t idx = 0;
+    while (idx < entries.size() && _total_size >= target_size) {
+        _total_size -= sizeof(entries[idx].hashes[0])
+                       * entries[idx].hashes.size();
+
+        const auto path = entries[idx].ntp.path();
+
+        // Increment the next filename in the map. This must be done before
+        // moving the ntp. Even if the flush fails we have gaps in file names,
+        // which is fine because the filenames can be arbitrary and the hash
+        // loader will read all files in the NTP dir.
+        _ntp_flush_states[entries[idx].ntp].next_file_name += 1;
+
+        co_await flush_ntp_hashes(
+          std::move(entries[idx].ntp),
+          std::move(entries[idx].hashes),
+          entries[idx].file_name);
+
+        vlog(
+          cst_log.trace,
+          "Flushed ntp {}, size in memory {}, target {}",
+          path,
+          _total_size,
+          target_size);
+        idx += 1;
+    }
+
+    vlog(cst_log.trace, "After flush, size in memory {}", _total_size);
+
+    // Put back in all the hashes which were not flushed.
+    for (; idx < entries.size(); ++idx) {
+        _ntp_flush_states[entries[idx].ntp].hashes = std::move(
+          entries[idx].hashes);
+    }
+}
+
+ss::future<> inventory_consumer::flush_ntp_hashes(
+  model::ntp ntp, fragmented_vector<uint64_t> hashes, uint64_t file_name) {
+    auto ntp_hash_path = _hash_store_path / std::string_view{ntp.path()};
+    const auto ntp_hash_dir = ntp_hash_path.string();
+
+    if (!co_await ss::file_exists(ntp_hash_dir)) {
+        co_await ss::recursive_touch_directory(ntp_hash_dir);
+    }
+
+    ntp_hash_path /= fmt::format("{}", file_name);
+    co_return co_await ss::with_file_close_on_failure(
+      ss::open_file_dma(
+        ntp_hash_path.string(), ss::open_flags::create | ss::open_flags::wo),
+      [hashes = std::move(hashes), this](auto& f) mutable {
+          return write_hashes_to_file(f, std::move(hashes));
+      });
+}
+
+ss::future<> inventory_consumer::write_hashes_to_file(
+  ss::file& f, fragmented_vector<uint64_t> hashes) {
+    vlog(cst_log.trace, "Writing {} hashe(s) to disk", hashes.size());
+    std::exception_ptr ep;
+    auto stream = co_await ss::make_file_output_stream(f);
+    try {
+        co_await write_hashes_to_file(stream, std::move(hashes));
+    } catch (...) {
+        ep = std::current_exception();
+    }
+
+    co_await stream.close();
+    if (ep) {
+        std::rethrow_exception(ep);
+    }
+}
+
+ss::future<> inventory_consumer::write_hashes_to_file(
+  ss::output_stream<char>& stream, fragmented_vector<uint64_t> hashes) {
+    iobuf serialized;
+    serde::write(serialized, std::move(hashes));
+
+    iobuf chunk_size;
+    serde::write(chunk_size, serialized.size_bytes());
+
+    co_await write_iobuf_to_output_stream(std::move(chunk_size), stream);
+
+    for (const auto& frag : serialized) {
+        co_await stream.write(frag.get(), frag.size());
+    }
+}
+
+ss::future<> inventory_consumer::stop() { co_await _gate.close(); }
+
+std::optional<model::ntp>
+inventory_consumer::ntp_from_path(std::string_view path) {
+    std::string ns;
+    std::string tp;
+    int pid{};
+
+    if (!RE2::FullMatch(path, path_expr, &ns, &tp, &pid)) {
+        return std::nullopt;
+    }
+
+    return model::ntp{
+      model::ns{ns}, model::topic{tp}, model::partition_id{pid}};
+}
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/inv_consumer.h
+++ b/src/v/cloud_storage/inventory/inv_consumer.h
@@ -1,0 +1,122 @@
+
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "cloud_storage/inventory/report_parser.h"
+#include "container/fragmented_vector.h"
+#include "model/fundamental.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/iostream.hh>
+
+#include <absl/container/node_hash_map.h>
+#include <absl/container/node_hash_set.h>
+
+namespace cloud_storage::inventory {
+
+/// The inventory consumer reads a CSV inventory report, which may be GZip
+/// compressed, and stores the hashes for file paths from the report. Each row
+/// in the report is expected to contain a path to a segment in the bucket for
+/// which the inventory was generated. A set of NTPs is provided to the consumer
+/// for validation, and only paths belonging to these NTPs are processed. For
+/// each path, its 64 bit hash is calculated and stored in memory. Once the
+/// cumulative size in memory of the stored hashes grows over a prescribed
+/// limit, the hashes for the invidividual NTPs are written to disk until the
+/// cumulative memory usage drops below the desired limit. On completion of the
+/// report consumption, all hashes in memory are flushed to disk.
+class inventory_consumer {
+    using write_all_t = ss::bool_class<struct write_all_tag>;
+
+public:
+    inventory_consumer(const inventory_consumer&) = delete;
+    inventory_consumer& operator=(const inventory_consumer&) = delete;
+    inventory_consumer(inventory_consumer&&) = delete;
+    inventory_consumer& operator=(inventory_consumer&&) = delete;
+
+    inventory_consumer(
+      std::filesystem::path hash_store_path,
+      absl::node_hash_set<model::ntp> ntps,
+      size_t max_hash_size_in_memory);
+
+    /// Consumes the report provided as input stream and populates in memory
+    /// path hashes. A flush to disk may be performed if the size of hashes
+    /// exceeds the prescribed limit.
+    ss::future<>
+    consume(ss::input_stream<char> s, is_gzip_compressed is_report_compressed);
+
+    static std::optional<model::ntp> ntp_from_path(std::string_view path);
+    static std::vector<ss::sstring> parse_row(ss::sstring row);
+
+    /// Ensures that streams opened by consumer are closed. Called during
+    /// exception handling if an exception is thrown during a stream
+    /// consumption.
+    ss::future<> stop();
+
+    ~inventory_consumer() = default;
+
+private:
+    ss::future<> process_paths(fragmented_vector<ss::sstring> paths);
+
+    // Checks if the path belongs to one of the NTPs whose leadership belongs to
+    // this node. If so, the path is hashed and added to the `_path_hashes` map.
+    void process_path(ss::sstring path);
+
+    // Writes the largest hash vectors to disk. The vectors are written in files
+    // named after their NTP. If write_all_entries is true, all hashes are
+    // written to disk. If it is not true, we write the vectors until total
+    // memory used falls below the max hash size limit.
+    ss::future<> flush(write_all_t write_all_entries = write_all_t::no);
+
+    // Writes hashes for a single NTP to a data file. The data file is
+    // located in path: namespace/topic/partition_id/{seq}. The parent
+    // directories are created if missing. A new data file is created for each
+    // flush operation.
+    ss::future<> flush_ntp_hashes(
+      model::ntp ntp, fragmented_vector<uint64_t> hashes, uint64_t file_name);
+    ss::future<>
+    write_hashes_to_file(ss::file& f, fragmented_vector<uint64_t> hashes);
+
+    ss::future<> write_hashes_to_file(
+      ss::output_stream<char>& stream, fragmented_vector<uint64_t> hashes);
+
+    // The root directory for hash files
+    std::filesystem::path _hash_store_path;
+
+    // NTPs for which leaders are shards on this node. The data produced by this
+    // class is expected to be used by the scrubbers which run on this node.
+    // Since scrubbing for an NTP is done by its partition leader, we need data
+    // for all possible scrubs done via this node, so we collect the NTPs led by
+    // this node up front and only process rows related to these.
+    absl::node_hash_set<model::ntp> _ntps;
+
+    struct flush_state {
+        uint64_t next_file_name{0};
+        fragmented_vector<uint64_t> hashes{};
+    };
+    // Mapping of hash vectors per NTP, populated as paths from inventory are
+    // processed.
+    absl::node_hash_map<model::ntp, flush_state> _ntp_flush_states;
+
+    // Max size of path hashes (8 bytes each) held in memory before a flush is
+    // performed to free up memory.
+    size_t _max_hash_size_in_memory;
+
+    // Total size of path hashes held in memory
+    size_t _total_size{};
+
+    size_t _num_flushes{};
+
+    ss::gate _gate;
+};
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/ntp_hashes.cc
+++ b/src/v/cloud_storage/inventory/ntp_hashes.cc
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/inventory/ntp_hashes.h"
+
+#include "cloud_storage/logger.h"
+#include "container/fragmented_vector.h"
+#include "hashing/xx.h"
+#include "serde/serde.h"
+#include "utils/directory_walker.h"
+
+#include <seastar/core/fstream.hh>
+#include <seastar/core/seastar.hh>
+#include <seastar/util/file.hh>
+
+#include <charconv>
+
+namespace {
+
+bool is_valid_hash_file(const ss::sstring& filename) {
+    uint64_t v;
+    return std::from_chars(
+             filename.data(), filename.data() + filename.size(), v)
+             .ec
+           != std::errc::invalid_argument;
+}
+
+} // namespace
+
+namespace cloud_storage::inventory {
+ntp_path_hashes::ntp_path_hashes(
+  model::ntp ntp, std::filesystem::path hash_store_path)
+  : _ntp{std::move(ntp)}
+  , _ntp_hashes_path{hash_store_path / std::string_view{_ntp.path()}}
+  , _rtc{_as}
+  , _ctxlog{cst_log, _rtc, _ntp.path()} {}
+
+ss::future<bool> ntp_path_hashes::load_hashes() {
+    auto h = _gate.hold();
+    if (co_await ss::file_exists(_ntp_hashes_path.string())) {
+        co_await directory_walker::walk(
+          _ntp_hashes_path.string(),
+          [this](auto de) { return load_hashes(de); });
+        _loaded = true;
+
+        vlog(
+          _ctxlog.trace,
+          "loaded {} hashes from disk, possible collisions {}",
+          _path_hashes.size(),
+          _possible_collisions.size());
+        co_return true;
+    }
+
+    vlog(_ctxlog.warn, "hash dir {} not found", _ntp_hashes_path.string());
+    co_return false;
+}
+
+ss::future<> ntp_path_hashes::load_hashes(ss::directory_entry de) {
+    if (
+      de.type.has_value()
+      && de.type.value() == ss::directory_entry_type::regular
+      && is_valid_hash_file(de.name)) {
+        co_return co_await ss::util::with_file_input_stream(
+          _ntp_hashes_path / std::string{de.name},
+          [this](auto& stream) { return load_hashes(stream); });
+    }
+}
+
+ss::future<> ntp_path_hashes::load_hashes(ss::input_stream<char>& stream) {
+    while (!stream.eof()) {
+        auto chunk_size_buffer = co_await stream.read_exactly(sizeof(size_t));
+        if (chunk_size_buffer.empty()) {
+            break;
+        }
+
+        iobuf c;
+        c.append(std::move(chunk_size_buffer));
+        auto size_parser = iobuf_parser(std::move(c));
+
+        auto chunk_size = serde::read<size_t>(size_parser);
+        iobuf chunk;
+        chunk.append(co_await stream.read_exactly(chunk_size));
+
+        auto chunk_parser = iobuf_parser{std::move(chunk)};
+        auto hashes = serde::read<fragmented_vector<uint64_t>>(chunk_parser);
+        vlog(_ctxlog.trace, "read {} path hashes from disk", hashes.size());
+
+        for (auto hash : hashes) {
+            if (unlikely(_path_hashes.contains(hash))) {
+                _possible_collisions.insert(hash);
+            } else {
+                _path_hashes.insert(hash);
+            }
+        }
+    }
+}
+
+ss::future<> ntp_path_hashes::stop() { co_await _gate.close(); }
+
+lookup_result ntp_path_hashes::exists(const remote_segment_path& path) const {
+    vassert(_loaded, "lookup without loading hashes from disk");
+    const auto& s = path().string();
+    const auto hash = xxhash_64(s.data(), s.size());
+    if (unlikely(_possible_collisions.contains(hash))) {
+        return lookup_result::possible_collision;
+    }
+
+    if (_path_hashes.contains(hash)) {
+        return lookup_result::exists;
+    }
+
+    return lookup_result::missing;
+}
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/ntp_hashes.h
+++ b/src/v/cloud_storage/inventory/ntp_hashes.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "model/fundamental.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/file.hh>
+#include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
+
+#include <absl/container/node_hash_set.h>
+
+namespace cloud_storage::inventory {
+
+enum class lookup_result {
+    exists,
+    missing,
+    possible_collision,
+};
+
+class ntp_path_hashes {
+public:
+    ntp_path_hashes(model::ntp ntp, std::filesystem::path hash_store_path);
+
+    ss::future<bool> load_hashes();
+
+    lookup_result exists(const remote_segment_path& path) const;
+
+    ss::future<> stop();
+
+private:
+    ss::future<> load_hashes(ss::directory_entry de);
+    ss::future<> load_hashes(ss::input_stream<char>& stream);
+
+    model::ntp _ntp;
+    std::filesystem::path _ntp_hashes_path;
+    absl::node_hash_set<uint64_t> _path_hashes;
+    absl::node_hash_set<uint64_t> _possible_collisions;
+    bool _loaded{false};
+    ss::abort_source _as;
+    retry_chain_node _rtc;
+    retry_chain_logger _ctxlog;
+    ss::gate _gate;
+};
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/report_parser.cc
+++ b/src/v/cloud_storage/inventory/report_parser.cc
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/inventory/report_parser.h"
+
+#include "base/vassert.h"
+#include "bytes/iobuf_parser.h"
+
+#include <seastar/util/short_streams.hh>
+
+#include <zlib.h>
+
+namespace {
+constexpr auto newline{'\n'};
+
+bool has_newline(const iobuf& b) {
+    iobuf::byte_iterator begin{b.cbegin(), b.cend()};
+    iobuf::byte_iterator end{b.cend(), b.cend()};
+    while (begin != end) {
+        if (*begin == newline) {
+            return true;
+        }
+        ++begin;
+    }
+    return false;
+}
+
+} // namespace
+
+namespace cloud_storage::inventory {
+
+report_parser::report_parser(
+  ss::input_stream<char> stream,
+  is_gzip_compressed is_compressed,
+  size_t chunk_size)
+  : _stream{std::move(stream)}
+  , _is_compressed{is_compressed}
+  , _chunk_size{chunk_size} {
+    if (_is_compressed) {
+        _stream_inflate.emplace(std::move(_stream), _chunk_size);
+    }
+}
+
+ss::future<report_parser::rows_t> report_parser::next() {
+    auto h = _gate.hold();
+    while (!has_newline(_buffer)) {
+        auto fill_res = co_await fill_buffer();
+        if (!fill_res.has_value()) {
+            _eof = true;
+            break;
+        }
+        _buffer.append(std::move(fill_res.value()));
+    }
+
+    if (_buffer.empty()) {
+        co_return rows_t{};
+    }
+
+    if (eof() && !has_newline(_buffer)) {
+        iobuf_parser p{std::move(_buffer)};
+        co_return rows_t{p.read_string(p.bytes_left())};
+    }
+
+    vassert(
+      has_newline(_buffer), "Buffer {} does not contain a newline", _buffer);
+    co_return split_to_rows();
+}
+
+ss::future<> report_parser::stop() {
+    co_await _gate.close();
+    if (_decompression_started) {
+        co_await _stream_inflate->stop();
+    }
+}
+
+report_parser::rows_t report_parser::split_to_rows() {
+    using ibi = iobuf::byte_iterator;
+    rows_t rows;
+    fragmented_vector<char> row;
+    for (auto begin = ibi{_buffer.cbegin(), _buffer.cend()},
+              end = ibi{_buffer.cend(), _buffer.cend()};
+         begin != end;
+         ++begin) {
+        if (*begin == newline) {
+            rows.emplace_back(row.begin(), row.end());
+            row.clear();
+        } else {
+            row.push_back(*begin);
+        }
+    }
+    _buffer.trim_front(_buffer.size_bytes() - row.size());
+    return rows;
+}
+
+ss::future<std::optional<iobuf>> report_parser::fill_buffer() {
+    if (_is_compressed) {
+        vassert(
+          _stream_inflate.has_value(),
+          "decompression context not initialized, cannot decompress report");
+        if (unlikely(!_decompression_started)) {
+            _decompression_started = true;
+            _stream_inflate->reset();
+        }
+        co_return co_await _stream_inflate->next();
+    }
+
+    auto buf = co_await _stream.read_up_to(_chunk_size);
+    if (buf.empty()) {
+        co_return std::nullopt;
+    }
+    iobuf b;
+    b.append(std::move(buf));
+    co_return b;
+}
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/report_parser.h
+++ b/src/v/cloud_storage/inventory/report_parser.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "base/seastarx.h"
+#include "bytes/details/io_allocation_size.h"
+#include "compression/gzip_stream_decompression.h"
+#include "container/fragmented_vector.h"
+
+#include <seastar/core/iostream.hh>
+
+#include <zlib.h>
+
+namespace cloud_storage::inventory {
+
+using is_gzip_compressed = ss::bool_class<struct gzip_compressed_tag>;
+
+template<typename C>
+concept RowsConsumer = requires(C c, fragmented_vector<ss::sstring> rows) {
+    { c(rows) } -> std::same_as<ss::future<>>;
+};
+
+class report_decompression_error : public std::runtime_error {
+public:
+    using runtime_error::runtime_error;
+};
+
+/// Parses newline delimited inventory report, supplied as an input stream.
+/// The report may optionally be GZip compressed. The rows returned by the
+/// parser have newlines stripped off, but no other modifications are
+/// performed. In particular, whitespaces and carriage returns are still
+/// present in the returned row. For CSV files, parsing of the row is not
+/// performed and must be done by the caller.
+class report_parser {
+public:
+    using row_t = iobuf;
+    using rows_t = fragmented_vector<ss::sstring>;
+
+    report_parser(const report_parser&) = delete;
+    report_parser& operator=(const report_parser&) = delete;
+
+    report_parser(report_parser&&) = delete;
+    report_parser& operator=(report_parser&&) = delete;
+
+    // The chunk size supplied here controls the following behavior:
+    // 1. The size of data read from the input stream per read_up_to
+    // invocation
+    // 2. The max buffer size allocated during chunk decompression if the
+    // report is compressed
+    explicit report_parser(
+      ss::input_stream<char> stream,
+      is_gzip_compressed is_compressed = is_gzip_compressed::no,
+      size_t chunk_size = details::io_allocation_size::max_chunk_size);
+
+    // Returns the next line from the input stream, or nullopt if the stream
+    // is fully consumed.
+    ss::future<rows_t> next();
+    bool eof() const { return _eof; }
+
+    // High level API for consuming a report. The consumer is supplied with
+    // batches of rows in the stream until EOF. The consumer must return a
+    // future
+    template<RowsConsumer Consumer>
+    ss::future<> consume(Consumer c) {
+        auto h = _gate.hold();
+        for (auto rows = co_await next(); !rows.empty();
+             rows = co_await next()) {
+            co_await c(std::move(rows));
+        }
+    }
+
+    ss::future<> stop();
+
+private:
+    ss::future<std::optional<iobuf>> fill_buffer();
+
+    // Splits the buffer into rows on newline characters, upto the last newline.
+    // The rows are removed from _buffer and returned. The remaining part of the
+    // buffer after the last newline is preserved.
+    rows_t split_to_rows();
+
+    ss::input_stream<char> _stream;
+    const is_gzip_compressed _is_compressed;
+
+    row_t _buffer;
+    bool _eof{false};
+
+    bool _decompression_started{false};
+    size_t _chunk_size;
+    std::optional<compression::gzip_stream_decompressor> _stream_inflate;
+    ss::gate _gate;
+};
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/inventory/tests/CMakeLists.txt
@@ -3,8 +3,10 @@ rp_test(
   GTEST
   BINARY_NAME inv_api
   SOURCES
+    common.cc
     create_inventory_config_test.cc
     fetch_report_tests.cc
+    report_parser_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     Boost::unit_test_framework

--- a/src/v/cloud_storage/inventory/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/inventory/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ rp_test(
     create_inventory_config_test.cc
     fetch_report_tests.cc
     report_parser_tests.cc
+    inv_consumer_tests.cc
   DEFINITIONS BOOST_TEST_DYN_LINK
   LIBRARIES
     Boost::unit_test_framework

--- a/src/v/cloud_storage/inventory/tests/common.cc
+++ b/src/v/cloud_storage/inventory/tests/common.cc
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/inventory/tests/common.h"
+
+#include "bytes/iostream.h"
+#include "compression/internal/gzip_compressor.h"
+
+namespace cloud_storage::inventory {
+ss::input_stream<char>
+make_report_stream(ss::sstring s, is_gzip_compressed compress) {
+    iobuf b;
+    b.append(s.data(), s.size());
+    if (compress) {
+        return make_iobuf_input_stream(
+          compression::internal::gzip_compressor::compress(b));
+    }
+    return make_iobuf_input_stream(std::move(b));
+}
+
+ss::input_stream<char>
+make_report_stream(std::vector<ss::sstring> rows, is_gzip_compressed compress) {
+    return make_report_stream(
+      fmt::format("{}", fmt::join(rows, "\n")), compress);
+}
+
+} // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/tests/common.h
+++ b/src/v/cloud_storage/inventory/tests/common.h
@@ -58,4 +58,14 @@ ss::input_stream<char> make_report_stream(
   std::vector<ss::sstring> rows,
   is_gzip_compressed compress = is_gzip_compressed::no);
 
+class inventory_consumer_accessor {
+public:
+    explicit inventory_consumer_accessor(inventory_consumer& c);
+
+    size_t num_flushes() const;
+
+private:
+    inventory_consumer& _c;
+};
+
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/tests/common.h
+++ b/src/v/cloud_storage/inventory/tests/common.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_storage/inventory/report_parser.h"
 #include "cloud_storage/remote.h"
 
 #include <gmock/gmock.h>
@@ -48,5 +49,12 @@ public:
        existence_check_type),
       (override));
 };
+
+ss::input_stream<char> make_report_stream(
+  ss::sstring s, is_gzip_compressed compress = is_gzip_compressed::no);
+
+ss::input_stream<char> make_report_stream(
+  std::vector<ss::sstring> rows,
+  is_gzip_compressed compress = is_gzip_compressed::no);
 
 } // namespace cloud_storage::inventory

--- a/src/v/cloud_storage/inventory/tests/common.h
+++ b/src/v/cloud_storage/inventory/tests/common.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "cloud_storage/inventory/inv_consumer.h"
 #include "cloud_storage/inventory/report_parser.h"
 #include "cloud_storage/remote.h"
 

--- a/src/v/cloud_storage/inventory/tests/inv_consumer_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/inv_consumer_tests.cc
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "cloud_storage/inventory/inv_consumer.h"
+#include "cloud_storage/inventory/tests/common.h"
+#include "test_utils/tmp_dir.h"
+
+#include <absl/container/flat_hash_set.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <charconv>
+
+using namespace cloud_storage::inventory;
+
+namespace {
+
+model::ntp make_ntp(std::string_view ns, std::string_view tp, int pid) {
+    return model::ntp{
+      model::ns{ns}, model::topic{tp}, model::partition_id{pid}};
+}
+
+// Wraps a string into a CSV row expected to be in the CSV report:
+// "bucket","path"
+ss::sstring r(std::string_view s) {
+    return fmt::format(R"("bucket", "{}")", s);
+}
+
+bool is_hash_file(const std::filesystem::directory_entry& de) {
+    const auto& p_str = de.path().filename().string();
+    long v{};
+    return de.is_regular_file()
+           && std::from_chars(p_str.data(), p_str.data() + p_str.size(), v).ec
+                != std::errc::invalid_argument;
+}
+
+std::vector<std::filesystem::path>
+collect_hash_files(const std::filesystem::path& p) {
+    std::vector<std::filesystem::path> hash_files;
+    auto hash_files_view
+      = std::filesystem::directory_iterator{p}
+        | std::views::filter(is_hash_file)
+        | std::views::transform(&std::filesystem::directory_entry::path)
+        | std::views::transform(&std::filesystem::path::filename);
+    std::ranges::copy(hash_files_view, std::back_inserter(hash_files));
+    return hash_files;
+}
+} // namespace
+
+TEST(ParseNTPFromPath, Consumer) {
+    using p = std::pair<std::string_view, std::optional<model::ntp>>;
+    std::vector<p> test_data{
+      {"a0a6eeb8/kafka/topic-x/999_24/178-188-1574137-1-v1.log.1",
+       std::make_optional(make_ntp("kafka", "topic-x", 999))},
+      {"a/k/t/1_24/---", std::make_optional(make_ntp("k", "t", 1))},
+      // Bad hex m
+      {"m/k/t/1_24/---", std::nullopt},
+      // Non-int pid
+      {"a/k/t/x_24/---", std::nullopt},
+      // Non-int rev-id
+      {"a/k/t/1_x/---", std::nullopt},
+      // Path ends without segment
+      {"a/k/t/1_24", std::nullopt},
+      // Malformed paths
+      {"a/k/t/1_/---", std::nullopt},
+      {"a/k/t/_0/---", std::nullopt},
+      {"", std::nullopt},
+      {"1_1", std::nullopt},
+      {"////", std::nullopt},
+    };
+
+    for (const auto& [input, expected] : test_data) {
+        EXPECT_EQ(inventory_consumer::ntp_from_path(input), expected);
+    }
+}
+
+TEST(ParseCSV, Consumer) {
+    inventory_consumer c{"", {}, 0};
+    using p = std::pair<const char*, std::vector<ss::sstring>>;
+    std::vector<p> test_data{
+      {"x", {"x"}},
+      {"x,y", {"x", "y"}},
+      {"x,", {"x", ""}},
+      {"", {}},
+      {R"("bucket", "entry1")", {"bucket", "entry1"}},
+      {R"("", "entry1")", {"", "entry1"}},
+      {R"(, "entry1")", {"", "entry1"}},
+      {R"("bucket", "entry1")"
+       "\r\n",
+       {"bucket", "entry1"}},
+      {"\"bucket\", \"entry1\"\r", {"bucket", "entry1"}},
+      {"\r\rbucket\n\n,\r\nentry1\r\r\n\n\r\r", {"bucket", "entry1"}},
+    };
+    for (const auto& [in, out] : test_data) {
+        EXPECT_EQ(inventory_consumer::parse_row(in), out);
+    }
+}
+
+TEST(LargeNumberOfPaths, Consumer) {
+    temporary_dir t{"test_inv_consumer"};
+    const auto p0 = make_ntp("kafka", "topic-A", 110);
+
+    std::vector<ss::sstring> rows{
+      100000, r("03be712b/kafka/topic-A/110_24/554-559-1573504-1-v1.log.2")};
+
+    absl::node_hash_set<model::ntp> ntps{p0};
+    inventory_consumer c{t.get_path(), ntps, 4096};
+
+    c.consume(make_report_stream(rows), is_gzip_compressed::no).get();
+    c.stop().get();
+
+    auto hash_files = collect_hash_files(t.get_path() / std::string{p0.path()});
+    ASSERT_GT(hash_files.size(), 1);
+
+    // Make sure that all the sequence ids are seen as hash files in the data
+    // path. The hash loader will pick up all files in the path, so the files
+    // should not be in sequence, but this check makes sure that the inventory
+    // consumer correctly increments the file sequence when writing, so we don't
+    // end up overwriting any data.
+    absl::flat_hash_set<ss::sstring> hash_file_names{
+      hash_files.begin(), hash_files.end()};
+
+    size_t min_expected = 0;
+    size_t max_expected = hash_file_names.size() - 1;
+    for (auto i = min_expected; i <= max_expected; ++i) {
+        ASSERT_THAT(hash_file_names, testing::Contains(fmt::format("{}", i)));
+    }
+}

--- a/src/v/cloud_storage/inventory/tests/inv_consumer_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/inv_consumer_tests.cc
@@ -10,8 +10,10 @@
  */
 
 #include "cloud_storage/inventory/inv_consumer.h"
+#include "cloud_storage/inventory/ntp_hashes.h"
 #include "cloud_storage/inventory/tests/common.h"
 #include "test_utils/tmp_dir.h"
+#include "utils/base64.h"
 
 #include <absl/container/flat_hash_set.h>
 #include <gmock/gmock.h>
@@ -53,6 +55,52 @@ collect_hash_files(const std::filesystem::path& p) {
     std::ranges::copy(hash_files_view, std::back_inserter(hash_files));
     return hash_files;
 }
+
+// some paths from the following compressed file:
+// 03be712b/kafka/topic-A/110_24/554-559-1573504-1-v1.log.2
+// 15d8084c/kafka/topic-A/110_24/680-685-1573504-1-v1.log.2
+// 2762eee5/kafka/toro/110_24/661-666-1573504-1-v1.log.2
+// 28e3e323/kafka/toro/110_24/275-280-1573504-1-v1.log.1
+// ea2201bd/kafka/partagas/2_24/142-147-1573504-1-v1.log.1
+// eba06988/kafka/partagas/0_24/195-200-1573504-1-v1.log.1
+// cac7164a/kafka/topic-B/2_24/305-310-1573504-1-v1.log.1
+// cb18cb4d/kafka/topic-B/2_24/440-445-1573504-1-v1.log.2
+constexpr auto compressed
+  = "H4sICLOMcmYAA3Rlc3QAjZjJclw3DEX3+QytQ4sEMZBL50dcHG2XnJJLlvL9QavbivwMhm+"
+    "nzTvCcHEB9l1x9aU9jOe7P++873OCD/"
+    "cPZT6U++fH71+b+3gfgv8EeI8RHcbsAkkkjy64f8KHb4+"
+    "fP8DdH3fvKbEOCVBtChE6ohMUGWm0gjYFYnAQ+"
+    "XdKOFAyTvFhkRFoLGDFcqAE6sknbDaFk3ecaJtRYJ6Q4oISwd1qKyGvIxHqjI1XjOjiayQp+"
+    "BDXlNZiqwkWfRbvUE7kMwAl83/5PD2+Ndl7R/4Mokih1A0E++T4ksMGAZBbbq0YCARwCLJtL/"
+    "BsjN1MBMERGohjFMIwxiArEQ6O2ZDqEZFGHNpBAwHaDVCVbRNpvYTYxEpEkqO0L2eMcXafZCGw"
+    "fFHpvqIx0oBRF8Mrwcl+"
+    "dGNuLKWkxejqkADgnlKBJbaVASS1kXQilllmg7GoCrBTO9ox0Heqfi4YIi7BCcYUJlqMPwfUkd"
+    "lbKzJHQVpZaxIH+UQsjQGjX5gIg5oi7B0AR66CfUGBqLFcxw+D/"
+    "r2KhcLFRmShFdLpIzE6dIiFYsk0uSwoSRdX2leXhErnNG1KiDrG0ajLMSNltA7L6rJjS3PHWGq"
+    "IWd1+YfSUHPLeE6h5EYp9kZF+uF+"
+    "h1KKvjEflXiurNSGrJsc4ZpVE4zjLV2cK4iLsVUtz4GwpWgyVrKXYA4FjmnP+"
+    "pvtbFEGtYO8nXKoHrCYDcnbR752N25RJcuzKbW2p29O+s5JzoNiOir9tT1VHPMWYGVq2GMlZG/"
+    "yQiHSOJQCZBc0ahD/BGMVHElNejGqLuB9cmVF0YI6De7N4XTeyb4pM9Y/ejyZ/Lah+h34/"
+    "KqnWlFDMODArI+9zSXP4WfjXpvx1E0fWcmyjyL5H8dMkRF2Z6it7RvShNigWQ58ZDvx+"
+    "VDIW9rWAxQiXs8oy9iODS8RB3WLoTZTSniDaEZ2IG+Hpsb78eH689USPGUx7M866/"
+    "SuNbDHC5S2D+0yKvmVy7dNisAfHfn+rFl94jGrmEvRMDNd6/O/"
+    "CLRk61BhMxiWGsLfiUpp6T7TrwbomeW/"
+    "GpQHo7q8WAzQOOBFH9VWg5GYy1EjBMtIjQ4sVejQVpgtDB25vpDVU1P8lptLx0pMTcUDXbBjNu"
+    "Q+6FOBEHOSh6cPHzEU9kGXvP5U66NhOMxed/"
+    "HBi8itnyn2QyRDtq+"
+    "wfIjW1ktIwc0E9uDHt56WWWQNVs6ZMeuayv87LZX5XjNpEd5zphIjqH7T3jzpj61yTyVBHR973"
+    "pYUyA/"
+    "KxHvCqdT1+"
+    "IO5fmS330gmHxSB9khGciKM0CYzHerwyoic9ok7EUUNqFY8zB9eaeoe4Pyn75acSKcctd81F+"
+    "0qWBx0ZVFoa4diXaxx6DCLsfb2z3rZ++"
+    "hujji9fH8YVkTUCv69Gz75BHdUgMIsO7W3w01qkvQyqkYeBUIlaCj3GUGMHevtd6T0gXN4IV2H"
+    "g67JbIXpjPRvYSoOcnKiD5jD57Xp6DyA1DbJM41iHWUdisupAuk/0sblFDH3PxPimiV/"
+    "SiLqm4wlEFg69W5IIl2do3t9wo4CeWfXnhHwvT8/lc/"
+    "lxg6BaqPXT1hFSi+ec0hFy9WFVJ5xQ56hj5DTZhJC/qGtvgKPrSk9oQ3TdOODrJSc6/"
+    "ctIumDNbz8ItS8vT+3L12/f7kXkU7gHfbBA2B+E0/"
+    "chBXGBQdLdQvsmT6BeCOcCEy7PpzPRxIGthL7AaDCUfh//IwT14MeQFxDvrunI5aW+QqSRe24/"
+    "DeDv0l+eHm/fq2ZPSHa2Hn3D/CvhqjW6fL5/P80xO7e31rxHUGY9kW2l/QtIMRWsCRkAAA==";
+
 } // namespace
 
 TEST(ParseNTPFromPath, Consumer) {
@@ -133,4 +181,97 @@ TEST(LargeNumberOfPaths, Consumer) {
     for (auto i = min_expected; i <= max_expected; ++i) {
         ASSERT_THAT(hash_file_names, testing::Contains(fmt::format("{}", i)));
     }
+}
+
+TEST(WriteThenReadHashes, Consumer) {
+    temporary_dir t{"test_inv_consumer"};
+
+    const auto p0 = make_ntp("kafka", "partagas", 0);
+    const auto p2 = make_ntp("kafka", "partagas", 2);
+    absl::node_hash_set<model::ntp> ntps{
+      make_ntp("kafka", "topic-A", 110),
+      make_ntp("kafka", "toro", 110),
+      p0,
+      p2,
+      make_ntp("kafka", "topic-B", 2)};
+    inventory_consumer c{t.get_path(), ntps, 20};
+    auto decoded = base64_to_string(compressed);
+    auto stream = make_report_stream(decoded);
+    c.consume(std::move(stream), is_gzip_compressed::yes).get();
+    c.stop().get();
+
+    absl::node_hash_map<model::ntp, ss::lw_shared_ptr<ntp_path_hashes>> hashes;
+    for (const auto& ntp : ntps) {
+        auto h = ss::make_lw_shared<ntp_path_hashes>(ntp, t.get_path());
+        hashes.insert({ntp, h});
+        ASSERT_TRUE(hashes.at(ntp)->load_hashes().get());
+    }
+
+    EXPECT_EQ(
+      hashes.at(p0)->exists(cloud_storage::remote_segment_path{
+        "eba06988/kafka/partagas/0_24/195-200-1573504-1-v1.log.1"}),
+      lookup_result::exists);
+    EXPECT_EQ(
+      hashes.at(p0)->exists(cloud_storage::remote_segment_path{"missing"}),
+      lookup_result::missing);
+    EXPECT_EQ(
+      hashes.at(p2)->exists(cloud_storage::remote_segment_path{
+        "ea2201bd/kafka/partagas/2_24/142-147-1573504-1-v1.log.1"}),
+      lookup_result::exists);
+
+    for (auto h : std::views::values(hashes)) {
+        h->stop().get();
+    }
+}
+
+TEST(CollisionDetection, Consumer) {
+    temporary_dir t{"test_inv_consumer"};
+    const auto p0 = make_ntp("kafka", "topic-A", 110);
+
+    std::vector<ss::sstring> duplicate_rows{
+      r("03be712b/kafka/topic-A/110_24/554-559-1573504-1-v1.log.2"),
+      r("03be712b/kafka/topic-A/110_24/554-559-1573504-1-v1.log.2")};
+
+    absl::node_hash_set<model::ntp> ntps{p0};
+    inventory_consumer c{t.get_path(), ntps, 20};
+    c.consume(make_report_stream(duplicate_rows), is_gzip_compressed::no).get();
+    c.stop().get();
+
+    ntp_path_hashes h{p0, t.get_path()};
+    ASSERT_TRUE(h.load_hashes().get());
+
+    EXPECT_EQ(
+      h.exists(cloud_storage::remote_segment_path{
+        "03be712b/kafka/topic-A/110_24/554-559-1573504-1-v1.log.2"}),
+      lookup_result::possible_collision);
+    h.stop().get();
+}
+
+TEST(ConsumeMultipleStreams, Consumer) {
+    temporary_dir t{"test_inv_consumer"};
+    const auto p0 = make_ntp("kafka", "partagas", 0);
+
+    absl::node_hash_set<model::ntp> ntps{p0};
+    inventory_consumer c{t.get_path(), ntps, 20};
+    auto decoded = base64_to_string(compressed);
+    auto fn = [&c](ss::input_stream<char> stream) {
+        return c.consume(std::move(stream), is_gzip_compressed::yes);
+    };
+
+    // Simulates downloading multiple files and then consuming them. Since the
+    // consumer will be used with remote, which provides the downloaded file as
+    // a stream to the callback, this code simulates running the consumer in
+    // sequence on multiple downloads.
+    fn(make_report_stream(decoded)).get();
+    fn(make_report_stream(decoded)).get();
+    c.stop().get();
+
+    ntp_path_hashes h{p0, t.get_path()};
+    ASSERT_TRUE(h.load_hashes().get());
+
+    EXPECT_EQ(
+      h.exists(cloud_storage::remote_segment_path{
+        "eba06988/kafka/partagas/0_24/195-200-1573504-1-v1.log.1"}),
+      lookup_result::possible_collision);
+    h.stop().get();
 }

--- a/src/v/cloud_storage/inventory/tests/report_parser_tests.cc
+++ b/src/v/cloud_storage/inventory/tests/report_parser_tests.cc
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "base/seastarx.h"
+#include "cloud_storage/inventory/report_parser.h"
+#include "cloud_storage/inventory/tests/common.h"
+#include "test_utils/randoms.h"
+#include "utils/base64.h"
+
+#include <seastar/core/iostream.hh>
+#include <seastar/util/file.hh>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using namespace cloud_storage::inventory;
+
+namespace {
+
+std::vector<ss::sstring> collect(report_parser& p) {
+    std::vector<ss::sstring> collected;
+    p.consume([&collected](auto&& rows) {
+         collected.insert(
+           collected.end(),
+           std::make_move_iterator(rows.begin()),
+           std::make_move_iterator(rows.end()));
+         return ss::make_ready_future();
+     })
+      .get();
+    EXPECT_TRUE(p.eof());
+    p.stop().get();
+    return collected;
+}
+
+template<typename Content>
+report_parser make_parser(
+  Content content,
+  is_gzip_compressed compress,
+  size_t chunk_size = details::io_allocation_size::max_chunk_size) {
+    return report_parser{
+      make_report_stream(content, compress), compress, chunk_size};
+}
+} // namespace
+
+TEST(ParseReport, Parser) {
+    auto input = std::vector<ss::sstring>{"foo", "bar", "x"};
+    for (const auto compression :
+         {is_gzip_compressed::no, is_gzip_compressed::yes}) {
+        auto p = make_parser(input, compression);
+        EXPECT_EQ(collect(p), input);
+    }
+}
+
+TEST(ParseEmptyString, Parser) {
+    std::string input{};
+    for (const auto compression :
+         {is_gzip_compressed::no, is_gzip_compressed::yes}) {
+        auto p = make_parser(input, compression);
+        EXPECT_EQ(collect(p), std::vector<ss::sstring>{});
+    }
+}
+
+TEST(ParseTrailingNewLine, Parser) {
+    std::string input{"foobar\n"};
+    std::vector<ss::sstring> expected{"foobar"};
+    for (const auto compression :
+         {is_gzip_compressed::no, is_gzip_compressed::yes}) {
+        auto p = make_parser(input, compression);
+        EXPECT_EQ(collect(p), expected);
+    }
+}
+
+TEST(ParseLargePayloadWithSmallChunkSize, Parser) {
+    std::vector<ss::sstring> input;
+    input.reserve(1024);
+    for (auto i = 0; i < 1024; ++i) {
+        input.push_back(tests::random_named_string<ss::sstring>(1024));
+    }
+
+    for (const auto chunk_size : {16, 1024, 64 * 1024}) {
+        auto p = make_parser(input, is_gzip_compressed::yes, chunk_size);
+        EXPECT_EQ(collect(p), input);
+    }
+}
+
+TEST(ParseGzippedFile, Parser) {
+    // This is the base64 encoding of a gzipped file containing the strings 1, 2
+    // and 3, one per line.
+    constexpr auto gzipped_data
+      = "H4sICLuDbmYAA3Rlc3QAM+Qy4jLmAgDYVF93BgAAAA==";
+    auto p = report_parser{
+      make_report_stream(base64_to_string(gzipped_data)),
+      is_gzip_compressed::yes};
+    EXPECT_EQ(collect(p), (std::vector<ss::sstring>{"1", "2", "3"}));
+}
+
+TEST(BatchSizeControlledByChunkSize, Parser) {
+    size_t chunk_size{4096};
+
+    std::vector<ss::sstring> input;
+    input.reserve(1024);
+
+    for (auto i = 0; i < 1024; ++i) {
+        // make each row slightly overshoot the chunk size, so the parser has to
+        // keep data around between calls to next()
+        input.push_back(
+          tests::random_named_string<ss::sstring>(chunk_size + 1));
+    }
+
+    auto parser = make_parser(input, is_gzip_compressed::yes, chunk_size);
+    report_parser::rows_t rows;
+    do {
+        rows = parser.next().get();
+        const auto sizes = rows | std::views::transform(&ss::sstring::size);
+        // The stream compressor can return upto two chunks. The parser could
+        // have cached slightly less than one chunk between calls. The total
+        // chars returned should be below this limit.
+        ASSERT_LE(
+          std::accumulate(sizes.begin(), sizes.end(), 0ul), chunk_size * 3 + 3);
+    } while (!rows.empty());
+
+    ASSERT_TRUE(parser.eof());
+    parser.stop().get();
+}

--- a/src/v/compression/CMakeLists.txt
+++ b/src/v/compression/CMakeLists.txt
@@ -12,6 +12,7 @@ v_cc_library(
     "async_stream_zstd.cc"
     "snappy_standard_compressor.cc"
     "lz4_decompression_buffers.cc"
+    "gzip_stream_decompression.cc"
     "internal/snappy_java_compressor.cc"
     "internal/lz4_frame_compressor.cc"
     "internal/gzip_compressor.cc"

--- a/src/v/compression/gzip_stream_decompression.cc
+++ b/src/v/compression/gzip_stream_decompression.cc
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "compression/gzip_stream_decompression.h"
+
+namespace compression {
+
+gzip_stream_decompressor::gzip_stream_decompressor(
+  ss::input_stream<char> stream, size_t chunk_size)
+  : _stream{std::move(stream)}
+  , _chunk_size{chunk_size} {}
+
+void gzip_stream_decompressor::reset() {
+    vassert(!_decompression_started, "decompressor initialized twice");
+    constexpr auto default_windowbits = 15;
+    constexpr auto decode_with_header_detection = 32;
+    if (auto init_res = inflateInit2(
+          &_zs, default_windowbits + decode_with_header_detection);
+        init_res != Z_OK) {
+        throw stream_decompression_error{fmt::format(
+          "Failed to initialize decompression context: {}", zError(init_res))};
+    }
+    _decompression_started = true;
+}
+
+ss::future<> gzip_stream_decompressor::stop() { co_await _gate.close(); }
+
+gzip_stream_decompressor::~gzip_stream_decompressor() {
+    vassert(
+      _gate.is_closed(), "gzip_stream_decompressor destroyed without stopping");
+    if (_decompression_started) {
+        inflateEnd(&_zs);
+    }
+}
+
+ss::future<> gzip_stream_decompressor::read_from_stream() {
+    auto h = _gate.hold();
+    vassert(
+      _zs.avail_in == 0,
+      "attempt to read from stream when there are {} unprocessed input bytes)",
+      _zs.avail_in);
+    _buffer = co_await _stream.read_up_to(_chunk_size);
+    if (_buffer.empty()) {
+        _eof = true;
+        co_return;
+    }
+
+    _zs.next_in = const_cast<unsigned char*>(
+      reinterpret_cast<const unsigned char*>(_buffer.get()));
+    _zs.avail_in = _buffer.size();
+}
+
+ss::future<std::optional<iobuf>> gzip_stream_decompressor::next() {
+    auto h = _gate.hold();
+    vassert(
+      _decompression_started,
+      "Attempt to decompress without initializing stream");
+
+    if (_zs.avail_in == 0) {
+        co_await read_from_stream();
+    }
+
+    if (eof()) {
+        co_return std::nullopt;
+    }
+
+    iobuf result;
+    // TODO this construct could potentially _not_ be a while loop. In one
+    // iteration we end up with at most _chunk_size bytes of output. If we reach
+    // that limit, we bail out of this while loop and we return the iobuf. If we
+    // end up short of _chunk_size, then _zs.avail_in should have reached 0 ie
+    // we fully consumed the input. In either case there would probably be only
+    // one iteration of this loop per call to next().
+    while (_zs.avail_in > 0 && result.size_bytes() <= _chunk_size) {
+        // At most one _chunk_size worth of data will be returned in this call.
+        ss::temporary_buffer<char> decompressed{_chunk_size};
+
+        _zs.next_out = reinterpret_cast<unsigned char*>(
+          decompressed.get_write());
+        _zs.avail_out = decompressed.size();
+
+        const auto available = _zs.avail_in;
+        const auto out = _zs.avail_out;
+
+        if (auto code = inflate(&_zs, Z_NO_FLUSH);
+            code != Z_OK && code != Z_STREAM_END) {
+            throw stream_decompression_error(
+              fmt::format("Failed to decompress chunk: {}", zError(code)));
+        }
+
+        // It is possible for the avail_in field not to change, if the
+        // decompressed data does not fit into the output buffer fully. Several
+        // loop iterations may be required to consume avail_in. However if both
+        // avail_in and avail_out do not change, then we are stuck in a loop, as
+        // no progress was made by the inflate call.
+        if (_zs.avail_in == available && _zs.avail_out == out) {
+            throw stream_decompression_error{fmt::format(
+              "decompression stuck in loop: bytes left in chunk: {}, bytes "
+              "available in output buffer: {}",
+              _zs.avail_in,
+              _zs.avail_out)};
+        }
+
+        auto bytes_read = decompressed.size() - _zs.avail_out;
+        decompressed.trim(bytes_read);
+        if (!decompressed.empty()) {
+            result.append(std::move(decompressed));
+        }
+    }
+    co_return result;
+}
+
+} // namespace compression

--- a/src/v/compression/include/compression/gzip_stream_decompression.h
+++ b/src/v/compression/include/compression/gzip_stream_decompression.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#pragma once
+
+#include "bytes/iobuf.h"
+
+#include <seastar/core/gate.hh>
+#include <seastar/core/iostream.hh>
+
+#include <zlib.h>
+
+namespace compression {
+
+class stream_decompression_error : public std::runtime_error {
+public:
+    using runtime_error::runtime_error;
+};
+
+/// Decompresses a gzip compressed stream by reading chunks from it at a time.
+/// Before starting decompression, reset() should be called to initialize the
+/// zlib stream. On destruction of decompressor the stream and associated
+/// context are freed.
+class gzip_stream_decompressor {
+public:
+    // The chunk size controls how much data is read in from the input stream at
+    // a time.
+    gzip_stream_decompressor(ss::input_stream<char> stream, size_t chunk_size);
+
+    gzip_stream_decompressor(const gzip_stream_decompressor&) = delete;
+    gzip_stream_decompressor& operator=(const gzip_stream_decompressor&)
+      = delete;
+
+    gzip_stream_decompressor(gzip_stream_decompressor&&) = delete;
+    gzip_stream_decompressor& operator=(gzip_stream_decompressor&&) = delete;
+
+    // Initializes the zlib stream. Can only be called once for this object's
+    // lifetime.
+    void reset();
+
+    // Returns the next decompressed chunk of data, or std::nullopt on end of
+    // stream. At most chunk_size bytes are returned. Any data over the size
+    // limit is preserved in the z_stream buffer.
+    ss::future<std::optional<iobuf>> next();
+
+    bool eof() const { return _eof; }
+
+    ss::future<> stop();
+
+    ~gzip_stream_decompressor();
+
+private:
+    ss::future<> read_from_stream();
+
+    ss::input_stream<char> _stream;
+    bool _decompression_started{false};
+    bool _eof{false};
+    size_t _chunk_size;
+
+    z_stream _zs{
+      .next_in = Z_NULL,
+      .avail_in = 0,
+      .zalloc = Z_NULL,
+      .zfree = Z_NULL,
+      .opaque = Z_NULL,
+    };
+
+    ss::temporary_buffer<char> _buffer;
+    ss::gate _gate;
+};
+
+} // namespace compression

--- a/src/v/compression/tests/CMakeLists.txt
+++ b/src/v/compression/tests/CMakeLists.txt
@@ -23,3 +23,14 @@ rp_test(
   LABELS compression
   ARGS "-- -c 1"
 )
+
+
+rp_test(
+  UNIT_TEST
+  GTEST
+  BINARY_NAME gzip_stream_decompression_tests
+  SOURCES gzip_stream_decompression_tests.cc
+  LIBRARIES v::compression v::gtest_main v::utils
+  LABELS compression
+  ARGS "-- -c 1"
+)

--- a/src/v/compression/tests/gzip_stream_decompression_tests.cc
+++ b/src/v/compression/tests/gzip_stream_decompression_tests.cc
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+
+#include "bytes/iobuf.h"
+#include "bytes/iostream.h"
+#include "compression/gzip_stream_decompression.h"
+#include "compression/internal/gzip_compressor.h"
+#include "utils/base64.h"
+
+#include <seastar/core/iostream.hh>
+
+#include <gmock/gmock.h>
+
+using namespace compression;
+
+namespace {
+
+ss::input_stream<char> make_compressed_stream(ss::sstring s) {
+    iobuf b;
+    b.append(s.data(), s.size());
+    return make_iobuf_input_stream(internal::gzip_compressor::compress(b));
+}
+
+ss::sstring consume(gzip_stream_decompressor& gsd) {
+    ss::sstring output;
+    while (true) {
+        auto buffer = gsd.next().get();
+        if (!buffer) {
+            break;
+        }
+        for (const auto& frag : *buffer) {
+            output.append(frag.get(), frag.size());
+        }
+    }
+    return output;
+}
+
+} // namespace
+
+TEST(SmallChunkSize, GzStrm) {
+    ss::sstring test_string(100000, 'a');
+    gzip_stream_decompressor gsd{make_compressed_stream(test_string), 5};
+    gsd.reset();
+    auto output = consume(gsd);
+    ASSERT_TRUE(gsd.eof());
+    ASSERT_EQ(output, test_string);
+    gsd.stop().get();
+}
+
+TEST(SmallPayloadLargeChunkSize, GzStrm) {
+    ss::sstring test_string("xyz");
+    gzip_stream_decompressor gsd{make_compressed_stream(test_string), 4096};
+    gsd.reset();
+    auto output = consume(gsd);
+    ASSERT_TRUE(gsd.eof());
+    ASSERT_EQ(output, test_string);
+    gsd.stop().get();
+}
+
+TEST(EmptyString, GzStrm) {
+    ss::sstring test_string;
+    gzip_stream_decompressor gsd{make_compressed_stream(test_string), 4096};
+    gsd.reset();
+    auto output = consume(gsd);
+    ASSERT_TRUE(gsd.eof());
+    ASSERT_EQ(output, test_string);
+    gsd.stop().get();
+}
+
+TEST(NonStandardCompressionMethod, GzStrm) {
+    // Tests payload compressed with gzip -9
+    const auto payload
+      = "H4sICG5pgmYCA21vYnktZGlja2FoAFVXwY7kthG9N9D/"
+        "wL3ZgNxAznNYbMZJdmBnbXgGWeRkUFJJoociFZJqWXvaj8ghAZKf2y/"
+        "Je0X17AReeFoUWax69epV6X6yS5FkYjAfJ+tdGI0L5hfXZmNDfz4Z85TW7jn/"
+        "ejmf+PTl839+"
+        "CtgtJnadzQ7nHky2mylbNHEwZZIsZo4hw2o232wwKvlbs6TY2tbvZsYzDcG6GYRPjck+"
+        "bniVNzfP8KBR+3agX7BnIv6XGrO5MsE3mMtYtsFY2skFm798/"
+        "jfXUtwOH0yeYsLyf803T5KSNd+"
+        "LN39eZYzfNowhXmF7m1w36e5WpJtorSQRI78XCb30xpVs2mRDh6AuNPbl8z9//"
+        "d6mzQW98W9xt6PwSms+2LImAJjLK6i+fP7XI6KAq96/"
+        "wRGY7rx1M2zz2tkWRG+zWRfgiPOB+E8um0ls3xjGYTf1Cz972K5+/Wa3XG/"
+        "1NsGBx0XSrPkT0/mIBJSoR2jmQIRW2mhLQ5wEF+tdriisyHkuNhTTSy7Id0Fe7xDsa/"
+        "8bM8Rk9rgmmvLuKpkh3WDB7akwClxbPfnBeS/pFRqPEUAbgClpb8y8w/"
+        "s+N0hoUbP0NgHxIEzOYB2u/Dg5WNIURa90xDVLRMqxBTjBW/"
+        "fMQLhFufbm5tAHxAPmwvhjDGN148bgqdEDySZkz/"
+        "fVYbjkevIJWJKdI4N4CJqP2AkIN8UZtyAsxEFT78zoiBpYObtxArYbmCr1ge6luvoO1n6g"
+        "lwc527iGnjxWAou9vAIRd772t/53//7dz09/+sX84WJ+jJE1kvX9PfJi4NNDnmYr/"
+        "oKjeNqBI8p3jDBZwcSJHt5vxsM0alE6l8XveD/"
+        "ZK6ydT96VgquR4RBZvrJrVLtZ1pRJUhgIkQWI80iT61ZwjzxzAQwBbeDH+"
+        "QQCaOU1UIUyxZU4PJgtrgA5I6PGIvZC4tb7aDZLzfAGUqZdrcNQRWqLyfcX86BoWmzZYQ4"
+        "+a9H1yV0rqkfNL14kVN1KMsLBcqNG51KnzzFckG2psDyYgcDMO8AYzAj54P4xubn6eT5pl"
+        "eLXdMfU1lPucKa389LQiU+fIF4fIClzy9cKW0bIX8+cT/9/"
+        "lQvX6NdQbHKeEa+"
+        "ZF7eCCoOviAdGNpATCGbJTQ2pTdjEfetS2Ys0EwZesJthDQL9QUyzSLlTZCUvyDQ4sr/"
+        "yBM5N+xKzGVEaeYUCgtnrAgkBsEHlYhbWhy0MNck/"
+        "Vof8ImAUG+"
+        "kzR9xzPi1wp3OLV7EBpa4SyAEzpDhDR7wDGMgodb3IstTOcuhSps6WI65ZwJTedernc4id"
+        "FvQiEbZVZuEJ5W4AXXE4kFu261BD6uCEGjMFmgo/"
+        "zicGhUtQVNTVDKXg3wfTWST+iaWMf8zP2ubiylpEZW2BtkavoLXwA8X1kbJozQIBijniD/"
+        "wzg4dOuTyZe6uRgDFwz82aVBVx3pDB2v7OPJxPgE4Koir2+UWT8+"
+        "QWukKhwOZbUeU1AdF8NGCsZdBeeb0j9aiZ5yAb4gVofo4ot1r6oe4Wl4D5CFTRTakBCggC"
+        "q73zfILqquPKlQDm0CvtL0yZCDs/WmgE6/pcu65KnnaHWVRtqs8BMgK/"
+        "VbHRNlQGOlf2m7j91QYkrETythVf0K8S9c60CAQSna4kE3ISeognTEEI8Q60J30RwZCR6C"
+        "7Os6ROiIsezy+"
+        "9aiKLsTxcMKdQYJg1L0NpXnErV8zhZdUVxkUdyezuSahVfdzAx40uVFWG19qZqohrAYTYe"
+        "iqA11xtNk/"
+        "CQPDr+lKXXcRrXW1x8yeu18nCAtgNsgsF1QJxqGaz0TY1EHBldT8OkF9YUm1/"
+        "NrhVFQvc6rXLq//"
+        "fjfYTByqms2bjnpI227mlrsmhcjUN0CaIA1j+"
+        "aFtENdVZKkSK319irdB7KCv7xPn0nreCnPcRFeyQjEfvlqr4upM114FXCBDtuMikw0CIqU"
+        "wVVXStQjgVbaj5W+"
+        "TvZ1AUoHiHJGT0cNRqpvkgPit1bSUF3WYSQNuiaLJrZMt816Ho5ZG6hDttZf3gfueAFg6a"
+        "Un4SfK8dEHhikaVkR8vR5mgP8CPf1frIHIH62x0CAQDGHJeODTABWLS7XI8xFEAj3mf1hE"
+        "WcDyBRvvawqlpkfRzKUZZoRG4cdaYF5d2gA4s2LQBOraKq1oGC5KNbxBTqJxCJP66lDtTn"
+        "EycVwkaiZABwp8wQeUYb2kEvAoy+"
+        "wPlYEw5oF285hFM1HQfOSKqu7NZgaEAz1kXcrPNtg8nR8ZcuYg58BpjvUetMfy0Rl9+"
+        "ad0lqV6TWMA3ikZsRA8Nb5YHpVeV2Vqm8JU8ZBLF8o0so85kFlW4Mb9D+OhXAkqzWA/"
+        "X4ZR44agys4tQD0dLZSfeA5RhCkXEcDKO8QQuuUqoTWhcRaVD8ZtNWIM+no/"
+        "jBCO9mV26aRVTv4CXYnbTDYsxOh1rbHoOq6MCxR65DxV5ac70LGg6dQtfu4M6HqOqOL50V"
+        "1zDHv/EH0h+0U90iQ05zhQrNODt+G3WH4FIeBmS7NoOLzo/"
+        "lECXZa6UgrTP5rPLBILEA1o8ri+AhMCLqhdaqnlLglbF4J/"
+        "p5x7ey5+ammXCJi+jksMLhkTXeGAGP2FZWPnDHBgAv5u8I7atTJOcaACCiF+/"
+        "Z1jEcoQscXzpjEAyN5upSWeWGO8b4vsZQ9SvOi825LlgaARZZjmqDPCfbHRlFpomIMuwny"
+        "JNSClzAgEgVYrnUCjTK+bTf8flrkfpj1PHoEgDsCX8Q/"
+        "dFZA2cyVBEtYQixtwEYhGJx8OsU3OlsouTorl77iH6S9vopUXsSu4S+r9mDgmKiQLu4+"
+        "Ubc7fxqGgBOAMmF88kB4R+"
+        "lKlf1qqWAfsdRXo4pLfB7asEgOVYt5PDRQzmQHk7AVRKRRyVMbWiz5de77vQy5uZ/"
+        "Lj+PWgAQAAA=";
+    const auto decoded = base64_to_string(payload);
+    iobuf b;
+    b.append(decoded.data(), decoded.size());
+    gzip_stream_decompressor gsd{make_iobuf_input_stream(std::move(b)), 4096};
+    gsd.reset();
+    auto output = consume(gsd);
+    ASSERT_TRUE(gsd.eof());
+    ASSERT_THAT(output, testing::HasSubstr("Call me Ishmael."));
+    gsd.stop().get();
+}


### PR DESCRIPTION
The following three utilities are added in this PR:

* inventory report parser
* inventory report consumer
* ntp hash loader


A report parser is added which will accept an input stream created during a report download, and fetch lines from it and provide them to a consumer. The report may optionally be gzip compressed, in this case it is decompressed while being read from the stream.

The inventory report consumer takes an input stream (or potentially multiple streams one after another) created from a report download, extracts rows from the stream using the report parser and converts them to path hashes. It then writes the path hashes to files per NTP on disk, making sure that total size held in memory is kept below a threshold by periodically flushing contents to disk.

The hash loader given an NTP, finds the correct file written by the inventory report consumer, reads the hashes from the file and populates a set in memory. The loader also identifies potential hash collisions and keeps track of them. It provides a query method which given a path responds if the path was:

* in the inventory report
* missing from the report
* is a possible hash collision

The scrubber will use the hash loader and is expected to make HEAD requests for the second and third cases above.

The inventory service (under development in https://github.com/redpanda-data/redpanda/pull/19860) will use the consumer to write incoming reports to disk.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
