### PR TITLE
[CORE-3185] schema registry - json compatibility checks for "enum"

### DIFF
--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -696,11 +696,7 @@ bool is_superset(json::Value const& older, json::Value const& newer) {
     }
 
     for (auto not_yet_handled_keyword : {
-           "id",
            "$schema",
-           "title",
-           "description",
-           "default",
            "additionalItems",
            "items",
            "maxItems",

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -247,6 +247,16 @@ static constexpr auto compatibility_test_cases
       .writer_schema = R"({"type": "string", "pattern": "^test"})",
       .reader_is_compatible_with_writer = true,
     },
+    // metadata is ignored
+    {
+      .reader_schema
+      = R"({"title": "myschema", "description": "this is my schema",
+            "default": true, "type": "boolean"})",
+      .writer_schema
+      = R"({"title": "MySchema", "description": "this schema is mine",
+            "default": false, "type": "boolean"})",
+      .reader_is_compatible_with_writer = true,
+    },
   });
 SEASTAR_THREAD_TEST_CASE(test_compatibility_check) {
     store_fixture f;

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -186,6 +186,12 @@ static constexpr auto compatibility_test_cases
       .writer_schema = R"({"type": "string", "pattern": "^test  +"})",
       .reader_is_compatible_with_writer = false,
     },
+    // enum checks
+    {
+      .reader_schema = R"({"type": "integer", "enum": [1, 2, 4]})",
+      .writer_schema = R"({"type": "integer", "enum": [4, 1, 3]})",
+      .reader_is_compatible_with_writer = false,
+    },
     //***** compatible section *****
     // same type
     {
@@ -255,6 +261,12 @@ static constexpr auto compatibility_test_cases
       .writer_schema
       = R"({"title": "MySchema", "description": "this schema is mine",
             "default": false, "type": "boolean"})",
+      .reader_is_compatible_with_writer = true,
+    },
+    // enum checks
+    {
+      .reader_schema = R"({"type": "integer", "enum": [1, 2, 4]})",
+      .writer_schema = R"({"type": "integer", "enum": [4, 1]})",
       .reader_is_compatible_with_writer = true,
     },
   });


### PR DESCRIPTION
extend check_compatible() to support the "enum" keyword.

check_compatible(reader, writer) iff
both are not "enum" schema
or
both are "enum" schema and every value in writer["enum"] is also in reader["enum"]

the current implementation is an O(n²) lookup, and for object values the equality is implemented as a O(n²) recursive operation.
The cardinality is usually low so this operation is ok, but this will be improved once normalization (field sorting) and <=> on normalized objects are implemented

Fixes https://redpandadata.atlassian.net/browse/CORE-3185

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

* none