### PR TITLE
schema_registry: Disable Fast partition movement for `_schemas`

### DIFF
--- a/src/v/pandaproxy/schema_registry/service.cc
+++ b/src/v/pandaproxy/schema_registry/service.cc
@@ -549,10 +549,10 @@ ss::future<> service::create_internal_topic() {
              .value{retain_forever}},
             {.name{ss::sstring{
                kafka::topic_property_initial_retention_local_target_bytes}},
-             .value{retain_forever}},
+             .value{std::nullopt}},
             {.name{ss::sstring{
                kafka::topic_property_initial_retention_local_target_ms}},
-             .value{retain_forever}}}};
+             .value{std::nullopt}}}};
     };
     auto res = co_await _client.local().create_topic(make_internal_topic());
     if (res.data.topics.size() != 1) {


### PR DESCRIPTION
Fast partition movement was enabled for `_schemas` topic with: https://github.com/redpanda-data/redpanda/pull/13941

Disable fast partition movement when creating the `_schemas` topic.

### Note to reviewer:
I don't think this works:
```
SUMMARY
=======
NAME        _schemas
PARTITIONS  1
REPLICAS    1

CONFIGS
=======
KEY        
cleanup.policy                        compact     DYNAMIC_TOPIC_CONFIG
compression.type                      none        DYNAMIC_TOPIC_CONFIG
flush.bytes                           262144      DEFAULT_CONFIG
flush.ms                              100         DEFAULT_CONFIG
initial.retention.local.target.bytes  -1          DEFAULT_CONFIG
initial.retention.local.target.ms     -1          DEFAULT_CONFIG
max.message.bytes                     1048576     DEFAULT_CONFIG
message.timestamp.type                CreateTime  DEFAULT_CONFIG
redpanda.remote.delete                true        DEFAULT_CONFIG
redpanda.remote.read                  false       DEFAULT_CONFIG
redpanda.remote.write                 false       DEFAULT_CONFIG
retention.bytes                       -1          DYNAMIC_TOPIC_CONFIG
retention.local.target.bytes          -1          DYNAMIC_TOPIC_CONFIG
retention.local.target.ms             -1          DYNAMIC_TOPIC_CONFIG
retention.ms                          -1          DYNAMIC_TOPIC_CONFIG
segment.bytes                         268435456   DEFAULT_CONFIG
segment.ms                            1209600000  DEFAULT_CONFIG
write.caching                         false       DEFAULT_CONFIG
```

Previously the values were:
```
initial.retention.local.target.bytes  -1          DYNAMIC_TOPIC_CONFIG
initial.retention.local.target.ms     -1          DYNAMIC_TOPIC_CONFIG
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Schema Registry: Disable fast partition movement when creating the `_schemas` topic.