### PR TITLE
CORE-4269 Quotas: add latency benchmarks

### DIFF
--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -120,7 +120,7 @@ rp_test(
   BENCHMARK_TEST
   BINARY_NAME quota_manager
   SOURCES quota_manager_bench.cc
-  LIBRARIES Seastar::seastar_perf_testing Boost::unit_test_framework v::application
+  LIBRARIES Seastar::seastar_perf_testing Boost::unit_test_framework v::kafka
 
   # the args below are just to keep it fast
   ARGS "-c 1 --duration=1 --runs=1 --memory=4G"

--- a/src/v/kafka/server/tests/CMakeLists.txt
+++ b/src/v/kafka/server/tests/CMakeLists.txt
@@ -123,6 +123,6 @@ rp_test(
   LIBRARIES Seastar::seastar_perf_testing Boost::unit_test_framework v::kafka
 
   # the args below are just to keep it fast
-  ARGS "-c 1 --duration=1 --runs=1 --memory=4G"
+  ARGS "-c 2 --duration=1 --runs=1 --memory=4G"
   LABELS kafka
 )

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -8,6 +8,7 @@
  * the Business Source License, use of this software will be governed
  * by the Apache License, Version 2.0
  */
+#include "cluster/client_quota_serde.h"
 #include "cluster/client_quota_store.h"
 #include "config/configuration.h"
 #include "kafka/server/quota_manager.h"
@@ -16,6 +17,8 @@
 #include <seastar/coroutine/maybe_yield.hh>
 #include <seastar/testing/perf_tests.hh>
 #include <seastar/util/later.hh>
+
+#include <fmt/format.h>
 
 #include <iostream>
 #include <limits>
@@ -133,5 +136,334 @@ PERF_TEST_CN(throughput_group, test_quota_manager_off_unique) {
     return run_tc(throughput_test_case{
       .fetch_tp = std::nullopt,
       .use_unique = true,
+    });
+}
+
+struct latency_test_case {
+    bool is_new_client;
+    bool is_produce_not_fetch;
+    int n_other_clients;
+    bool on_shard_0;
+    bool no_quotas;
+};
+
+const static size_t n_repeats = 100;
+
+future<size_t> run_latency_test(latency_test_case tc) {
+    ss::sharded<cluster::client_quota::store> quota_store;
+    kafka::quota_manager::client_quotas_t buckets_map;
+    ss::sharded<kafka::quota_manager> sqm;
+    co_await quota_store.start();
+    co_await sqm.start(std::ref(buckets_map), std::ref(quota_store));
+    co_await sqm.invoke_on_all(&kafka::quota_manager::start);
+
+    auto shard = tc.on_shard_0 ? 0 : 1;
+    BOOST_ASSERT_MSG(
+      shard < ss::smp::count, "Not enough cores available for the benchmark");
+
+    co_await ss::smp::submit_to(
+      shard,
+      // NOLINTNEXTLINE(cppcoreguidelines-avoid-capturing-lambda-coroutines)
+      seastar::coroutine::lambda([&sqm, &quota_store, tc]() -> ss::future<> {
+          auto& qm = sqm.local();
+
+          // Try to create a realistic setup
+          if (!tc.no_quotas) {
+              using cluster::client_quota::entity_key;
+              using cluster::client_quota::entity_value;
+              auto key = entity_key{entity_key::client_id_default_match{}};
+              auto value = entity_value{
+                .producer_byte_rate = 1 << 30, .consumer_byte_rate = 1 << 30};
+              co_await quota_store.invoke_on_all(
+                [&key, &value](cluster::client_quota::store& qs) {
+                    qs.set_quota(key, value);
+                });
+          }
+
+          auto now = kafka::quota_manager::clock::now();
+
+          // Have a non-trivial number of existing clients in the map
+          for (int i = 0; i < tc.n_other_clients; i++) {
+              co_await qm.record_produce_tp_and_throttle(
+                fmt::format("client-{}", i), 1, now);
+          }
+
+          // Pre-generate the client-id's used during the benchmark
+          auto client_ids = std::vector<ss::sstring>{};
+          client_ids.reserve(n_repeats);
+          if (tc.is_new_client) {
+              for (int i = 0; i < n_repeats; i++) {
+                  client_ids.emplace_back(fmt::format("new-client-{}", i));
+              }
+          } else {
+              for (int i = 0; i < n_repeats; i++) {
+                  client_ids.emplace_back(fixed_client_id);
+              }
+              // Ensure that the client id used is already "known"
+              co_await qm.record_produce_tp_and_throttle(
+                fixed_client_id, 1, now);
+          }
+
+          perf_tests::start_measuring_time();
+
+          // Run repeatedly to reduce the overhead of start/stop_measuring_time
+          for (int i = 0; i < n_repeats; i++) {
+              if (tc.is_produce_not_fetch) {
+                  // Produce
+                  auto res = co_await qm.record_produce_tp_and_throttle(
+                    client_ids[i], 1, now);
+                  perf_tests::do_not_optimize(res);
+              } else {
+                  // Fetch
+                  auto res = co_await qm.throttle_fetch_tp(client_ids[i], now);
+                  perf_tests::do_not_optimize(res);
+                  co_await qm.record_fetch_tp(client_ids[i], 1, now);
+              }
+          }
+
+          perf_tests::stop_measuring_time();
+      }));
+
+    co_await sqm.stop();
+    co_await quota_store.stop();
+
+    co_return n_repeats;
+}
+
+struct latency_group {};
+
+PERF_TEST_CN(latency_group, existing_client_produce_100_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 100,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_fetch_100_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 100,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_produce_100_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 100,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_fetch_100_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 100,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_produce_1000_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 1000,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_fetch_1000_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 1000,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_produce_1000_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 1000,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_fetch_1000_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 1000,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_produce_10000_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 10000,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_fetch_10000_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 10000,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_produce_10000_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 10000,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_fetch_10000_others) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 10000,
+      .on_shard_0 = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_produce_100_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 100,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_fetch_100_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 100,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_produce_100_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 100,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_fetch_100_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 100,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_produce_1000_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 1000,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_fetch_1000_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 1000,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_produce_1000_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 1000,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_fetch_1000_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 1000,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_produce_10000_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 10000,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, existing_client_fetch_10000_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = false,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 10000,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_produce_10000_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 10000,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, new_client_fetch_10000_others_not_shard_0) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 10000,
+      .on_shard_0 = false,
+    });
+}
+
+PERF_TEST_CN(latency_group, default_configs_produce_worst) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = true,
+      .n_other_clients = 0,
+      .on_shard_0 = false,
+      .no_quotas = true,
+    });
+}
+
+PERF_TEST_CN(latency_group, default_configs_fetch_worst) {
+    return run_latency_test(latency_test_case{
+      .is_new_client = true,
+      .is_produce_not_fetch = false,
+      .n_other_clients = 0,
+      .on_shard_0 = false,
+      .no_quotas = true,
     });
 }


### PR DESCRIPTION
The existing benchmarks around quota manager are effectively measuring
the throughput of recording client quotas because they measure an
average latency across a large number of runs on multiple cores.

This adds more microbenchmarks around quota manager that are more aimed
at measuring the latency of recording client quotas because they make a
low number of calls to quota_manager and measure it many times. The new
benchmarks also cover a wider range of scenarios, trying to trigger
various worst cases of client quota throttling.

### Benchmark results

The latency benchmarks clearly highlight that with >=1000 client ids in the map, the map copying becomes very expensive. I have a follow-up PR to avoid this (https://github.com/redpanda-data/redpanda/pull/19941). The next biggest latency factor is the cross-shard `invoke_on()` adding on the order of ~2us. Furthermore, there are a few allocations on the hot path - the ones that I could detect so far are in the creation of the `entity_key`'s `absl::flat_hash_set` and the `entity_key::part`'s string copies inside `client_quota_translator`.

```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          32
random seed:              910598060

test                                                            iterations      median         mad         min         max      allocs       tasks        inst
throughput_group.test_quota_manager_on_unlimited_shared           41943040    30.046ns     0.034ns    28.910ns    30.080ns       0.656       0.000       205.8
throughput_group.test_quota_manager_on_unlimited_unique           52428800    23.716ns     0.844ns    22.382ns    25.668ns       0.319       0.001       195.9
throughput_group.test_quota_manager_on_limited_shared             41943040    29.774ns     0.192ns    28.722ns    30.487ns       0.656       0.000       206.3
throughput_group.test_quota_manager_on_limited_unique             41943040    23.453ns     1.009ns    22.444ns    24.808ns       0.319       0.001       196.3
throughput_group.test_quota_manager_off_shared                    41943040    22.983ns     0.265ns    22.717ns    23.853ns       0.531       0.000       154.8
throughput_group.test_quota_manager_off_unique                    52428800    21.420ns     0.106ns    21.059ns    21.527ns       0.263       0.001       161.0
latency_group.existing_client_produce_100_others                     53800   311.323ns     0.141ns   311.087ns   324.849ns      11.000       0.000      3807.7
latency_group.existing_client_fetch_100_others                       52900   615.206ns     8.428ns   606.778ns   633.733ns      22.000       0.000      7471.9
latency_group.new_client_produce_100_others                          33200    12.340us   369.234ns    11.948us    15.226us     199.510       7.049     84324.1
latency_group.new_client_fetch_100_others                            32600    12.607us   103.789ns    12.478us    13.573us     204.510       7.050     87601.8
latency_group.existing_client_produce_1000_others                     3300   314.942ns     0.601ns   313.178ns   318.884ns      11.000       0.002      3811.1
latency_group.existing_client_fetch_1000_others                       4300   612.837ns     7.702ns   605.135ns   746.002ns      22.000       0.004      7479.8
latency_group.new_client_produce_1000_others                          3700    39.338us   221.473ns    39.117us    48.772us    1099.500       7.080    367760.7
latency_group.new_client_fetch_1000_others                            3700    40.131us   296.165ns    39.300us    51.641us    1104.500       7.087    371495.9
latency_group.existing_client_produce_10000_others                     100   211.080ns     6.610ns   203.800ns   256.400ns      11.000       0.000      3807.7
latency_group.existing_client_fetch_10000_others                       100   610.490ns   163.780ns   396.570ns   774.270ns      22.000       0.004      7480.0
latency_group.new_client_produce_10000_others                          100   348.980us   984.130ns   340.793us   353.052us   10099.500       7.060   3156697.0
latency_group.new_client_fetch_10000_others                            100   348.492us     2.304us   343.639us   359.006us   10104.500       7.050   3163616.6
latency_group.existing_client_produce_100_others_not_shard_0         47000   331.363ns     1.126ns   328.551ns   343.110ns      11.000       0.000      2299.0
latency_group.existing_client_fetch_100_others_not_shard_0           36200   642.933ns     3.705ns   633.810ns   647.724ns      22.000       0.000      4536.8
latency_group.new_client_produce_100_others_not_shard_0              27700    15.398us   275.368ns    15.111us    18.499us       6.000       4.000     95304.2
latency_group.new_client_fetch_100_others_not_shard_0                27500    15.439us    27.381ns    15.412us    17.675us      11.000       4.002     96944.9
latency_group.existing_client_produce_1000_others_not_shard_0         3800   340.481ns     2.430ns   336.433ns   424.011ns      11.000       0.001      2330.8
latency_group.existing_client_fetch_1000_others_not_shard_0           3700   677.772ns    11.319ns   655.850ns   804.149ns      22.000       0.003      4630.5
latency_group.new_client_produce_1000_others_not_shard_0              3200    44.276us     1.436us    42.840us    48.290us       6.000       4.000    377731.8
latency_group.new_client_fetch_1000_others_not_shard_0                3200    43.582us   158.793ns    43.423us    51.895us      11.000       4.001    381313.4
latency_group.existing_client_produce_10000_others_not_shard_0         100   388.090ns     2.910ns   385.180ns   395.830ns      11.000       0.000      2729.2
latency_group.existing_client_fetch_10000_others_not_shard_0           100   781.810ns     2.690ns   684.660ns   787.670ns      22.000       0.000      5630.2
latency_group.new_client_produce_10000_others_not_shard_0              100   417.769us     2.168us   415.601us   480.368us       6.000       4.000   3162343.3
latency_group.new_client_fetch_10000_others_not_shard_0                100   419.680us   825.210ns   418.855us   423.894us      11.000       4.000   3169235.6
latency_group.default_configs_produce_worst                          40600    12.595us   120.663ns    12.474us    99.020us       5.010       4.000    112919.7
latency_group.default_configs_fetch_worst                           120300   306.073ns     3.930ns   302.144ns   370.509ns       6.000       0.000      2209.0
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
