### PR TITLE
CORE-4269 Quotas: avoid map copies when adding new quota trackers

### DIFF
--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -536,32 +536,6 @@ void quota_manager::gc() {
         });
 }
 
-namespace {
-
-/// A simplified copy paste of `std::set_intersection`. Copied here because we
-/// rely on the fact that we're allowed to have first1 == result for in-place
-/// set intersection in `do_gc()` which the contract of `std::set_intersection`
-/// does not allow despite that its implementation does.
-/// Requires: the inputs to be sorted
-/// Guarantees: the output to be sorted
-template<typename It1, typename It2, typename ItR>
-ItR set_intersection(It1 first1, It1 last1, It2 first2, It2 last2, ItR result) {
-    while (first1 != last1 && first2 != last2) {
-        if (*first1 < *first2) {
-            ++first1;
-        } else if (*first2 < *first1) {
-            ++first2;
-        } else { // *first1 == *first2
-            *result = *first1;
-            ++first1;
-            ++first2;
-        }
-    }
-    return result;
-}
-
-} // namespace
-
 ss::future<> quota_manager::do_global_gc() {
     vassert(
       ss::this_shard_id() == quotas_shard,

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -128,7 +128,8 @@ private:
     // erase inactive tracked quotas. windows are considered inactive if they
     // have not received any updates in ten window's worth of time.
     void gc();
-    ss::future<> do_gc(clock::time_point expire_threshold);
+    ss::future<> do_local_gc(clock::time_point expire_threshold);
+    ss::future<> do_global_gc();
 
     ss::future<clock::duration> maybe_add_and_retrieve_quota(
       tracker_key quota_id,

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -13,11 +13,11 @@
 #include "base/seastarx.h"
 #include "config/client_group_byte_rate_quota.h"
 #include "config/property.h"
+#include "container/chunked_hash_map.h"
 #include "kafka/server/atomic_token_bucket.h"
 #include "kafka/server/client_quota_translator.h"
-#include "ssx/sharded_ptr.h"
 #include "ssx/sharded_value.h"
-#include "utils/absl_sstring_hash.h"
+#include "utils/mutex.h"
 
 #include <seastar/core/future.hh>
 #include <seastar/core/lowres_clock.hh>
@@ -27,8 +27,6 @@
 #include <seastar/core/timer.hh>
 #include <seastar/util/noncopyable_function.hh>
 #include <seastar/util/shared_token_bucket.hh>
-
-#include <absl/container/node_hash_map.h>
 
 #include <chrono>
 #include <memory>
@@ -73,12 +71,13 @@ public:
         std::optional<atomic_token_bucket> pm_rate;
     };
 
-    using client_quotas_map_t
-      = absl::node_hash_map<tracker_key, ss::lw_shared_ptr<client_quota>>;
-    using client_quotas_t = ssx::sharded_ptr<client_quotas_map_t>;
+    using local_map_t
+      = chunked_hash_map<tracker_key, std::shared_ptr<client_quota>>;
 
-    quota_manager(
-      client_quotas_t& client_quotas,
+    using global_map_t
+      = chunked_hash_map<tracker_key, std::shared_ptr<client_quota>>;
+
+    explicit quota_manager(
       ss::sharded<cluster::client_quota::store>& client_quota_store);
     quota_manager(const quota_manager&) = delete;
     quota_manager& operator=(const quota_manager&) = delete;
@@ -115,6 +114,8 @@ public:
       uint32_t mutations,
       clock::time_point now = clock::now());
 
+    const std::optional<global_map_t>& get_global_map_for_testing() const;
+
 private:
     using quota_mutation_callback_t
       = ss::noncopyable_function<clock::duration(client_quota&)>;
@@ -133,14 +134,17 @@ private:
       tracker_key quota_id,
       clock::time_point now,
       quota_mutation_callback_t cb);
-    ss::future<> add_quota_id(tracker_key quota_id, clock::time_point now);
+    ss::future<std::shared_ptr<quota_manager::client_quota>>
+    add_quota_id(tracker_key quota_id, clock::time_point now);
     void update_client_quotas();
+    ss::future<> do_update_client_quotas();
 
     config::binding<int16_t> _default_num_windows;
     config::binding<std::chrono::milliseconds> _default_window_width;
     config::binding<std::optional<int64_t>> _replenish_threshold;
 
-    client_quotas_t& _client_quotas;
+    local_map_t _local_map;
+    std::optional<global_map_t> _global_map; // Only on shard 0
     client_quota_translator _translator;
     std::unique_ptr<client_quotas_probe<clock>> _probe;
 
@@ -148,6 +152,7 @@ private:
     clock::duration _gc_freq;
     config::binding<std::chrono::milliseconds> _max_delay;
     ss::gate _gate;
+    std::optional<mutex> _global_map_mutex; // Only on shard 0
 };
 
 } // namespace kafka

--- a/src/v/kafka/server/tests/quota_manager_bench.cc
+++ b/src/v/kafka/server/tests/quota_manager_bench.cc
@@ -66,10 +66,9 @@ send_requests(kafka::quota_manager& qm, size_t count, bool use_unique) {
 
 ss::future<> test_quota_manager(size_t count, bool use_unique) {
     ss::sharded<cluster::client_quota::store> quota_store;
-    kafka::quota_manager::client_quotas_t buckets_map;
     ss::sharded<kafka::quota_manager> sqm;
     co_await quota_store.start();
-    co_await sqm.start(std::ref(buckets_map), std::ref(quota_store));
+    co_await sqm.start(std::ref(quota_store));
     co_await sqm.invoke_on_all(&kafka::quota_manager::start);
 
     perf_tests::start_measuring_time();
@@ -151,10 +150,9 @@ const static size_t n_repeats = 100;
 
 future<size_t> run_latency_test(latency_test_case tc) {
     ss::sharded<cluster::client_quota::store> quota_store;
-    kafka::quota_manager::client_quotas_t buckets_map;
     ss::sharded<kafka::quota_manager> sqm;
     co_await quota_store.start();
-    co_await sqm.start(std::ref(buckets_map), std::ref(quota_store));
+    co_await sqm.start(std::ref(quota_store));
     co_await sqm.invoke_on_all(&kafka::quota_manager::start);
 
     auto shard = tc.on_shard_0 ? 0 : 1;

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -1717,11 +1717,7 @@ void application::wire_up_redpanda_services(
 
     // metrics and quota management
     syschecks::systemd_message("Adding kafka quota managers").get();
-    construct_service(
-      quota_mgr,
-      std::ref(quota_mgr_state),
-      std::ref(controller->get_quota_store()))
-      .get();
+    construct_service(quota_mgr, std::ref(controller->get_quota_store())).get();
     construct_service(snc_quota_mgr, std::ref(snc_node_quota)).get();
 
     syschecks::systemd_message("Creating auditing subsystem").get();

--- a/src/v/redpanda/application.h
+++ b/src/v/redpanda/application.h
@@ -31,7 +31,6 @@
 #include "kafka/client/configuration.h"
 #include "kafka/client/fwd.h"
 #include "kafka/server/fwd.h"
-#include "kafka/server/quota_manager.h"
 #include "kafka/server/snc_quota_manager.h"
 #include "metrics/aggregate_metrics_watcher.h"
 #include "metrics/metrics.h"
@@ -159,7 +158,6 @@ public:
 
     ss::sharded<kafka::coordinator_ntp_mapper> coordinator_ntp_mapper;
     ss::sharded<kafka::group_router> group_router;
-    kafka::quota_manager::client_quotas_t quota_mgr_state;
     ss::sharded<kafka::quota_manager> quota_mgr;
     kafka::snc_quota_manager::buckets_t snc_node_quota;
     ss::sharded<kafka::snc_quota_manager> snc_quota_mgr;


### PR DESCRIPTION
This PR changes the way client quota tracking is implemented inside quota_manager in order to avoid taking copies of the quota tracker map on the request path, since this was identified as high-latency during benchmarking (see https://github.com/redpanda-data/redpanda/pull/19940 for data).

The problem with representing the quota tracker map as a single `ssx::sharded_ptr<map_t>` of immutable `map_t`'s is that we need to make sure that updates to the map are done on copies, all cores are referencing the same map. Instead, what we can do is we can have 2 types of maps: a single "global" map that contains references to all the existing quota trackers and local maps on each shard that only reference quotas that the local core comes across. Updates to the global map are only done on shard 0 (a lot like updates to the `ssx::sharded_ptr<map_t>` were only done on shard 0). Whenever there is a miss in the local map and there's a need to insert it into the local map, we go to shard 0, insert a new quota into the global map if one doesn't already exist, and return a reference to the quota to the caller shard which can insert it into its local map. Garbage collecting long-not-seen client ids is implemented by gc'ing the local maps independently and then gc'ing the global map where we can remove a quota tracker when no local map references it.

Fixes https://redpandadata.atlassian.net/browse/CORE-4269

### Benchmark results

With this PR, the microbenchmarks show that we avoid the high added latency of map copies we saw in the previous benchmarks on https://github.com/redpanda-data/redpanda/pull/19940.

```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          32
random seed:              2263596557

test                                                            iterations      median         mad         min         max      allocs       tasks        inst
throughput_group.test_quota_manager_on_unlimited_shared           31457280    30.225ns     0.097ns    30.128ns    31.696ns       0.656       0.000       204.6
throughput_group.test_quota_manager_on_unlimited_unique           41943040    25.529ns     0.027ns    25.346ns    25.556ns       0.251       0.003       168.3
throughput_group.test_quota_manager_on_limited_shared             31457280    31.516ns     0.177ns    31.339ns    32.484ns       0.656       0.000       205.1
throughput_group.test_quota_manager_on_limited_unique             41943040    26.033ns     0.039ns    25.994ns    26.447ns       0.251       0.003       168.2
throughput_group.test_quota_manager_off_shared                    52428800    20.154ns     0.015ns    20.139ns    20.183ns       0.531       0.000       154.2
throughput_group.test_quota_manager_off_unique                    73400320    16.035ns     0.065ns    15.925ns    16.129ns       0.188       0.002       121.3
latency_group.existing_client_produce_100_others                    107000   307.161ns     0.139ns   306.974ns   307.564ns      11.000       0.000      3795.7
latency_group.existing_client_fetch_100_others                      103100   597.473ns     0.222ns   597.033ns   597.723ns      22.000       0.000      7447.7
latency_group.new_client_produce_100_others                         103700   726.334ns     1.411ns   724.922ns   761.838ns      11.040       0.000      7893.9
latency_group.new_client_fetch_100_others                           100400   989.760ns     0.540ns   988.897ns     1.234us      16.040       0.003     10912.3
latency_group.existing_client_produce_1000_others                    67100   180.730ns     0.187ns   180.186ns   180.917ns      11.000       0.000      3781.7
latency_group.existing_client_fetch_1000_others                      62700   362.774ns     0.302ns   362.362ns   363.522ns      22.000       0.000      7419.7
latency_group.new_client_produce_1000_others                         66700   537.177ns     0.342ns   536.801ns   537.947ns      11.020       0.000      8244.5
latency_group.new_client_fetch_1000_others                           65300   708.079ns     0.935ns   706.968ns   710.781ns      16.020       0.000     11249.2
latency_group.existing_client_produce_10000_others                   14400   190.390ns     0.582ns   187.803ns   191.267ns      11.000       0.002      3812.6
latency_group.existing_client_fetch_10000_others                     14100   379.501ns     2.403ns   375.826ns   384.663ns      22.000       0.002      7478.1
latency_group.new_client_produce_10000_others                        13800   541.229ns     3.199ns   520.437ns   571.278ns      11.000       0.003      7305.0
latency_group.new_client_fetch_10000_others                          14600   672.157ns     3.421ns   668.735ns   704.212ns      16.000       0.004     10311.2
latency_group.existing_client_produce_100_others_not_shard_0         81800   339.712ns     0.039ns   339.569ns   339.751ns      11.000       0.000      2812.9
latency_group.existing_client_fetch_100_others_not_shard_0           80800   660.603ns     0.438ns   659.780ns   661.053ns      22.000       0.000      5563.0
latency_group.new_client_produce_100_others_not_shard_0              71000     2.605us     0.178ns     2.605us     2.609us       6.020       3.000     19026.9
latency_group.new_client_fetch_100_others_not_shard_0                69200     2.999us     5.997ns     2.993us     3.016us      11.020       3.002     21764.9
latency_group.existing_client_produce_1000_others_not_shard_0        25800   346.265ns     1.099ns   345.166ns   347.997ns      11.000       0.000      2854.0
latency_group.existing_client_fetch_1000_others_not_shard_0          25500   675.072ns     0.970ns   674.070ns   676.589ns      22.000       0.000      5662.4
latency_group.new_client_produce_1000_others_not_shard_0             24500     2.722us     6.623ns     2.714us     2.736us       6.010       3.000     19368.2
latency_group.new_client_fetch_1000_others_not_shard_0               24200     3.134us     2.753ns     3.124us     3.136us      11.010       3.002     22230.7
latency_group.existing_client_produce_10000_others_not_shard_0        3500   351.470ns     0.338ns   350.206ns   354.284ns      11.000       0.001      2879.0
latency_group.existing_client_fetch_10000_others_not_shard_0          3500   693.170ns     0.996ns   689.071ns   698.699ns      22.000       0.002      5724.5
latency_group.new_client_produce_10000_others_not_shard_0             3400     2.724us     9.236ns     2.698us     2.734us       6.000       3.000     18367.6
latency_group.new_client_fetch_10000_others_not_shard_0               3400     3.011us    25.512ns     2.982us     3.037us      11.000       3.002     20695.1
latency_group.default_configs_produce_worst                          90200     2.923us     0.876ns     2.918us     2.927us       5.150       3.000     17811.4
latency_group.default_configs_fetch_worst                           121000   301.977ns     0.179ns   301.398ns   328.324ns       6.000       0.000      2034.7
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
