### PR TITLE
rpk registry: accept JSON files when creating schemas

### DIFF
--- a/src/go/rpk/pkg/cli/registry/schema/check_compatibility.go
+++ b/src/go/rpk/pkg/cli/registry/schema/check_compatibility.go
@@ -34,7 +34,7 @@ func newCheckCompatibilityCommand(fs afero.Fs, p *config.Params) *cobra.Command 
 		sversion   string
 	)
 	cmd := &cobra.Command{
-		Use:   "check-compatibility SUBJECT",
+		Use:   "check-compatibility [SUBJECT]",
 		Short: "Check schema compatibility with existing schemas in the subject",
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
@@ -80,7 +80,7 @@ func newCheckCompatibilityCommand(fs afero.Fs, p *config.Params) *cobra.Command 
 		},
 	}
 
-	cmd.Flags().StringVar(&schemaFile, "schema", "", "Schema filepath to check, must be .avro or .proto")
+	cmd.Flags().StringVar(&schemaFile, "schema", "", "Schema filepath to check, must be .avro, .json, or .proto")
 	cmd.Flags().StringVar(&schemaType, "type", "", fmt.Sprintf("Schema type (%v); overrides schema file extension", strings.Join(supportedTypes, ",")))
 	cmd.Flags().StringVar(&sversion, "schema-version", "", "Schema version to check compatibility with (latest, 0, 1...)")
 	cmd.Flags().StringVar(&refs, "references", "", "Comma-separated list of references (name:subject:version) or path to reference file")

--- a/src/go/rpk/pkg/cli/registry/schema/create.go
+++ b/src/go/rpk/pkg/cli/registry/schema/create.go
@@ -35,8 +35,8 @@ func newCreateCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 
 This uploads a schema to the registry, creating the schema if it does not
 exist. The schema type is detected by the filename extension: ".avro" or ".avsc"
-for Avro and ".proto" for Protobuf. You can manually specify the type with the 
---type flag.
+for Avro, ".json" for JSON, and ".proto" for Protobuf. You can manually specify 
+the type with the --type flag.
 
 You may pass the references using the --reference flag, which accepts either a
 comma separated list of <name>:<subject>:<version> or a path to a file. The file 
@@ -67,11 +67,11 @@ version 1:
 			cl, err := schemaregistry.NewClient(fs, p)
 			out.MaybeDie(err, "unable to initialize schema registry client: %v", err)
 
-			file, err := os.ReadFile(schemaFile)
-			out.MaybeDie(err, "unable to read %q: %v", schemaFile, err)
-
 			t, err := resolveSchemaType(schemaType, schemaFile)
 			out.MaybeDieErr(err)
+
+			file, err := os.ReadFile(schemaFile)
+			out.MaybeDie(err, "unable to read %q: %v", schemaFile, err)
 
 			references, err := parseReferenceFlag(fs, refs)
 			out.MaybeDie(err, "unable to parse reference flag %q: %v", refs, err)

--- a/src/go/rpk/pkg/cli/registry/schema/get.go
+++ b/src/go/rpk/pkg/cli/registry/schema/get.go
@@ -134,7 +134,7 @@ To print the schema, use the '--print-schema' flag.
 
 	cmd.Flags().StringVar(&sversion, "schema-version", "", "Schema version to lookup (latest, 0, 1...); subject required")
 	cmd.Flags().IntVar(&id, "id", 0, "ID to lookup schemas usages of; subject optional")
-	cmd.Flags().StringVar(&schemaFile, "schema", "", "Schema file to check existence of, must be .avro or .proto; subject required")
+	cmd.Flags().StringVar(&schemaFile, "schema", "", "Schema file to check existence of, must be .avro, .json or .proto; subject required")
 	cmd.Flags().StringVar(&schemaType, "type", "", fmt.Sprintf("Schema type of the file used to lookup (%v); overrides schema file extension", strings.Join(supportedTypes, ",")))
 	cmd.Flags().BoolVar(&deleted, "deleted", false, "If true, also return deleted schemas")
 	cmd.Flags().BoolVar(&printSchema, "print-schema", false, "If true, print the schema JSON")

--- a/src/go/rpk/pkg/cli/registry/schema/schema.go
+++ b/src/go/rpk/pkg/cli/registry/schema/schema.go
@@ -21,7 +21,7 @@ import (
 	"github.com/twmb/franz-go/pkg/sr"
 )
 
-var supportedTypes = []string{"avro", "protobuf"}
+var supportedTypes = []string{"avro", "protobuf", "json"}
 
 func NewCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 	cmd := &cobra.Command{
@@ -117,6 +117,8 @@ func typeFromFlag(typeFlag string) (sr.SchemaType, error) {
 		return sr.TypeAvro, nil
 	case "proto", "protobuf":
 		return sr.TypeProtobuf, nil
+	case "json":
+		return sr.TypeJSON, nil
 	default:
 		return 0, fmt.Errorf("unrecognized type %q", typeFlag)
 	}
@@ -128,6 +130,8 @@ func typeFromFile(schemaFile string) (sr.SchemaType, error) {
 		return sr.TypeAvro, nil
 	case strings.HasSuffix(schemaFile, ".proto") || strings.HasSuffix(schemaFile, ".protobuf"):
 		return sr.TypeProtobuf, nil
+	case strings.HasSuffix(schemaFile, ".json"):
+		return sr.TypeJSON, nil
 	default:
 		return 0, fmt.Errorf("unable to determine the schema type from %q", schemaFile)
 	}


### PR DESCRIPTION
This allows `rpk registry` to read/create/list JSON schemas.

First step to support JSON schemas in `rpk`. Next step is to support producing and consuming.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x


I'll add release notes with the PR that introduce support for producing and consuming (once we have the JSON schema support in Redpanda)

## Release Notes

* none
