### PR TITLE
rpk: improve help text and minor bug fix

### DIFF
--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -119,10 +119,11 @@ Start a three-broker cluster:
 Start a single-broker cluster, selecting random ports for every listener:
   rpk container start --any-port
 
-Start a three-broker cluster, selecting the seed kafka and console port only:
+Start a three-broker cluster, selecting the seed Kafka and Redpanda Console 
+ports only:
   rpk container start --kafka-ports 9092 --console-port 8080
 
-Start a three-broker cluster, selecting every admin API port:
+Start a three-broker cluster, selecting the Admin API port for each broker:
   rpk container start --admin-ports 9644,9645,9646
 `,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
@@ -187,7 +188,7 @@ You can retry profile creation by running:
 		},
 	}
 
-	command.Flags().UintVarP(&nodes, "nodes", "n", 1, "The number of brokers(nodes) to start")
+	command.Flags().UintVarP(&nodes, "nodes", "n", 1, "The number of brokers (nodes) to start")
 	command.Flags().UintVar(&retries, "retries", 10, "The amount of times to check for the cluster before considering it unstable and exiting")
 	command.Flags().StringVar(&image, "image", common.DefaultRedpandaImage(), "An arbitrary Redpanda container image to use")
 	command.Flags().StringVar(&consoleImage, "console-image", common.DefaultConsoleImage(), "An arbitrary Redpanda Console container image to use")
@@ -322,9 +323,9 @@ func startCluster(
 		seedID,
 		nodeAddr(seedKafkaPort),
 	}
-	kafkaAddr := []string{fmt.Sprintf("%v:%d", seedState.ContainerIP, seedKafkaPort)}
-	srAddr := []string{fmt.Sprintf("http://rp-node-%d:%d", seedID, seedSchemaRegPort)}
-	adminAddr := []string{fmt.Sprintf("http://rp-node-%d:%d", seedID, seedAdminPort)}
+	kafkaAddr := []string{fmt.Sprintf("%v:%d", seedState.ContainerIP, config.DefaultKafkaPort)}
+	srAddr := []string{fmt.Sprintf("http://rp-node-%d:%d", seedID, config.DefaultSchemaRegPort)}
+	adminAddr := []string{fmt.Sprintf("http://rp-node-%d:%d", seedID, config.DefaultAdminPort)}
 
 	nodes := []node{seedNode}
 
@@ -374,9 +375,9 @@ func startCluster(
 				id:   id,
 				addr: nodeAddr(state.HostKafkaPort),
 			})
-			kafkaAddr = append(kafkaAddr, fmt.Sprintf("%v:%d", state.ContainerIP, kafkaPort))
-			srAddr = append(srAddr, fmt.Sprintf("http://rp-node-%d:%d", id, schemaRegPort))
-			adminAddr = append(adminAddr, fmt.Sprintf("http://rp-node-%d:%d", id, adminPort))
+			kafkaAddr = append(kafkaAddr, fmt.Sprintf("%v:%d", state.ContainerIP, config.DefaultKafkaPort))
+			srAddr = append(srAddr, fmt.Sprintf("http://rp-node-%d:%d", id, config.DefaultSchemaRegPort))
+			adminAddr = append(adminAddr, fmt.Sprintf("http://rp-node-%d:%d", id, config.DefaultAdminPort))
 			mu.Unlock()
 			return nil
 		})

--- a/src/go/rpk/pkg/cli/container/start.go
+++ b/src/go/rpk/pkg/cli/container/start.go
@@ -87,8 +87,9 @@ func newStartCommand(fs afero.Fs, p *config.Params) *cobra.Command {
 		Short: "Start a local container cluster",
 		Long: `Start a local container cluster.
 
-This command utilizes Docker to initiate a local container cluster. Use the
-'--nodes'/'-n' flag to specify the number of brokers.
+This command uses Docker to initiate a local Redpanda container cluster,
+including Redpanda Console. Use the '--nodes'/'-n' flag to specify the number of
+brokers.
 
 The initial broker starts on default ports, with subsequent brokers' ports
 offset by 1000. You can use the listeners flag to specify ports:
@@ -98,27 +99,30 @@ offset by 1000. You can use the listeners flag to specify ports:
   * --rpc-ports
   * --schema-registry-ports
   * --proxy-ports
+  * --console-port
 
 Each flag accepts a comma-separated list of ports for your listeners. Use the
-'--any-port' flag to let rpk select random available ports on the host machine.
+'--any-port' flag to let rpk select random available ports for every listener on
+the host machine.
 
-Optionally, specify a container image; the default image is
-redpandadata/redpanda:latest.
+By default, this command uses the redpandadata/redpanda:latest and 
+redpandadata/console:latest container images. You can specify a container image 
+by using the '--image' flag.
 
 In case of IP address pool conflict, you may specify a custom subnet and gateway
 using the '--subnet' and '--gateway' flags respectively.
 `,
 		Example: `
-Start a 3-broker cluster:
+Start a three-broker cluster:
   rpk container start -n 3
 
-Start a 1-broker cluster, selecting random ports for every listener:
+Start a single-broker cluster, selecting random ports for every listener:
   rpk container start --any-port
 
-Start a 3-broker cluster, selecting the seed kafka and console port only:
+Start a three-broker cluster, selecting the seed kafka and console port only:
   rpk container start --kafka-ports 9092 --console-port 8080
 
-Start a 3-broker cluster, selecting every admin API port:
+Start a three-broker cluster, selecting every admin API port:
   rpk container start --admin-ports 9644,9645,9646
 `,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
@@ -183,17 +187,17 @@ You can retry profile creation by running:
 		},
 	}
 
-	command.Flags().UintVarP(&nodes, "nodes", "n", 1, "The number of nodes to start")
+	command.Flags().UintVarP(&nodes, "nodes", "n", 1, "The number of brokers(nodes) to start")
 	command.Flags().UintVar(&retries, "retries", 10, "The amount of times to check for the cluster before considering it unstable and exiting")
-	command.Flags().StringVar(&image, "image", common.DefaultRedpandaImage(), "An arbitrary container Redpanda image to use")
-	command.Flags().StringVar(&consoleImage, "console-image", common.DefaultConsoleImage(), "An arbitrary container Redpanda Console image to use")
+	command.Flags().StringVar(&image, "image", common.DefaultRedpandaImage(), "An arbitrary Redpanda container image to use")
+	command.Flags().StringVar(&consoleImage, "console-image", common.DefaultConsoleImage(), "An arbitrary Redpanda Console container image to use")
 	command.Flags().BoolVar(&pull, "pull", false, "Force pull the container image used")
 	command.Flags().BoolVar(&noProfile, "no-profile", false, "If true, rpk will not create an rpk profile after creating a cluster")
 	command.Flags().String("set", "", "Redpanda configuration property to set upon start. Follows 'rpk redpanda config set' format")
 	command.Flags().StringSliceVar(&kPorts, flagKafkaPorts, nil, "Kafka protocol ports to listen on; check help text for more information")
 	command.Flags().StringSliceVar(&aPorts, flagAdminPorts, nil, "Redpanda Admin API ports to listen on; check help text for more information")
-	command.Flags().StringSliceVar(&srPorts, flagSRPorts, nil, "Schema registry ports to listen on; check help text for more information")
-	command.Flags().StringSliceVar(&pPorts, flagProxyPorts, nil, "Pandaproxy ports to listen on; check help text for more information")
+	command.Flags().StringSliceVar(&srPorts, flagSRPorts, nil, "Schema Registry ports to listen on; check help text for more information")
+	command.Flags().StringSliceVar(&pPorts, flagProxyPorts, nil, "HTTP Proxy ports to listen on; check help text for more information")
 	command.Flags().StringSliceVar(&rPorts, flagRPCPorts, nil, "RPC ports to listen on; check help text for more information")
 	command.Flags().StringVar(&consolePort, flagConsolePort, "8080", "Redpanda console ports to listen on; check help text for more information")
 	// opt-in for 'any' in all listeners


### PR DESCRIPTION
This brings the documentation changes from https://github.com/redpanda-data/docs/pull/559/files to rpk codebase.

Also fixes a bug that prevented `--any-port` from working with console when using a cluster with more than 1 node.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [X] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


### Bug Fixes

* rpk: fixed a bug that prevented `--any-port` from working with Redpanda Console when using a cluster with more than 1 node.
