### PR TITLE
[v24.1.x] kafka: fix timequery failing for empty topics

### DIFF
--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -467,8 +467,8 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         assert not any([e > 0 for e in errors])
 
     @cluster(num_nodes=4)
-    # @parametrize(cloud_storage=True, spillover=False)
-    # @parametrize(cloud_storage=True, spillover=True)
+    @parametrize(cloud_storage=True, spillover=False)
+    @parametrize(cloud_storage=True, spillover=True)
     @parametrize(cloud_storage=False, spillover=False)
     def test_timequery_with_trim_prefix(self, cloud_storage: bool,
                                         spillover: bool):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/19937
