### PR TITLE
[v23.3.x] kafka: fix timequery failing for empty topics

### DIFF
--- a/src/v/kafka/server/handlers/list_offsets.cc
+++ b/src/v/kafka/server/handlers/list_offsets.cc
@@ -19,6 +19,7 @@
 #include "kafka/server/replicated_partition.h"
 #include "kafka/server/request_context.h"
 #include "kafka/server/response.h"
+#include "model/fundamental.h"
 #include "model/namespace.h"
 #include "resource_mgmt/io_priority.h"
 #include "utils/fragmented_vector.h"
@@ -129,10 +130,22 @@ static ss::future<list_offset_partition_response> list_offsets_partition(
           offset,
           kafka_partition->leader_epoch());
     }
+    auto min_offset = kafka_partition->start_offset();
+    auto max_offset = model::prev_offset(offset);
+
+    // Empty partition.
+    if (max_offset < min_offset) {
+        co_return list_offsets_response::make_partition(
+          ktp.get_partition(),
+          model::timestamp(-1),
+          model::offset(-1),
+          kafka_partition->leader_epoch());
+    }
+
     auto res = co_await kafka_partition->timequery(storage::timequery_config{
-      kafka_partition->start_offset(),
+      min_offset,
       timestamp,
-      model::prev_offset(offset),
+      max_offset,
       kafka_read_priority(),
       {model::record_batch_type::raft_data},
       octx.rctx.abort_source().local()});

--- a/tests/rptest/tests/timequery_test.py
+++ b/tests/rptest/tests/timequery_test.py
@@ -467,8 +467,8 @@ class TimeQueryTest(RedpandaTest, BaseTimeQuery):
         assert not any([e > 0 for e in errors])
 
     @cluster(num_nodes=4)
-    # @parametrize(cloud_storage=True, spillover=False)
-    # @parametrize(cloud_storage=True, spillover=True)
+    @parametrize(cloud_storage=True, spillover=False)
+    @parametrize(cloud_storage=True, spillover=True)
     @parametrize(cloud_storage=False, spillover=False)
     def test_timequery_with_trim_prefix(self, cloud_storage: bool,
                                         spillover: bool):


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/19937
