### PR TITLE
[CORE-4729] schema_registry: Wire up JSON Schema support

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -305,7 +305,7 @@ get_schemas_types(server::request_t rq, server::reply_t rp) {
     rq.req.reset();
 
     static const std::vector<std::string_view> schemas_types{
-      "PROTOBUF", "AVRO"};
+      "JSON", "PROTOBUF", "AVRO"};
     auto json_rslt = ppj::rjson_serialize(schemas_types);
     rp.rep->write_body("json", json_rslt);
     return ss::make_ready_future<server::reply_t>(std::move(rp));

--- a/src/v/pandaproxy/schema_registry/test/get_schema_types.cc
+++ b/src/v/pandaproxy/schema_registry/test/get_schema_types.cc
@@ -30,7 +30,7 @@ FIXTURE_TEST(schema_registry_get_schema_types, pandaproxy_test_fixture) {
         auto res = http_request(client, "/schemas/types");
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
-        BOOST_REQUIRE_EQUAL(res.body, R"(["PROTOBUF","AVRO"])");
+        BOOST_REQUIRE_EQUAL(res.body, R"(["JSON","PROTOBUF","AVRO"])");
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
           to_header_value(ppj::serialization_format::schema_registry_v1_json));
@@ -46,7 +46,7 @@ FIXTURE_TEST(schema_registry_get_schema_types, pandaproxy_test_fixture) {
           ppj::serialization_format::schema_registry_json);
         BOOST_REQUIRE_EQUAL(
           res.headers.result(), boost::beast::http::status::ok);
-        BOOST_REQUIRE_EQUAL(res.body, R"(["PROTOBUF","AVRO"])");
+        BOOST_REQUIRE_EQUAL(res.body, R"(["JSON","PROTOBUF","AVRO"])");
         BOOST_REQUIRE_EQUAL(
           res.headers.at(boost::beast::http::field::content_type),
           to_header_value(ppj::serialization_format::schema_registry_json));

--- a/src/v/pandaproxy/schema_registry/types.h
+++ b/src/v/pandaproxy/schema_registry/types.h
@@ -277,8 +277,10 @@ private:
 
 ///\brief A schema that has been validated.
 class valid_schema {
-    using impl
-      = std::variant<avro_schema_definition, protobuf_schema_definition>;
+    using impl = std::variant<
+      avro_schema_definition,
+      protobuf_schema_definition,
+      json_schema_definition>;
 
     template<typename T>
     using disable_if_valid_schema = std::

--- a/tests/rptest/tests/rpk_registry_test.py
+++ b/tests/rptest/tests/rpk_registry_test.py
@@ -40,6 +40,8 @@ message Test2 {
   Simple id =  1;
 }"""
 
+json_number_schema_def = '{"type": "number"}'
+
 
 class RpkRegistryTest(RedpandaTest):
     username = "red"
@@ -112,6 +114,7 @@ class RpkRegistryTest(RedpandaTest):
         subject_1 = "test_subject_1"
         subject_2 = "test_subject_2"
         subject_3 = "test_subject_3"
+        subject_4 = "test_subject_4"
 
         self.create_schema(subject_1, schema1_avro_def,
                            ".avro")  # version: 1, ID: 1
@@ -199,6 +202,14 @@ class RpkRegistryTest(RedpandaTest):
         self._rpk.delete_schema(subject_1, version="1", permanent=True)
         out = self._rpk.list_schemas(deleted=True)
         assert not find_subject(out, subject_1)  # Not in the deleted list.
+
+        self.create_schema(subject_4, json_number_schema_def,
+                           ".json")  # version: 1, ID: 4
+        out = self._rpk.get_schema(subject_4, version="1")
+        assert len(out) == 1
+        assert out[0]["subject"] == subject_4
+        assert out[0]["id"] == 4
+        assert out[0]["type"] == "JSON"
 
     @cluster(num_nodes=1)
     def test_registry_compatibility_level(self):


### PR DESCRIPTION
Support is currently quite restricted, it's not ready yet.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
