### PR TITLE
Transfer leadership before stepping down after reconfiguration

### DIFF
--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -3027,6 +3027,10 @@ ss::future<> consensus::maybe_commit_configuration(ssx::semaphore_units u) {
           _ctxlog.trace,
           "current node is not longer group member, stepping down");
         do_step_down("not_longer_member");
+        if (_leader_id) {
+            _leader_id = std::nullopt;
+            trigger_leadership_notification();
+        }
     }
 }
 

--- a/src/v/raft/consensus.cc
+++ b/src/v/raft/consensus.cc
@@ -57,6 +57,7 @@
 #include <chrono>
 #include <iterator>
 #include <optional>
+#include <ranges>
 #include <system_error>
 
 template<>
@@ -3026,7 +3027,7 @@ ss::future<> consensus::maybe_commit_configuration(ssx::semaphore_units u) {
         vlog(
           _ctxlog.trace,
           "current node is not longer group member, stepping down");
-        do_step_down("not_longer_member");
+        co_await transfer_and_stepdown("no_longer_member");
         if (_leader_id) {
             _leader_id = std::nullopt;
             trigger_leadership_notification();
@@ -3574,6 +3575,67 @@ consensus::do_transfer_leadership(transfer_leadership_request req) {
     });
 
     return f.finally([this] { _transferring_leadership = false; });
+}
+
+ss::future<> consensus::transfer_and_stepdown(std::string_view ctx) {
+    // select a follower with longest log
+    auto voters = _fstats
+                  | std::views::filter(
+                    [](const follower_stats::container_t::value_type& p) {
+                        return !p.second.is_learner;
+                    });
+    auto it = std::max_element(
+      voters.begin(), voters.end(), [](const auto& a, const auto& b) {
+          return a.second.last_dirty_log_index < b.second.last_dirty_log_index;
+      });
+
+    if (unlikely(it == voters.end())) {
+        vlog(
+          _ctxlog.warn,
+          "Unable to find a follower that would be an eligible candidate to "
+          "take over the leadership");
+        do_step_down(ctx);
+        co_return;
+    }
+
+    const auto target = it->first;
+    vlog(
+      _ctxlog.info,
+      "[{}] stepping down as leader in term {}, dirty offset {}, with "
+      "leadership transfer to {}",
+      ctx,
+      _term,
+      _log->offsets().dirty_offset,
+      target);
+
+    timeout_now_request req{
+      .target_node_id = target,
+      .node_id = _self,
+      .group = _group,
+      .term = _term,
+    };
+    auto timeout = raft::clock_type::now()
+                   + config::shard_local_cfg().raft_timeout_now_timeout_ms();
+    auto r = co_await _client_protocol.timeout_now(
+      target.id(), std::move(req), rpc::client_opts(timeout));
+
+    if (r.has_error()) {
+        vlog(
+          _ctxlog.warn,
+          "[{}] stepping down - failed to request timeout_now from {} - "
+          "{}",
+          ctx,
+          target,
+          r.error().message());
+    } else {
+        vlog(
+          _ctxlog.trace,
+          "[{}]  stepping down - timeout now reply result: {} from node {}",
+          ctx,
+          r.value(),
+          target);
+    }
+    do_step_down(ctx);
 }
 
 ss::future<> consensus::remove_persistent_state() {

--- a/src/v/raft/consensus.h
+++ b/src/v/raft/consensus.h
@@ -549,6 +549,9 @@ private:
     // all these private functions assume that we are under exclusive operations
     // via the _op_sem
     void do_step_down(std::string_view);
+    // steps down and requests the other replica to start leader election
+    // immediately
+    ss::future<> transfer_and_stepdown(std::string_view);
     ss::future<vote_reply> do_vote(vote_request);
     ss::future<append_entries_reply>
     do_append_entries(append_entries_request&&);

--- a/src/v/raft/tests/basic_raft_fixture_test.cc
+++ b/src/v/raft/tests/basic_raft_fixture_test.cc
@@ -20,7 +20,11 @@
 #include "test_utils/async.h"
 #include "test_utils/test.h"
 
+#include <seastar/core/circular_buffer.hh>
+
 #include <algorithm>
+#include <chrono>
+#include <ranges>
 
 using namespace raft;
 
@@ -695,4 +699,115 @@ TEST_F_CORO(raft_fixture, test_delayed_snapshot_request) {
     co_await tests::cooperative_spin_wait_with_timeout(10s, [&] {
         return nodes().begin()->second->raft()->term() > term_snapshot;
     });
+}
+
+TEST_F_CORO(raft_fixture, leadership_transfer_delay) {
+    set_election_timeout(1500ms);
+    co_await create_simple_group(4);
+    auto replicate_some_data = [&] {
+        return retry_with_leader(
+                 10s + model::timeout_clock::now(),
+                 [this](raft_node_instance& leader_node) {
+                     return leader_node.raft()->replicate(
+                       make_batches(10, 10, 128),
+                       replicate_options(consistency_level::quorum_ack));
+                 })
+          .then([&](result<replicate_result> result) {
+              if (result) {
+                  vlog(
+                    tstlog.info,
+                    "replication result last offset: {}",
+                    result.value().last_offset);
+              } else {
+                  vlog(
+                    tstlog.info,
+                    "replication error: {}",
+                    result.error().message());
+              }
+          });
+    };
+    using clock_t = std::chrono::high_resolution_clock;
+    co_await replicate_some_data();
+    struct leadership_changed_event {
+        model::node_id node;
+        leadership_status status;
+        clock_t::time_point timestamp;
+    };
+    ss::circular_buffer<leadership_changed_event> events;
+
+    register_leader_callback([&](model::node_id id, leadership_status status) {
+        events.push_back(leadership_changed_event{
+          .node = id,
+          .status = status,
+          .timestamp = clock_t::now(),
+        });
+    });
+    auto leader_id = get_leader().value();
+    auto& leader_node = node(leader_id);
+    auto current_term = leader_node.raft()->term();
+    auto r = co_await leader_node.raft()->transfer_leadership(
+      transfer_leadership_request{.group = leader_node.raft()->group()});
+    ASSERT_TRUE_CORO(r.success);
+    // here we wait for all the replicas to notify about the leadership changes,
+    // each replica will notify two times, one when there is no leader, second
+    // time when the leader is elected. We have 4 replicas so in total we expect
+    // 8 notifications to be fired.
+    co_await tests::cooperative_spin_wait_with_timeout(
+      10s, [&] { return events.size() >= 8; });
+
+    // calculate the time needed to transfer leadership, in our case it is the
+    // time between first notification reporting no leader and first reporting
+    // new leader.
+    auto new_leader_reported_ev = std::find_if(
+      events.begin(), events.end(), [&](leadership_changed_event& ev) {
+          return ev.status.current_leader.has_value()
+                 && ev.status.term > current_term;
+      });
+
+    auto transfer_time = new_leader_reported_ev->timestamp
+                         - events.begin()->timestamp;
+    vlog(
+      tstlog.info,
+      "leadership_transfer - new leader reported after: {} ms",
+      (transfer_time) / 1ms);
+    events.clear();
+    // now remove the current leader from the raft group
+    leader_id = get_leader().value();
+    auto new_nodes = all_vnodes() | std::views::filter([&](vnode n) {
+                         return n.id() != leader_id;
+                     });
+    auto& new_leader_node = node(leader_id);
+    current_term = new_leader_node.raft()->term();
+    co_await new_leader_node.raft()->replace_configuration(
+      std::vector<vnode>{new_nodes.begin(), new_nodes.end()},
+      model::revision_id(2));
+    // analogically to the previous case we wait for 6 notifications as
+    // currently the group has only 3 replicas
+    co_await tests::cooperative_spin_wait_with_timeout(
+      10s, [&] { return events.size() >= 6; });
+
+    auto leader_reported_after_reconfiguration = std::find_if(
+      events.begin(), events.end(), [&](leadership_changed_event& ev) {
+          return ev.status.current_leader.has_value()
+                 && ev.status.term > current_term;
+      });
+
+    auto election_time = leader_reported_after_reconfiguration->timestamp
+                         - events.begin()->timestamp;
+    vlog(
+      tstlog.info,
+      "reconfiguration - new leader reported after: {} ms",
+      (election_time) / 1ms);
+
+    for (auto& vn : all_vnodes()) {
+        co_await stop_node(vn.id());
+    }
+
+    auto tolerance = 0.15;
+    /**
+     * Validate that election time  after reconfiguration is simillar to the
+     * time needed for leadership transfer
+     */
+    ASSERT_LE_CORO(election_time, transfer_time * (1.0 + tolerance));
+    ASSERT_GE_CORO(election_time, transfer_time * (1.0 - tolerance));
 }

--- a/src/v/raft/tests/raft_fixture.cc
+++ b/src/v/raft/tests/raft_fixture.cc
@@ -360,27 +360,18 @@ raft_node_instance::raft_node_instance(
   raft_node_map& node_map,
   ss::sharded<features::feature_table>& feature_table,
   leader_update_clb_t leader_update_clb,
-  bool enable_longest_log_detection)
-  : _id(id)
-  , _revision(revision)
-  , _logger(test_log, fmt::format("[node: {}]", _id))
-  , _base_directory(fmt::format(
-      "test_raft_{}_{}", _id, random_generators::gen_alphanum_string(12)))
-  , _protocol(ss::make_shared<in_memory_test_protocol>(node_map, _logger))
-  , _features(feature_table)
-  , _recovery_mem_quota([] {
-      return raft::recovery_memory_quota::configuration{
-        .max_recovery_memory = config::mock_binding<std::optional<size_t>>(
-          200_MiB),
-        .default_read_buffer_size = config::mock_binding<size_t>(128_KiB),
-      };
-  })
-  , _recovery_scheduler(
-      config::mock_binding<size_t>(64), config::mock_binding(10ms))
-  , _leader_clb(std::move(leader_update_clb))
-  , _enable_longest_log_detection(enable_longest_log_detection) {
-    config::shard_local_cfg().disable_metrics.set_value(true);
-}
+  bool enable_longest_log_detection,
+  std::chrono::milliseconds election_timeout)
+  : raft_node_instance(
+    id,
+    revision,
+    fmt::format(
+      "test_raft_{}_{}", _id, random_generators::gen_alphanum_string(12)),
+    node_map,
+    feature_table,
+    std::move(leader_update_clb),
+    enable_longest_log_detection,
+    election_timeout) {}
 
 raft_node_instance::raft_node_instance(
   model::node_id id,
@@ -389,7 +380,8 @@ raft_node_instance::raft_node_instance(
   raft_node_map& node_map,
   ss::sharded<features::feature_table>& feature_table,
   leader_update_clb_t leader_update_clb,
-  bool enable_longest_log_detection)
+  bool enable_longest_log_detection,
+  std::chrono::milliseconds election_timeout)
   : _id(id)
   , _revision(revision)
   , _logger(test_log, fmt::format("[node: {}]", _id))
@@ -406,14 +398,16 @@ raft_node_instance::raft_node_instance(
   , _recovery_scheduler(
       config::mock_binding<size_t>(64), config::mock_binding(10ms))
   , _leader_clb(std::move(leader_update_clb))
-  , _enable_longest_log_detection(enable_longest_log_detection) {
+  , _enable_longest_log_detection(enable_longest_log_detection)
+  , _election_timeout(
+      config::mock_binding<std::chrono::milliseconds>(election_timeout)) {
     config::shard_local_cfg().disable_metrics.set_value(true);
 }
 
 ss::future<>
 raft_node_instance::initialise(std::vector<raft::vnode> initial_nodes) {
     _hb_manager = std::make_unique<heartbeat_manager>(
-      config::mock_binding<std::chrono::milliseconds>(50ms),
+      config::mock_binding<std::chrono::milliseconds>(_election_timeout() / 10),
       consensus_client_protocol(_protocol),
       _id,
       config::mock_binding<std::chrono::milliseconds>(1000ms),
@@ -597,8 +591,14 @@ raft_fixture::add_node(model::node_id id, model::revision_id rev) {
       rev,
       *this,
       _features,
-      [id, this](leadership_status lst) { _leaders_view[id] = lst; },
-      _enable_longest_log_detection);
+      [id, this](leadership_status lst) {
+          _leaders_view[id] = lst;
+          if (_leader_clb) {
+              _leader_clb.value()(id, lst);
+          }
+      },
+      _enable_longest_log_detection,
+      _election_timeout);
 
     auto [it, success] = _nodes.emplace(id, std::move(instance));
     return *it->second;
@@ -612,8 +612,14 @@ raft_node_instance& raft_fixture::add_node(
       std::move(base_dir),
       *this,
       _features,
-      [id, this](leadership_status lst) { _leaders_view[id] = lst; },
-      _enable_longest_log_detection);
+      [id, this](leadership_status lst) {
+          _leaders_view[id] = lst;
+          if (_leader_clb) {
+              _leader_clb.value()(id, lst);
+          }
+      },
+      _enable_longest_log_detection,
+      _election_timeout);
 
     auto [it, success] = _nodes.emplace(id, std::move(instance));
     return *it->second;

--- a/src/v/raft/tests/raft_fixture.h
+++ b/src/v/raft/tests/raft_fixture.h
@@ -169,7 +169,8 @@ public:
       raft_node_map& node_map,
       ss::sharded<features::feature_table>& feature_table,
       leader_update_clb_t leader_update_clb,
-      bool enable_longest_log_detection);
+      bool enable_longest_log_detection,
+      std::chrono::milliseconds election_timeout);
 
     raft_node_instance(
       model::node_id id,
@@ -177,7 +178,8 @@ public:
       raft_node_map& node_map,
       ss::sharded<features::feature_table>& feature_table,
       leader_update_clb_t leader_update_clb,
-      bool enable_longest_log_detection);
+      bool enable_longest_log_detection,
+      std::chrono::milliseconds election_timeout);
 
     raft_node_instance(const raft_node_instance&) = delete;
     raft_node_instance(raft_node_instance&&) noexcept = delete;
@@ -249,8 +251,6 @@ private:
     ss::sstring _base_directory;
     ss::shared_ptr<in_memory_test_protocol> _protocol;
     ss::sharded<storage::api> _storage;
-    config::binding<std::chrono::milliseconds> _election_timeout
-      = config::mock_binding(500ms);
     ss::sharded<features::feature_table>& _features;
     ss::sharded<coordinated_recovery_throttle> _recovery_throttle;
     recovery_memory_quota _recovery_mem_quota;
@@ -260,12 +260,15 @@ private:
     ss::lw_shared_ptr<consensus> _raft;
     bool started = false;
     bool _enable_longest_log_detection;
+    config::binding<std::chrono::milliseconds> _election_timeout;
 };
 
 class raft_fixture
   : public seastar_test
   , public raft_node_map {
 public:
+    using leader_update_clb_t
+      = ss::noncopyable_function<void(model::node_id, leadership_status)>;
     raft_fixture()
       : _logger("raft-fixture") {}
     using raft_nodes_t = absl::
@@ -526,6 +529,14 @@ public:
         _enable_longest_log_detection = value;
     }
 
+    void register_leader_callback(leader_update_clb_t clb) {
+        _leader_clb = std::move(clb);
+    }
+
+    void set_election_timeout(std::chrono::milliseconds timeout) {
+        _election_timeout = timeout;
+    }
+
 private:
     void validate_leaders();
 
@@ -536,6 +547,8 @@ private:
 
     ss::sharded<features::feature_table> _features;
     bool _enable_longest_log_detection = true;
+    std::optional<leader_update_clb_t> _leader_clb;
+    std::chrono::milliseconds _election_timeout = 500ms;
 };
 
 template<class... STM>


### PR DESCRIPTION
When a node currently being a raft group leader is not a part of new
configuration it must step down and become a follower. When stepping
down a leader stops sending heartbeats to the followers allowing them to
trigger election. The election starts only after an election timeout
elapsed on on of the followers. This makes the whole process
slow and during the whole time clients can not write and read from the
raft group as it is leaderless. To address this issue a new method of
step down was introduced. The new stepdown implementation which is
going to be used for reconfiguration requests one of the followers to
timeout immediately and trigger leader election. This speeds up the
whole process and makes it much less disruptive as the stepdown is now
comparable to leadership transfer.

Time to elect a leader before the fix: 
```
INFO  2024-06-24 11:19:34,717 [shard  0:main] raft_test - basic_raft_fixture_test.cc:782 - leadership_transfer - new leader reported after: 74 ms
```
after reconfiguration:
```
INFO  2024-06-24 11:19:36,607 [shard  0:main] raft_test - basic_raft_fixture_test.cc:815 - reconfiguration - new leader reported after: 1690 ms
```

with the fix: 
```
INFO  2024-06-24 12:14:45,170 [shard  0:main] raft_test - basic_raft_fixture_test.cc:817 - reconfiguration - new leader reported after: 66 ms
```


<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

### Improvements
- Made leadership changes related with reconfiguration faster and less disruptive 