### PR TITLE
storage/tests: fix `min_size` value in `test_offset_range_size_incremental`

### DIFF
--- a/src/v/storage/tests/storage_e2e_test.cc
+++ b/src/v/storage/tests/storage_e2e_test.cc
@@ -4604,7 +4604,7 @@ FIXTURE_TEST(test_offset_range_size_incremental, storage_test_fixture) {
     };
     std::vector<size_target> size_classes = {
       {100, 0, 100},
-      {2000, 1_KiB, 2000},
+      {2000, 256, 2000},
       {10_KiB, 1_KiB, 10_KiB},
       {50_KiB, 1_KiB, 50_KiB},
       {500_KiB, 1_KiB, 500_KiB},


### PR DESCRIPTION
We were undershooting a `min_size` target for one of the storage test cases consistently in CI. Reduce its value to be more permissive for the test case.

Fixes #18496 

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

