### PR TITLE
CORE-3046 Quotas: implement deprecated notice for quota configs

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -500,7 +500,7 @@ configuration::configuration()
       {.needs_restart = needs_restart::no,
        .example = "1073741824",
        .visibility = visibility::user},
-      2_GiB,
+      target_produce_quota_byte_rate_default,
       {.min = 1_MiB})
   , target_fetch_quota_byte_rate(
       *this,

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -46,6 +46,8 @@ namespace config {
 /// can not depend on any other module to prevent cyclic dependencies.
 
 struct configuration final : public config_store {
+    constexpr static auto target_produce_quota_byte_rate_default = 2_GiB;
+
     // WAL
     bounded_property<uint64_t> log_segment_size;
     property<std::optional<uint64_t>> log_segment_size_min;

--- a/src/v/kafka/server/client_quota_translator.h
+++ b/src/v/kafka/server/client_quota_translator.h
@@ -145,6 +145,8 @@ private:
     using quota_config
       = std::unordered_map<ss::sstring, config::client_group_quota>;
 
+    using config_callback = std::function<void(void)>;
+
     const quota_config& get_quota_config(client_quota_type qt) const;
     std::optional<uint64_t> get_default_config(client_quota_type qt) const;
 
@@ -153,6 +155,7 @@ private:
 
     ss::sharded<cluster::client_quota::store>& _quota_store;
 
+    std::vector<config_callback> _config_callbacks;
     config::binding<uint32_t> _default_target_produce_tp_rate;
     config::binding<std::optional<uint32_t>> _default_target_fetch_tp_rate;
     config::binding<std::optional<uint32_t>> _target_partition_mutation_quota;

--- a/src/v/kafka/server/client_quota_translator.h
+++ b/src/v/kafka/server/client_quota_translator.h
@@ -153,6 +153,8 @@ private:
     client_quota_value get_client_quota_value(
       const tracker_key& quota_id, client_quota_type qt) const;
 
+    void maybe_log_deprecated_configs_nag() const;
+
     ss::sharded<cluster::client_quota::store>& _quota_store;
 
     std::vector<config_callback> _config_callbacks;

--- a/src/v/kafka/server/tests/client_quota_translator_test.cc
+++ b/src/v/kafka/server/tests/client_quota_translator_test.cc
@@ -427,3 +427,20 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_priority_order) {
       53,
       client_quota_rule::kafka_client_id);
 }
+
+SEASTAR_THREAD_TEST_CASE(quota_translator_watch_test) {
+    reset_configs();
+
+    fixture f;
+
+    bool first_called = false;
+    bool second_called = false;
+
+    f.tr.watch([&first_called]() mutable { first_called = true; });
+    f.tr.watch([&second_called]() mutable { second_called = true; });
+
+    config::shard_local_cfg().target_quota_byte_rate.set_value(P_DEF);
+
+    BOOST_CHECK(first_called);
+    BOOST_CHECK(second_called);
+}

--- a/tests/rptest/tests/client_quota_deprecated_configs_test.py
+++ b/tests/rptest/tests/client_quota_deprecated_configs_test.py
@@ -1,0 +1,50 @@
+# Copyright 2024 Redpanda Data, Inc.
+#
+# Use of this software is governed by the Business Source License
+# included in the file licenses/BSL.md
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0
+
+from rptest.util import wait_until_result
+from rptest.tests.redpanda_test import RedpandaTest
+from rptest.services.cluster import cluster
+from rptest.services.redpanda import RedpandaService
+
+NON_DEFAULT_QUOTA_CONFIGS = {"target_fetch_quota_byte_rate": 10240}
+
+
+def _has_config_nag(redpanda: RedpandaService):
+    return redpanda.search_log_any(
+        "You have configured client quotas using cluster configs.*")
+
+
+class ClientQuotaDeprecatedConfigs_ConfigUpdateTest(RedpandaTest):
+    @cluster(num_nodes=3)
+    def test_config_update(self):
+        assert not _has_config_nag(self.redpanda), \
+            f"We should not see the nag with the default configs"
+
+        self.redpanda.set_cluster_config(NON_DEFAULT_QUOTA_CONFIGS)
+
+        wait_until_result(
+            lambda: _has_config_nag(self.redpanda),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timeout waiting for config nag to show up in the logs")
+
+
+class ClientQuotaDeprecatedConfigs_StartupTest(RedpandaTest):
+    def __init__(self, *args, **kwargs):
+        super().__init__(extra_rp_conf=NON_DEFAULT_QUOTA_CONFIGS,
+                         *args,
+                         **kwargs)
+
+    @cluster(num_nodes=3)
+    def test_startup(self):
+        wait_until_result(
+            lambda: _has_config_nag(self.redpanda),
+            timeout_sec=30,
+            backoff_sec=1,
+            err_msg="Timeout waiting for config nag to show up in the logs")


### PR DESCRIPTION
This adds a warning log message to remind operators that the client quotas are now node-wide and that they are going to be deprecated in v25.1.

Fixes https://redpandadata.atlassian.net/browse/CORE-3046

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
