### PR TITLE
Transforms: Fix deploy-time timequery bug

### DIFF
--- a/src/v/transform/api.cc
+++ b/src/v/transform/api.cc
@@ -147,7 +147,7 @@ public:
         return model::offset_cast(model::prev_offset(result.value()));
     }
 
-    ss::future<kafka::offset>
+    ss::future<std::optional<kafka::offset>>
     offset_at_timestamp(model::timestamp ts, ss::abort_source* as) final {
         auto result = co_await _partition.timequery(storage::timequery_config(
           _partition.start_offset(),
@@ -158,7 +158,7 @@ public:
           /*as=*/*as,
           /*client_addr=*/std::nullopt));
         if (!result.has_value()) {
-            co_return kafka::offset::min();
+            co_return std::nullopt;
         }
         co_return model::offset_cast(result->offset);
     }

--- a/src/v/transform/io.h
+++ b/src/v/transform/io.h
@@ -55,9 +55,10 @@ public:
 
     /**
      * The offset of a record the log for a given timestamp - if the log is
-     * empty then `kafka::offset::min()` is returned.
+     * empty or the timestamp is greater than max_timestamp, then std::nullopt
+     * is returned.
      */
-    virtual ss::future<kafka::offset>
+    virtual ss::future<std::optional<kafka::offset>>
     offset_at_timestamp(model::timestamp, ss::abort_source*) = 0;
 
     /**

--- a/src/v/transform/tests/test_fixture.cc
+++ b/src/v/transform/tests/test_fixture.cc
@@ -68,7 +68,7 @@ kafka::offset fake_source::latest_offset() {
     return _batches.rbegin()->first;
 }
 
-ss::future<kafka::offset>
+ss::future<std::optional<kafka::offset>>
 fake_source::offset_at_timestamp(model::timestamp ts, ss::abort_source*) {
     // Walk through the batches from most recent and look for the first batch
     // where the timestamp bounds is inclusive of `ts`.
@@ -85,7 +85,7 @@ fake_source::offset_at_timestamp(model::timestamp ts, ss::abort_source*) {
             co_return model::offset_cast(batch.second.header().last_offset());
         }
     }
-    co_return kafka::offset{};
+    co_return std::nullopt;
 }
 
 ss::future<model::record_batch_reader>

--- a/src/v/transform/tests/test_fixture.h
+++ b/src/v/transform/tests/test_fixture.h
@@ -77,7 +77,7 @@ public:
     ss::future<> start() override;
     ss::future<> stop() override;
     kafka::offset latest_offset() override;
-    ss::future<kafka::offset>
+    ss::future<std::optional<kafka::offset>>
     offset_at_timestamp(model::timestamp, ss::abort_source*) override;
     ss::future<model::record_batch_reader>
     read_batch(kafka::offset offset, ss::abort_source* as) override;

--- a/tests/rptest/tests/data_transforms_test.py
+++ b/tests/rptest/tests/data_transforms_test.py
@@ -398,6 +398,24 @@ class DataTransformsTest(BaseDataTransformsTest):
                        err_msg="some partitions did not clear their envs",
                        retry_on_exc=True)
 
+    @cluster(num_nodes=4)
+    def test_consume_from_end(self):
+        """
+        Test that by default transforms read from the end of the topic if no records
+        are produced between deploy time and transform start time.
+        """
+        input_topic = self.topics[0]
+        output_topic = self.topics[1]
+        producer_status = self._produce_input_topic(topic=self.topics[0])
+        self._deploy_wasm(name="identity-xform",
+                          input_topic=input_topic,
+                          output_topic=output_topic,
+                          wait_running=True)
+
+        with expect_exception(TimeoutError, lambda _: True):
+            consumer_status = self._consume_output_topic(
+                topic=self.topics[1], status=producer_status)
+
 
 class DataTransformsChainingTest(BaseDataTransformsTest):
     """


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

Default behavior is for transforms to start processing input from an offset
equivalent to "the latest committed offset at deploy time". However, in
situations where no records are committed between the moment the transform
was deployed and the moment the transform starts, the timequery servicing
this logic returns nullopt and we erroneously start processing at the
beginning of the topic.

This commit corrects the handling of the timequery result to commit the
latest offset (computed at start time) in the situation described above.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Bug Fixes

* Fix an issue where transforms would miscalculate their initial start offset, leading to consuming the whole input topic.

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
