### PR TITLE
Add error message on olv dir assert

### DIFF
--- a/tools/offline_log_viewer/storage.py
+++ b/tools/offline_log_viewer/storage.py
@@ -302,7 +302,9 @@ class Store:
             for topic in listdirs(join(self.base_dir, nspace)):
                 for part_ntp_id in listdirs(join(self.base_dir, nspace,
                                                  topic)):
-                    assert re.match("^\\d+_\\d+$", part_ntp_id)
+                    assert re.match("^\\d+_\\d+$", part_ntp_id), \
+                        "ntp dir at {} does not match expected format. Wrong --path or extra directories present?"\
+                        .format(join(self.base_dir, nspace, topic, part_ntp_id))
                     [part, ntp_id] = part_ntp_id.split("_")
                     ntp = Ntp(self.base_dir, nspace, topic, int(part),
                               int(ntp_id))


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [X] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none


### Improvements

A minor tweak, but olv can be confusing in how it reports this error. It expected that the dir passed to `--path` is a "true" Redpanda data dir. That means that if you pass it a dir that just happens to have (e.g.) `redpanda/controller/0_0/<segment_files>` in it, although it has all the data there, it may fail if there are other dirs present in the path you passed.

Until #19843, when processing controller logs in a debug bundle, you need to manually build up the dir structure. Depending on how you do this, this behaviour can be a gotcha.

Before:
```
$ python ~/repos/redpanda/tools/offline_log_viewer/viewer.py --type controller --path .
/Users/jflath/repos/redpanda/tools/offline_log_viewer/storage.py:43: SyntaxWarning: invalid escape sequence '\d'
  "(?P<base_offset>\d+)-(?P<term>\d+)-v(?P<version>\d)\.log")
INFO:viewer:starting metadata viewer with options: Namespace(path='.', type='controller', topic=None, verbose=False, dump=False, force=False)
Traceback (most recent call last):
  File "/Users/jflath/repos/redpanda/tools/offline_log_viewer/viewer.py", line 235, in <module>
    main()
  File "/Users/jflath/repos/redpanda/tools/offline_log_viewer/viewer.py", line 209, in main
    store = Store(options.path)
            ^^^^^^^^^^^^^^^^^^^
  File "/Users/jflath/repos/redpanda/tools/offline_log_viewer/storage.py", line 296, in __init__
    self.__search()
  File "/Users/jflath/repos/redpanda/tools/offline_log_viewer/storage.py", line 305, in __search
    assert re.match("^\\d+_\\d+$", part_ntp_id)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError
```

After:
```
$ python ~/repos/redpanda/tools/offline_log_viewer/viewer.py --type controller --path .
/Users/jflath/repos/redpanda/tools/offline_log_viewer/storage.py:43: SyntaxWarning: invalid escape sequence '\d'
  "(?P<base_offset>\d+)-(?P<term>\d+)-v(?P<version>\d)\.log")
INFO:viewer:starting metadata viewer with options: Namespace(path='.', type='controller', topic=None, verbose=False, dump=False, force=False)
Traceback (most recent call last):
  File "/Users/jflath/repos/redpanda/tools/offline_log_viewer/viewer.py", line 235, in <module>
    main()
  File "/Users/jflath/repos/redpanda/tools/offline_log_viewer/viewer.py", line 209, in main
    store = Store(options.path)
            ^^^^^^^^^^^^^^^^^^^
  File "/Users/jflath/repos/redpanda/tools/offline_log_viewer/storage.py", line 296, in __init__
    self.__search()
  File "/Users/jflath/repos/redpanda/tools/offline_log_viewer/storage.py", line 305, in __search
    assert re.match("^\\d+_\\d+$", part_ntp_id), \
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: ntp dir at /Users/jflath/Downloads/logs/1711111111-bundle/metrics/127.0.0.1-9644 does not match expected format. Wrong --path or extra directories present?
```