### PR TITLE
CORE-4600 - Quotas: disable produce quota by default 

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -496,12 +496,12 @@ configuration::configuration()
   , target_quota_byte_rate(
       *this,
       "target_quota_byte_rate",
-      "Target request size quota byte rate (bytes per second) - 2GB default",
+      "Target request size quota byte rate (bytes per second)",
       {.needs_restart = needs_restart::no,
        .example = "1073741824",
        .visibility = visibility::user},
       target_produce_quota_byte_rate_default,
-      {.min = 1_MiB})
+      {.min = 0})
   , target_fetch_quota_byte_rate(
       *this,
       "target_fetch_quota_byte_rate",

--- a/src/v/config/configuration.h
+++ b/src/v/config/configuration.h
@@ -46,7 +46,8 @@ namespace config {
 /// can not depend on any other module to prevent cyclic dependencies.
 
 struct configuration final : public config_store {
-    constexpr static auto target_produce_quota_byte_rate_default = 2_GiB;
+    constexpr static auto target_produce_quota_byte_rate_default
+      = 0; // disabled
 
     // WAL
     bounded_property<uint64_t> log_segment_size;

--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -18,6 +18,8 @@
 #include <seastar/core/shard_id.hh>
 #include <seastar/util/variant_utils.hh>
 
+#include <absl/algorithm/container.h>
+
 #include <optional>
 
 namespace kafka {
@@ -328,6 +330,13 @@ void client_quota_translator::maybe_log_deprecated_configs_nag() const {
           "kafka_admin_topic_api_rate, kafka_client_group_byte_rate_quota and "
           "kafka_client_group_fetch_byte_rate_quota.");
     }
+}
+
+bool client_quota_translator::is_empty() const {
+    return _quota_store.local().size() == 0
+           && absl::c_all_of(all_client_quota_types, [this](auto qt) {
+                  return !get_default_config(qt);
+              });
 }
 
 } // namespace kafka

--- a/src/v/kafka/server/client_quota_translator.cc
+++ b/src/v/kafka/server/client_quota_translator.cc
@@ -18,6 +18,8 @@
 #include <seastar/core/shard_id.hh>
 #include <seastar/util/variant_utils.hh>
 
+#include <optional>
+
 namespace kafka {
 
 using cluster::client_quota::entity_key;
@@ -292,8 +294,11 @@ client_quota_translator::get_quota_config(client_quota_type qt) const {
 std::optional<uint64_t>
 client_quota_translator::get_default_config(client_quota_type qt) const {
     switch (qt) {
-    case kafka::client_quota_type::produce_quota:
-        return _default_target_produce_tp_rate();
+    case kafka::client_quota_type::produce_quota: {
+        auto produce_quota = _default_target_produce_tp_rate();
+        return (produce_quota > 0) ? std::make_optional<uint64_t>(produce_quota)
+                                   : std::nullopt;
+    }
     case kafka::client_quota_type::fetch_quota:
         return _default_target_fetch_tp_rate();
     case kafka::client_quota_type::partition_mutation_quota:

--- a/src/v/kafka/server/client_quota_translator.h
+++ b/src/v/kafka/server/client_quota_translator.h
@@ -141,6 +141,9 @@ public:
     /// `watch` can be used to register for quota changes
     void watch(on_change_fn&& fn);
 
+    /// Returns true if there are no quotas configured
+    bool is_empty() const;
+
 private:
     using quota_config
       = std::unordered_map<ss::sstring, config::client_group_quota>;

--- a/src/v/kafka/server/quota_manager.cc
+++ b/src/v/kafka/server/quota_manager.cc
@@ -320,6 +320,9 @@ ss::future<std::chrono::milliseconds> quota_manager::record_partition_mutations(
     /// KIP-599 throttles create_topics / delete_topics / create_partitions
     /// request. This delay should only be applied to these requests if the
     /// quota has been exceeded
+    if (_translator.is_empty()) {
+        co_return 0ms;
+    }
     auto ctx = client_quota_request_ctx{
       .q_type = client_quota_type::partition_mutation_quota,
       .client_id = client_id,
@@ -391,6 +394,9 @@ ss::future<clock::duration> quota_manager::record_produce_tp_and_throttle(
   std::optional<std::string_view> client_id,
   uint64_t bytes,
   clock::time_point now) {
+    if (_translator.is_empty()) {
+        co_return 0ms;
+    }
     auto ctx = client_quota_request_ctx{
       .q_type = client_quota_type::produce_quota,
       .client_id = client_id,
@@ -440,6 +446,9 @@ ss::future<> quota_manager::record_fetch_tp(
   std::optional<std::string_view> client_id,
   uint64_t bytes,
   clock::time_point now) {
+    if (_translator.is_empty()) {
+        co_return;
+    }
     auto ctx = client_quota_request_ctx{
       .q_type = client_quota_type::fetch_quota,
       .client_id = client_id,
@@ -469,6 +478,9 @@ ss::future<> quota_manager::record_fetch_tp(
 
 ss::future<clock::duration> quota_manager::throttle_fetch_tp(
   std::optional<std::string_view> client_id, clock::time_point now) {
+    if (_translator.is_empty()) {
+        co_return 0ms;
+    }
     auto ctx = client_quota_request_ctx{
       .q_type = client_quota_type::fetch_quota,
       .client_id = client_id,

--- a/src/v/kafka/server/tests/client_quota_translator_test.cc
+++ b/src/v/kafka/server/tests/client_quota_translator_test.cc
@@ -96,6 +96,7 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_default_test) {
     auto limits = f.tr.find_quota_value(key);
     BOOST_CHECK_EQUAL(test_client_id_key, key);
     BOOST_CHECK_EQUAL(default_limits, limits);
+    BOOST_CHECK(f.tr.is_empty());
 }
 
 SEASTAR_THREAD_TEST_CASE(quota_translator_modified_default_test) {
@@ -116,6 +117,7 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_modified_default_test) {
     auto limits = f.tr.find_quota_value(key);
     BOOST_CHECK_EQUAL(test_client_id_key, key);
     BOOST_CHECK_EQUAL(expected_limits, limits);
+    BOOST_CHECK(!f.tr.is_empty());
 }
 
 void run_quota_translator_client_group_test(fixture& f) {

--- a/src/v/kafka/server/tests/client_quota_translator_test.cc
+++ b/src/v/kafka/server/tests/client_quota_translator_test.cc
@@ -87,7 +87,7 @@ SEASTAR_THREAD_TEST_CASE(quota_translator_default_test) {
     fixture f;
 
     auto default_limits = client_quota_limits{
-      .produce_limit = scale_to_smp_count(2147483648),
+      .produce_limit = std::nullopt,
       .fetch_limit = std::nullopt,
       .partition_mutation_limit = std::nullopt,
     };


### PR DESCRIPTION
During performance testing it became apparent that the overhead of quota management, while small, is non-negligible (~400ns/request). It is believed that some of our latency sensitive customers would prefer to avoid having this overhead on the request path. Therefore, this PR adds the ability to disable the produce quota config and sets it to disabled by default.

This is implemented without changing the configuration type (from `bounded_property<uint32_t>` to `property<std::optional<uint32_t>>`), instead I opted to use 0 as a sentinel value for disabled. Locally, I tested the change to `property<std::optional<uint32_t>>` as well, and it seems to work since the values are serialized to `ss::sstring` into the controller log and the serialized values of `uint32` seem to be a subset of those of `optional<uint32>`. However, it still seems lower risk to just use a sentinel value here because it's hard to pin down and test all the places where the config values are serialized into a yaml/json and how those serializations will change if we change the config value into a `std::optional<uint32_t>`. Since these configs are deprecated and going to be removed in 2 major versions, I believe this is a reasonable trade off.

Fixes https://redpandadata.atlassian.net/browse/CORE-4600

### Benchmark results
As expected, all the benchmarks that have the quotas off improve - which now also includes the default case for produce.

```
single run iterations:    0
single run duration:      1.000s
number of runs:           5
number of cores:          32
random seed:              2540878669

test                                                            iterations      median         mad         min         max      allocs       tasks        inst
throughput_group.test_quota_manager_on_unlimited_shared           41943040    28.397ns     0.012ns    28.368ns    28.410ns       0.656       0.000         0.0
throughput_group.test_quota_manager_on_unlimited_unique           41943040    27.000ns     0.087ns    26.840ns    28.767ns       0.252       0.001         0.0
throughput_group.test_quota_manager_on_limited_shared             41943040    31.136ns     0.155ns    30.972ns    31.410ns       0.656       0.000         0.0
throughput_group.test_quota_manager_on_limited_unique             41943040    27.482ns     0.126ns    27.294ns    27.608ns       0.252       0.001         0.0
throughput_group.test_quota_manager_off_shared                   608174080     1.597ns     0.009ns     1.588ns     1.727ns       0.094       0.000         0.0
throughput_group.test_quota_manager_off_unique                   618659840     1.524ns     0.009ns     1.515ns     1.721ns       0.063       0.000         0.0
latency_group.existing_client_produce_100_others                    110100   305.827ns     2.455ns   300.770ns   370.914ns      11.000       0.000         0.0
latency_group.existing_client_fetch_100_others                      105000   607.491ns     1.238ns   600.661ns   724.629ns      22.000       0.000         0.0
latency_group.new_client_produce_100_others                         102800   739.801ns     5.008ns   734.794ns   836.278ns      12.040       0.000         0.0
latency_group.new_client_fetch_100_others                           101200     1.016us     0.782ns     1.011us     1.122us      17.040       0.002         0.0
latency_group.existing_client_produce_1000_others                    58700   169.915ns     0.214ns   169.287ns   170.129ns      11.000       0.000         0.0
latency_group.existing_client_fetch_1000_others                      60700   345.662ns     2.627ns   342.027ns   395.834ns      22.000       0.000         0.0
latency_group.new_client_produce_1000_others                         65300   531.249ns     1.291ns   529.958ns   608.963ns      12.020       0.001         0.0
latency_group.new_client_fetch_1000_others                           60100   706.559ns     0.445ns   706.114ns   780.256ns      17.020       0.001         0.0
latency_group.existing_client_produce_10000_others                   13100   172.368ns     0.335ns   172.033ns   173.614ns      11.000       0.000         0.0
latency_group.existing_client_fetch_10000_others                     14400   352.623ns     1.389ns   350.707ns   354.012ns      22.000       0.000         0.0
latency_group.new_client_produce_10000_others                        14300   507.215ns     1.931ns   505.284ns   516.292ns      12.000       0.001         0.0
latency_group.new_client_fetch_10000_others                          14400   696.061ns     4.296ns   691.765ns   705.216ns      17.000       0.001         0.0
latency_group.existing_client_produce_100_others_not_shard_0         71700   376.862ns     3.136ns   373.006ns   379.997ns      11.000       0.002         0.0
latency_group.existing_client_fetch_100_others_not_shard_0           82600   701.857ns     7.485ns   694.373ns   818.803ns      22.000       0.005         0.0
latency_group.new_client_produce_100_others_not_shard_0              70600     2.779us     3.321ns     2.776us     3.208us       6.020       3.000         0.0
latency_group.new_client_fetch_100_others_not_shard_0                68500     3.066us     3.891ns     3.062us     3.546us      11.020       3.001         0.0
latency_group.existing_client_produce_1000_others_not_shard_0        25300   341.737ns     0.975ns   340.613ns   343.275ns      11.000       0.001         0.0
latency_group.existing_client_fetch_1000_others_not_shard_0          25000   688.687ns     5.226ns   683.461ns   718.709ns      22.000       0.002         0.0
latency_group.new_client_produce_1000_others_not_shard_0             23300     3.067us    20.573ns     3.012us     3.087us       6.010       3.000         0.0
latency_group.new_client_fetch_1000_others_not_shard_0               23600     3.252us     2.168ns     3.247us     3.255us      11.010       3.001         0.0
latency_group.existing_client_produce_10000_others_not_shard_0        3400   339.762ns     1.056ns   337.747ns   342.591ns      11.000       0.001         0.0
latency_group.existing_client_fetch_10000_others_not_shard_0          3400   667.726ns     1.000ns   666.725ns   672.398ns      22.000       0.004         0.0
latency_group.new_client_produce_10000_others_not_shard_0             3300     2.815us     5.786ns     2.797us     2.829us       6.000       3.000         0.0
latency_group.new_client_fetch_10000_others_not_shard_0               3300     3.108us    19.237ns     3.076us     4.192us      11.000       3.001         0.0
latency_group.default_configs_produce_worst                         127200    26.415ns     0.197ns    26.003ns    33.435ns       1.000       0.000         0.0
latency_group.default_configs_fetch_worst                           126000    47.980ns     0.153ns    47.827ns    54.350ns       2.000       0.000         0.0
```

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
