### PR TITLE
[CORE-3245] schema_registry: Support -1 as latest for get_subject_version

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -70,8 +70,9 @@ result<schema_version> parse_numerical_schema_version(const ss::sstring& ver) {
 
 result<std::optional<schema_version>>
 parse_schema_version(const ss::sstring& ver) {
-    return ver == "latest" ? std::optional<schema_version>{}
-                           : parse_numerical_schema_version(ver).value();
+    return (ver == "latest" || ver == "-1")
+             ? std::optional<schema_version>{}
+             : parse_numerical_schema_version(ver).value();
 }
 
 ss::future<server::reply_t>

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -2299,6 +2299,14 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         assert result["subject"] == f"{topic}-key"
         assert result["version"] == 1
 
+        self.logger.debug("Get latest (-1) schema version for subject key")
+        result_raw = self._get_subjects_subject_versions_version(
+            subject=f"{topic}-key", version="-1", auth=self.super_auth)
+        assert result_raw.status_code == requests.codes.ok
+        result = result_raw.json()
+        assert result["subject"] == f"{topic}-key"
+        assert result["version"] == 1
+
         self.logger.debug("Get schema version 1")
         result_raw = self._get_schemas_ids_id(id=1, auth=self.public_auth)
         assert result_raw.json()['error_code'] == 40101


### PR DESCRIPTION
This is an undocumented compatibility "feature".

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Schema Registry: `GET /subject/<subject>/versions/` now supports `-1` as an alias for `latest`.
