### PR TITLE
[v23.3.x] [CORE-3245] schema_registry: Support -1 as latest for get_subject_version

### DIFF
--- a/src/v/pandaproxy/schema_registry/handlers.cc
+++ b/src/v/pandaproxy/schema_registry/handlers.cc
@@ -73,8 +73,9 @@ result<schema_version> parse_numerical_schema_version(const ss::sstring& ver) {
 
 result<std::optional<schema_version>>
 parse_schema_version(const ss::sstring& ver) {
-    return ver == "latest" ? std::optional<schema_version>{}
-                           : parse_numerical_schema_version(ver).value();
+    return (ver == "latest" || ver == "-1")
+             ? std::optional<schema_version>{}
+             : parse_numerical_schema_version(ver).value();
 }
 
 ss::future<server::reply_t>

--- a/tests/rptest/tests/schema_registry_test.py
+++ b/tests/rptest/tests/schema_registry_test.py
@@ -2268,6 +2268,14 @@ class SchemaRegistryBasicAuthTest(SchemaRegistryEndpoints):
         assert result["subject"] == f"{topic}-key"
         assert result["version"] == 1
 
+        self.logger.debug("Get latest (-1) schema version for subject key")
+        result_raw = self._get_subjects_subject_versions_version(
+            subject=f"{topic}-key", version="-1", auth=self.super_auth)
+        assert result_raw.status_code == requests.codes.ok
+        result = result_raw.json()
+        assert result["subject"] == f"{topic}-key"
+        assert result["version"] == 1
+
         self.logger.debug("Get schema version 1")
         result_raw = self._get_schemas_ids_id(id=1, auth=self.public_auth)
         assert result_raw.json()['error_code'] == 40101


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/20146
