### PR TITLE
Correct verbiage about data partition in redpanda.yaml

### DIFF
--- a/conf/redpanda.yaml
+++ b/conf/redpanda.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 Redpanda Data, Inc.
+# Copyright 2024 Redpanda Data, Inc.
 #
 # Use of this software is governed by the Business Source License
 # included in the file licenses/BSL.md
@@ -11,7 +11,7 @@
 
 redpanda:
   # Data directory where all the files will be stored.
-  # This directory MUST resides on xfs partion.
+  # This directory MUST reside on an ext4 or xfs partition.
   data_directory: "/var/lib/redpanda/data"
 
   # The initial cluster nodes addresses


### PR DESCRIPTION
We have been supporting Ext4 for awhile now. This changes the verbiage in our default configuration file to reflect that as well as corrects some typos. While here, updates the year in the copyright line.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
