### PR TITLE
[rpk connect] add /connect to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ vbuild/
 /.vtools.yml
 /vtools
 /benthos
+/connect
 /Taskfile.yml
 /.dockerignore
 /.task/


### PR DESCRIPTION
During bundling of the `.rpk.ac.connect` plugin with `rpk`, we will now checkout code from https://github.com/redpanda-data/connect instead of https://github.com/redpanda-data/benthos.  We must add `/connect` to `.gitignore` to ensure local redpanda repo looks clean during packaging operations.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none