### PR TITLE
tests/node_ops: avoid interference betwen failure injections and ops

### DIFF
--- a/tests/rptest/tests/random_node_operations_test.py
+++ b/tests/rptest/tests/random_node_operations_test.py
@@ -463,7 +463,8 @@ class RandomNodeOperationsTest(PreallocNodesTest):
             self.redpanda,
             self.logger,
             lock,
-            progress_timeout=120 if enable_failures else 60)
+            progress_timeout=120 if enable_failures else 60,
+            wait_after_stop=30 if enable_failures else 0)
         for i, op in enumerate(
                 generate_random_workload(
                     available_nodes=self.active_node_idxs)):

--- a/tests/rptest/utils/node_operations.py
+++ b/tests/rptest/utils/node_operations.py
@@ -215,12 +215,14 @@ class NodeOpsExecutor():
                  redpanda: RedpandaService,
                  logger,
                  lock: threading.Lock,
-                 progress_timeout=60):
+                 progress_timeout=60,
+                 wait_after_stop=0):
         self.redpanda = redpanda
         self.logger = logger
         self.timeout = 360
         self.lock = lock
         self.progress_timeout = progress_timeout
+        self.wait_after_stop = wait_after_stop
 
     def node_id(self, idx):
         return self.redpanda.node_id(self.redpanda.get_node(idx),
@@ -330,6 +332,7 @@ class NodeOpsExecutor():
         with self.lock:
             self.redpanda.remove_from_started_nodes(node)
             self.redpanda.stop_node(node)
+            time.sleep(self.wait_after_stop)
         self.redpanda.clean_node(node,
                                  preserve_logs=True,
                                  preserve_current_install=True)


### PR DESCRIPTION
They can already be separated with a lock, but it's not sufficient. We need certain delay between them.

Fixes #18272

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
