### PR TITLE
cloud_storage: add topic manifest downloader

### DIFF
--- a/src/v/bytes/include/bytes/iobuf.h
+++ b/src/v/bytes/include/bytes/iobuf.h
@@ -76,6 +76,12 @@ public:
     using byte_iterator = details::io_byte_iterator;
     using placeholder = details::io_placeholder;
 
+    static iobuf from(std::string_view view) {
+        iobuf i;
+        i.append(view.data(), view.size());
+        return i;
+    }
+
     // NOLINTNEXTLINE
     iobuf() noexcept {
         // nothing allocates memory, but boost intrusive list is not marked as

--- a/src/v/cloud_storage/CMakeLists.txt
+++ b/src/v/cloud_storage/CMakeLists.txt
@@ -42,6 +42,7 @@ v_cc_library(
     segment_chunk_data_source.cc
     segment_path_utils.cc
     topic_manifest.cc
+    topic_manifest_downloader.cc
     topic_path_utils.cc
     async_manifest_view.cc
     materialized_manifest_cache.cc

--- a/src/v/cloud_storage/base_manifest.h
+++ b/src/v/cloud_storage/base_manifest.h
@@ -60,13 +60,6 @@ public:
     /// Manifest object format and name in S3
     virtual remote_manifest_path get_manifest_path() const = 0;
 
-    /// default implementation for derived classed that don't support multiple
-    /// formats
-    virtual std::pair<manifest_format, remote_manifest_path>
-    get_manifest_format_and_path() const {
-        return {manifest_format::json, get_manifest_path()};
-    }
-
     /// Get manifest type
     virtual manifest_type get_manifest_type() const = 0;
 };

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -201,7 +201,7 @@ public:
 
     /// Manifest object name in S3
     std::pair<manifest_format, remote_manifest_path>
-    get_manifest_format_and_path() const override;
+    get_manifest_format_and_path() const;
 
     remote_manifest_path get_manifest_path(manifest_format fmt) const {
         switch (fmt) {

--- a/src/v/cloud_storage/remote.cc
+++ b/src/v/cloud_storage/remote.cc
@@ -204,12 +204,21 @@ ss::future<download_result> remote::download_manifest(
     return do_download_manifest(bucket, format_key, manifest, parent);
 }
 
-ss::future<download_result> remote::download_manifest(
+ss::future<download_result> remote::download_manifest_json(
   const cloud_storage_clients::bucket_name& bucket,
   const remote_manifest_path& key,
   base_manifest& manifest,
   retry_chain_node& parent) {
     auto fk = std::pair{manifest_format::json, key};
+    co_return co_await do_download_manifest(
+      bucket, fk, manifest, parent, false);
+}
+ss::future<download_result> remote::download_manifest_bin(
+  const cloud_storage_clients::bucket_name& bucket,
+  const remote_manifest_path& key,
+  base_manifest& manifest,
+  retry_chain_node& parent) {
+    auto fk = std::pair{manifest_format::serde, key};
     co_return co_await do_download_manifest(
       bucket, fk, manifest, parent, false);
 }

--- a/src/v/cloud_storage/remote.h
+++ b/src/v/cloud_storage/remote.h
@@ -237,7 +237,13 @@ public:
       retry_chain_node& parent);
 
     /// compatibility version of download_manifest for json format
-    ss::future<download_result> download_manifest(
+    ss::future<download_result> download_manifest_json(
+      const cloud_storage_clients::bucket_name& bucket,
+      const remote_manifest_path& key,
+      base_manifest& manifest,
+      retry_chain_node& parent);
+    /// version of download_manifest for serde format
+    ss::future<download_result> download_manifest_bin(
       const cloud_storage_clients::bucket_name& bucket,
       const remote_manifest_path& key,
       base_manifest& manifest,

--- a/src/v/cloud_storage/tests/CMakeLists.txt
+++ b/src/v/cloud_storage/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ rp_test(
     remote_path_provider_test.cc
     remote_test.cc
     s3_imposter.cc
+    topic_manifest_downloader_test.cc
     util.cc
   LIBRARIES
     v::gtest_main

--- a/src/v/cloud_storage/tests/topic_manifest_downloader_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_downloader_test.cc
@@ -1,0 +1,399 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "bytes/iostream.h"
+#include "bytes/streambuf.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/tests/s3_imposter.h"
+#include "cloud_storage/topic_manifest.h"
+#include "cloud_storage/topic_manifest_downloader.h"
+#include "cloud_storage/topic_path_utils.h"
+#include "cloud_storage/types.h"
+#include "cloud_storage_clients/client_pool.h"
+#include "cloud_storage_clients/types.h"
+#include "model/fundamental.h"
+#include "model/metadata.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+#include <gtest/gtest.h>
+
+using namespace cloud_storage;
+using namespace std::chrono_literals;
+
+namespace {
+
+ss::abort_source never_abort{};
+
+constexpr model::cloud_credentials_source config_file{
+  model::cloud_credentials_source::config_file};
+
+const ss::sstring test_uuid_str = "deadbeef-0000-0000-0000-000000000000";
+const model::cluster_uuid test_uuid{uuid_t::from_string(test_uuid_str)};
+const remote_label test_label{test_uuid};
+const model::topic_namespace test_tp_ns{model::ns{"kafka"}, model::topic{"tp"}};
+const model::initial_revision_id test_rev{21};
+
+ss::sstring topic_manifest_json(
+  const model::topic_namespace& tp_ns, model::initial_revision_id rev) {
+    return fmt::format(
+      R"JSON({{
+      "version": 1,
+      "namespace": "{}",
+      "topic": "{}",
+      "partition_count": 1,
+      "replication_factor": 1,
+      "revision_id": {}
+    }})JSON",
+      tp_ns.ns(),
+      tp_ns.tp(),
+      rev());
+}
+
+topic_manifest dummy_topic_manifest() {
+    const auto tm_json = topic_manifest_json(test_tp_ns, test_rev);
+    auto json_stream = make_iobuf_input_stream(iobuf::from(tm_json));
+    topic_manifest tm;
+    tm.update(manifest_format::json, std::move(json_stream)).get();
+    return tm;
+}
+} // namespace
+
+class TopicManifestDownloaderTest
+  : public ::testing::Test
+  , public s3_imposter_fixture {
+public:
+    void SetUp() override {
+        pool_.start(10, ss::sharded_parameter([this] { return conf; })).get();
+        remote_
+          .start(
+            std::ref(pool_),
+            ss::sharded_parameter([this] { return conf; }),
+            ss::sharded_parameter([] { return config_file; }))
+          .get();
+        // Tests will use the remote API, no hard coded responses.
+        set_expectations_and_listen({});
+    }
+
+    void TearDown() override {
+        pool_.local().shutdown_connections();
+        remote_.stop().get();
+        pool_.stop().get();
+    }
+
+    // Serializes the given topic manifest into JSON and uploads the result to
+    // the appropriate path with the hash-prefixing scheme.
+    void upload_json_manifest(const topic_manifest& tm) {
+        retry_chain_node retry(never_abort, 1s, 10ms);
+        iobuf buf;
+        iobuf_ostreambuf obuf(buf);
+        std::ostream os(&obuf);
+        tm.serialize_v1_json(os);
+        upload_request json_req{
+            .transfer_details = transfer_details{
+                .bucket = bucket_name,
+                  .key = cloud_storage_clients::object_key{prefixed_topic_manifest_json_path(test_tp_ns)},
+                  .parent_rtc = retry,
+            },
+            .type = cloud_storage::upload_type::manifest,
+            .payload = std::move(buf),
+        };
+        auto upload_res
+          = remote_.local().upload_object(std::move(json_req)).get();
+        ASSERT_EQ(upload_result::success, upload_res);
+    }
+
+protected:
+    ss::sharded<cloud_storage_clients::client_pool> pool_;
+    ss::sharded<remote> remote_;
+};
+
+TEST_F(TopicManifestDownloaderTest, TestDownloadLabeledManifest) {
+    auto tm = dummy_topic_manifest();
+    auto labeled_path = labeled_topic_manifest_path(
+      test_label, test_tp_ns, test_rev);
+
+    retry_chain_node retry(never_abort, 1s, 10ms);
+    auto upload_res
+      = remote_.local()
+          .upload_manifest(
+            bucket_name, tm, remote_manifest_path{labeled_path}, retry)
+          .get();
+    ASSERT_EQ(upload_result::success, upload_res);
+
+    topic_manifest_downloader dl(
+      bucket_name, /*hint=*/std::nullopt, test_tp_ns, remote_.local());
+    topic_manifest dl_tm;
+    auto dl_res = dl.download_manifest(
+                      retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                    .get();
+    ASSERT_FALSE(dl_res.has_error());
+    ASSERT_TRUE(tm == dl_tm);
+}
+
+TEST_F(TopicManifestDownloaderTest, TestDownloadMultipleLabeledManifests) {
+    auto tm = dummy_topic_manifest();
+    auto labeled_path1 = labeled_topic_manifest_path(
+      test_label, test_tp_ns, test_rev);
+    auto labeled_path2 = labeled_topic_manifest_path(
+      test_label, test_tp_ns, model::initial_revision_id{test_rev() + 1});
+
+    // Upload two manifests of the same topic, but with different revisions.
+    retry_chain_node retry(never_abort, 1s, 10ms);
+    for (const auto& path : {labeled_path1, labeled_path2}) {
+        auto upload_res
+          = remote_.local()
+              .upload_manifest(
+                bucket_name, tm, remote_manifest_path{path}, retry)
+              .get();
+        ASSERT_EQ(upload_result::success, upload_res);
+    }
+
+    chunked_vector<std::optional<ss::sstring>> bad_hints{
+      std::nullopt,
+      test_uuid_str,
+    };
+    for (const auto& hint : bad_hints) {
+        topic_manifest_downloader dl(
+          bucket_name, hint, test_tp_ns, remote_.local());
+        topic_manifest dl_tm;
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_EQ(
+          dl_res.value(),
+          find_topic_manifest_outcome::multiple_matching_manifests);
+    }
+    topic_manifest_downloader dl(
+      bucket_name,
+      fmt::format("{}/{}", test_uuid_str, test_rev()),
+      test_tp_ns,
+      remote_.local());
+    topic_manifest dl_tm;
+    auto dl_res = dl.download_manifest(
+                      retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                    .get();
+    ASSERT_FALSE(dl_res.has_error());
+    ASSERT_EQ(tm, dl_tm);
+}
+
+TEST_F(TopicManifestDownloaderTest, TestDownloadLabeledManifestWithHint) {
+    auto tm = dummy_topic_manifest();
+    auto labeled_path = labeled_topic_manifest_path(
+      test_label, test_tp_ns, test_rev);
+
+    retry_chain_node retry(never_abort, 1s, 10ms);
+    auto upload_res
+      = remote_.local()
+          .upload_manifest(
+            bucket_name, tm, remote_manifest_path{labeled_path}, retry)
+          .get();
+    ASSERT_EQ(upload_result::success, upload_res);
+
+    for (int i = 0; i < test_uuid_str.size(); i++) {
+        auto uuid_substr = test_uuid_str.substr(0, i);
+        topic_manifest_downloader dl(
+          bucket_name, uuid_substr, test_tp_ns, remote_.local());
+        topic_manifest dl_tm;
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_TRUE(tm == dl_tm);
+    }
+    const chunked_vector<ss::sstring> good_hints = {
+      fmt::format("{}/", test_uuid_str, test_rev()),
+      fmt::format("{}/{}", test_uuid_str, test_rev()),
+      fmt::format("{}/{}/", test_uuid_str, test_rev()),
+      fmt::format("{}/{}/topic_ma", test_uuid_str, test_rev()),
+      fmt::format("{}/{}/topic_manifest.bin", test_uuid_str, test_rev()),
+    };
+    for (const auto& hint : good_hints) {
+        // Adding a trailing slash and the revision.
+        topic_manifest_downloader dl(
+          bucket_name, hint, test_tp_ns, remote_.local());
+        topic_manifest dl_tm;
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_TRUE(tm == dl_tm);
+    }
+    chunked_vector<ss::sstring> bad_hints = {
+      // Bad slash.
+      fmt::format("{}//", test_uuid_str),
+      fmt::format("/{}", test_uuid_str),
+
+      // Bad revision.
+      fmt::format("{}/{}", test_uuid_str, test_rev() + 1),
+
+      // Missing revision.
+      fmt::format("{}/topic_manifest.bin", test_uuid_str),
+    };
+    for (const auto& hint : bad_hints) {
+        topic_manifest_downloader dl(
+          bucket_name, hint, test_tp_ns, remote_.local());
+        topic_manifest dl_tm;
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_EQ(
+          dl_res.value(), find_topic_manifest_outcome::no_matching_manifest);
+    }
+}
+
+TEST_F(TopicManifestDownloaderTest, TestDownloadPrefixedBinaryManifest) {
+    auto tm = dummy_topic_manifest();
+    auto hashed_path = prefixed_topic_manifest_bin_path(test_tp_ns);
+
+    retry_chain_node retry(never_abort, 1s, 10ms);
+    auto upload_res
+      = remote_.local()
+          .upload_manifest(
+            bucket_name, tm, remote_manifest_path{hashed_path}, retry)
+          .get();
+    ASSERT_EQ(upload_result::success, upload_res);
+
+    chunked_vector<std::optional<ss::sstring>> hints{
+      std::nullopt,
+
+      // NOTE: since there is no labeled manifest, hints are inconsequential.
+      test_uuid_str,
+      "foo",
+    };
+    for (const auto& hint : hints) {
+        topic_manifest_downloader dl(
+          bucket_name, hint, test_tp_ns, remote_.local());
+        topic_manifest dl_tm;
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_TRUE(tm == dl_tm);
+    }
+}
+
+TEST_F(TopicManifestDownloaderTest, TestDownloadPrefixedJsonManifest) {
+    auto tm = dummy_topic_manifest();
+    ASSERT_NO_FATAL_FAILURE(upload_json_manifest(tm));
+
+    chunked_vector<std::optional<ss::sstring>> hints{
+      std::nullopt,
+
+      // NOTE: since there is no labeled manifest, hints are inconsequential.
+      test_uuid_str,
+      "foo",
+    };
+    retry_chain_node retry(never_abort, 1s, 10ms);
+    for (const auto& hint : hints) {
+        topic_manifest_downloader dl(
+          bucket_name, hint, test_tp_ns, remote_.local());
+        topic_manifest dl_tm;
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_TRUE(tm == dl_tm);
+    }
+}
+
+TEST_F(TopicManifestDownloaderTest, TestDownloadWithRemoteError) {
+    auto tm = dummy_topic_manifest();
+    auto labeled_path = labeled_topic_manifest_path(
+      test_label, test_tp_ns, test_rev);
+
+    retry_chain_node retry(never_abort, 1s, 10ms);
+    auto upload_res
+      = remote_.local()
+          .upload_manifest(
+            bucket_name, tm, remote_manifest_path{labeled_path}, retry)
+          .get();
+    ASSERT_EQ(upload_result::success, upload_res);
+
+    retry_chain_node bad_retry(
+      never_abort, ss::lowres_clock::time_point::min(), 10ms);
+    topic_manifest_downloader dl(
+      bucket_name, /*hint=*/std::nullopt, test_tp_ns, remote_.local());
+    topic_manifest dl_tm;
+    auto dl_res = dl.download_manifest(
+                      retry, ss::lowres_clock::time_point::min(), 10ms, &dl_tm)
+                    .get();
+    ASSERT_TRUE(dl_res.has_error());
+    ASSERT_EQ(dl_res.error(), error_outcome::manifest_download_error);
+}
+
+TEST_F(TopicManifestDownloaderTest, TestDownloadPrecedence) {
+    auto tm = dummy_topic_manifest();
+    ASSERT_NO_FATAL_FAILURE(upload_json_manifest(tm));
+    topic_manifest_downloader dl(
+      bucket_name, /*hint=*/std::nullopt, test_tp_ns, remote_.local());
+    topic_manifest dl_tm;
+
+    // When there's just a JSON manifest in the bucket, it will be downloaded.
+    retry_chain_node retry(never_abort, 1s, 10ms);
+    {
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_TRUE(tm == dl_tm);
+        ASSERT_FALSE(get_requests().empty());
+        const auto& last_req = get_requests().back();
+        EXPECT_STREQ(last_req.method.c_str(), "GET");
+        EXPECT_STREQ(
+          last_req.url.c_str(), "/e0000000/meta/kafka/tp/topic_manifest.json");
+    }
+
+    // If there's both a JSON manifest and a binary manifest with the hash
+    // prefixing scheme, the binary manifest is returned.
+    auto hashed_path = prefixed_topic_manifest_bin_path(test_tp_ns);
+    auto upload_res
+      = remote_.local()
+          .upload_manifest(
+            bucket_name, tm, remote_manifest_path{hashed_path}, retry)
+          .get();
+    ASSERT_EQ(upload_result::success, upload_res);
+    {
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_TRUE(tm == dl_tm);
+        ASSERT_FALSE(get_requests().empty());
+        const auto& last_req = get_requests().back();
+        EXPECT_STREQ(last_req.method.c_str(), "GET");
+        EXPECT_STREQ(
+          last_req.url.c_str(), "/e0000000/meta/kafka/tp/topic_manifest.bin");
+    }
+
+    // If there is a labeled manifest, it is prefered over the others.
+    auto labeled_path = labeled_topic_manifest_path(
+      test_label, test_tp_ns, test_rev);
+    upload_res = remote_.local()
+                   .upload_manifest(
+                     bucket_name, tm, remote_manifest_path{labeled_path}, retry)
+                   .get();
+    ASSERT_EQ(upload_result::success, upload_res);
+    {
+        auto dl_res = dl.download_manifest(
+                          retry, ss::lowres_clock::now() + 1s, 10ms, &dl_tm)
+                        .get();
+        ASSERT_FALSE(dl_res.has_error());
+        ASSERT_TRUE(tm == dl_tm);
+        ASSERT_FALSE(get_requests().empty());
+        const auto& last_req = get_requests().back();
+        EXPECT_STREQ(last_req.method.c_str(), "GET");
+        EXPECT_STREQ(
+          last_req.url.c_str(),
+          "/meta/kafka/tp/deadbeef-0000-0000-0000-000000000000/21/"
+          "topic_manifest.bin");
+    }
+}

--- a/src/v/cloud_storage/tests/topic_manifest_test.cc
+++ b/src/v/cloud_storage/tests/topic_manifest_test.cc
@@ -12,6 +12,7 @@
 #include "bytes/iobuf.h"
 #include "bytes/iobuf_parser.h"
 #include "bytes/iostream.h"
+#include "bytes/streambuf.h"
 #include "cloud_storage/topic_manifest.h"
 #include "cloud_storage/types.h"
 #include "cluster/types.h"
@@ -156,10 +157,12 @@ SEASTAR_THREAD_TEST_CASE(create_topic_manifest_correct_path) {
 
 SEASTAR_THREAD_TEST_CASE(update_topic_manifest_correct_path) {
     topic_manifest m;
-    m.update(make_manifest_stream(min_topic_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(min_topic_manifest_json))
+      .get();
     auto path = m.get_manifest_path();
     BOOST_REQUIRE_EQUAL(
-      path, "70000000/meta/test-namespace/test-topic/topic_manifest.json");
+      path, "70000000/meta/test-namespace/test-topic/topic_manifest.bin");
 }
 
 SEASTAR_THREAD_TEST_CASE(construct_serialize_update_same_object) {
@@ -179,7 +182,9 @@ SEASTAR_THREAD_TEST_CASE(construct_serialize_update_same_object) {
 
 SEASTAR_THREAD_TEST_CASE(update_serialize_update_same_object) {
     topic_manifest m;
-    m.update(make_manifest_stream(min_topic_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(min_topic_manifest_json))
+      .get();
     auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
@@ -194,7 +199,9 @@ SEASTAR_THREAD_TEST_CASE(update_serialize_update_same_object) {
 
 SEASTAR_THREAD_TEST_CASE(min_config_update_all_fields_correct) {
     topic_manifest m;
-    m.update(make_manifest_stream(min_topic_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(min_topic_manifest_json))
+      .get();
 
     auto topic_config = m.get_topic_config().value();
     BOOST_REQUIRE_EQUAL(m.get_revision(), model::initial_revision_id(0));
@@ -215,7 +222,9 @@ SEASTAR_THREAD_TEST_CASE(min_config_update_all_fields_correct) {
 
 SEASTAR_THREAD_TEST_CASE(full_config_update_all_fields_correct) {
     topic_manifest m;
-    m.update(make_manifest_stream(full_topic_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(full_topic_manifest_json))
+      .get();
 
     auto topic_config = m.get_topic_config().value();
     BOOST_REQUIRE_EQUAL(m.get_revision(), model::initial_revision_id(1));
@@ -261,14 +270,14 @@ SEASTAR_THREAD_TEST_CASE(topic_manifest_min_serialization) {
 
     features::feature_table local_ft;
     topic_manifest m(min_cfg, model::initial_revision_id{0}, local_ft);
-    auto [is, size] = m.serialize().get();
     iobuf buf;
-    auto os = make_iobuf_ref_output_stream(buf);
-    ss::copy(is, os).get();
+    iobuf_ostreambuf obuf(buf);
+    std::ostream os(&obuf);
+    m.serialize_v1_json(os);
 
     auto rstr = make_iobuf_input_stream(std::move(buf));
     topic_manifest restored;
-    restored.update(std::move(rstr)).get();
+    restored.update(manifest_format::json, std::move(rstr)).get();
     BOOST_CHECK_EQUAL(m.get_revision(), restored.get_revision());
     auto restored_cfg = restored.get_topic_config().value();
     // as a safety net, negative values for retention_duration are converted to
@@ -292,21 +301,23 @@ SEASTAR_THREAD_TEST_CASE(topic_manifest_max_serialization) {
       std::numeric_limits<size_t>::max());
     auto local_ft = features::feature_table{};
     topic_manifest m(max_cfg, model::initial_revision_id{0}, local_ft);
-    auto [is, size] = m.serialize().get();
     iobuf buf;
-    auto os = make_iobuf_ref_output_stream(buf);
-    ss::copy(is, os).get();
+    iobuf_ostreambuf obuf(buf);
+    std::ostream os(&obuf);
+    m.serialize_v1_json(os);
 
     auto rstr = make_iobuf_input_stream(std::move(buf));
     topic_manifest restored;
-    restored.update(std::move(rstr)).get();
+    restored.update(manifest_format::json, std::move(rstr)).get();
     BOOST_REQUIRE(m == restored);
 }
 
 SEASTAR_THREAD_TEST_CASE(missing_required_fields_throws) {
     topic_manifest m;
     BOOST_REQUIRE_EXCEPTION(
-      m.update(make_manifest_stream(missing_partition_count)).get(),
+      m.update(
+         manifest_format::json, make_manifest_stream(missing_partition_count))
+        .get(),
       std::runtime_error,
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
@@ -319,7 +330,8 @@ SEASTAR_THREAD_TEST_CASE(missing_required_fields_throws) {
 SEASTAR_THREAD_TEST_CASE(wrong_version_throws) {
     topic_manifest m;
     BOOST_REQUIRE_EXCEPTION(
-      m.update(make_manifest_stream(wrong_version)).get(),
+      m.update(manifest_format::json, make_manifest_stream(wrong_version))
+        .get(),
       std::runtime_error,
       [](std::runtime_error ex) {
           return std::string(ex.what()).find(
@@ -331,21 +343,22 @@ SEASTAR_THREAD_TEST_CASE(wrong_version_throws) {
 SEASTAR_THREAD_TEST_CASE(wrong_compaction_strategy_throws) {
     topic_manifest m;
     BOOST_REQUIRE_EXCEPTION(
-      m.update(make_manifest_stream(wrong_compaction_strategy)).get(),
+      m.update(
+         manifest_format::json, make_manifest_stream(wrong_compaction_strategy))
+        .get(),
       std::runtime_error,
       [](std::runtime_error ex) {
-          return std::string(ex.what()).find(
-                   "Failed to parse topic manifest "
-                   "\"30000000/meta/full-test-namespace/full-test-topic/"
-                   "topic_manifest.json\": Invalid compaction_strategy: "
-                   "wrong_value")
+          return std::string(ex.what()).find("Invalid compaction_strategy: "
+                                             "wrong_value")
                  != std::string::npos;
       });
 }
 
 SEASTAR_THREAD_TEST_CASE(full_update_serialize_update_same_object) {
     topic_manifest m;
-    m.update(make_manifest_stream(full_topic_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(full_topic_manifest_json))
+      .get();
 
     auto [is, size] = m.serialize().get();
     iobuf buf;
@@ -362,7 +375,9 @@ SEASTAR_THREAD_TEST_CASE(full_update_serialize_update_same_object) {
 SEASTAR_THREAD_TEST_CASE(update_non_empty_manifest) {
     auto local_ft = features::feature_table{};
     topic_manifest m(cfg, model::initial_revision_id(0), local_ft);
-    m.update(make_manifest_stream(full_topic_manifest_json)).get();
+    m.update(
+       manifest_format::json, make_manifest_stream(full_topic_manifest_json))
+      .get();
     auto [is, size] = m.serialize().get();
     iobuf buf;
     auto os = make_iobuf_ref_output_stream(buf);
@@ -378,7 +393,10 @@ SEASTAR_THREAD_TEST_CASE(update_non_empty_manifest) {
 SEASTAR_THREAD_TEST_CASE(test_negative_property_manifest) {
     auto local_ft = features::feature_table{};
     topic_manifest m(cfg, model::initial_revision_id(0), local_ft);
-    m.update(make_manifest_stream(negative_properties_manifest)).get();
+    m.update(
+       manifest_format::json,
+       make_manifest_stream(negative_properties_manifest))
+      .get();
     auto tp_cfg = m.get_topic_config();
     BOOST_REQUIRE(tp_cfg.has_value());
     BOOST_REQUIRE_EQUAL(64, tp_cfg->partition_count);
@@ -476,12 +494,8 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
     // topic_manifest and check that the result is equal
     auto manifest = topic_manifest{
       random_topic_configuration, random_initial_revision_id, local_ft};
-    BOOST_CHECK(
-      manifest.get_manifest_version() == topic_manifest::serde_version);
     BOOST_CHECK(manifest.get_revision() == random_initial_revision_id);
     BOOST_CHECK(manifest.get_manifest_path()().extension() == ".bin");
-    BOOST_CHECK(
-      manifest.get_manifest_format_and_path().first == manifest_format::serde);
 
     auto serialized_manifest = manifest.serialize().get().stream;
 
@@ -489,9 +503,6 @@ SEASTAR_THREAD_TEST_CASE(test_topic_manifest_serde_feature_table) {
     reconstructed_serde_manifest
       .update(manifest_format::serde, std::move(serialized_manifest))
       .get();
-    BOOST_CHECK(
-      reconstructed_serde_manifest.get_manifest_version()
-      == topic_manifest::serde_version);
     BOOST_CHECK(
       reconstructed_serde_manifest.get_revision()
       == random_initial_revision_id);

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -225,7 +225,11 @@ struct topic_manifest_handler
     key_string _key;
 
     // required fields
+
+    // NOTE: version is no longer explicitly tracked, now that we use the
+    // versioned topic_manifest_state to serialize.
     std::optional<int32_t> _version;
+
     std::optional<model::ns> _namespace{};
     std::optional<model::topic> _topic;
     std::optional<int32_t> _partition_count;
@@ -253,13 +257,9 @@ struct topic_manifest_handler
 topic_manifest::topic_manifest(
   const cluster::topic_configuration& cfg,
   model::initial_revision_id rev,
-  const features::feature_table& ft)
+  const features::feature_table&)
   : _topic_config(cfg)
-  , _rev(rev)
-  , _manifest_version(
-      ft.is_active(features::feature::cluster_topic_manifest_format_v2)
-        ? serde_version
-        : first_version) {}
+  , _rev(rev) {}
 
 topic_manifest::topic_manifest()
   : _topic_config(std::nullopt) {}
@@ -271,10 +271,6 @@ void topic_manifest::do_update(const topic_manifest_handler& handler) {
           "topic manifest version {} is not supported",
           handler._version));
     }
-
-    // just to be explicit, set _manifest_version to first_version, even if it's
-    // already the default construction value
-    _manifest_version = topic_manifest::first_version;
 
     _rev = handler._revision_id.value();
 
@@ -432,7 +428,6 @@ topic_manifest::update(manifest_format format, ss::input_stream<char> is) {
           std::move(result));
         _topic_config = std::move(m_state.cfg);
         _rev = m_state.initial_revision;
-        _manifest_version = topic_manifest::serde_version;
         break;
     }
 
@@ -441,27 +436,6 @@ topic_manifest::update(manifest_format format, ss::input_stream<char> is) {
 
 ss::future<serialized_data_stream> topic_manifest::serialize() const {
     vassert(_topic_config.has_value(), "_topic_config is not initialized");
-
-    if (_manifest_version == first_version) {
-        // serialize in json format. this could still be required in unit-tests
-        // and mixed-versions clusters, when the old node is not yet running
-        // with features::feature::cluster_topic_manifest_format_v2
-        iobuf serialized;
-        iobuf_ostreambuf obuf(serialized);
-        std::ostream os(&obuf);
-        serialize_v1_json(os);
-        if (!os.good()) {
-            throw std::runtime_error(fmt_with_ctx(
-              fmt::format,
-              "could not serialize topic manifest {}",
-              get_manifest_path()));
-        }
-        size_t size_bytes = serialized.size_bytes();
-        co_return serialized_data_stream{
-          .stream = make_iobuf_input_stream(std::move(serialized)),
-          .size_bytes = size_bytes};
-    }
-
     // serialize in binary format
     auto serialized = serde::to_iobuf(topic_manifest_state{
       .cfg = _topic_config.value(), .initial_revision = _rev});
@@ -551,9 +525,7 @@ void topic_manifest::serialize_v1_json(std::ostream& out) const {
 
     // do not serialize fields that are not deserializable by previous versions
     // of redpanda
-    if (
-      _manifest_version > first_version
-      && _topic_config->properties.mpx_virtual_cluster_id) {
+    if (_topic_config->properties.mpx_virtual_cluster_id) {
         w.Key("virtual_cluster_id");
         w.String(fmt::format(
           "{}", _topic_config->properties.mpx_virtual_cluster_id.value()));
@@ -580,17 +552,7 @@ remote_manifest_path topic_manifest::get_manifest_path() const {
     // The path is <prefix>/meta/<ns>/<topic>/topic_manifest.json
     vassert(_topic_config, "Topic config is not set");
     return get_topic_manifest_path(
-      _topic_config->tp_ns.ns,
-      _topic_config->tp_ns.tp,
-      _manifest_version == first_version ? manifest_format::json
-                                         : manifest_format::serde);
+      _topic_config->tp_ns.ns, _topic_config->tp_ns.tp, manifest_format::serde);
 }
 
-std::pair<manifest_format, remote_manifest_path>
-topic_manifest::get_manifest_format_and_path() const {
-    return std::make_pair(
-      _manifest_version == first_version ? manifest_format::json
-                                         : manifest_format::serde,
-      get_manifest_path());
-}
 } // namespace cloud_storage

--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -42,8 +42,8 @@ public:
     topic_manifest();
 
     ss::future<> update(ss::input_stream<char> is) override {
-        // assume format is json
-        return update(manifest_format::json, std::move(is));
+        // assume format is serde
+        return update(manifest_format::serde, std::move(is));
     }
 
     /// Update manifest file from input_stream (remote set)
@@ -80,15 +80,6 @@ public:
         return _topic_config;
     }
 
-    /// return the version of the decoded manifest. useful to decide if to fill
-    /// a field that was not encoded in a previous version
-    version_t get_manifest_version() const noexcept {
-        return _manifest_version;
-    }
-
-    std::pair<manifest_format, remote_manifest_path>
-    get_manifest_format_and_path() const override;
-
     bool operator==(const topic_manifest& other) const {
         return std::tie(_topic_config, _rev)
                == std::tie(other._topic_config, other._rev);
@@ -101,6 +92,5 @@ private:
 
     std::optional<cluster::topic_configuration> _topic_config;
     model::initial_revision_id _rev;
-    version_t _manifest_version{first_version};
 };
 } // namespace cloud_storage

--- a/src/v/cloud_storage/topic_manifest_downloader.cc
+++ b/src/v/cloud_storage/topic_manifest_downloader.cc
@@ -1,0 +1,112 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+#include "cloud_storage/topic_manifest_downloader.h"
+
+#include "base/outcome.h"
+#include "cloud_storage/topic_manifest.h"
+#include "cloud_storage/topic_path_utils.h"
+#include "cloud_storage/types.h"
+#include "cloud_storage_clients/client.h"
+#include "container/fragmented_vector.h"
+#include "hashing/xx.h"
+#include "utils/retry_chain_node.h"
+
+#include <seastar/core/lowres_clock.hh>
+
+namespace cloud_storage {
+
+namespace {
+bool bin_manifest_filter(
+  const cloud_storage_clients::client::list_bucket_item& i) {
+    return i.key.ends_with("topic_manifest.bin");
+};
+} // namespace
+topic_manifest_downloader::topic_manifest_downloader(
+  const cloud_storage_clients::bucket_name bucket,
+  std::optional<ss::sstring> hint,
+  const model::topic_namespace topic,
+  remote& remote)
+  : bucket_(bucket)
+  , label_hint_(std::move(hint))
+  , topic_(topic)
+  , remote_(remote) {}
+
+ss::future<result<find_topic_manifest_outcome, error_outcome>>
+topic_manifest_downloader::download_manifest(
+  retry_chain_node& parent_retry,
+  ss::lowres_clock::time_point deadline,
+  model::timestamp_clock::duration backoff,
+  topic_manifest* manifest) {
+    retry_chain_node retry_node(deadline, backoff, &parent_retry);
+
+    // First look for topic manifests with a label.
+    ss::sstring remote_label_str = label_hint_.value_or("");
+    const auto labeled_manifest_filter = fmt::format(
+      "{}/{}", labeled_topic_manifest_root(topic_), remote_label_str);
+    auto list_res = co_await remote_.list_objects(
+      bucket_,
+      retry_node,
+      cloud_storage_clients::object_key{labeled_manifest_filter},
+      std::nullopt,
+      bin_manifest_filter);
+    if (list_res.has_error()) {
+        co_return error_outcome::manifest_download_error;
+    }
+    // If there's more than one, callers will need to pass a label (or a more
+    // specific one).
+    auto list_contents = std::move(list_res.value().contents);
+    if (list_contents.size() > 1) {
+        co_return find_topic_manifest_outcome::multiple_matching_manifests;
+    }
+    // If there's exactly one, presume it's the one we care about. Since
+    // labeled manifests are newer, they take precedence over prefixed
+    // manifests.
+    if (list_contents.size() == 1) {
+        const auto labeled_manifest = remote_manifest_path{
+          list_contents[0].key};
+        auto manifest_res = co_await remote_.download_manifest_bin(
+          bucket_, labeled_manifest, *manifest, retry_node);
+        if (manifest_res == cloud_storage::download_result::success) {
+            co_return find_topic_manifest_outcome::success;
+        }
+        // Regardless of the outcome (i.e. even not-found), return an error. If
+        // we had a list result but it was deleted, something is suspicious, so
+        // don't proceed.
+        co_return error_outcome::manifest_download_error;
+    }
+
+    // Then look for prefixed binary manifests. If we find one, return it:
+    // since they're newer than JSON manifests, they take precedence.
+    const remote_manifest_path prefixed_bin_path(
+      prefixed_topic_manifest_bin_path(topic_));
+    auto bin_manifest_res = co_await remote_.download_manifest_bin(
+      bucket_, prefixed_bin_path, *manifest, retry_node);
+    if (bin_manifest_res == cloud_storage::download_result::success) {
+        co_return find_topic_manifest_outcome::success;
+    }
+    if (bin_manifest_res != cloud_storage::download_result::notfound) {
+        co_return error_outcome::manifest_download_error;
+    }
+
+    // Finally, look for prefixed json topic manifest.
+    const remote_manifest_path prefixed_json_path(
+      prefixed_topic_manifest_json_path(topic_));
+    auto json_manifest_res = co_await remote_.download_manifest_json(
+      bucket_, prefixed_json_path, *manifest, retry_node);
+    if (json_manifest_res == cloud_storage::download_result::success) {
+        co_return find_topic_manifest_outcome::success;
+    }
+    if (json_manifest_res != cloud_storage::download_result::notfound) {
+        co_return error_outcome::manifest_download_error;
+    }
+    co_return find_topic_manifest_outcome::no_matching_manifest;
+}
+
+} // namespace cloud_storage

--- a/src/v/cloud_storage/topic_manifest_downloader.h
+++ b/src/v/cloud_storage/topic_manifest_downloader.h
@@ -1,0 +1,67 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+#pragma once
+
+#include "base/outcome.h"
+#include "cloud_storage/remote.h"
+#include "cloud_storage/remote_label.h"
+#include "cloud_storage/topic_manifest.h"
+#include "model/fundamental.h"
+
+namespace cloud_storage {
+
+enum class find_topic_manifest_outcome {
+    success = 0,
+
+    // There are no topic manifests belonging to a given topic.
+    no_matching_manifest,
+
+    // Indicates that multiple topic manifests are found for the given topic
+    // and a hint must be provided to determine winner.
+    multiple_matching_manifests,
+};
+
+// Encapsulates downloading manifests for a given topic.
+//
+// Topic manifests have gone through a few format/naming schemes:
+// - v24.2 and up: cluster-uuid-labeled, binary format
+// - v24.1 and up: hash-prefixed, binary format
+// - below v24.1: hash-prefixed, JSON format
+//
+// Precednece of manifests is reverse chronological, matching the top-down
+// order of the above list.
+//
+// This downloader returns the topic manifest, hiding the details of this
+// history from callers.
+class topic_manifest_downloader {
+public:
+    topic_manifest_downloader(
+      const cloud_storage_clients::bucket_name bucket,
+      std::optional<ss::sstring> hint,
+      const model::topic_namespace topoic,
+      remote& remote);
+
+    // Attempts to download the topic manifest, transparently checking paths
+    // that have been used by older versions of Redpanda if a new manifest
+    // isn't found.
+    ss::future<result<find_topic_manifest_outcome, error_outcome>>
+    download_manifest(
+      retry_chain_node& parent_retry,
+      ss::lowres_clock::time_point deadline,
+      model::timestamp_clock::duration backoff,
+      topic_manifest*);
+
+private:
+    const cloud_storage_clients::bucket_name bucket_;
+    const std::optional<ss::sstring> label_hint_;
+    const model::topic_namespace topic_;
+    remote& remote_;
+};
+
+} // namespace cloud_storage

--- a/src/v/cluster/cloud_metadata/manifest_downloads.cc
+++ b/src/v/cluster/cloud_metadata/manifest_downloads.cc
@@ -102,7 +102,7 @@ ss::future<cluster_manifest_result> download_highest_manifest_for_cluster(
     }
 
     // Deserialize the manifest.
-    auto manifest_res = co_await remote.download_manifest(
+    auto manifest_res = co_await remote.download_manifest_json(
       bucket,
       cluster_manifest_key(cluster_uuid, highest_meta_id),
       manifest,
@@ -243,7 +243,7 @@ ss::future<cluster_manifest_result> download_highest_manifest_in_bucket(
         co_return error_outcome::no_matching_metadata;
     }
     cluster_metadata_manifest manifest;
-    auto manifest_res = co_await remote.download_manifest(
+    auto manifest_res = co_await remote.download_manifest_json(
       bucket,
       cluster_manifest_key(uuid_with_highest_meta_id, highest_meta_id),
       manifest,

--- a/src/v/cluster/remote_topic_configuration_source.cc
+++ b/src/v/cluster/remote_topic_configuration_source.cc
@@ -74,7 +74,7 @@ download_topic_manifest(
       cloud_storage::manifest_format::json,
       cloud_storage::topic_manifest::get_topic_manifest_path(
         ns, topic, cloud_storage::manifest_format::json)};
-    res = co_await remote.download_manifest(
+    res = co_await remote.download_manifest_json(
       bucket, json_path.second, manifest, rc_node);
 
     if (res == cloud_storage::download_result::success) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
When performing topic recovery, Redpanda looks for topic manifests for
the target topic, first looking for a binary manifest, and then looking
for a JSON manifest (see cluster/remote_topic_configuration_source.cc).

With the upcoming naming scheme changes, this will need to change to
account for cluster UUID labels.

This commit introduces a topic manifest downloader for this purpose.
A later commit will replace most of `download_topic_manifest()` in
cluster/remote_topic_configuration_source.cc with this new downloader.
For now, this just adds the class and adds some tests.

Note that the new downloader has an optional "hint" that can be used to
differentiate topic manifests from different clusters (or even from
different revisions in the same cluster).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
