### PR TITLE
Node-local core assignment: core count decrease

### DIFF
--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -486,6 +486,8 @@ ss::future<> copy_persistent_state(
   ss::shard_id target_shard,
   ss::sharded<storage::api>& storage) {
     return ss::when_all_succeed(
+             storage::disk_log_impl::copy_kvstore_state(
+               ntp, source_kvs, target_shard, storage),
              raft::details::copy_persistent_state(
                group, source_kvs, target_shard, storage),
              storage::offset_translator::copy_persistent_state(
@@ -498,6 +500,7 @@ ss::future<> copy_persistent_state(
 ss::future<> remove_persistent_state(
   const model::ntp& ntp, raft::group_id group, storage::kvstore& source_kvs) {
     return ss::when_all_succeed(
+             storage::disk_log_impl::remove_kvstore_state(ntp, source_kvs),
              raft::details::remove_persistent_state(group, source_kvs),
              storage::offset_translator::remove_persistent_state(
                group, source_kvs),

--- a/src/v/cluster/cluster_utils.cc
+++ b/src/v/cluster/cluster_utils.cc
@@ -401,18 +401,7 @@ std::optional<ss::sstring> check_result_configuration(
           new_configuration.id());
     }
     auto& current_configuration = it->second.broker;
-    /**
-     * do no allow to decrease node core count
-     */
-    if (
-      current_configuration.properties().cores
-      > new_configuration.properties().cores) {
-        return fmt::format(
-          "core count must not decrease on any broker, currently configured "
-          "core count: {}, requested core count: {}",
-          current_configuration.properties().cores,
-          new_configuration.properties().cores);
-    }
+
     /**
      * When cluster member configuration changes Redpanda by default doesn't
      * allow the change if a new cluster configuration would have two

--- a/src/v/cluster/cluster_utils.h
+++ b/src/v/cluster/cluster_utils.h
@@ -354,4 +354,17 @@ std::optional<ss::sstring> check_result_configuration(
   const members_table::cache_t& current_brokers,
   const model::broker& to_update);
 
+/// Copies all bits of partition kvstore state from source kvstore to kvstore on
+/// target shard.
+ss::future<> copy_persistent_state(
+  const model::ntp&,
+  raft::group_id,
+  storage::kvstore& source_kvs,
+  ss::shard_id target_shard,
+  ss::sharded<storage::api>&);
+
+/// Removes all bits of partition kvstore state in source kvstore.
+ss::future<> remove_persistent_state(
+  const model::ntp&, raft::group_id, storage::kvstore& source_kvs);
+
 } // namespace cluster

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -470,7 +470,9 @@ ss::future<> controller::start(
       std::ref(_backend),
       config::shard_local_cfg().core_balancing_on_core_count_change.bind(),
       config::shard_local_cfg().core_balancing_continuous.bind(),
-      config::shard_local_cfg().core_balancing_debounce_timeout.bind());
+      config::shard_local_cfg().core_balancing_debounce_timeout.bind(),
+      config::shard_local_cfg().topic_partitions_per_shard.bind(),
+      config::shard_local_cfg().topic_partitions_reserve_shard0.bind());
 
     co_await _drain_manager.invoke_on_all(&drain_manager::start);
 

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -204,8 +204,10 @@ ss::future<> controller::wire_up() {
             std::ref(_node_status_table));
       })
       .then([this] {
-          return _shard_placement.start(ss::sharded_parameter(
-            [this] { return std::ref(_storage.local().kvs()); }));
+          return _shard_placement.start(
+            ss::sharded_parameter([] { return ss::this_shard_id(); }),
+            ss::sharded_parameter(
+              [this] { return std::ref(_storage.local().kvs()); }));
       })
       .then([this] { _probe.start(); });
 }

--- a/src/v/cluster/controller.h
+++ b/src/v/cluster/controller.h
@@ -256,7 +256,7 @@ private:
     std::optional<cloud_storage_clients::bucket_name> get_configured_bucket();
 
     // Checks configuration invariants stored in kvstore
-    ss::future<> validate_configuration_invariants();
+    ss::future<configuration_invariants> validate_configuration_invariants();
 
     config_manager::preload_result _config_preload;
 

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1725,7 +1725,7 @@ ss::future<std::error_code> controller_backend::transfer_partition(
       log_revision);
 
     auto maybe_dest = co_await _shard_placement.prepare_transfer(
-      ntp, log_revision);
+      ntp, log_revision, _shard_placement.container());
     if (maybe_dest.has_error()) {
         co_return maybe_dest.error();
     }

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1738,11 +1738,11 @@ ss::future<std::error_code> controller_backend::transfer_partition(
 
     // TODO: copy, not move
     co_await raft::details::move_persistent_state(
-      group, ss::this_shard_id(), destination, _storage);
+      group, _storage.local().kvs(), destination, _storage);
     co_await storage::offset_translator::move_persistent_state(
-      group, ss::this_shard_id(), destination, _storage);
+      group, _storage.local().kvs(), destination, _storage);
     co_await raft::move_persistent_stm_state(
-      ntp, ss::this_shard_id(), destination, _storage);
+      ntp, _storage.local().kvs(), destination, _storage);
 
     co_await container().invoke_on(
       destination, [&ntp, log_revision](controller_backend& dest) {

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -1736,12 +1736,8 @@ ss::future<std::error_code> controller_backend::transfer_partition(
         co_await shutdown_partition(std::move(partition));
     }
 
-    co_await raft::details::copy_persistent_state(
-      group, _storage.local().kvs(), destination, _storage);
-    co_await storage::offset_translator::copy_persistent_state(
-      group, _storage.local().kvs(), destination, _storage);
-    co_await raft::copy_persistent_stm_state(
-      ntp, _storage.local().kvs(), destination, _storage);
+    co_await copy_persistent_state(
+      ntp, group, _storage.local().kvs(), destination, _storage);
 
     co_await container().invoke_on(
       destination, [&ntp, log_revision](controller_backend& dest) {
@@ -1755,11 +1751,7 @@ ss::future<std::error_code> controller_backend::transfer_partition(
             });
       });
 
-    co_await raft::details::remove_persistent_state(
-      group, _storage.local().kvs());
-    co_await storage::offset_translator::remove_persistent_state(
-      group, _storage.local().kvs());
-    co_await raft::remove_persistent_stm_state(ntp, _storage.local().kvs());
+    co_await remove_persistent_state(ntp, group, _storage.local().kvs());
 
     co_await _shard_placement.finish_transfer_on_source(ntp, log_revision);
     co_return errc::success;

--- a/src/v/cluster/controller_backend.h
+++ b/src/v/cluster/controller_backend.h
@@ -306,6 +306,9 @@ private:
       model::revision_id cmd_revision,
       partition_removal_mode mode);
 
+    ss::future<> remove_partition_kvstore_state(
+      model::ntp, raft::group_id, model::revision_id log_revision);
+
     ss::future<result<ss::stop_iteration>> reconcile_partition_reconfiguration(
       ntp_reconciliation_state&,
       ss::lw_shared_ptr<partition>,

--- a/src/v/cluster/scheduling/allocation_node.cc
+++ b/src/v/cluster/scheduling/allocation_node.cc
@@ -142,15 +142,13 @@ void allocation_node::remove_final_count(partition_allocation_domain domain) {
 }
 
 void allocation_node::update_core_count(uint32_t core_count) {
-    vassert(
-      core_count >= cpus(),
-      "decreasing node core count is not supported, current core count {} > "
-      "requested core count {}",
-      cpus(),
-      core_count);
-    auto current_cpus = cpus();
-    for (auto i = current_cpus; i < core_count; ++i) {
-        _weights.push_back(0);
+    auto old_count = _weights.size();
+    if (core_count < old_count) {
+        _weights.resize(core_count);
+    } else {
+        for (auto i = old_count; i < core_count; ++i) {
+            _weights.push_back(0);
+        }
     }
     _max_capacity = allocation_capacity(
       (core_count * _partitions_per_shard()) - _partitions_reserve_shard0());

--- a/src/v/cluster/shard_balancer.cc
+++ b/src/v/cluster/shard_balancer.cc
@@ -118,7 +118,7 @@ ss::future<> shard_balancer::start() {
     // 2. restore shard_placement_table from the kvstore or from topic_table.
 
     if (_shard_placement.is_persistence_enabled()) {
-        co_await _shard_placement.initialize_from_kvstore(local_group2ntp);
+        co_await _shard_placement.initialize_from_kvstore(local_group2ntp, {});
     } else if (_features.is_active(
                  features::feature::node_local_core_assignment)) {
         // joiner node? enable persistence without initializing

--- a/src/v/cluster/shard_balancer.h
+++ b/src/v/cluster/shard_balancer.h
@@ -42,7 +42,9 @@ public:
       ss::sharded<controller_backend>&,
       config::binding<bool> balancing_on_core_count_change,
       config::binding<bool> balancing_continuous,
-      config::binding<std::chrono::milliseconds> debounce_timeout);
+      config::binding<std::chrono::milliseconds> debounce_timeout,
+      config::binding<uint32_t> partitions_per_shard,
+      config::binding<uint32_t> partitions_reserve_shard0);
 
     ss::future<> start(size_t kvstore_shard_count);
     ss::future<> stop();
@@ -119,6 +121,8 @@ private:
     config::binding<bool> _balancing_continuous;
     config::binding<std::chrono::milliseconds> _debounce_timeout;
     simple_time_jitter<ss::lowres_clock> _debounce_jitter;
+    config::binding<uint32_t> _partitions_per_shard;
+    config::binding<uint32_t> _partitions_reserve_shard0;
 
     cluster::notification_id_type _topic_table_notify_handle;
     ss::timer<ss::lowres_clock> _balance_timer;

--- a/src/v/cluster/shard_placement_table.cc
+++ b/src/v/cluster/shard_placement_table.cc
@@ -527,7 +527,7 @@ ss::future<> shard_placement_table::scatter_init_data(
                         .revision = init_data.receiving.revision};
                   }
               } else if (
-                _shard != init_data.receiving.shard
+                _shard != init_data.receiving.shard || !init_data.hosted.shard
                 || _shard >= ss::smp::count) {
                   state.current->status = hosted_status::obsolete;
               }

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -94,7 +94,9 @@ public:
 
     enum class reconciliation_action {
         /// Partition must be removed from this node
-        remove,
+        remove_partition,
+        /// Partition kvstore state must be removed from this shard
+        remove_kvstore_state,
         /// Partition must be transferred to other shard
         transfer,
         /// Wait until target catches up with topic_table

--- a/src/v/cluster/shard_placement_table.h
+++ b/src/v/cluster/shard_placement_table.h
@@ -131,6 +131,11 @@ public:
             return !current && !_is_initial_for && !assigned;
         }
 
+        struct versioned_shard {
+            ss::shard_id shard;
+            model::shard_revision_id revision;
+        };
+
         /// If this shard is the initial shard for some incarnation of this
         /// partition on this node, this field will contain the corresponding
         /// log revision. Invariant: if both _is_initial_for and current
@@ -139,7 +144,7 @@ public:
         /// If x-shard transfer is in progress, will hold the destination. Note
         /// that it is initialized from target but in contrast to target, it
         /// can't change mid-transfer.
-        std::optional<ss::shard_id> _next;
+        std::optional<versioned_shard> _next;
     };
 
     using ntp2state_t = absl::node_hash_map<model::ntp, placement_state>;
@@ -191,21 +196,30 @@ public:
     ss::future<std::error_code>
     prepare_create(const model::ntp&, model::revision_id expected_log_rev);
 
-    // return value is a tri-state:
-    // * if it returns a shard_id value, a transfer to that shard must be
-    // performed
-    // * if it returns errc::success, transfer has already been performed
-    // * else, we must wait before we begin the transfer.
-    ss::future<result<ss::shard_id>> prepare_transfer(
+    struct prepare_transfer_info {
+        // will hold non-success value if source shard is not yet ready for
+        // transfer.
+        errc source_error = errc::success;
+        // will hold destination shard if source_error == success.
+        std::optional<ss::shard_id> destination;
+        // will hold non-success value if destination shard is not yet ready for
+        // transfer.
+        errc dest_error = errc::success;
+        // true if the caller doesn't have to do anything else - the transfer is
+        // already finished
+        bool is_finished = false;
+    };
+
+    ss::future<prepare_transfer_info> prepare_transfer(
       const model::ntp&,
       model::revision_id expected_log_rev,
       ss::sharded<shard_placement_table>&);
 
-    ss::future<> finish_transfer_on_destination(
-      const model::ntp&, model::revision_id expected_log_rev);
-
-    ss::future<> finish_transfer_on_source(
-      const model::ntp&, model::revision_id expected_log_rev);
+    ss::future<> finish_transfer(
+      const model::ntp&,
+      model::revision_id expected_log_rev,
+      ss::sharded<shard_placement_table>&,
+      shard_callback_t);
 
     ss::future<std::error_code>
     prepare_delete(const model::ntp&, model::revision_id cmd_revision);

--- a/src/v/cluster/tests/shard_placement_table_test.cc
+++ b/src/v/cluster/tests/shard_placement_table_test.cc
@@ -996,6 +996,7 @@ public:
             config::mock_binding(10ms),
             test_dir,
             storage::make_sanitized_file_config()),
+          ss::sharded_parameter([] { return ss::this_shard_id(); }),
           ss::sharded_parameter([this] { return std::ref(sr.local()); }),
           std::ref(ft));
         co_await kvs->invoke_on_all(

--- a/src/v/raft/consensus_utils.cc
+++ b/src/v/raft/consensus_utils.cc
@@ -238,7 +238,7 @@ bytes serialize_group_key(raft::group_id group, metadata_key key_type) {
 
 ss::future<> move_persistent_state(
   raft::group_id group,
-  ss::shard_id source_shard,
+  storage::kvstore& source_kvs,
   ss::shard_id target_shard,
   ss::sharded<storage::api>& api) {
     struct persistent_state {
@@ -249,98 +249,84 @@ ss::future<> move_persistent_state(
         std::optional<iobuf> highest_known_offset;
         std::optional<iobuf> next_cfg_idx;
     };
-    using state_ptr = std::unique_ptr<persistent_state>;
-    using state_fptr = ss::foreign_ptr<std::unique_ptr<persistent_state>>;
-
-    state_fptr state = co_await api.invoke_on(
-      source_shard, [gr = group](storage::api& api) {
-          const auto ks = storage::kvstore::key_space::consensus;
-          persistent_state state{
-            .voted_for = api.kvs().get(
-              ks, serialize_group_key(gr, metadata_key::voted_for)),
-            .last_applied = api.kvs().get(
-              ks, serialize_group_key(gr, metadata_key::last_applied_offset)),
-            .unique_run_id = api.kvs().get(
-              ks, serialize_group_key(gr, metadata_key::unique_local_id)),
-            .configuration_map = api.kvs().get(
-              ks, serialize_group_key(gr, metadata_key::config_map)),
-            .highest_known_offset = api.kvs().get(
-              ks,
-              serialize_group_key(
-                gr, metadata_key::config_latest_known_offset)),
-            .next_cfg_idx = api.kvs().get(
-              ks, serialize_group_key(gr, metadata_key::config_next_cfg_idx))};
-          return ss::make_foreign<state_ptr>(
-            std::make_unique<persistent_state>(std::move(state)));
-      });
+    const auto ks = storage::kvstore::key_space::consensus;
+    const persistent_state state{
+      .voted_for = source_kvs.get(
+        ks, serialize_group_key(group, metadata_key::voted_for)),
+      .last_applied = source_kvs.get(
+        ks, serialize_group_key(group, metadata_key::last_applied_offset)),
+      .unique_run_id = source_kvs.get(
+        ks, serialize_group_key(group, metadata_key::unique_local_id)),
+      .configuration_map = source_kvs.get(
+        ks, serialize_group_key(group, metadata_key::config_map)),
+      .highest_known_offset = source_kvs.get(
+        ks,
+        serialize_group_key(group, metadata_key::config_latest_known_offset)),
+      .next_cfg_idx = source_kvs.get(
+        ks, serialize_group_key(group, metadata_key::config_next_cfg_idx))};
 
     co_await api.invoke_on(
-      target_shard, [gr = group, state = std::move(state)](storage::api& api) {
+      target_shard, [gr = group, &state](storage::api& api) {
           const auto ks = storage::kvstore::key_space::consensus;
           std::vector<ss::future<>> write_futures;
           write_futures.reserve(6);
-          if (state->voted_for) {
+          if (state.voted_for) {
               write_futures.push_back(api.kvs().put(
                 ks,
                 serialize_group_key(gr, metadata_key::voted_for),
-                state->voted_for->copy()));
+                state.voted_for->copy()));
           }
-          if (state->last_applied) {
+          if (state.last_applied) {
               write_futures.push_back(api.kvs().put(
                 ks,
                 serialize_group_key(gr, metadata_key::last_applied_offset),
-                state->last_applied->copy()));
+                state.last_applied->copy()));
           }
-          if (state->unique_run_id) {
+          if (state.unique_run_id) {
               write_futures.push_back(api.kvs().put(
                 ks,
                 serialize_group_key(gr, metadata_key::unique_local_id),
-                state->unique_run_id->copy()));
+                state.unique_run_id->copy()));
           }
-          if (state->configuration_map) {
+          if (state.configuration_map) {
               write_futures.push_back(api.kvs().put(
                 ks,
                 serialize_group_key(gr, metadata_key::config_map),
-                state->configuration_map->copy()));
+                state.configuration_map->copy()));
           }
-          if (state->highest_known_offset) {
+          if (state.highest_known_offset) {
               write_futures.push_back(api.kvs().put(
                 ks,
                 serialize_group_key(
                   gr, metadata_key::config_latest_known_offset),
-                state->highest_known_offset->copy()));
+                state.highest_known_offset->copy()));
           }
-          if (state->next_cfg_idx) {
+          if (state.next_cfg_idx) {
               write_futures.push_back(api.kvs().put(
                 ks,
                 serialize_group_key(gr, metadata_key::config_next_cfg_idx),
-                state->next_cfg_idx->copy()));
+                state.next_cfg_idx->copy()));
           }
-          return ss::when_all_succeed(
-            write_futures.begin(), write_futures.end());
+          return ss::when_all_succeed(std::move(write_futures));
       });
 
     // remove on source shard
-    co_await api.invoke_on(source_shard, [gr = group](storage::api& api) {
-        const auto ks = storage::kvstore::key_space::consensus;
-        std::vector<ss::future<>> remove_futures;
-        remove_futures.reserve(6);
-        remove_futures.push_back(api.kvs().remove(
-          ks, serialize_group_key(gr, metadata_key::voted_for)));
-        remove_futures.push_back(api.kvs().remove(
-          ks, serialize_group_key(gr, metadata_key::last_applied_offset)));
-        remove_futures.push_back(api.kvs().remove(
-          ks, serialize_group_key(gr, metadata_key::unique_local_id)));
-        remove_futures.push_back(api.kvs().remove(
-          ks, serialize_group_key(gr, metadata_key::config_map)));
-        remove_futures.push_back(api.kvs().remove(
-          ks,
-          serialize_group_key(gr, metadata_key::config_latest_known_offset)));
-        remove_futures.push_back(api.kvs().remove(
-          ks, serialize_group_key(gr, metadata_key::config_next_cfg_idx)));
-        return ss::when_all_succeed(
-          remove_futures.begin(), remove_futures.end());
-    });
+    std::vector<ss::future<>> remove_futures;
+    remove_futures.reserve(6);
+    remove_futures.push_back(source_kvs.remove(
+      ks, serialize_group_key(group, metadata_key::voted_for)));
+    remove_futures.push_back(source_kvs.remove(
+      ks, serialize_group_key(group, metadata_key::last_applied_offset)));
+    remove_futures.push_back(source_kvs.remove(
+      ks, serialize_group_key(group, metadata_key::unique_local_id)));
+    remove_futures.push_back(source_kvs.remove(
+      ks, serialize_group_key(group, metadata_key::config_map)));
+    remove_futures.push_back(source_kvs.remove(
+      ks,
+      serialize_group_key(group, metadata_key::config_latest_known_offset)));
+    remove_futures.push_back(source_kvs.remove(
+      ks, serialize_group_key(group, metadata_key::config_next_cfg_idx)));
+    co_await ss::when_all_succeed(std::move(remove_futures));
 }
 
 // Return previous offset. This is different from

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -187,7 +187,7 @@ bytes serialize_group_key(raft::group_id, metadata_key);
  */
 ss::future<> move_persistent_state(
   raft::group_id,
-  ss::shard_id source_shard,
+  storage::kvstore& source_kvs,
   ss::shard_id target_shard,
   ss::sharded<storage::api>&);
 

--- a/src/v/raft/consensus_utils.h
+++ b/src/v/raft/consensus_utils.h
@@ -182,14 +182,19 @@ auto for_each_ref_extract_configuration(
 
 bytes serialize_group_key(raft::group_id, metadata_key);
 /**
- * moves raft persistent state from KV store on source shard to the one on
+ * copies raft persistent state from KV store on source shard to the one on
  * target shard.
  */
-ss::future<> move_persistent_state(
+ss::future<> copy_persistent_state(
   raft::group_id,
   storage::kvstore& source_kvs,
   ss::shard_id target_shard,
   ss::sharded<storage::api>&);
+
+/**
+ * removes raft persistent state from a kvstore.
+ */
+ss::future<> remove_persistent_state(raft::group_id, storage::kvstore&);
 
 /// Creates persitent state for pre-existing partition (stored in S3 bucket).
 ///

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -121,7 +121,7 @@ private:
 
 ss::future<> move_persistent_stm_state(
   model::ntp ntp,
-  ss::shard_id source_shard,
+  storage::kvstore& source_kvs,
   ss::shard_id target_shard,
   ss::sharded<storage::api>&);
 

--- a/src/v/raft/persisted_stm.h
+++ b/src/v/raft/persisted_stm.h
@@ -119,11 +119,13 @@ private:
     storage::kvstore& _kvstore;
 };
 
-ss::future<> move_persistent_stm_state(
+ss::future<> copy_persistent_stm_state(
   model::ntp ntp,
   storage::kvstore& source_kvs,
   ss::shard_id target_shard,
   ss::sharded<storage::api>&);
+
+ss::future<> remove_persistent_stm_state(model::ntp ntp, storage::kvstore&);
 
 template<typename T>
 concept supported_stm_snapshot = requires(T s, stm_snapshot&& snapshot) {

--- a/src/v/storage/disk_log_impl.h
+++ b/src/v/storage/disk_log_impl.h
@@ -208,6 +208,15 @@ public:
 
     const auto& compaction_ratio() const { return _compaction_ratio; }
 
+    static ss::future<> copy_kvstore_state(
+      model::ntp,
+      storage::kvstore& source_kvs,
+      ss::shard_id target_shard,
+      ss::sharded<storage::api>&);
+
+    static ss::future<>
+    remove_kvstore_state(const model::ntp&, storage::kvstore&);
+
 private:
     friend class disk_log_appender; // for multi-term appends
     friend class disk_log_builder;  // for tests

--- a/src/v/storage/kvstore.cc
+++ b/src/v/storage/kvstore.cc
@@ -37,12 +37,13 @@ namespace storage {
 
 kvstore::kvstore(
   kvstore_config kv_conf,
+  ss::shard_id shard,
   storage_resources& resources,
   ss::sharded<features::feature_table>& feature_table)
   : _conf(kv_conf)
   , _resources(resources)
   , _feature_table(feature_table)
-  , _ntpc(model::kvstore_ntp(ss::this_shard_id()), _conf.base_dir)
+  , _ntpc(model::kvstore_ntp(shard), _conf.base_dir)
   , _snap(
       std::filesystem::path(_ntpc.work_directory()),
       simple_snapshot_manager::default_snapshot_filename,
@@ -59,7 +60,9 @@ kvstore::~kvstore() noexcept = default;
 ss::future<> kvstore::start() {
     vlog(lg.debug, "Starting kvstore: dir {}", _ntpc.work_directory());
 
-    if (!config::shard_local_cfg().disable_metrics()) {
+    bool is_main_instance = static_cast<int>(ss::this_shard_id())
+                            == _ntpc.ntp().tp.partition();
+    if (is_main_instance && !config::shard_local_cfg().disable_metrics()) {
         _probe.metrics.add_group(
           prometheus_sanitize::metrics_name("storage:kvstore"),
           {

--- a/src/v/storage/kvstore.h
+++ b/src/v/storage/kvstore.h
@@ -107,6 +107,7 @@ public:
 
     explicit kvstore(
       kvstore_config kv_conf,
+      ss::shard_id shard,
       storage_resources&,
       ss::sharded<features::feature_table>& feature_table);
     ~kvstore() noexcept;

--- a/src/v/storage/offset_translator.cc
+++ b/src/v/storage/offset_translator.cc
@@ -379,71 +379,57 @@ ss::future<> offset_translator::do_checkpoint() {
 
 ss::future<> offset_translator::move_persistent_state(
   raft::group_id group,
-  ss::shard_id source_shard,
+  storage::kvstore& source_kvs,
   ss::shard_id target_shard,
   ss::sharded<storage::api>& api) {
     struct ot_state {
         std::optional<iobuf> highest_known_offset;
         std::optional<iobuf> offset_map;
     };
-    using state_ptr = std::unique_ptr<ot_state>;
     vlog(
       storage::stlog.debug,
-      "moving group {} offset translator state from {} to {}",
+      "moving group {} offset translator state to {}",
       group,
-      source_shard,
       target_shard);
     static constexpr auto ks = storage::kvstore::key_space::offset_translator;
-    auto state = co_await api.invoke_on(
-      source_shard, [gr = group](storage::api& api) {
-          ot_state st{
-            .highest_known_offset = api.kvs().get(
-              ks,
-              serialize_kvstore_key(
-                gr, kvstore_key_type::highest_known_offset)),
-            .offset_map = api.kvs().get(
-              ks, serialize_kvstore_key(gr, kvstore_key_type::offsets_map)),
-          };
-          return ss::make_foreign<state_ptr>(
-            std::make_unique<ot_state>(std::move(st)));
-      });
+    ot_state state{
+      .highest_known_offset = source_kvs.get(
+        ks,
+        serialize_kvstore_key(group, kvstore_key_type::highest_known_offset)),
+      .offset_map = source_kvs.get(
+        ks, serialize_kvstore_key(group, kvstore_key_type::offsets_map)),
+    };
 
     co_await api.invoke_on(
-      target_shard,
-      [gr = group,
-       state = std::move(state)](storage::api& api) -> ss::future<> {
+      target_shard, [gr = group, &state](storage::api& api) -> ss::future<> {
           std::vector<ss::future<>> write_futures;
           write_futures.reserve(2);
-          if (state->offset_map) {
+          if (state.offset_map) {
               write_futures.push_back(api.kvs().put(
                 ks,
                 serialize_kvstore_key(gr, kvstore_key_type::offsets_map),
-                state->offset_map->copy()));
+                state.offset_map->copy()));
           }
-          if (state->highest_known_offset) {
+          if (state.highest_known_offset) {
               write_futures.push_back(api.kvs().put(
                 ks,
                 serialize_kvstore_key(
                   gr, kvstore_key_type::highest_known_offset),
-                state->highest_known_offset->copy()));
+                state.highest_known_offset->copy()));
           }
 
-          return ss::when_all_succeed(
-            write_futures.begin(), write_futures.end());
+          return ss::when_all_succeed(std::move(write_futures));
       });
 
     // remove on source shard
-    co_await api.invoke_on(source_shard, [gr = group](storage::api& api) {
-        std::vector<ss::future<>> remove_futures;
-        remove_futures.reserve(2);
-        remove_futures.push_back(api.kvs().remove(
-          ks,
-          serialize_kvstore_key(gr, kvstore_key_type::highest_known_offset)));
-        remove_futures.push_back(api.kvs().remove(
-          ks, serialize_kvstore_key(gr, kvstore_key_type::offsets_map)));
-        return ss::when_all_succeed(
-          remove_futures.begin(), remove_futures.end());
-    });
+    std::vector<ss::future<>> remove_futures;
+    remove_futures.reserve(2);
+    remove_futures.push_back(source_kvs.remove(
+      ks,
+      serialize_kvstore_key(group, kvstore_key_type::highest_known_offset)));
+    remove_futures.push_back(source_kvs.remove(
+      ks, serialize_kvstore_key(group, kvstore_key_type::offsets_map)));
+    co_await ss::when_all_succeed(std::move(remove_futures));
 }
 
 } // namespace storage

--- a/src/v/storage/offset_translator.h
+++ b/src/v/storage/offset_translator.h
@@ -103,13 +103,16 @@ public:
 
     ss::future<> remove_persistent_state();
 
-    /// Moves offset translator persistent state from source to target shard.
-    /// Note when move state on the source shard is deleted
-    static ss::future<> move_persistent_state(
+    /// Copies offset translator persistent state from source to target shard.
+    static ss::future<> copy_persistent_state(
       raft::group_id,
       storage::kvstore& source_kvs,
       ss::shard_id target_shard,
       ss::sharded<storage::api>&);
+
+    /// Removes offset translator persistent state from a kvstore.
+    static ss::future<>
+    remove_persistent_state(raft::group_id, storage::kvstore&);
 
     /// Get offset translator storage::kvstore keys. Used only for testing
     bytes offsets_map_key() const;

--- a/src/v/storage/offset_translator.h
+++ b/src/v/storage/offset_translator.h
@@ -107,7 +107,7 @@ public:
     /// Note when move state on the source shard is deleted
     static ss::future<> move_persistent_state(
       raft::group_id,
-      ss::shard_id source_shard,
+      storage::kvstore& source_kvs,
       ss::shard_id target_shard,
       ss::sharded<storage::api>&);
 

--- a/src/v/storage/tests/kvstore_fixture.h
+++ b/src/v/storage/tests/kvstore_fixture.h
@@ -34,7 +34,7 @@ public:
 
     std::unique_ptr<storage::kvstore> make_kvstore() {
         return std::make_unique<storage::kvstore>(
-          _kv_config, resources, _feature_table);
+          _kv_config, ss::this_shard_id(), resources, _feature_table);
     }
 
     ~kvstore_test_fixture() {

--- a/src/v/storage/tests/offset_translator_tests.cc
+++ b/src/v/storage/tests/offset_translator_tests.cc
@@ -641,8 +641,11 @@ FIXTURE_TEST(test_moving_persistent_state, base_fixture) {
     // use last available shard
     auto target_shard = ss::smp::count - 1;
     // move state to target shard
-    storage::offset_translator::move_persistent_state(
+    storage::offset_translator::copy_persistent_state(
       raft::group_id(0), _api.local().kvs(), target_shard, _api)
+      .get();
+    storage::offset_translator::remove_persistent_state(
+      raft::group_id(0), _api.local().kvs())
       .get();
 
     // validate translation on target shard

--- a/src/v/storage/tests/offset_translator_tests.cc
+++ b/src/v/storage/tests/offset_translator_tests.cc
@@ -642,7 +642,7 @@ FIXTURE_TEST(test_moving_persistent_state, base_fixture) {
     auto target_shard = ss::smp::count - 1;
     // move state to target shard
     storage::offset_translator::move_persistent_state(
-      raft::group_id(0), ss::this_shard_id(), target_shard, _api)
+      raft::group_id(0), _api.local().kvs(), target_shard, _api)
       .get();
 
     // validate translation on target shard

--- a/src/v/storage/tests/storage_test_fixture.h
+++ b/src/v/storage/tests/storage_test_fixture.h
@@ -205,6 +205,7 @@ public:
             config::mock_binding(10ms),
             test_dir,
             storage::make_sanitized_file_config()),
+          ss::this_shard_id(),
           resources,
           feature_table) {
         configure_unit_test_logging();

--- a/tests/rptest/tests/node_resize_test.py
+++ b/tests/rptest/tests/node_resize_test.py
@@ -18,17 +18,15 @@ from rptest.services.cluster import cluster
 from rptest.tests.redpanda_test import RedpandaTest
 
 RESIZE_LOG_ALLOW_LIST = RESTART_LOG_ALLOW_LIST + [
-    re.compile("Decreasing redpanda core count is not allowed"),
-    re.compile(
-        "Failure during startup: cluster::configuration_invariants_changed")
+    re.compile("Detected decrease in number of cores"),
 ]
 
 
 class NodeResizeTest(RedpandaTest):
     """
     Validate redpanda behaviour on node core count changes.  At time of writing this simply checks
-    that redpanda refuses to start if core count has decreased: if we make node resizes more
-    flexible in future, this test should be updated to exercise that.
+    that redpanda refuses to start if core count has decreased and core balancing on core count
+    change is unavailable.
     """
 
     INITIAL_NUM_CPUS = 2
@@ -37,6 +35,7 @@ class NodeResizeTest(RedpandaTest):
         super().__init__(
             *args,
             resource_settings=ResourceSettings(num_cpus=self.INITIAL_NUM_CPUS),
+            extra_rp_conf={"core_balancing_on_core_count_change": False},
             **kwargs)
 
     def _restart_with_num_cpus(self, node: ClusterNode, num_cpus: int,


### PR DESCRIPTION
Implement copying partition data from extra kvstore shards (i.e. kvstore shards with ids >= current shard count) and use it to allow decreasing core count.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
### Features
* Allow decreasing core count if node-local core assignment is enabled.
