### PR TITLE
Transforms JS SDK: plumb `environ` down into `process.env`

### DIFF
--- a/src/transform-sdk/js/README.md
+++ b/src/transform-sdk/js/README.md
@@ -7,7 +7,7 @@ To use this SDK manually here are the steps:
 
 ```shell
 # Compile the C++
-docker run -v `pwd`/..:/src -w /src/js ghcr.io/webassembly/wasi-sdk \
+docker run -v `pwd`/..:/src -w /src/js ghcr.io/webassembly/wasi-sdk:wasi-sdk-21 \
   /bin/bash -c 'apt update && apt install -y git && cmake --preset release-static && cmake --build --preset release-static -- redpanda_js_transform -j32'
 # Convert the JavaScript file into a WebAssembly text file
 cat user_code.js | ./generate_js_provider.py > js_user_code.wat


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

This PR adds a `Process` class and injects an instance into the global namespace as `globalThis.process`. Currently we implement a top-level `env` object that reflects the contents of `environ` at init time, but in principle this could take on [other process stuff](https://nodejs.org/api/process.html).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
