### PR TITLE
Coroutine bench updates

### DIFF
--- a/src/v/utils/tests/CMakeLists.txt
+++ b/src/v/utils/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ rp_test(
   UNIT_TEST
   GTEST
   BINARY_NAME gtest_utils
-  SOURCES     
+  SOURCES
     xid_test.cc
   LIBRARIES v::utils absl::flat_hash_map v::random v::gtest_main
   LABELS utils
@@ -83,8 +83,18 @@ rp_test(
 
 rp_test(
   BENCHMARK_TEST
+  BINARY_NAME coro
+  SOURCES
+    coro_bench.cc
+  LIBRARIES Seastar::seastar_perf_testing v::utils
+  LABELS utils
+)
+
+rp_test(
+  BENCHMARK_TEST
   BINARY_NAME vint
-  SOURCES vint_bench.cc
+  SOURCES
+    vint_bench.cc
   LIBRARIES Seastar::seastar_perf_testing v::utils
   LABELS utils
 )

--- a/src/v/utils/tests/coro_bench.cc
+++ b/src/v/utils/tests/coro_bench.cc
@@ -1,0 +1,107 @@
+#include "base/seastarx.h"
+
+#include <seastar/core/coroutine.hh>
+#include <seastar/core/future.hh>
+#include <seastar/testing/perf_tests.hh>
+#include <seastar/util/later.hh>
+
+bool always_false_coro = false;
+
+namespace {
+
+static constexpr size_t ITERS = 10000;
+
+template<typename F>
+ss::future<size_t> co_await_in_loop(F f) {
+    perf_tests::start_measuring_time();
+    for (int i = 0; i < ITERS; i++) {
+        co_await f();
+    }
+    perf_tests::stop_measuring_time();
+    co_return ITERS;
+}
+
+template<typename F>
+ss::future<size_t> collect_futures(F f) {
+    std::vector<ss::future<>> futs;
+    futs.reserve(ITERS);
+    perf_tests::start_measuring_time();
+    for (int i = 0; i < ITERS; i++) {
+        futs.emplace_back(f());
+    }
+    perf_tests::stop_measuring_time();
+
+    for (auto& fut : futs) {
+        co_await std::move(fut);
+    }
+    co_return ITERS;
+}
+
+[[gnu::noinline]] ss::future<> ss_now() { return ss::now(); }
+
+[[gnu::noinline]] ss::future<> empty_cont() { return ss::maybe_yield(); }
+
+[[gnu::noinline]] static auto ready_future() {
+    return ss::make_ready_future<int>(1);
+}
+
+ss::future<int> empty_coro() {
+    int x = 0;
+    if (always_false_coro) {
+        x = co_await seastar::coroutine::without_preemption_check(
+          ready_future());
+    }
+    co_return x;
+}
+
+ss::future<> never_awaits() {
+    if (always_false_coro) {
+        co_await ss::make_ready_future<>();
+    }
+}
+
+struct coro_bench {};
+
+inline ss::future<> co_await_ready() { co_await ss::make_ready_future<>(); }
+inline ss::future<> co_await_ready_nest2() { co_await co_await_ready(); }
+inline ss::future<> co_await_ready_nest3() { co_await co_await_ready_nest2(); }
+
+} // namespace
+
+PERF_TEST_F(coro_bench, empty_cont) { return co_await_in_loop(empty_cont); }
+
+PERF_TEST_F(coro_bench, ss_now) { return co_await_in_loop(ss_now); }
+
+PERF_TEST_F(coro_bench, ss_now_collect) { return collect_futures(ss_now); }
+
+PERF_TEST_F(coro_bench, co_await_ready) {
+    return co_await_in_loop(co_await_ready);
+}
+
+PERF_TEST_F(coro_bench, co_await_ready_collect) {
+    return collect_futures(co_await_ready);
+}
+
+PERF_TEST_F(coro_bench, co_await_ready_nest2) {
+    return co_await_in_loop(co_await_ready_nest2);
+}
+
+PERF_TEST_F(coro_bench, co_await_ready_nest2_collect) {
+    return collect_futures(co_await_ready_nest2);
+}
+
+PERF_TEST_F(coro_bench, co_await_ready_nest3) {
+    return co_await_in_loop(co_await_ready_nest3);
+}
+
+PERF_TEST_F(coro_bench, co_await_ready_nest3_collect) {
+    return collect_futures(co_await_ready_nest3);
+}
+
+PERF_TEST_F(coro_bench, empty_coro) { return co_await_in_loop(empty_coro); }
+
+PERF_TEST_F(coro_bench, never_awaits) { return co_await_in_loop(never_awaits); }
+
+PERF_TEST_F(coro_bench, never_awaits_collect) {
+    return collect_futures(never_awaits);
+}

--- a/src/v/utils/tests/coro_bench.cc
+++ b/src/v/utils/tests/coro_bench.cc
@@ -1,15 +1,26 @@
 #include "base/seastarx.h"
+#include "ssx/future-util.h"
 
 #include <seastar/core/coroutine.hh>
 #include <seastar/core/future.hh>
 #include <seastar/testing/perf_tests.hh>
 #include <seastar/util/later.hh>
 
-bool always_false_coro = false;
+#include <string>
+#include <utility>
 
 namespace {
 
 static constexpr size_t ITERS = 10000;
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+static bool always_false_global = false;
+
+// always return false, but the compiler can't prove it
+bool always_false() {
+    perf_tests::do_not_optimize(always_false_global);
+    return always_false_global;
+}
 
 template<typename F>
 ss::future<size_t> co_await_in_loop(F f) {
@@ -45,26 +56,151 @@ ss::future<size_t> collect_futures(F f) {
     return ss::make_ready_future<int>(1);
 }
 
-ss::future<int> empty_coro() {
+ss::future<int> always_ready_coro() {
     int x = 0;
-    if (always_false_coro) {
+    if (always_false()) {
         x = co_await seastar::coroutine::without_preemption_check(
           ready_future());
     }
     co_return x;
 }
 
+/**
+ * @brief Returns always ready future, but across an optimization barrier.
+ */
+inline ss::future<> always_ready() {
+    if (always_false()) [[unlikely]] {
+        return ss::yield();
+    }
+    return ss::now();
+}
+
+template<typename T>
+inline ss::future<T> always_ready(T&& t) {
+    if (always_false()) [[unlikely]] {
+        return ss::yield().then([=]() mutable { return std::move(t); });
+    }
+    return ssx::now(std::forward<T>(t));
+}
+
+/**
+ * @brief Returns an always ready future after co_awaiting it.
+ */
 ss::future<> never_awaits() {
-    if (always_false_coro) {
+    if (always_false()) {
         co_await ss::make_ready_future<>();
     }
 }
 
 struct coro_bench {};
 
-inline ss::future<> co_await_ready() { co_await ss::make_ready_future<>(); }
-inline ss::future<> co_await_ready_nest2() { co_await co_await_ready(); }
-inline ss::future<> co_await_ready_nest3() { co_await co_await_ready_nest2(); }
+volatile int some_int;
+
+void do_work() { some_int = 1; }
+
+template<typename T>
+auto do_work(T& t) {
+    return always_ready(std::move(t));
+}
+
+inline ss::future<> co_await_ready() {
+    co_await always_ready();
+    do_work();
+}
+
+template<size_t depth>
+inline ss::future<> co_await_ready_nested() {
+    static_assert(depth > 0);
+
+    if constexpr (depth == 1) {
+        co_await always_ready();
+    } else {
+        co_await co_await_ready_nested<depth - 1>();
+    }
+    do_work();
+}
+
+struct small_object {
+    char x;
+};
+
+struct large_object {
+    char x[33];
+};
+
+/**
+ * Does an unconditional yield, followed by series of
+ * non-yielding then continuations, but which are all tested
+ * inside the single then() chained off of the yield.
+ *
+ * Compared to the chained_after_yield immediately after, where
+ * all the continuations are directly chained, it shows the
+ * efficiency of the nesting here, because the yield causes
+ * each continuation in the attached chain to become a separate
+ * task, even if they would never yield themselves. The nesting
+ * avoids this as it isn't even evaluated until after the yield
+ * finishes.
+ */
+ss::future<> nested_after_yield() {
+    using T = small_object;
+    T t{};
+    return yield().then([t = t]() mutable {
+        return do_work(t)
+          .then([](T t) { return do_work(t); })
+          .then([](T t) { return do_work(t); })
+          .then([](T t) { return do_work(t); })
+          .then([](T t) { return do_work(t); })
+          .then([](T) { return always_ready(); });
+    });
+}
+
+ss::future<> chained_after_yield() {
+    using T = small_object;
+    T t{};
+    return yield()
+      .then([t = t]() mutable { return do_work(t); })
+      .then([](T t) { return do_work(t); })
+      .then([](T t) { return do_work(t); })
+      .then([](T t) { return do_work(t); })
+      .then([](T t) { return do_work(t); })
+      .then([](T) { return always_ready(); })
+      .finally([] {})
+      .finally([] {});
+}
+
+ss::future<> coro_after_yield() {
+    small_object t{};
+    co_await yield();
+
+    t = co_await do_work(t);
+    t = co_await do_work(t);
+    t = co_await do_work(t);
+    t = co_await do_work(t);
+    t = co_await do_work(t);
+}
+
+ss::future<> chain_then5() {
+    using T = std::string;
+    T t{};
+    return do_work(t)
+      .then([](T t) { return t; })
+      .then([](T t) { return t; })
+      .then([](T t) { return t; })
+      .then([](T t) { return t; })
+      .then([](T t) { return t; })
+      .then([](T) { return always_ready(); });
+}
+
+inline ss::future<> nested_then5() {
+    return always_ready().then([] {
+        return always_ready().then([] {
+            return always_ready().then([] {
+                return always_ready().then(
+                  [] { return always_ready().then([] { do_work(); }); });
+            });
+        });
+    });
+}
 
 } // namespace
 
@@ -82,25 +218,33 @@ PERF_TEST_F(coro_bench, co_await_ready_collect) {
     return collect_futures(co_await_ready);
 }
 
-PERF_TEST_F(coro_bench, co_await_ready_nest2) {
-    return co_await_in_loop(co_await_ready_nest2);
+PERF_TEST_F(coro_bench, nested_then5) { return co_await_in_loop(nested_then5); }
+
+PERF_TEST_F(coro_bench, chain_then5) { return co_await_in_loop(chain_then5); }
+
+PERF_TEST_F(coro_bench, nested_after_yield) {
+    return co_await_in_loop(nested_after_yield);
 }
 
-PERF_TEST_F(coro_bench, co_await_ready_nest2_collect) {
-    return collect_futures(co_await_ready_nest2);
+PERF_TEST_F(coro_bench, chained_after_yield) {
+    return co_await_in_loop(chained_after_yield);
 }
 
-PERF_TEST_F(coro_bench, co_await_ready_nest3) {
-    return co_await_in_loop(co_await_ready_nest3);
+PERF_TEST_F(coro_bench, coro_after_yield) {
+    return co_await_in_loop(coro_after_yield);
 }
 
-PERF_TEST_F(coro_bench, co_await_ready_nest3_collect) {
-    return collect_futures(co_await_ready_nest3);
+PERF_TEST_F(coro_bench, co_await_ready_nested3) {
+    return co_await_in_loop(co_await_ready_nested<3>);
 }
 
-PERF_TEST_F(coro_bench, empty_coro) { return co_await_in_loop(empty_coro); }
+PERF_TEST_F(coro_bench, co_await_ready_nested5) {
+    return co_await_in_loop(co_await_ready_nested<5>);
+}
 
-PERF_TEST_F(coro_bench, never_awaits) { return co_await_in_loop(never_awaits); }
+PERF_TEST_F(coro_bench, empty_coro) {
+    return co_await_in_loop(always_ready_coro);
+}
 
 PERF_TEST_F(coro_bench, never_awaits_collect) {
     return collect_futures(never_awaits);

--- a/src/v/utils/tests/vint_bench.cc
+++ b/src/v/utils/tests/vint_bench.cc
@@ -269,66 +269,6 @@ static constexpr size_t STREAM_SIZE = 1000;
     return count;
 }
 
-[[gnu::noinline]] ss::future<> ss_now() { return ss::now(); }
-
-[[gnu::noinline]] ss::future<> empty_cont() {
-    // return yield().then([] { return; });
-    return maybe_yield();
-}
-
-bool always_false = false;
-
-[[gnu::noinline]] static auto ready_future() {
-    return make_ready_future<int>(1);
-}
-
-ss::future<int> empty_coro() {
-    int x = 0;
-    if (always_false) {
-        x = co_await seastar::coroutine::without_preemption_check(
-          ready_future());
-    }
-    co_return x;
-}
-
-ss::future<> never_awaits() {
-    if (always_false) {
-        co_await make_ready_future<>();
-    }
-}
-
-inline ss::future<> co_await_ready() { co_await make_ready_future<>(); }
-inline ss::future<> co_await_ready_nest2() { co_await co_await_ready(); }
-inline ss::future<> co_await_ready_nest3() { co_await co_await_ready_nest2(); }
-
-static constexpr size_t ITERS = 10000;
-
-template<typename F>
-ss::future<size_t> co_await_in_loop(F f) {
-    perf_tests::start_measuring_time();
-    for (size_t i = 0; i < ITERS; i++) {
-        co_await f();
-    }
-    perf_tests::stop_measuring_time();
-    co_return ITERS;
-}
-
-template<typename F>
-ss::future<size_t> collect_futures(F f) {
-    std::vector<ss::future<>> futs;
-    futs.reserve(ITERS);
-    perf_tests::start_measuring_time();
-    for (size_t i = 0; i < ITERS; i++) {
-        futs.emplace_back(f());
-    }
-    perf_tests::stop_measuring_time();
-
-    for (auto& fut : futs) {
-        co_await std::move(fut);
-    }
-    co_return ITERS;
-}
-
 namespace {
 template<typename F>
 inline ss::future<size_t> decode_test(F f) {
@@ -368,44 +308,6 @@ PERF_TEST_F(vint_bench, decode_iobuf_sync) {
     perf_tests::stop_measuring_time();
     assert(s == STREAM_SIZE);
     return s;
-}
-
-PERF_TEST_F(vint_bench, empty_cont) { return co_await_in_loop(empty_cont); }
-
-PERF_TEST_F(vint_bench, ss_now) { return co_await_in_loop(ss_now); }
-
-PERF_TEST_F(vint_bench, ss_now_collect) { return collect_futures(ss_now); }
-
-PERF_TEST_F(vint_bench, co_await_ready) {
-    return co_await_in_loop(co_await_ready);
-}
-
-PERF_TEST_F(vint_bench, co_await_ready_collect) {
-    return collect_futures(co_await_ready);
-}
-
-PERF_TEST_F(vint_bench, co_await_ready_nest2) {
-    return co_await_in_loop(co_await_ready_nest2);
-}
-
-PERF_TEST_F(vint_bench, co_await_ready_nest2_collect) {
-    return collect_futures(co_await_ready_nest2);
-}
-
-PERF_TEST_F(vint_bench, co_await_ready_nest3) {
-    return co_await_in_loop(co_await_ready_nest3);
-}
-
-PERF_TEST_F(vint_bench, co_await_ready_nest3_collect) {
-    return collect_futures(co_await_ready_nest3);
-}
-
-PERF_TEST_F(vint_bench, empty_coro) { return co_await_in_loop(empty_coro); }
-
-PERF_TEST_F(vint_bench, never_awaits) { return co_await_in_loop(never_awaits); }
-
-PERF_TEST_F(vint_bench, never_awaits_collect) {
-    return collect_futures(never_awaits);
 }
 
 PERF_TEST(vint_bench, make_stream) {


### PR DESCRIPTION
bench: split out coro_rpbench from vint_rpbench

Split vint_bench into vint_bench and coro_bench, with the latter having
the generic coroutine/continuation type benches and vint only being
left with the specific vint stream decoding stuff.

coro_bench: updates with more patterns

Test a few more call patterns such as chaining vs nesting when the first
future is non-ready.

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
