### PR TITLE
rp_storage_tool: account for labels

### DIFF
--- a/tools/rp_storage_tool/src/bucket_reader.rs
+++ b/tools/rp_storage_tool/src/bucket_reader.rs
@@ -1,12 +1,14 @@
 use crate::batch_reader::BatchStream;
 use crate::error::BucketReaderError;
 use crate::fundamental::{
-    raw_to_kafka, KafkaOffset, RaftTerm, RawOffset, Timestamp, NTP, NTPR, NTR,
+    raw_to_kafka, KafkaOffset, LabeledNTPR, LabeledNTR, RaftTerm, RawOffset, Timestamp, NTP, NTPR,
+    NTR,
 };
 use crate::ntp_mask::NTPFilter;
 use crate::remote_types::{
     parse_segment_shortname, ArchivePartitionManifest, ClusterMetadataManifest, LifecycleMarker,
-    LifecycleStatus, PartitionManifest, PartitionManifestSegment, RpSerde, TopicManifest,
+    LifecycleStatus, PartitionManifest, PartitionManifestSegment, RemoteLabel, RpSerde,
+    TopicManifest,
 };
 use crate::repair::{maybe_adjust_manifest, project_repairs, RepairEdit};
 use async_stream::stream;
@@ -236,10 +238,10 @@ pub struct Anomalies {
     pub malformed_topic_manifests: HashSet<String>,
 
     /// NTPR that had segment objects, but no partition manifest
-    pub ntpr_no_manifest: HashSet<NTPR>,
+    pub ntpr_no_manifest: HashSet<LabeledNTPR>,
 
     /// NTR that had segment objects and/or partition manifests, but no topic manifest
-    pub ntr_no_topic_manifest: HashSet<NTR>,
+    pub ntr_no_topic_manifest: HashSet<LabeledNTR>,
 
     /// Keys that do not look like any object we expect
     pub unknown_keys: HashSet<String>,
@@ -248,17 +250,17 @@ pub struct Anomalies {
     pub missing_segments: HashSet<String>,
 
     /// NTPR that failed consistency checks on its segments' metadata
-    pub ntpr_bad_deltas: HashSet<NTPR>,
+    pub ntpr_bad_deltas: HashSet<LabeledNTPR>,
 
     /// Consistency checks found overlapping segments, which may be readable but
     /// indicate a bug in the code that wrote them.
-    pub ntpr_overlap_offsets: HashSet<NTPR>,
+    pub ntpr_overlap_offsets: HashSet<LabeledNTPR>,
 
     /// Where a partition manifest has two segments whose commited+base offsets
     /// are discontinuous.  This gap is reported as an anomaly, and may also be
     /// used to cue subsequent data scans.
     /// Ref Incident 259
-    pub metadata_offset_gaps: HashMap<NTPR, Vec<MetadataGap>>,
+    pub metadata_offset_gaps: HashMap<LabeledNTPR, Vec<MetadataGap>>,
 
     /// Files referenced by the cluster manifest with the highest metadata ID which do not exist in
     /// the bucket.
@@ -290,7 +292,7 @@ pub struct PartitionMetadataSummary {
 #[derive(Serialize)]
 pub struct MetadataSummary {
     pub anomalies: Anomalies,
-    pub partitions: BTreeMap<NTPR, PartitionMetadataSummary>,
+    pub partitions: BTreeMap<LabeledNTPR, PartitionMetadataSummary>,
 }
 
 impl Anomalies {
@@ -508,10 +510,10 @@ pub struct ClusterMetadata {
 
 /// Find all the partitions and their segments within a bucket
 pub struct BucketReader {
-    pub partitions: HashMap<NTPR, PartitionObjects>,
-    pub partition_manifests: HashMap<NTPR, PartitionMetadata>,
-    pub topic_manifests: HashMap<NTR, TopicManifest>,
-    pub lifecycle_markers: HashMap<NTR, LifecycleMarker>,
+    pub partitions: HashMap<LabeledNTPR, PartitionObjects>,
+    pub partition_manifests: HashMap<LabeledNTPR, PartitionMetadata>,
+    pub topic_manifests: HashMap<LabeledNTR, TopicManifest>,
+    pub lifecycle_markers: HashMap<LabeledNTR, LifecycleMarker>,
     pub cluster_metadata: HashMap<String, ClusterMetadata>,
     pub anomalies: Anomalies,
     pub client: Arc<dyn ObjectStore>,
@@ -519,10 +521,10 @@ pub struct BucketReader {
 
 #[derive(Serialize, Deserialize)]
 struct SavedBucketReader {
-    pub partitions: HashMap<NTPR, PartitionObjects>,
-    pub partition_manifests: HashMap<NTPR, PartitionMetadata>,
-    pub topic_manifests: HashMap<NTR, TopicManifest>,
-    pub lifecycle_markers: HashMap<NTR, LifecycleMarker>,
+    pub partitions: HashMap<LabeledNTPR, PartitionObjects>,
+    pub partition_manifests: HashMap<LabeledNTPR, PartitionMetadata>,
+    pub topic_manifests: HashMap<LabeledNTR, TopicManifest>,
+    pub lifecycle_markers: HashMap<LabeledNTR, LifecycleMarker>,
     pub cluster_metadata: HashMap<String, ClusterMetadata>,
 }
 
@@ -585,19 +587,19 @@ impl BucketReader {
         self.partitions = self
             .partitions
             .drain()
-            .filter(|i| filter.match_ntpr(&i.0))
+            .filter(|i| filter.match_lntpr(&i.0))
             .collect();
 
         self.partition_manifests = self
             .partition_manifests
             .drain()
-            .filter(|i| filter.match_ntpr(&i.0))
+            .filter(|i| filter.match_lntpr(&i.0))
             .collect();
 
         self.topic_manifests = self
             .topic_manifests
             .drain()
-            .filter(|i| filter.match_ntr(&i.0))
+            .filter(|i| filter.match_lntr(&i.0))
             .collect();
     }
 
@@ -747,17 +749,21 @@ impl BucketReader {
 
     pub fn get_summary(&self) -> MetadataSummary {
         let mut partitions = BTreeMap::new();
-        for (ntpr, partition_meta) in &self.partition_manifests {
+        for (lntpr, partition_meta) in &self.partition_manifests {
             if let Some(manifest) = &partition_meta.head_manifest {
                 let ntr = NTR {
                     namespace: manifest.namespace.clone(),
                     topic: manifest.namespace.clone(),
                     revision_id: manifest.revision,
                 };
+                let labeled_ntr = LabeledNTR {
+                    ntr,
+                    label: lntpr.label.clone(),
+                };
 
                 let kafka_offsets = manifest.kafka_watermarks();
                 partitions.insert(
-                    ntpr.clone(),
+                    lntpr.clone(),
                     PartitionMetadataSummary {
                         bytes: manifest.get_size_bytes(),
                         raw_start_offset: manifest.start_offsets().0,
@@ -766,7 +772,7 @@ impl BucketReader {
                         kafka_hwm: kafka_offsets.map(|x| x.1),
                         lifecycle_status: self
                             .lifecycle_markers
-                            .get(&ntr)
+                            .get(&labeled_ntr)
                             .and_then(|m| Some(m.status.clone())),
                     },
                 );
@@ -787,33 +793,39 @@ impl BucketReader {
         // to deleted topics.  To avoid making output hard to read when filtering on NTP (without R),
         // suppress old revisions.
         let mut latest_revision: HashMap<(String, String), i64> = HashMap::new();
-        for ntpr in self.partitions.keys() {
+        for lntpr in self.partitions.keys() {
             // FIXME: these clones are gratuitous
-            let nt = (ntpr.ntp.namespace.clone(), ntpr.ntp.topic.clone());
+            let nt = (
+                lntpr.ntpr.ntp.namespace.clone(),
+                lntpr.ntpr.ntp.topic.clone(),
+            );
             if let Some(current_max) = latest_revision.get(&nt) {
-                if current_max >= &ntpr.revision_id {
+                if current_max >= &lntpr.ntpr.revision_id {
                     continue;
                 }
             }
 
-            latest_revision.insert(nt, ntpr.revision_id);
+            latest_revision.insert(nt, lntpr.ntpr.revision_id);
         }
 
-        let match_ntpr = |ntpr: &NTPR| {
+        let match_ntpr = |lntpr: &LabeledNTPR| {
             // FIXME: these clones are gratuitous
-            let nt = (ntpr.ntp.namespace.clone(), ntpr.ntp.topic.clone());
+            let nt = (
+                lntpr.ntpr.ntp.namespace.clone(),
+                lntpr.ntpr.ntp.topic.clone(),
+            );
             if let Some(latest) = latest_revision.get(&nt) {
-                ntpr.revision_id == *latest
+                lntpr.ntpr.revision_id == *latest
             } else {
                 true
             }
         };
 
-        let match_ntr = |ntr: &NTR| {
+        let match_ntr = |lntr: &LabeledNTR| {
             // FIXME: these clones are gratuitous
-            let nt = (ntr.namespace.clone(), ntr.topic.clone());
+            let nt = (lntr.ntr.namespace.clone(), lntr.ntr.topic.clone());
             if let Some(latest) = latest_revision.get(&nt) {
-                ntr.revision_id == *latest
+                lntr.ntr.revision_id == *latest
             } else {
                 true
             }
@@ -845,27 +857,28 @@ impl BucketReader {
     pub async fn repair_manifest_ntp(
         &mut self,
         gaps: &Vec<MetadataGap>,
-        ntpr: &NTPR,
+        lntpr: &LabeledNTPR,
     ) -> Result<Vec<RepairEdit>, BucketReaderError> {
-        let initial_repairs = maybe_adjust_manifest(&ntpr, &gaps, self).await?;
+        let initial_repairs = maybe_adjust_manifest(&lntpr, &gaps, self).await?;
         info!(
             "[{}] Found {} repairs to manifest, projecting.",
-            ntpr,
+            lntpr,
             initial_repairs.len()
         );
 
-        let objects = if let Some(o) = self.partitions.get_mut(&ntpr) {
+        let objects = if let Some(o) = self.partitions.get_mut(&lntpr) {
             o
         } else {
             return Ok(Vec::new());
         };
 
-        if let Some(metadata) = self.partition_manifests.get_mut(&ntpr) {
+        if let Some(metadata) = self.partition_manifests.get_mut(&lntpr) {
             if let Some(manifest) = metadata.head_manifest.as_mut() {
                 project_repairs(manifest, &initial_repairs);
 
+                let remote_label = RemoteLabel::from_string(&lntpr.label);
                 for seg in manifest.segments.values() {
-                    if let Some(segment_key) = manifest.segment_key(seg) {
+                    if let Some(segment_key) = manifest.segment_key(seg, &remote_label) {
                         // Our repair might mean that a segment from the 'dropped' list
                         // is now referenced by the manifest: use the 'adjust' side effect
                         // of this function to swap that segment into the main list.:w
@@ -888,25 +901,25 @@ impl BucketReader {
         // during the initial bucket scan.  Accumulate them here for ingesting afterwards.
         let mut discovered_objects: Vec<ObjectMeta> = vec![];
 
-        for (ntpr, partition_objects) in &mut self.partitions {
-            if !filter.match_ntpr(ntpr) {
+        for (lntpr, partition_objects) in &mut self.partitions {
+            if !filter.match_lntpr(lntpr) {
                 continue;
             }
 
-            if ntpr.ntp.partition_id == 0 {
-                let t_manifest_o = self.topic_manifests.get(&ntpr.to_ntr());
+            if lntpr.ntpr.ntp.partition_id == 0 {
+                let t_manifest_o = self.topic_manifests.get(&lntpr.to_ntr());
                 if let None = t_manifest_o {
-                    self.anomalies.ntr_no_topic_manifest.insert(ntpr.to_ntr());
+                    self.anomalies.ntr_no_topic_manifest.insert(lntpr.to_ntr());
                 }
             }
 
-            let p_metadata_o = self.partition_manifests.get(ntpr);
+            let p_metadata_o = self.partition_manifests.get(lntpr);
             match p_metadata_o {
                 None => {
                     // The manifest may be missing because we couldn't load it, in which
                     // case that is already tracked in malformed_manifests
-                    let manifest_key_bin = PartitionManifest::manifest_key(ntpr, "bin");
-                    let manifest_key_json = PartitionManifest::manifest_key(ntpr, "json");
+                    let manifest_key_bin = PartitionManifest::manifest_key(&lntpr, "bin");
+                    let manifest_key_json = PartitionManifest::manifest_key(&lntpr, "json");
                     if self
                         .anomalies
                         .malformed_manifests
@@ -916,9 +929,9 @@ impl BucketReader {
                             .malformed_manifests
                             .contains(&manifest_key_json)
                     {
-                        debug!("Not reporting {} as missing because it's already reported as malformed", ntpr);
+                        debug!("Not reporting {} as missing because it's already reported as malformed", lntpr);
                     } else {
-                        self.anomalies.ntpr_no_manifest.insert(ntpr.clone());
+                        self.anomalies.ntpr_no_manifest.insert(lntpr.clone());
                     }
                 }
                 Some(p_metadata) => {
@@ -941,10 +954,10 @@ impl BucketReader {
         }
 
         let mut new_anomalies: Anomalies = Default::default();
-        for (ntpr, partition_metadata) in &self.partition_manifests {
-            let mut raw_objects = self.partitions.get_mut(&ntpr);
+        for (lntpr, partition_metadata) in &self.partition_manifests {
+            let mut raw_objects = self.partitions.get_mut(&lntpr);
 
-            if !filter.match_ntpr(&ntpr) {
+            if !filter.match_lntpr(&lntpr) {
                 continue;
             }
 
@@ -955,14 +968,14 @@ impl BucketReader {
                 for am in &partition_metadata.archive_manifests {
                     self.anomalies
                         .archive_manifests_outside_manifest
-                        .insert(am.key(&ntpr));
+                        .insert(am.key(&lntpr));
                 }
             }
 
             if partition_metadata.head_manifest.is_some() {
                 let anomalies = Self::analyze_manifest(
                     self.client.clone(),
-                    &ntpr,
+                    &lntpr,
                     partition_metadata.head_manifest.as_ref().unwrap(),
                     &mut raw_objects,
                     &mut discovered_objects,
@@ -975,7 +988,7 @@ impl BucketReader {
             for archive_manifest in &partition_metadata.archive_manifests {
                 let anomalies = Self::analyze_archive_manifest(
                     self.client.clone(),
-                    &ntpr,
+                    &lntpr,
                     partition_metadata.head_manifest.as_ref().unwrap(),
                     archive_manifest,
                     &mut raw_objects,
@@ -988,13 +1001,13 @@ impl BucketReader {
 
         self.anomalies.merge(new_anomalies);
 
-        for (ntpr, _) in &mut self.partition_manifests {
-            if !filter.match_ntpr(ntpr) {
+        for (lntpr, _) in &mut self.partition_manifests {
+            if !filter.match_lntpr(lntpr) {
                 continue;
             }
-            let t_manifest_o = self.topic_manifests.get(&ntpr.to_ntr());
+            let t_manifest_o = self.topic_manifests.get(&lntpr.to_ntr());
             if let None = t_manifest_o {
-                self.anomalies.ntr_no_topic_manifest.insert(ntpr.to_ntr());
+                self.anomalies.ntr_no_topic_manifest.insert(lntpr.to_ntr());
             }
         }
 
@@ -1045,7 +1058,7 @@ impl BucketReader {
 
     async fn analyze_archive_manifest(
         client: Arc<dyn object_store::ObjectStore>,
-        ntpr: &NTPR,
+        lntpr: &LabeledNTPR,
         head_manifest: &PartitionManifest,
         archive_manifest: &ArchivePartitionManifest,
         raw_objects: &mut Option<&mut PartitionObjects>,
@@ -1054,7 +1067,7 @@ impl BucketReader {
         // TODO(vlad): validate parsed name against contents
         Self::analyze_manifest(
             client,
-            ntpr,
+            lntpr,
             &archive_manifest.manifest,
             raw_objects,
             discovered,
@@ -1065,7 +1078,7 @@ impl BucketReader {
 
     async fn analyze_manifest(
         client: Arc<dyn object_store::ObjectStore>,
-        ntpr: &NTPR,
+        lntpr: &LabeledNTPR,
         partition_manifest: &PartitionManifest,
         raw_objects: &mut Option<&mut PartitionObjects>,
         discovered: &mut Vec<ObjectMeta>,
@@ -1097,7 +1110,8 @@ impl BucketReader {
                 partition_manifest.ntp(),
                 segment_short_name
             );
-            if let Some(expect_key) = partition_manifest.segment_key(segment) {
+            let remote_label = RemoteLabel::from_string(&lntpr.label);
+            if let Some(expect_key) = partition_manifest.segment_key(segment, &remote_label) {
                 debug!("Calculated segment {}", expect_key);
                 let so = archive_start_offset.unwrap_or(RawOffset::MIN);
                 let bo = segment.base_offset;
@@ -1137,17 +1151,17 @@ impl BucketReader {
                         // as well.
                         warn!(
                             "[{}] Segment {} has missing delta_offset",
-                            ntpr, segment.base_offset
+                            lntpr, segment.base_offset
                         );
-                        anomalies.ntpr_bad_deltas.insert(ntpr.clone());
+                        anomalies.ntpr_bad_deltas.insert(lntpr.clone());
                     }
                     Some(seg_delta) => {
                         if seg_delta < last_delta {
                             warn!(
                                 "[{}] Segment {} has delta lower than previous",
-                                ntpr, segment.base_offset
+                                lntpr, segment.base_offset
                             );
-                            anomalies.ntpr_bad_deltas.insert(ntpr.clone());
+                            anomalies.ntpr_bad_deltas.insert(lntpr.clone());
                         }
                     }
                 }
@@ -1159,9 +1173,9 @@ impl BucketReader {
                 if d_off > d_off_end {
                     warn!(
                         "[{}] Segment {} has end delta lower than base delta",
-                        ntpr, segment.base_offset
+                        lntpr, segment.base_offset
                     );
-                    anomalies.ntpr_bad_deltas.insert(ntpr.clone());
+                    anomalies.ntpr_bad_deltas.insert(lntpr.clone());
                 }
             }
 
@@ -1174,7 +1188,7 @@ impl BucketReader {
 
                     warn!(
                             "[{}] Segment {} has gap between base offset and previous segment's committed offset ({}).  Missing {} records, from ts {} to ts {} ({})",
-                            ntpr,
+                            lntpr,
                             segment.base_offset,
                             last_committed_offset,
                             segment.base_offset as RawOffset - (last_committed_offset + 1),
@@ -1183,7 +1197,7 @@ impl BucketReader {
                             dt.to_rfc3339());
                     let gap_list = anomalies
                         .metadata_offset_gaps
-                        .entry(ntpr.clone())
+                        .entry(lntpr.clone())
                         .or_insert_with(|| Vec::new());
 
                     let kafka_gap_begin =
@@ -1203,9 +1217,9 @@ impl BucketReader {
                 } else if (segment.base_offset as RawOffset) < last_committed_offset + 1 {
                     warn!(
                             "[{}] Segment {} has overlap between base offset and previous segment's committed offset ({})",
-                            ntpr, segment.base_offset, last_committed_offset
+                            lntpr, segment.base_offset, last_committed_offset
                         );
-                    anomalies.ntpr_overlap_offsets.insert(ntpr.clone());
+                    anomalies.ntpr_overlap_offsets.insert(lntpr.clone());
                 }
             }
 
@@ -1286,7 +1300,7 @@ impl BucketReader {
         fn maybe_stash_partition_key(keys: &mut Vec<FetchKey>, k: FetchKey, filter: &NTPFilter) {
             lazy_static! {
                 static ref META_NTP_PREFIX: Regex =
-                    Regex::new("[a-f0-9]+/meta/([^]]+)/([^]]+)/(\\d+)_(\\d+)/.+").unwrap();
+                    Regex::new("[-a-f0-9]+/meta/([^]]+)/([^]]+)/(\\d+)_(\\d+)/.+").unwrap();
             }
             if let Some(grps) = META_NTP_PREFIX.captures(k.as_str()) {
                 let ns = grps.get(1).unwrap().as_str();
@@ -1309,10 +1323,10 @@ impl BucketReader {
 
         fn maybe_stash_topic_key(keys: &mut Vec<FetchKey>, k: FetchKey, filter: &NTPFilter) {
             lazy_static! {
-                static ref META_NTP_PREFIX: Regex =
+                static ref META_TP_PREFIX: Regex =
                     Regex::new("[a-f0-9]+/meta/([^]]+)/([^]]+)/.+").unwrap();
             }
-            if let Some(grps) = META_NTP_PREFIX.captures(k.as_str()) {
+            if let Some(grps) = META_TP_PREFIX.captures(k.as_str()) {
                 let ns = grps.get(1).unwrap().as_str();
                 let topic = grps.get(2).unwrap().as_str();
 
@@ -1402,14 +1416,14 @@ impl BucketReader {
     /// Yield a byte stream for each segment
     pub fn stream(
         &self,
-        ntpr: &NTPR,
+        lntpr: &LabeledNTPR,
         seek: Option<RawOffset>, //) -> Pin<Box<dyn Stream<Item = Result<BoxStream<'static, object_store::Result<bytes::Bytes>>, BucketReaderError> + '_>>
     ) -> impl Stream<Item = SegmentStream> + '_ {
         // TODO error handling for parittion DNE
 
         // TODO go via metadata: if we have no manifest, we should synthesize one and validate
         // rather than just stepping throuhg objects naively.
-        let partition_objects = self.partitions.get(ntpr).unwrap();
+        let partition_objects = self.partitions.get(lntpr).unwrap();
         // Box::pin(
         //     futures::stream::iter(0..partition_objects.segment_objects.len())
         //         .then(|i| self.stream_one(&partition_objects.segment_objects[i])),
@@ -1527,13 +1541,16 @@ impl BucketReader {
         };
 
         let key = PartitionManifest::manifest_key(
-            &NTPR {
-                ntp: NTP {
-                    namespace: manifest.namespace,
-                    topic: manifest.topic,
-                    partition_id: manifest.partition,
+            &LabeledNTPR {
+                ntpr: NTPR {
+                    ntp: NTP {
+                        namespace: manifest.namespace,
+                        topic: manifest.topic,
+                        partition_id: manifest.partition,
+                    },
+                    revision_id: manifest.revision,
                 },
-                revision_id: manifest.revision,
+                label: None,
             },
             extension,
         );
@@ -1548,16 +1565,17 @@ impl BucketReader {
     ) -> Result<(), BucketReaderError> {
         lazy_static! {
             static ref PARTITION_MANIFEST_KEY: Regex =
-                Regex::new("[a-f0-9]+/meta/([^]]+)/([^]]+)/(\\d+)_(\\d+)/manifest.(json|bin)")
+                Regex::new("([-a-f0-9]+)/meta/([^]]+)/([^]]+)/(\\d+)_(\\d+)/manifest.(json|bin)")
                     .unwrap();
         }
         if let Some(grps) = PARTITION_MANIFEST_KEY.captures(key) {
+            let prefix = grps.get(1).unwrap().as_str().to_string();
             // Group::get calls are safe to unwrap() because regex always has those groups if it matched
-            let ns = grps.get(1).unwrap().as_str().to_string();
-            let topic = grps.get(2).unwrap().as_str().to_string();
+            let ns = grps.get(2).unwrap().as_str().to_string();
+            let topic = grps.get(3).unwrap().as_str().to_string();
             // (TODO: these aren't really-truly safe to unwrap because the string might have had too many digits)
-            let partition_id = grps.get(3).unwrap().as_str().parse::<u32>().unwrap();
-            let partition_revision = grps.get(4).unwrap().as_str().parse::<i64>().unwrap();
+            let partition_id = grps.get(4).unwrap().as_str().parse::<u32>().unwrap();
+            let partition_revision = grps.get(5).unwrap().as_str().parse::<i64>().unwrap();
             let ntpr = NTPR {
                 ntp: NTP {
                     namespace: ns,
@@ -1566,7 +1584,7 @@ impl BucketReader {
                 },
                 revision_id: partition_revision,
             };
-
+            let labeled_ntpr = LabeledNTPR::from_ntpr_and_prefix(ntpr, prefix);
             let manifest = match Self::decode_partition_manifest(key, body) {
                 Ok(m) => m,
                 Err(e) => {
@@ -1577,7 +1595,7 @@ impl BucketReader {
             };
 
             // Note: assuming memory is sufficient for manifests
-            match self.partition_manifests.get_mut(&ntpr) {
+            match self.partition_manifests.get_mut(&labeled_ntpr) {
                 Some(meta) => {
                     // Avoid overwriting a binary manifest with a JSON manifest
                     if meta.head_manifest.is_none()
@@ -1588,7 +1606,7 @@ impl BucketReader {
                 }
                 None => {
                     self.partition_manifests.insert(
-                        ntpr,
+                        labeled_ntpr,
                         PartitionMetadata {
                             head_manifest: Some(manifest),
                             archive_manifests: vec![],
@@ -1610,22 +1628,23 @@ impl BucketReader {
     ) -> Result<(), BucketReaderError> {
         lazy_static! {
             static ref PARTITION_MANIFEST_KEY: Regex =
-                Regex::new("[a-f0-9]+/meta/([^]]+)/([^]]+)/(\\d+)_(\\d+)/manifest.(?:json|bin)\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)").unwrap();
+                Regex::new("([-a-f0-9]+)/meta/([^]]+)/([^]]+)/(\\d+)_(\\d+)/manifest.(?:json|bin)\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)\\.(\\d+)").unwrap();
         }
         if let Some(grps) = PARTITION_MANIFEST_KEY.captures(key) {
+            let prefix = grps.get(1).unwrap().as_str().to_string();
             // Group::get calls are safe to unwrap() because regex always has those groups if it matched
-            let ns = grps.get(1).unwrap().as_str().to_string();
-            let topic = grps.get(2).unwrap().as_str().to_string();
+            let ns = grps.get(2).unwrap().as_str().to_string();
+            let topic = grps.get(3).unwrap().as_str().to_string();
             // (TODO: these aren't really-truly safe to unwrap because the string might have had too many digits)
-            let partition_id = grps.get(3).unwrap().as_str().parse::<u32>().unwrap();
-            let partition_revision = grps.get(4).unwrap().as_str().parse::<i64>().unwrap();
+            let partition_id = grps.get(4).unwrap().as_str().parse::<u32>().unwrap();
+            let partition_revision = grps.get(5).unwrap().as_str().parse::<i64>().unwrap();
 
-            let base_offset = grps.get(5).unwrap().as_str().parse::<u64>().unwrap();
-            let committed_offset = grps.get(6).unwrap().as_str().parse::<u64>().unwrap();
-            let base_kafka_offset = grps.get(7).unwrap().as_str().parse::<u64>().unwrap();
-            let next_kafka_offset = grps.get(8).unwrap().as_str().parse::<u64>().unwrap();
-            let base_ts = grps.get(9).unwrap().as_str().parse::<u64>().unwrap();
-            let last_ts = grps.get(10).unwrap().as_str().parse::<u64>().unwrap();
+            let base_offset = grps.get(6).unwrap().as_str().parse::<u64>().unwrap();
+            let committed_offset = grps.get(7).unwrap().as_str().parse::<u64>().unwrap();
+            let base_kafka_offset = grps.get(8).unwrap().as_str().parse::<u64>().unwrap();
+            let next_kafka_offset = grps.get(9).unwrap().as_str().parse::<u64>().unwrap();
+            let base_ts = grps.get(10).unwrap().as_str().parse::<u64>().unwrap();
+            let last_ts = grps.get(11).unwrap().as_str().parse::<u64>().unwrap();
 
             let ntpr = NTPR {
                 ntp: NTP {
@@ -1635,9 +1654,13 @@ impl BucketReader {
                 },
                 revision_id: partition_revision,
             };
+            let labeled_ntpr = LabeledNTPR::from_ntpr_and_prefix(ntpr, prefix);
 
             // Note: assuming memory is sufficient for manifests
-            debug!("Storing archive manifest for {} from key {}", ntpr, key);
+            debug!(
+                "Storing archive manifest for {} from key {}",
+                labeled_ntpr, key
+            );
 
             let manifest: PartitionManifest = match Self::decode_partition_manifest(key, body) {
                 Ok(m) => m,
@@ -1660,13 +1683,13 @@ impl BucketReader {
             };
 
             // Note: assuming memory is sufficient for manifests
-            match self.partition_manifests.get_mut(&ntpr) {
+            match self.partition_manifests.get_mut(&labeled_ntpr) {
                 Some(meta) => {
                     meta.archive_manifests.push(archive_manifest);
                 }
                 None => {
                     self.partition_manifests.insert(
-                        ntpr,
+                        labeled_ntpr,
                         PartitionMetadata {
                             head_manifest: None,
                             archive_manifests: vec![archive_manifest],
@@ -1759,10 +1782,18 @@ impl BucketReader {
                     topic,
                     revision_id: manifest.revision_id as i64,
                 };
+                // TODO: this tool doesn't support binary format manifests at all.
+                let labeled_ntr = LabeledNTR {
+                    ntr: ntr.clone(),
+                    label: None,
+                };
 
-                debug!("Storing topic manifest for {} from key {}", ntr, key);
+                debug!(
+                    "Storing topic manifest for {} from key {}",
+                    &labeled_ntr, key
+                );
 
-                if let Some(_) = self.topic_manifests.insert(ntr, manifest) {
+                if self.topic_manifests.insert(labeled_ntr, manifest).is_some() {
                     warn!("Two topic manifests for same NTR seen ({})", key);
                 }
             } else {
@@ -1806,6 +1837,11 @@ impl BucketReader {
                 topic,
                 revision_id: initial_revision as i64,
             };
+            // TODO: this tool doesn't support binary format manifests at all.
+            let labeled_ntr = LabeledNTR {
+                ntr: ntr.clone(),
+                label: None,
+            };
 
             let mut cursor = std::io::Cursor::new(body.as_ref());
             let marker = match LifecycleMarker::from_bytes(&mut cursor) {
@@ -1821,7 +1857,7 @@ impl BucketReader {
 
             debug!("Storing lifecycle marker for {} from key {}", ntr, key);
 
-            if let Some(_) = self.lifecycle_markers.insert(ntr, marker) {
+            if self.lifecycle_markers.insert(labeled_ntr, marker).is_some() {
                 warn!("Two lifecycle markers for same NTR seen ({})", key);
             }
         } else {
@@ -1845,21 +1881,22 @@ impl BucketReader {
 
         lazy_static! {
             static ref SEGMENT_KEY: Regex = Regex::new(
-                "[a-f0-9]+/([^]]+)/([^]]+)/(\\d+)_(\\d+)/(\\d+)-(\\d+)-(\\d+)-(\\d+)-v1.log.(\\d+)"
+                "([-a-f0-9]+)/([^]]+)/([^]]+)/(\\d+)_(\\d+)/(\\d+)-(\\d+)-(\\d+)-(\\d+)-v1.log.(\\d+)"
             )
             .unwrap();
         }
-        let (ntpr, segment) = if let Some(grps) = SEGMENT_KEY.captures(key) {
-            let ns = grps.get(1).unwrap().as_str().to_string();
-            let topic = grps.get(2).unwrap().as_str().to_string();
+        let (lntpr, segment) = if let Some(grps) = SEGMENT_KEY.captures(key) {
+            let prefix = grps.get(1).unwrap().as_str().to_string();
+            let ns = grps.get(2).unwrap().as_str().to_string();
+            let topic = grps.get(3).unwrap().as_str().to_string();
             // (TODO: these aren't really-truly safe to unwrap because the string might have had too many digits)
-            let partition_id = grps.get(3).unwrap().as_str().parse::<u32>().unwrap();
-            let partition_revision = grps.get(4).unwrap().as_str().parse::<i64>().unwrap();
-            let start_offset = grps.get(5).unwrap().as_str().parse::<RawOffset>().unwrap();
-            let _committed_offset = grps.get(6).unwrap().as_str();
-            let size_bytes = grps.get(7).unwrap().as_str().parse::<u64>().unwrap();
-            let original_term = grps.get(8).unwrap().as_str().parse::<RaftTerm>().unwrap();
-            let upload_term = grps.get(9).unwrap().as_str().parse::<RaftTerm>().unwrap();
+            let partition_id = grps.get(4).unwrap().as_str().parse::<u32>().unwrap();
+            let partition_revision = grps.get(5).unwrap().as_str().parse::<i64>().unwrap();
+            let start_offset = grps.get(6).unwrap().as_str().parse::<RawOffset>().unwrap();
+            let _committed_offset = grps.get(7).unwrap().as_str();
+            let size_bytes = grps.get(8).unwrap().as_str().parse::<u64>().unwrap();
+            let original_term = grps.get(9).unwrap().as_str().parse::<RaftTerm>().unwrap();
+            let upload_term = grps.get(10).unwrap().as_str().parse::<RaftTerm>().unwrap();
             debug!(
                 "ingest_segment v2+ {}/{}/{} {} (key {}",
                 ns, topic, partition_id, start_offset, key
@@ -1873,13 +1910,13 @@ impl BucketReader {
                 },
                 revision_id: partition_revision,
             };
-
-            if !filter.match_ntp(&ntpr.ntp) {
+            let labeled_ntpr = LabeledNTPR::from_ntpr_and_prefix(ntpr, prefix);
+            if !filter.match_ntp(&labeled_ntpr.ntpr.ntp) {
                 return;
             }
 
             (
-                ntpr,
+                labeled_ntpr,
                 SegmentObject {
                     key: key.to_string(),
                     base_offset: start_offset,
@@ -1910,13 +1947,14 @@ impl BucketReader {
                 },
                 revision_id: partition_revision,
             };
+            let labeled_ntpr = LabeledNTPR { ntpr, label: None };
 
-            if !filter.match_ntp(&ntpr.ntp) {
+            if !filter.match_ntp(&labeled_ntpr.ntpr.ntp) {
                 return;
             }
 
             (
-                ntpr,
+                labeled_ntpr,
                 SegmentObject {
                     key: key.to_string(),
                     base_offset: start_offset,
@@ -1934,7 +1972,7 @@ impl BucketReader {
 
         let values = self
             .partitions
-            .entry(ntpr)
+            .entry(lntpr)
             .or_insert_with(|| PartitionObjects::new());
         values.push(segment);
     }

--- a/tools/rp_storage_tool/src/fundamental.rs
+++ b/tools/rp_storage_tool/src/fundamental.rs
@@ -95,6 +95,175 @@ impl<'de> Deserialize<'de> for NTR {
     }
 }
 
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
+pub struct LabeledNTR {
+    pub ntr: NTR,
+    pub label: Option<String>,
+}
+
+impl LabeledNTR {
+    pub fn from_str(s: &str) -> Self {
+        lazy_static! {
+            static ref NTP_MASK_EXPR: Regex =
+                Regex::new("([^]]+/)?([^]]+)/([^]]+)_([^_]+)").unwrap();
+        }
+
+        if let Some(grps) = NTP_MASK_EXPR.captures(&s) {
+            // Remove the trailing /.
+            let label = grps
+                .get(1)
+                .map(|s| s.as_str().chars().take(s.len() - 1).collect());
+
+            let namespace = grps.get(2).unwrap().as_str().to_string();
+            let topic = grps.get(3).unwrap().as_str().to_string();
+            let revision = grps.get(4).unwrap().as_str().to_string();
+
+            let ntr = NTR {
+                namespace,
+                topic,
+                revision_id: revision.parse::<i64>().unwrap(),
+            };
+            Self { ntr, label }
+        } else {
+            panic!("Malformed NTP query string");
+        }
+    }
+}
+
+impl fmt::Display for LabeledNTR {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let maybe_label = self
+            .label
+            .as_ref()
+            .map_or("".to_owned(), |l| format!("{}/", l));
+        write!(
+            f,
+            "{}{}/{}_{}",
+            maybe_label, self.ntr.namespace, self.ntr.topic, self.ntr.revision_id
+        )
+    }
+}
+
+impl Serialize for LabeledNTR {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let stringized = format!("{}", self);
+        stringized.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LabeledNTR {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let stringized = String::deserialize(deserializer)?;
+        Ok(Self::from_str(stringized.as_str()))
+    }
+}
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
+pub struct LabeledNTPR {
+    pub ntpr: NTPR,
+    pub label: Option<String>,
+}
+
+impl LabeledNTPR {
+    pub fn to_ntr(&self) -> LabeledNTR {
+        return LabeledNTR {
+            ntr: NTR {
+                namespace: self.ntpr.ntp.namespace.clone(),
+                topic: self.ntpr.ntp.topic.clone(),
+                revision_id: self.ntpr.revision_id,
+            },
+            label: self.label.clone(),
+        };
+    }
+
+    // Converts the given NTPR and prefix of a manifest or segment path and constructs a labeled
+    // NTPR.
+    pub fn from_ntpr_and_prefix(ntpr: NTPR, prefix: String) -> Self {
+        Self {
+            ntpr,
+            // Prefixes of exactly 8 characters are hashes rather than labels.
+            label: if prefix.len() != 8 {
+                Some(prefix)
+            } else {
+                None
+            },
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        lazy_static! {
+            static ref NTP_MASK_EXPR: Regex =
+                Regex::new("([^]]+/)?([^]]+)/([^]]+)/([^_]+)_([^_]+)").unwrap();
+        }
+
+        if let Some(grps) = NTP_MASK_EXPR.captures(&s) {
+            // Remove the trailing /.
+            let label = grps
+                .get(1)
+                .map(|s| s.as_str().chars().take(s.len() - 1).collect());
+
+            let namespace = grps.get(2).unwrap().as_str().to_string();
+            let topic = grps.get(3).unwrap().as_str().to_string();
+            let partition = grps.get(4).unwrap().as_str().to_string();
+            let revision = grps.get(5).unwrap().as_str().to_string();
+
+            Self {
+                ntpr: NTPR {
+                    ntp: NTP {
+                        namespace,
+                        topic,
+                        partition_id: partition.parse::<u32>().unwrap(),
+                    },
+                    revision_id: revision.parse::<i64>().unwrap(),
+                },
+                label,
+            }
+        } else {
+            panic!("Malformed NTP query string");
+        }
+    }
+}
+
+impl Serialize for LabeledNTPR {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let stringized = format!("{}", self);
+        stringized.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LabeledNTPR {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let stringized = String::deserialize(deserializer)?;
+        Ok(Self::from_str(stringized.as_str()))
+    }
+}
+
+impl fmt::Display for LabeledNTPR {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let maybe_label = if let Some(l) = &self.label {
+            format!("{}/", l)
+        } else {
+            "".to_string()
+        };
+        f.write_fmt(format_args!(
+            "{}{}_{}",
+            maybe_label, self.ntpr.ntp, self.ntpr.revision_id
+        ))
+    }
+}
+
 /// A Partition, uniquely identified by its revision ID
 #[derive(Eq, PartialEq, Hash, Debug, Clone, Ord, PartialOrd)]
 pub struct NTPR {

--- a/tools/rp_storage_tool/src/ntp_mask.rs
+++ b/tools/rp_storage_tool/src/ntp_mask.rs
@@ -1,4 +1,4 @@
-use crate::fundamental::{NTP, NTR};
+use crate::fundamental::{LabeledNTPR, LabeledNTR, NTP, NTR};
 use crate::NTPR;
 use regex::Regex;
 use std::fmt::{Display, Formatter};
@@ -167,6 +167,15 @@ impl NTPFilter {
         self.match_parts(&ntr.namespace, &ntr.topic, None, Some(ntr.revision_id))
     }
 
+    pub fn match_lntr(&self, lntr: &LabeledNTR) -> bool {
+        self.match_parts(
+            &lntr.ntr.namespace,
+            &lntr.ntr.topic,
+            None,
+            Some(lntr.ntr.revision_id),
+        )
+    }
+
     pub fn match_ntp(&self, ntp: &NTP) -> bool {
         self.match_parts(&ntp.namespace, &ntp.topic, Some(ntp.partition_id), None)
     }
@@ -177,6 +186,14 @@ impl NTPFilter {
             &ntpr.ntp.topic,
             Some(ntpr.ntp.partition_id),
             Some(ntpr.revision_id),
+        )
+    }
+    pub fn match_lntpr(&self, lntpr: &LabeledNTPR) -> bool {
+        self.match_parts(
+            &lntpr.ntpr.ntp.namespace,
+            &lntpr.ntpr.ntp.topic,
+            Some(lntpr.ntpr.ntp.partition_id),
+            Some(lntpr.ntpr.revision_id),
         )
     }
 }


### PR DESCRIPTION
Upcoming changes will enable supplying a cluster UUID to a topic to change the remote paths that get used. To account for this, this changes rp_storage_tool to look for the new path format and collect the cluster UUID labels. This will allow us to continue running rp_storage_tool in ducktape tests once the feature is enabled.

The high level approach taken here is to collect and serialize labels as a part of the NTPR and NTR objects that are associated with objects and anomalies. The label is optional, and a None label will refer to hash-prefixed objects.

This has change has been seen to allow CI to pass in a feature branch I'm working in: https://buildkite.com/redpanda/redpanda/builds/50695#_

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
