### PR TITLE
[rpk connect] fwd port .rpk.ac-connect bundling changes from v24.1.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,6 +32,10 @@ licenses           @emaxerrno @dswang
 # rpk
 #
 /src/go/rpk        @twmb @r-vasquez @gene-redpanda @Deflaimun
+# There are now two copies goreleaser.yaml in the interim `rpk connect` arch
+# Adding devprod to code owners to review any changes (e.g. they should stay in sync)
+/src/go/.goreleaser.yaml @twmb @r-vasquez @gene-redpanda @Deflaimun @redpanda-data/devprod
+/src/go/.goreleaser_rpk_connect.yaml @twmb @r-vasquez @gene-redpanda @Deflaimun @redpanda-data/devprod
 
 #
 # testing

--- a/.gitignore
+++ b/.gitignore
@@ -247,6 +247,7 @@ vbuild/
 /.vtools.yml
 /vtools
 /benthos
+/connect
 /Taskfile.yml
 /.dockerignore
 /.task/

--- a/src/go/.goreleaser_rp_connect.yaml
+++ b/src/go/.goreleaser_rp_connect.yaml
@@ -1,0 +1,171 @@
+project_name: rpk
+builds:
+  # rpk-windows-and-linux is deprecated; will be replaced by rpk-windows, rpk-linux, rpk-linux-microsoft-go
+  - id: rpk-windows-and-linux
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-linux-darwin-connect
+    builder: prebuilt
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    prebuilt:
+      # We expect to see $RP_CONNECT_BUILD_ROOT/go/linux/amd64/.rpk.ac-connect, etc.
+      path: '{{ .Env.RP_CONNECT_BUILD_ROOT }}/go/{{ .Os }}/{{ .Arch }}/bin/.rpk.ac-connect'
+    binary: .rpk.ac-connect
+  - id: rpk-linux-microsoft-go
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - 'CGO_ENABLED={{ if index .Env "CGO_ENABLED" }}{{ .Env.CGO_ENABLED }}{{ else }}0{{ end }}'
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-linux
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-windows
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+  - id: rpk-darwin
+    dir: ./rpk/
+    main: ./cmd/rpk
+    binary: rpk
+    ldflags:
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.version={{.Tag}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.rev={{.ShortCommit}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.buildTime={{.Date}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostOs={{.Os}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/version.hostArch={{.Arch}}
+      - -X github.com/redpanda-data/redpanda/src/go/rpk/pkg/cli/container/common.tag={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    hooks:
+      post:
+        # The binary is signed and notarized when running a production release, but for snapshot builds notarization is
+        # skipped and only ad-hoc signing is performed (not cryptographic material is needed).
+        #
+        # note: environment variables required for signing and notarization (set in CI) but are not needed for snapshot builds
+        #    QUILL_SIGN_P12, QUILL_SIGN_PASSWORD, QUILL_NOTARY_KEY, QUILL_NOTARY_KEY_ID, QUILL_NOTARY_ISSUER
+        - cmd: quill sign-and-notarize "{{ .Path }}" --dry-run={{ .IsSnapshot }} --ad-hoc={{ .IsSnapshot }} -vv
+          env:
+            - QUILL_LOG_FILE=dist/quill-{{ .Target }}.log
+archives:
+  - id: rpk-zip
+    builds:
+      - rpk-windows-and-linux
+      - rpk-linux-darwin-connect
+      - rpk-darwin
+    format: zip
+    name_template: "rpk-{{ .Os }}-{{ .Arch }}"
+    allow_different_binary_count: true
+release:
+  github:
+    owner: redpanda-data
+    name: redpanda
+  ids:
+    - rpk-zip
+  draft: true
+  discussion_category_name: Releases
+brews:
+  - name: redpanda
+    homepage: "https://redpanda.com"
+    description: "Redpanda CLI & toolbox"
+    repository:
+      owner: redpanda-data
+      name: homebrew-tap
+    folder: Formula
+    skip_upload: auto
+    ids:
+      - rpk-zip
+    extra_install: |
+      generate_completions_from_executable(bin/"rpk", "generate", "shell-completion", base_name: "rpk")
+    caveats: |
+        Redpanda Keeper (rpk) is Redpanda's command line interface (CLI)
+        utility. The rpk commands let you configure, manage, and tune
+        Redpanda clusters. They also let you manage topics, groups,
+        and access control lists (ACLs).
+        Start a three-node docker cluster locally:
+
+            rpk container start -n 3
+
+        Interact with the cluster using commands like:
+
+            rpk topic list
+
+        When done, stop and delete the docker cluster:
+
+            rpk container purge
+
+        For more examples and guides, visit: https://docs.redpanda.com
+    commit_author:
+      name: vbotbuildovich
+      email: vbot@redpanda.com
+announce:
+  skip: "true"


### PR DESCRIPTION
`.rpk.ac-connect` bundling to support `rpk connect` out of box was first introduced in `v24.1.x`.  We plan to continue with this bundling pattern until at least `v24.2.x`, our next minor release.  Therefore changes relevant to bundling support must be ported over.

This PR must land before any related vtools forward port PRs.  E.g. vtools will depend on `.goreleaser_rp_connect.yml`.

Specifically, I checked that `.goreleaser.yml` did not change between `v24.1.x` and `dev`, which means `.goreleaser_rp_connect.yml` could be safely picked from `v24.1.x` without any changes.  In other words, the delta between `.goreleaser.yml` and `.goreleaser_rp_connect.yml` did not change between `v24.1.x` and in this `dev` PR.

Original changes in `v24.1.x` branch:

* https://github.com/redpanda-data/redpanda/pull/20158
* https://github.com/redpanda-data/redpanda/pull/18755

## Backports Required

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none