### PR TITLE
cloud_storage: add clarifying comments around naming and versions

### DIFF
--- a/src/v/cloud_storage/partition_path_utils.h
+++ b/src/v/cloud_storage/partition_path_utils.h
@@ -17,6 +17,16 @@
 
 namespace cloud_storage {
 
+// Redpanda has supported different formats and naming schemes for partition
+// manifests through its lifetime:
+// - v24.2 and up: cluster-uuid-labeled name, binary format
+// - v23.2 and up: hash-prefixed name, binary format
+// - below v23.2: hash-prefixed name, JSON format
+//
+// Because manifests are persistent state, we must be able to access older
+// versions, in cases we need to read when newer manifests have not yet been
+// written. This header contains methods to build paths for all versions.
+
 // 806a0f4a-e691-4a2b-9352-ec4b769a5e6e/meta/kafka/panda-topic/0_123
 ss::sstring labeled_partition_manifest_prefix(
   const remote_label& cluster_hint,

--- a/src/v/cloud_storage/segment_path_utils.h
+++ b/src/v/cloud_storage/segment_path_utils.h
@@ -16,6 +16,19 @@
 
 namespace cloud_storage {
 
+// Redpanda has supported different naming schemes for segments through its
+// lifetime:
+// - v24.2 and up: cluster-uuid-labeled name
+// - below v24.2: hash-prefixed name
+//
+// Because segments are persistent state, we must be able to access older
+// versions, in cases we need to read when newer manifests have not yet been
+// written. This header contains methods to build paths for all versions.
+//
+// NOTE: the exact segment-name format is still determined by manifest state.
+// As such, this class only guides the prefix, and leaves filename generation
+// to callers (typically via methods in partition_manifest).
+
 // 806a0f4a-e691-4a2b-9352-ec4b769a5e6e/kafka/panda-topic/0_123/0-100-1024-16-v1.log.16
 ss::sstring labeled_segment_path(
   const remote_label& remote_label,

--- a/src/v/cloud_storage/topic_path_utils.h
+++ b/src/v/cloud_storage/topic_path_utils.h
@@ -17,6 +17,16 @@
 
 namespace cloud_storage {
 
+// Redpanda has supported different formats and naming schemes for topic
+// manifests through its lifetime:
+// - v24.2 and up: cluster-uuid-labeled name, binary format
+// - v24.1 and up: hash-prefixed name, binary format
+// - below v24.1: hash-prefixed name, JSON format
+//
+// Because manifests are persistent state, we must be able to access older
+// versions, in cases we need to read when newer manifests have not yet been
+// written. This header contains methods to build paths for all versions.
+
 // meta/kafka/panda-topic
 ss::sstring labeled_topic_manifest_root(const model::topic_namespace& topic);
 


### PR DESCRIPTION
Adds some comments describing labeled and prefixed paths.

This is review follow-up from #20149

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
