### PR TITLE
self-test disk test enhancements

### DIFF
--- a/src/v/cluster/self_test/diskcheck.cc
+++ b/src/v/cluster/self_test/diskcheck.cc
@@ -144,7 +144,8 @@ diskcheck::run_configured_benchmarks(ss::file& file) {
     auto write_metrics = co_await do_run_benchmark<read_or_write::write>(file);
     auto result = write_metrics.to_st_result();
     result.name = _opts.name;
-    result.info = "write run";
+    result.info = fmt::format(
+      "write run (iodepth: {}, dsync: {})", _opts.parallelism, _opts.dsync);
     result.test_type = "disk";
     if (_cancelled) {
         result.warning = "Run was manually cancelled";

--- a/src/v/cluster/self_test_rpc_types.h
+++ b/src/v/cluster/self_test_rpc_types.h
@@ -46,7 +46,7 @@ struct diskcheck_opts
   : serde::
       envelope<diskcheck_opts, serde::version<0>, serde::compat_version<0>> {
     /// Descriptive name given to test run
-    ss::sstring name{"512K sequential r/w disk test"};
+    ss::sstring name{"unspecified"};
     /// Where files this benchmark will read/write to exist
     std::filesystem::path dir{config::node().disk_benchmark_path()};
     /// Open the file with O_DSYNC flag option
@@ -56,7 +56,7 @@ struct diskcheck_opts
     /// Set to true to disable the read portion of the benchmark
     bool skip_read{false};
     /// Total size of all benchmark files to exist on disk
-    uint64_t data_size{10ULL << 30}; // 1GiB
+    uint64_t data_size{10ULL << 30}; // 10GiB
     /// Size of individual read and/or write requests
     size_t request_size{512 << 10}; // 512KiB
     /// Total duration of the benchmark

--- a/tests/rptest/tests/self_test_test.py
+++ b/tests/rptest/tests/self_test_test.py
@@ -43,7 +43,7 @@ class SelfTestTest(EndToEndTest):
             return not any([x['status'] == 'running'
                             for x in node_reports]), node_reports
 
-        return wait_until_result(all_idle, timeout_sec=30, backoff_sec=1)
+        return wait_until_result(all_idle, timeout_sec=90, backoff_sec=1)
 
     @cluster(num_nodes=3)
     @matrix(remote_read=[True, False], remote_write=[True, False])
@@ -101,9 +101,9 @@ class SelfTestTest(EndToEndTest):
         # on specific results, but rather what tests are oberved to have run
         reports = flat_map(lambda node: node['results'], node_reports)
 
-        # Ensure 4 disk tests per node, read/write & latency/throughput
+        # Ensure 10 disk tests per node (see the RPK code for the full list)
         disk_results = [r for r in reports if r['test_type'] == 'disk']
-        expected_disk_results = num_nodes * 4
+        expected_disk_results = num_nodes * 10
         assert len(
             disk_results
         ) == expected_disk_results, f"Expected {expected_disk_results} disk reports observed {len(disk_results)}"


### PR DESCRIPTION
rpk: add additional disk self tests

Add 16K block size disk tests, a common block size written by Redpanda,
at varying IO depths: 1, 8 and 32 times the shard count (the
multiplication by the shard count happens in Redpanda and is
inevitable).

This will help better assess the performance of block storage which is
a bit outside the usual, in particular how it response to io depth
changes.

Additionally, add a 4K test which is the same as the existing one but
with dsync off. This is critical to assess the impact of fdatasync
on the storage layer: locally, _for me_ on my consumer SSD this makes a
257x difference (!!) in throughput though the effect is much more muted,
perhaps close to zero on other SSD types.

On the redpanda side, when we complete a self test the API returns
info about the runincluding an info field which says "write run" currently
(for a disk test). Enhance this to include information about whether
dsync was enabled and the total io depth (which is the client-specified
parallelism value times the number of shards).

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Improvements

* Add more cases to the rpk disk self-test to better probe write performance at various IO depths, and at 16K block sizes. Return more information about the specifics of the test in the output.
