### PR TITLE
cloud_storage: add some convenience methods for working with path provider

### DIFF
--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -415,6 +415,17 @@ partition_manifest::generate_segment_path(const lw_segment_meta& meta) const {
     return generate_segment_path(lw_segment_meta::convert(meta));
 }
 
+remote_segment_path partition_manifest::generate_segment_path(
+  const segment_meta& meta, const remote_path_provider& path_provider) const {
+    return remote_segment_path{path_provider.segment_path(*this, meta)};
+}
+
+remote_segment_path partition_manifest::generate_segment_path(
+  const lw_segment_meta& meta,
+  const remote_path_provider& path_provider) const {
+    return generate_segment_path(lw_segment_meta::convert(meta), path_provider);
+}
+
 segment_name partition_manifest::generate_remote_segment_name(
   const partition_manifest::value& val) {
     switch (val.sname_format) {

--- a/src/v/cloud_storage/partition_manifest.cc
+++ b/src/v/cloud_storage/partition_manifest.cc
@@ -16,6 +16,7 @@
 #include "bytes/streambuf.h"
 #include "cloud_storage/base_manifest.h"
 #include "cloud_storage/logger.h"
+#include "cloud_storage/remote_path_provider.h"
 #include "cloud_storage/segment_meta_cstore.h"
 #include "cloud_storage/types.h"
 #include "hashing/xx.h"
@@ -217,6 +218,11 @@ partition_manifest::get_manifest_format_and_path() const {
     return {
       manifest_format::serde,
       generate_partition_manifest_path(_ntp, _rev, manifest_format::serde)};
+}
+
+remote_manifest_path partition_manifest::get_manifest_path(
+  const remote_path_provider& path_provider) const {
+    return remote_manifest_path{path_provider.partition_manifest_path(*this)};
 }
 
 std::pair<manifest_format, remote_manifest_path>

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/base_manifest.h"
+#include "cloud_storage/fwd.h"
 #include "cloud_storage/types.h"
 #include "container/fragmented_vector.h"
 #include "model/fundamental.h"
@@ -211,6 +212,9 @@ public:
             return get_manifest_format_and_path().second;
         }
     }
+
+    virtual remote_manifest_path
+    get_manifest_path(const remote_path_provider&) const;
 
     static ss::sstring filename() { return "manifest.bin"; }
     virtual ss::sstring get_manifest_filename() const { return filename(); }

--- a/src/v/cloud_storage/partition_manifest.h
+++ b/src/v/cloud_storage/partition_manifest.h
@@ -278,6 +278,11 @@ public:
     remote_segment_path generate_segment_path(const segment_meta&) const;
     remote_segment_path generate_segment_path(const lw_segment_meta&) const;
 
+    remote_segment_path generate_segment_path(
+      const segment_meta&, const remote_path_provider&) const;
+    remote_segment_path generate_segment_path(
+      const lw_segment_meta&, const remote_path_provider&) const;
+
     /// Return an iterator to the first addressable segment (i.e. base offset
     /// is greater than or equal to the start offset). If no such segment
     /// exists, return the end iterator.

--- a/src/v/cloud_storage/remote_path_provider.cc
+++ b/src/v/cloud_storage/remote_path_provider.cc
@@ -37,6 +37,14 @@ ss::sstring remote_path_provider::topic_manifest_path(
     return prefixed_topic_manifest_bin_path(topic);
 }
 
+std::optional<ss::sstring> remote_path_provider::topic_manifest_path_json(
+  const model::topic_namespace& topic) const {
+    if (label_.has_value()) {
+        return std::nullopt;
+    }
+    return prefixed_topic_manifest_json_path(topic);
+}
+
 ss::sstring remote_path_provider::partition_manifest_prefix(
   const model::ntp& ntp, model::initial_revision_id rev) const {
     if (label_.has_value()) {

--- a/src/v/cloud_storage/remote_path_provider.h
+++ b/src/v/cloud_storage/remote_path_provider.h
@@ -32,6 +32,8 @@ public:
     // Topic manifest path.
     ss::sstring topic_manifest_path(
       const model::topic_namespace& topic, model::initial_revision_id) const;
+    std::optional<ss::sstring>
+    topic_manifest_path_json(const model::topic_namespace& topic) const;
 
     // Prefix of the partition manifest path. This can be used to filter
     // objects to find partition or spillover manifests.

--- a/src/v/cloud_storage/spillover_manifest.h
+++ b/src/v/cloud_storage/spillover_manifest.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/partition_manifest.h"
+#include "cloud_storage/remote_path_provider.h"
 #include "cloud_storage/types.h"
 #include "model/metadata.h"
 
@@ -50,6 +51,12 @@ class spillover_manifest final : public partition_manifest {
 public:
     spillover_manifest(const model::ntp& ntp, model::initial_revision_id rev)
       : partition_manifest(ntp, rev) {}
+
+    remote_manifest_path get_manifest_path(
+      const remote_path_provider& path_provider) const override {
+        return remote_manifest_path{
+          path_provider.partition_manifest_path(*this)};
+    }
 
     static ss::sstring filename(const spillover_manifest_path_components& c) {
         return fmt::format(

--- a/src/v/cloud_storage/tests/remote_path_provider_test.cc
+++ b/src/v/cloud_storage/tests/remote_path_provider_test.cc
@@ -93,11 +93,21 @@ TEST(RemotePathProviderTest, TestPrefixedPartitionManifestPaths) {
     EXPECT_STREQ(
       path_provider.spillover_manifest_path(pm, test_spill_comps).c_str(),
       "e0000000/meta/kafka/tp/5_21/manifest.bin.10.11.0.1.999.1000");
+    EXPECT_STREQ(
+      pm.get_manifest_path(path_provider)().native().c_str(),
+      "e0000000/meta/kafka/tp/5_21/manifest.bin");
 
     spillover_manifest spill_m(test_ntp, test_rev);
     spill_m.add(test_smeta);
     EXPECT_STREQ(
       path_provider.partition_manifest_path(spill_m).c_str(),
+      "e0000000/meta/kafka/tp/5_21/manifest.bin.10.11.0.1.999.1000");
+    EXPECT_STREQ(
+      spill_m.get_manifest_path(path_provider)().native().c_str(),
+      "e0000000/meta/kafka/tp/5_21/manifest.bin.10.11.0.1.999.1000");
+    partition_manifest* disguised_manifest = &spill_m;
+    EXPECT_STREQ(
+      disguised_manifest->get_manifest_path(path_provider)().native().c_str(),
       "e0000000/meta/kafka/tp/5_21/manifest.bin.10.11.0.1.999.1000");
 }
 
@@ -119,6 +129,9 @@ TEST(RemotePathProviderTest, TestLabeledPartitionManifestPaths) {
       path_provider.partition_manifest_path(pm).c_str(),
       "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/manifest.bin");
     EXPECT_STREQ(
+      pm.get_manifest_path(path_provider)().native().c_str(),
+      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/manifest.bin");
+    EXPECT_STREQ(
       path_provider.spillover_manifest_path(pm, test_spill_comps).c_str(),
       "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/"
       "manifest.bin.10.11.0.1.999.1000");
@@ -127,6 +140,15 @@ TEST(RemotePathProviderTest, TestLabeledPartitionManifestPaths) {
     spill_m.add(test_smeta);
     EXPECT_STREQ(
       path_provider.partition_manifest_path(spill_m).c_str(),
+      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/"
+      "manifest.bin.10.11.0.1.999.1000");
+    EXPECT_STREQ(
+      spill_m.get_manifest_path(path_provider)().native().c_str(),
+      "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/"
+      "manifest.bin.10.11.0.1.999.1000");
+    partition_manifest* disguised_manifest = &spill_m;
+    EXPECT_STREQ(
+      disguised_manifest->get_manifest_path(path_provider)().native().c_str(),
       "deadbeef-0000-0000-0000-000000000000/meta/kafka/tp/5_21/"
       "manifest.bin.10.11.0.1.999.1000");
 }

--- a/src/v/cloud_storage/tests/remote_path_provider_test.cc
+++ b/src/v/cloud_storage/tests/remote_path_provider_test.cc
@@ -58,6 +58,10 @@ TEST(RemotePathProviderTest, TestPrefixedTopicManifestPaths) {
     EXPECT_STREQ(
       path_provider.topic_manifest_prefix(test_tp_ns).c_str(),
       "e0000000/meta/kafka/tp");
+    const auto json_str = path_provider.topic_manifest_path_json(test_tp_ns);
+    ASSERT_TRUE(json_str.has_value());
+    EXPECT_STREQ(
+      json_str->c_str(), "e0000000/meta/kafka/tp/topic_manifest.json");
 }
 
 TEST(RemotePathProviderTest, TestLabeledTopicManifestPaths) {
@@ -69,6 +73,11 @@ TEST(RemotePathProviderTest, TestLabeledTopicManifestPaths) {
     EXPECT_STREQ(
       path_provider.topic_manifest_prefix(test_tp_ns).c_str(),
       "meta/kafka/tp/deadbeef-0000-0000-0000-000000000000");
+
+    // We don't expect to read or write JSON topic manifests with the cluster
+    // uuid labels.
+    const auto json_str = path_provider.topic_manifest_path_json(test_tp_ns);
+    ASSERT_FALSE(json_str.has_value());
 }
 
 TEST(RemotePathProviderTest, TestPrefixedPartitionManifestPaths) {

--- a/src/v/cloud_storage/topic_manifest.cc
+++ b/src/v/cloud_storage/topic_manifest.cc
@@ -13,6 +13,7 @@
 #include "bytes/iostream.h"
 #include "bytes/streambuf.h"
 #include "cloud_storage/logger.h"
+#include "cloud_storage/remote_path_provider.h"
 #include "cloud_storage/types.h"
 #include "cluster/types.h"
 #include "hashing/xx.h"
@@ -553,6 +554,13 @@ remote_manifest_path topic_manifest::get_manifest_path() const {
     vassert(_topic_config, "Topic config is not set");
     return get_topic_manifest_path(
       _topic_config->tp_ns.ns, _topic_config->tp_ns.tp, manifest_format::serde);
+}
+
+remote_manifest_path topic_manifest::get_manifest_path(
+  const remote_path_provider& path_provider) const {
+    vassert(_topic_config, "Topic config is not set");
+    return remote_manifest_path{
+      path_provider.topic_manifest_path(_topic_config->tp_ns, _rev)};
 }
 
 } // namespace cloud_storage

--- a/src/v/cloud_storage/topic_manifest.h
+++ b/src/v/cloud_storage/topic_manifest.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "cloud_storage/base_manifest.h"
+#include "cloud_storage/fwd.h"
 #include "cloud_storage/types.h"
 #include "cluster/types.h"
 #include "features/feature_table.h"
@@ -56,6 +57,7 @@ public:
 
     /// Manifest object name in S3
     remote_manifest_path get_manifest_path() const override;
+    remote_manifest_path get_manifest_path(const remote_path_provider&) const;
 
     static remote_manifest_path
     get_topic_manifest_path(model::ns ns, model::topic topic, manifest_format);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

- adds some methods to partition_manifest and topic_manifest to ease the transition towards using path provider everywhere
- adds to the path provider a method to get the topic manifest JSON path, if supported (similar to the one for partition manifests)

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
