### PR TITLE
Do not set transaction timeout in tests that do not need it

### DIFF
--- a/tests/rptest/transactions/transactions_test.py
+++ b/tests/rptest/transactions/transactions_test.py
@@ -179,7 +179,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         producer.init_transactions()
@@ -198,7 +197,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         consumer1 = ck.Consumer({
@@ -276,7 +274,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         group_name = "test"
@@ -334,7 +331,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         group_name = "test"
@@ -951,7 +947,6 @@ class TransactionsStreamsTest(RedpandaTest, TransactionsMixin):
         producer_conf = {
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': 'streams',
-            'transaction.timeout.ms': 10000,
         }
         producer = ck.Producer(producer_conf)
         consumer_conf = {
@@ -1137,7 +1132,6 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
         producer_cfg = {
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         }
 
         user = self.USER_1
@@ -1166,7 +1160,6 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
         producer_cfg = {
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         }
         consumer_cfg = {
             'bootstrap.servers': self.redpanda.brokers(),
@@ -1352,7 +1345,6 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         producer.init_transactions()
@@ -1375,7 +1367,6 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         producer.init_transactions()
@@ -1457,7 +1448,6 @@ class TxUpgradeTest(RedpandaTest):
             producer = ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'transactional.id': self._tx_id(i),
-                'transaction.timeout.ms': 10000,
             })
             producer.init_transactions()
             producer.begin_transaction()

--- a/tests/rptest/transactions/tx_coordinator_migration_test.py
+++ b/tests/rptest/transactions/tx_coordinator_migration_test.py
@@ -53,7 +53,6 @@ class TxCoordinatorMigrationTest(RedpandaTest):
             producer = ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'transactional.id': self._tx_id(i),
-                'transaction.timeout.ms': 10000,
             })
             producer.init_transactions()
             producer.begin_transaction()


### PR DESCRIPTION
Most of our transactions tests were build based with the same code which often were copy pasted. The test were setting the default transaction timeout to 10 seconds as they might have been based on the test that validated the transactions expiration. Updated the tests to make sure that the timeout is set in the test that need it.

The timeout made some tests to fail intermittently.

Fixes: #18184

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [x] v24.1.x
- [x] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none