### PR TITLE
[v24.1.x] Do not set transaction timeout in tests that do not need it

### DIFF
--- a/tests/rptest/tests/transactions_test.py
+++ b/tests/rptest/tests/transactions_test.py
@@ -163,7 +163,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         producer.init_transactions()
@@ -182,7 +181,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         consumer1 = ck.Consumer({
@@ -260,7 +258,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         group_name = "test"
@@ -318,7 +315,6 @@ class TransactionsTest(RedpandaTest, TransactionsMixin):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         group_name = "test"
@@ -947,7 +943,6 @@ class TransactionsStreamsTest(RedpandaTest, TransactionsMixin):
         producer_conf = {
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': 'streams',
-            'transaction.timeout.ms': 10000,
         }
         producer = ck.Producer(producer_conf)
         consumer_conf = {
@@ -1128,7 +1123,6 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
         producer_cfg = {
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         }
 
         user = self.USER_1
@@ -1157,7 +1151,6 @@ class TransactionsAuthorizationTest(RedpandaTest, TransactionsMixin):
         producer_cfg = {
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         }
         consumer_cfg = {
             'bootstrap.servers': self.redpanda.brokers(),
@@ -1343,7 +1336,6 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         producer.init_transactions()
@@ -1366,7 +1358,6 @@ class GATransaction_v22_1_UpgradeTest(RedpandaTest):
         producer = ck.Producer({
             'bootstrap.servers': self.redpanda.brokers(),
             'transactional.id': '0',
-            'transaction.timeout.ms': 10000,
         })
 
         producer.init_transactions()
@@ -1448,7 +1439,6 @@ class TxUpgradeTest(RedpandaTest):
             producer = ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'transactional.id': self._tx_id(i),
-                'transaction.timeout.ms': 10000,
             })
             producer.init_transactions()
             producer.begin_transaction()

--- a/tests/rptest/tests/tx_coordinator_migration_test.py
+++ b/tests/rptest/tests/tx_coordinator_migration_test.py
@@ -53,7 +53,6 @@ class TxCoordinatorMigrationTest(RedpandaTest):
             producer = ck.Producer({
                 'bootstrap.servers': self.redpanda.brokers(),
                 'transactional.id': self._tx_id(i),
-                'transaction.timeout.ms': 10000,
             })
             producer.init_transactions()
             producer.begin_transaction()


### PR DESCRIPTION
Backport of PR https://github.com/redpanda-data/redpanda/pull/20743
Fixes: https://github.com/redpanda-data/redpanda/issues/20746,