### PR TITLE
[rptest] Azure CDT bringup

### DIFF
--- a/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
+++ b/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
@@ -100,7 +100,7 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
         # az-cli is installed via snap and /snap/bin only appears in
         # $PATH on *interactive* shells
         cmd = self.redpanda.kubectl._ssh_prefix() + [
-            'env', 'PATH=/usr/bin:/bin:/snap/bin',
+            'env', 'PATH=/usr/local/bin:/usr/bin:/bin:/snap/bin',
             'az', 'aks', 'nodepool', 'list',
             '--cluster-name', f'aks-rpcloud-{self._clusterId}',
             '--resource-group', f'rg-rpcloud-{self._clusterId}',
@@ -111,15 +111,12 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
         res = subprocess.check_output(cmd)
         resd = json.loads(res)
 
-        self.logger.debug(
-            "asserting nodes_count: expected: {}, actual: {}".format(
-                self._configProfile['nodes_count'], len(resd)))
-        assert len(resd) == self._configProfile['nodes_count']
+        nc = self._configProfile['nodes_count']
+        assert len(
+            resd) == nc, f"expected nodes_count: {nc}, actual: {len(resd)}"
 
-        self.logger.debug(
-            "asserting machineType: expected: {}, actual: {}".format(
-                self._configProfile['machine_type'], resd[1]))
-        assert resd[1] == self._configProfile['machine_type']
+        mt = self._configProfile['machine_type']
+        assert resd[1] == mt, f"expected machineType: {mt}, actual: {resd[1]}"
 
     def _check_gcp_nodes(self):
         cmd = self.redpanda.kubectl._ssh_prefix() + [

--- a/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
+++ b/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
@@ -65,7 +65,8 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
         self.logger.debug(
             "asserting we got the config for the right cluster: expected rp-{}, actual: {}"
             .format(self._clusterId, clusterConfig["cluster_id"]))
-        assert "rp-{}".format(self._clusterId) == clusterConfig['cluster_id']
+        assert clusterConfig['cluster_id'] in (self._clusterId,
+                                               f'rp-{self._clusterId}')
 
         for k, v in self._configProfile["cluster_config"].items():
             self.logger.debug(

--- a/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
+++ b/tests/rptest/redpanda_cloud_tests/config_profile_verify_test.py
@@ -48,10 +48,13 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
         self.logger.debug("Here we go")
 
         # assert isinstance(self.redpanda, RedpandaServiceCloud)
-        if self._configProfile['cloud_provider'] == 'gcp':
-            self._check_gcp_nodes()
-        else:
-            self._check_aws_nodes()
+        match self._configProfile['cloud_provider']:
+            case 'aws':
+                self._check_aws_nodes()
+            case 'gcp':
+                self._check_gcp_nodes()
+            case 'azure':
+                self._check_azure_nodes()
 
         self._check_rp_config()
 
@@ -70,6 +73,52 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
                 .format(k, v, clusterConfig[k]))
             if clusterConfig[k] != v and "{}".format(clusterConfig[k]) != v:
                 assert False
+
+    def _check_aws_nodes(self):
+        cmd = self.redpanda.kubectl._ssh_prefix() + [
+            'aws', 'ec2', 'describe-instances',
+            '--filters="Name=tag:Name, Values=redpanda-{}-rp"'.format(
+                self._clusterId),
+            '--query="Reservations[0].Instances[*].InstanceType"'
+        ]
+        res = subprocess.check_output(cmd)
+        resd = json.loads(res)
+
+        self.logger.debug(
+            "asserting nodes_count: expected: {}, actual: {}".format(
+                self._configProfile['nodes_count'], len(resd)))
+        assert len(resd) == self._configProfile['nodes_count']
+
+        self.logger.debug(
+            "asserting machineType: expected: {}, actual: {}".format(
+                self._configProfile['machine_type'], resd[0]))
+        assert resd[0] == self._configProfile['machine_type']
+
+    def _check_azure_nodes(self):
+        # currently, we have to override the PATH for azure because
+        # az-cli is installed via snap and /snap/bin only appears in
+        # $PATH on *interactive* shells
+        cmd = self.redpanda.kubectl._ssh_prefix() + [
+            'env', 'PATH=/usr/bin:/bin:/snap/bin',
+            'az', 'aks', 'nodepool', 'list',
+            '--cluster-name', f'aks-rpcloud-{self._clusterId}',
+            '--resource-group', f'rg-rpcloud-{self._clusterId}',
+            '--query', "'[?starts_with(name,`redpanda`)].vmSize'",
+            '--output', 'json'
+        ] # yapf: disable
+
+        res = subprocess.check_output(cmd)
+        resd = json.loads(res)
+
+        self.logger.debug(
+            "asserting nodes_count: expected: {}, actual: {}".format(
+                self._configProfile['nodes_count'], len(resd)))
+        assert len(resd) == self._configProfile['nodes_count']
+
+        self.logger.debug(
+            "asserting machineType: expected: {}, actual: {}".format(
+                self._configProfile['machine_type'], resd[1]))
+        assert resd[1] == self._configProfile['machine_type']
 
     def _check_gcp_nodes(self):
         cmd = self.redpanda.kubectl._ssh_prefix() + [
@@ -101,23 +150,3 @@ class ConfigProfileVerifyTest(RedpandaCloudTest):
                 .format(n["name"], self._configProfile["storage_size_bytes"],
                         total))
             assert total == self._configProfile['storage_size_bytes']
-
-    def _check_aws_nodes(self):
-        cmd = self.redpanda.kubectl._ssh_prefix() + [
-            'aws', 'ec2', 'describe-instances',
-            '--filters="Name=tag:Name, Values=redpanda-{}-rp"'.format(
-                self._clusterId),
-            '--query="Reservations[0].Instances[*].InstanceType"'
-        ]
-        res = subprocess.check_output(cmd)
-        resd = json.loads(res)
-
-        self.logger.debug(
-            "asserting nodes_count: expected: {}, actual: {}".format(
-                self._configProfile['nodes_count'], len(resd)))
-        assert len(resd) == self._configProfile['nodes_count']
-
-        self.logger.debug(
-            "asserting machineType: expected: {}, actual: {}".format(
-                self._configProfile['machine_type'], resd[0]))
-        assert resd[0] == self._configProfile['machine_type']

--- a/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
+++ b/tests/rptest/redpanda_cloud_tests/high_throughput_test.py
@@ -62,6 +62,8 @@ MachineTypeMemory = {
     'im4gn.large': 8 * GiB,
     'im4gn.xlarge': 16 * GiB,
     'im4gn.8xlarge': 128 * GiB,
+    'Standard_L8s_v3': 64 * GiB,
+    'Standard_L8as_v3': 64 * GiB,
     'n2d-standard-2': 8 * GiB,
     'n2d-standard-4': 16 * GiB,
     'n2d-standard-16': 64 * GiB,

--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -44,6 +44,9 @@ class CloudBroker():
         #    self._meta['labels']['operator.redpanda.com/node-id'])
 
         # Other dirty way to get node-id
+        self.logger.debug(
+            f"broker pod name: {self.name}, generateName: {self._meta['generateName']}"
+        )
         self.slot_id = int(self.name.replace(self._meta['generateName'], ""))
         self.uuid = self._meta['uid']
 

--- a/tests/rptest/services/cloud_broker.py
+++ b/tests/rptest/services/cloud_broker.py
@@ -44,9 +44,6 @@ class CloudBroker():
         #    self._meta['labels']['operator.redpanda.com/node-id'])
 
         # Other dirty way to get node-id
-        self.logger.debug(
-            f"broker pod name: {self.name}, generateName: {self._meta['generateName']}"
-        )
         self.slot_id = int(self.name.replace(self._meta['generateName'], ""))
         self.uuid = self._meta['uid']
 

--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -53,6 +53,11 @@ class CloudClusterUtils:
             self.gcp_project_id = self._get_gcp_project_id(infra_id)
             self.logger.info(f"Using GCP project '{self.gcp_project_id}'")
             self.env.update({"GOOGLE_APPLICATION_CREDENTIALS": infra_id})
+        elif self.provider == 'azure':
+            self.subscription_id = context.globals.get('azure_subscription_id',
+                                                       None)
+            self.logger.debug(
+                f"Using Azure subscription ID: {self.subscription_id}")
 
     def _get_gcp_project_id(self, keyfilepath):
         project_id = None
@@ -131,8 +136,14 @@ class CloudClusterUtils:
         self.logger.debug("Deploying cluster agent")
         cmd = self._get_rpk_cloud_cmd()
         cmd += ["byoc", self.provider, "apply", f"--redpanda-id={cluster_id}"]
-        if self.provider == 'gcp':
-            cmd += ["--project-id=" + self.gcp_project_id]
+        match self.provider:
+            case 'gcp':
+                cmd += [f"--project-id={self.gcp_project_id}"]
+            case 'azure':
+                cmd += [
+                    f"--subscription-id={self.subscription_id}",
+                    "--identity=cli", "--credential-source=cli"
+                ]
         out = self._exec(cmd, timeout=1800)
         # TODO: Handle errors
         return out

--- a/tests/rptest/services/cloud_cluster_utils.py
+++ b/tests/rptest/services/cloud_cluster_utils.py
@@ -54,8 +54,7 @@ class CloudClusterUtils:
             self.logger.info(f"Using GCP project '{self.gcp_project_id}'")
             self.env.update({"GOOGLE_APPLICATION_CREDENTIALS": infra_id})
         elif self.provider == 'azure':
-            self.subscription_id = context.globals.get('azure_subscription_id',
-                                                       None)
+            self.subscription_id = context.globals['azure_subscription_id']
             self.logger.debug(
                 f"Using Azure subscription ID: {self.subscription_id}")
 

--- a/tests/rptest/services/machinetype.py
+++ b/tests/rptest/services/machinetype.py
@@ -18,7 +18,7 @@ class MachineTypeName(str, Enum):
     IM4GN_8XLARGE = 'im4gn.8xlarge'
 
     # Azure X86
-    STANDARD_L8S_V3 = 'Standard_L8as_v3'
+    STANDARD_L8S_V3 = 'Standard_L8s_v3'
     STANDARD_L8AS_V3 = 'Standard_L8as_v3'
 
     # GCP X86

--- a/tests/rptest/services/machinetype.py
+++ b/tests/rptest/services/machinetype.py
@@ -17,6 +17,10 @@ class MachineTypeName(str, Enum):
     IM4GN_XLARGE = 'im4gn.xlarge'
     IM4GN_8XLARGE = 'im4gn.8xlarge'
 
+    # Azure X86
+    STANDARD_L8S_V3 = 'Standard_L8as_v3'
+    STANDARD_L8AS_V3 = 'Standard_L8as_v3'
+
     # GCP X86
     N2_STANDARD_2 = 'n2-standard-2'
     N2_STANDARD_4 = 'n2-standard-4'
@@ -65,6 +69,12 @@ MachineTypeConfigs = {
     MachineTypeConfig(num_shards=3, memory=16 * GiB),
     MachineTypeName.IM4GN_8XLARGE:
     MachineTypeConfig(num_shards=31, memory=128 * GiB),
+
+    # Azure X86
+    MachineTypeName.STANDARD_L8S_V3:
+    MachineTypeConfig(num_shards=7, memory=64 * GiB),
+    MachineTypeName.STANDARD_L8AS_V3:
+    MachineTypeConfig(num_shards=7, memory=64 * GiB),
 
     # GCP X86
     MachineTypeName.N2_STANDARD_2:

--- a/tests/rptest/services/provider_clients/__init__.py
+++ b/tests/rptest/services/provider_clients/__init__.py
@@ -1,12 +1,16 @@
 from rptest.services.provider_clients.ec2_client import EC2Client
 from rptest.services.provider_clients.gcp_client import GCPClient
+from rptest.services.provider_clients.azure_client import AzureClient
 
 
-def make_provider_client(provider, logger, region, key, secret):
+def make_provider_client(provider, logger, region, key, secret, tenant=None):
+    provider = provider.upper()
     _client = None
     if provider == 'AWS':
         _client = EC2Client(region, key, secret, logger)
     elif provider == 'GCP':
         # In scope of GCP, key contains path to keyfile
         _client = GCPClient(region, key, logger)
+    elif provider == 'AZURE':
+        _client = AzureClient(region, key, secret, tenant, logger)
     return _client

--- a/tests/rptest/services/provider_clients/azure_client.py
+++ b/tests/rptest/services/provider_clients/azure_client.py
@@ -1,0 +1,99 @@
+from rptest.services.provider_clients.client_utils import query_instance_meta
+
+headers = {"Metadata-Flavor": "Microsoft"}
+
+
+class AzureClient:
+    """
+    Azure Client class.
+    Should implement function similar to AWS EC2 client
+    """
+    def __init__(self,
+                 region,
+                 key,
+                 secret,
+                 tenant,
+                 logger,
+                 endpoint=None,
+                 disable_ssl=True):
+
+        self._region = region
+        self._access_key = key
+        self._secret_key = secret
+        self._tenant = tenant
+        self._endpoint = endpoint
+        self._disable_ssl = disable_ssl
+        self._cli = self._make_client()
+
+    def _make_client(self):
+        # TODO: Work on Azure client
+        return None
+
+    @property
+    def project_id(self):
+        return "devprod-cicd-infra"  # HACK
+
+    def create_vpc_peering(self, params, facing_vpcs=True):
+        """
+        Creates two peering connections facing each other
+        """
+        return "hardcode"  # HACK
+
+    def get_vpc_by_network_id(self, network_id, prefix=None, project_id=None):
+        """
+        Get VPC Network
+        """
+        return "hardcode"  # HACK
+
+    def find_vpc_peering_connection(self, state, params):
+        return None
+
+    def accept_vpc_peering(self, peering_id, dry_run=False):
+        return None
+
+    def get_vpc_peering_status(self, vpc_peering_id):
+        return None
+
+    def get_route_table_ids_for_cluster(self, cluster_id):
+        return None
+
+    def get_route_table_ids_for_vpc(self, vpc_id):
+        return None
+
+    def create_route(self, rtb_id, destCidrBlock, vpc_peering_id):
+        return None
+
+    def get_single_zone(self, region):
+        """
+        Get list of available zones based on region
+        Example zone item returned by list:
+        """
+        return f"{region}-az2"  # HACK, hardcoded
+
+    def get_instance_meta(self, target='localhost'):
+        """
+        Query meta from local node.
+        Source: https://cloud.google.com/compute/docs/metadata/querying-metadata
+        """
+        # prepare request data
+        _prefix = "http://"
+        _suffix = "/computeMetadata/v1/instance/"
+        _target = "169.254.169.254" if target == 'localhost' else target
+        uri = f"{_prefix}{_target}{_suffix}"
+
+        return query_instance_meta(uri, headers=headers)
+
+    def block_bucket_access(self, cluster_id, bucket_name):
+        return False
+
+    def unblock_bucket_access(self, cluster_id, bucket_name, binding):
+        """
+        Add binding to bucket iam policy
+        """
+        pass
+
+    def list_buckets(self):
+        raise NotImplementedError("Bucket operations is not supported for GCP")
+
+    def delete_buckets(self):
+        raise NotImplementedError("Bucket operations is not supported for GCP")

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -72,17 +72,15 @@ class RpCloudApiClient(object):
     def _http_get(self,
                   endpoint='',
                   base_url=None,
-                  override_headers=None,
+                  override_headers={},
                   text_response=False,
                   quite=False,
                   **kwargs) -> Union[None, dict, str]:
-        headers = override_headers
-        if headers is None:
-            token = self._get_token()
-            headers = {
-                'Authorization': f'Bearer {token}',
-                'Accept': 'application/json'
-            }
+        token = self._get_token()
+        headers = override_headers or {
+            'Authorization': f'Bearer {token}',
+            'Accept': 'application/json'
+        }
         _base = base_url if base_url else self._config.api_url
         resp = requests.get(f'{_base}{endpoint}', headers=headers, **kwargs)
         _r = self._handle_error(resp, quite=quite)
@@ -94,20 +92,15 @@ class RpCloudApiClient(object):
     def _http_post(self,
                    base_url=None,
                    endpoint='',
-                   override_headers=None,
+                   override_headers={},
                    **kwargs):
         token = self._get_token()
         headers = {
             'Authorization': f'Bearer {token}',
             'Accept': 'application/json'
-        }
-        if override_headers:
-            headers.update(override_headers)
-        if base_url is None:
-            base_url = self._config.api_url
-        resp = requests.post(f'{base_url}{endpoint}',
-                             headers=headers,
-                             **kwargs)
+        } | override_headers
+        _base = base_url if base_url else self._config.api_url
+        resp = requests.post(f'{_base}{endpoint}', headers=headers, **kwargs)
         _r = self._handle_error(resp)
         return _r if _r is None else _r.json()
 

--- a/tests/rptest/services/provider_clients/rpcloud_client.py
+++ b/tests/rptest/services/provider_clients/rpcloud_client.py
@@ -91,12 +91,18 @@ class RpCloudApiClient(object):
         else:
             return _r.json()
 
-    def _http_post(self, base_url=None, endpoint='', **kwargs):
+    def _http_post(self,
+                   base_url=None,
+                   endpoint='',
+                   override_headers=None,
+                   **kwargs):
         token = self._get_token()
         headers = {
             'Authorization': f'Bearer {token}',
             'Accept': 'application/json'
         }
+        if override_headers:
+            headers.update(override_headers)
         if base_url is None:
             base_url = self._config.api_url
         resp = requests.post(f'{base_url}{endpoint}',

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1813,8 +1813,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         provider = self._cloud_cluster.config.provider
 
         return [
-            p for p in pods['items']
-            if is_redpanda_pod(p, self.cluster_id, provider)
+            p for p in pods['items'] if is_redpanda_pod(p, self.cluster_id)
         ]
 
     @property

--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -1670,7 +1670,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
 
         self._provider_config = {}
         match get_cloud_provider():
-            case "aws":
+            case "aws" | "gcp":
                 self._provider_config.update({
                     'access_key':
                         context.globals.get(SISettings.GLOBAL_S3_ACCESS_KEY, None),
@@ -1718,7 +1718,7 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             self,
             remote_uri=remote_uri,
             cluster_id=cluster_id,
-            cluster_privider=self._cloud_cluster.config.provider,
+            cluster_provider=self._cloud_cluster.config.provider,
             cluster_region=self._cloud_cluster.config.region,
             tp_proxy=self._cloud_cluster.config.teleport_auth_server,
             tp_token=self._cloud_cluster.config.teleport_bot_token)
@@ -1810,6 +1810,8 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
 
     def get_redpanda_statefulset(self):
         """Get the statefulset for redpanda brokers"""
+        if not self.__is_operator_v2_cluster():
+            return None
         return json.loads(
             self.kubectl.cmd(
                 'get statefulset -n redpanda redpanda-broker -o json'))
@@ -1882,8 +1884,8 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
         # Call to rebuild metadata for all cloud brokers
         self.rebuild_pods_classes()
 
-    def is_operator_v2_cluster(self):
-        return len(self.__kubectl.cmd(['get', 'redpanda', '-n=redpanda'])) > 0
+    def __is_operator_v2_cluster(self):
+        return len(self.kubectl.cmd(['get', 'redpanda', '-n=redpanda'])) > 0
 
     def rolling_restart_pods(self, pod_timeout: int = 180):
         """Restart all pods in the cluster one at a time.
@@ -1894,27 +1896,17 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
 
         :param pod_timeout: seconds to wait for each pod to be ready after restart
         """
-        is_operator_v2 = self.is_operator_v2_cluster()
-        self.logger.info(
-            "Detected operator v2 ... rolling restart of pods will be done using operator v2 mode"
-        )
 
         pod_names = [p.name for p in self.pods]
         self.logger.info(f'rolling restart on pods: {pod_names}')
 
         for pod_name in pod_names:
             self.restart_pod(pod_name, pod_timeout)
-            if is_operator_v2:
-                expected_replicas = self.cluster_desired_replicas_operator_v2()
-                # Check cluster readiness after pod restart
-                self.check_cluster_readiness_operator_v2(
-                    expected_replicas, pod_timeout)
-            else:
-                cluster_name = f'rp-{self._cloud_cluster.cluster_id}'
-                expected_replicas = self.cluster_desired_replicas(cluster_name)
-                # Check cluster readiness after pod restart
-                self.check_cluster_readiness(cluster_name, expected_replicas,
-                                             pod_timeout)
+            cluster_name = f'rp-{self._cloud_cluster.cluster_id}'
+            expected_replicas = self.cluster_desired_replicas(cluster_name)
+            # Check cluster readiness after pod restart
+            self.check_cluster_readiness(cluster_name, expected_replicas,
+                                         pod_timeout)
 
     def concurrent_restart_pods(self, pod_timeout):
         """
@@ -1970,27 +1962,11 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             f"Cluster {cluster_name} arrived at readyReplicas {expected_replicas}"
         )
 
-    def check_cluster_readiness_operator_v2(self, expected_replicas: int,
-                                            pod_timeout: int):
-        """Checks if the cluster has the expected number of ready replicas."""
-        self.logger.info(
-            f"Waiting for cluster (operator-v2) to have readyReplicas {expected_replicas} with timeout {pod_timeout}"
-        )
-
-        wait_until(
-            lambda: self.cluster_ready_replicas_operator_v2(
-            ) == expected_replicas,
-            timeout_sec=pod_timeout,
-            backoff_sec=1,
-            err_msg=
-            f"Cluster (operator-v2) failed to arrive at readyReplicas {expected_replicas}"
-        )
-
-        self.logger.info(
-            f"Cluster (operator-v2) arrived at readyReplicas {expected_replicas}"
-        )
-
-    def cluster_desired_replicas(self, cluster_name: str):
+    def cluster_desired_replicas(self, cluster_name: str = ''):
+        """Return cluster desired replica count."""
+        if self.__is_operator_v2_cluster():
+            rp_statefulset = self.get_redpanda_statefulset()
+            return int(rp_statefulset['status']['replicas'])
         expected_replicas = int(
             self.kubectl.cmd([
                 'get', 'cluster', cluster_name, '-n=redpanda',
@@ -1998,29 +1974,16 @@ class RedpandaServiceCloud(KubeServiceMixin, RedpandaServiceABC):
             ]))
         return expected_replicas
 
-    def cluster_desired_replicas_operator_v2(self):
-        """Return cluster desired replica count for operator v2"""
-        try:
-            rp_statefulset = self.get_redpanda_statefulset()
-            return int(rp_statefulset["status"]["replicas"])
-        except (subprocess.CalledProcessError, KeyError, TypeError):
-            return None
-
-    def cluster_ready_replicas(self, cluster_name: str):
+    def cluster_ready_replicas(self, cluster_name: str = ''):
         """Retrieves the number of ready replicas for the given cluster."""
+        if self.__is_operator_v2_cluster():
+            rp_statefulset = self.get_redpanda_statefulset()
+            return int(rp_statefulset['status']['readyReplicas'])
         ret = self.kubectl.cmd([
             'get', 'cluster', cluster_name, '-n=redpanda',
             "-o=jsonpath='{.status.readyReplicas}'"
         ])
         return int(0 if not ret else ret)
-
-    def cluster_ready_replicas_operator_v2(self):
-        """Return cluster ready replica count for operator v2"""
-        try:
-            rp_statefulset = self.get_redpanda_statefulset()
-            return int(rp_statefulset["status"]["readyReplicas"])
-        except (subprocess.CalledProcessError, KeyError, TypeError):
-            return None
 
     def verify_basic_produce_consume(self, producer, consumer):
         self.logger.info("Checking basic producer functions")

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -133,6 +133,7 @@ class CloudClusterConfig:
     install_pack_auth: str = ""
     grafana_token: str = ""
     grafana_alerts_url: str = ""
+    require_broker_metrics_in_health_check: bool = True
 
 
 @dataclass
@@ -880,7 +881,13 @@ class CloudCluster():
             if _metric.name == "redpanda_cluster_brokers":
                 _brokers_metric = _metric
         if _brokers_metric is None:
-            return warn_and_return("Failed to get brokers metric")
+            if self.config.require_broker_metrics_in_health_check:
+                return warn_and_return("Failed to get brokers metric")
+            else:
+                self._logger.info(
+                    "Public metric 'redpanda_cluster_brokers' is unavailable, but it is not required."
+                )
+                return None
         else:
             self._logger.info("Public metric 'redpanda_cluster_brokers' "
                               "is available")

--- a/tests/rptest/services/redpanda_cloud.py
+++ b/tests/rptest/services/redpanda_cloud.py
@@ -34,7 +34,7 @@ PROVIDER_AZURE = 'AZURE'
 TIER_DEFAULTS = {
     PROVIDER_AWS: "tier-1-aws",
     PROVIDER_GCP: "tier-1-gcp",
-    PROVIDER_AZURE: "tier-1-azure-v1-x86"
+    PROVIDER_AZURE: "tier-1-azure-v2-x86"
 }
 
 
@@ -87,15 +87,15 @@ class CloudTierName(Enum):
     GCP_5_P5 = 'tco-p5-tier-5-gcp'
     GCP_6_P5 = 'tco-p5-tier-6-gcp'
     GCP_7_P5 = 'tco-p5-tier-7-gcp'
-    AZURE_1 = 'tier-1-azure-v1-x86'
-    AZURE_2 = 'tier-2-azure-v1-x86'
-    AZURE_3 = 'tier-3-azure-v1-x86'
-    AZURE_4 = 'tier-4-azure-v1-x86'
-    AZURE_5 = 'tier-5-azure-v1-x86'
-    AZURE_6 = 'tier-6-azure-v1-x86'
-    AZURE_7 = 'tier-7-azure-v1-x86'
-    AZURE_8 = 'tier-8-azure-v1-x86'
-    AZURE_9 = 'tier-9-azure-v1-x86'
+    AZURE_1 = 'tier-1-azure-v2-x86'
+    AZURE_2 = 'tier-2-azure-v2-x86'
+    AZURE_3 = 'tier-3-azure-v2-x86'
+    AZURE_4 = 'tier-4-azure-v2-x86'
+    AZURE_5 = 'tier-5-azure-v2-x86'
+    AZURE_6 = 'tier-6-azure-v2-x86'
+    AZURE_7 = 'tier-7-azure-v2-x86'
+    AZURE_8 = 'tier-8-azure-v2-x86'
+    AZURE_9 = 'tier-9-azure-v2-x86'
 
     @classmethod
     def list(cls):
@@ -232,6 +232,12 @@ class CloudCluster():
         # Init API client
         self.cloudv2 = RpCloudApiClient(self.config, logger)
 
+        # copy the regular config, but override the api_url to point
+        # to the public API instead
+        public_config = CloudClusterConfig(**cluster_config)
+        public_config.api_url = public_config.public_api_url
+        self.public_api = RpCloudApiClient(public_config, logger)
+
         # Create helper bool variable
         self.isPublicNetwork = self.config.network == 'public'
 
@@ -251,18 +257,22 @@ class CloudCluster():
         if self.config.provider == PROVIDER_AWS:
             self.provider_key = provider_config['access_key']
             self.provider_secret = provider_config['secret_key']
+            self.provider_tenant = None
         elif self.config.provider == PROVIDER_GCP:
             self.provider_key = self.config.gcp_keyfile
             self.provider_secret = None
+            self.provider_tenant = None
         elif self.config.provider == PROVIDER_AZURE:
-            self.provider_key = provider_config['azure_provider_key']
-            self.provider_secret = provider_config['azure_provider_secret']
-            self.client_id = provider_config['azure_client_id']
+            self.provider_key = provider_config['azure_client_id']
+            self.provider_secret = provider_config['azure_client_secret']
+            self.provider_tenant = provider_config['azure_tenant_id']
         # Create client for the provider
-        self.provider_cli = make_provider_client(self.config.provider, logger,
+        self.provider_cli = make_provider_client(self.config.provider,
+                                                 logger,
                                                  self.config.region,
                                                  self.provider_key,
-                                                 self.provider_secret)
+                                                 self.provider_secret,
+                                                 tenant=self.provider_tenant)
         if self.config.network != 'public':
             # Check that private network is a correct CIDR
             self.config.network = self.validate_cidr(self.config.network)
@@ -290,10 +300,10 @@ class CloudCluster():
                     'subscription-id']
 
             # Currently we need provider client only for VCP in private networking
-            # Raise exception is client in not implemented yet
+            # Raise exception if client is not implemented yet
             if self.provider_cli is None and self.config.network != 'public':
                 self._logger.error(
-                    f"Current provider is not yet supports private networking "
+                    f"Current provider does not yet support private networking"
                 )
                 raise RuntimeError("Private networking is not implemented "
                                    f"for '{self.config.provider}'")
@@ -398,11 +408,14 @@ class CloudCluster():
         name = self._format_namespace_name()
         self._logger.debug(f'creating namespace name {name}')
         body = {'name': name}
-        r = self.cloudv2._http_post(endpoint='/api/v1/namespaces', json=body)
-        self._logger.debug(f'created namespaceUuid {r["id"]}')
+        # namespace, resource-group… totally the same thing
+        r = self.public_api._http_post(endpoint='/v1beta2/resource-groups',
+                                       json=body)
+        _id = r['resource_group']['id']
+        self._logger.debug(f"created namespaceUuid {_id}")
         # save namespace name
         self.config.namespace = name
-        return r['id']
+        return _id
 
     def _cluster_ready(self):
         # Get cluster info
@@ -437,15 +450,6 @@ class CloudCluster():
         return cluster['status']['listeners']['redpandaConsole']['default'][
             'urls'][0]
 
-    def _get_network_id(self):
-        """
-        Get network id.
-        :return: networkId as a string or None if not found
-        """
-        _cluster = self.cloudv2._http_get(
-            endpoint=f'/api/v1/clusters/{self.current.cluster_id}')
-        return _cluster['spec']['networkId']
-
     def _get_network(self):
         return self.cloudv2._http_get(
             endpoint=f"/api/v1/networks/{self.current.network_id}")
@@ -469,19 +473,21 @@ class CloudCluster():
     def _get_region_id(self):
         """Get the region id for a region.
 
-        :param cluster_type: cluster type, e.g. 'FMC'
-        :param provider: cloud provider, e.g. 'AWS'
-        :param region: region name, e.g. 'us-west-2'
+        :param cloudProvider: cloud provider, e.g. 'CLOUD_PROVIDER_AWS'
+        :param name: region name, e.g. 'us-west-2'
         :return: id, e.g. 'cckac9vvbr5ofm048jjg'
         """
 
-        params = {'cluster_type': self.config.type}
-        regions = self.cloudv2._http_get(
-            endpoint='/api/v1/clusters-resources/regions', params=params)
-        for r in regions[self.config.provider]:
-            if r['name'] == self.current.region:
-                return r['id']
-        return None
+        provider = f'CLOUD_PROVIDER_{self.config.provider}'
+        body = {'cloudProvider': provider, 'name': self.current.region}
+        regions = self.public_api._http_post(
+            endpoint='/redpanda.api.ui.v1alpha1.RegionService/ListRegions',
+            override_headers={'connect-protocol-version': '1'},
+            json=body)
+
+        return next(
+            filter(lambda r: r['name'] == self.current.region,
+                   regions['regions']), {'id': None})['id']
 
     def _get_product_name(self, config_profile_name):
         """Get the product name for the first matching config
@@ -512,40 +518,35 @@ class CloudCluster():
                              f"request: '{params}', response:\n{products}")
         return None
 
-    def _create_cluster_payload(self):
+    def _create_network_payload(self):
+        _net = self.config.network,
+        _provider = f"CLOUD_PROVIDER_{self.config.provider.upper()}"
+        _type = 'TYPE_BYOC' if self.config.type == 'BYOC' else 'TYPE_DEDICATED'
         # In case of private network, the value of config.network
-        # should be CIDR. We are validatin it in init
-        _cidr = "10.1.0.0/16" if self.isPublicNetwork else self.config.network
+        # should be a CIDR, but we're validating that in __init__
         return {
-            "cluster": {
-                "name": self.current.name,
-                "spec": {
-                    "productName": self.current.product_name,
-                    "clusterType": self.config.type,
-                    "connectors": {
-                        "enabled": True
-                    },
-                    "installPackVersion": self.current.install_pack_ver,
-                    "isMultiAz": False,
-                    "networkId": "",
-                    "provider": self.config.provider,
-                    "region": self.config.region,
-                    "zones": self.current.zones,
-                }
-            },
-            "connectionType": self.current.connection_type,
-            "namespaceUuid": self.current.namespace_uuid,
-            "network": {
-                "displayName":
-                f"{self.current.connection_type}-network-{self.current.name}",
-                "spec": {
-                    "cidr": _cidr,
-                    "deploymentType": self.config.type,
-                    "installPackVersion": self.current.install_pack_ver,
-                    "provider": self.config.provider,
-                    "regionId": self.current.region_id,
-                }
-            },
+            "cidr_block": "10.1.0.0/16" if self.isPublicNetwork else _net,
+            "cloud_provider": _provider,
+            "cluster_type": _type,
+            "name": f"{self.current.name}-network",
+            "region": self.config.region,
+            "resource_group_id": self.current.namespace_uuid
+        }
+
+    def _create_cluster_payload(self):
+        _conn_type = f"CONNECTION_TYPE_{self.current.connection_type.upper()}"
+        _provider = f"CLOUD_PROVIDER_{self.config.provider.upper()}"
+        _type = 'TYPE_BYOC' if self.config.type == 'BYOC' else 'TYPE_DEDICATED'
+        return {
+            "cloud_provider": _provider,
+            "connection_type": _conn_type,
+            "name": self.current.name,
+            "network_id": self.current.network_id,
+            "region": self.config.region,
+            "resource_group_id": self.current.namespace_uuid,
+            "throughput_tier": self.current.product_name,
+            "type": _type,
+            "zones": [self.current.zones]
         }
 
     def _get_cluster(self, _id) -> dict[str, Any]:
@@ -644,18 +645,33 @@ class CloudCluster():
                 _id = cf.read()
         return _id
 
-    def _wait_for_cluster_id(self, uuid, timeout=120):
-        wait_until(lambda: self._cluster_id_updated(uuid),
+    def _netop_complete(self, netop_id: str, target: str) -> bool:
+        n = self.public_api._http_get(
+            endpoint=f'/v1beta2/operations/{netop_id}')
+        if n is None:
+            return False
+        if 'operation' not in n or 'state' not in n['operation']:
+            return False
+        self._logger.debug(
+            f"reached target state: {n['operation']['state'] == target}")
+        return n['operation']['state'] == target
+
+    def _wait_for_netop_id(self,
+                           netop_id,
+                           timeout=300,
+                           target='STATE_COMPLETED') -> str:
+        self._logger.debug(f'polling /v1beta2/operations/{netop_id}')
+        wait_until(lambda: self._netop_complete(netop_id, target) == True,
                    timeout_sec=timeout,
                    backoff_sec=10,
                    err_msg='Failed to get proper id '
                    f'of cloud cluster {self.current.name}')
-
-        # Use clusters handle to wait for non-uuid id :)
-        _cluster = self.cloudv2._http_get(endpoint=f'/api/v1/clusters/{uuid}')
-        _id = _cluster['id']
-        self._logger.info(f"Cluster ID is '{_id}'")
-        return _id
+        n = self.public_api._http_get(
+            endpoint=f'/v1beta2/operations/{netop_id}')
+        if n is None or 'operation' not in n or 'resource_id' not in n[
+                'operation']:
+            return ""
+        return n['operation']['resource_id']
 
     def _create_new_cluster(self):
         # In order not to have long list of arguments in each internal
@@ -685,29 +701,38 @@ class CloudCluster():
                                f"'{self.config.install_pack_ver}', "
                                f"'{self.config.region}'")
 
-        # Call Api to create cluster
+        # Call public API to create network
+        self._logger.warning(
+            f'creating network name "{self.current.name}-network"')
+        # Prepare network payload block
+        _body = self._create_network_payload()
+        self._logger.debug(
+            f'POST to /v1beta2/networks body: {json.dumps(_body)}')
+        # Send API request to create network
+        n = self.public_api._http_post(endpoint='/v1beta2/networks',
+                                       json=_body)
+        if n is None:
+            raise RuntimeError(self.cloudv2.lasterror)
+        netop_id = n['operation']['id']
+        self.current.network_id = self._wait_for_netop_id(netop_id)
+
+        # Call public API to create cluster
         self._logger.warning(f'creating cluster name {self.current.name}')
         # Prepare cluster payload block
         _body = self._create_cluster_payload()
-        self._logger.debug(f'body: {json.dumps(_body)}')
+        self._logger.debug(
+            f'POST to /v1beta2/clusters body: {json.dumps(_body)}')
         # Send API request to create cluster
-        r = self.cloudv2._http_post(
-            endpoint='/api/v1/workflows/network-cluster', json=_body)
-
+        r = self.public_api._http_post(endpoint='/v1beta2/clusters',
+                                       json=_body)
         # handle error on CloudV2 side
         if r is None:
             raise RuntimeError(self.cloudv2.lasterror)
+        netop_id = r['operation']['id']
 
         try:
-            # At this point cluster has UUID instead of normal one
-
-            # For BYOC creation a non-uuid is needed
-            # It gets updated when spec makes it through
-            # the workslow, so just wait
-
-            # For FMC, we just make sure that cluster is created
-            # in API and its status is updated
-            _cluster_id = self._wait_for_cluster_id(r['id'])
+            _cluster_id = self._wait_for_netop_id(netop_id,
+                                                  target='STATE_IN_PROGRESS')
             c = self._get_cluster(_cluster_id)
             self.current.last_status = c['state']
             self._logger.warning(f"Cluster ID is {_cluster_id}, last status: "
@@ -725,6 +750,7 @@ class CloudCluster():
             self.current.cluster_id = _cluster_id
             # Kick off cluster creation
             # Timeout for this is half an hour as this is only agent
+            self.utils.rpk_cloud_byoc_install(_cluster_id)
             self.utils.rpk_cloud_apply(_cluster_id)
         elif self.config.type == CLOUD_TYPE_FMC:
             # Nothing to do here
@@ -739,16 +765,14 @@ class CloudCluster():
         # Announce wait
         self._logger.info(
             f'waiting for creation of cluster {self.current.name} '
-            f'({self.current.cluster_id}), namespaceUuid {r["namespaceUuid"]},'
+            f'({self.current.cluster_id}), namespaceUuid {self.current.namespace_uuid},'
             f' checking every {self.CHECK_BACKOFF_SEC} seconds')
         wait_until(lambda: self._cluster_ready(),
                    timeout_sec=self.CHECK_TIMEOUT_SEC,
                    backoff_sec=self.CHECK_BACKOFF_SEC,
-                   err_msg='Unable to deterimine readiness '
+                   err_msg='Unable to determine readiness '
                    f'of cloud cluster {self.current.name}; '
                    f'last state {self.current.last_status}')
-
-        self.current.network_id = self._get_network_id()
 
         # at this point cluster is ready
         # just save the id to reuse it in next test

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -411,17 +411,20 @@ class KubectlLocalOnlyTest(Test):
             "hit_legacy_pod_name": {
                 "pod": {
                     "metadata": {
-                        "name": "rp-CLUSTER-NAME-anysuffix",
-                    },
+                        "name": "rp-CLUSTER_ID-4"
+                    }
                 },
-                "result": False
+                "result": True
             },
         }
         for test_name, test_case in test_cases.items():
             pod_obj = test_case["pod"]
             expected_result = test_case["result"]
-            # Provider should not matter, AT ALL... but let's test for it
-            actual_result = is_redpanda_pod(pod_obj, "CLUSTER_ID")
+            try:
+                actual_result = is_redpanda_pod(pod_obj, "CLUSTER_ID")
+            except KeyError as err:
+                self.logger.error(f"KeyError from is_redpanda_pod: {err}")
+                actual_result = False
             assert expected_result is actual_result, f"Failed for test case '{test_name}' (expected={expected_result}, actual={actual_result})"
 
 

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -367,9 +367,11 @@ class KubectlSelfTest(Test):
                 pass
 
 
-class KubectlLocalOnlyTest(Test):
+from ducktape.mark.resource import cluster as dt_cluster
 
-    # @cluster(num_nodes=0)
+
+class KubectlLocalOnlyTest(Test):
+    @dt_cluster(num_nodes=0)
     def test_is_redpanda_pod(self):
         test_cases = {
             "regular_hit": {

--- a/tests/rptest/tests/services_self_test.py
+++ b/tests/rptest/tests/services_self_test.py
@@ -9,6 +9,7 @@
 
 from subprocess import CalledProcessError
 from ducktape.mark import matrix
+from ducktape.mark.resource import cluster as dt_cluster
 from ducktape.tests.test import Test
 
 from rptest.tests.redpanda_test import RedpandaMixedTest, RedpandaTest
@@ -365,9 +366,6 @@ class KubectlSelfTest(Test):
                 assert False, 'expected this command to throw'
             except CalledProcessError:
                 pass
-
-
-from ducktape.mark.resource import cluster as dt_cluster
 
 
 class KubectlLocalOnlyTest(Test):


### PR DESCRIPTION
Bug fixes to tests and test infrastructure for running CDT on Azure. (Note: Currently includes commit from #18827, which this PR continues and builds upon.)

## Backports Required

- [x] none - not a (product) bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

### Improvements

- replaces several instances of deprecated Cloud API usage with new Public API (because the old endpoints don't return Azure resources)
- successfully installs BYOC Azure agent
- allow override headers on POST requests for rpcloud_client
- workaround for /snap/bin not showing up in $PATH (making `az` CLI not show up as an available command)
- Azure support for config_profile_verify test