### PR TITLE
cdt-perf: Put OMB warmup to two minutes

### DIFF
--- a/tests/rptest/perf/openmessaging_perf_test.py
+++ b/tests/rptest/perf/openmessaging_perf_test.py
@@ -40,7 +40,7 @@ class RedPandaOpenMessagingBenchmarkPerf(RedpandaTest):
             "payload_file": "payload/payload-1Kb.data",
             "consumer_backlog_size_GB": 0,
             "test_duration_minutes": 5,
-            "warmup_duration_minutes": 1,
+            "warmup_duration_minutes": 2,
         }
         driver = {
             "name": "CommonWorkloadDriver",

--- a/tests/rptest/perf/small_batches_test.py
+++ b/tests/rptest/perf/small_batches_test.py
@@ -28,7 +28,7 @@ class SmallBatchesTest(RedpandaTest):
             "payload_file": "payload/payload-100b.data",
             "consumer_backlog_size_GB": 0,
             "test_duration_minutes": 5,
-            "warmup_duration_minutes": 1,
+            "warmup_duration_minutes": 2,
         }
         driver = {
             "name": "SmallBatchesDriver",

--- a/tests/rptest/perf/ts_write_openmessaging_test.py
+++ b/tests/rptest/perf/ts_write_openmessaging_test.py
@@ -53,7 +53,7 @@ class TSWriteOpenmessagingTest(RedpandaTest):
             "payload_file": "payload/payload-1Kb.data",
             "consumer_backlog_size_GB": 0,
             "test_duration_minutes": 5,
-            "warmup_duration_minutes": 1,
+            "warmup_duration_minutes": 2,
         }
         driver = {
             "name": "TSWriteDriver",


### PR DESCRIPTION
Leader balancer only kicks after 0-2 minutes. If it kicks in after the
warmup period ends it will cause noisy results.

Up the warmup to two minutes to make sure it falls into the warmup
period.

We don't have any many partition tests here so the process should finish
relatively fast. Also there is a little bit of leeway as the warmup
doesn't immediatley start after the topic has been created.

Note I am not changing the TS read test because I first need to confirm
it still behaves fine in regards to the backlog.



<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes


* none

