### PR TITLE
cloud_storage: topic_manifest_downloader::find_manifests

### DIFF
--- a/src/v/cloud_storage/topic_manifest_downloader.h
+++ b/src/v/cloud_storage/topic_manifest_downloader.h
@@ -12,6 +12,7 @@
 #include "cloud_storage/remote.h"
 #include "cloud_storage/remote_label.h"
 #include "cloud_storage/topic_manifest.h"
+#include "cloud_storage/types.h"
 #include "model/fundamental.h"
 
 namespace cloud_storage {
@@ -56,6 +57,19 @@ public:
       ss::lowres_clock::time_point deadline,
       model::timestamp_clock::duration backoff,
       topic_manifest*);
+
+    // Attempts to scan the topic manifest root paths for any topic manifests
+    // that match the given filter.
+    using tp_ns_filter_t = std::function<bool(const model::topic_namespace&)>;
+    static ss::future<result<find_topic_manifest_outcome, error_outcome>>
+    find_manifests(
+      remote& remote,
+      cloud_storage_clients::bucket_name bucket,
+      retry_chain_node& parent_retry,
+      ss::lowres_clock::time_point deadline,
+      model::timestamp_clock::duration backoff,
+      std::optional<tp_ns_filter_t> tp_filter,
+      chunked_vector<topic_manifest>*);
 
 private:
     const cloud_storage_clients::bucket_name bucket_;

--- a/src/v/cloud_storage/topic_path_utils.cc
+++ b/src/v/cloud_storage/topic_path_utils.cc
@@ -24,8 +24,21 @@ const std::regex labeled_manifest_path_expr{
   R"REGEX(meta/([^/]+)/([^/]+)/[^/]+/\d+/topic_manifest\.bin)REGEX"};
 } // namespace
 
+ss::sstring labeled_topic_manifests_root() { return "meta"; }
+
+chunked_vector<ss::sstring> prefixed_topic_manifests_roots() {
+    constexpr static auto hex_chars = std::string_view{"0123456789abcdef"};
+    chunked_vector<ss::sstring> roots;
+    roots.reserve(hex_chars.size());
+    for (char c : hex_chars) {
+        roots.emplace_back(fmt::format("{}0000000", c));
+    }
+    return roots;
+}
+
 ss::sstring labeled_topic_manifest_root(const model::topic_namespace& topic) {
-    return fmt::format("meta/{}/{}", topic.ns(), topic.tp());
+    return fmt::format(
+      "{}/{}/{}", labeled_topic_manifests_root(), topic.ns(), topic.tp());
 }
 
 ss::sstring labeled_topic_manifest_prefix(

--- a/src/v/cloud_storage/topic_path_utils.h
+++ b/src/v/cloud_storage/topic_path_utils.h
@@ -51,4 +51,14 @@ prefixed_topic_manifest_bin_path(const model::topic_namespace& topic);
 ss::sstring
 prefixed_topic_manifest_json_path(const model::topic_namespace& topic);
 
+// Returns the topic_namespace of the given labeled manifest path, or
+// std::nullopt if the input is not a labeled manifest path.
+std::optional<model::topic_namespace>
+tp_ns_from_labeled_path(const std::string& path);
+
+// Returns the topic_namespace of the given prefixed manifest path, or
+// std::nullopt if the input is not a prefixed manifest path.
+std::optional<model::topic_namespace>
+tp_ns_from_prefixed_path(const std::string& path);
+
 } // namespace cloud_storage

--- a/src/v/cloud_storage/topic_path_utils.h
+++ b/src/v/cloud_storage/topic_path_utils.h
@@ -10,6 +10,7 @@
 
 #include "base/seastarx.h"
 #include "cloud_storage/remote_label.h"
+#include "container/fragmented_vector.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
 
@@ -27,6 +28,9 @@ namespace cloud_storage {
 // versions, in cases we need to read when newer manifests have not yet been
 // written. This header contains methods to build paths for all versions.
 
+// meta
+ss::sstring labeled_topic_manifests_root();
+
 // meta/kafka/panda-topic
 ss::sstring labeled_topic_manifest_root(const model::topic_namespace& topic);
 
@@ -39,6 +43,9 @@ ss::sstring labeled_topic_manifest_path(
   const remote_label& label,
   const model::topic_namespace& topic,
   model::initial_revision_id rev);
+
+//[0-9a-f]0000000
+chunked_vector<ss::sstring> prefixed_topic_manifests_roots();
 
 // a0000000/meta/kafka/panda-topic
 ss::sstring prefixed_topic_manifest_prefix(const model::topic_namespace& topic);


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->
This adds a find_manifests() method to the topic_manifest_downloader.
This will subsume the logic currently in topic_recovery_service, that
lists objects in the buckets looking for objects that look like topic
manifests. With our object naming scheme changing, this will need to
account for the new naming scheme.

Admittedly, there's somewhat of an impedence mismatch since the
topic_manifest_downloader expects to target one topic, so this just
makes the method static. But it still feels natural for this logic and
its tests to be coupled to topic_manifest_downloader.

The code isn't as optimal as it could be in terms of number of list/get
operations performed, since I wanted to rely on the downloader to
duplicating some of the path-related complexity. But this endpoint is
likely not going to be widely used, particularly as we begin having more
clusters per bucket. Instead controller snapshot-based restore will be
used.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
