### PR TITLE
rpk: allow names to be URIs in the reference flag when creating a schema.

### DIFF
--- a/src/go/rpk/pkg/cli/registry/schema/schema.go
+++ b/src/go/rpk/pkg/cli/registry/schema/schema.go
@@ -11,6 +11,7 @@ package schema
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -137,6 +138,19 @@ func typeFromFile(schemaFile string) (sr.SchemaType, error) {
 	}
 }
 
+// This regexp captures the reference flag in its simplest form which is:
+//
+//	name:subject:version
+//
+// However, name can also be a URI. Therefore, this regexp has 3 capturing
+// groups:
+//  1. Either alphabetic characters (scheme) followed by '://', then followed by
+//     any other character except ':', or ':' followed by numbers and more
+//     characters to capture optional ports in the authority and the path.
+//  2. Captures any character except ':' (subject).
+//  3. Captures any character except ':' (version).
+var referenceRegex = regexp.MustCompile(`^([a-zA-Z]+://[^:]+(?::\d+)?(?:/[^:]+)*|[^:]+):([^:]+):([^:]+)$`)
+
 // parseReferenceFlag parses the --reference flag which can be either a comma
 // separated list of name:subject:version or a path to a file containing the
 // schema references.
@@ -149,11 +163,11 @@ func parseReferenceFlag(fs afero.Fs, referenceFlag string) ([]sr.SchemaReference
 	if strings.Contains(referenceFlag, ":") {
 		split := strings.Split(referenceFlag, ",")
 		for _, v := range split {
-			s := strings.SplitN(v, ":", 3)
-			if len(s) != 3 {
+			match := referenceRegex.FindStringSubmatch(v)
+			if len(match) == 0 {
 				return nil, fmt.Errorf("unexpected format %q, please use name:subject:version format", referenceFlag)
 			}
-			name, subject, versionString := s[0], s[1], s[2]
+			name, subject, versionString := match[1], match[2], match[3] // match[0] is the full match
 			if name == "" || subject == "" || versionString == "" {
 				return nil, fmt.Errorf("invalid empty values in %q", referenceFlag)
 			}

--- a/src/go/rpk/pkg/cli/registry/schema/schema_test.go
+++ b/src/go/rpk/pkg/cli/registry/schema/schema_test.go
@@ -83,6 +83,22 @@ foo bar 2`,
   subject: bar
   version: 2`,
 			exp: []sr.SchemaReference{{Name: "foo", Subject: "bar", Version: 1}, {Name: "foo", Subject: "bar", Version: 2}},
+		}, {
+			name:          "single URL reference",
+			referenceFlag: "http://example.com/foo/referenced.json:ref_test:1",
+			exp:           []sr.SchemaReference{{Name: "http://example.com/foo/referenced.json", Subject: "ref_test", Version: 1}},
+		}, {
+			name:          "single URL reference with port",
+			referenceFlag: "http://example.com:8080/referenced.json:ref_test:1",
+			exp:           []sr.SchemaReference{{Name: "http://example.com:8080/referenced.json", Subject: "ref_test", Version: 1}},
+		}, {
+			name:          "multiple URL reference + normal references",
+			referenceFlag: "http://example.com/asdf/referenced.json:ref_test:1,foo:bar:2,file:///tmp/foo.json:ref_test:3",
+			exp: []sr.SchemaReference{
+				{Name: "http://example.com/asdf/referenced.json", Subject: "ref_test", Version: 1},
+				{Name: "foo", Subject: "bar", Version: 2},
+				{Name: "file:///tmp/foo.json", Subject: "ref_test", Version: 3},
+			},
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
jsonschema will introduce URIs as valid reference names.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [X] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes



* none
