### PR TITLE
Quotas: address post merge code review comments

### DIFF
--- a/src/v/cluster/client_quota_serde.h
+++ b/src/v/cluster/client_quota_serde.h
@@ -170,13 +170,13 @@ struct entity_value
 struct entity_value_diff
   : serde::
       envelope<entity_value_diff, serde::version<0>, serde::compat_version<0>> {
-    enum key : int8_t {
+    enum class key {
         producer_byte_rate = 0,
         consumer_byte_rate,
         controller_mutation_rate,
     };
 
-    enum operation : int8_t {
+    enum class operation {
         upsert = 0,
         remove,
     };

--- a/src/v/cluster/tests/client_quota_store_test.cc
+++ b/src/v/cluster/tests/client_quota_store_test.cc
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(quota_store_snapshot_delta) {
             .key = key1,
             .diff = {
               .entries = {
-                entity_value_diff::entry(entity_value_diff::remove, entity_value_diff::key::producer_byte_rate, 0),
+                entity_value_diff::entry(entity_value_diff::operation::remove, entity_value_diff::key::producer_byte_rate, 0),
               },
             },
           },

--- a/src/v/kafka/server/quota_manager.h
+++ b/src/v/kafka/server/quota_manager.h
@@ -71,6 +71,16 @@ public:
         std::optional<atomic_token_bucket> pm_rate;
     };
 
+    // Note: the use of std::shared_ptr<> is generally discouraged in the
+    // redpanda codebase because of the overhead of the atomic reference count
+    // and because seastar's memory model expects data to be deallocated on the
+    // same shard as where it was allocated and sharing std::shared_ptr<>'s
+    // across cores makes it easy to have the deallocation be on a different
+    // shard. The reason why it is acceptable to use a std::shared_ptr<> here is
+    // because (1) we're always allocating and deallocating the objects inside
+    // std::shared_ptr<> on shard 0 and (2) we need a way to keep track of a
+    // reference count across multiple shards, which is exactly what
+    // std::shared_ptr<> is meant for.
     using local_map_t
       = chunked_hash_map<tracker_key, std::shared_ptr<client_quota>>;
 


### PR DESCRIPTION
This addresses some comments from @dotnwat on previous PRs:
* https://github.com/redpanda-data/redpanda/pull/19795#discussion_r1656138146
> you can drop int8_t -- serde will always store them as 32-bit integers.

* https://github.com/redpanda-data/redpanda/pull/19941#discussion_r1655233044:
> where is the use of std::shared_ptr being documented? there is probably what like 1 or 2 uses in the entire tree, and its always discouraged. this use case is fine, but how will future developers learn about the usage? a good place for it would be in the code as a comment, or in the commit message, but i don't see any information in either place. can you please point me at the documentaiton or submit a pr that adds it?


## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
