### PR TITLE
CORE-2074 Quotas: redirect alter quotas command to leader

### DIFF
--- a/src/v/cluster/client_quota_frontend.cc
+++ b/src/v/cluster/client_quota_frontend.cc
@@ -9,11 +9,58 @@
 
 #include "cluster/client_quota_frontend.h"
 
+#include "cluster/client_quota_serde.h"
 #include "cluster/cluster_utils.h"
+#include "cluster/controller_service.h"
+#include "cluster/partition_leaders_table.h"
+#include "rpc/connection_cache.h"
+
+#include <seastar/core/future.hh>
 
 namespace cluster::client_quota {
 
 ss::future<cluster::errc> frontend::alter_quotas(
+  alter_delta_cmd_data data, model::timeout_clock::time_point tout) {
+    auto cluster_leader = _leaders.local().get_leader(model::controller_ntp);
+    if (!cluster_leader) {
+        return ss::make_ready_future<cluster::errc>(errc::no_leader_controller);
+    } else if (*cluster_leader != _self) {
+        return dispatch_alter_to_remote(
+          *cluster_leader, std::move(data), tout - model::timeout_clock::now());
+    } else {
+        return do_alter_quotas(std::move(data), tout);
+    }
+}
+
+ss::future<cluster::errc> frontend::dispatch_alter_to_remote(
+  model::node_id cluster_leader,
+  alter_delta_cmd_data cmd,
+  model::timeout_clock::duration timeout) {
+    return _connections.local()
+      .with_node_client<controller_client_protocol>(
+        _self,
+        ss::this_shard_id(),
+        cluster_leader,
+        timeout,
+        [cmd = std::move(cmd),
+         timeout](controller_client_protocol client) mutable {
+            return client
+              .alter_client_quotas(
+                alter_quotas_request{
+                  .cmd_data = std::move(cmd), .timeout = timeout},
+                rpc::client_opts(timeout))
+              .then(&rpc::get_ctx_data<alter_quotas_response>);
+        })
+      .then([](result<alter_quotas_response> r) {
+          if (r.has_error()) {
+              return map_update_interruption_error_code(r.error());
+          }
+          return r.value().ec;
+      });
+    ;
+}
+
+ss::future<cluster::errc> frontend::do_alter_quotas(
   alter_delta_cmd_data data, model::timeout_clock::time_point tout) {
     alter_quotas_delta_cmd cmd(0 /*unused*/, std::move(data));
     return replicate_and_wait(_stm, _as, std::move(cmd), tout)

--- a/src/v/cluster/client_quota_frontend.cc
+++ b/src/v/cluster/client_quota_frontend.cc
@@ -13,10 +13,11 @@
 
 namespace cluster::client_quota {
 
-ss::future<std::error_code> frontend::alter_quotas(
+ss::future<cluster::errc> frontend::alter_quotas(
   alter_delta_cmd_data data, model::timeout_clock::time_point tout) {
     alter_quotas_delta_cmd cmd(0 /*unused*/, std::move(data));
-    return replicate_and_wait(_stm, _as, std::move(cmd), tout);
+    return replicate_and_wait(_stm, _as, std::move(cmd), tout)
+      .then(map_update_interruption_error_code);
 }
 
 } // namespace cluster::client_quota

--- a/src/v/cluster/client_quota_frontend.h
+++ b/src/v/cluster/client_quota_frontend.h
@@ -9,12 +9,11 @@
 #pragma once
 
 #include "cluster/client_quota_serde.h"
+#include "cluster/errc.h"
 #include "cluster/fwd.h"
 #include "model/timeout_clock.h"
 
 #include <seastar/core/sharded.hh>
-
-#include <system_error>
 
 namespace cluster::client_quota {
 
@@ -32,7 +31,7 @@ public:
     /// There are no client quota store-specific errors, because the upsert and
     /// remove operations always succeed regardless of the previous state of the
     /// given quota (eg. there is no error for removing non-existent quotas).
-    ss::future<std::error_code>
+    ss::future<cluster::errc>
       alter_quotas(alter_delta_cmd_data, model::timeout_clock::time_point);
 
 private:

--- a/src/v/cluster/client_quota_serde.h
+++ b/src/v/cluster/client_quota_serde.h
@@ -10,6 +10,8 @@
 #pragma once
 
 #include "base/seastarx.h"
+#include "cluster/errc.h"
+#include "model/timeout_clock.h"
 #include "seastar/core/sstring.hh"
 #include "serde/envelope.h"
 #include "serde/rw/variant.h"
@@ -272,5 +274,35 @@ from_string_view<entity_value_diff::key>(std::string_view v) {
         entity_value_diff::key::controller_mutation_rate)
       .default_match(std::nullopt);
 }
+
+// Internal RPC request/response structs
+struct alter_quotas_request
+  : serde::envelope<
+      alter_quotas_request,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    alter_delta_cmd_data cmd_data;
+    model::timeout_clock::duration timeout{};
+
+    friend bool
+    operator==(const alter_quotas_request&, const alter_quotas_request&)
+      = default;
+};
+
+struct alter_quotas_response
+  : serde::envelope<
+      alter_quotas_response,
+      serde::version<0>,
+      serde::compat_version<0>> {
+    using rpc_adl_exempt = std::true_type;
+
+    cluster::errc ec;
+
+    friend bool
+    operator==(const alter_quotas_response&, const alter_quotas_response&)
+      = default;
+};
 
 } // namespace cluster::client_quota

--- a/src/v/cluster/controller.cc
+++ b/src/v/cluster/controller.cc
@@ -414,7 +414,12 @@ ss::future<> controller::start(
       ss::sharded_parameter([this] { return &_connections.local(); }),
       ss::sharded_parameter([this] { return &_as.local(); }));
 
-    co_await _quota_frontend.start(std::ref(_stm), std::ref(_as));
+    co_await _quota_frontend.start(
+      _raft0->self().id(),
+      std::ref(_stm),
+      std::ref(_connections),
+      std::ref(_partition_leaders),
+      std::ref(_as));
 
     co_await _members_backend.start_single(
       std::ref(_tp_frontend),

--- a/src/v/cluster/controller.json
+++ b/src/v/cluster/controller.json
@@ -3,7 +3,8 @@
     "service_name": "controller",
     "includes": [
         "cluster/types.h",
-        "cluster/health_monitor_types.h"
+        "cluster/health_monitor_types.h",
+        "cluster/client_quota_serde.h"
     ],
     "methods": [
         {
@@ -165,6 +166,11 @@
             "name": "set_partition_shard",
             "input_type": "set_partition_shard_request",
             "output_type": "set_partition_shard_reply"
+        },
+        {
+            "name": "alter_client_quotas",
+            "input_type": "client_quota::alter_quotas_request",
+            "output_type": "client_quota::alter_quotas_response"
         }
     ]
 }

--- a/src/v/cluster/service.cc
+++ b/src/v/cluster/service.cc
@@ -10,6 +10,8 @@
 #include "cluster/service.h"
 
 #include "base/vlog.h"
+#include "cluster/client_quota_frontend.h"
+#include "cluster/client_quota_serde.h"
 #include "cluster/config_frontend.h"
 #include "cluster/controller.h"
 #include "cluster/controller_api.h"
@@ -58,7 +60,8 @@ service::service(
   ss::sharded<health_monitor_frontend>& hm_frontend,
   ss::sharded<rpc::connection_cache>& conn_cache,
   ss::sharded<partition_manager>& partition_manager,
-  ss::sharded<node_status_backend>& node_status_backend)
+  ss::sharded<node_status_backend>& node_status_backend,
+  ss::sharded<client_quota::frontend>& quotas_frontend)
   : controller_service(sg, ssg)
   , _controller(controller)
   , _topics_frontend(tf)
@@ -75,7 +78,8 @@ service::service(
   , _conn_cache(conn_cache)
   , _partition_manager(partition_manager)
   , _plugin_frontend(pf)
-  , _node_status_backend(node_status_backend) {}
+  , _node_status_backend(node_status_backend)
+  , _quotas_frontend(quotas_frontend) {}
 
 ss::future<join_node_reply>
 service::join_node(join_node_request req, rpc::streaming_context&) {
@@ -822,6 +826,15 @@ ss::future<set_partition_shard_reply> service::set_partition_shard(
     auto ec = co_await _topics_frontend.local().set_local_partition_shard(
       req.ntp, req.shard);
     co_return set_partition_shard_reply{.ec = ec};
+}
+
+ss::future<client_quota::alter_quotas_response> service::alter_client_quotas(
+  client_quota::alter_quotas_request req, rpc::streaming_context&) {
+    co_await ss::coroutine::switch_to(get_scheduling_group());
+    auto deadline = model::timeout_clock::now() + req.timeout;
+    auto ec = co_await _quotas_frontend.local().alter_quotas(
+      std::move(req.cmd_data), deadline);
+    co_return client_quota::alter_quotas_response{.ec = ec};
 }
 
 } // namespace cluster

--- a/src/v/cluster/service.h
+++ b/src/v/cluster/service.h
@@ -42,7 +42,8 @@ public:
       ss::sharded<health_monitor_frontend>&,
       ss::sharded<rpc::connection_cache>&,
       ss::sharded<partition_manager>&,
-      ss::sharded<node_status_backend>&);
+      ss::sharded<node_status_backend>&,
+      ss::sharded<client_quota::frontend>&);
 
     virtual ss::future<join_node_reply>
     join_node(join_node_request, rpc::streaming_context&) override;
@@ -139,6 +140,9 @@ public:
     ss::future<set_partition_shard_reply> set_partition_shard(
       set_partition_shard_request, rpc::streaming_context&) final;
 
+    ss::future<client_quota::alter_quotas_response> alter_client_quotas(
+      client_quota::alter_quotas_request, rpc::streaming_context&) final;
+
 private:
     static constexpr auto default_move_interruption_timeout = 10s;
     std::pair<std::vector<model::topic_metadata>, topic_configuration_vector>
@@ -194,5 +198,6 @@ private:
     ss::sharded<partition_manager>& _partition_manager;
     ss::sharded<plugin_frontend>& _plugin_frontend;
     ss::sharded<node_status_backend>& _node_status_backend;
+    ss::sharded<client_quota::frontend>& _quotas_frontend;
 };
 } // namespace cluster

--- a/src/v/redpanda/application.cc
+++ b/src/v/redpanda/application.cc
@@ -2807,7 +2807,8 @@ void application::start_runtime_services(
             std::ref(controller->get_health_monitor()),
             std::ref(_connection_cache),
             std::ref(controller->get_partition_manager()),
-            std::ref(node_status_backend)));
+            std::ref(node_status_backend),
+            std::ref(controller->get_quota_frontend())));
           runtime_services.push_back(
             std::make_unique<cluster::metadata_dissemination_handler>(
               sched_groups.cluster_sg(),

--- a/tests/rptest/clients/rpk.py
+++ b/tests/rptest/clients/rpk.py
@@ -1256,11 +1256,10 @@ class RpkTool:
             ]
         return flags
 
-    def _kafka_conn_settings(self):
-        flags = [
-            "-X",
-            "brokers=" + self._redpanda.brokers(),
-        ]
+    def _kafka_conn_settings(self, node: Optional[ClusterNode] = None):
+        brokers = self._redpanda.broker_address(node) if node else \
+                  self._redpanda.brokers()
+        flags = ["-X", "brokers=" + brokers]
         if self._username:
             # u, p and mechanism must always be all set or all unset
             assert self._password and self._sasl_mechanism
@@ -1889,7 +1888,8 @@ class RpkTool:
                              default=[],
                              name=[],
                              dry=False,
-                             output_format="json"):
+                             output_format="json",
+                             node: Optional[ClusterNode] = None):
         cmd = ["alter"]
 
         if dry:
@@ -1903,16 +1903,21 @@ class RpkTool:
         if len(name) > 0:
             cmd += ["--name", ",".join(name)]
 
-        return self._run_cluster_quotas(cmd, output_format=output_format)
+        return self._run_cluster_quotas(cmd,
+                                        output_format=output_format,
+                                        node=node)
 
-    def _run_cluster_quotas(self, cmd, output_format="json"):
+    def _run_cluster_quotas(self,
+                            cmd,
+                            output_format="json",
+                            node: Optional[ClusterNode] = None):
         cmd = [
             self._rpk_binary(),
             "cluster",
             "quotas",
             "--format",
             output_format,
-        ] + self._kafka_conn_settings() + cmd
+        ] + self._kafka_conn_settings(node) + cmd
 
         out = self._execute(cmd)
 


### PR DESCRIPTION
While testing client quotas on real clusters I noticed that the alter command was failing occasionally when the alter request was sent to a node that wasn't the controller leader. I was previously under the impression that kafka admin requests are automatically redirected to the controller leader, however, that is not the case. Neither rpk nor kafka-configs.sh redirects kafka admin requests to the controller leader. It is only the admin API requests that rpk automatically sends to the controller leader.

This PR implements redirecting alter client quota commands to the controller leader and improves the error reporting on update failures.

https://redpandadata.atlassian.net/browse/CORE-2074

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
