### PR TITLE
chore: fix -Wsign-compare warnings

### DIFF
--- a/src/v/compression/tests/zstd_tests.cc
+++ b/src/v/compression/tests/zstd_tests.cc
@@ -64,7 +64,7 @@ static std::vector<size_t> get_test_sizes() {
 
 static inline iobuf gen(const size_t data_size) {
     iobuf ret;
-    for (auto i = 0; i < data_size; i += 512) {
+    for (size_t i = 0; i < data_size; i += 512) {
         const auto data = random_generators::gen_alphanum_string(512);
         ret.append(data.data(), data.size());
     }

--- a/src/v/container/tests/fragmented_vector_async_test.cc
+++ b/src/v/container/tests/fragmented_vector_async_test.cc
@@ -46,8 +46,8 @@ SEASTAR_THREAD_TEST_CASE(fragmented_vector_clear_async_test) {
     BOOST_REQUIRE(v.size() == 0);
 
     // many fragments
-    for (int i = 0; i < 5; ++i) {
-        for (int j = 0; j < v.elements_per_fragment(); ++j) {
+    for (size_t i = 0; i < 5; ++i) {
+        for (size_t j = 0; j < v.elements_per_fragment(); ++j) {
             v.push_back(j);
         }
     }

--- a/src/v/container/tests/fragmented_vector_test.cc
+++ b/src/v/container/tests/fragmented_vector_test.cc
@@ -468,7 +468,7 @@ TEST(Vector, FromInitializerListConstructor) {
 TEST(ChunkedVector, PushPop) {
     for (int i = 0; i < 100; ++i) {
         chunked_vector<int32_t> vec;
-        for (int i = 0; i < vec.elements_per_fragment(); ++i) {
+        for (size_t i = 0; i < vec.elements_per_fragment(); ++i) {
             bool push_back = vec.empty() || bool(random_generators::get_int(1));
             if (push_back) {
                 vec.push_back(i);
@@ -483,7 +483,7 @@ TEST(ChunkedVector, PushPop) {
 TEST(ChunkedVector, PushPopN) {
     for (int i = 0; i < 100; ++i) {
         chunked_vector<int32_t> vec;
-        for (int i = 0; i < vec.elements_per_fragment(); ++i) {
+        for (size_t i = 0; i < vec.elements_per_fragment(); ++i) {
             // Slight preference to make larger vectors because we could be
             // popping back multiple
             switch (random_generators::get_int(4)) {
@@ -508,7 +508,7 @@ TEST(ChunkedVector, PushPopN) {
 
 TEST(ChunkedVector, FirstChunkCapacityDoubles) {
     chunked_vector<int32_t> vec;
-    for (int i = 0; i < vec.elements_per_fragment(); ++i) {
+    for (size_t i = 0; i < vec.elements_per_fragment(); ++i) {
         vec.push_back(i);
         EXPECT_TRUE(fragmented_vector_validator::validate(vec));
     }
@@ -519,7 +519,7 @@ TEST(ChunkedVector, ReserveAndPushBack) {
     vec.reserve(vec.elements_per_fragment());
     vec.push_back(-1);
     int* initial_location = &vec.front();
-    for (int i = 0; i < vec.elements_per_fragment(); ++i) {
+    for (size_t i = 0; i < vec.elements_per_fragment(); ++i) {
         vec.push_back(i);
         EXPECT_EQ(initial_location, &vec.front());
     }
@@ -527,7 +527,8 @@ TEST(ChunkedVector, ReserveAndPushBack) {
 
 TEST(ChunkedVector, Reserve) {
     chunked_vector<int32_t> growing_vec;
-    for (int i = 0; i < chunked_vector<int32_t>::elements_per_fragment(); ++i) {
+    for (size_t i = 0; i < chunked_vector<int32_t>::elements_per_fragment();
+         ++i) {
         growing_vec.reserve(i);
         EXPECT_EQ(growing_vec.capacity(), i);
         EXPECT_TRUE(fragmented_vector_validator::validate(growing_vec));

--- a/src/v/container/tests/interval_set_test.cc
+++ b/src/v/container/tests/interval_set_test.cc
@@ -269,9 +269,9 @@ TEST_P(RandomizedIntervalSetTest, RandomInsertsSequentialErase) {
     const auto params = GetParam();
     const auto interval_max_size = params.interval_max_size;
     const double target_fill_percent = params.target_fill_percent;
-    const auto buf_size = 5000;
+    const size_t buf_size = 5000;
 
-    const int target_fill_size = target_fill_percent * buf_size;
+    const size_t target_fill_size = target_fill_percent * buf_size;
 
     ss::sstring buf(buf_size, 'O');
     auto current_filled = [&buf] {
@@ -291,7 +291,7 @@ TEST_P(RandomizedIntervalSetTest, RandomInsertsSequentialErase) {
         const int start_max = buf_size - rand_size;
         const uint64_t rand_start = random_generators::get_int(0, start_max);
         EXPECT_TRUE(filled_intervals.insert({rand_start, rand_size}).second);
-        for (int i = 0; i < rand_size; i++) {
+        for (size_t i = 0; i < rand_size; i++) {
             buf[rand_start + i] = 'X';
         }
     }

--- a/src/v/container/tests/map_bench.cc
+++ b/src/v/container/tests/map_bench.cc
@@ -29,7 +29,7 @@ class MapBenchTest {
         std::vector<key_t> keys;
         keys.reserve(int(KeySetSize * (FillPercent / 100.0)));
         for (auto i : boost::irange<key_t>(0, KeySetSize)) {
-            if (random_generators::get_int(0, 100) <= FillPercent) {
+            if (random_generators::get_int<size_t>(0, 100) <= FillPercent) {
                 keys.push_back(i);
             }
         }

--- a/src/v/random/tests/random_test.cc
+++ b/src/v/random/tests/random_test.cc
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(alphanum_max_distinct_generator) {
     for (auto i = 0; i < 100; i++) {
         auto s = random_generators::gen_alphanum_max_distinct(cardinality);
         // ensure no \0 in size
-        for (auto j = 0; j < random_generators::alphanum_max_distinct_strlen;
+        for (size_t j = 0; j < random_generators::alphanum_max_distinct_strlen;
              j++) {
             BOOST_REQUIRE('\0' != s[j]);
         }

--- a/src/v/utils/tests/uuid_test.cc
+++ b/src/v/utils/tests/uuid_test.cc
@@ -115,7 +115,7 @@ SEASTAR_THREAD_TEST_CASE(complex_uuid_types_test) {
     BOOST_CHECK(us.opt2 == r.opt2);
     BOOST_CHECK_EQUAL(us.vec, r.vec);
     BOOST_CHECK_EQUAL(us.opt_vec.size(), r.opt_vec.size());
-    for (int i = 0; i < us.opt_vec.size(); ++i) {
+    for (size_t i = 0; i < us.opt_vec.size(); ++i) {
         BOOST_CHECK(us.opt_vec[i] == r.opt_vec[i]);
     }
 

--- a/src/v/utils/tests/vint_bench.cc
+++ b/src/v/utils/tests/vint_bench.cc
@@ -306,7 +306,7 @@ static constexpr size_t ITERS = 10000;
 template<typename F>
 ss::future<size_t> co_await_in_loop(F f) {
     perf_tests::start_measuring_time();
-    for (int i = 0; i < ITERS; i++) {
+    for (size_t i = 0; i < ITERS; i++) {
         co_await f();
     }
     perf_tests::stop_measuring_time();
@@ -318,7 +318,7 @@ ss::future<size_t> collect_futures(F f) {
     std::vector<ss::future<>> futs;
     futs.reserve(ITERS);
     perf_tests::start_measuring_time();
-    for (int i = 0; i < ITERS; i++) {
+    for (size_t i = 0; i < ITERS; i++) {
         futs.emplace_back(f());
     }
     perf_tests::stop_measuring_time();


### PR DESCRIPTION
chore: fix -Wsign-compare warnings

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

