### PR TITLE
Using `contiguous_range_map` to store partitions assignments

### DIFF
--- a/src/v/cluster/controller_api.cc
+++ b/src/v/cluster/controller_api.cc
@@ -139,11 +139,11 @@ controller_api::get_reconciliation_state(model::topic_namespace_view tp_ns) {
     ntps.reserve(metadata->get().get_assignments().size());
 
     std::transform(
-      metadata->get().get_assignments().cbegin(),
-      metadata->get().get_assignments().cend(),
+      metadata->get().get_assignments().begin(),
+      metadata->get().get_assignments().end(),
       std::back_inserter(ntps),
-      [tp_ns](const partition_assignment& p_as) {
-          return model::ntp(tp_ns.ns, tp_ns.tp, p_as.id);
+      [tp_ns](const assignments_set::value_type& p_as) {
+          return model::ntp(tp_ns.ns, tp_ns.tp, p_as.second.id);
       });
 
     co_return co_await get_reconciliation_state(std::move(ntps));
@@ -296,7 +296,7 @@ ss::future<std::error_code> controller_api::wait_for_topic(
             continue;
         }
         std::deque<model::ntp> all_ntps;
-        for (const auto& p_as : metadata->get().get_assignments()) {
+        for (const auto& [_, p_as] : metadata->get().get_assignments()) {
             all_ntps.emplace_back(tp_ns.ns, tp_ns.tp, p_as.id);
         }
 

--- a/src/v/cluster/controller_backend.cc
+++ b/src/v/cluster/controller_backend.cc
@@ -418,7 +418,7 @@ create_topic_table_snapshot(
         if (!ntp_meta) {
             continue;
         }
-        for (const auto& p : ntp_meta->get_assignments()) {
+        for (const auto& [_, p] : ntp_meta->get_assignments()) {
             auto ntp = model::ntp(nt.ns, nt.tp, p.id);
             auto revision_id = ntp_meta->get_revision();
             if (cluster::contains_node(p.replicas, current_node)) {

--- a/src/v/cluster/metadata_cache.cc
+++ b/src/v/cluster/metadata_cache.cc
@@ -74,7 +74,7 @@ std::optional<model::topic_metadata> metadata_cache::get_model_topic_metadata(
 
     model::topic_metadata metadata(md->get_configuration().tp_ns);
     metadata.partitions.reserve(md->get_assignments().size());
-    for (const auto& p_as : md->get_assignments()) {
+    for (const auto& [_, p_as] : md->get_assignments()) {
         metadata.partitions.push_back(p_as.create_partition_metadata());
     }
 

--- a/src/v/cluster/partition_balancer_planner.cc
+++ b/src/v/cluster/partition_balancer_planner.cc
@@ -487,7 +487,7 @@ partition_balancer_planner::init_topic_node_counts(request_context& ctx) {
          ++it) {
         auto& counts = ctx._topic2node_counts[it->first];
         const auto& assignments = it->second.get_assignments();
-        for (const auto& p_as : assignments) {
+        for (const auto& [_, p_as] : assignments) {
             for (const auto& bs : p_as.replicas) {
                 counts[bs.node_id] += 1;
             }
@@ -1029,7 +1029,7 @@ ss::future<> partition_balancer_planner::request_context::for_each_partition(
          it != topics.topics_iterator_end();
          ++it) {
         const auto& assignments = it->second.get_assignments();
-        for (const auto& assignment : assignments) {
+        for (const auto& [_, assignment] : assignments) {
             auto ntp = model::ntp(it->first.ns, it->first.tp, assignment.id);
             auto stop = do_with_partition(ntp, assignment, visitor);
             if (stop == ss::stop_iteration::yes) {
@@ -1055,7 +1055,7 @@ partition_balancer_planner::request_context::for_each_replica_random_order(
 
     fragmented_vector<item> replicas;
     for (const auto& t : _parent._state.topics().topics_map()) {
-        for (const auto& a : t.second.get_assignments()) {
+        for (const auto& [_, a] : t.second.get_assignments()) {
             auto reassignment_it = _reassignments.find(
               model::ntp(t.first.ns, t.first.tp, a.id));
             const auto& ntp_replicas
@@ -1108,7 +1108,7 @@ ss::future<> partition_balancer_planner::request_context::with_partition(
         co_return;
     }
 
-    do_with_partition(ntp, *it, visitor);
+    do_with_partition(ntp, it->second, visitor);
 }
 
 allocation_constraints

--- a/src/v/cluster/scheduling/leader_balancer.cc
+++ b/src/v/cluster/scheduling/leader_balancer.cc
@@ -662,7 +662,7 @@ leader_balancer::build_group_id_to_topic_rev() const {
 
     // for each ntp in the cluster
     for (const auto& topic : _topics.topics_map()) {
-        for (const auto& partition : topic.second.get_assignments()) {
+        for (const auto& [_, partition] : topic.second.get_assignments()) {
             if (partition.replicas.empty()) {
                 vlog(
                   clusterlog.warn,
@@ -707,7 +707,7 @@ leader_balancer::collect_group_replicas_from_health_report(
               [&](const partition_status& partition) {
                   auto as_it = meta.get_assignments().find(partition.id);
                   if (as_it != meta.get_assignments().end()) {
-                      group_replicas[as_it->group].push_back(
+                      group_replicas[as_it->second.group].push_back(
                         model::broker_shard{
                           .node_id = node->id,
                           .shard = partition.shard,
@@ -735,7 +735,7 @@ leader_balancer::index_type leader_balancer::build_index(
     // for each ntp in the cluster
     for (const auto& topic : _topics.topics_map()) {
         const auto* disabled_set = _topics.get_topic_disabled_set(topic.first);
-        for (const auto& partition : topic.second.get_assignments()) {
+        for (const auto& [_, partition] : topic.second.get_assignments()) {
             /*
              * skip balancing for the controller partition, otherwise we might
              * just constantly move ourselves around.

--- a/src/v/cluster/shard_balancer.cc
+++ b/src/v/cluster/shard_balancer.cc
@@ -16,6 +16,7 @@
 #include "config/node_config.h"
 #include "random/generators.h"
 #include "ssx/async_algorithm.h"
+#include "types.h"
 
 namespace cluster {
 
@@ -104,11 +105,11 @@ ss::future<> shard_balancer::start(size_t kvstore_shard_count) {
           counter,
           md_item.get_assignments().begin(),
           md_item.get_assignments().end(),
-          [&](const partition_assignment& p_as) {
+          [&](const assignments_set::value_type& p) {
               vassert(
                 tt_version == topics.topics_map_revision(),
                 "topic_table unexpectedly changed");
-
+              const auto& [_, p_as] = p;
               model::ntp ntp{ns_tp.ns, ns_tp.tp, p_as.id};
               auto replicas_view = topics.get_replicas_view(ntp, md_item, p_as);
               auto log_rev = log_revision_on_node(replicas_view, _self);

--- a/src/v/cluster/shard_placement_table.cc
+++ b/src/v/cluster/shard_placement_table.cc
@@ -15,6 +15,7 @@
 #include "cluster/logger.h"
 #include "cluster/topic_table.h"
 #include "ssx/async_algorithm.h"
+#include "types.h"
 
 #include <seastar/util/defer.hh>
 
@@ -605,11 +606,11 @@ ss::future<> shard_placement_table::do_initialize_from_topic_table(
           counter,
           md_item.get_assignments().begin(),
           md_item.get_assignments().end(),
-          [&](const partition_assignment& p_as) {
+          [&](const assignments_set::value_type& p) {
               vassert(
                 tt_version == topics.topics_map_revision(),
                 "topic_table unexpectedly changed");
-
+              auto& [_, p_as] = p;
               model::ntp ntp{ns_tp.ns, ns_tp.tp, p_as.id};
               auto replicas_view = topics.get_replicas_view(ntp, md_item, p_as);
               auto target = placement_target_on_node(replicas_view, self);

--- a/src/v/cluster/tests/cluster_test_fixture.h
+++ b/src/v/cluster/tests/cluster_test_fixture.h
@@ -19,6 +19,7 @@
 #include "redpanda/tests/fixture.h"
 #include "resource_mgmt/cpu_scheduling.h"
 #include "test_utils/async.h"
+#include "types.h"
 
 #include <seastar/core/metrics_api.hh>
 #include <seastar/core/sharded.hh>
@@ -274,8 +275,8 @@ public:
                    && std::all_of(
                      md->get_assignments().begin(),
                      md->get_assignments().end(),
-                     [&](const cluster::partition_assignment& p) {
-                         return leaders.get_leader(tp_ns, p.id);
+                     [&](const cluster::assignments_set::value_type& p) {
+                         return leaders.get_leader(tp_ns, p.second.id);
                      });
         }).get0();
     }

--- a/src/v/cluster/tests/metadata_dissemination_test.cc
+++ b/src/v/cluster/tests/metadata_dissemination_test.cc
@@ -48,7 +48,7 @@ wait_for_leaders_updates(int id, cluster::metadata_cache& cache) {
         if (tp_md->get_assignments().size() != 3) {
             return false;
         }
-        for (auto& p_md : tp_md->get_assignments()) {
+        for (auto& [_, p_md] : tp_md->get_assignments()) {
             auto leader_id = cache.get_leader_id(tn, p_md.id);
             test_logger.info(
               "waiting for leaders on node {}, partition {}, leader_id: {}",

--- a/src/v/cluster/tests/partition_balancer_simulator_test.cc
+++ b/src/v/cluster/tests/partition_balancer_simulator_test.cc
@@ -289,7 +289,7 @@ public:
 
     void print_replica_map() const {
         for (const auto& t : topics().topics_map()) {
-            for (const auto& a : t.second.get_assignments()) {
+            for (const auto& [_, a] : t.second.get_assignments()) {
                 auto ntp = model::ntp(t.first.ns, t.first.tp, a.id);
                 std::vector<model::node_id> replicas;
                 for (const auto& bs : a.replicas) {
@@ -348,7 +348,7 @@ public:
 
         for (auto& [tp_ns, topic_md] :
              _workers.table.local().all_topics_metadata()) {
-            for (auto& p_as : topic_md.get_assignments()) {
+            for (auto& [_, p_as] : topic_md.get_assignments()) {
                 total_topic_replicas[tp_ns] += p_as.replicas.size();
                 for (auto& r : p_as.replicas) {
                     topic_replica_distribution[tp_ns][r.node_id]++;
@@ -434,7 +434,7 @@ private:
                 continue;
             }
 
-            for (const auto& p_as : topic_md.get_assignments()) {
+            for (const auto& [_, p_as] : topic_md.get_assignments()) {
                 for (const auto& r1 : p_as.replicas) {
                     for (const auto& r2 : p_as.replicas) {
                         if (r1.node_id != r2.node_id) {

--- a/src/v/cluster/tests/rebalancing_tests_fixture.h
+++ b/src/v/cluster/tests/rebalancing_tests_fixture.h
@@ -96,7 +96,7 @@ public:
                     .local()
                     .get_topic_metadata_ref(model::topic_namespace_view(ntp));
 
-        return md->get().get_assignments().begin()->replicas;
+        return md->get().get_assignments().begin()->second.replicas;
     }
 
     void create_topic(cluster::topic_configuration cfg) {
@@ -185,7 +185,7 @@ public:
     void populate_all_topics_with_data() {
         auto& md = get_local_cache(model::node_id(0)).all_topics_metadata();
         for (auto& [tp_ns, topic_metadata] : md) {
-            for (auto& p : topic_metadata.get_assignments()) {
+            for (auto& [_, p] : topic_metadata.get_assignments()) {
                 model::ntp ntp(tp_ns.ns, tp_ns.tp, p.id);
                 replicate_data(ntp, 10);
             }

--- a/src/v/cluster/tests/replicas_rebalancing_tests.cc
+++ b/src/v/cluster/tests/replicas_rebalancing_tests.cc
@@ -20,7 +20,7 @@ calculate_replicas_per_node(const cluster::metadata_cache& cache) {
         if (tp_ns.ns == model::redpanda_ns) {
             continue;
         }
-        for (auto& p_md : tp_md.get_assignments()) {
+        for (auto& [_, p_md] : tp_md.get_assignments()) {
             for (auto replica : p_md.replicas) {
                 ret[replica.node_id]++;
             }

--- a/src/v/cluster/tests/topic_table_test.cc
+++ b/src/v/cluster/tests/topic_table_test.cc
@@ -181,7 +181,7 @@ void validate_brokers_revisions(
     BOOST_REQUIRE(p_meta_it != tp_it->second.partitions.end());
     const auto& revisions = p_meta_it->second.replicas_revisions;
 
-    for (auto& bs : p_it->replicas) {
+    for (auto& bs : p_it->second.replicas) {
         fmt::print("replica: {}\n", bs);
     }
     for (auto& bs : expected_revisions) {

--- a/src/v/cluster/topic_table.cc
+++ b/src/v/cluster/topic_table.cc
@@ -69,20 +69,20 @@ topic_table::apply(create_topic_cmd cmd, model::offset offset) {
     md.partitions.reserve(cmd.value.assignments.size());
     auto rev_id = model::revision_id{offset};
     for (auto& pas : md.get_assignments()) {
-        auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, pas.id);
+        auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, pas.second.id);
         replicas_revision_map replica_revisions;
         _partition_count++;
-        for (auto& r : pas.replicas) {
+        for (auto& r : pas.second.replicas) {
             replica_revisions[r.node_id] = rev_id;
         }
         md.partitions.emplace(
-          pas.id,
+          pas.second.id,
           partition_meta{
             .replicas_revisions = replica_revisions,
             .last_update_finished_revision = rev_id});
         _pending_deltas.emplace_back(
           std::move(ntp),
-          pas.group,
+          pas.second.group,
           model::revision_id(offset),
           topic_table_delta_type::added);
     }
@@ -116,7 +116,7 @@ topic_table::do_local_delete(model::topic_namespace nt, model::offset offset) {
         return errc::resource_is_being_migrated;
     }
     if (auto tp = _topics.find(nt); tp != _topics.end()) {
-        for (auto& p_as : tp->second.get_assignments()) {
+        for (auto& [_, p_as] : tp->second.get_assignments()) {
             _partition_count--;
             auto ntp = model::ntp(nt.ns, nt.tp, p_as.id);
             _updates_in_progress.erase(ntp);
@@ -225,7 +225,7 @@ topic_table::apply(create_partition_cmd cmd, model::offset offset) {
     for (auto& p_as : cmd.value.assignments) {
         _partition_count++;
         p_as.id += model::partition_id(prev_partition_count);
-        tp->second.get_assignments().emplace(p_as);
+        tp->second.get_assignments().emplace(p_as.id, p_as);
         // propagate deltas
         auto ntp = model::ntp(cmd.key.ns, cmd.key.tp, p_as.id);
         replicas_revision_map replicas_revisions;
@@ -289,7 +289,7 @@ ss::future<std::error_code> topic_table::do_apply(
     change_partition_replicas(
       std::move(cmd_data.ntp),
       cmd_data.replicas,
-      *current_assignment_it,
+      current_assignment_it->second,
       o,
       false,
       cmd_data.policy);
@@ -339,7 +339,7 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
           errc::partition_not_exists);
     }
 
-    if (current_assignment_it->replicas != cmd.value) {
+    if (current_assignment_it->second.replicas != cmd.value) {
         return ss::make_ready_future<std::error_code>(
           errc::invalid_node_operation);
     }
@@ -373,7 +373,7 @@ topic_table::apply(finish_moving_partition_replicas_cmd cmd, model::offset o) {
     // notify backend about finished update
     _pending_deltas.emplace_back(
       std::move(cmd.key),
-      current_assignment_it->group,
+      current_assignment_it->second.group,
       model::revision_id(o),
       topic_table_delta_type::replicas_updated);
 
@@ -437,16 +437,16 @@ topic_table::apply(cancel_moving_partition_replicas_cmd cmd, model::offset o) {
                       : reconfiguration_state::cancelled,
       model::revision_id{o});
 
-    auto replicas = current_assignment_it->replicas;
+    auto replicas = current_assignment_it->second.replicas;
     // replace replica set with set from in progress operation
-    current_assignment_it->replicas
+    current_assignment_it->second.replicas
       = in_progress_it->second.get_previous_replicas();
 
     _topics_map_revision++;
 
     _pending_deltas.emplace_back(
       std::move(cmd.key),
-      current_assignment_it->group,
+      current_assignment_it->second.group,
       model::revision_id(o),
       topic_table_delta_type::replicas_updated);
     notify_waiters();
@@ -493,13 +493,13 @@ topic_table::apply(revert_cancel_partition_move_cmd cmd, model::offset o) {
     }
 
     // revert replica set update
-    current_assignment_it->replicas
+    current_assignment_it->second.replicas
       = in_progress_it->second.get_target_replicas();
 
     partition_assignment delta_assignment{
-      current_assignment_it->group,
-      current_assignment_it->id,
-      current_assignment_it->replicas,
+      current_assignment_it->second.group,
+      current_assignment_it->second.id,
+      current_assignment_it->second.replicas,
     };
 
     // update partition_meta object:
@@ -507,7 +507,7 @@ topic_table::apply(revert_cancel_partition_move_cmd cmd, model::offset o) {
     // update replicas_revisions.
     p_meta_it->second.replicas_revisions = update_replicas_revisions(
       std::move(p_meta_it->second.replicas_revisions),
-      current_assignment_it->replicas,
+      current_assignment_it->second.replicas,
       in_progress_it->second.get_update_revision());
     p_meta_it->second.last_update_finished_revision = model::revision_id{o};
 
@@ -519,7 +519,7 @@ topic_table::apply(revert_cancel_partition_move_cmd cmd, model::offset o) {
     // notify backend about finished update
     _pending_deltas.emplace_back(
       ntp,
-      current_assignment_it->group,
+      current_assignment_it->second.group,
       model::revision_id(o),
       topic_table_delta_type::replicas_updated);
     notify_waiters();
@@ -583,7 +583,7 @@ topic_table::apply(move_topic_replicas_cmd cmd, model::offset o) {
         change_partition_replicas(
           model::ntp(cmd.key.ns, cmd.key.tp, partition_id),
           new_replicas,
-          *assignment,
+          assignment->second,
           o,
           false,
           // for up replication we use a default reconfiguration policy
@@ -624,7 +624,7 @@ topic_table::apply(force_partition_reconfiguration_cmd cmd, model::offset o) {
     change_partition_replicas(
       cmd.key,
       cmd.value.replicas,
-      *current_assignment_it,
+      current_assignment_it->second,
       o,
       true,
       /**
@@ -670,7 +670,7 @@ topic_table::apply(set_topic_partitions_disabled_cmd cmd, model::offset o) {
         _pending_deltas.emplace_back(
           model::ntp{
             cmd.value.ns_tp.ns, cmd.value.ns_tp.tp, *cmd.value.partition_id},
-          assignment_it->group,
+          assignment_it->second.group,
           model::revision_id{o},
           topic_table_delta_type::disabled_flag_updated);
     } else {
@@ -688,7 +688,7 @@ topic_table::apply(set_topic_partitions_disabled_cmd cmd, model::offset o) {
             }
         }
 
-        for (const auto& p_as : assignments) {
+        for (const auto& [_, p_as] : assignments) {
             if (old_disabled_set.is_disabled(p_as.id) == cmd.value.disabled) {
                 continue;
             }
@@ -944,7 +944,7 @@ topic_table::apply(update_topic_properties_cmd cmd, model::offset o) {
 
     // generate deltas for controller backend
     const auto& assignments = tp->second.get_assignments();
-    for (auto& p_as : assignments) {
+    for (auto& [_, p_as] : assignments) {
         _pending_deltas.emplace_back(
           model::ntp(cmd.key.ns, cmd.key.tp, p_as.id),
           p_as.group,
@@ -969,7 +969,7 @@ topic_table::fill_snapshot(controller_snapshot& controller_snap) const {
           controller_snapshot_parts::topics_t::update_t>
           updates;
 
-        for (const auto& p_as : md_item.get_assignments()) {
+        for (const auto& [_, p_as] : md_item.get_assignments()) {
             replicas_t replicas;
             model::ntp ntp(ns_tp.ns, ns_tp.tp, p_as.id);
             if (auto upd_it = _updates_in_progress.find(ntp);
@@ -1073,7 +1073,7 @@ public:
           clusterlog.trace,
           "deleting topic {} not in controller snapshot",
           ns_tp);
-        for (const auto& p_as : old_md_item.get_assignments()) {
+        for (const auto& [_, p_as] : old_md_item.get_assignments()) {
             delete_ntp(ns_tp, p_as);
             co_await ss::coroutine::maybe_yield();
         }
@@ -1106,7 +1106,7 @@ public:
         model::revision_id prev_update_finished_revision;
         if (auto as_it = md_item.get_assignments().find(p_id);
             as_it != md_item.get_assignments().end()) {
-            prev_assignment = std::move(*as_it);
+            prev_assignment = std::move(as_it->second);
             md_item.get_assignments().erase(as_it);
 
             auto p_it = md_item.partitions.find(p_id);
@@ -1134,9 +1134,9 @@ public:
         // info in the snapshot about an in-progress update, we'll have to
         // update replicas later in this function.
         partition_assignment& cur_assignment
-          = *md_item.get_assignments()
-               .emplace(partition.group, p_id, partition.replicas)
-               .first;
+          = md_item.get_assignments()
+              .emplace(p_id, partition.group, p_id, partition.replicas)
+              .first->second;
 
         md_item.partitions[p_id] = partition_meta{
           .replicas_revisions = partition.replicas_revisions,
@@ -1337,8 +1337,9 @@ ss::future<> topic_table::apply_snapshot(
                 for (auto as_it = md_item.get_assignments().begin();
                      as_it != md_item.get_assignments().end();) {
                     auto as_it_copy = as_it++;
-                    if (!topic_snapshot.partitions.contains(as_it_copy->id)) {
-                        applier.delete_ntp(ns_tp, *as_it_copy);
+                    if (!topic_snapshot.partitions.contains(
+                          as_it_copy->second.id)) {
+                        applier.delete_ntp(ns_tp, as_it_copy->second);
                         md_item.get_assignments().erase(as_it_copy);
                         _topics_map_revision++;
                     }
@@ -1430,7 +1431,7 @@ size_t topic_table::all_topics_count() const { return _topics.size(); }
 std::optional<topic_metadata>
 topic_table::get_topic_metadata(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {
-        return it->second.metadata;
+        return it->second.metadata.copy();
     }
     return {};
 }
@@ -1461,7 +1462,7 @@ std::optional<replication_factor> topic_table::get_topic_replication_factor(
 std::optional<assignments_set>
 topic_table::get_topic_assignments(model::topic_namespace_view tp) const {
     if (auto it = _topics.find(tp); it != _topics.end()) {
-        return it->second.get_assignments();
+        return it->second.get_assignments().copy();
     }
     return std::nullopt;
 }
@@ -1488,7 +1489,7 @@ topic_table::get_replicas_view(const model::ntp& ntp) const {
     if (as_it == topic_it->second.get_assignments().end()) {
         return std::nullopt;
     }
-    return get_replicas_view(ntp, topic_it->second, *as_it);
+    return get_replicas_view(ntp, topic_it->second, as_it->second);
 }
 
 topic_table::partition_replicas_view topic_table::get_replicas_view(
@@ -1547,11 +1548,11 @@ topic_table::get_partition_assignment(const model::ntp& ntp) const {
 
     auto p_it = it->second.get_assignments().find(ntp.tp.partition);
 
-    if (p_it == it->second.get_assignments().cend()) {
+    if (p_it == it->second.get_assignments().end()) {
         return {};
     }
 
-    return *p_it;
+    return p_it->second;
 }
 
 bool topic_table::is_update_in_progress(const model::ntp& ntp) const {
@@ -1705,8 +1706,8 @@ size_t topic_table::get_node_partition_count(model::node_id id) const {
         cnt += std::count_if(
           tp_md.get_assignments().begin(),
           tp_md.get_assignments().end(),
-          [id](const partition_assignment& p_as) {
-              return contains_node(p_as.replicas, id);
+          [id](const assignments_set::value_type& p_as) {
+              return contains_node(p_as.second.replicas, id);
           });
     }
     return cnt;

--- a/src/v/cluster/topic_table_partition_generator.cc
+++ b/src/v/cluster/topic_table_partition_generator.cc
@@ -50,9 +50,9 @@ topic_table_partition_generator::next_batch() {
 
     while (!_exhausted && batch.size() < _batch_size) {
         model::topic_namespace tn = _topic_iterator->first;
-        model::partition_id pid = _partition_iterator->id;
+        model::partition_id pid = _partition_iterator->second.id;
         std::vector<model::broker_shard> replicas
-          = _partition_iterator->replicas;
+          = _partition_iterator->second.replicas;
         partition_replicas entry{
           .partition = model::ntp{tn.ns, tn.tp, pid},
           .replicas = std::move(replicas)};

--- a/src/v/cluster/tx_gateway_frontend.cc
+++ b/src/v/cluster/tx_gateway_frontend.cc
@@ -3128,7 +3128,7 @@ void tx_gateway_frontend::expire_old_txs() {
 
         std::vector<model::partition_id> partitions;
         partitions.reserve(ntp_meta->get_assignments().size());
-        for (auto& pa : ntp_meta->get_assignments()) {
+        for (auto& [_, pa] : ntp_meta->get_assignments()) {
             partitions.push_back(pa.id);
         }
 
@@ -3351,7 +3351,7 @@ tx_gateway_frontend::get_all_transactions() {
     }
 
     tx_gateway_frontend::return_all_txs_res res{{}};
-    for (const auto& pa : ntp_meta->get_assignments()) {
+    for (const auto& [_, pa] : ntp_meta->get_assignments()) {
         auto tx_manager_ntp = model::ntp(
           model::tx_manager_nt.ns, model::tx_manager_nt.tp, pa.id);
         auto ntp_res = co_await get_all_transactions_for_one_tx_partition(

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -412,7 +412,8 @@ cluster::assignments_set to_assignments_map(
   ss::chunked_fifo<cluster::partition_assignment> assignment_vector) {
     cluster::assignments_set ret;
     for (auto& p_as : assignment_vector) {
-        ret.emplace(std::move(p_as));
+        const auto id = p_as.id;
+        ret.emplace(id, std::move(p_as));
     }
     return ret;
 }
@@ -479,7 +480,7 @@ replication_factor topic_metadata::get_replication_factor() const {
     // topic
     auto it = _assignments.find(model::partition_id(0));
     return replication_factor(
-      static_cast<replication_factor::type>(it->replicas.size()));
+      static_cast<replication_factor::type>(it->second.replicas.size()));
 }
 
 topic_metadata topic_metadata::copy() const {
@@ -772,7 +773,7 @@ void topic_disabled_partitions_set::remove(
     if (!partitions) {
         partitions = absl::node_hash_set<model::partition_id>{};
         partitions->reserve(all_partitions.size());
-        for (const auto& p : all_partitions) {
+        for (const auto& [_, p] : all_partitions) {
             partitions->insert(p.id);
         }
     }

--- a/src/v/cluster/types.cc
+++ b/src/v/cluster/types.cc
@@ -482,6 +482,10 @@ replication_factor topic_metadata::get_replication_factor() const {
       static_cast<replication_factor::type>(it->replicas.size()));
 }
 
+topic_metadata topic_metadata::copy() const {
+    return {_fields, _assignments.copy()};
+}
+
 std::ostream& operator<<(std::ostream& o, const reconciliation_status& s) {
     switch (s) {
     case reconciliation_status::done:

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -20,6 +20,7 @@
 #include "cluster/tx_errc.h"
 #include "cluster/tx_hash_ranges.h"
 #include "cluster/version.h"
+#include "container/contiguous_range_map.h"
 #include "model/adl_serde.h"
 #include "model/fundamental.h"
 #include "model/metadata.h"
@@ -2469,7 +2470,7 @@ struct partition_assignment_cmp {
 };
 
 using assignments_set
-  = absl::btree_set<partition_assignment, partition_assignment_cmp>;
+  = contiguous_range_map<model::partition_id::type, partition_assignment>;
 
 struct topic_metadata_fields
   : serde::envelope<

--- a/src/v/cluster/types.h
+++ b/src/v/cluster/types.h
@@ -2529,6 +2529,8 @@ public:
 
     replication_factor get_replication_factor() const;
 
+    topic_metadata copy() const;
+
 private:
     topic_metadata_fields _fields;
     assignments_set _assignments;

--- a/src/v/container/include/container/contiguous_range_map.h
+++ b/src/v/container/include/container/contiguous_range_map.h
@@ -145,7 +145,8 @@ public:
      */
     bool contains(KeyT key) const {
         check_key(key);
-        return _values.size() > key && _values[key].has_value();
+        return _values.size() > static_cast<size_t>(key)
+               && _values[key].has_value();
     }
 
     /**
@@ -282,6 +283,13 @@ public:
             mutable_it._it->reset();
             --_size;
         }
+    }
+
+    contiguous_range_map copy() const {
+        contiguous_range_map<KeyT, ValueT> ret;
+        ret._values = _values.copy();
+        ret._size = _size;
+        return ret;
     }
 
 private:

--- a/src/v/kafka/server/handlers/metadata.cc
+++ b/src/v/kafka/server/handlers/metadata.cc
@@ -126,7 +126,7 @@ metadata_response::topic make_topic_response_from_topic_metadata(
     const bool is_user_topic = model::is_user_topic(tp_ns);
     const auto* disabled_set = md_cache.get_topic_disabled_set(tp_ns);
 
-    for (const auto& p_as : tp_md.get_assignments()) {
+    for (const auto& [_, p_as] : tp_md.get_assignments()) {
         std::vector<model::node_id> replicas{};
         replicas.reserve(p_as.replicas.size());
         // current replica set

--- a/src/v/kafka/server/handlers/topics/topic_utils.cc
+++ b/src/v/kafka/server/handlers/topics/topic_utils.cc
@@ -54,7 +54,7 @@ ss::future<> wait_for_leaders(
           [&r, &md_cache, deadline](const auto& p_as) {
               return md_cache
                 .get_leader(
-                  model::ntp(r.tp_ns.ns, r.tp_ns.tp, p_as.id), deadline)
+                  model::ntp(r.tp_ns.ns, r.tp_ns.tp, p_as.second.id), deadline)
                 .discard_result();
           });
     }

--- a/src/v/redpanda/admin/partition.cc
+++ b/src/v/redpanda/admin/partition.cc
@@ -954,7 +954,7 @@ admin_server::get_topic_partitions_handler(
       = _controller->get_topics_state().local().get_topic_disabled_set(tp_ns);
 
     // Normal topic
-    for (const auto& p_as : assignments) {
+    for (const auto& [_, p_as] : assignments) {
         partition_t p;
         p.ns = tp_ns.ns;
         p.topic = tp_ns.tp;

--- a/src/v/redpanda/admin/server.cc
+++ b/src/v/redpanda/admin/server.cc
@@ -3279,12 +3279,12 @@ fragmented_vector<cluster_partition_info> topic2cluster_partitions(
             ret.push_back(cluster_partition_info{
               .ns_tp = shared_ns_tp,
               .id = id,
-              .replicas = as_it->replicas,
+              .replicas = as_it->second.replicas,
               .disabled = true,
             });
         }
     } else {
-        for (const auto& p_as : assignments) {
+        for (const auto& [_, p_as] : assignments) {
             bool disabled = disabled_set && disabled_set->is_disabled(p_as.id);
 
             if (disabled_filter && *disabled_filter != disabled) {

--- a/src/v/redpanda/tests/fixture.h
+++ b/src/v/redpanda/tests/fixture.h
@@ -564,10 +564,11 @@ public:
                            && std::all_of(
                              md->get_assignments().begin(),
                              md->get_assignments().end(),
-                             [this,
-                              &r](const cluster::partition_assignment& p) {
+                             [this, &r](
+                               const cluster::assignments_set::value_type& p) {
                                  return app.shard_table.local().shard_for(
-                                   model::ntp(r.tp_ns.ns, r.tp_ns.tp, p.id));
+                                   model::ntp(
+                                     r.tp_ns.ns, r.tp_ns.tp, p.second.id));
                              });
                 });
           });


### PR DESCRIPTION
The partition assignments set is a great candidate to use the
`contiguous_range_map` as it always contains all the topic partitions
starting from 0 up to the partition count.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
- none