### PR TITLE
tests: Downgrade warning for non-fatal anomalies

### DIFF
--- a/tests/rptest/services/redpanda.py
+++ b/tests/rptest/services/redpanda.py
@@ -4733,7 +4733,7 @@ class RedpandaService(RedpandaServiceBase):
         if not any_anomalies:
             self.logger.info(f"No anomalies in object storage scrub")
         elif not fatal_anomalies:
-            self.logger.warn(
+            self.logger.info(
                 f"Non-fatal anomalies in remote storage: {json.dumps(report, indent=2)}"
             )
         else:


### PR DESCRIPTION
Lots of tests implicitly trigger the non-fatal cases as they don't wait
for all uploads to finish.

It being a warning means it gets output on the main DT output (the one
with all the test results) and hence causes quite a bit of noise.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

* none

