### PR TITLE
[CORE-4181] schema registry json support validating drafts 5 6 and 7 

### DIFF
--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -253,6 +253,17 @@ ss::future<> check_references(sharded_store& store, canonical_schema schema) {
     }
 }
 
+// helper struct to format json::Value
+struct pj {
+    json::Value const& v;
+    friend std::ostream& operator<<(std::ostream& os, pj const& p) {
+        auto osw = json::OStreamWrapper{os};
+        auto writer = json::Writer<json::OStreamWrapper>{osw};
+        p.v.Accept(writer);
+        return os;
+    }
+};
+
 result<json::Document> parse_json(std::string_view v) {
     // validation pre-step: compile metaschema for json draft
     static const auto metaschema_doc = [] {
@@ -331,17 +342,6 @@ bool is_superset(json::Value const& older, json::Value const& newer);
 
 // close the implementation in a namespace to keep it contained
 namespace is_superset_impl {
-
-// helper struct to format json::Value
-struct pj {
-    json::Value const& v;
-    friend std::ostream& operator<<(std::ostream& os, pj const& p) {
-        auto osw = json::OStreamWrapper{os};
-        auto writer = json::Writer<json::OStreamWrapper>{osw};
-        p.v.Accept(writer);
-        return os;
-    }
-};
 
 enum class json_type : uint8_t {
     string = 0,

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -429,6 +429,231 @@ constexpr std::string_view json_draft_6_metaschema = R"json(
 }
 )json";
 
+/*
+ From https://json-schema.org/draft-07/schema, this is the draft7 metaschema
+ used to validate draft7 json schemas.
+ TODO It's implemented in the draft4 dialect, because the current version
+ of rapidjson only support draft4, change this when it's upgraded
+ For reference, this is the diff applied to the original metaschema:
+--- draft7.json	2024-07-02 09:53:23.943963373 +0200
++++ draft7.asdraft4.json	2024-07-05 15:55:21.160409278 +0200
+@@ -1,4 +1,4 @@
+ {
+-    "$schema": "http://json-schema.org/draft-07/schema#",
+-    "$id": "http://json-schema.org/draft-07/schema#",
++    "$schema": "http://json-schema.org/draft-04/schema#",
++    "id": "http://json-schema.org/draft-07/schema#",
+     "title": "Core schema meta-schema",
+@@ -46,3 +46,4 @@
+             "type": "string",
+-            "format": "uri"
++            "format": "uri",
++            "enum": ["http://json-schema.org/draft-07/schema#"]
+         },
+@@ -61,3 +62,3 @@
+         },
+-        "default": true,
++        "default": {},
+         "readOnly": {
+@@ -72,3 +73,3 @@
+             "type": "array",
+-            "items": true
++            "items": {}
+         },
+@@ -76,3 +77,4 @@
+             "type": "number",
+-            "exclusiveMinimum": 0
++            "minimum": 0,
++            "exclusiveMinimum": true
+         },
+@@ -141,6 +143,6 @@
+         "propertyNames": { "$ref": "#" },
+-        "const": true,
++        "const": {},
+         "enum": {
+             "type": "array",
+-            "items": true,
++            "items": {},
+             "minItems": 1,
+*/
+
+constexpr std::string_view json_draft_7_metaschema = R"json(
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri",
+            "enum": ["http://json-schema.org/draft-07/schema#"]
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "writeOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": {}
+        },
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": true
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": {},
+        "enum": {
+            "type": "array",
+            "items": {},
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "if": { "$ref": "#" },
+        "then": { "$ref": "#" },
+        "else": { "$ref": "#" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": true
+}
+)json";
+
 result<json::Document> parse_json(std::string_view v);
 
 ss::future<> check_references(sharded_store& store, canonical_schema schema) {
@@ -449,6 +674,7 @@ enum class json_schema_dialect {
     draft4,
     draft5,
     draft6,
+    draft7,
 };
 
 constexpr std::string_view to_uri(json_schema_dialect draft) {
@@ -460,6 +686,8 @@ constexpr std::string_view to_uri(json_schema_dialect draft) {
         return "http://json-schema.org/draft-05/schema#";
     case draft6:
         return "http://json-schema.org/draft-06/schema#";
+    case draft7:
+        return "http://json-schema.org/draft-07/schema#";
     }
 }
 
@@ -469,6 +697,7 @@ constexpr std::optional<json_schema_dialect> from_uri(std::string_view uri) {
       .match(to_uri(draft4), draft4)
       .match(to_uri(draft5), draft5)
       .match(to_uri(draft6), draft6)
+      .match(to_uri(draft7), draft7)
       .default_match(std::nullopt);
 }
 
@@ -498,6 +727,8 @@ json::SchemaDocument const& get_metaschema() {
                 return json_draft_4_metaschema;
             case json_schema_dialect::draft6:
                 return json_draft_6_metaschema;
+            case json_schema_dialect::draft7:
+                return json_draft_7_metaschema;
             }
         }();
 
@@ -526,6 +757,8 @@ result<void> validate_json_schema(
             return get_metaschema<draft4>();
         case draft6:
             return get_metaschema<draft6>();
+        case draft7:
+            return get_metaschema<draft7>();
         }
     }();
 
@@ -568,7 +801,7 @@ result<void> try_validate_json_schema(json::Document const& schema) {
 
     // no explicit $schema: try to validate from newest to oldest draft
     auto first_error = std::optional<error_info>{};
-    for (auto d : {draft6, draft4}) {
+    for (auto d : {draft7, draft6, draft4}) {
         auto res = validate_json_schema(d, schema);
         if (res.has_value()) {
             return outcome::success();
@@ -1590,6 +1823,14 @@ bool is_superset(json::Value const& older, json::Value const& newer) {
            "contains",
            "examples",
            "propertyNames",
+           // draft 7 unhandled keywords
+           "contentEncoding",
+           "contentMediaType",
+           "readOnly",
+           "writeOnly",
+           "if",
+           "then",
+           "else",
            // later drafts:
            "prefixItems",
          }) {

--- a/src/v/pandaproxy/schema_registry/json.cc
+++ b/src/v/pandaproxy/schema_registry/json.cc
@@ -253,6 +253,26 @@ ss::future<> check_references(sharded_store& store, canonical_schema schema) {
     }
 }
 
+// this is the list of supported dialects
+enum class json_schema_dialect {
+    draft4,
+};
+
+constexpr std::string_view to_uri(json_schema_dialect draft) {
+    using enum json_schema_dialect;
+    switch (draft) {
+    case draft4:
+        return "http://json-schema.org/draft-04/schema#";
+    }
+}
+
+constexpr std::optional<json_schema_dialect> from_uri(std::string_view uri) {
+    using enum json_schema_dialect;
+    return string_switch<std::optional<json_schema_dialect>>{uri}
+      .match(to_uri(draft4), draft4)
+      .default_match(std::nullopt);
+}
+
 // helper struct to format json::Value
 struct pj {
     json::Value const& v;

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -123,6 +123,13 @@ static constexpr auto valid_test_cases = std::to_array<std::string_view>({
   "minimum": 0,
   "exclusiveMinimum": false
 })",
+  R"(
+{
+  "$schema": "http://json-schema.org/draft-05/schema#",
+  "type": "number",
+  "minimum": 0,
+  "exclusiveMinimum": false
+})",
 });
 SEASTAR_THREAD_TEST_CASE(test_make_valid_json_schema) {
     for (const auto& data : valid_test_cases) {

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -144,6 +144,22 @@ static constexpr auto valid_test_cases = std::to_array<std::string_view>({
   "propertyNames": { "enum": ["a", "b"] }
 }
   )json",
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "a": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "b": true
+  },
+  "propertyNames": { "enum": ["a", "b"] },
+  "if": true,
+  "then": true
+}
+  )json",
 });
 SEASTAR_THREAD_TEST_CASE(test_make_valid_json_schema) {
     for (const auto& data : valid_test_cases) {

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -160,6 +160,10 @@ static constexpr auto valid_test_cases = std::to_array<std::string_view>({
   "then": true
 }
   )json",
+  R"json({"$schema": "http://json-schema.org/draft-07/schema"})json",
+  R"json({"$schema": "http://json-schema.org/draft-06/schema"})json",
+  R"json({"$schema": "http://json-schema.org/draft-05/schema"})json",
+  R"json({"$schema": "http://json-schema.org/draft-04/schema"})json",
 });
 SEASTAR_THREAD_TEST_CASE(test_make_valid_json_schema) {
     for (const auto& data : valid_test_cases) {

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -546,6 +546,18 @@ static constexpr auto compatibility_test_cases = std::to_array<
 })",
     .reader_is_compatible_with_writer = true,
   },
+  // array checks: same
+  {
+    .reader_schema = R"({"type": "array"})",
+    .writer_schema = R"({"type": "array"})",
+    .reader_is_compatible_with_writer = true,
+  },
+  // array checks: uniqueItems explicit value to false
+  {
+    .reader_schema = R"({"type": "array", "uniqueItems": false})",
+    .writer_schema = R"({"type": "array"})",
+    .reader_is_compatible_with_writer = true,
+  },
   // array checks:
   // - size decrease
   // - items change and new items added

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -130,6 +130,20 @@ static constexpr auto valid_test_cases = std::to_array<std::string_view>({
   "minimum": 0,
   "exclusiveMinimum": false
 })",
+  R"json(
+{
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "type": "object",
+  "properties": {
+    "a": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "b": true
+  },
+  "propertyNames": { "enum": ["a", "b"] }
+}
+  )json",
 });
 SEASTAR_THREAD_TEST_CASE(test_make_valid_json_schema) {
     for (const auto& data : valid_test_cases) {

--- a/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
+++ b/src/v/pandaproxy/schema_registry/test/test_json_schema.cc
@@ -70,8 +70,12 @@ static const auto error_test_cases = std::to_array({
     R"({"$schema": "unsupported_dialect"})",
     pps::error_info{
       pps::error_code::schema_invalid,
-      "Invalid json schema: '#/%24schema', invalid metaschema: "
-      "'#/properties/%24schema', invalid keyword: 'enum'"}},
+      R"(Unsupported json schema dialect: '"unsupported_dialect"')"}},
+  error_test_case{
+    R"({"$schema": 42})",
+    pps::error_info{
+      pps::error_code::schema_invalid,
+      "Unsupported json schema dialect: '42'"}},
 });
 SEASTAR_THREAD_TEST_CASE(test_make_invalid_json_schema) {
     for (const auto& data : error_test_cases) {
@@ -112,7 +116,13 @@ static constexpr auto valid_test_cases = std::to_array<std::string_view>({
   R"({})",
   R"({"the json schema is an open model": "it means this object is is equivalent to a empty one"})",
   // schemas
-  R"({"$schema": "http://json-schema.org/draft-04/schema#"})",
+  R"(
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "number",
+  "minimum": 0,
+  "exclusiveMinimum": false
+})",
 });
 SEASTAR_THREAD_TEST_CASE(test_make_valid_json_schema) {
     for (const auto& data : valid_test_cases) {


### PR DESCRIPTION
<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

- break recursion for `is_superset(get_true_schema(), ...)` and `is_superset(..., get_false_schema())` these two cases can happens for properties that don't have a default value: for example `{"type": "array"}` has no `"items"`, so it gets the default value of `{}`. without this early break, we get in an infinite recursion where `{}` is passes through `is_array_superset` and that in turn will call `is_superset` and so on

- add support for draft5: according to the official documentation, this dialect reuses the metaschema for draft4, and so does the code
- support for draft6 : the metaschema is adapted to draft4, because the current version of rapidjson implements only draft4
- support for draft7 : the metaschema is adapted to draft4, same reasons

- support for schemas uris without trailing # 

Fixes https://redpandadata.atlassian.net/browse/CORE-4181

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->

 * none 