### PR TITLE
replication_monitor/test: add diagnostic on assertion failure

### DIFF
--- a/src/v/raft/tests/replication_monitor_tests.cc
+++ b/src/v/raft/tests/replication_monitor_tests.cc
@@ -59,14 +59,14 @@ TEST_P_CORO(monitor_test_fixture, replication_monitor_wait) {
     auto raft = node(leader).raft();
 
     auto all = ::populate_waiters(raft, write_caching(), num_waiters());
-    co_await ss::sleep(2s);
+    co_await ss::sleep(500ms);
     ASSERT_FALSE_CORO(all.available());
 
     for (auto i = 0; i < num_waiters(); i++) {
         auto result = co_await raft->replicate(
           make_batches({{"k", "v"}}),
           replicate_options{raft::consistency_level::quorum_ack});
-        ASSERT_TRUE_CORO(result.has_value());
+        ASSERT_TRUE_CORO(result.has_value()) << result.error();
     }
 
     co_await tests::cooperative_spin_wait_with_timeout(
@@ -86,13 +86,13 @@ TEST_P_CORO(monitor_test_fixture, truncation_detection) {
 
     auto raft = node(leader).raft();
     auto all = ::populate_waiters(raft, write_caching(), num_waiters());
-    co_await ss::sleep(2s);
+    co_await ss::sleep(500ms);
     ASSERT_FALSE_CORO(all.available());
 
     for (auto& [id, node] : nodes()) {
         if (id == leader) {
             node->on_dispatch(
-              [](model::node_id, raft::msg_type) { return ss::sleep(5s); });
+              [](model::node_id, raft::msg_type) { return ss::sleep(3s); });
         }
     }
 


### PR DESCRIPTION
Additionally reduces sleep durations to make the test faster.

<!--
See https://github.com/redpanda-data/redpanda/blob/dev/CONTRIBUTING.md#pull-request-body
for more details and examples of what is expected in a PR body.

Content in this top section is REQUIRED. Describe, in plain language, the motivation
behind the change (bug fix, feature, improvement) in this PR and how the included
commits address it.

Add the GitHub keyword `Fixes` to link to bug(s) this PR will fix, e.g.
  Fixes #ISSUE-NUMBER, Fixes #ISSUE-NUMBER, ...

If this PR is a backport, link to the original with `Backport of PR`, e.g.
  Backport of PR #PR-NUMBER
-->

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes
* none
<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

* none

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
