### PR TITLE
rpk: add support to produce/consume with jsonschema

### DIFF
--- a/src/go/rpk/go.mod
+++ b/src/go/rpk/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/prometheus/common v0.53.0
 	github.com/rs/xid v1.5.0
 	github.com/safchain/ethtool v0.3.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/schollz/progressbar/v3 v3.14.2
 	github.com/sethgrid/pester v1.2.0
 	github.com/spf13/afero v1.11.0

--- a/src/go/rpk/go.sum
+++ b/src/go/rpk/go.sum
@@ -58,6 +58,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0 h1:rpfIENRNNilwHwZeG5+P150SMrnN
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.3.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/docker/docker v26.1.1+incompatible h1:oI+4kkAgIwwb54b9OC7Xc3hSgu1RlJA/Lln/DF72djQ=
 github.com/docker/docker v26.1.1+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=
@@ -219,6 +221,8 @@ github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/safchain/ethtool v0.3.0 h1:gimQJpsI6sc1yIqP/y8GYgiXn/NjgvpM0RNoWLVVmP0=
 github.com/safchain/ethtool v0.3.0/go.mod h1:SA9BwrgyAqNo7M+uaL6IYbxpm5wk3L7Mm6ocLW+CJUs=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 h1:PKK9DyHxif4LZo+uQSgXNqs0jj5+xZwwfKHgph2lxBw=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/schollz/progressbar/v3 v3.14.2 h1:EducH6uNLIWsr560zSV1KrTeUb/wZGAHqyMFIEa99ks=
 github.com/schollz/progressbar/v3 v3.14.2/go.mod h1:aQAZQnhF4JGFtRJiw/eobaXpsqpVQAftEQ+hLGXaRc4=
 github.com/sethgrid/pester v1.2.0 h1:adC9RS29rRUef3rIKWPOuP1Jm3/MmB6ke+OhE5giENI=

--- a/src/go/rpk/pkg/serde/avro.go
+++ b/src/go/rpk/pkg/serde/avro.go
@@ -63,7 +63,7 @@ func newAvroDecoder(codec *goavro.Codec) (serdeFunc, error) {
 func generateAvroCodec(ctx context.Context, cl *sr.Client, schema *sr.Schema) (*goavro.Codec, error) {
 	schemaStr := schema.Schema
 	if len(schema.References) > 0 {
-		err := parseReferences(ctx, cl, schema)
+		err := parseAvroReferences(ctx, cl, schema)
 		if err != nil {
 			return nil, fmt.Errorf("unable to parse references: %v", err)
 		}
@@ -82,10 +82,10 @@ func generateAvroCodec(ctx context.Context, cl *sr.Client, schema *sr.Schema) (*
 	return codec, nil
 }
 
-// parseReferences uses hamba/avro Parse method to parse every reference. We
+// parseAvroReferences uses hamba/avro Parse method to parse every reference. We
 // don't need to store the references since the library already cache these
 // schemas and use it later for handling references in the parent schema.
-func parseReferences(ctx context.Context, cl *sr.Client, schema *sr.Schema) error {
+func parseAvroReferences(ctx context.Context, cl *sr.Client, schema *sr.Schema) error {
 	if len(schema.References) == 0 {
 		_, err := avro.Parse(schema.Schema)
 		if err != nil {
@@ -99,7 +99,7 @@ func parseReferences(ctx context.Context, cl *sr.Client, schema *sr.Schema) erro
 			return err
 		}
 		refSchema := r.Schema
-		err = parseReferences(ctx, cl, &refSchema)
+		err = parseAvroReferences(ctx, cl, &refSchema)
 		if err != nil {
 			return fmt.Errorf("unable to parse schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
 		}

--- a/src/go/rpk/pkg/serde/avro_test.go
+++ b/src/go/rpk/pkg/serde/avro_test.go
@@ -129,6 +129,7 @@ func Test_encodeDecodeAvroRecordNoReferences(t *testing.T) {
 			noopCl, _ := sr.NewClient()
 			schema := sr.Schema{
 				Schema: tt.schema,
+				Type:   sr.TypeAvro,
 			}
 			serde, err := NewSerde(context.Background(), noopCl, &schema, tt.schemaID, "")
 			if tt.expErr {

--- a/src/go/rpk/pkg/serde/jsonschema.go
+++ b/src/go/rpk/pkg/serde/jsonschema.go
@@ -1,0 +1,100 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package serde
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+func compileJsonschema(ctx context.Context, cl *sr.Client, schema *sr.Schema) (*jsonschema.Schema, error) {
+	c := jsonschema.NewCompiler()
+	err := parseJsonschemaReferences(ctx, cl, schema, c)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse json schema references: %v", err)
+	}
+	sch, err := jsonschema.UnmarshalJSON(strings.NewReader(schema.Schema))
+	if err != nil {
+		return nil, fmt.Errorf("unable to unmarshal base schema: %v", err)
+	}
+	baseFileName := "redpanda_jsonschema.json"
+	err = c.AddResource(baseFileName, sch)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add base json schema to the compiler resource: %v", err)
+	}
+	return c.Compile(baseFileName)
+}
+
+func newJsonschemaEncoder(schemaID int, jSchema *jsonschema.Schema) (serdeFunc, error) {
+	return func(record []byte) ([]byte, error) {
+		sch, err := jsonschema.UnmarshalJSON(bytes.NewReader(record))
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal record: %v", err)
+		}
+		err = jSchema.Validate(sch)
+		if err != nil {
+			return nil, fmt.Errorf("unable to validate json schema: %v", err)
+		}
+		// Append the magic byte + the schema ID bytes.
+		var serdeHeader sr.ConfluentHeader
+		h, err := serdeHeader.AppendEncode(nil, schemaID, nil)
+		if err != nil {
+			return nil, fmt.Errorf("unable to append header: %v", err)
+		}
+		return append(h, record...), nil
+	}, nil
+}
+
+func newJsonschemaDecoder(jSchema *jsonschema.Schema) (serdeFunc, error) {
+	return func(record []byte) ([]byte, error) {
+		var recordDec any
+		err := json.Unmarshal(record, &recordDec)
+		if err != nil {
+			return nil, fmt.Errorf("unable to unmarshal record: %v", err)
+		}
+		err = jSchema.Validate(recordDec)
+		if err != nil {
+			return nil, fmt.Errorf("unable to validate record: %v", err)
+		}
+		return record, nil
+	}, nil
+}
+
+func parseJsonschemaReferences(ctx context.Context, cl *sr.Client, schema *sr.Schema, compiler *jsonschema.Compiler) error {
+	for _, ref := range schema.References {
+		r, err := cl.SchemaByVersion(ctx, ref.Subject, ref.Version)
+		if err != nil {
+			return fmt.Errorf("unable to get schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
+		}
+		refSchema := r.Schema
+
+		sch, err := jsonschema.UnmarshalJSON(strings.NewReader(refSchema.Schema))
+		if err != nil {
+			return fmt.Errorf("unable to unmarshal json schema %q: %v", ref.Name, err)
+		}
+
+		err = compiler.AddResource(ref.Name, sch)
+		if err != nil {
+			return fmt.Errorf("unable to add schema %v: %v", ref.Name, err)
+		}
+
+		err = parseJsonschemaReferences(ctx, cl, &refSchema, compiler)
+		if err != nil {
+			return fmt.Errorf("unable to parse schema with subject %q and version %v: %v", ref.Subject, ref.Version, err)
+		}
+	}
+	return nil
+}

--- a/src/go/rpk/pkg/serde/jsonschema_test.go
+++ b/src/go/rpk/pkg/serde/jsonschema_test.go
@@ -1,0 +1,444 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.md
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0
+
+package serde
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/config"
+	"github.com/redpanda-data/redpanda/src/go/rpk/pkg/schemaregistry"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"github.com/twmb/franz-go/pkg/sr"
+)
+
+const allTypesSchema = `{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" },
+    "id": { "type": ["string", "number"] },
+    "telephone": { "type": "integer" },
+    "member": { "type": "boolean" },
+    "apartments": { "type": "array" },
+    "tags": { "type": "object" },
+    "friends": { "type": "null" }
+  },
+  "required": ["name"]
+}`
+
+const nestedSchema = `{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/product.schema.json",
+  "title": "Product",
+  "description": "A product from Acme's catalog",
+  "type": "object",
+  "properties": {
+    "productId": {
+      "description": "The unique identifier for a product",
+      "type": "integer"
+    },
+    "productName": {
+      "description": "Name of the product",
+      "type": "string"
+    },
+    "price": {
+      "description": "The price of the product",
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "tags": {
+      "description": "Tags for the product",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "dimensions": {
+      "type": "object",
+      "properties": {
+        "length": {
+          "type": "number"
+        },
+        "width": {
+          "type": "number"
+        },
+        "height": {
+          "type": "number"
+        }
+      },
+      "required": [ "length", "width", "height" ]
+    }
+  },
+  "required": [ "productId", "productName", "price" ]
+}`
+
+func Test_encodeDecodeJsonSchemaNoReferences(t *testing.T) {
+	tests := []struct {
+		name      string
+		schema    string
+		schemaID  int
+		record    string
+		expErr    bool // error building the Serde.
+		expEncErr bool // error encoding the record.
+	}{
+		{
+			name:     "Valid schema, record with all fields",
+			schema:   allTypesSchema,
+			schemaID: 2206,
+			record: `{
+  "name":"foo",
+  "id": 20.20,
+  "telephone": 12322212,
+  "member": true,
+  "apartments": [906, 2206, "test"],
+  "tags": { "random": "value" }
+}`,
+		},
+		{
+			name:     "Valid schema, record with minimum fields",
+			schema:   allTypesSchema,
+			schemaID: 94,
+			record:   `{"name":"foo"}`,
+		},
+		{
+			name:     "Valid schema, record with extra fields",
+			schema:   allTypesSchema,
+			schemaID: 11,
+			record:   `{"name":"foo", "extra":"yes"}`,
+		},
+		{
+			name:     "Nested schema", // Example from jsonschema docs
+			schema:   nestedSchema,
+			schemaID: 123,
+			record: `{
+  "productId": 12345,
+  "productName": "Acme Widget",
+  "price": 13.23,
+  "tags": ["electronics", "gadgets", "widgets"],
+  "dimensions": {
+    "length": 10.5,
+    "width": 5.0,
+    "height": 3.25
+  }
+}`,
+		},
+		{
+			name:     "Valid schema, empty json",
+			schema:   `{"type": "object","properties":{"name":{"type":"string"}}}`,
+			schemaID: 12,
+			record:   `{}`,
+		},
+		{
+			name: "Valid schema, with no additionalProperties",
+			schema: `{
+  "type": "object",
+  "properties": {
+    "name": { "type": "string" }
+  },
+  "additionalProperties": false
+}`,
+			schemaID:  8,
+			record:    `{"name":"foo", "bar":"baz"}`,
+			expEncErr: true,
+		},
+		{
+			name:     "Error in schema",
+			schema:   `{"type": "object","properties":{"name":{"tpe":"string"}}`, // missing }, typo.
+			schemaID: 12,
+			record:   `{"name":"foo"}`,
+			expErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			noopCl, _ := sr.NewClient()
+			schema := sr.Schema{
+				Schema: tt.schema,
+				Type:   sr.TypeJSON,
+			}
+			serde, err := NewSerde(context.Background(), noopCl, &schema, tt.schemaID, "")
+			if tt.expErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			got, err := serde.EncodeRecord([]byte(tt.record))
+			if tt.expEncErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Validate Magic Byte.
+			require.Equal(t, uint8(0), got[0])
+
+			var serdeHeader sr.ConfluentHeader
+			id, encRecord, err := serdeHeader.DecodeID(got)
+			require.NoError(t, err)
+			require.Equal(t, tt.schemaID, id)
+			if len(got) == 5 {
+				return // It's an empty record.
+			}
+
+			// Validate encoded record. Decode and compare to original:
+			gotDecoded, err := serde.DecodeRecord(encRecord)
+			if err != nil {
+				return
+			}
+			require.NoError(t, err)
+
+			// To avoid any mismatch in the decode order of the elements, we
+			// better unmarshal and compare the unmarshaled records.
+			var gotU, expU map[string]any
+			err = json.Unmarshal(gotDecoded, &gotU)
+			require.NoError(t, err)
+			err = json.Unmarshal([]byte(tt.record), &expU)
+			require.NoError(t, err)
+
+			require.Equal(t, expU, gotU)
+		})
+	}
+}
+
+func Test_encodeDecodeJsonsRecordWithReferences(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   *sr.Schema
+		schemaID int
+		record   string
+	}{
+		{
+			name:     "single reference + nested",
+			schemaID: 123,
+			record: `{
+  "productId": 123,
+  "productName": "redpanda plush", 
+  "tags": ["foo", "bar"],
+  "dimensions": {
+    "length": 10.5,
+    "width": 5.0,
+    "height": 3.25
+  },
+  "warehouseLocation": {
+    "latitude": 37.2795481,
+    "longitude": 127.047077
+  }
+}`,
+			schema: &sr.Schema{
+				Schema: `{
+   "type":"object",
+   "properties":{
+      "productId":{
+         "type":"integer"
+      },
+      "productName":{
+         "type":"string"
+      },
+      "tags":{
+         "type":"array",
+         "items":{
+            "type":"string"
+         }
+      },
+      "dimensions":{
+         "type":"object",
+         "properties":{
+            "length":{
+               "type":"number"
+            },
+            "width":{
+               "type":"number"
+            },
+            "height":{
+               "type":"number"
+            }
+         }
+      },
+      "warehouseLocation":{
+         "$ref":"https://example.com/geographical-location.schema.json"
+      }
+   }
+}`,
+				References: []sr.SchemaReference{
+					{
+						Name:    "https://example.com/geographical-location.schema.json",
+						Subject: "single",
+						Version: 0,
+					},
+				},
+			},
+		},
+		{
+			name:     "multiple single references",
+			schemaID: 123,
+			record: `{
+  "productId": 123,
+  "productName": "redpanda plush", 
+  "warehouseLocation": {
+    "latitude": 37.2795481,
+    "longitude": 127.047077
+  },
+  "colors": {
+    "available": ["red", "orange"]
+  }
+}`,
+			schema: &sr.Schema{
+				Schema: `{
+   "type":"object",
+   "properties":{
+      "productId":{
+         "type":"integer"
+      },
+      "productName":{
+         "type":"string"
+      },
+      "warehouseLocation":{
+         "$ref":"https://example.com/geographical-location.schema.json"
+      },
+      "colors":{
+          "$ref":"file:///tmp/colors.json"
+      }
+   }
+}`,
+				References: []sr.SchemaReference{
+					{
+						Name:    "https://example.com/geographical-location.schema.json",
+						Subject: "single",
+						Version: 0,
+					},
+					{
+						Name:    "file:///tmp/colors.json",
+						Subject: "single",
+						Version: 1,
+					},
+				},
+			},
+		},
+		{
+			name:     "multiple single references",
+			schemaID: 123,
+			record: `{
+  "productId": 123,
+  "productName": "redpanda plush", 
+  "warehouseLocation": {
+    "coordinates": {
+      "latitude": 37.2795481,
+      "longitude": 127.047077
+    }
+  }
+}`,
+			schema: &sr.Schema{
+				Schema: `{
+   "type":"object",
+   "properties":{
+      "productId":{
+         "type":"integer"
+      },
+      "productName":{
+         "type":"string"
+      },
+      "warehouseLocation":{
+         "$ref":"nested.json"
+      }
+   }
+}`,
+				References: []sr.SchemaReference{
+					{
+						Name:    "nested.json",
+						Subject: "nested",
+						Version: 2,
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(jsonReferenceHandler())
+			defer ts.Close()
+
+			fs := afero.NewMemMapFs()
+			params := &config.Params{ConfigFlag: "/some/path/redpanda.yaml"}
+			p, err := params.LoadVirtualProfile(fs)
+			require.NoError(t, err)
+
+			p.SR.Addresses = []string{ts.URL}
+
+			client, err := schemaregistry.NewClient(fs, p)
+			require.NoError(t, err)
+
+			tt.schema.Type = sr.TypeJSON
+			serde, err := NewSerde(context.Background(), client, tt.schema, tt.schemaID, "")
+			require.NoError(t, err)
+
+			got, err := serde.EncodeRecord([]byte(tt.record))
+			require.NoError(t, err)
+
+			// Validate Magic Byte.
+			require.Equal(t, uint8(0), got[0])
+
+			var serdeHeader sr.ConfluentHeader
+			id, encRecord, err := serdeHeader.DecodeID(got)
+			require.NoError(t, err)
+			require.Equal(t, tt.schemaID, id)
+			if len(got) == 5 {
+				return // It's an empty record.
+			}
+
+			// Validate encoded record. Decode and compare to original:
+			gotDecoded, err := serde.DecodeRecord(encRecord)
+			require.NoError(t, err)
+
+			// To avoid any mismatch in the decode order of the elements, we
+			// better unmarshal and compare the unmarshaled records.
+			var gotU, expU map[string]any
+			err = json.Unmarshal(gotDecoded, &gotU)
+			require.NoError(t, err)
+			err = json.Unmarshal([]byte(tt.record), &expU)
+			require.NoError(t, err)
+
+			require.Equal(t, expU, gotU)
+		})
+	}
+}
+
+var jsonschemaReferenceMap = map[string]string{
+	"single-0": `{"schema":"{\"type\":\"object\",\"properties\":{\"latitude\":{\"type\":\"number\"},\"longitude\":{\"type\":\"number\"}}}"}`,
+	"single-1": `{"schema":"{\"type\":\"object\",\"properties\":{\"available\":{\"type\":\"array\"}}}"}`,
+	"nested-2": `{"references":[{"name":"https://example.com/geographical-location.schema.json","subject":"single","version":0}],"schema":"{\"type\":\"object\",\"properties\":{\"coordinates\":{\"$ref\":\"https://example.com/geographical-location.schema.json\"}}}"}`,
+}
+
+func jsonReferenceHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// Split the URL path by '/' to get individual path segments
+		segments := strings.Split(r.URL.Path, "/")
+
+		// /subjects/{subject}/versions/{version}"
+		if len(segments) >= 4 && segments[1] == "subjects" && segments[3] == "versions" {
+			subject := segments[2]
+			version := segments[4]
+			id := subject + "-" + version
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(jsonschemaReferenceMap[id]))
+		} else {
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}
+}

--- a/src/go/rpk/pkg/serde/serde.go
+++ b/src/go/rpk/pkg/serde/serde.go
@@ -70,6 +70,23 @@ func NewSerde(ctx context.Context, cl *sr.Client, schema *sr.Schema, schemaID in
 			return nil, fmt.Errorf("unable to build protobuf decoder: %v", err)
 		}
 		return &Serde{encFn, decFn}, nil
+	case sr.TypeJSON:
+		compiledSchema, err := compileJsonschema(ctx, cl, schema)
+		if err != nil {
+			return nil, fmt.Errorf("unable to compile jsonschema: %v", err)
+		}
+
+		encFn, err := newJsonschemaEncoder(schemaID, compiledSchema)
+		if err != nil {
+			return nil, fmt.Errorf("unable to build jsonschema encoder: %v", err)
+		}
+
+		decFn, err := newJsonschemaDecoder(compiledSchema)
+		if err != nil {
+			return nil, fmt.Errorf("unable to build jsonschema decoder: %v", err)
+		}
+
+		return &Serde{encFn, decFn}, nil
 	default:
 		return nil, fmt.Errorf("schema with ID %v contains an unsupported schema type %v", schemaID, schema.Type)
 	}


### PR DESCRIPTION
Now rpk support "encoding" and "decoding" records using JSON schemas in the schema registry. rpk will validate the record before decoding or encoding it.

Along with https://github.com/redpanda-data/redpanda/pull/19947 and https://github.com/redpanda-data/redpanda/pull/20757 this completes the support of JSON schemas in rpk.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [ ] none - not a bug fix
- [ ] none - this is a backport
- [x] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

### Features

* rpk: Add support to JSON Schema to rpk, now supported in `rpk registry` and `rpk topic produce/consume`
