### PR TITLE
security: fix security-config circular dependency

### DIFF
--- a/src/v/config/configuration.cc
+++ b/src/v/config/configuration.cc
@@ -17,7 +17,6 @@
 #include "model/metadata.h"
 #include "model/namespace.h"
 #include "security/config.h"
-#include "security/gssapi_principal_mapper.h"
 #include "security/oidc_url_parser.h"
 #include "serde/rw/chrono.h"
 #include "ssx/sformat.h"

--- a/src/v/config/property.h
+++ b/src/v/config/property.h
@@ -22,8 +22,6 @@
 
 #include <seastar/util/noncopyable_function.hh>
 
-#include <boost/intrusive/list.hpp>
-
 #include <chrono>
 #include <functional>
 #include <optional>

--- a/src/v/config/tls_config.cc
+++ b/src/v/config/tls_config.cc
@@ -17,8 +17,6 @@
 #include <seastar/core/do_with.hh>
 #include <seastar/core/shared_ptr.hh>
 
-#include <boost/filesystem.hpp>
-
 namespace config {
 ss::future<std::optional<ss::tls::credentials_builder>>
 tls_config::get_credentials_builder() const& {

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -27,7 +27,7 @@ v_cc_library(
     license.cc
     mtls.cc
     oidc_authenticator.cc
-    oidc_principal_mapping.cc
+    oidc_principal_mapping_applicator.cc
     oidc_service.cc
     request_auth.cc
     role.cc

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -3,6 +3,7 @@ v_cc_library(
   SRCS
     config_bsl.cc
     config_rcl.cc
+    mtls_rule.cc
   DEPS
     v::json
     Seastar::seastar

--- a/src/v/security/CMakeLists.txt
+++ b/src/v/security/CMakeLists.txt
@@ -4,6 +4,8 @@ v_cc_library(
     config_bsl.cc
     config_rcl.cc
     mtls_rule.cc
+    gssapi_rule.cc
+    logger.cc
   DEPS
     v::json
     Seastar::seastar

--- a/src/v/security/acl.cc
+++ b/src/v/security/acl.cc
@@ -23,8 +23,6 @@
 
 namespace security {
 
-seastar::logger seclog("security");
-
 void acl_entry_set::insert(acl_entry entry) {
     auto [it, ins] = _entries.insert(std::move(entry));
     if (const auto& principal = it->principal();

--- a/src/v/security/config.h
+++ b/src/v/security/config.h
@@ -17,6 +17,13 @@
 #include <optional>
 #include <vector>
 
+namespace security {
+
+std::optional<ss::sstring>
+validate_kerberos_mapping_rules(const std::vector<ss::sstring>& r) noexcept;
+
+}
+
 namespace security::tls {
 
 std::optional<ss::sstring>

--- a/src/v/security/config_bsl.cc
+++ b/src/v/security/config_bsl.cc
@@ -10,7 +10,7 @@
  */
 
 #include "security/config.h"
-#include "security/mtls.h"
+#include "security/mtls_rule.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
 
@@ -106,18 +106,6 @@ parse_rules(std::optional<std::vector<ss::sstring>> unparsed_rules) {
 }
 
 } // namespace detail
-
-rule::rule(
-  std::string_view pattern,
-  std::optional<std::string_view> replacement,
-  make_lower to_lower,
-  make_upper to_upper)
-  : _regex{detail::make_regex(pattern)}
-  , _pattern{pattern}
-  , _replacement{replacement}
-  , _is_default{false}
-  , _to_lower{to_lower}
-  , _to_upper{to_upper} {}
 
 std::optional<ss::sstring> rule::apply(std::string_view dn) const {
     if (_is_default) {

--- a/src/v/security/config_rcl.cc
+++ b/src/v/security/config_rcl.cc
@@ -10,7 +10,7 @@
 
 #include "security/config.h"
 #include "security/gssapi_principal_mapper.h"
-#include "security/mtls.h"
+#include "security/mtls_rule.h"
 #include "security/oidc_error.h"
 #include "security/oidc_principal_mapping.h"
 #include "security/oidc_url_parser.h"

--- a/src/v/security/config_rcl.cc
+++ b/src/v/security/config_rcl.cc
@@ -14,6 +14,7 @@
 #include "security/oidc_error.h"
 #include "security/oidc_principal_mapping.h"
 #include "security/oidc_url_parser.h"
+#include "ssx/sformat.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <re2/re2.h>

--- a/src/v/security/config_rcl.cc
+++ b/src/v/security/config_rcl.cc
@@ -9,7 +9,7 @@
  */
 
 #include "security/config.h"
-#include "security/gssapi_principal_mapper.h"
+#include "security/gssapi_rule.h"
 #include "security/mtls_rule.h"
 #include "security/oidc_error.h"
 #include "security/oidc_principal_mapping.h"
@@ -116,27 +116,6 @@ parse_rules(const std::vector<ss::sstring>& unparsed_rules) {
     return rv;
 }
 } // namespace gssapi::detail
-
-gssapi_rule::gssapi_rule(
-  int number_of_components,
-  std::string_view format,
-  std::string_view match,
-  std::string_view from_pattern,
-  std::string_view to_pattern,
-  repeat repeat_,
-  case_change_operation case_change)
-  : _is_default(false)
-  , _number_of_components(number_of_components)
-  , _format(format)
-  , _match(match)
-  , _from_pattern(std::regex{
-      from_pattern.begin(),
-      from_pattern.length(),
-      std::regex_constants::ECMAScript | std::regex_constants::optimize})
-  , _from_pattern_str(from_pattern)
-  , _to_pattern(to_pattern)
-  , _repeat(repeat_)
-  , _case_change(case_change) {}
 
 std::optional<ss::sstring>
 validate_kerberos_mapping_rules(const std::vector<ss::sstring>& r) noexcept {

--- a/src/v/security/gssapi_principal_mapper.cc
+++ b/src/v/security/gssapi_principal_mapper.cc
@@ -33,8 +33,6 @@ namespace security {
 namespace gssapi {
 static constexpr std::string_view gssapi_name_pattern
   = R"(([^/@]*)(/([^/@]*))?@([^/@]*))";
-static constexpr std::string_view non_simple_pattern = R"([/@])";
-static constexpr std::string_view parameter_pattern = R"(([^$]*)(\$(\d*))?)";
 
 namespace detail {
 std::vector<gssapi_rule>
@@ -90,199 +88,6 @@ const ss::sstring& gssapi_name::host_name() const noexcept {
 }
 
 const ss::sstring& gssapi_name::realm() const noexcept { return _realm; }
-std::optional<ss::sstring> gssapi_rule::apply(
-  std::string_view default_realm, std::vector<std::string_view> params) const {
-    static thread_local const re2::RE2 non_simple_regex(
-      gssapi::non_simple_pattern, re2::RE2::Quiet);
-    const re2::StringPiece match_piece(_match.data(), _match.size());
-    const re2::RE2 match_regex(match_piece, re2::RE2::Quiet);
-    vassert(
-      non_simple_regex.ok(),
-      "Invalid non-simple-regex: {}",
-      non_simple_regex.error());
-    // Even if _match is empty, the RE2 will be 'ok'
-    vassert(match_regex.ok(), "Invalid match regex: {}", match_regex.error());
-
-    /*
-     * How this works:
-     *
-     * Take a rule like this:
-     *
-     * RULE:[2:$1foo$2](Admin\.(.*)s/Admin\.(.*)/$1/
-     *
-     * And say the GSSAPI principal name is:
-     * Admin.site-user/example.com@REALM.com.
-     *
-     * The name breaks down to:
-     * service-name: Admin.site-user
-     * host-name: example.com
-     * realm: REALM.com
-     *
-     * First, the "2" at the beginning ensures there are two parameters in the
-     * principal name (ignoring realm, we have the service-name and host-name).
-     *
-     * If we were missing the host-name, then we would only have one parameter
-     * and this rule would be ignored.
-     *
-     * Now, the "$1foo$2".  This is the 'format'.  This formats the GSSAPI name,
-     * so it can be fed into the next match regex.
-     *
-     * $0 - Realm
-     * $1 - service-name
-     * $2 - host-name
-     *
-     * So this 'format' takes the name and turns it into
-     * "Admin.site-userfooexample.com"
-     *
-     * Next, we test if this formatted name matches the "match" regex which in
-     * this case is "(Admin\.(.*))".  Meaning anything that begins with "Admin".
-     *
-     * It does, so then we move on to the replacement regex:
-     * "s/Admin\.(.*)/$1/".
-     *
-     * The "Admin\.(.*)" is the from pattern.
-     * The "$1" is the to pattern.
-     *
-     * This rule effectively removes the "Admin." at the beginning of the
-     * formatted name:
-     * "site-userfooexample.com" is the result.
-     */
-
-    ss::sstring result;
-
-    if (_is_default && params.size() >= 2) {
-        // If rule is a default rule, check to see if the realm and default
-        // realm matches and then use the primary value
-        if (default_realm == params.at(0)) {
-            result = ss::sstring(params.at(1));
-        }
-    } else if (
-      !params.empty()
-      && params.size() - 1 == static_cast<size_t>(_number_of_components)) {
-        auto base = replace_parameters(_format, params);
-        if (!base) {
-            return std::nullopt;
-        }
-        const re2::StringPiece base_piece(base->data(), base->size());
-        if (_match.empty() || re2::RE2::FullMatch(base_piece, match_regex)) {
-            if (_from_pattern_str.empty()) {
-                result = *base;
-            } else {
-                result = replace_substitution(
-                  *base, *_from_pattern, _to_pattern, _repeat);
-            }
-        }
-    }
-
-    const re2::StringPiece result_piece(result.data(), result.size());
-    if (
-      !result.empty()
-      && re2::RE2::PartialMatch(result_piece, non_simple_regex)) {
-        vlog(
-          seclog.error,
-          "Non-simple name {} after auth_to_local rule {}",
-          result,
-          *this);
-        return std::nullopt;
-    }
-
-    if (!result.empty()) {
-        switch (_case_change) {
-        case case_change_operation::noop:
-            break;
-
-        case case_change_operation::make_lower:
-            boost::algorithm::to_lower(result, std::locale::classic());
-            break;
-
-        case case_change_operation::make_upper:
-            boost::algorithm::to_upper(result, std::locale::classic());
-            break;
-        }
-    }
-
-    if (result.empty()) {
-        return std::nullopt;
-    } else {
-        return result;
-    }
-}
-
-std::optional<ss::sstring> gssapi_rule::replace_parameters(
-  std::string_view format, std::vector<std::string_view> params) {
-    static thread_local const re2::RE2 parameter_parser(
-      gssapi::parameter_pattern, re2::RE2::Quiet);
-    vassert(
-      parameter_parser.ok(),
-      "Invalid parameter pattern: {}",
-      parameter_parser.error());
-
-    ss::sstring result;
-    re2::StringPiece format_piece(format.data(), format.size());
-
-    re2::StringPiece text_replace, index_replace;
-    while (re2::RE2::Consume(
-      &format_piece,
-      parameter_parser,
-      &text_replace,
-      nullptr,
-      &index_replace)) {
-        if (!text_replace.empty()) {
-            result.append(text_replace.data(), text_replace.size());
-        }
-        if (!index_replace.empty()) {
-            std::size_t index = std::numeric_limits<std::size_t>::max();
-            auto conv_result = std::from_chars(
-              index_replace.begin(), index_replace.end(), index);
-            if (conv_result.ec != std::errc()) {
-                vlog(
-                  seclog.warn,
-                  "Bad format in username mapping in {}",
-                  std::string_view{index_replace.data(), index_replace.size()});
-                return std::nullopt;
-            } else if (index >= params.size()) {
-                vlog(
-                  seclog.warn,
-                  "Invalid index provided ({}).  Outside range of "
-                  "parameters (length {})",
-                  index,
-                  params.size());
-                return std::nullopt;
-            } else {
-                const auto& param_index = params[index];
-                result.append(param_index.data(), param_index.size());
-            }
-        }
-
-        // format_piece will be empty if we have parsed all of format_piece
-        // text_replace and index_replace will be empty if nothing was grouped
-        // into those but re2::RE2::Consume still returns true (and doesn't
-        // update format_piece)
-        if (
-          format_piece.empty()
-          || (text_replace.empty() && index_replace.empty())) {
-            break;
-        }
-    }
-
-    return result;
-}
-
-ss::sstring gssapi_rule::replace_substitution(
-  std::string_view base,
-  const std::regex& from,
-  std::string_view to,
-  repeat repeat_) {
-    ss::sstring replace_value;
-
-    std::regex_constants::match_flag_type const flags
-      = std::regex_constants::format_default
-        | (repeat_ ? std::regex_constants::match_default : std::regex_constants::format_first_only);
-
-    replace_value = std::regex_replace(base.data(), from, to.data(), flags);
-
-    return replace_value;
-}
 
 gssapi_principal_mapper::gssapi_principal_mapper(
   config::binding<std::vector<ss::sstring>> principal_to_local_rules_cb)
@@ -328,11 +133,6 @@ std::ostream& operator<<(std::ostream& os, const gssapi_name& n) {
     return os;
 }
 
-std::ostream& operator<<(std::ostream& os, const gssapi_rule& r) {
-    fmt::print(os, "{}", r);
-    return os;
-}
-
 std::ostream& operator<<(std::ostream& os, const gssapi_principal_mapper& m) {
     fmt::print(os, "{}", m);
     return os;
@@ -355,41 +155,6 @@ fmt::formatter<security::gssapi_name, char, void>::format<
     }
     if (!r._realm.empty()) {
         fmt::format_to(ctx.out(), "@{}", r._realm);
-    }
-
-    return ctx.out();
-}
-
-template<>
-typename fmt::basic_format_context<fmt::appender, char>::iterator
-fmt::formatter<security::gssapi_rule, char, void>::format<
-  fmt::basic_format_context<fmt::appender, char>>(
-  security::gssapi_rule const& r,
-  fmt::basic_format_context<fmt::appender, char>& ctx) const {
-    if (r._is_default) {
-        return fmt::format_to(ctx.out(), "DEFAULT");
-    }
-    fmt::format_to(
-      ctx.out(), "RULE:[{}:{}]", r._number_of_components, r._format);
-    if (!r._match.empty()) {
-        fmt::format_to(ctx.out(), "({})", r._match);
-    }
-    if (r._from_pattern) {
-        fmt::format_to(
-          ctx.out(), "s/{}/{}/", r._from_pattern_str, r._to_pattern);
-        if (r._repeat) {
-            fmt::format_to(ctx.out(), "g");
-        }
-    }
-    switch (r._case_change) {
-    case security::gssapi_rule::noop:
-        break;
-    case security::gssapi_rule::make_lower:
-        fmt::format_to(ctx.out(), "/L");
-        break;
-    case security::gssapi_rule::make_upper:
-        fmt::format_to(ctx.out(), "/U");
-        break;
     }
 
     return ctx.out();

--- a/src/v/security/gssapi_principal_mapper.h
+++ b/src/v/security/gssapi_principal_mapper.h
@@ -12,13 +12,12 @@
 
 #include "base/seastarx.h"
 #include "config/property.h"
+#include "security/gssapi_rule.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
 
 #include <fmt/core.h>
-
-#include <regex>
 
 namespace security {
 
@@ -42,67 +41,6 @@ private:
     ss::sstring _primary;
     ss::sstring _host_name;
     ss::sstring _realm;
-};
-
-class gssapi_rule {
-public:
-    enum case_change_operation { noop, make_lower, make_upper };
-    using repeat = ss::bool_class<struct repeat_tag>;
-
-    gssapi_rule() = default;
-
-    gssapi_rule(
-      int number_of_components,
-      std::string_view format,
-      std::string_view match,
-      std::string_view from_pattern,
-      std::string_view to_pattern,
-      repeat repeat_,
-      case_change_operation case_change);
-
-    /**
-     * Applies the rule to the provided parameters
-     * @param default_realm The default realm to use when applying the rules
-     * @param params The first element is realm, second and later elements are
-     * the components of the name "a/b@FOO" -> {"FOO", "a", "b"}
-     * @return The short name if this rule applies or nothing
-     * @throws std::invalid_argument If there is something wrong with the rules
-     */
-    std::optional<ss::sstring> apply(
-      std::string_view default_realm,
-      std::vector<std::string_view> params) const;
-
-private:
-    friend struct fmt::formatter<gssapi_rule>;
-
-    friend std::ostream& operator<<(std::ostream& os, const gssapi_rule& r);
-
-    static std::optional<ss::sstring> replace_parameters(
-      std::string_view format, std::vector<std::string_view> params);
-    static ss::sstring replace_substitution(
-      std::string_view base,
-      const std::regex& from,
-      std::string_view to,
-      repeat repeat_);
-
-    bool _is_default{true};
-    int _number_of_components{0};
-    ss::sstring _format;
-    ss::sstring _match;
-    // Reason for using std::regex -
-    // This regex is used to replace the selected GSSAPI principal name
-    // components using the regex found at the end of the rule.  The regex
-    // allows for group selection and replacement using "$n" to select which
-    // group to use.  Google's RE2 uses "\n" to select a group.
-    // See:
-    // https://github.com/google/re2/blob/4be240789d5b322df9f02b7e19c8651f3ccbf205/re2/re2.h#L455
-    // So instead of having to write another regex to parse through that and
-    // replace the "$" with the "\", I opted to just use std::regex.
-    std::optional<std::regex> _from_pattern;
-    ss::sstring _from_pattern_str;
-    ss::sstring _to_pattern;
-    repeat _repeat{false};
-    case_change_operation _case_change{case_change_operation::noop};
 };
 
 class gssapi_principal_mapper {
@@ -135,17 +73,6 @@ validate_kerberos_mapping_rules(const std::vector<ss::sstring>& r) noexcept;
 template<>
 struct fmt::formatter<security::gssapi_name> {
     using type = security::gssapi_name;
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    typename FormatContext::iterator
-    format(const type& r, FormatContext& ctx) const;
-};
-
-template<>
-struct fmt::formatter<security::gssapi_rule> {
-    using type = security::gssapi_rule;
 
     constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
 

--- a/src/v/security/gssapi_principal_mapper.h
+++ b/src/v/security/gssapi_principal_mapper.h
@@ -12,6 +12,7 @@
 
 #include "base/seastarx.h"
 #include "config/property.h"
+#include "security/config.h"
 #include "security/gssapi_rule.h"
 
 #include <seastar/core/sstring.hh>
@@ -66,8 +67,6 @@ private:
     std::vector<gssapi_rule> _rules;
 };
 
-std::optional<ss::sstring>
-validate_kerberos_mapping_rules(const std::vector<ss::sstring>& r) noexcept;
 } // namespace security
 
 template<>

--- a/src/v/security/gssapi_rule.cc
+++ b/src/v/security/gssapi_rule.cc
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#include "security/gssapi_rule.h"
+
+#include "base/vassert.h"
+#include "base/vlog.h"
+#include "security/logger.h"
+
+#include <boost/algorithm/string/case_conv.hpp>
+#include <re2/re2.h>
+
+#include <charconv>
+#include <optional>
+
+namespace security {
+
+namespace gssapi {
+static constexpr std::string_view non_simple_pattern = R"([/@])";
+static constexpr std::string_view parameter_pattern = R"(([^$]*)(\$(\d*))?)";
+} // namespace gssapi
+
+gssapi_rule::gssapi_rule(
+  int number_of_components,
+  // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
+  std::string_view format,
+  std::string_view match,
+  std::string_view from_pattern,
+  std::string_view to_pattern,
+  repeat repeat_,
+  case_change_operation case_change)
+  : _is_default(false)
+  , _number_of_components(number_of_components)
+  , _format(format)
+  , _match(match)
+  , _from_pattern(std::regex{
+      from_pattern.begin(),
+      from_pattern.length(),
+      std::regex_constants::ECMAScript | std::regex_constants::optimize})
+  , _from_pattern_str(from_pattern)
+  , _to_pattern(to_pattern)
+  , _repeat(repeat_)
+  , _case_change(case_change) {}
+
+std::optional<ss::sstring> gssapi_rule::apply(
+  std::string_view default_realm, std::vector<std::string_view> params) const {
+    static thread_local const re2::RE2 non_simple_regex(
+      gssapi::non_simple_pattern, re2::RE2::Quiet);
+    const re2::StringPiece match_piece(_match.data(), _match.size());
+    const re2::RE2 match_regex(match_piece, re2::RE2::Quiet);
+    vassert(
+      non_simple_regex.ok(),
+      "Invalid non-simple-regex: {}",
+      non_simple_regex.error());
+    // Even if _match is empty, the RE2 will be 'ok'
+    vassert(match_regex.ok(), "Invalid match regex: {}", match_regex.error());
+
+    /*
+     * How this works:
+     *
+     * Take a rule like this:
+     *
+     * RULE:[2:$1foo$2](Admin\.(.*)s/Admin\.(.*)/$1/
+     *
+     * And say the GSSAPI principal name is:
+     * Admin.site-user/example.com@REALM.com.
+     *
+     * The name breaks down to:
+     * service-name: Admin.site-user
+     * host-name: example.com
+     * realm: REALM.com
+     *
+     * First, the "2" at the beginning ensures there are two parameters in the
+     * principal name (ignoring realm, we have the service-name and host-name).
+     *
+     * If we were missing the host-name, then we would only have one parameter
+     * and this rule would be ignored.
+     *
+     * Now, the "$1foo$2".  This is the 'format'.  This formats the GSSAPI name,
+     * so it can be fed into the next match regex.
+     *
+     * $0 - Realm
+     * $1 - service-name
+     * $2 - host-name
+     *
+     * So this 'format' takes the name and turns it into
+     * "Admin.site-userfooexample.com"
+     *
+     * Next, we test if this formatted name matches the "match" regex which in
+     * this case is "(Admin\.(.*))".  Meaning anything that begins with "Admin".
+     *
+     * It does, so then we move on to the replacement regex:
+     * "s/Admin\.(.*)/$1/".
+     *
+     * The "Admin\.(.*)" is the from pattern.
+     * The "$1" is the to pattern.
+     *
+     * This rule effectively removes the "Admin." at the beginning of the
+     * formatted name:
+     * "site-userfooexample.com" is the result.
+     */
+
+    ss::sstring result;
+
+    if (_is_default && params.size() >= 2) {
+        // If rule is a default rule, check to see if the realm and default
+        // realm matches and then use the primary value
+        if (default_realm == params.at(0)) {
+            result = ss::sstring(params.at(1));
+        }
+    } else if (
+      !params.empty()
+      && params.size() - 1 == static_cast<size_t>(_number_of_components)) {
+        auto base = replace_parameters(_format, params);
+        if (!base) {
+            return std::nullopt;
+        }
+        const re2::StringPiece base_piece(base->data(), base->size());
+        if (_match.empty() || re2::RE2::FullMatch(base_piece, match_regex)) {
+            if (_from_pattern_str.empty()) {
+                result = *base;
+            } else {
+                result = replace_substitution(
+                  *base, *_from_pattern, _to_pattern, _repeat);
+            }
+        }
+    }
+
+    const re2::StringPiece result_piece(result.data(), result.size());
+    if (
+      !result.empty()
+      && re2::RE2::PartialMatch(result_piece, non_simple_regex)) {
+        vlog(
+          seclog.error,
+          "Non-simple name {} after auth_to_local rule {}",
+          result,
+          *this);
+        return std::nullopt;
+    }
+
+    if (!result.empty()) {
+        switch (_case_change) {
+        case case_change_operation::noop:
+            break;
+
+        case case_change_operation::make_lower:
+            boost::algorithm::to_lower(result, std::locale::classic());
+            break;
+
+        case case_change_operation::make_upper:
+            boost::algorithm::to_upper(result, std::locale::classic());
+            break;
+        }
+    }
+
+    if (result.empty()) {
+        return std::nullopt;
+    } else {
+        return result;
+    }
+}
+
+std::optional<ss::sstring> gssapi_rule::replace_parameters(
+  std::string_view format, std::vector<std::string_view> params) {
+    static thread_local const re2::RE2 parameter_parser(
+      gssapi::parameter_pattern, re2::RE2::Quiet);
+    vassert(
+      parameter_parser.ok(),
+      "Invalid parameter pattern: {}",
+      parameter_parser.error());
+
+    ss::sstring result;
+    re2::StringPiece format_piece(format.data(), format.size());
+
+    re2::StringPiece text_replace, index_replace;
+    while (re2::RE2::Consume(
+      &format_piece,
+      parameter_parser,
+      &text_replace,
+      nullptr,
+      &index_replace)) {
+        if (!text_replace.empty()) {
+            result.append(text_replace.data(), text_replace.size());
+        }
+        if (!index_replace.empty()) {
+            std::size_t index = std::numeric_limits<std::size_t>::max();
+            auto conv_result = std::from_chars(
+              index_replace.begin(), index_replace.end(), index);
+            if (conv_result.ec != std::errc()) {
+                vlog(
+                  seclog.warn,
+                  "Bad format in username mapping in {}",
+                  std::string_view{index_replace.data(), index_replace.size()});
+                return std::nullopt;
+            } else if (index >= params.size()) {
+                vlog(
+                  seclog.warn,
+                  "Invalid index provided ({}).  Outside range of "
+                  "parameters (length {})",
+                  index,
+                  params.size());
+                return std::nullopt;
+            } else {
+                const auto& param_index = params[index];
+                result.append(param_index.data(), param_index.size());
+            }
+        }
+
+        // format_piece will be empty if we have parsed all of format_piece
+        // text_replace and index_replace will be empty if nothing was grouped
+        // into those but re2::RE2::Consume still returns true (and doesn't
+        // update format_piece)
+        if (
+          format_piece.empty()
+          || (text_replace.empty() && index_replace.empty())) {
+            break;
+        }
+    }
+
+    return result;
+}
+
+ss::sstring gssapi_rule::replace_substitution(
+  std::string_view base,
+  const std::regex& from,
+  std::string_view to,
+  repeat repeat_) {
+    ss::sstring replace_value;
+
+    std::regex_constants::match_flag_type const flags
+      = std::regex_constants::format_default
+        | (repeat_ ? std::regex_constants::match_default : std::regex_constants::format_first_only);
+
+    replace_value = std::regex_replace(base.data(), from, to.data(), flags);
+
+    return replace_value;
+}
+
+std::ostream& operator<<(std::ostream& os, const gssapi_rule& r) {
+    fmt::print(os, "{}", r);
+    return os;
+}
+
+} // namespace security
+
+template<>
+typename fmt::basic_format_context<fmt::appender, char>::iterator
+fmt::formatter<security::gssapi_rule, char, void>::format<
+  fmt::basic_format_context<fmt::appender, char>>(
+  security::gssapi_rule const& r,
+  fmt::basic_format_context<fmt::appender, char>& ctx) const {
+    if (r._is_default) {
+        return fmt::format_to(ctx.out(), "DEFAULT");
+    }
+    fmt::format_to(
+      ctx.out(), "RULE:[{}:{}]", r._number_of_components, r._format);
+    if (!r._match.empty()) {
+        fmt::format_to(ctx.out(), "({})", r._match);
+    }
+    if (r._from_pattern) {
+        fmt::format_to(
+          ctx.out(), "s/{}/{}/", r._from_pattern_str, r._to_pattern);
+        if (r._repeat) {
+            fmt::format_to(ctx.out(), "g");
+        }
+    }
+    switch (r._case_change) {
+    case security::gssapi_rule::noop:
+        break;
+    case security::gssapi_rule::make_lower:
+        fmt::format_to(ctx.out(), "/L");
+        break;
+    case security::gssapi_rule::make_upper:
+        fmt::format_to(ctx.out(), "/U");
+        break;
+    }
+
+    return ctx.out();
+}

--- a/src/v/security/gssapi_rule.h
+++ b/src/v/security/gssapi_rule.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <fmt/core.h>
+
+#include <regex>
+#include <string_view>
+
+namespace security {
+
+class gssapi_rule {
+public:
+    enum case_change_operation { noop, make_lower, make_upper };
+    using repeat = ss::bool_class<struct repeat_tag>;
+
+    gssapi_rule() = default;
+
+    gssapi_rule(
+      int number_of_components,
+      std::string_view format,
+      std::string_view match,
+      std::string_view from_pattern,
+      std::string_view to_pattern,
+      repeat repeat_,
+      case_change_operation case_change);
+
+    /**
+     * Applies the rule to the provided parameters
+     * @param default_realm The default realm to use when applying the rules
+     * @param params The first element is realm, second and later elements are
+     * the components of the name "a/b@FOO" -> {"FOO", "a", "b"}
+     * @return The short name if this rule applies or nothing
+     * @throws std::invalid_argument If there is something wrong with the rules
+     */
+    std::optional<ss::sstring> apply(
+      std::string_view default_realm,
+      std::vector<std::string_view> params) const;
+
+private:
+    friend struct fmt::formatter<gssapi_rule>;
+
+    friend std::ostream& operator<<(std::ostream& os, const gssapi_rule& r);
+
+    static std::optional<ss::sstring> replace_parameters(
+      std::string_view format, std::vector<std::string_view> params);
+    static ss::sstring replace_substitution(
+      std::string_view base,
+      const std::regex& from,
+      std::string_view to,
+      repeat repeat_);
+
+    bool _is_default{true};
+    int _number_of_components{0};
+    ss::sstring _format;
+    ss::sstring _match;
+    // Reason for using std::regex -
+    // This regex is used to replace the selected GSSAPI principal name
+    // components using the regex found at the end of the rule.  The regex
+    // allows for group selection and replacement using "$n" to select which
+    // group to use.  Google's RE2 uses "\n" to select a group.
+    // See:
+    // https://github.com/google/re2/blob/4be240789d5b322df9f02b7e19c8651f3ccbf205/re2/re2.h#L455
+    // So instead of having to write another regex to parse through that and
+    // replace the "$" with the "\", I opted to just use std::regex.
+    std::optional<std::regex> _from_pattern;
+    ss::sstring _from_pattern_str;
+    ss::sstring _to_pattern;
+    repeat _repeat{false};
+    case_change_operation _case_change{case_change_operation::noop};
+};
+
+} // namespace security
+
+template<>
+struct fmt::formatter<security::gssapi_rule> {
+    using type = security::gssapi_rule;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator
+    format(const type& r, FormatContext& ctx) const;
+};

--- a/src/v/security/logger.cc
+++ b/src/v/security/logger.cc
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include <seastar/util/log.hh>
+
+namespace security {
+
+seastar::logger seclog("security");
+
+}

--- a/src/v/security/mtls.cc
+++ b/src/v/security/mtls.cc
@@ -27,11 +27,6 @@ parse_rules(std::optional<std::vector<ss::sstring>> unparsed_rules);
 
 } // namespace detail
 
-std::ostream& operator<<(std::ostream& os, const rule& r) {
-    fmt::print(os, "{}", r);
-    return os;
-}
-
 std::ostream& operator<<(std::ostream& os, const principal_mapper& p) {
     fmt::print(os, "{}", p);
     return os;
@@ -57,30 +52,6 @@ std::optional<ss::sstring> principal_mapper::apply(std::string_view sv) const {
 
 // explicit instantiations so as to avoid bringing in <fmt/ranges.h> in the
 // header, whch breaks compilation in another part of the codebase.
-template<>
-typename fmt::basic_format_context<fmt::appender, char>::iterator
-fmt::formatter<security::tls::rule, char, void>::format<
-  fmt::basic_format_context<fmt::appender, char>>(
-  security::tls::rule const& r,
-  fmt::basic_format_context<fmt::appender, char>& ctx) const {
-    if (r._is_default) {
-        return fmt::format_to(ctx.out(), "DEFAULT");
-    }
-    fmt::format_to(ctx.out(), "RULE:");
-    if (r._pattern.has_value()) {
-        fmt::format_to(ctx.out(), "{}", *r._pattern);
-    }
-    if (r._replacement.has_value()) {
-        fmt::format_to(ctx.out(), "/{}", *r._replacement);
-    }
-    if (r._to_lower) {
-        fmt::format_to(ctx.out(), "/L");
-    } else if (r._to_upper) {
-        fmt::format_to(ctx.out(), "/U");
-    }
-    return ctx.out();
-}
-
 template<>
 typename fmt::basic_format_context<fmt::appender, char>::iterator
 fmt::formatter<security::tls::principal_mapper, char, void>::format<

--- a/src/v/security/mtls.h
+++ b/src/v/security/mtls.h
@@ -14,6 +14,7 @@
 #include "base/seastarx.h"
 #include "config/property.h"
 #include "security/acl.h"
+#include "security/mtls_rule.h"
 
 #include <seastar/core/sstring.hh>
 #include <seastar/util/bool_class.hh>
@@ -25,34 +26,6 @@
 #include <string_view>
 
 namespace security::tls {
-
-class rule {
-public:
-    using make_lower = ss::bool_class<struct make_lower_tag>;
-    using make_upper = ss::bool_class<struct make_upper_tag>;
-
-    rule() = default;
-
-    rule(
-      std::string_view pattern,
-      std::optional<std::string_view> replacement,
-      make_lower to_lower,
-      make_upper to_upper);
-
-    std::optional<ss::sstring> apply(std::string_view dn) const;
-
-private:
-    friend struct fmt::formatter<rule>;
-
-    friend std::ostream& operator<<(std::ostream& os, const rule& r);
-
-    std::regex _regex;
-    std::optional<ss::sstring> _pattern;
-    std::optional<ss::sstring> _replacement;
-    bool _is_default{true};
-    make_lower _to_lower{false};
-    make_upper _to_upper{false};
-};
 
 class principal_mapper {
 public:
@@ -87,17 +60,6 @@ private:
 };
 
 } // namespace security::tls
-
-template<>
-struct fmt::formatter<security::tls::rule> {
-    using type = security::tls::rule;
-
-    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
-
-    template<typename FormatContext>
-    typename FormatContext::iterator
-    format(const type& r, FormatContext& ctx) const;
-};
 
 template<>
 struct fmt::formatter<security::tls::principal_mapper> {

--- a/src/v/security/mtls_rule.cc
+++ b/src/v/security/mtls_rule.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#include "security/mtls_rule.h"
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+#include <regex>
+
+namespace {
+std::regex make_regex(std::string_view sv) {
+    return std::regex{
+      sv.begin(),
+      sv.length(),
+      std::regex_constants::ECMAScript | std::regex_constants::optimize};
+}
+} // namespace
+
+namespace security::tls {
+
+rule::rule(
+  std::string_view pattern,
+  std::optional<std::string_view> replacement,
+  make_lower to_lower,
+  make_upper to_upper)
+  : _regex{make_regex(pattern)}
+  , _pattern{pattern}
+  , _replacement{replacement}
+  , _is_default{false}
+  , _to_lower{to_lower}
+  , _to_upper{to_upper} {}
+
+std::ostream& operator<<(std::ostream& os, const rule& r) {
+    fmt::print(os, "{}", r);
+    return os;
+}
+
+} // namespace security::tls
+
+template<>
+typename fmt::basic_format_context<fmt::appender, char>::iterator
+fmt::formatter<security::tls::rule, char, void>::format<
+  fmt::basic_format_context<fmt::appender, char>>(
+  security::tls::rule const& r,
+  fmt::basic_format_context<fmt::appender, char>& ctx) const {
+    if (r._is_default) {
+        return fmt::format_to(ctx.out(), "DEFAULT");
+    }
+    fmt::format_to(ctx.out(), "RULE:");
+    if (r._pattern.has_value()) {
+        fmt::format_to(ctx.out(), "{}", *r._pattern);
+    }
+    if (r._replacement.has_value()) {
+        fmt::format_to(ctx.out(), "/{}", *r._replacement);
+    }
+    if (r._to_lower) {
+        fmt::format_to(ctx.out(), "/L");
+    } else if (r._to_upper) {
+        fmt::format_to(ctx.out(), "/U");
+    }
+    return ctx.out();
+}

--- a/src/v/security/mtls_rule.h
+++ b/src/v/security/mtls_rule.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Use of this software is governed by the Business Source License
+ * included in the file licenses/BSL.md
+ *
+ * As of the Change Date specified in that file, in accordance with
+ * the Business Source License, use of this software will be governed
+ * by the Apache License, Version 2.0
+ */
+#pragma once
+
+#include "base/seastarx.h"
+
+#include <seastar/core/sstring.hh>
+#include <seastar/util/bool_class.hh>
+
+#include <fmt/core.h>
+
+#include <optional>
+#include <regex>
+#include <string_view>
+
+namespace security::tls {
+
+class rule {
+public:
+    using make_lower = ss::bool_class<struct make_lower_tag>;
+    using make_upper = ss::bool_class<struct make_upper_tag>;
+
+    rule() = default;
+
+    rule(
+      std::string_view pattern,
+      std::optional<std::string_view> replacement,
+      make_lower to_lower,
+      make_upper to_upper);
+
+    std::optional<ss::sstring> apply(std::string_view dn) const;
+
+private:
+    friend struct fmt::formatter<rule>;
+
+    friend std::ostream& operator<<(std::ostream& os, const rule& r);
+
+    std::regex _regex;
+    std::optional<ss::sstring> _pattern;
+    std::optional<ss::sstring> _replacement;
+    bool _is_default{true};
+    make_lower _to_lower{false};
+    make_upper _to_upper{false};
+};
+
+} // namespace security::tls
+
+template<>
+struct fmt::formatter<security::tls::rule> {
+    using type = security::tls::rule;
+
+    constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator
+    format(const type& r, FormatContext& ctx) const;
+};

--- a/src/v/security/oidc_authenticator.cc
+++ b/src/v/security/oidc_authenticator.cc
@@ -15,7 +15,7 @@
 #include "security/errc.h"
 #include "security/jwt.h"
 #include "security/logger.h"
-#include "security/oidc_principal_mapping.h"
+#include "security/oidc_principal_mapping_applicator.h"
 #include "security/oidc_service.h"
 
 #include <seastar/core/lowres_clock.hh>
@@ -61,7 +61,7 @@ result<authentication_data> authenticate(
         return errc::jwt_invalid_nbf;
     }
 
-    auto principal = mapping.apply(jwt);
+    auto principal = principal_mapping_rule_apply(mapping, jwt);
     if (principal.has_error()) {
         return principal.assume_error();
     }

--- a/src/v/security/oidc_principal_mapping.h
+++ b/src/v/security/oidc_principal_mapping.h
@@ -8,17 +8,12 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 #pragma once
+
 #include "base/outcome.h"
-#include "base/seastarx.h"
-#include "config/property.h"
 #include "json/pointer.h"
-#include "security/acl.h"
-#include "security/fwd.h"
-#include "security/mtls.h"
+#include "security/mtls_rule.h"
 
-#include <seastar/core/sstring.hh>
-
-#include <optional>
+#include <string_view>
 
 namespace security::oidc {
 
@@ -32,7 +27,8 @@ public:
         swap(_claim, claim);
     }
 
-    result<acl_principal> apply(jwt const& jwt) const;
+    const json::Pointer& claim() const { return _claim; }
+    const tls::rule& mapping() const { return _mapping; }
 
 private:
     json::Pointer _claim{"/sub"};

--- a/src/v/security/oidc_principal_mapping_applicator.cc
+++ b/src/v/security/oidc_principal_mapping_applicator.cc
@@ -8,22 +8,22 @@
  * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
  */
 
-#include "security/oidc_principal_mapping.h"
+#include "security/oidc_principal_mapping_applicator.h"
 
-#include "security/jwt.h"
 #include "security/logger.h"
 
 #include <rapidjson/pointer.h>
 
 namespace security::oidc {
 
-result<acl_principal> principal_mapping_rule::apply(jwt const& jwt) const {
-    auto claim = jwt.claim(_claim);
+result<acl_principal> principal_mapping_rule_apply(
+  const principal_mapping_rule& mapping, jwt const& jwt) {
+    auto claim = jwt.claim(mapping.claim());
     if (claim.value_or("").empty()) {
         return errc::jwt_invalid_principal;
     }
 
-    auto principal = _mapping.apply(claim.value());
+    auto principal = mapping.mapping().apply(claim.value());
     if (principal.value_or("").empty()) {
         return errc::jwt_invalid_principal;
     }

--- a/src/v/security/oidc_principal_mapping_applicator.h
+++ b/src/v/security/oidc_principal_mapping_applicator.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Redpanda Data, Inc.
+ *
+ * Licensed as a Redpanda Enterprise file under the Redpanda Community
+ * License (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * https://github.com/redpanda-data/redpanda/blob/master/licenses/rcl.md
+ */
+#pragma once
+
+#include "base/outcome.h"
+#include "security/acl.h"
+#include "security/jwt.h"
+#include "security/oidc_principal_mapping.h"
+
+namespace security::oidc {
+
+result<acl_principal>
+principal_mapping_rule_apply(const principal_mapping_rule&, jwt const& jwt);
+
+}

--- a/src/v/security/tests/oidc_principal_mapping_test.cc
+++ b/src/v/security/tests/oidc_principal_mapping_test.cc
@@ -10,7 +10,7 @@
 #include "config/property.h"
 #include "json/document.h"
 #include "security/jwt.h"
-#include "security/oidc_principal_mapping.h"
+#include "security/oidc_principal_mapping_applicator.h"
 
 #include <seastar/core/sstring.hh>
 
@@ -110,7 +110,7 @@ BOOST_DATA_TEST_CASE(
     auto jwt = security::oidc::jwt::make(std::move(header), std::move(payload));
     BOOST_REQUIRE(!jwt.has_error());
 
-    auto principal = mapper.apply(jwt.assume_value());
+    auto principal = principal_mapping_rule_apply(mapper, jwt.assume_value());
     if (
       d.principal.has_error()
       && d.principal.assume_error() != security::oidc::errc::success) {


### PR DESCRIPTION
Fixes circular dependency between security and config libraries.

## Backports Required

<!-- Checking at least one of the checkboxes is REQUIRED if this PR is not a backport. -->

- [x] none - not a bug fix
- [ ] none - this is a backport
- [ ] none - issue does not exist in previous branches
- [ ] none - papercut/not impactful enough to backport
- [ ] v24.1.x
- [ ] v23.3.x
- [ ] v23.2.x

## Release Notes

<!--
If the changes in this PR do not need to be mentioned in the release
notes, then don't add a sub-section and simply list `none`, e.g.

Otherwise, adding a sub-section or `none` is REQUIRED if the PR is not a backport PR.
If this is a backport PR, adding contents to this section will override
the release notes section inherited from the original PR to dev.

Add one or more of the sub-sections with a short description bullet
point of the change, e.g.

### Bug Fixes

* Short description of the bug fix if this is a PR to `dev` branch.

### Features

* Short description of the feature. Explain how to configure.

### Improvements

* Short description of how this PR improves existing behavior.

-->
* none

